### PR TITLE
fix(agents): show stderr spinner during `nemo agents invoke` (AIRCORE-574)

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/cli_progress.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/cli_progress.py
@@ -15,12 +15,29 @@ from __future__ import annotations
 import os
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Optional
 
 from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn, TimeElapsedColumn
+from rich.progress import Progress, SpinnerColumn, Task, TaskID, TextColumn, TimeElapsedColumn
+from rich.text import Text
 
 _OPT_OUT_ENV_VARS = ("NO_COLOR", "CI", "NEMO_NO_PROGRESS")
+
+
+class _MinutesSecondsElapsedColumn(TimeElapsedColumn):
+    """Elapsed-time column rendered as MM:SS instead of Rich's default H:MM:SS.
+
+    The leading ``0:`` hour marker visually implies hour-scale waits, which
+    these CLI requests never reach in practice. Minutes are allowed to grow
+    past 59 rather than rolling into hours.
+    """
+
+    def render(self, task: Task) -> Text:
+        elapsed = task.finished_time if task.finished else task.elapsed
+        if elapsed is None:
+            return Text("--:--", style="progress.elapsed")
+        seconds = max(0, int(elapsed))
+        minutes, secs = divmod(seconds, 60)
+        return Text(f"{minutes:02d}:{secs:02d}", style="progress.elapsed")
 
 
 def _progress_disabled(console: Console, disabled: bool) -> bool:
@@ -34,7 +51,7 @@ def _progress_disabled(console: Console, disabled: bool) -> bool:
 class _ProgressHandle:
     """Caller-facing handle for updating the spinner message mid-flight."""
 
-    def __init__(self, progress: Optional[Progress], task_id: Optional[TaskID]) -> None:
+    def __init__(self, progress: Progress | None, task_id: TaskID | None) -> None:
         self._progress = progress
         self._task_id = task_id
 
