### PR TITLE
build: fix the generated docs on PRs to have the right link

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,6 @@ permissions:
 
 env:
   PAGES_BRANCH: gh-pages
-  DOCS_PREVIEW_BASE_URL: https://jubilant-adventure-g4rv38m.pages.github.io
 
 jobs:
   build:
@@ -235,16 +234,24 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Resolve GitHub Pages URL
+        id: pages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PAGES_URL=$(gh api "repos/${GITHUB_REPOSITORY}/pages" --jq .html_url)
+          echo "url=${PAGES_URL%/}/" >> "$GITHUB_OUTPUT"
+
       - name: Deploy PR preview
         env:
-          PAGES_URL: ${{ env.DOCS_PREVIEW_BASE_URL }}/
+          PAGES_URL: ${{ steps.pages.outputs.url }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: make -C docs deploy-pr-preview PR_NUMBER="${PR_NUMBER}" PR_PREVIEW_SITE_URL="${PAGES_URL}pr-preview/pr-${PR_NUMBER}/"
 
       - name: Add PR preview comment
         uses: actions/github-script@v7
         env:
-          PREVIEW_URL: ${{ env.DOCS_PREVIEW_BASE_URL }}/pr-preview/pr-${{ github.event.pull_request.number }}/pr-${{ github.event.pull_request.number }}/
+          PREVIEW_URL: ${{ steps.pages.outputs.url }}pr-preview/pr-${{ github.event.pull_request.number }}/pr-${{ github.event.pull_request.number }}/
         with:
           script: |
             const marker = '<!-- docs-preview-url -->';


### PR DESCRIPTION
Currently the link on our preview is broken with the move. Since we're public we can just use the regular URL.

Example broken link
<img width="911" height="264" alt="Screenshot 2026-05-25 at 5 26 16 PM" src="https://github.com/user-attachments/assets/6cb60e00-13c8-4f87-be0f-df7da161893f" />
