### PR TITLE
feat(intake): Expand gen_ai attribute catalog

### DIFF
--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -6792,7 +6792,7 @@ paths:
           $ref: '#/components/schemas/SpanFilter'
         description: Filter spans by session_id, parent_span_id, project, evaluation
           context fields, source, kind, status, model, tool_name, provider, agent_id,
-          and started_at.
+          agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27719,8 +27719,17 @@ components:
         prompt_id:
           title: Prompt Id
           type: string
+        prompt_name:
+          title: Prompt Name
+          type: string
+        prompt_version:
+          title: Prompt Version
+          type: string
         agent_id:
           title: Agent Id
+          type: string
+        agent_name:
+          title: Agent Name
           type: string
         tool_name:
           title: Tool Name
@@ -27881,6 +27890,18 @@ components:
         agent_id:
           description: Filter by agent identifier.
           title: Agent Id
+          type: string
+        agent_name:
+          description: Filter by agent application name (e.g. 'claude-code', 'codex').
+          title: Agent Name
+          type: string
+        prompt_name:
+          description: Filter by prompt template name.
+          title: Prompt Name
+          type: string
+        prompt_version:
+          description: Filter by prompt template version.
+          title: Prompt Version
           type: string
         parent_span_id:
           description: Filter by parent span id. Use to fetch direct children of a

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -6792,7 +6792,7 @@ paths:
           $ref: '#/components/schemas/SpanFilter'
         description: Filter spans by session_id, parent_span_id, project, evaluation
           context fields, source, kind, status, model, tool_name, provider, agent_id,
-          and started_at.
+          agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27719,8 +27719,17 @@ components:
         prompt_id:
           title: Prompt Id
           type: string
+        prompt_name:
+          title: Prompt Name
+          type: string
+        prompt_version:
+          title: Prompt Version
+          type: string
         agent_id:
           title: Agent Id
+          type: string
+        agent_name:
+          title: Agent Name
           type: string
         tool_name:
           title: Tool Name
@@ -27881,6 +27890,18 @@ components:
         agent_id:
           description: Filter by agent identifier.
           title: Agent Id
+          type: string
+        agent_name:
+          description: Filter by agent application name (e.g. 'claude-code', 'codex').
+          title: Agent Name
+          type: string
+        prompt_name:
+          description: Filter by prompt template name.
+          title: Prompt Name
+          type: string
+        prompt_version:
+          description: Filter by prompt template version.
+          title: Prompt Version
           type: string
         parent_span_id:
           description: Filter by parent span id. Use to fetch direct children of a

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -6792,7 +6792,7 @@ paths:
           $ref: '#/components/schemas/SpanFilter'
         description: Filter spans by session_id, parent_span_id, project, evaluation
           context fields, source, kind, status, model, tool_name, provider, agent_id,
-          and started_at.
+          agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27719,8 +27719,17 @@ components:
         prompt_id:
           title: Prompt Id
           type: string
+        prompt_name:
+          title: Prompt Name
+          type: string
+        prompt_version:
+          title: Prompt Version
+          type: string
         agent_id:
           title: Agent Id
+          type: string
+        agent_name:
+          title: Agent Name
           type: string
         tool_name:
           title: Tool Name
@@ -27881,6 +27890,18 @@ components:
         agent_id:
           description: Filter by agent identifier.
           title: Agent Id
+          type: string
+        agent_name:
+          description: Filter by agent application name (e.g. 'claude-code', 'codex').
+          title: Agent Name
+          type: string
+        prompt_name:
+          description: Filter by prompt template name.
+          title: Prompt Name
+          type: string
+        prompt_version:
+          description: Filter by prompt template version.
+          title: Prompt Version
           type: string
         parent_span_id:
           description: Filter by parent span id. Use to fetch direct children of a

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/__init__.py
@@ -39,11 +39,14 @@ def list_spans(
         typer.Option(
             "--filter",
             metavar="FILTER_JSON",
-            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, and started_at.",
+            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.",
             rich_help_panel="Filter Options",
         ),
     ] = None,
     filter_agent_id: Annotated[str | None, typer.Option("--filter.agent-id", rich_help_panel="Filter Options")] = None,
+    filter_agent_name: Annotated[
+        str | None, typer.Option("--filter.agent-name", rich_help_panel="Filter Options")
+    ] = None,
     filter_dataset_id: Annotated[
         str | None, typer.Option("--filter.dataset-id", rich_help_panel="Filter Options")
     ] = None,