@@ -53,7 +70,7 @@ def request_progress(
     message: str,
     *,
     disabled: bool = False,
-    console: Optional[Console] = None,
+    console: Console | None = None,
 ) -> Iterator[_ProgressHandle]:
     """Render a stderr spinner with elapsed-time while the block runs.
 
@@ -76,7 +93,7 @@ def request_progress(
     with Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),
-        TimeElapsedColumn(),
+        _MinutesSecondsElapsedColumn(),
         console=console,
         transient=True,
     ) as progress:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/cli_progress.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/cli_progress.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stderr progress indicators for long-running plugin CLI requests.
+
+`request_progress` wraps a synchronous in-flight HTTP call (or any blocking
+operation) with a spinner + elapsed-time counter rendered on stderr. The
+spinner auto-disables when stderr isn't a TTY or when the user opts out via
+``--no-progress`` / ``NO_COLOR`` / ``CI`` / ``NEMO_NO_PROGRESS``, so piping
+stdout to ``jq`` or redirecting in CI stays clean.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Optional
+
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn, TimeElapsedColumn
+
+_OPT_OUT_ENV_VARS = ("NO_COLOR", "CI", "NEMO_NO_PROGRESS")
+
+
+def _progress_disabled(console: Console, disabled: bool) -> bool:
+    if disabled:
+        return True
+    if not console.is_terminal:
+        return True
+    return any(os.environ.get(name) for name in _OPT_OUT_ENV_VARS)
+
+
+class _ProgressHandle:
+    """Caller-facing handle for updating the spinner message mid-flight."""
+
+    def __init__(self, progress: Optional[Progress], task_id: Optional[TaskID]) -> None:
+        self._progress = progress
+        self._task_id = task_id
+
+    @property
+    def is_active(self) -> bool:
+        """True when a Rich Progress widget is actually backing this handle."""
+        return self._progress is not None and self._task_id is not None
+
+    def update(self, message: str) -> None:
+        if self._progress is not None and self._task_id is not None:
+            self._progress.update(self._task_id, description=message)
+
+
+@contextmanager
+def request_progress(
+    message: str,
+    *,
+    disabled: bool = False,
+    console: Optional[Console] = None,
+) -> Iterator[_ProgressHandle]:
+    """Render a stderr spinner with elapsed-time while the block runs.
+
+    Args:
+        message: Description shown next to the spinner (e.g. ``"Waiting for agent..."``).
+        disabled: Force-disable the spinner regardless of TTY/env detection.
+            Wire this to the command's ``--no-progress`` flag.
+        console: Optional Rich Console override (mostly for tests). Defaults to
+            a stderr console.
+
+    Yields:
+        A handle whose ``update(msg)`` swaps the spinner description while the
+        block is still active. Useful for surfacing intermediate progress.
+    """
+    console = console if console is not None else Console(stderr=True)
+    if _progress_disabled(console, disabled):
+        yield _ProgressHandle(None, None)
+        return
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeElapsedColumn(),
+        console=console,
+        transient=True,
+    ) as progress:
+        task_id = progress.add_task(message, total=None)
+        yield _ProgressHandle(progress, task_id)

--- a/packages/nemo_platform_plugin/tests/test_cli_progress.py
+++ b/packages/nemo_platform_plugin/tests/test_cli_progress.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import io
 
 import pytest
-from nemo_platform_plugin.cli_progress import request_progress
+from nemo_platform_plugin.cli_progress import _MinutesSecondsElapsedColumn, request_progress
 from rich.console import Console
 
 
@@ -73,3 +73,25 @@ def test_handle_update_is_safe_when_disabled() -> None:
     with request_progress("Should not appear", disabled=True, console=console) as handle:
         handle.update("This must not raise")
     assert console.export_text() == ""
+
+
+@pytest.mark.parametrize(
+    "elapsed,expected",
+    [
+        (None, "--:--"),
+        (0, "00:00"),
+        (7, "00:07"),
+        (65, "01:05"),
+        # Minutes intentionally roll past 59 rather than spilling into an hours field.
+        (3725, "62:05"),
+    ],
+)
+def test_elapsed_column_renders_minutes_seconds(elapsed: float | None, expected: str) -> None:
+    class _StubTask:
+        def __init__(self, elapsed: float | None) -> None:
+            self.elapsed = elapsed
+            self.finished = False
+            self.finished_time = None
+
+    rendered = _MinutesSecondsElapsedColumn().render(_StubTask(elapsed))  # type: ignore[arg-type]
+    assert rendered.plain == expected

--- a/packages/nemo_platform_plugin/tests/test_cli_progress.py
+++ b/packages/nemo_platform_plugin/tests/test_cli_progress.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from nemo_platform_plugin.cli_progress import request_progress
+from rich.console import Console
+
+
+def _tty_console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=True, width=80, record=True)
+
+
+def _pipe_console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=False, width=80, record=True)
+
+
+@pytest.fixture(autouse=True)
+def _clear_opt_out_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure CI/NO_COLOR/NEMO_NO_PROGRESS don't leak in from the runner.
+
+    GitHub Actions sets ``CI=true`` automatically, which would otherwise
+    force the spinner off regardless of the test's intent.
+    """
+    for name in ("NO_COLOR", "CI", "NEMO_NO_PROGRESS"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_creates_progress_widget_when_stderr_is_a_tty() -> None:
+    """A TTY stderr should yield an active Rich Progress backing the handle.
+
+    Tests the contract structurally rather than asserting on rendered text:
+    transient Progress + Live's refresh thread make output-capture timing
+    flaky in CI, and the value we actually want to guarantee is that the
+    spinner *is* wired up when stderr supports it.
+    """
+    console = _tty_console()
+    with request_progress("Waiting for agent...", console=console) as handle:
+        assert handle.is_active
+        handle.update("Still waiting...")
+
+
+def test_disabled_flag_yields_inert_handle() -> None:
+    console = _tty_console()
+    with request_progress("Should not appear", disabled=True, console=console) as handle:
+        assert not handle.is_active
+    assert console.export_text() == ""
+
+
+def test_non_tty_stderr_yields_inert_handle() -> None:
+    console = _pipe_console()
+    with request_progress("Should not appear", console=console) as handle:
+        assert not handle.is_active
+    assert console.export_text() == ""
+
+
+@pytest.mark.parametrize("env_var", ["NO_COLOR", "CI", "NEMO_NO_PROGRESS"])
+def test_opt_out_env_vars_yield_inert_handle(monkeypatch: pytest.MonkeyPatch, env_var: str) -> None:
+    for name in ("NO_COLOR", "CI", "NEMO_NO_PROGRESS"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(env_var, "1")
+    console = _tty_console()
+    with request_progress("Should not appear", console=console) as handle:
+        assert not handle.is_active
+    assert console.export_text() == ""
+
+
+def test_handle_update_is_safe_when_disabled() -> None:
+    console = _tty_console()
+    with request_progress("Should not appear", disabled=True, console=console) as handle:
+        handle.update("This must not raise")
+    assert console.export_text() == ""

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -49,6 +49,7 @@ from nemo_agents_plugin.leaderboard.cli import register_leaderboard_commands
 from nemo_agents_plugin.usage.cli import register_usage_commands
 from nemo_platform_plugin.cli import NemoCLI
 from nemo_platform_plugin.cli_errors import print_http_request_error, print_http_status_error
+from nemo_platform_plugin.cli_progress import request_progress
 
 logger = logging.getLogger(__name__)
 
@@ -135,12 +136,26 @@ def _register_local_commands(app: typer.Typer) -> None:
             envvar="NEMO_AGENTS_INVOKE_TIMEOUT",
             help="Request timeout in seconds for platform invocation.",
         ),
+        no_progress: bool = typer.Option(
+            False,
+            "--no-progress",
+            help="Suppress the stderr spinner while waiting for the response.",
+        ),
     ) -> None:
         """Invoke an agent — locally (with --agent-config) or via the platform (with --agent or --agent-deployment)."""
         if agent_config:
             _local_invoke(agent_config, input, input_file, workspace=workspace, base_url=base_url)
         elif agent or agent_deployment:
