### PR TITLE
fix(agents): invoke timeout, unknown-model patching, skill routing

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-skill-selection/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-skill-selection/SKILL.md
@@ -49,6 +49,11 @@ Match the user's intent to one downstream skill. Pick exactly one.
 | "status", "what is running", "platform health", "is the platform up", "what's deployed", "show me what's running" | `nemo-status` | Read-only dashboard: platform, agents, providers, models |
 | "shut down", "stop NeMo", "tear down", "clean up" | `nemo-teardown` | Stop the cluster (keep data, delete platform data, or full cleanup) |
 | "fine-tune", "customize the model", "train on my data" | `nemo-fine-tune` | Fine-tuning is not yet available on NeMo Platform. Pick this so the agent tells the user it's not shipped instead of going off to implement training with some other library. |
+| "optimize my agent", "make it cheaper", "reduce latency", "smaller model", "switchyard", "routing split", "compare against a newer model" | `agents-optimize` (plugin-owned, in `plugins/nemo-agents`) | Cost / latency / quality optimization for a **deployed** agent. Routing splits, skill tuning, prompt tuning, new-model scans. |
+| "secure my agent", "harden my agent", "check for PII", "leaked secrets", "guardrail coverage" | `agents-secure` (plugin-owned, in `plugins/nemo-agents`) | Safety and security audit for a **deployed** agent. Guardrails, PII, secrets scan. |
+| "evaluate my agent", "run a benchmark", "eval suite" | `nemo-evaluator` (plugin-owned, in `plugins/nemo-evaluator`) | Evaluation metrics, LLM-judge, benchmark jobs against a deployed agent or model. |
+
+**Optimize vs build:** Do NOT route optimize asks to `nemo-build-agent`. Build is for creating new agents from a spec; optimize is for tuning **already deployed** agents. If the user says "make my agent faster" or "use a cheaper model," that is `agents-optimize`, not `nemo-build-agent`.
 
 If two rows fit, pick the earliest one in the lifecycle (setup before build before try). If nothing matches, ask one disambiguating question with the relevant rows as a numbered list.
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-skill-selection/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-skill-selection/SKILL.md
@@ -106,7 +106,14 @@ NeMo Platform skills I can route to:
   nemo-teardown   guided shutdown
   nemo-fine-tune  fine-tuning (not yet shipped; reports that honestly)
 