@@ -68,6 +71,12 @@ def list_spans(
         str | None, typer.Option("--filter.parent-span-id", rich_help_panel="Filter Options")
     ] = None,
     filter_project: Annotated[str | None, typer.Option("--filter.project", rich_help_panel="Filter Options")] = None,
+    filter_prompt_name: Annotated[
+        str | None, typer.Option("--filter.prompt-name", rich_help_panel="Filter Options")
+    ] = None,
+    filter_prompt_version: Annotated[
+        str | None, typer.Option("--filter.prompt-version", rich_help_panel="Filter Options")
+    ] = None,
     filter_provider: Annotated[str | None, typer.Option("--filter.provider", rich_help_panel="Filter Options")] = None,
     filter_session_id: Annotated[
         str | None, typer.Option("--filter.session-id", rich_help_panel="Filter Options")
@@ -108,6 +117,7 @@ def list_spans(
         filter=merge_filter_dict(
             filter,
             agent_id=filter_agent_id,
+            agent_name=filter_agent_name,
             dataset_id=filter_dataset_id,
             dataset_name=filter_dataset_name,
             dataset_version=filter_dataset_version,
@@ -118,6 +128,8 @@ def list_spans(
             model=filter_model,
             parent_span_id=filter_parent_span_id,
             project=filter_project,
+            prompt_name=filter_prompt_name,
+            prompt_version=filter_prompt_version,
             provider=filter_provider,
             session_id=filter_session_id,
             source=filter_source,

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -6792,7 +6792,7 @@ paths:
           $ref: '#/components/schemas/SpanFilter'
         description: Filter spans by session_id, parent_span_id, project, evaluation
           context fields, source, kind, status, model, tool_name, provider, agent_id,
-          and started_at.
+          agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27719,8 +27719,17 @@ components:
         prompt_id:
           title: Prompt Id
           type: string
+        prompt_name:
+          title: Prompt Name
+          type: string
+        prompt_version:
+          title: Prompt Version
+          type: string
         agent_id:
           title: Agent Id
+          type: string
+        agent_name:
+          title: Agent Name
           type: string
         tool_name:
           title: Tool Name
@@ -27881,6 +27890,18 @@ components:
         agent_id:
           description: Filter by agent identifier.
           title: Agent Id
+          type: string
+        agent_name:
+          description: Filter by agent application name (e.g. 'claude-code', 'codex').
+          title: Agent Name
+          type: string
+        prompt_name:
+          description: Filter by prompt template name.
+          title: Prompt Name
+          type: string
+        prompt_version:
+          description: Filter by prompt template version.
+          title: Prompt Version
           type: string
         parent_span_id:
           description: Filter by parent span id. Use to fetch direct children of a

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/__init__.py
@@ -39,11 +39,14 @@ def list_spans(
         typer.Option(
             "--filter",
             metavar="FILTER_JSON",
-            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, and started_at.",
+            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.",
             rich_help_panel="Filter Options",
         ),
     ] = None,
     filter_agent_id: Annotated[str | None, typer.Option("--filter.agent-id", rich_help_panel="Filter Options")] = None,
+    filter_agent_name: Annotated[
+        str | None, typer.Option("--filter.agent-name", rich_help_panel="Filter Options")
+    ] = None,
     filter_dataset_id: Annotated[
         str | None, typer.Option("--filter.dataset-id", rich_help_panel="Filter Options")
     ] = None,
@@ -68,6 +71,12 @@ def list_spans(
         str | None, typer.Option("--filter.parent-span-id", rich_help_panel="Filter Options")
     ] = None,
     filter_project: Annotated[str | None, typer.Option("--filter.project", rich_help_panel="Filter Options")] = None,
+    filter_prompt_name: Annotated[
+        str | None, typer.Option("--filter.prompt-name", rich_help_panel="Filter Options")
+    ] = None,
+    filter_prompt_version: Annotated[
+        str | None, typer.Option("--filter.prompt-version", rich_help_panel="Filter Options")
+    ] = None,
     filter_provider: Annotated[str | None, typer.Option("--filter.provider", rich_help_panel="Filter Options")] = None,
     filter_session_id: Annotated[
         str | None, typer.Option("--filter.session-id", rich_help_panel="Filter Options")
@@ -108,6 +117,7 @@ def list_spans(
         filter=merge_filter_dict(
             filter,
             agent_id=filter_agent_id,
+            agent_name=filter_agent_name,
             dataset_id=filter_dataset_id,
             dataset_name=filter_dataset_name,
             dataset_version=filter_dataset_version,
@@ -118,6 +128,8 @@ def list_spans(
             model=filter_model,
             parent_span_id=filter_parent_span_id,
             project=filter_project,
+            prompt_name=filter_prompt_name,
+            prompt_version=filter_prompt_version,
             provider=filter_provider,
             session_id=filter_session_id,
             source=filter_source,

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/intake/spans/spans.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/intake/spans/spans.py
@@ -134,7 +134,8 @@ class SpansResource(SyncAPIResource):
 
         Args:
           filter: Filter spans by session_id, parent_span_id, project, evaluation context fields,
-              source, kind, status, model, tool_name, provider, agent_id, and started_at.
+              source, kind, status, model, tool_name, provider, agent_id, agent_name,
+              prompt_name, prompt_version, and started_at.
 
           page: Page number.
 
@@ -260,7 +261,8 @@ class AsyncSpansResource(AsyncAPIResource):
 
         Args:
           filter: Filter spans by session_id, parent_span_id, project, evaluation context fields,
-              source, kind, status, model, tool_name, provider, agent_id, and started_at.
+              source, kind, status, model, tool_name, provider, agent_id, agent_name,
+              prompt_name, prompt_version, and started_at.
 
           page: Page number.
 

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/span.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/span.py
@@ -45,6 +45,8 @@ class Span(BaseModel):
 
     agent_id: Optional[str] = None
 
+    agent_name: Optional[str] = None
+
     cached_tokens: Optional[int] = None
 
     cost_details: Optional[Dict[str, float]] = None
@@ -80,6 +82,10 @@ class Span(BaseModel):
     project: Optional[str] = None
 
     prompt_id: Optional[str] = None
+
+    prompt_name: Optional[str] = None
+
+    prompt_version: Optional[str] = None
 
     provider: Optional[str] = None
 

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_filter_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_filter_param.py
@@ -30,6 +30,9 @@ class SpanFilterParam(TypedDict, total=False):
     agent_id: str
     """Filter by agent identifier."""
 
+    agent_name: str
+    """Filter by agent application name (e.g. 'claude-code', 'codex')."""
+
     dataset_id: str
     """Filter by dataset id."""
 
@@ -63,6 +66,12 @@ class SpanFilterParam(TypedDict, total=False):
 
     project: str
     """Filter by project name."""
+
+    prompt_name: str
+    """Filter by prompt template name."""
+
+    prompt_version: str
+    """Filter by prompt template version."""
 
     provider: str
     """Filter by provider (e.g. 'openai', 'nim', 'anthropic')."""

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_list_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_list_params.py
@@ -31,7 +31,8 @@ class SpanListParams(TypedDict, total=False):
     filter: SpanFilterParam
     """
     Filter spans by session_id, parent_span_id, project, evaluation context fields,
-    source, kind, status, model, tool_name, provider, agent_id, and started_at.
+    source, kind, status, model, tool_name, provider, agent_id, agent_name,
+    prompt_name, prompt_version, and started_at.
     """
 
     mode: Literal["summary", "detailed"]

--- a/sdk/python/nemo-platform/tests/api_resources/intake/test_spans.py
+++ b/sdk/python/nemo-platform/tests/api_resources/intake/test_spans.py
@@ -101,6 +101,7 @@ class TestSpans:
             workspace="workspace",
             filter={
                 "agent_id": "agent_id",
+                "agent_name": "agent_name",
                 "dataset_id": "dataset_id",
                 "dataset_name": "dataset_name",
                 "dataset_version": "dataset_version",
@@ -111,6 +112,8 @@ class TestSpans:
                 "model": "model",
                 "parent_span_id": "parent_span_id",
                 "project": "project",
+                "prompt_name": "prompt_name",
+                "prompt_version": "prompt_version",
                 "provider": "provider",
                 "session_id": "session_id",
                 "source": "source",
@@ -236,6 +239,7 @@ class TestAsyncSpans:
             workspace="workspace",
             filter={
                 "agent_id": "agent_id",
+                "agent_name": "agent_name",
                 "dataset_id": "dataset_id",
                 "dataset_name": "dataset_name",
                 "dataset_version": "dataset_version",
@@ -246,6 +250,8 @@ class TestAsyncSpans:
                 "model": "model",
                 "parent_span_id": "parent_span_id",
                 "project": "project",
+                "prompt_name": "prompt_name",
+                "prompt_version": "prompt_version",
                 "provider": "provider",
                 "session_id": "session_id",
                 "source": "source",

--- a/services/intake/src/nmp/intake/spans/api/spans.py
+++ b/services/intake/src/nmp/intake/spans/api/spans.py
@@ -41,6 +41,9 @@ ATTRIBUTE_EQ_FILTER_FIELDS = frozenset(
         "tool_name",
         "provider",
         "agent_id",
+        "agent_name",
+        "prompt_name",
+        "prompt_version",
     }
 )
 
@@ -54,7 +57,8 @@ ATTRIBUTE_EQ_FILTER_FIELDS = frozenset(
         filter_schema=SpanFilter,
         filter_description=(
             "Filter spans by session_id, parent_span_id, project, evaluation context fields, "
-            "source, kind, status, model, tool_name, provider, agent_id, and started_at."
+            "source, kind, status, model, tool_name, provider, agent_id, agent_name, "
+            "prompt_name, prompt_version, and started_at."
         ),
     ),
 )

--- a/services/intake/src/nmp/intake/spans/api/spans_schemas.py
+++ b/services/intake/src/nmp/intake/spans/api/spans_schemas.py
@@ -50,6 +50,11 @@ class SpanFilter(BaseModel):
     tool_name: str | None = Field(default=None, description="Filter by tool name.")
     provider: str | None = Field(default=None, description="Filter by provider (e.g. 'openai', 'nim', 'anthropic').")
     agent_id: str | None = Field(default=None, description="Filter by agent identifier.")
+    agent_name: str | None = Field(
+        default=None, description="Filter by agent application name (e.g. 'claude-code', 'codex')."
+    )
+    prompt_name: str | None = Field(default=None, description="Filter by prompt template name.")
+    prompt_version: str | None = Field(default=None, description="Filter by prompt template version.")
     parent_span_id: str | None = Field(
         default=None, description="Filter by parent span id. Use to fetch direct children of a span."
     )
@@ -125,7 +130,10 @@ class Span(BaseModel):
     provider: str | None = None
     model: str | None = None
     prompt_id: str | None = None
+    prompt_name: str | None = None
+    prompt_version: str | None = None
     agent_id: str | None = None
+    agent_name: str | None = None
     tool_name: str | None = None
     input_tokens: int | None = Field(default=None, ge=0)
     output_tokens: int | None = Field(default=None, ge=0)
@@ -170,7 +178,10 @@ class Span(BaseModel):
             provider=semantic_attributes.provider,
             model=semantic_attributes.model,
             prompt_id=semantic_attributes.prompt_id,
+            prompt_name=semantic_attributes.prompt_name,
+            prompt_version=semantic_attributes.prompt_version,
             agent_id=semantic_attributes.agent_id,
+            agent_name=semantic_attributes.agent_name,
             tool_name=semantic_attributes.tool_name,
             input_tokens=semantic_attributes.input_tokens,
             output_tokens=semantic_attributes.output_tokens,

--- a/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
+++ b/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
@@ -125,7 +125,7 @@ def _trajectory_to_span(
     external_span_id = stable_id(workspace, trajectory.session_id, "trajectory", prefix="span")
     attribute_bags = _span_attributes(
         model=trajectory.agent.model_name,
-        agent_id=trajectory.agent.name,
+        agent_name=trajectory.agent.name,
         evaluation_context=trajectory.evaluation_context,
         input_tokens=final_metrics.total_prompt_tokens if final_metrics is not None else None,
         output_tokens=final_metrics.total_completion_tokens if final_metrics is not None else None,
@@ -182,7 +182,7 @@ def _step_to_span(
     )
     attribute_bags = _span_attributes(
         model=model_name or default_model_name,
-        agent_id=default_agent_name,
+        agent_name=default_agent_name,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         cached_tokens=metrics.cached_tokens if metrics is not None else None,
@@ -237,7 +237,7 @@ def _tool_call_to_span(
     )
     attribute_bags = _span_attributes(
         model=_step_model_name(step) or default_model_name,
-        agent_id=default_agent_name,
+        agent_name=default_agent_name,
         tool_name=tool_call.function_name,
         error_message=error_message,
         raw_attributes={
@@ -297,7 +297,7 @@ def _subagent_ref_to_span(
     )
     attribute_bags = _span_attributes(
         model=_step_model_name(step) or default_model_name,
-        agent_id=default_agent_name,
+        agent_name=default_agent_name,
         error_message=error_message,
         raw_attributes={
             "step_id": step.step_id,
@@ -390,7 +390,7 @@ def _evaluator_result_to_span(
     )
     attribute_bags = _span_attributes(
         model=trajectory.agent.model_name,
-        agent_id=trajectory.agent.name,
+        agent_name=trajectory.agent.name,
         raw_attributes=raw_attributes,
     )
     return [
@@ -419,7 +419,7 @@ def _evaluator_result_to_span(
 def _span_attributes(
     *,
     model: str | None = None,
-    agent_id: str | None = None,
+    agent_name: str | None = None,
     evaluation_context: EvaluationContext | None = None,
     tool_name: str | None = None,
     error_message: str | None = None,
@@ -432,7 +432,7 @@ def _span_attributes(
 ) -> SpanAttributeBags:
     semantic_attributes = SpanSemanticAttributes(
         model=model,
-        agent_id=agent_id,
+        agent_name=agent_name,
         evaluation_id=evaluation_context.evaluation_id if evaluation_context is not None else None,
         evaluation_sha=evaluation_context.evaluation_sha if evaluation_context is not None else None,
         evaluation_run_id=evaluation_context.evaluation_run_id if evaluation_context is not None else None,

--- a/services/intake/src/nmp/intake/spans/span_attribute_catalog.py
+++ b/services/intake/src/nmp/intake/spans/span_attribute_catalog.py
@@ -31,7 +31,10 @@ class SpanAttributeField(StrEnum):
     MODEL = "model"
     PROVIDER = "provider"
     PROMPT_ID = "prompt_id"
+    PROMPT_NAME = "prompt_name"
+    PROMPT_VERSION = "prompt_version"
     AGENT_ID = "agent_id"
+    AGENT_NAME = "agent_name"
     TOOL_NAME = "tool_name"
     PROJECT = "project"
     EVALUATION_ID = "evaluation_id"
@@ -104,12 +107,42 @@ ATTRIBUTE_SPECS = (
         ),
     ),
     AttributeSpec(
+        field=SpanAttributeField.PROMPT_NAME,
+        bag=AttributeBag.STRING,
+        bag_key="prompt.name",
+        source_keys=(
+            "gen_ai.prompt.name",
+            "llm.prompt_template.name",
+            "prompt.name",
+        ),
+    ),
+    AttributeSpec(
+        field=SpanAttributeField.PROMPT_VERSION,
+        bag=AttributeBag.STRING,
+        bag_key="prompt.version",
+        source_keys=(
+            "gen_ai.prompt.version",
+            "llm.prompt_template.version",
+            "prompt.version",
+        ),
+    ),
+    AttributeSpec(
         field=SpanAttributeField.AGENT_ID,
         bag=AttributeBag.STRING,
         bag_key="gen_ai.agent.id",
         source_keys=(
             "gen_ai.agent.id",
             "agent.id",
+        ),
+    ),
+    AttributeSpec(
+        field=SpanAttributeField.AGENT_NAME,
+        bag=AttributeBag.STRING,
+        bag_key="gen_ai.agent.name",
+        source_keys=(
+            "gen_ai.agent.name",
+            "llm.agent.name",
+            "agent.name",
         ),
     ),
     AttributeSpec(
@@ -230,6 +263,7 @@ ATTRIBUTE_SPECS = (
         bag_key="llm.token_count.cached",
         source_keys=(
             "gen_ai.usage.cached_tokens",
+            "gen_ai.usage.input_cache_tokens",
             "llm.token_count.prompt_details.cache_read",
             "llm.token_count.cached",
         ),

--- a/services/intake/src/nmp/intake/spans/span_semantic_attributes.py
+++ b/services/intake/src/nmp/intake/spans/span_semantic_attributes.py
@@ -25,7 +25,10 @@ class SpanSemanticAttributes(BaseModel):
     model: str | None = None
     provider: str | None = None
     prompt_id: str | None = None
+    prompt_name: str | None = None
+    prompt_version: str | None = None
     agent_id: str | None = None
+    agent_name: str | None = None
     tool_name: str | None = None
     project: str | None = None
     evaluation_id: str | None = None

--- a/services/intake/tests/integration/spans/test_atif_ingest.py
+++ b/services/intake/tests/integration/spans/test_atif_ingest.py
@@ -335,7 +335,7 @@ def test_atif_ingest_accepts_example_trajectory_and_reconstructs_read_side_data(
     assert trajectory["kind"] == "AGENT"
     assert trajectory["source"] == "atif"
     assert trajectory["model"] == "provider/sample-model"
-    assert trajectory["agent_id"] == "sample-agent"
+    assert trajectory["agent_name"] == "sample-agent"
     assert trajectory["input_tokens"] == 51701
     assert trajectory["output_tokens"] == 255
     assert trajectory["cached_tokens"] == 0

--- a/web/packages/sdk/generated/platform/schema/ListSpansParams.ts
+++ b/web/packages/sdk/generated/platform/schema/ListSpansParams.ts
@@ -25,7 +25,7 @@ export type ListSpansParams = {
   sort?: SpanSortField;
   mode?: ListSpansMode;
   /**
-   * Filter spans by session_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, and started_at.
+   * Filter spans by session_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.
    */
   filter?: SpanFilter;
 };

--- a/web/packages/sdk/generated/platform/schema/Span.ts
+++ b/web/packages/sdk/generated/platform/schema/Span.ts
@@ -31,7 +31,10 @@ export interface Span {
   provider?: string;
   model?: string;
   prompt_id?: string;
+  prompt_name?: string;
+  prompt_version?: string;
   agent_id?: string;
+  agent_name?: string;
   tool_name?: string;
   /** @minimum 0 */
   input_tokens?: number;

--- a/web/packages/sdk/generated/platform/schema/SpanFilter.ts
+++ b/web/packages/sdk/generated/platform/schema/SpanFilter.ts
@@ -43,6 +43,12 @@ export interface SpanFilter {
   provider?: string;
   /** Filter by agent identifier. */
   agent_id?: string;
+  /** Filter by agent application name (e.g. 'claude-code', 'codex'). */
+  agent_name?: string;
+  /** Filter by prompt template name. */
+  prompt_name?: string;
+  /** Filter by prompt template version. */
+  prompt_version?: string;
   /** Filter by parent span id. Use to fetch direct children of a span. */
   parent_span_id?: string;
   /** Filter by span start timestamp. */

--- a/web/packages/sdk/generated/platform/zod/spans.ts
+++ b/web/packages/sdk/generated/platform/zod/spans.ts
@@ -79,6 +79,12 @@ export const ListSpansQueryParams = zod.object({
         .optional()
         .describe("Filter by provider (e.g. 'openai', 'nim', 'anthropic')."),
       agent_id: zod.string().optional().describe('Filter by agent identifier.'),
+      agent_name: zod
+        .string()
+        .optional()
+        .describe("Filter by agent application name (e.g. 'claude-code', 'codex')."),
+      prompt_name: zod.string().optional().describe('Filter by prompt template name.'),
+      prompt_version: zod.string().optional().describe('Filter by prompt template version.'),
       parent_span_id: zod
         .string()
         .optional()
@@ -101,7 +107,7 @@ export const ListSpansQueryParams = zod.object({
     })
     .optional()
     .describe(
-      'Filter spans by session_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, and started_at.'
+      'Filter spans by session_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.'
     ),
 });
 
@@ -156,7 +162,10 @@ export const ListSpansResponse = zod.object({
       provider: zod.string().optional(),
       model: zod.string().optional(),
       prompt_id: zod.string().optional(),
+      prompt_name: zod.string().optional(),
+      prompt_version: zod.string().optional(),
       agent_id: zod.string().optional(),
+      agent_name: zod.string().optional(),
       tool_name: zod.string().optional(),
       input_tokens: zod.number().min(listSpansResponseDataItemInputTokensMin).optional(),
       output_tokens: zod.number().min(listSpansResponseDataItemOutputTokensMin).optional(),
@@ -244,7 +253,10 @@ export const GetSpanResponse = zod.object({
   provider: zod.string().optional(),
   model: zod.string().optional(),
   prompt_id: zod.string().optional(),
+  prompt_name: zod.string().optional(),
+  prompt_version: zod.string().optional(),
   agent_id: zod.string().optional(),
+  agent_name: zod.string().optional(),
   tool_name: zod.string().optional(),
   input_tokens: zod.number().min(getSpanResponseInputTokensMin).optional(),
   output_tokens: zod.number().min(getSpanResponseOutputTokensMin).optional(),


### PR DESCRIPTION
- Added typed fields: `prompt_name`, `prompt_version`, `agent_name` (with matching filters)
- Added `gen_ai.usage.input_cache_tokens` as alias for `cached_tokens` (older semconv spelling)
- ATIF: `agent.name` now maps to `agent_name` (semantically correct; was `agent_id`)