### PR TITLE
fix(docs): various docs fixes

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -20,13 +20,13 @@ The {{platform_name}} CLI (`nemo`) is a command-line tool for interacting with {
 ### Install in a Virtual Environment
 
 ```bash
-pip install nemo-platform
+pip install nemo-platform[services]
 ```
 
 Or with uv:
 
 ```bash
-uv pip install nemo-platform
+uv pip install nemo-platform[services]
 ```
 
 !!! warning "When installed in a virtual environment, the `nemo` command is only available when the environment is activated."
@@ -95,7 +95,7 @@ nemo setup
 curl -s http://localhost:8080/health/ready
 
 # View service logs
-cat .nemo-services.log
+cat ~/.local/state/nmp/instances/<scope>/services.log
 
 # Stop services
 pkill -f "nemo services run"

--- a/docs/contributing/skills-spec.md
+++ b/docs/contributing/skills-spec.md
@@ -101,7 +101,7 @@ Every skill ships with the following YAML frontmatter at the top of `SKILL.md`. 
 
 Library-prefix naming (`nemo-*`) is required for user-invocable skills (skills install into shared agent catalogs alongside skills from other plugins; the prefix prevents collisions). It's optional for internal helpers.
 
-**Canonical location:** `packages/nemo_platform_ext/src/nemo_platform_ext/skills/<name>/`. Skills there ship with `pip install nemo-platform`.
+**Canonical location:** `packages/nemo_platform_ext/src/nemo_platform_ext/skills/<name>/`. Skills there ship with `pip install nemo-platform[services]`.
 
 ---
 

--- a/docs/customizer/tutorials/_snippets/customizer-prereqs.md
+++ b/docs/customizer/tutorials/_snippets/customizer-prereqs.md
@@ -6,7 +6,7 @@
     Before starting, make sure you have:
 
     - {{platform_name}} installed and deployed (see [Setup](../../get-started/setup.md))
-    - The `nemo-platform` Python SDK installed (`pip install nemo-platform`)
+    - The `nemo-platform` Python SDK installed (`pip install nemo-platform[services]`)
     - (Optional) Weights & Biases account and API key for enhanced visualization
 
     **Set up environment variables:**

--- a/docs/customizer/tutorials/distillation-customization-job.ipynb
+++ b/docs/customizer/tutorials/distillation-customization-job.ipynb
@@ -67,7 +67,7 @@
         "Before starting this tutorial, ensure you have:\n",
         "\n",
         "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-        "2. **Installed the Python SDK** (included with `pip install nemo-platform`)\n",
+        "2. **Installed the Python SDK** (included with `pip install nemo-platform[services]`)\n",
         "3. **Installed evaluation dependencies:**\n",
         "\n",
         "```sh\n",

--- a/docs/customizer/tutorials/dpo-customization-job.ipynb
+++ b/docs/customizer/tutorials/dpo-customization-job.ipynb
@@ -59,7 +59,7 @@
         "Before starting this tutorial, ensure you have:\n",
         "\n",
         "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-        "2. **Installed the Python SDK** (included with `pip install nemo-platform`)"
+        "2. **Installed the Python SDK** (included with `pip install nemo-platform[services]`)"
       ]
     },
     {

--- a/docs/customizer/tutorials/embedding-customization-job.ipynb
+++ b/docs/customizer/tutorials/embedding-customization-job.ipynb
@@ -49,7 +49,7 @@
     "Before starting this tutorial, ensure you have:\n",
     "\n",
     "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-    "2. **Installed the Python SDK** (included with `pip install nemo-platform`)\n",
+    "2. **Installed the Python SDK** (included with `pip install nemo-platform[services]`)\n",
     "3. **HuggingFace token** with read access to download the SPECTER dataset (get one at [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens))\n",
     "4. **NGC API key** to pull NIM container images from nvcr.io (get one at [ngc.nvidia.com](https://ngc.nvidia.com/) → Setup → Generate API Key)"
    ]

--- a/docs/customizer/tutorials/lora-customization-job.ipynb
+++ b/docs/customizer/tutorials/lora-customization-job.ipynb
@@ -25,7 +25,7 @@
     "Before starting this tutorial, ensure you have:\n",
     "\n",
     "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-    "2. **Installed the Python SDK** (included with `pip install nemo-platform`)\n",
