### PR TITLE
fix(jobs): read subprocess secrets from value field

### DIFF
--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess_runtime.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess_runtime.py
@@ -217,10 +217,10 @@ def _fetch_secret(*, api_base_url: str, principal: Principal | None, workspace: 
     except URLError as exc:
         raise RuntimeError(f"failed to fetch secret {workspace}/{secret_name}: {exc.reason}") from exc
 
-    data = payload.get("data")
-    if not isinstance(data, str):
-        raise RuntimeError(f"failed to fetch secret {workspace}/{secret_name}: missing string data field")
-    return data
+    value = payload.get("value")
+    if not isinstance(value, str):
+        raise RuntimeError(f"failed to fetch secret {workspace}/{secret_name}: missing string value field")
+    return value
 
 
 def _validate_http_url(url: str, field_name: str) -> None:

--- a/services/core/jobs/tests/controllers/test_subprocess_runtime.py
+++ b/services/core/jobs/tests/controllers/test_subprocess_runtime.py
@@ -46,7 +46,7 @@ def test_inject_secret_env_vars():
     }
 
     response = MagicMock()
-    response.read.return_value = json.dumps({"data": "secret-value"}).encode("utf-8")
+    response.read.return_value = json.dumps({"value": "secret-value"}).encode("utf-8")
     response.__enter__.return_value = response
     response.__exit__.return_value = None
 
@@ -58,6 +58,21 @@ def test_inject_secret_env_vars():
     assert request.full_url == "http://secrets.example/apis/secrets/v2/workspaces/default/secrets/hf-token/access"
     assert request.get_header("X-nmp-principal-id") == "service:jobs"
     assert request.get_header("X-nmp-principal-on-behalf-of") == "creator@example.com"
+
+
+def test_inject_secret_env_vars_rejects_missing_value_field():
+    env = {
+        NEMO_JOB_SECRETS_ENVVAR: "HF_TOKEN=default/hf-token",
+        "NMP_SECRETS_URL": "http://secrets.example",
+    }
+    response = MagicMock()
+    response.read.return_value = json.dumps({"data": "secret-value"}).encode("utf-8")
+    response.__enter__.return_value = response
+    response.__exit__.return_value = None
+
+    with patch("nmp.core.jobs.controllers.backends.subprocess_runtime.urlopen", return_value=response):
+        with pytest.raises(RuntimeError, match="missing string value field"):
+            inject_secret_env_vars(env.copy())
 
 
 def test_inject_secret_env_vars_rejects_non_http_secrets_url():


### PR DESCRIPTION
## Summary
- Update subprocess secret injection to read the current secrets access response field, value
- Add coverage that rejects the old data-shaped response so this does not silently regress

## Context
The subprocess executor was introduced in NVIDIA-NeMo/Platform commit aaa45abf6 (#259) when secret access responses used data. The secrets API later renamed data to value in commit c68ea061e (#466), but the subprocess runtime consumer was not updated.

## Validation
- uv run --frozen ruff check services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess_runtime.py services/core/jobs/tests/controllers/test_subprocess_runtime.py
- uv run --frozen --extra cpu ty check services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess_runtime.py services/core/jobs/tests/controllers/test_subprocess_runtime.py
- uv run --frozen pytest services/core/jobs/tests/controllers/test_subprocess_runtime.py -q