### PR TITLE
refactor(plugins): re-route nmp.common job imports (ASTD-166)

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/job.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/job.py
@@ -70,11 +70,12 @@ import logging
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin._base import _NamedPlugin
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from nemo_platform_plugin.job_context import JobContext
-    from pydantic import BaseModel
 
 
 logger = logging.getLogger(__name__)
@@ -226,7 +227,7 @@ class NemoJob(_NamedPlugin):
         *,
         workspace: str,
         entity_client: object,
-        async_sdk: object,
+        async_sdk: AsyncNeMoPlatform,
         is_local: bool,
     ) -> "BaseModel":
         """Transform *input_spec* into a canonical :attr:`spec_schema` instance.
@@ -271,7 +272,7 @@ class NemoJob(_NamedPlugin):
         spec: "BaseModel",
         entity_client: object,
         job_name: str | None,
-        async_sdk: object,
+        async_sdk: AsyncNeMoPlatform,
         profile: str | None = None,
         options: dict | None = None,
     ) -> object:

--- a/packages/nemo_platform_plugin/tests/test_scheduler.py
+++ b/packages/nemo_platform_plugin/tests/test_scheduler.py
@@ -22,10 +22,11 @@ Phase 1 wires :meth:`NemoJobScheduler.run_local`, :meth:`submit_remote`, and
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import pytest
+from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import LocalJobResults
@@ -721,7 +722,7 @@ class TestCompileMarker:
                     spec=_DummySpec(),
                     entity_client=None,
                     job_name=None,
-                    async_sdk=None,
+                    async_sdk=cast(AsyncNeMoPlatform, None),
                 )
             )
 

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/jobs/run.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/jobs/run.py
@@ -32,8 +32,8 @@ from nemo_platform_plugin.jobs.api_factory import (
     PlatformJobSpec,
     PlatformJobStep,
 )
-from nmp.common.jobs.constants import DEFAULT_JOB_STORAGE_PATH, PERSISTENT_JOB_STORAGE_PATH_ENVVAR
-from nmp.common.jobs.exceptions import PlatformJobCompilationError
+from nemo_platform_plugin.jobs.constants import DEFAULT_JOB_STORAGE_PATH, PERSISTENT_JOB_STORAGE_PATH_ENVVAR
+from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from nmp.common.jobs.image import get_qualified_image
 from pydantic import BaseModel
 

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/tasks/anonymizer/run.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/tasks/anonymizer/run.py
@@ -22,7 +22,7 @@ from nemo_anonymizer_plugin.app.upstream_logging import preserve_root_logging
 from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import PlatformJobResults
-from nmp.common.jobs.constants import (
+from nemo_platform_plugin.jobs.constants import (
     EPHEMERAL_TASK_STORAGE_PATH_ENVVAR,
     NEMO_JOB_ID_ENVVAR,
     NEMO_JOB_STEP_CONFIG_FILE_PATH_ENVVAR,

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
@@ -21,7 +21,7 @@ from nemo_platform_plugin.jobs.api_factory import (
     PlatformJobSpec,
     PlatformJobStep,
 )
-from nmp.common.jobs.exceptions import PlatformJobCompilationError
+from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from nmp.common.jobs.image import get_qualified_image
 from pydantic import BaseModel
 


### PR DESCRIPTION
## Summary

Phase A of slimming `nmp-common` in plugin installs (ASTD-166, follow-up to ASTD-165).

- Swap `nmp.common.jobs.{constants,exceptions}` imports to direct `nemo_platform_plugin.jobs.{constants,exceptions}` imports. `nmp.common` re-exports these unchanged — routing through it is dead indirection.
- Tighten `NemoJob.to_spec` / `NemoJob.compile` base signatures: `async_sdk: object` → `async_sdk: AsyncNeMoPlatform`. Resolves Liskov override violations every concrete subclass previously hit. `nemo-platform-plugin` already depends on `nemo-platform-sdk` so the new import has no cycle.
- Cast `async_sdk=None` in `test_scheduler.py`'s `NotImplementedError` guard test (base raises before reading the arg).

**No install-footprint change** — plugins still depend on `nmp-common` for `image.get_qualified_image` + `sdk_factory.get_platform_sdk`. Phase B (move `get_qualified_image` into `nemo_platform_plugin.jobs.image`) and Phase C (add slim `get_platform_sdk` to `nemo_platform_plugin`) will move those + drop the dep entirely. Estimated 50-70 MB per plugin install once complete.

## Test plan

- [x] `uv run --frozen ty check <touched files>` — All checks passed
- [x] Full-repo `ty check` count: 183 → 181 (net -2, no new errors elsewhere)
- [x] `uv run --frozen pytest packages/nemo_platform_plugin/tests plugins/nemo-anonymizer/tests plugins/nemo-data-designer/tests` — 772 passed, 1 skipped
- [x] pre-commit hooks (ruff format / ty / copyright headers) green