+    "2. **Installed the Python SDK** (included with `pip install nemo-platform[services]`)\n",
     "3. **Installed the `datasets` package** for loading SQuAD: `pip install datasets`\n",
     "4. **At least one GPU with CUDA 12.8+**\n"
    ]

--- a/docs/customizer/tutorials/optimize-throughput.ipynb
+++ b/docs/customizer/tutorials/optimize-throughput.ipynb
@@ -29,7 +29,7 @@
         "Before starting this tutorial, ensure you have:\n",
         "\n",
         "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-        "2. **Installed the Python SDK** (included with `pip install nemo-platform`)"
+        "2. **Installed the Python SDK** (included with `pip install nemo-platform[services]`)"
       ]
     },
     {

--- a/docs/customizer/tutorials/sft-customization-job.ipynb
+++ b/docs/customizer/tutorials/sft-customization-job.ipynb
@@ -58,7 +58,7 @@
         "Before starting this tutorial, ensure you have:\n",
         "\n",
         "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-        "2. **Installed the Python SDK** (included with `pip install nemo-platform`)"
+        "2. **Installed the Python SDK** (included with `pip install nemo-platform[services]`)"
       ]
     },
     {

--- a/docs/evaluator/tutorials/run-llm-judge-evaluation.md
+++ b/docs/evaluator/tutorials/run-llm-judge-evaluation.md
@@ -1,7 +1,7 @@
 <!-- @nemo-nb: process -->
 <!-- @nemo-nb: download -->
 <!-- @nemo-nb: skip-test -->
-<!-- TODO: Contains %%bash cell that runs `pip install nemo-platform` and `nemo setup` — incompatible with sandboxed test execution. Refactor to use SDK directly. -->
+<!-- TODO: Contains %%bash cell that runs `pip install nemo-platform[services]` and `nemo setup` — incompatible with sandboxed test execution. Refactor to use SDK directly. -->
 <!--
 ```python
 # @nemo-nb: hide
@@ -41,7 +41,7 @@ This tutorial shows you how to build, validate, and iterate on LLM judge metrics
 1. Install and start {{platform_name}} using the [Setup guide](../../get-started/setup.md).
 
 ```bash
-! pip install nemo-platform
+! pip install nemo-platform[services]
 ! nemo setup
 ```
 

--- a/docs/example-applications/tool-calling.ipynb
+++ b/docs/example-applications/tool-calling.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "Before starting this tutorial, ensure you have:\n",
     "\n",
-    "1. **Installed the Python SDK with the Data Designer extra** (`uv pip install nemo-platform[data-designer]`)\n",
+    "1. **Installed the Python SDK with the Data Designer extra** (`uv pip install nemo-platform[services]`)\n",
     "1. **Completed the [Quickstart](../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
     "1. (Optional if running outside of Quickstart) **Authenticated with the platform** using the CLI:\n",
     "   ```bash\n",

--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -172,11 +172,11 @@ An asynchronous client is also available. See the [SDK reference](../pysdk/index
 
 ### Platform won't start
 
-Check `.nemo-services.log` in the directory where you ran `nemo setup`. The most common cause is port 8080 already in use.
+Check `~/.local/state/nmp/instances/<scope>/services.log` in the directory where you ran `nemo setup`. The most common cause is port 8080 already in use.
 
 ### Studio returns 404 or unavailable
 
-Studio requires the FastAPI web assets built by `make bootstrap-studio`. If `make bootstrap` warned that Studio asset bootstrap did not complete, install Node.js with pnpm using `pnpm env use --global 22.18.0`, then rerun `make bootstrap-studio` from the repository root.
+Studio requires the FastAPI web assets built by `make bootstrap-studio`. If `make bootstrap` warned that Studio asset bootstrap did not complete, install Node.js with pnpm using `pnpm env use --global 22.18.0`, then rerun `make bootstrap-studio` and `nemo services restart` from the repository root.
 
 ### No models discovered
 
@@ -204,6 +204,6 @@ nemo services run
 
 ```bash
 curl -s http://localhost:8080/health/ready   # check if running
-cat .nemo-services.log                 # view service output
+cat ~/.local/state/nmp/instances/<scope>/services.log                 # view service output
 pkill -f "nemo services run"           # stop all services
 ```

--- a/docs/pysdk/index.md
+++ b/docs/pysdk/index.md
@@ -8,7 +8,7 @@ The [{{platform_name}} Python SDK](https://pypi.org/project/nemo-platform/) is a
 Install the {{platform_name}} Python SDK using `pip`:
 
 ```bash
-pip install nemo-platform
+pip install nemo-platform[services]
 ```
 
 !!! note "This project will download and install additional third-party open source software projects. Review the license terms of these open source projects before use."

--- a/docs/safe-synthesizer/tutorials/differential-privacy.md
+++ b/docs/safe-synthesizer/tutorials/differential-privacy.md
@@ -61,9 +61,9 @@ Install the {{platform_name}} SDK with Safe Synthesizer support:
 
 ```shell
 if command -v uv &> /dev/null; then
- uv pip install nemo-platform[safe-synthesizer] kagglehub matplotlib
+ uv pip install nemo-platform[services] kagglehub matplotlib
 else
- pip install nemo-platform[safe-synthesizer] kagglehub matplotlib
+ pip install nemo-platform[services] kagglehub matplotlib
 fi
 ```
 

--- a/docs/safe-synthesizer/tutorials/index.md
+++ b/docs/safe-synthesizer/tutorials/index.md
@@ -10,7 +10,7 @@ Before starting any tutorial, ensure you have:
 - [{{nss_short_name}} deployed](../getting-started.md) using Docker Compose or Helm
 - Python environment with `nemo-platform` SDK installed:
  ```bash
- pip install nemo-platform[safe-synthesizer]
+ pip install nemo-platform[services]
  ```
 - Jupyter environment for running tutorial notebooks
 

--- a/docs/safe-synthesizer/tutorials/safe-synthesizer-101.md
+++ b/docs/safe-synthesizer/tutorials/safe-synthesizer-101.md
@@ -33,9 +33,9 @@ Install the {{platform_name}} SDK with Safe Synthesizer support. Run the followi
 
 ```shell
 if command -v uv &> /dev/null; then
- uv pip install nemo-platform[safe-synthesizer] kagglehub matplotlib
+ uv pip install nemo-platform[services] kagglehub matplotlib
 else
- pip install nemo-platform[safe-synthesizer] kagglehub matplotlib
+ pip install nemo-platform[services] kagglehub matplotlib
 fi
 ```
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -19,7 +19,7 @@ Docker Compose, Helm, Kubernetes, and OpenShift deployment paths are not part of
 
 | Area | Supported | Notes |
 |------|-----------|-------|
-| Package installation | `uv` recommended; `pip` supported | The one-line installer sets up `uv` automatically. Published packages can also be installed with `pip install nemo-platform`. |
+| Package installation | `uv` recommended; `pip` supported | The one-line installer sets up `uv` automatically. Published packages can also be installed with `pip install nemo-platform[services]`. |
 | Shell | Bash or zsh | Used by the installer, setup commands, and documented examples. |
 | Browser | Current Chrome, Edge, Firefox, or Safari | Required for the Studio UI and generated documentation. |
 

--- a/docs/troubleshooting/data-designer.md
+++ b/docs/troubleshooting/data-designer.md
@@ -27,11 +27,11 @@ nemo setup
 
 ## Check Service Logs
 
-Local setup writes service output to `.nemo-services.log` in the directory where services were started.
+Local setup writes service output to `~/.local/state/nmp/instances/<scope>/services.log` in the directory where services were started.
 
 ```bash
-tail -n 200 .nemo-services.log
-tail -f .nemo-services.log
+tail -n 200 ~/.local/state/nmp/instances/<scope>/services.log
+tail -f ~/.local/state/nmp/instances/<scope>/services.log
 ```
 
 Look for startup errors, provider authentication failures, port conflicts, or Data Designer request failures.

--- a/packages/nemo_platform/README.md
+++ b/packages/nemo_platform/README.md
@@ -1,6 +1,6 @@
 # nemo-platform
 
-Wrapper distribution for NeMo Platform. When users run `pip install nemo-platform`, this is the wheel they get.
+Wrapper distribution for NeMo Platform. When users run `pip install nemo-platform[services]`, this is the wheel they get.
 
 The wheel bundles the SDK, shared runtime packages, default first-party plugins, and services directly from source via hatch force-include. As sub-packages are published independently to PyPI, they'll be removed from the bundle and added as normal dependencies instead.
 
@@ -121,7 +121,7 @@ To publish a bundled package independently:
 2. Add it as a normal dependency in `[project.dependencies]` (or in the appropriate optional group)
 3. Run `make vendor` to regenerate the dependency groups
 
-The wheel gets thinner, the dependency metadata stays correct, and `pip install nemo-platform` continues to work.
+The wheel gets thinner, the dependency metadata stays correct, and `pip install nemo-platform[services]` continues to work.
 
 ## Other vendoring (`make vendor`)
 

--- a/packages/nemo_platform_ext/pyproject.toml
+++ b/packages/nemo_platform_ext/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://docs.nvidia.com/nemo/microservices/latest/about/index.html"
+Homepage = "https://nvidia-nemo.github.io/nemo-platform/main/"
 
 [dependency-groups]
 dev = [

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/app.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/app.py
@@ -220,7 +220,7 @@ def main(
     """
     Command-line interface for NeMo Platform.
 
-    :books: Documentation: https://docs.nvidia.com/nemo/microservices/latest/about/index.html
+    :books: Documentation: https://nvidia-nemo.github.io/nemo-platform/main/
 
     [green]Getting started:[/]
     - Browse documentation with [cyan]`nemo docs --list`[/]

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -123,7 +123,7 @@ _KNOWN_PROVIDERS_BY_NAME: dict[str, KnownProvider] = {p.name: p for p in KNOWN_P
 # ---------------------------------------------------------------------------
 
 
-_NEMO_DOCS_URL = "https://docs.nvidia.com/nemo/platform"
+_NEMO_DOCS_URL = "https://nvidia-nemo.github.io/nemo-platform/main/"
 
 
 @dataclass(frozen=True)

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -2307,7 +2307,7 @@ class TestRenderOnboardingCard:
         panel = mock_console.print.call_args_list[0].args[0]
         content = panel.renderable
         assert "What can I do with NeMo Platform?" in content
-        assert "docs.nvidia.com/nemo/platform" in content
+        assert "nvidia-nemo.github.io/nemo-platform" in content
 
     def test_unknown_value_is_silently_skipped(self):
         with patch(f"{SETUP_MOD}.console") as mock_console:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/README.md
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/README.md
@@ -33,11 +33,11 @@ Every surface class requires a non-empty `name: ClassVar[str]`. Checked at class
 
 ## Next steps
 
-- [QUICKSTART.md](docs/QUICKSTART.md) — build your first plugin end-to-end
-- [SERVICE.md](docs/SERVICE.md) — HTTP routes, CRUD patterns, testing
-- [JOB.md](docs/JOB.md) — jobs, CLI commands, auto-generated job commands
-- [CONTROLLER.md](docs/CONTROLLER.md) — reconcile loops, state machines, service principal
-- [CONFIG.md](docs/CONFIG.md) — typed configuration, env vars, YAML, test overrides
-- [ENTITY.md](docs/ENTITY.md) — entity store, CRUD client, pagination, optimistic locking
-- [INFERENCE_MIDDLEWARE.md](docs/INFERENCE_MIDDLEWARE.md) — inference request/response middleware, typed bodies, and response annotations
-- [ARCHITECTURE.md](docs/ARCHITECTURE.md) — discovery, startup, all surfaces, SDK surface
+- [QUICKSTART.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/QUICKSTART.md) — build your first plugin end-to-end
+- [SERVICE.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/SERVICE.md) — HTTP routes, CRUD patterns, testing
+- [JOB.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/JOB.md) — jobs, CLI commands, auto-generated job commands
+- [CONTROLLER.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/CONTROLLER.md) — reconcile loops, state machines, service principal
+- [CONFIG.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/CONFIG.md) — typed configuration, env vars, YAML, test overrides
+- [ENTITY.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/ENTITY.md) — entity store, CRUD client, pagination, optimistic locking
+- [INFERENCE_MIDDLEWARE.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/INFERENCE_MIDDLEWARE.md) — inference request/response middleware, typed bodies, and response annotations
+- [ARCHITECTURE.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/ARCHITECTURE.md) — discovery, startup, all surfaces, SDK surface

--- a/sdk/python/nemo-platform/README.md
+++ b/sdk/python/nemo-platform/README.md
@@ -18,7 +18,7 @@ The [NVIDIA NeMo Platform APIs](https://docs.nvidia.com/nemo/microservices/lates
 This project downloads and installs additional third-party open source software projects. Review the license terms of these open source projects before use.
 
 ```sh
-pip install nemo-platform
+pip install nemo-platform[services]
 ```
 
 ## Usage

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/app.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/app.py
@@ -220,7 +220,7 @@ def main(
     """
     Command-line interface for NeMo Platform.
 
-    :books: Documentation: https://docs.nvidia.com/nemo/microservices/latest/about/index.html
+    :books: Documentation: https://nvidia-nemo.github.io/nemo-platform/main/
 
     [green]Getting started:[/]
     - Browse documentation with [cyan]`nemo docs --list`[/]

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
@@ -123,7 +123,7 @@ _KNOWN_PROVIDERS_BY_NAME: dict[str, KnownProvider] = {p.name: p for p in KNOWN_P
 # ---------------------------------------------------------------------------
 
 
-_NEMO_DOCS_URL = "https://docs.nvidia.com/nemo/platform"
+_NEMO_DOCS_URL = "https://nvidia-nemo.github.io/nemo-platform/main/"
 
 
 @dataclass(frozen=True)

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
@@ -2307,7 +2307,7 @@ class TestRenderOnboardingCard:
         panel = mock_console.print.call_args_list[0].args[0]
         content = panel.renderable
         assert "What can I do with NeMo Platform?" in content
-        assert "docs.nvidia.com/nemo/platform" in content
+        assert "nvidia-nemo.github.io/nemo-platform" in content
 
     def test_unknown_value_is_silently_skipped(self):
         with patch(f"{SETUP_MOD}.console") as mock_console:

--- a/sdk/python/overrides/nemo-platform/README/02_installation.md
+++ b/sdk/python/overrides/nemo-platform/README/02_installation.md
@@ -3,5 +3,5 @@
 This project downloads and installs additional third-party open source software projects. Review the license terms of these open source projects before use.
 
 ```sh
-pip install nemo-platform
+pip install nemo-platform[services]
 ```

--- a/services/core/mcp/README.md
+++ b/services/core/mcp/README.md
@@ -187,4 +187,4 @@ async def my_tool(param: str) -> dict[str, Any]:
 
 - [MCP Specification](https://modelcontextprotocol.io/specification/2025-11-25)
 - [FastMCP Documentation](https://gofastmcp.com/)
-- [NeMo Platform Docs](https://docs.nvidia.com/nemo/microservices/latest/)
+- [NeMo Platform Docs](https://nvidia-nemo.github.io/nemo-platform/main/)

--- a/services/core/mcp/src/nmp/core/mcp/server.py
+++ b/services/core/mcp/src/nmp/core/mcp/server.py
@@ -48,7 +48,7 @@ def create_server(base_url: str | None = None) -> FastMCP:
     # Initialize platform aggregator
     platform = FastMCP(
         "NeMo Platform",
-        website_url="https://docs.nvidia.com/nemo/microservices/latest/about/index.html",
+        website_url="https://nvidia-nemo.github.io/nemo-platform/main/",
     )
 
     # Mount per service MCP servers

--- a/services/studio/src/nmp/studio/service.py
+++ b/services/studio/src/nmp/studio/service.py
@@ -256,9 +256,10 @@ class StudioService(Service[StudioConfig]):
       <p>The platform is running, but Studio cannot be served because the built web assets were not found.</p>
       <p>Requested path: <code>{escape(route)}</code></p>
       <p>Expected assets at: <code>{escape(str(static_path))}</code></p>
-      <p>Install Node.js matching <code>web/package.json</code> with pnpm, and rebuild Studio:</p>
+      <p>Install Node.js matching <code>web/package.json</code> with pnpm, rebuild Studio, and restart services:</p>
       <pre>pnpm env use --global 22.18.0
-make bootstrap-studio</pre>
+make bootstrap-studio
+nemo services restart</pre>
     </main>
   </body>
 </html>


### PR DESCRIPTION
1. Update to new docs link everywhere except Studio and generated SDK.
2. Default documentation to `pip install nemo-platform[services]` everywhere.
3. Update services log location.
4. Update Studio troubleshooting steps.
5. Fix broken relative links on nemo-platform-plugin PyPI page.