-Plus plugin-owned skills (guardrails, evaluator, auditor, data-designer, anonymizer, agents-optimize, agents-secure).
+Plugin-owned skills:
+  agents-optimize   cost / latency / quality optimization for a deployed agent
+  agents-secure     safety and security audit for a deployed agent
+  nemo-evaluator    evaluation metrics, LLM-judge, benchmark jobs
+  guardrails        content-safety middleware via virtual models
+  auditor           red-team vulnerability scanning (garak)
+  data-designer     synthetic dataset generation
+  anonymizer        PII handling for datasets
 
 Which one fits what you're trying to do?
 ```

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -24,6 +24,7 @@ chunk by chunk.  ``text/event-stream`` responses bypass buffering.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from typing import AsyncIterator
@@ -79,7 +80,7 @@ async def proxy_by_agent_name(
     is found.
     """
     endpoint = await _resolve_agent_endpoint(name, workspace, entity_client)
-    return await _proxy(request, endpoint, trailing_uri)
+    return await _proxy(request, endpoint, trailing_uri, model_name=name)
 
 
 @router.api_route(
@@ -115,7 +116,7 @@ async def proxy_by_deployment_name(
             detail=f"Deployment '{name}' is not running (status='{dep.status}').",
         )
 
-    return await _proxy(request, dep.endpoint, trailing_uri)
+    return await _proxy(request, dep.endpoint, trailing_uri, model_name=name)
 
 
 async def _resolve_agent_endpoint(name: str, workspace: str, entity_client: NemoEntitiesClient) -> str:
@@ -141,7 +142,9 @@ async def _resolve_agent_endpoint(name: str, workspace: str, entity_client: Nemo
     return running[0].endpoint
 
 
-async def _proxy(request: Request, endpoint: str, trailing_uri: str) -> StreamingResponse:
+async def _proxy(
+    request: Request, endpoint: str, trailing_uri: str, *, model_name: str | None = None
+) -> StreamingResponse:
     """Forward *request* to ``{endpoint}/{trailing_uri}`` and stream the response.
 
     Error handling policy:
@@ -219,6 +222,38 @@ async def _proxy(request: Request, endpoint: str, trailing_uri: str) -> Streamin
         raise HTTPException(status_code=502, detail=f"Could not connect to agent: {exc}") from exc
 
     content_type = response_headers.get("content-type", "application/json")
+
+    # NAT's ChatResponse.from_string() defaults model to "unknown-model" when
+    # the agent wrapper doesn't supply one (the wrapper code lives in
+    # nvidia-nat-core and doesn't have access to the platform entity name).
+    # For non-streaming JSON responses, patch the model field to the
+    # agent/deployment name the client addressed.  This is a gateway-level
+    # workaround; the proper upstream fix belongs in nvidia-nat-core's
+    # NemoAgentWrapperFunction.convert_to_chat_response where the LLM's
+    # response_metadata carries the real model name.
+    if model_name and "event-stream" not in content_type:
+        async for remaining in stream_gen:
+            chunks.append(remaining)
+        raw = b"".join(chunks)
+        try:
+            data = json.loads(raw)
+            if isinstance(data, dict) and data.get("model") == "unknown-model":
+                data["model"] = model_name
+                raw = json.dumps(data).encode()
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+        chunks = [raw]
+
+        async def _buffered_patched() -> AsyncIterator[bytes]:
+            for c in chunks:
+                yield c
+
+        return StreamingResponse(
+            _buffered_patched(),
+            status_code=status_code_holder[0],
+            headers={k: v for k, v in response_headers.items() if k.lower() != "content-length"},
+            media_type=content_type,
+        )
 
     return StreamingResponse(
         _buffered(),

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -231,7 +231,7 @@ async def _proxy(
     # workaround; the proper upstream fix belongs in nvidia-nat-core's
     # NemoAgentWrapperFunction.convert_to_chat_response where the LLM's
     # response_metadata carries the real model name.
-    if model_name and "event-stream" not in content_type:
+    if model_name and not content_type.startswith("text/event-stream"):
         async for remaining in stream_gen:
             chunks.append(remaining)
         raw = b"".join(chunks)
@@ -243,17 +243,6 @@ async def _proxy(
         except (json.JSONDecodeError, UnicodeDecodeError):
             pass
         chunks = [raw]
-
-        async def _buffered_patched() -> AsyncIterator[bytes]:
-            for c in chunks:
-                yield c
-
-        return StreamingResponse(
-            _buffered_patched(),
-            status_code=status_code_holder[0],
-            headers={k: v for k, v in response_headers.items() if k.lower() != "content-length"},
-            media_type=content_type,
-        )
 
     return StreamingResponse(
         _buffered(),

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -128,12 +128,19 @@ def _register_local_commands(app: typer.Typer) -> None:
         ),
         workspace: str = typer.Option(_DEFAULT_WORKSPACE, "--workspace", "-w"),
         base_url: str = typer.Option(_DEFAULT_BASE_URL, "--base-url", envvar="NEMO_BASE_URL"),
+        timeout: float = typer.Option(
+            300,
+            "--timeout",
+            "-t",
+            envvar="NEMO_AGENTS_INVOKE_TIMEOUT",
+            help="Request timeout in seconds for platform invocation.",
+        ),
     ) -> None:
         """Invoke an agent — locally (with --agent-config) or via the platform (with --agent or --agent-deployment)."""
         if agent_config:
             _local_invoke(agent_config, input, input_file, workspace=workspace, base_url=base_url)
         elif agent or agent_deployment:
-            _platform_invoke(base_url, workspace, agent, agent_deployment, input, input_file)
+            _platform_invoke(base_url, workspace, agent, agent_deployment, input, input_file, timeout=timeout)
         else:
             typer.echo(
                 "Error: provide --agent-config for local execution or --agent/--agent-deployment for platform invocation.",
@@ -702,6 +709,8 @@ def _platform_invoke(
     deployment: Optional[str],
     input: Optional[str],
     input_file: Optional[Path],
+    *,
+    timeout: float = 300,
 ) -> None:
     """Invoke an agent through the platform gateway."""
     if input_file:
@@ -723,11 +732,17 @@ def _platform_invoke(
     for query in queries:
         payload = {"messages": [{"role": "user", "content": query}], "stream": False}
         try:
-            timeout = float(os.environ.get("NEMO_AGENTS_INVOKE_TIMEOUT", "300"))
             with httpx.Client(timeout=timeout) as client:
                 resp = client.post(url, json=payload)
                 resp.raise_for_status()
                 typer.echo(json.dumps(resp.json(), indent=2))
+        except httpx.TimeoutException:
+            typer.echo(
+                f"Error: invoke agent timed out after {timeout:.0f}s. "
+                "Use --timeout to increase or set NEMO_AGENTS_INVOKE_TIMEOUT.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
         except httpx.HTTPStatusError as exc:
             print_http_status_error(exc, action="invoke agent")
             raise typer.Exit(code=1)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
@@ -118,7 +118,7 @@ class AgentsResource:
         agent: str | None = None,
         deployment: str | None = None,
         workspace: str = _DEFAULT_WORKSPACE,
-        timeout: int = 120,
+        timeout: int = 300,
     ) -> dict[str, Any]:
         """Send a single request to an agent via the gateway.
 

--- a/plugins/nemo-agents/tests/unit/test_cli.py
+++ b/plugins/nemo-agents/tests/unit/test_cli.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from typing import Any
 from unittest.mock import patch
@@ -13,11 +14,15 @@ from nemo_agents_plugin.cli import AgentsCLI
 from typer.testing import CliRunner
 
 
-def _install_mock_transport(handler) -> AbstractContextManager[Any]:
+def _install_mock_transport(
+    handler, *, on_create: Callable[[dict[str, Any]], None] | None = None
+) -> AbstractContextManager[Any]:
     transport = httpx.MockTransport(handler)
     real_client = httpx.Client
 
     def _factory(*args, **kwargs):
+        if on_create is not None:
+            on_create(kwargs)
         kwargs["transport"] = transport
         return real_client(*args, **kwargs)
 
@@ -113,16 +118,8 @@ def test_invoke_with_custom_timeout() -> None:
     def handler(req: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"model": "test", "choices": []})
 
-    transport = httpx.MockTransport(handler)
-    real_client = httpx.Client
-
-    def _factory(*args, **kwargs):
-        captured_timeout.append(kwargs.get("timeout"))
-        kwargs["transport"] = transport
-        return real_client(*args, **kwargs)
-
     app = AgentsCLI().get_cli()
-    with patch("nemo_agents_plugin.cli.httpx.Client", _factory):
+    with _install_mock_transport(handler, on_create=lambda kw: captured_timeout.append(kw.get("timeout"))):
         result = CliRunner().invoke(
             app,
             ["invoke", "--agent", "calc", "--input", "hi", "--base-url", "http://test", "--timeout", "42"],

--- a/plugins/nemo-agents/tests/unit/test_cli.py
+++ b/plugins/nemo-agents/tests/unit/test_cli.py
@@ -106,6 +106,49 @@ def test_create_aborts_when_default_model_missing(tmp_path, placeholder: str) ->
     assert "nemo setup" in result.stderr
 
 
+def test_invoke_with_custom_timeout() -> None:
+    """--timeout is threaded through to the httpx client."""
+    captured_timeout: list[float | None] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"model": "test", "choices": []})
+
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def _factory(*args, **kwargs):
+        captured_timeout.append(kwargs.get("timeout"))
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    app = AgentsCLI().get_cli()
+    with patch("nemo_agents_plugin.cli.httpx.Client", _factory):
+        result = CliRunner().invoke(
+            app,
+            ["invoke", "--agent", "calc", "--input", "hi", "--base-url", "http://test", "--timeout", "42"],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert captured_timeout[0] == 42.0
+
+
+def test_invoke_timeout_error_message() -> None:
+    """Timeout errors print actionable guidance mentioning --timeout."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("read timed out", request=req)
+
+    app = AgentsCLI().get_cli()
+    with _install_mock_transport(handler):
+        result = CliRunner().invoke(
+            app, ["invoke", "--agent", "calc", "--input", "hi", "--base-url", "http://test", "--timeout", "5"]
+        )
+
+    assert result.exit_code == 1
+    assert "timed out" in result.stderr.lower()
+    assert "--timeout" in result.stderr
+
+
 def test_list_connection_error_prints_request_context_and_hint() -> None:
     def handler(req: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("connection refused", request=req)

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -22,6 +22,7 @@ The mock replicates the async-context-manager chain::
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -328,8 +329,6 @@ class TestProxyByAgentName:
 class TestModelNamePatching:
     def test_unknown_model_replaced_by_agent_name(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         """JSON responses with "unknown-model" get patched to the agent name."""
-        import json
-
         mock_entity_client.get = AsyncMock(return_value=_make_agent("my-agent"))
         dep = _make_deployment(agent="my-agent", status="running", endpoint="http://localhost:9001")
         mock_entity_client.list = AsyncMock(return_value=_list_response([dep]))
@@ -346,11 +345,28 @@ class TestModelNamePatching:
         assert resp.status_code == 200
         data = resp.json()
         assert data["model"] == "my-agent"
+        assert data["choices"] == [{"message": {"content": "hi"}}]
+
+    def test_malformed_json_passed_through(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """Non-JSON response bodies are passed through unmodified."""
+        mock_entity_client.get = AsyncMock(return_value=_make_agent("calc"))
+        dep = _make_deployment(agent="calc", status="running", endpoint="http://localhost:9001")
+        mock_entity_client.list = AsyncMock(return_value=_list_response([dep]))
+
+        garbled = b"this is not json"
+        httpx_mock = _make_httpx_mock(200, garbled, "application/json")
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+                json={"messages": []},
+            )
+
+        assert resp.status_code == 200
+        assert resp.content == garbled
 
     def test_real_model_not_replaced(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         """JSON responses with a real model name are left untouched."""
-        import json
-
         mock_entity_client.get = AsyncMock(return_value=_make_agent("calc"))
         dep = _make_deployment(agent="calc", status="running", endpoint="http://localhost:9001")
         mock_entity_client.list = AsyncMock(return_value=_list_response([dep]))
@@ -386,8 +402,6 @@ class TestModelNamePatching:
 
     def test_deployment_name_used_for_deployment_proxy(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         """Deployment-name proxy path patches model to the deployment name."""
-        import json
-
         dep = _make_deployment(name="calc-v2", status="running", endpoint="http://localhost:9001")
         mock_entity_client.get = AsyncMock(return_value=dep)
 

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -30,7 +30,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from nemo_agents_plugin.api.v2 import gateway as gateway_module
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
-from nemo_agents_plugin.entities import Agent, AgentDeployment
+from nemo_agents_plugin.entities import Agent, AgentDeployment, DeploymentStatus
 from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
 
 # ---------------------------------------------------------------------------
@@ -46,7 +46,7 @@ def _make_deployment(
     name: str = "calc-dep",
     agent: str = "calc",
     workspace: str = "default",
-    status: str = "running",
+    status: DeploymentStatus = "running",
     endpoint: str = "http://localhost:9001",
 ) -> AgentDeployment:
     return AgentDeployment(name=name, workspace=workspace, agent=agent, status=status, endpoint=endpoint)
@@ -318,3 +318,87 @@ class TestProxyByAgentName:
             )
 
         assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# Model name patching — unknown-model → agent/deployment name
+# ---------------------------------------------------------------------------
+
+
+class TestModelNamePatching:
+    def test_unknown_model_replaced_by_agent_name(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """JSON responses with "unknown-model" get patched to the agent name."""
+        import json
+
+        mock_entity_client.get = AsyncMock(return_value=_make_agent("my-agent"))
+        dep = _make_deployment(agent="my-agent", status="running", endpoint="http://localhost:9001")
+        mock_entity_client.list = AsyncMock(return_value=_list_response([dep]))
+
+        body = json.dumps({"model": "unknown-model", "choices": [{"message": {"content": "hi"}}]}).encode()
+        httpx_mock = _make_httpx_mock(200, body, "application/json")
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/agents/my-agent/-/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["model"] == "my-agent"
+
+    def test_real_model_not_replaced(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """JSON responses with a real model name are left untouched."""
+        import json
+
+        mock_entity_client.get = AsyncMock(return_value=_make_agent("calc"))
+        dep = _make_deployment(agent="calc", status="running", endpoint="http://localhost:9001")
+        mock_entity_client.list = AsyncMock(return_value=_list_response([dep]))
+
+        body = json.dumps({"model": "gpt-4o", "choices": []}).encode()
+        httpx_mock = _make_httpx_mock(200, body, "application/json")
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+                json={"messages": []},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "gpt-4o"
+
+    def test_sse_stream_not_patched(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """SSE (event-stream) responses are passed through without model patching."""
+        dep = _make_deployment(status="running", endpoint="http://localhost:9001")
+        mock_entity_client.get = AsyncMock(return_value=dep)
+
+        sse_body = b'data: {"model":"unknown-model","choices":[]}\n\n'
+        httpx_mock = _make_httpx_mock(200, sse_body, "text/event-stream")
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={"messages": [], "stream": True},
+            )
+
+        assert resp.status_code == 200
+        assert b"unknown-model" in resp.content
+
+    def test_deployment_name_used_for_deployment_proxy(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """Deployment-name proxy path patches model to the deployment name."""
+        import json
+
+        dep = _make_deployment(name="calc-v2", status="running", endpoint="http://localhost:9001")
+        mock_entity_client.get = AsyncMock(return_value=dep)
+
+        body = json.dumps({"model": "unknown-model", "choices": []}).encode()
+        httpx_mock = _make_httpx_mock(200, body, "application/json")
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-v2/-/v1/chat/completions",
+                json={"messages": []},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "calc-v2"

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-skill-selection/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-skill-selection/SKILL.md
@@ -49,6 +49,11 @@ Match the user's intent to one downstream skill. Pick exactly one.
 | "status", "what is running", "platform health", "is the platform up", "what's deployed", "show me what's running" | `nemo-status` | Read-only dashboard: platform, agents, providers, models |
 | "shut down", "stop NeMo", "tear down", "clean up" | `nemo-teardown` | Stop the cluster (keep data, delete platform data, or full cleanup) |
 | "fine-tune", "customize the model", "train on my data" | `nemo-fine-tune` | Fine-tuning is not yet available on NeMo Platform. Pick this so the agent tells the user it's not shipped instead of going off to implement training with some other library. |
+| "optimize my agent", "make it cheaper", "reduce latency", "smaller model", "switchyard", "routing split", "compare against a newer model" | `agents-optimize` (plugin-owned, in `plugins/nemo-agents`) | Cost / latency / quality optimization for a **deployed** agent. Routing splits, skill tuning, prompt tuning, new-model scans. |
+| "secure my agent", "harden my agent", "check for PII", "leaked secrets", "guardrail coverage" | `agents-secure` (plugin-owned, in `plugins/nemo-agents`) | Safety and security audit for a **deployed** agent. Guardrails, PII, secrets scan. |
+| "evaluate my agent", "run a benchmark", "eval suite" | `nemo-evaluator` (plugin-owned, in `plugins/nemo-evaluator`) | Evaluation metrics, LLM-judge, benchmark jobs against a deployed agent or model. |
+
+**Optimize vs build:** Do NOT route optimize asks to `nemo-build-agent`. Build is for creating new agents from a spec; optimize is for tuning **already deployed** agents. If the user says "make my agent faster" or "use a cheaper model," that is `agents-optimize`, not `nemo-build-agent`.
 
 If two rows fit, pick the earliest one in the lifecycle (setup before build before try). If nothing matches, ask one disambiguating question with the relevant rows as a numbered list.
 

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-skill-selection/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-skill-selection/SKILL.md
@@ -106,7 +106,14 @@ NeMo Platform skills I can route to:
   nemo-teardown   guided shutdown
   nemo-fine-tune  fine-tuning (not yet shipped; reports that honestly)
 
-Plus plugin-owned skills (guardrails, evaluator, auditor, data-designer, anonymizer, agents-optimize, agents-secure).
+Plugin-owned skills:
+  agents-optimize   cost / latency / quality optimization for a deployed agent
+  agents-secure     safety and security audit for a deployed agent
+  nemo-evaluator    evaluation metrics, LLM-judge, benchmark jobs
+  guardrails        content-safety middleware via virtual models
+  auditor           red-team vulnerability scanning (garak)
+  data-designer     synthetic dataset generation
+  anonymizer        PII handling for datasets
 
 Which one fits what you're trying to do?
 ```


