### PR TITLE
feat(agentic-use): export ATIF traces for agents

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/skills/registry.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/skills/registry.py
@@ -337,21 +337,29 @@ def _discover_skill_providers() -> dict[str, SkillProvider]:
     from ``nemo_platform_plugin.discovery.discover_entry_points`` and used to filter
     candidates before resolution.
     """
+    candidates_by_name: dict[str, list[SkillProvider]] = defaultdict(list)
+
     try:
         from nemo_platform_plugin.discovery import discover_entry_points
     except ImportError:
-        return {}
+        logger.warning("nemo-platform-plugin is unavailable; loading only bundled platform skills", exc_info=True)
+    else:
+        allowed_names = set(discover_entry_points("nemo.skills").keys())
+        for ep in _raw_entry_points("nemo.skills"):
+            if ep.name not in allowed_names:
+                continue
+            skills_root = _resolve_provider_candidate(ep)
+            if skills_root is None:
+                continue
+            dist_name = ep.dist.name if ep.dist is not None else None
+            candidates_by_name[ep.name].append(SkillProvider(name=ep.name, path=skills_root, dist_name=dist_name))
 
-    allowed_names = set(discover_entry_points("nemo.skills").keys())
-    candidates_by_name: dict[str, list[SkillProvider]] = defaultdict(list)
-    for ep in _raw_entry_points("nemo.skills"):
-        if ep.name not in allowed_names:
-            continue
-        skills_root = _resolve_provider_candidate(ep)
-        if skills_root is None:
-            continue
-        dist_name = ep.dist.name if ep.dist is not None else None
-        candidates_by_name[ep.name].append(SkillProvider(name=ep.name, path=skills_root, dist_name=dist_name))
+    if "platform" not in candidates_by_name:
+        from nemo_platform_ext.skills import skills_dir
+
+        candidates_by_name["platform"].append(
+            SkillProvider(name="platform", path=skills_dir(), dist_name="nemo-platform-ext")
+        )
 
     return {name: _join_same_name_candidates(name, candidates) for name, candidates in candidates_by_name.items()}
 

--- a/packages/nemo_platform_ext/tests/cli/commands/skills/test_registry.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/skills/test_registry.py
@@ -126,6 +126,17 @@ def test_load_skills_includes_platform_skills():
     assert {"inference"} <= skills.keys()
 
 
+def test_load_skills_includes_platform_skills_without_entry_point_metadata(monkeypatch):
+    """Bundled platform skills remain available even if entry-point metadata is absent."""
+    monkeypatch.setattr("nemo_platform_plugin.discovery.discover_entry_points", lambda _group: {})
+    monkeypatch.setattr("nemo_platform_ext.cli.commands.skills.registry._raw_entry_points", lambda _group: ())
+
+    skills = load_skills()
+
+    assert {"inference"} <= skills.keys()
+    assert skills["inference"].source_dist == "nemo-platform-ext"
+
+
 def test_load_skills_includes_example_plugin_skills(monkeypatch):
     """Adding a provider on top of the platform should expose its skills too."""
     monkeypatch.setattr(

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/skills/registry.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/skills/registry.py
@@ -337,21 +337,27 @@ def _discover_skill_providers() -> dict[str, SkillProvider]:
     from ``nemo_platform_plugin.discovery.discover_entry_points`` and used to filter
     candidates before resolution.
     """
+    candidates_by_name: dict[str, list[SkillProvider]] = defaultdict(list)
+
     try:
         from nemo_platform_plugin.discovery import discover_entry_points
     except ImportError:
-        return {}
+        logger.warning("nemo-platform-plugin is unavailable; loading only bundled platform skills", exc_info=True)
+    else:
+        allowed_names = set(discover_entry_points("nemo.skills").keys())
+        for ep in _raw_entry_points("nemo.skills"):
+            if ep.name not in allowed_names:
+                continue
+            skills_root = _resolve_provider_candidate(ep)
+            if skills_root is None:
+                continue
+            dist_name = ep.dist.name if ep.dist is not None else None
+            candidates_by_name[ep.name].append(SkillProvider(name=ep.name, path=skills_root, dist_name=dist_name))
 
-    allowed_names = set(discover_entry_points("nemo.skills").keys())
-    candidates_by_name: dict[str, list[SkillProvider]] = defaultdict(list)
-    for ep in _raw_entry_points("nemo.skills"):
-        if ep.name not in allowed_names:
-            continue
-        skills_root = _resolve_provider_candidate(ep)
-        if skills_root is None:
-            continue
-        dist_name = ep.dist.name if ep.dist is not None else None
-        candidates_by_name[ep.name].append(SkillProvider(name=ep.name, path=skills_root, dist_name=dist_name))
+    if "platform" not in candidates_by_name:
+        from nemo_platform.skills import skills_dir
+
+        candidates_by_name["platform"].append(SkillProvider(name="platform", path=skills_dir(), dist_name="nemo-platform"))
 
     return {name: _join_same_name_candidates(name, candidates) for name, candidates in candidates_by_name.items()}
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/skills/registry.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/skills/registry.py
@@ -357,7 +357,9 @@ def _discover_skill_providers() -> dict[str, SkillProvider]:
     if "platform" not in candidates_by_name:
         from nemo_platform.skills import skills_dir
 
-        candidates_by_name["platform"].append(SkillProvider(name="platform", path=skills_dir(), dist_name="nemo-platform"))
+        candidates_by_name["platform"].append(
+            SkillProvider(name="platform", path=skills_dir(), dist_name="nemo-platform-ext")
+        )
 
     return {name: _join_same_name_candidates(name, candidates) for name, candidates in candidates_by_name.items()}
 

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/skills/test_registry.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/skills/test_registry.py
@@ -126,6 +126,17 @@ def test_load_skills_includes_platform_skills():
     assert {"inference"} <= skills.keys()
 
 
