### PR TITLE
fix(studio): force NODE_ENV=production during build

### DIFF
--- a/web/packages/studio/package.json
+++ b/web/packages/studio/package.json
@@ -10,7 +10,7 @@
     "start": "vite --mode dev",
     "start:stg": "vite --mode stg",
     "start:dev": "VITE_IS_LOC_ENV='true' vite --mode dev",
-    "build": "vite build",
+    "build": "NODE_ENV=production vite build",
     "build:dev": "tsc && vite build --mode dev",
     "build:fastapi": "pnpm build --mode fastapi",
     "build:fastapi:dev": "export NODE_ENV=fastapi && pnpm build --mode fastapi",


### PR DESCRIPTION
## Summary

- Force `NODE_ENV=production` in the Studio `build` script so the production bundle is built correctly regardless of the developer's shell environment.
- Fixes a blank Studio page at http://localhost:8080/studio/ after `make bootstrap-studio` when `NODE_ENV=development` (or any non-production value) is exported in the shell.

## Background

Vite 8 / Rolldown emits a *throwing-Proxy* stub for browser-externalized modules unless `NODE_ENV=production` at build time (see rolldown/rolldown#9359). `object-inspect` — a transitive dep of `react-oidc-context` — reads `utilInspect.custom` at module load, which crashes the bundle and leaves React unmounted.

Symptoms in the browser:

- `#app` stays empty with `aria-busy="true"`.
- Console error: `Module "" has been externalized for browser compatibility. Cannot access ".custom" in client code.`

Vite normally sets `NODE_ENV=production` itself during `vite build`, but it defers to `process.env.NODE_ENV` if it's already set. The inline `NODE_ENV=production` in the `build` script clobbers shell-leaked values just for that command.

This same protection already exists for the Python wheel build path (`packages/nemo_platform/hatch_build.py` uses `env.setdefault("NODE_ENV", "production")`). The fix here closes the gap for `make bootstrap-studio` and the CI `licenses:extract` job, both of which call `pnpm build` without setting `NODE_ENV`.

## Test plan

- [x] `NODE_ENV=development make bootstrap-studio` succeeds (this is the reporter's local setup).
- [x] After `nemo services run`, http://localhost:8080/studio/ renders the UI (no blank page, no `aria-busy="true"` left on `#app`, no externalized-`util` console error).