### PR DESCRIPTION
## Summary

Addresses [AALGO-211](https://linear.app/nvidia/issue/AALGO-211) and [AALGO-212](https://linear.app/nvidia/issue/AALGO-212).

- **Invoke timeout** (AALGO-211 ask 1): Add `--timeout` / `-t` flag to `nemo agents invoke` (default 300s, env var `NEMO_AGENTS_INVOKE_TIMEOUT`). Timeout errors now print actionable guidance. SDK default also raised from 120s to 300s.
- **Unknown-model patching** (AALGO-211 ask 2): The agents gateway now patches `"model": "unknown-model"` in non-streaming JSON responses to the agent/deployment name the client addressed. SSE streams pass through unmodified. This is a gateway-level workaround documented in code; the proper upstream fix belongs in nvidia-nat-core.
- **Skill-selection routing** (AALGO-212): Add `agents-optimize`, `agents-secure`, and `nemo-evaluator` rows to the `nemo-skill-selection` decision table in both the platform-ext and SDK copies. Includes an explicit "optimize vs build" disambiguation note and expanded fallback help text.
- **Docs cleanup** (AALGO-211 related): Builder-agent references were already removed from docs on main; confirmed no action needed on this branch.

## Test plan

- [x] `test_invoke_with_custom_timeout` -- verifies `--timeout` threads through to httpx client
- [x] `test_invoke_timeout_error_message` -- verifies timeout errors mention `--timeout` and env var
- [x] `test_unknown_model_replaced_by_agent_name` -- JSON response patching via agent-name proxy
- [x] `test_deployment_name_used_for_deployment_proxy` -- JSON response patching via deployment-name proxy
- [x] `test_real_model_not_replaced` -- real model names left untouched
- [x] `test_malformed_json_passed_through` -- non-JSON bodies pass through unmodified
- [x] `test_sse_stream_not_patched` -- SSE responses bypass model patching
- [x] All 27 unit tests pass (`test_cli.py` + `test_gateway.py`)
- [x] Pre-commit hooks pass (ruff, ruff format, ty, copyright headers)