+def test_load_skills_includes_platform_skills_without_entry_point_metadata(monkeypatch):
+    """Bundled platform skills remain available even if entry-point metadata is absent."""
+    monkeypatch.setattr("nemo_platform_plugin.discovery.discover_entry_points", lambda _group: {})
+    monkeypatch.setattr("nemo_platform.cli.commands.skills.registry._raw_entry_points", lambda _group: ())
+
+    skills = load_skills()
+
+    assert {"inference"} <= skills.keys()
+    assert skills["inference"].source_dist == "nemo-platform"
+
+
 def test_load_skills_includes_example_plugin_skills(monkeypatch):
     """Adding a provider on top of the platform should expose its skills too."""
     monkeypatch.setattr(

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/skills/test_registry.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/skills/test_registry.py
@@ -134,7 +134,7 @@ def test_load_skills_includes_platform_skills_without_entry_point_metadata(monke
     skills = load_skills()
 
     assert {"inference"} <= skills.keys()
-    assert skills["inference"].source_dist == "nemo-platform"
+    assert skills["inference"].source_dist == "nemo-platform-ext"
 
 
 def test_load_skills_includes_example_plugin_skills(monkeypatch):

--- a/tests/agentic-use/nat_runner.py
+++ b/tests/agentic-use/nat_runner.py
@@ -88,6 +88,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 TASKS_DIR = Path(__file__).resolve().parent
 SHARED_DIR = TASKS_DIR / "shared"
 CODEX_AGENT_SCRIPT_TEMPLATE_PATH = TASKS_DIR / "scripts" / "codex_agent_runner.sh"
+NAT_TRACE_EXPORT_SCRIPT_CONTAINER_PATH = "/app/tests/agentic-use/scripts/nat_trace_export.py"
 
 DEFAULT_TIMEOUT = int(os.environ.get("NAT_TIMEOUT", "600"))
 DEFAULT_JOBS_DIR = REPO_ROOT / "nat-jobs"
@@ -127,7 +128,9 @@ _CANDIDATE_PARAM_KEYS = _CANDIDATE_PARAM_STRING_KEYS | _CANDIDATE_PARAM_NUMBER_K
 
 
 def _coerce_candidate_number_param(key: str, value: object) -> int | float:
-    if type(value) in (int, float):
+    if isinstance(value, bool):
+        raise ValueError(f"--candidate-params key {key!r} must be numeric")
+    if isinstance(value, int | float):
         return value
     if isinstance(value, str):
         try:
@@ -528,6 +531,21 @@ def _build_workflow_agent_cmd(workflow_container: str, instruction_container: st
               2>&1 | tee /tmp/nat_agent.log
             EXIT=${{PIPESTATUS[0]}}
             cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
+            if [ -f /logs/agent/intermediate_steps.jsonl ]; then
+              /app/.venv/bin/python {NAT_TRACE_EXPORT_SCRIPT_CONTAINER_PATH} convert-jsonl \\
+                --input /logs/agent/intermediate_steps.jsonl \\
+                --output /logs/agent/trajectory.json \\
+                >> /tmp/nat_agent.log 2>&1
+              CONVERT_EXIT=$?
+              cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
+              if [ $EXIT -eq 0 ] && [ $CONVERT_EXIT -ne 0 ]; then
+                exit $CONVERT_EXIT
+              fi
+            elif [ $EXIT -eq 0 ]; then
+              echo "NAT telemetry exporter did not create /logs/agent/intermediate_steps.jsonl" | tee -a /tmp/nat_agent.log
+              cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
+              exit 1
+            fi
             exit $EXIT
         """),
     ]
@@ -544,9 +562,9 @@ def _build_aut_agent_cmd(instruction_container: str) -> list[str]:
     3. Optionally seeding inference providers + secrets so AUT configs that
        resolve models via the platform's inference gateway can run inside an
        ephemeral test container with no pre-existing entities.
-    4. Deploying the AUT, waiting for ``/health`` readiness, and POSTing the
-       task instruction to ``/generate`` (with ``/generate/full`` as a
-       schema/path-compat fallback).
+    4. Deploying the AUT, waiting for ``/health`` readiness, and invoking the
+       task instruction through an artifact-capture helper that prefers NAT's
+       ``/generate/atif`` endpoint and falls back to legacy generate routes.
     5. Collecting diagnostics (deployment list/get, NeMo Platform API logs, NAT
        subprocess logs) into ``/logs/agent/`` on failure.
 
@@ -673,52 +691,12 @@ def _build_aut_agent_cmd(instruction_container: str) -> list[str]:
               exit 1
             fi
             set +e
-            DEP_ENDPOINT="$dep_endpoint" /app/.venv/bin/python - <<'PY' 2>&1 | tee /tmp/nat_agent.log
-import json
-import os
-import urllib.error
-import urllib.request
-import time
-
-instruction = open("{instruction_container}", "r", encoding="utf-8").read()
-payload = json.dumps({{"input_message": instruction}}).encode("utf-8")
-base_endpoint = os.environ["DEP_ENDPOINT"].rstrip("/")
-invoke_timeout = int(os.environ.get("AUT_INVOKE_HTTP_TIMEOUT", "600"))
-last_error: Exception | None = None
-for suffix in ("/generate", "/generate/full"):
-    endpoint = f"{{base_endpoint}}{{suffix}}"
-    request = urllib.request.Request(
-        endpoint,
-        data=payload,
-        headers={{"Content-Type": "application/json"}},
-        method="POST",
-    )
-    for attempt in range(3):
-        try:
-            with urllib.request.urlopen(request, timeout=invoke_timeout) as response:
-                print(response.read().decode("utf-8"))
-            last_error = None
-            break
-        except urllib.error.HTTPError as err:
-            # Keep trying endpoint variants for schema/path compatibility.
-            last_error = err
-            if err.code in {{404, 422}}:
-                break
-            raise
-        except urllib.error.URLError as err:
-            # Endpoint can flap briefly after /health returns ready.
-            last_error = err
-            if attempt < 2:
-                time.sleep(1.0)
-                continue
-            raise
-    if last_error is None:
-        break
-else:
-    if last_error is not None:
-        raise last_error
-    raise RuntimeError("AUT invocation failed: no endpoint variants succeeded")
-PY
+            /app/.venv/bin/python {NAT_TRACE_EXPORT_SCRIPT_CONTAINER_PATH} invoke-aut \
+              --endpoint "$dep_endpoint" \
+              --instruction {instruction_container} \
+              --output-dir /logs/agent \
+              --timeout "${{AUT_INVOKE_HTTP_TIMEOUT:-600}}" \
+              2>&1 | tee /tmp/nat_agent.log
             rc=${{PIPESTATUS[0]}}
             set -e
             if [ $rc -ne 0 ]; then
@@ -750,6 +728,8 @@ def _build_claude_code_agent_cmd(instruction_container: str, agent_params: dict[
               model_args=(--model "${{AGENT_MODEL}}")
             fi
             extra_args=({extra_args})
+            export CLAUDE_CONFIG_DIR=/logs/agent/sessions
+            mkdir -p "$CLAUDE_CONFIG_DIR"
             set +e
             claude -p "$(cat {instruction_container})" \
               "${{model_args[@]}}" \
@@ -760,6 +740,16 @@ def _build_claude_code_agent_cmd(instruction_container: str, agent_params: dict[
             set -e
             cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
             cp /tmp/nat_agent.stderr /logs/agent/nat_agent.stderr 2>/dev/null || true
+            if [ $rc -eq 0 ]; then
+              /app/.venv/bin/python {NAT_TRACE_EXPORT_SCRIPT_CONTAINER_PATH} convert-claude-session \
+                --projects-dir /logs/agent/sessions/projects \
+                --output /logs/agent/trajectory.json \
+                --instruction {instruction_container} \
+                --final-message /logs/agent/nat_agent.log \
+                >> /tmp/nat_agent.log 2>&1
+              rc=$?
+              cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
+            fi
             exit $rc
         """),
     ]
@@ -824,7 +814,7 @@ def _build_cursor_agent_cmd(instruction_container: str, agent_params: dict[str, 
             set +e
             cursor-agent \
               --print \
-              --output-format json \
+              --output-format stream-json \
               --trust \
               --workspace /app \
               "${{model_args[@]}}" \
@@ -835,7 +825,16 @@ def _build_cursor_agent_cmd(instruction_container: str, agent_params: dict[str, 
             set -e
             cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
             cp /tmp/nat_agent.stderr /logs/agent/nat_agent.stderr 2>/dev/null || true
-            cp /tmp/nat_agent.log /logs/agent/final_message.json 2>/dev/null || true
+            if [ $rc -eq 0 ]; then
+              /app/.venv/bin/python {NAT_TRACE_EXPORT_SCRIPT_CONTAINER_PATH} convert-cursor-jsonl \
+                --input /logs/agent/nat_agent.log \
+                --output /logs/agent/trajectory.json \
+                --instruction {instruction_container} \
+                --final-message /logs/agent/final_message.json \
+                >> /tmp/nat_agent.log 2>&1
+              rc=$?
+              cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
+            fi
             exit $rc
         """),
     ]
@@ -1082,7 +1081,6 @@ def _prepare_workflow_for_runtime(
     with existing task files, we rewrite that shape at runtime.
     """
     text = workflow_path.read_text()
-    original_text = text
     # Ensure MCP server URL follows runner's effective base URL.
     text = text.replace("http://localhost:8080", nmp_base_url)
     if nat_model:
@@ -1098,9 +1096,27 @@ def _prepare_workflow_for_runtime(
         if "\nfunction_groups:\n" not in text and "\nfunctions:\n" in text:
             text = text.replace("\nfunctions:\n", "\nfunction_groups:\n", 1)
 
-    if text == original_text:
-        return workflow_path
+    config = yaml.safe_load(text)
+    if not isinstance(config, dict):
+        raise ValueError(f"Workflow config must be a mapping: {workflow_path}")
+    general = config.setdefault("general", {})
+    if not isinstance(general, dict):
+        raise ValueError(f"Workflow general config must be a mapping: {workflow_path}")
+    telemetry = general.setdefault("telemetry", {})
+    if not isinstance(telemetry, dict):
+        raise ValueError(f"Workflow telemetry config must be a mapping: {workflow_path}")
+    tracing = telemetry.setdefault("tracing", {})
+    if not isinstance(tracing, dict):
+        raise ValueError(f"Workflow telemetry tracing config must be a mapping: {workflow_path}")
+    tracing["agentic_use_file_trace"] = {
+        "_type": "file",
+        "output_path": "/logs/agent/intermediate_steps.jsonl",
+        "project": "agentic-use",
+        "mode": "overwrite",
+        "cleanup_on_init": True,
+    }
 
+    text = yaml.dump(config, default_flow_style=False, sort_keys=False)
     rewritten = output_dir / "workflow.runtime.yml"
     rewritten.write_text(text)
     return rewritten

--- a/tests/agentic-use/scripts/codex_agent_runner.sh
+++ b/tests/agentic-use/scripts/codex_agent_runner.sh
@@ -32,4 +32,14 @@ rc=$?
 set -e
 cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
 cp /tmp/nat_agent.stderr /logs/agent/nat_agent.stderr 2>/dev/null || true
+if [ $rc -eq 0 ]; then
+  /app/.venv/bin/python /app/tests/agentic-use/scripts/nat_trace_export.py convert-codex-jsonl \
+    --input /logs/agent/nat_agent.log \
+    --output /logs/agent/trajectory.json \
+    --instruction @@INSTRUCTION_CONTAINER@@ \
+    --final-message /logs/agent/final_message.txt \
+    >> /tmp/nat_agent.log 2>&1
+  rc=$?
+  cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
+fi
 exit $rc

--- a/tests/agentic-use/scripts/nat_trace_export.py
+++ b/tests/agentic-use/scripts/nat_trace_export.py
@@ -1,0 +1,876 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run NAT agents and export evaluator-ready ATIF trajectories."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject = dict[str, JsonValue]
+
+
+def _json_object_array(values: Sequence[JsonObject]) -> list[JsonValue]:
+    return [value for value in values]
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_final_message(output_dir: Path, final_result: JsonValue) -> None:
+    final_payload = final_result if isinstance(final_result, dict) else {"result": final_result}
+    _write_json(output_dir / "final_message.json", final_payload)
+    if isinstance(final_result, str):
+        (output_dir / "final_message.txt").write_text(final_result.strip() + "\n", encoding="utf-8")
+
+
+def _trajectory_to_json_dict(trajectory) -> JsonObject:
+    return trajectory.model_dump(mode="json", exclude_none=True)
+
+
+def _write_atif_trajectory(path: Path, trajectory) -> None:
+    from nat.atif import ATIFTrajectory
+
+    payload = _trajectory_to_json_dict(trajectory)
+    ATIFTrajectory.model_validate(payload)
+    _write_json(path, payload)
+
+
+def _read_jsonl(path: Path) -> list[JsonObject]:
+    events: list[JsonObject] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            logger.debug("Skipping non-JSON line %d in %s", line_number, path)
+            continue
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events
+
+
+def _load_instruction(path: Path | None) -> str:
+    if path is None or not path.is_file():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace").strip()
+
+
+def _read_final_message(path: Path | None) -> str:
+    if path is None or not path.is_file():
+        return ""
+    text = path.read_text(encoding="utf-8", errors="replace").strip()
+    if not text:
+        return ""
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return text
+    extracted = _extract_text(payload)
+    return extracted or text
+
+
+def _write_final_message_artifact(path: Path | None, final_message: str) -> None:
+    if path is None or not final_message.strip():
+        return
+    if path.suffix == ".json":
+        _write_json(path, {"result": final_message.strip()})
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(final_message.strip() + "\n", encoding="utf-8")
+
+
+def _extract_text(value: JsonValue) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, int | float | bool):
+        return str(value)
+    if isinstance(value, list):
+        parts = [_extract_text(item) for item in value]
+        return "\n".join(part for part in parts if part).strip()
+    if not isinstance(value, dict):
+        return ""
+
+    for key in ("text", "content", "message", "result", "response", "output", "summary", "final_summary"):
+        text = _extract_text(value.get(key))
+        if text:
+            return text
+
+    choices = value.get("choices")
+    if isinstance(choices, list):
+        for choice in choices:
+            text = _extract_text(choice)
+            if text:
+                return text
+    return ""
+
+
+def _compact_payload(value: JsonValue, *, max_chars: int = 4000) -> str:
+    if isinstance(value, str):
+        text = value
+    else:
+        text = json.dumps(value, sort_keys=True)
+    return text if len(text) <= max_chars else text[:max_chars] + "...[truncated]"
+
+
+def _arguments_from_value(value: JsonValue) -> JsonObject:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            payload = json.loads(value)
+        except json.JSONDecodeError:
+            return {"value": value}
+        return payload if isinstance(payload, dict) else {"value": payload}
+    if value is None:
+        return {}
+    return {"value": value}
+
+
+def _event_type(event: JsonObject) -> str:
+    for key in ("type", "event", "event_type", "kind"):
+        value = event.get(key)
+        if isinstance(value, str):
+            return value
+    return "unknown"
+
+
+def _iso_now() -> str:
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+class _DirectATIFBuilder:
+    def __init__(self, *, agent_name: str, instruction: str = "", source_file: str | None = None) -> None:
+        self._agent_name = agent_name
+        self._source_file = source_file
+        self._steps: list[JsonObject] = []
+        self._pending_tool_step: dict[str, JsonObject] = {}
+        self._next_step_id = 1
+        self._next_tool_id = 1
+        if instruction.strip():
+            self.add_user_step(instruction.strip())
+
+    def add_user_step(self, message: str) -> None:
+        self._steps.append(
+            {
+                "step_id": self._allocate_step_id(),
+                "source": "user",
+                "message": message,
+                "timestamp": _iso_now(),
+                "extra": self._extra("instruction"),
+            }
+        )
+
+    def add_agent_step(
+        self,
+        *,
+        message: str = "",
+        tool_calls: list[JsonObject] | None = None,
+        observations: list[JsonObject] | None = None,
+        extra: JsonObject | None = None,
+    ) -> JsonObject:
+        step: JsonObject = {
+            "step_id": self._allocate_step_id(),
+            "source": "agent",
+            "message": message,
+            "timestamp": _iso_now(),
+            "extra": self._extra("agent", extra),
+        }
+        if tool_calls:
+            step["tool_calls"] = _json_object_array(tool_calls)
+        if observations:
+            step["observation"] = {"results": _json_object_array(observations)}
+        self._steps.append(step)
+        for call in tool_calls or []:
+            call_id = call.get("tool_call_id")
+            if isinstance(call_id, str):
+                self._pending_tool_step[call_id] = step
+        return step
+
+    def add_tool_call(
+        self,
+        *,
+        tool_call_id: str | None,
+        function_name: str,
+        arguments: JsonObject | None = None,
+        message: str = "",
+        extra: JsonObject | None = None,
+    ) -> str:
+        call_id = tool_call_id or self._allocate_tool_call_id()
+        tool_call: JsonObject = {
+            "tool_call_id": call_id,
+            "function_name": function_name or "unknown_tool",
+            "arguments": arguments or {},
+        }
+        if extra:
+            tool_call["extra"] = extra
+        self.add_agent_step(message=message, tool_calls=[tool_call], extra=extra)
+        return call_id
+
+    def add_observation(self, *, tool_call_id: str | None, content: str, extra: JsonObject | None = None) -> None:
+        observation: JsonObject = {
+            "source_call_id": tool_call_id,
+            "content": content,
+        }
+        if extra:
+            observation["extra"] = extra
+        target = self._pending_tool_step.get(tool_call_id or "")
+        if target is None:
+            self.add_agent_step(observations=[observation], extra=extra)
+            return
+        existing = target.get("observation")
+        if not isinstance(existing, dict):
+            target["observation"] = {"results": _json_object_array([observation])}
+            return
+        results = existing.get("results")
+        if isinstance(results, list):
+            results.append(observation)
+        else:
+            existing["results"] = _json_object_array([observation])
+
+    def finalize(self, *, final_message: str = "") -> JsonObject:
+        if final_message.strip():
+            last_agent = next((step for step in reversed(self._steps) if step.get("source") == "agent"), None)
+            if not isinstance(last_agent, dict) or _extract_text(last_agent.get("message")) != final_message.strip():
+                self.add_agent_step(message=final_message.strip(), extra={"event_type": "final_message"})
+        trajectory: JsonObject = {
+            "agent": {"name": self._agent_name, "version": "0.0.0"},
+            "session_id": str(uuid.uuid4()),
+            "steps": _json_object_array(self._steps),
+        }
+        from nat.atif import ATIFTrajectory
+
+        return _trajectory_to_json_dict(ATIFTrajectory.model_validate(trajectory))
+
+    def _allocate_step_id(self) -> int:
+        step_id = self._next_step_id
+        self._next_step_id += 1
+        return step_id
+
+    def _allocate_tool_call_id(self) -> str:
+        tool_call_id = f"call_{self._next_tool_id}"
+        self._next_tool_id += 1
+        return tool_call_id
+
+    def _extra(self, event_type: str, extra: JsonObject | None = None) -> JsonObject:
+        payload: JsonObject = {"event_type": event_type, "backend": self._agent_name}
+        if self._source_file:
+            payload["source_file"] = self._source_file
+        if extra:
+            payload.update(extra)
+        return payload
+
+
+def _convert_intermediate_steps_jsonl(input_path: Path, output_path: Path, session_id: str) -> int:
+    from nat.data_models.intermediate_step import IntermediateStep
+    from nat.utils.atif_converter import IntermediateStepToATIFConverter
+
+    steps: list[IntermediateStep] = []
+    for line_number, line in enumerate(input_path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid IntermediateStep JSON on line {line_number} of {input_path}") from exc
+        steps.append(IntermediateStep.model_validate(payload))
+
+    trajectory = IntermediateStepToATIFConverter().convert(steps, session_id=session_id)
+    _write_atif_trajectory(output_path, trajectory)
+    print(f"ATIF trajectory written to {output_path} from {len(steps)} IntermediateStep events")
+    return 0
+
+
+def _latest_jsonl(projects_dir: Path) -> Path:
+    files = [path for path in projects_dir.rglob("*.jsonl") if path.is_file()]
+    if not files:
+        raise FileNotFoundError(f"No session JSONL files found under {projects_dir}")
+    files.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    return files[0]
+
+
+def _raw_event_extra(event: JsonObject) -> JsonObject:
+    return {
+        "event_type": _event_type(event),
+        "raw_event": _compact_payload(event),
+    }
+
+
+def _message_content(event: JsonObject) -> JsonValue:
+    message = event.get("message")
+    if isinstance(message, dict):
+        return message.get("content")
+    return event.get("content")
+
+
+def _content_blocks(event: JsonObject) -> list[JsonObject]:
+    content = _message_content(event)
+    if not isinstance(content, list):
+        return []
+    return [item for item in content if isinstance(item, dict)]
+
+
+def _tool_name(block: JsonObject) -> str:
+    for key in ("name", "tool_name", "function_name", "function", "tool"):
+        value = block.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return "unknown_tool"
+
+
+def _tool_call_id(block: JsonObject) -> str | None:
+    for key in ("id", "tool_call_id", "call_id", "tool_use_id"):
+        value = block.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _handle_message_event(builder: _DirectATIFBuilder, event: JsonObject) -> bool:
+    event_type = _event_type(event)
+    blocks = _content_blocks(event)
+    if blocks:
+        text_parts: list[str] = []
+        tool_calls: list[JsonObject] = []
+        observations: list[JsonObject] = []
+        for block in blocks:
+            block_type = _event_type(block)
+            if block_type == "text":
+                text = _extract_text(block)
+                if text:
+                    text_parts.append(text)
+            elif block_type in {"tool_use", "tool_call", "function_call"}:
+                call_id = _tool_call_id(block) or builder._allocate_tool_call_id()
+                tool_calls.append(
+                    {
+                        "tool_call_id": call_id,
+                        "function_name": _tool_name(block),
+                        "arguments": _arguments_from_value(block.get("input") or block.get("arguments")),
+                        "extra": {"event_type": block_type, "raw_event": _compact_payload(block)},
+                    }
+                )
+            elif block_type == "tool_result":
+                observations.append(
+                    {
+                        "source_call_id": _tool_call_id(block),
+                        "content": _extract_text(block) or _compact_payload(block),
+                        "extra": {"event_type": block_type, "is_error": bool(block.get("is_error"))},
+                    }
+                )
+        if event_type == "user":
+            text_parts = []
+        if tool_calls or text_parts:
+            builder.add_agent_step(
+                message="\n".join(text_parts),
+                tool_calls=tool_calls or None,
+                extra=_raw_event_extra(event),
+            )
+        for observation in observations:
+            source_call_id = observation.get("source_call_id")
+            observation_extra = observation.get("extra")
+            builder.add_observation(
+                tool_call_id=source_call_id if isinstance(source_call_id, str) else None,
+                content=str(observation.get("content") or ""),
+                extra=observation_extra if isinstance(observation_extra, dict) else None,
+            )
+        return bool(tool_calls or observations or text_parts)
+
+    message_text = _extract_text(_message_content(event))
+    if event_type in {"assistant", "agent_message", "message"} and message_text:
+        builder.add_agent_step(message=message_text, extra=_raw_event_extra(event))
+        return True
+    return False
+
+
+def _item_id(item: JsonObject) -> str | None:
+    for key in ("id", "item_id", "call_id", "tool_call_id"):
+        value = item.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _item_kind(item: JsonObject) -> str:
+    for key in ("type", "item_type", "kind"):
+        value = item.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _item_tool_name(item: JsonObject) -> str:
+    name = _tool_name(item)
+    if name != "unknown_tool":
+        return name
+    kind = _item_kind(item)
+    if "command" in kind:
+        return "shell"
+    return kind or "unknown_tool"
+
+
+def _item_arguments(item: JsonObject) -> JsonObject:
+    command = item.get("command")
+    if isinstance(command, str) and command:
+        return {"command": command}
+    return _arguments_from_value(item.get("arguments") or item.get("input"))
+
+
+def _item_output(item: JsonObject) -> str:
+    for key in ("aggregated_output", "output", "result", "stdout", "stderr"):
+        value = item.get(key)
+        text = _extract_text(value)
+        if text:
+            return text
+    exit_code = item.get("exit_code")
+    if isinstance(exit_code, int):
+        return f"exit code {exit_code}"
+    return ""
+
+
+def _cursor_tool_payload(event: JsonObject) -> JsonObject | None:
+    tool_call = event.get("tool_call")
+    if not isinstance(tool_call, dict):
+        return None
+    for value in tool_call.values():
+        if isinstance(value, dict):
+            return value
+    return tool_call
+
+
+def _cursor_tool_name(event: JsonObject, tool_payload: JsonObject) -> str:
+    tool_call = event.get("tool_call")
+    if isinstance(tool_call, dict):
+        for key in tool_call:
+            if key == "shellToolCall":
+                return "shell"
+            if key.endswith("ToolCall"):
+                return key.removesuffix("ToolCall")
+    return _tool_name(tool_payload)
+
+
+def _cursor_tool_arguments(tool_payload: JsonObject) -> JsonObject:
+    args = tool_payload.get("args")
+    if isinstance(args, dict):
+        return args
+    return _arguments_from_value(tool_payload.get("arguments") or tool_payload.get("input"))
+
+
+def _cursor_tool_result(tool_payload: JsonObject) -> str:
+    result = tool_payload.get("result")
+    if result is None:
+        return ""
+    return _extract_text(result) or _compact_payload(result)
+
+
+def _handle_top_level_tool_call_event(builder: _DirectATIFBuilder, event: JsonObject) -> bool:
+    if _event_type(event) != "tool_call":
+        return False
+    tool_payload = _cursor_tool_payload(event)
+    if tool_payload is None:
+        return False
+    call_id = event.get("call_id")
+    if not isinstance(call_id, str):
+        call_id = _tool_call_id(tool_payload)
+    subtype = event.get("subtype")
+    if subtype == "started":
+        builder.add_tool_call(
+            tool_call_id=call_id,
+            function_name=_cursor_tool_name(event, tool_payload),
+            arguments=_cursor_tool_arguments(tool_payload),
+            extra=_raw_event_extra(event),
+        )
+        return True
+    if subtype == "completed":
+        if call_id not in builder._pending_tool_step:
+            call_id = builder.add_tool_call(
+                tool_call_id=call_id,
+                function_name=_cursor_tool_name(event, tool_payload),
+                arguments=_cursor_tool_arguments(tool_payload),
+                extra=_raw_event_extra(event),
+            )
+        builder.add_observation(
+            tool_call_id=call_id,
+            content=_cursor_tool_result(tool_payload) or _compact_payload(tool_payload),
+            extra=_raw_event_extra(event),
+        )
+        return True
+    return False
+
+
+def _handle_item_event(builder: _DirectATIFBuilder, event: JsonObject) -> bool:
+    item = event.get("item")
+    if not isinstance(item, dict):
+        return False
+    event_type = _event_type(event)
+    item_kind = _item_kind(item)
+    looks_tool = any(marker in item_kind for marker in ("tool", "command", "function")) or isinstance(
+        item.get("command"), str
+    )
+    if not looks_tool:
+        text = _extract_text(item)
+        if text and (
+            event_type in {"agent_message", "item_completed", "item.completed", "message"}
+            or item_kind == "agent_message"
+        ):
+            builder.add_agent_step(message=text, extra=_raw_event_extra(event))
+            return True
+        return False
+
+    call_id = _item_id(item)
+    if any(marker in event_type for marker in ("started", "created", "begin")):
+        builder.add_tool_call(
+            tool_call_id=call_id,
+            function_name=_item_tool_name(item),
+            arguments=_item_arguments(item),
+            extra=_raw_event_extra(event),
+        )
+        return True
+
+    if any(marker in event_type for marker in ("completed", "finished", "end")):
+        if call_id not in builder._pending_tool_step:
+            call_id = builder.add_tool_call(
+                tool_call_id=call_id,
+                function_name=_item_tool_name(item),
+                arguments=_item_arguments(item),
+                extra=_raw_event_extra(event),
+            )
+        output = _item_output(item) or _compact_payload(item)
+        extra = _raw_event_extra(event)
+        exit_code = item.get("exit_code")
+        if isinstance(exit_code, int):
+            extra["exit_code"] = exit_code
+        builder.add_observation(tool_call_id=call_id, content=output, extra=extra)
+        return True
+
+    return False
+
+
+def _final_message_from_events(events: Sequence[JsonObject]) -> str:
+    for event in reversed(events):
+        event_type = _event_type(event)
+        if event_type in {"result", "final", "agent_message", "assistant", "message", "turn_completed"}:
+            text = _extract_text(event)
+            if text:
+                return text
+        item = event.get("item")
+        if isinstance(item, dict) and _item_kind(item) == "agent_message":
+            text = _extract_text(item)
+            if text:
+                return text
+    return ""
+
+
+def _convert_claude_session(
+    *,
+    projects_dir: Path,
+    output_path: Path,
+    instruction_path: Path | None,
+    final_message_path: Path | None,
+) -> int:
+    session_path = _latest_jsonl(projects_dir)
+    events = _read_jsonl(session_path)
+    if not events:
+        raise ValueError(f"Claude session file contains no JSON events: {session_path}")
+    instruction = _load_instruction(instruction_path)
+    if not instruction:
+        for event in events:
+            if _event_type(event) == "user":
+                text = _extract_text(_message_content(event))
+                if text:
+                    instruction = text
+                    break
+    builder = _DirectATIFBuilder(agent_name="claude-code", instruction=instruction, source_file=str(session_path))
+    for event in events:
+        _handle_message_event(builder, event)
+    final_message = _read_final_message(final_message_path) or _final_message_from_events(events)
+    _write_json(output_path, builder.finalize(final_message=final_message))
+    print(f"ATIF trajectory written to {output_path} from Claude session {session_path}")
+    return 0
+
+
+def _convert_agent_jsonl(
+    *,
+    input_path: Path,
+    output_path: Path,
+    instruction_path: Path | None,
+    final_message_path: Path | None,
+    agent_name: str,
+    write_final_message: bool = False,
+) -> int:
+    events = _read_jsonl(input_path)
+    if not events:
+        raise ValueError(f"Agent log contains no JSON events: {input_path}")
+    builder = _DirectATIFBuilder(
+        agent_name=agent_name,
+        instruction=_load_instruction(instruction_path),
+        source_file=str(input_path),
+    )
+    handled = False
+    for event in events:
+        handled = (
+            _handle_message_event(builder, event)
+            or _handle_top_level_tool_call_event(builder, event)
+            or _handle_item_event(builder, event)
+            or handled
+        )
+    final_message = _read_final_message(final_message_path) or _final_message_from_events(events)
+    if write_final_message:
+        _write_final_message_artifact(final_message_path, final_message)
+    if not handled and not final_message:
+        raise ValueError(f"No convertible {agent_name} events found in {input_path}")
+    _write_json(output_path, builder.finalize(final_message=final_message))
+    print(f"ATIF trajectory written to {output_path} from {agent_name} events in {input_path}")
+    return 0
+
+
+def _read_http_response(url: str, payload: bytes, timeout: int) -> str:
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def _iter_sse_data(text: str) -> Sequence[str]:
+    events: list[str] = []
+    current: list[str] = []
+    for line in text.splitlines():
+        if not line.strip():
+            if current:
+                events.append("\n".join(current))
+                current = []
+            continue
+        if line.startswith("data:"):
+            current.append(line.removeprefix("data:").strip())
+    if current:
+        events.append("\n".join(current))
+    if not events and text.strip():
+        events.append(text.strip())
+    return events
+
+
+def _decode_json_event(raw_event: str) -> JsonValue:
+    try:
+        return json.loads(raw_event)
+    except json.JSONDecodeError:
+        return raw_event
+
+
+def _assemble_atif_stream(events: Sequence[JsonValue]) -> tuple[JsonObject | None, JsonValue]:
+    from nat.atif import ATIFTrajectory
+
+    # TODO: If /generate/atif starts emitting raw IntermediateStep events, replace
+    # this assembler with nat.utils.atif_converter.ATIFStreamConverter.
+    steps: list[JsonObject] = []
+    summary: JsonObject | None = None
+    final_result: JsonValue = ""
+
+    for event in events:
+        if not isinstance(event, dict):
+            if event not in ("", None):
+                final_result = event
+            continue
+        if "code" in event and event.get("code") == "workflow_error":
+            raise RuntimeError(str(event))
+        if "step_id" in event and "source" in event:
+            steps.append(event)
+            continue
+        if "schema_version" in event and "session_id" in event and "agent" in event:
+            summary = event
+            continue
+        final_result = event
+
+    if summary is None:
+        return None, final_result
+
+    trajectory: JsonObject = {
+        "schema_version": summary["schema_version"],
+        "session_id": summary["session_id"],
+        "agent": summary["agent"],
+        "steps": _json_object_array(steps),
+    }
+    final_metrics = summary.get("final_metrics")
+    if final_metrics is not None:
+        trajectory["final_metrics"] = final_metrics
+
+    validated = ATIFTrajectory.model_validate(trajectory)
+    return _trajectory_to_json_dict(validated), final_result
+
+
+def _invoke_aut(endpoint: str, instruction: str, output_dir: Path, timeout: int) -> int:
+    payload = json.dumps({"input_message": instruction}).encode("utf-8")
+    base_endpoint = endpoint.rstrip("/")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    last_error: Exception | None = None
+
+    atif_url = f"{base_endpoint}/generate/atif"
+    for attempt in range(3):
+        try:
+            response_text = _read_http_response(atif_url, payload, timeout)
+            events = [_decode_json_event(raw_event) for raw_event in _iter_sse_data(response_text)]
+            trajectory, final_result = _assemble_atif_stream(events)
+            if trajectory is not None:
+                _write_json(output_dir / "trajectory.json", trajectory)
+            _write_json(output_dir / "atif_stream_events.json", events)
+            _write_final_message(output_dir, final_result)
+            print(json.dumps({"result": final_result}))
+            return 0
+        except urllib.error.HTTPError as err:
+            last_error = err
+            if err.code in {404, 422}:
+                break
+            raise
+        except urllib.error.URLError as err:
+            last_error = err
+            if attempt < 2:
+                time.sleep(1.0)
+                continue
+            raise
+
+    for suffix in ("/generate/full?filter_steps=none", "/generate"):
+        fallback_url = urllib.parse.urljoin(f"{base_endpoint}/", suffix.removeprefix("/"))
+        try:
+            response_text = _read_http_response(fallback_url, payload, timeout)
+            print(response_text)
+            try:
+                _write_final_message(output_dir, json.loads(response_text))
+            except json.JSONDecodeError:
+                _write_final_message(output_dir, response_text.strip())
+            return 0
+        except urllib.error.HTTPError as err:
+            last_error = err
+            if err.code in {404, 422}:
+                continue
+            raise
+
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("AUT invocation failed: no endpoint variants succeeded")
+
+
+def _convert_jsonl_command(args: argparse.Namespace) -> int:
+    return _convert_intermediate_steps_jsonl(
+        input_path=Path(args.input),
+        output_path=Path(args.output),
+        session_id=args.session_id or str(uuid.uuid4()),
+    )
+
+
+def _convert_claude_session_command(args: argparse.Namespace) -> int:
+    return _convert_claude_session(
+        projects_dir=Path(args.projects_dir),
+        output_path=Path(args.output),
+        instruction_path=Path(args.instruction) if args.instruction else None,
+        final_message_path=Path(args.final_message) if args.final_message else None,
+    )
+
+
+def _convert_codex_jsonl_command(args: argparse.Namespace) -> int:
+    return _convert_agent_jsonl(
+        input_path=Path(args.input),
+        output_path=Path(args.output),
+        instruction_path=Path(args.instruction) if args.instruction else None,
+        final_message_path=Path(args.final_message) if args.final_message else None,
+        agent_name="codex",
+    )
+
+
+def _convert_cursor_jsonl_command(args: argparse.Namespace) -> int:
+    return _convert_agent_jsonl(
+        input_path=Path(args.input),
+        output_path=Path(args.output),
+        instruction_path=Path(args.instruction) if args.instruction else None,
+        final_message_path=Path(args.final_message) if args.final_message else None,
+        agent_name="cursor-agent",
+        write_final_message=True,
+    )
+
+
+def _invoke_aut_command(args: argparse.Namespace) -> int:
+    instruction = Path(args.instruction).read_text(encoding="utf-8")
+    return _invoke_aut(
+        endpoint=args.endpoint,
+        instruction=instruction,
+        output_dir=Path(args.output_dir),
+        timeout=args.timeout,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    convert_jsonl = subparsers.add_parser("convert-jsonl", help="Convert NAT IntermediateStep JSONL to ATIF JSON.")
+    convert_jsonl.add_argument("--input", required=True)
+    convert_jsonl.add_argument("--output", required=True)
+    convert_jsonl.add_argument("--session-id")
+    convert_jsonl.set_defaults(func=_convert_jsonl_command)
+
+    claude_session = subparsers.add_parser(
+        "convert-claude-session",
+        help="Convert the newest Claude Code session JSONL to ATIF JSON.",
+    )
+    claude_session.add_argument("--projects-dir", required=True)
+    claude_session.add_argument("--output", required=True)
+    claude_session.add_argument("--instruction")
+    claude_session.add_argument("--final-message")
+    claude_session.set_defaults(func=_convert_claude_session_command)
+
+    codex_jsonl = subparsers.add_parser("convert-codex-jsonl", help="Convert Codex exec JSONL to ATIF JSON.")
+    codex_jsonl.add_argument("--input", required=True)
+    codex_jsonl.add_argument("--output", required=True)
+    codex_jsonl.add_argument("--instruction")
+    codex_jsonl.add_argument("--final-message")
+    codex_jsonl.set_defaults(func=_convert_codex_jsonl_command)
+
+    cursor_jsonl = subparsers.add_parser(
+        "convert-cursor-jsonl",
+        help="Convert Cursor Agent stream-json output to ATIF JSON.",
+    )
+    cursor_jsonl.add_argument("--input", required=True)
+    cursor_jsonl.add_argument("--output", required=True)
+    cursor_jsonl.add_argument("--instruction")
+    cursor_jsonl.add_argument("--final-message")
+    cursor_jsonl.set_defaults(func=_convert_cursor_jsonl_command)
+
+    aut = subparsers.add_parser("invoke-aut", help="Invoke a deployed NAT AUT and export ATIF artifacts.")
+    aut.add_argument("--endpoint", required=True)
+    aut.add_argument("--instruction", required=True)
+    aut.add_argument("--output-dir", required=True)
+    aut.add_argument("--timeout", type=int, default=600)
+    aut.set_defaults(func=_invoke_aut_command)
+    return parser
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.WARNING)
+    args = _build_parser().parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agentic-use/tests/fixtures/trace_outputs/claude/projects/-app/session.jsonl
+++ b/tests/agentic-use/tests/fixtures/trace_outputs/claude/projects/-app/session.jsonl
@@ -1,0 +1,4 @@
+{"type":"user","message":{"content":[{"type":"text","text":"Run the failing command."}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"I will try it."},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"false"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"Command failed with exit code 1","is_error":true}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"The command failed."}]}}

--- a/tests/agentic-use/tests/fixtures/trace_outputs/codex_exec.jsonl
+++ b/tests/agentic-use/tests/fixtures/trace_outputs/codex_exec.jsonl
@@ -1,0 +1,7 @@
+{"type":"thread.started","thread_id":"thread_fixture"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"I will inspect files."}}
+{"type":"item.started","item":{"id":"cmd-1","type":"command_execution","command":"rg Evaluator"}}
+{"type":"item.completed","item":{"id":"cmd-1","type":"command_execution","command":"rg Evaluator","aggregated_output":"tests/agentic-use/example.py:Evaluator","exit_code":0}}
+{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"Finished inspection."}}
+{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":10,"output_tokens":20}}

--- a/tests/agentic-use/tests/fixtures/trace_outputs/cursor_stream.jsonl
+++ b/tests/agentic-use/tests/fixtures/trace_outputs/cursor_stream.jsonl
@@ -1,0 +1,6 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"/app","session_id":"cursor-session-fixture","model":"fixture-model","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"List files."}]},"session_id":"cursor-session-fixture"}
+{"type":"tool_call","subtype":"started","call_id":"cursor-call-1","tool_call":{"shellToolCall":{"args":{"command":"ls","workingDirectory":"","toolCallId":"cursor-call-1"},"description":"List files"}},"session_id":"cursor-session-fixture"}
+{"type":"tool_call","subtype":"completed","call_id":"cursor-call-1","tool_call":{"shellToolCall":{"result":{"completed":{"command":"ls","workingDirectory":"/tmp","exitCode":0,"output":"README.md"}}}},"session_id":"cursor-session-fixture"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Done."}]},"session_id":"cursor-session-fixture"}
+{"type":"result","subtype":"success","duration_ms":1000,"is_error":false,"result":"Done listing files.","session_id":"cursor-session-fixture"}

--- a/tests/agentic-use/tests/fixtures/trace_outputs/nat_intermediate_steps.jsonl
+++ b/tests/agentic-use/tests/fixtures/trace_outputs/nat_intermediate_steps.jsonl
@@ -1,0 +1,2 @@
+{"parent_id":"root","function_ancestry":{"function_id":"root","function_name":"root"},"payload":{"event_type":"WORKFLOW_START","event_timestamp":1.0,"data":{"input":"Run the command."}}}
+{"parent_id":"root","function_ancestry":{"function_id":"root","function_name":"root"},"payload":{"event_type":"WORKFLOW_END","event_timestamp":2.0,"data":{"output":"Done."}}}

--- a/tests/agentic-use/tests/test_nat_runner_config.py
+++ b/tests/agentic-use/tests/test_nat_runner_config.py
@@ -5,6 +5,8 @@
 
 import json
 import subprocess
+import sys
+from importlib import util
 from pathlib import Path
 from typing import cast
 
@@ -19,13 +21,49 @@ from nat_runner import (
     _build_claude_code_agent_cmd,
     _build_codex_agent_cmd,
     _build_cursor_agent_cmd,
+    _build_workflow_agent_cmd,
     _extract_usage_metrics,
     _normalize_secret,
     _prepare_aut_config_for_runtime,
+    _prepare_workflow_for_runtime,
     run_agent_phase,
     run_task,
     run_verify_phase,
 )
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+TRACE_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "trace_outputs"
+
+spec = util.spec_from_file_location("nat_trace_export", SCRIPTS_DIR / "nat_trace_export.py")
+assert spec is not None
+assert spec.loader is not None
+nat_trace_export = util.module_from_spec(spec)
+sys.modules[spec.name] = nat_trace_export
+spec.loader.exec_module(nat_trace_export)
+
+
+def _run_trace_export_cli(monkeypatch: pytest.MonkeyPatch, args: list[str]) -> None:
+    monkeypatch.setattr(sys, "argv", ["nat_trace_export.py", *args])
+    assert nat_trace_export.main() == 0
+
+
+def _load_valid_atif(path: Path) -> dict[str, object]:
+    from nat.atif import ATIFTrajectory
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    ATIFTrajectory.model_validate(payload)
+    assert isinstance(payload, dict)
+    return cast(dict[str, object], payload)
+
+
+def _trajectory_steps(trajectory: dict[str, object]) -> list[dict[str, object]]:
+    steps = trajectory["steps"]
+    assert isinstance(steps, list)
+    return cast(list[dict[str, object]], steps)
+
+
+def _trajectory_tool_steps(trajectory: dict[str, object]) -> list[dict[str, object]]:
+    return [step for step in _trajectory_steps(trajectory) if step.get("tool_calls")]
 
 
 @pytest.fixture()
@@ -260,6 +298,11 @@ class TestAgentBackends:
         assert "--output-format json" in script
         assert "--permission-mode bypassPermissions" in script
         assert "--max-budget-usd 1.5" in script
+        assert "CLAUDE_CONFIG_DIR=/logs/agent/sessions" in script
+        assert "nat_trace_export.py convert-claude-session" in script
+        assert "--projects-dir /logs/agent/sessions/projects" in script
+        assert "--output /logs/agent/trajectory.json" in script
+        assert "--instruction /tmp/instruction.md" in script
 
     def test_build_aut_agent_cmd_recreates_existing_agent_when_config_is_present(self) -> None:
         cmd = _build_aut_agent_cmd("/tmp/instruction.md")
@@ -269,6 +312,92 @@ class TestAgentBackends:
         assert 'nemo agents undeploy --agent "${AUT_AGENT_NAME}"' in script
         assert 'nemo agents delete "${AUT_AGENT_NAME}"' in script
         assert 'nemo agents create --name "${AUT_AGENT_NAME}" --agent-config "${EFFECTIVE_AUT_AGENT_CONFIG}"' in script
+
+    def test_build_aut_agent_cmd_exports_atif_trace_artifacts(self) -> None:
+        cmd = _build_aut_agent_cmd("/tmp/instruction.md")
+        script = cmd[2]
+
+        assert cmd[:2] == ["bash", "-c"]
+        assert "nat_trace_export.py invoke-aut" in script
+        assert '--endpoint "$dep_endpoint"' in script
+        assert "--instruction /tmp/instruction.md" in script
+        assert "--output-dir /logs/agent" in script
+        assert "/generate/full" not in script
+
+    def test_build_workflow_agent_cmd_exports_atif_trace_artifacts(self) -> None:
+        cmd = _build_workflow_agent_cmd("/tmp/nat_workflow.yml", "/tmp/instruction.md")
+        script = cmd[2]
+
+        assert cmd[:2] == ["bash", "-c"]
+        assert "/app/.venv/bin/nat run" in script
+        assert "--config_file /tmp/nat_workflow.yml" in script
+        assert '--input "$(cat /tmp/instruction.md)"' in script
+        assert "nat_trace_export.py convert-jsonl" in script
+        assert "--input /logs/agent/intermediate_steps.jsonl" in script
+        assert "--output /logs/agent/trajectory.json" in script
+        assert "NAT telemetry exporter did not create /logs/agent/intermediate_steps.jsonl" in script
+
+    def test_prepare_workflow_for_runtime_injects_file_telemetry(self, tmp_path: Path) -> None:
+        workflow = tmp_path / "workflow.yml"
+        workflow.write_text(
+            """
+llms:
+  agent:
+    _type: openai
+    base_url: http://localhost:8080/v1
+    model_name: nvidia/llama-3.1-nemotron-70b-instruct
+workflow:
+  _type: react_agent
+  llm_name: agent
+""".strip(),
+            encoding="utf-8",
+        )
+
+        runtime_workflow = _prepare_workflow_for_runtime(
+            workflow,
+            tmp_path,
+            nmp_base_url="http://platform:8080",
+            nat_model="custom-model",
+        )
+        config = yaml.safe_load(runtime_workflow.read_text(encoding="utf-8"))
+
+        trace_config = config["general"]["telemetry"]["tracing"]["agentic_use_file_trace"]
+        assert config["llms"]["agent"]["base_url"] == "http://platform:8080/v1"
+        assert config["llms"]["agent"]["model_name"] == "custom-model"
+        assert trace_config == {
+            "_type": "file",
+            "output_path": "/logs/agent/intermediate_steps.jsonl",
+            "project": "agentic-use",
+            "mode": "overwrite",
+            "cleanup_on_init": True,
+        }
+
+    def test_nat_trace_export_assembles_atif_stream(self) -> None:
+        events = [
+            {
+                "step_id": 1,
+                "source": "user",
+                "message": "Do the thing.",
+            },
+            {
+                "step_id": 2,
+                "source": "agent",
+                "message": "Done.",
+            },
+            {"output": "final answer"},
+            {
+                "schema_version": "ATIF-v1.7",
+                "session_id": "session-1",
+                "agent": {"name": "nat-agent", "version": "0.0.0"},
+            },
+        ]
+
+        trajectory, final_result = nat_trace_export._assemble_atif_stream(events)
+
+        assert final_result == {"output": "final answer"}
+        assert trajectory is not None
+        assert trajectory["session_id"] == "session-1"
+        assert len(trajectory["steps"]) == 2
 
     def test_build_aut_agent_cmd_keeps_diagnostics_best_effort(self) -> None:
         cmd = _build_aut_agent_cmd("/tmp/instruction.md")
@@ -302,6 +431,10 @@ class TestAgentBackends:
         assert "codex_structured_prompt.md" not in script
         assert "output_files" not in script
         assert "final_message.txt" in script
+        assert "nat_trace_export.py convert-codex-jsonl" in script
+        assert "--input /logs/agent/nat_agent.log" in script
+        assert "--output /logs/agent/trajectory.json" in script
+        assert "--final-message /logs/agent/final_message.txt" in script
         assert "--dangerously-bypass-approvals-and-sandbox" not in script
         assert "--json" in script
         assert "AGENT_MODEL" in script
@@ -327,11 +460,16 @@ class TestAgentBackends:
         assert cmd[:2] == ["bash", "-c"]
         assert "cursor-agent" in script
         assert "--print" in script
-        assert "--output-format json" in script
+        assert "--output-format stream-json" in script
+        assert "--output-format json" not in script
         assert "--force" not in script
         assert "--sandbox enabled" in script
         assert "--mode plan" in script
         assert "--workspace /app" in script
+        assert "nat_trace_export.py convert-cursor-jsonl" in script
+        assert "--input /logs/agent/nat_agent.log" in script
+        assert "--output /logs/agent/trajectory.json" in script
+        assert "--final-message /logs/agent/final_message.json" in script
         assert "AGENT_MODEL" in script
         assert "CURSOR_MODEL" not in script
         assert "/tmp/instruction.md" in script
@@ -424,11 +562,10 @@ class TestAgentBackends:
         monkeypatch.setenv("INFERENCE_NVIDIA_API_KEY", "inference-secret")
         captured_env: dict[str, str] = {}
 
-        def fake_docker_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
-            env = kwargs["env"]
-            assert isinstance(env, dict)
-            captured_env.update(cast(dict[str, str], env))
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        def fake_docker_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess:
+            env = cast(dict[str, str], kwargs["env"])
+            captured_env.update(env)
+            return subprocess.CompletedProcess(args=["docker"], returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(nat_runner, "_docker_run", fake_docker_run)
 
@@ -476,11 +613,10 @@ class TestAgentBackends:
         workspace_dir = tmp_path / "workspace"
         captured_mounts: list[tuple[str, str]] = []
 
-        def fake_docker_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
-            mounts = kwargs["mounts"]
-            assert isinstance(mounts, list)
-            captured_mounts.extend(cast(list[tuple[str, str]], mounts))
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        def fake_docker_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess:
+            mounts = cast(list[tuple[str, str]], kwargs["mounts"])
+            captured_mounts.extend(mounts)
+            return subprocess.CompletedProcess(args=["docker"], returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(nat_runner, "_docker_run", fake_docker_run)
 
@@ -657,11 +793,10 @@ class TestAgentBackends:
         monkeypatch.setenv("NVIDIA_INFERENCE_API_KEY", " none ")
         captured_env: dict[str, str] = {}
 
-        def fake_docker_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
-            env = kwargs["env"]
-            assert isinstance(env, dict)
-            captured_env.update(cast(dict[str, str], env))
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        def fake_docker_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess:
+            env = cast(dict[str, str], kwargs["env"])
+            captured_env.update(env)
+            return subprocess.CompletedProcess(args=["docker"], returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(nat_runner, "_docker_run", fake_docker_run)
 
@@ -690,6 +825,119 @@ class TestAgentBackends:
         assert "OPENAI_API_KEY" not in captured_env
         assert "CURSOR_API_KEY" not in captured_env
         assert "INFERENCE_NVIDIA_API_KEY" not in captured_env
+
+
+class TestTraceExportCliFixtures:
+    """Exercise checked-in trace examples through the converter CLI surface."""
+
+    def test_convert_nat_intermediate_steps_fixture(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        output_path = tmp_path / "trajectory.json"
+
+        _run_trace_export_cli(
+            monkeypatch,
+            [
+                "convert-jsonl",
+                "--input",
+                str(TRACE_FIXTURES_DIR / "nat_intermediate_steps.jsonl"),
+                "--output",
+                str(output_path),
+                "--session-id",
+                "nat-fixture-session",
+            ],
+        )
+
+        trajectory = _load_valid_atif(output_path)
+        assert trajectory["session_id"] == "nat-fixture-session"
+        assert [step["source"] for step in _trajectory_steps(trajectory)] == ["user", "agent"]
+
+    def test_convert_claude_session_fixture(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        instruction_path = tmp_path / "instruction.md"
+        final_message_path = tmp_path / "final_message.json"
+        output_path = tmp_path / "trajectory.json"
+        instruction_path.write_text("Run the failing command.", encoding="utf-8")
+        final_message_path.write_text(json.dumps({"result": "The command failed."}), encoding="utf-8")
+
+        _run_trace_export_cli(
+            monkeypatch,
+            [
+                "convert-claude-session",
+                "--projects-dir",
+                str(TRACE_FIXTURES_DIR / "claude" / "projects"),
+                "--output",
+                str(output_path),
+                "--instruction",
+                str(instruction_path),
+                "--final-message",
+                str(final_message_path),
+            ],
+        )
+
+        trajectory = _load_valid_atif(output_path)
+        tool_steps = _trajectory_tool_steps(trajectory)
+        assert trajectory["agent"] == {"name": "claude-code", "version": "0.0.0"}
+        assert _trajectory_steps(trajectory)[0]["message"] == "Run the failing command."
+        assert cast(list[dict[str, object]], tool_steps[0]["tool_calls"])[0]["function_name"] == "Bash"
+        assert "exit code 1" in str(cast(dict[str, object], tool_steps[0]["observation"])["results"])
+
+    def test_convert_codex_jsonl_fixture(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        instruction_path = tmp_path / "instruction.md"
+        final_message_path = tmp_path / "final_message.txt"
+        output_path = tmp_path / "trajectory.json"
+        instruction_path.write_text("Inspect the repo.", encoding="utf-8")
+        final_message_path.write_text("Finished inspection.\n", encoding="utf-8")
+
+        _run_trace_export_cli(
+            monkeypatch,
+            [
+                "convert-codex-jsonl",
+                "--input",
+                str(TRACE_FIXTURES_DIR / "codex_exec.jsonl"),
+                "--output",
+                str(output_path),
+                "--instruction",
+                str(instruction_path),
+                "--final-message",
+                str(final_message_path),
+            ],
+        )
+
+        trajectory = _load_valid_atif(output_path)
+        tool_steps = _trajectory_tool_steps(trajectory)
+        assert trajectory["agent"] == {"name": "codex", "version": "0.0.0"}
+        assert _trajectory_steps(trajectory)[-1]["message"] == "Finished inspection."
+        assert cast(list[dict[str, object]], tool_steps[0]["tool_calls"])[0]["function_name"] == "shell"
+        assert "Evaluator" in str(cast(dict[str, object], tool_steps[0]["observation"])["results"])
+
+    def test_convert_cursor_stream_fixture(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        instruction_path = tmp_path / "instruction.md"
+        final_message_path = tmp_path / "final_message.json"
+        output_path = tmp_path / "trajectory.json"
+        instruction_path.write_text("List files.", encoding="utf-8")
+
+        _run_trace_export_cli(
+            monkeypatch,
+            [
+                "convert-cursor-jsonl",
+                "--input",
+                str(TRACE_FIXTURES_DIR / "cursor_stream.jsonl"),
+                "--output",
+                str(output_path),
+                "--instruction",
+                str(instruction_path),
+                "--final-message",
+                str(final_message_path),
+            ],
+        )
+
+        trajectory = _load_valid_atif(output_path)
+        final_message = json.loads(final_message_path.read_text(encoding="utf-8"))
+        tool_steps = _trajectory_tool_steps(trajectory)
+        tool_call = cast(list[dict[str, object]], tool_steps[0]["tool_calls"])[0]
+        assert trajectory["agent"] == {"name": "cursor-agent", "version": "0.0.0"}
+        assert final_message == {"result": "Done listing files."}
+        assert tool_call["tool_call_id"] == "cursor-call-1"
+        assert cast(dict[str, object], tool_call["arguments"])["command"] == "ls"
+        assert "README.md" in str(cast(dict[str, object], tool_steps[0]["observation"])["results"])
 
 
 class TestAgentLogWorkflowErrors:


### PR DESCRIPTION
## Summary

Adds evaluator-ready ATIF trace export for agentic-use benchmark runs.

- export ATIF trajectories for AUT, NAT workflow, Codex, Cursor, and Claude agent executions
- add a shared `nat_trace_export.py` helper for converting backend logs and NAT IntermediateStep telemetry into ATIF artifacts
- switch agent wrappers to preserve final messages plus trajectory artifacts under `/logs/agent`
- add fixture coverage for NAT, Claude, Codex, and Cursor trace conversion paths
- document when AUT stream assembly should move to NAT's `ATIFStreamConverter` if the endpoint begins emitting raw IntermediateStep events

## Validation

```bash
uv run --frozen pytest tests/agentic-use/tests/test_nat_runner_config.py -q
uv run --frozen ruff check tests/agentic-use/nat_runner.py tests/agentic-use/scripts/nat_trace_export.py tests/agentic-use/tests/test_nat_runner_config.py
```
