### PR TITLE
docs: fix cloned repo directory in setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ NeMo Platform brings NVIDIA NeMo libraries together under one CLI, Python SDK, a
 
 ```bash
 git clone https://github.com/NVIDIA-NeMo/nemo-platform.git
-cd Platform
+cd nemo-platform
 
 make bootstrap
 source .venv/bin/activate
@@ -84,7 +84,7 @@ nemo setup --auto --start-services --install-skills --deploy-agent
 
 ## Use NeMo Platform from your coding agent
 
-After installation, launch your coding agent (Claude Code, Codex, Cursor, OpenCode, etc) from inside the `Platform` directory. This is the primary way of interacting with the NeMo Platform.
+After installation, launch your coding agent (Claude Code, Codex, Cursor, OpenCode, etc) from inside the `nemo-platform` directory. This is the primary way of interacting with the NeMo Platform.
 
 Things you can ask it to do, once the platform is running:
 

--- a/docs/about/release-notes/current-release.md
+++ b/docs/about/release-notes/current-release.md
@@ -81,7 +81,7 @@ flow.
 
 ```bash
 git clone https://github.com/NVIDIA-NeMo/nemo-platform.git
-cd Platform
+cd nemo-platform
 make bootstrap
 nemo setup
 ```

--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -17,7 +17,7 @@ Clone the source repository and bootstrap the local environment:
 
 ```bash
 git clone https://github.com/NVIDIA-NeMo/nemo-platform.git
-cd Platform
+cd nemo-platform
 make bootstrap
 source .venv/bin/activate
 ```


### PR DESCRIPTION
## Summary

The setup docs cloned `NVIDIA-NeMo/nemo-platform` but then told users to `cd Platform`. That directory is not created by the clone command, so the copy-paste install flow fails before `make bootstrap`.

This updates the README, setup guide, and current release notes to use the actual cloned directory name: `nemo-platform`. The README prose now points coding-agent users at the same directory name.