-            _platform_invoke(base_url, workspace, agent, agent_deployment, input, input_file, timeout=timeout)
+            _platform_invoke(
+                base_url,
+                workspace,
+                agent,
+                agent_deployment,
+                input,
+                input_file,
+                timeout=timeout,
+                no_progress=no_progress,
+            )
         else:
             typer.echo(
                 "Error: provide --agent-config for local execution or --agent/--agent-deployment for platform invocation.",
@@ -711,6 +726,7 @@ def _platform_invoke(
     input_file: Optional[Path],
     *,
     timeout: float = 300,
+    no_progress: bool = False,
 ) -> None:
     """Invoke an agent through the platform gateway."""
     if input_file:
@@ -729,20 +745,16 @@ def _platform_invoke(
         path = f"/apis/agents/v2/workspaces/{workspace}/deployments/{deployment}/-/v1/chat/completions"
 
     url = base_url.rstrip("/") + path
+    target_label = agent or deployment
     for query in queries:
         payload = {"messages": [{"role": "user", "content": query}], "stream": False}
         try:
-            with httpx.Client(timeout=timeout) as client:
-                resp = client.post(url, json=payload)
-                resp.raise_for_status()
-                typer.echo(json.dumps(resp.json(), indent=2))
-        except httpx.TimeoutException:
-            typer.echo(
-                f"Error: invoke agent timed out after {timeout:.0f}s. "
-                "Use --timeout to increase or set NEMO_AGENTS_INVOKE_TIMEOUT.",
-                err=True,
-            )
-            raise typer.Exit(code=1)
+            with request_progress(f"Waiting for agent '{target_label}'...", disabled=no_progress):
+                with httpx.Client(timeout=timeout) as client:
+                    resp = client.post(url, json=payload)
+                    resp.raise_for_status()
+                    body = resp.json()
+                typer.echo(json.dumps(body, indent=2))
         except httpx.HTTPStatusError as exc:
             print_http_status_error(exc, action="invoke agent")
             raise typer.Exit(code=1)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -755,6 +755,13 @@ def _platform_invoke(
                     resp.raise_for_status()
                     body = resp.json()
                 typer.echo(json.dumps(body, indent=2))
+        except httpx.TimeoutException as exc:
+            typer.echo(
+                f"Error: invoke agent timed out after {timeout:.0f}s. "
+                "Use --timeout to increase or set NEMO_AGENTS_INVOKE_TIMEOUT.",
+                err=True,
+            )
+            raise typer.Exit(code=1) from exc
         except httpx.HTTPStatusError as exc:
             print_http_status_error(exc, action="invoke agent")
             raise typer.Exit(code=1)

--- a/plugins/nemo-agents/tests/unit/test_cli.py
+++ b/plugins/nemo-agents/tests/unit/test_cli.py
@@ -146,6 +146,45 @@ def test_invoke_timeout_error_message() -> None:
     assert "--timeout" in result.stderr
 
 
+def test_platform_invoke_writes_clean_json_to_stdout() -> None:
+    """`nemo agents invoke --agent` returns JSON on stdout with no spinner bleed.
+
+    AIRCORE-574: the spinner must render only on stderr so consumers can pipe
+    stdout to `jq`. CliRunner's non-TTY stderr auto-disables the spinner, so
+    here we just verify the response JSON is intact on stdout.
+    """
+    import json as _json
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": [{"message": {"content": "hi"}}]})
+
+    app = AgentsCLI().get_cli()
+    with _install_mock_transport(handler):
+        result = CliRunner().invoke(app, ["invoke", "--agent", "calc", "--input", "ping", "--base-url", "http://test"])
+
+    assert result.exit_code == 0, result.stderr
+    parsed = _json.loads(result.stdout)
+    assert parsed["choices"][0]["message"]["content"] == "hi"
+
+
+def test_platform_invoke_accepts_no_progress_flag() -> None:
+    """`--no-progress` is wired through and doesn't break invocation."""
+    import json as _json
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": [{"message": {"content": "hi"}}]})
+
+    app = AgentsCLI().get_cli()
+    with _install_mock_transport(handler):
+        result = CliRunner().invoke(
+            app,
+            ["invoke", "--agent", "calc", "--input", "ping", "--no-progress", "--base-url", "http://test"],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert _json.loads(result.stdout)["choices"][0]["message"]["content"] == "hi"
+
+
 def test_list_connection_error_prints_request_context_and_hint() -> None:
     def handler(req: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("connection refused", request=req)


### PR DESCRIPTION
## Summary

- `nemo agents invoke` previously printed nothing while a request was in flight — for slow agents this looked indistinguishable from a hang. Add a stderr spinner + elapsed-time counter so users get feedback, plus a `--no-progress` opt-out.
- New shared helper `nemo_platform_plugin.cli_progress.request_progress()` is a context manager: auto-disables on non-TTY stderr, `NO_COLOR`, `CI`, `NEMO_NO_PROGRESS`, or `disabled=True`. Stdout stays clean for `| jq` redirection.
- Helper lives in `nemo_platform_plugin` (not `nemo_platform_ext.cli.core`) so sister tickets AIRCORE-524 / AIRCORE-526 (the `nemo setup` waits) can reuse it.

Ticket: [AIRCORE-574](linear://nvidia/issue/AIRCORE-574/nemo-agents-invoke-gives-no-feedback-while-a-request-is-in-flight)

## Why not stream?

The endpoint (`/apis/agents/v2/.../v1/chat/completions`) does support SSE and the Inference Gateway already relays it, but `_platform_invoke` hardcodes `stream=False` and `typer.echo(json.dumps(...))` produces a single JSON blob. Flipping to streaming would change the output contract — separate ticket.

## Test plan

- [x] `uv run pytest packages/nemo_platform_plugin/tests/test_cli_progress.py plugins/nemo-agents/tests/unit/test_cli.py` — 16/16 pass (7 new helper tests, 2 new invoke integration tests, existing tests unchanged)
- [x] `uv run pre-commit run --files <touched>` — ruff, ruff format, ty, copyright headers, merge-conflict check all pass
- [ ] Live against a running platform: spinner visible on bare `nemo agents invoke`, suppressed by `2>/dev/null`, suppressed by `--no-progress`, suppressed by `CI=true`, JSON on stdout pipes cleanly to `jq`