### PR TITLE
feat(studio): Improve file support on preview panel and fix header

### DIFF
--- a/web/packages/common/src/components/CodeEditor/extensions/useLinter.spec.ts
+++ b/web/packages/common/src/components/CodeEditor/extensions/useLinter.spec.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ContentType } from '@nemo/common/src/components/CodeEditor/constants';
+import { getLinterExtension } from '@nemo/common/src/components/CodeEditor/extensions/useLinter';
+import { jsonlLinter, jsonLinter } from '@nemo/common/src/components/CodeEditor/linters/JsonLinter';
+import { yamlLinter } from '@nemo/common/src/components/CodeEditor/linters/yaml';
+
+describe('getLinterExtension', () => {
+  it('returns the JSON linter for ContentType.JSON', () => {
+    expect(getLinterExtension(ContentType.JSON, false)).toBe(jsonLinter);
+  });
+
+  it('returns the JSONL linter for ContentType.JSONL', () => {
+    expect(getLinterExtension(ContentType.JSONL, false)).toBe(jsonlLinter);
+  });
+
+  it('returns the YAML linter for ContentType.YAML', () => {
+    expect(getLinterExtension(ContentType.YAML, false)).toBe(yamlLinter);
+  });
+
+  it('returns no linter for ContentType.TEXT (prevents spurious JSON diagnostics on .txt/.log files)', () => {
+    expect(getLinterExtension(ContentType.TEXT, false)).toEqual([]);
+  });
+
+  it('returns no linter for ContentType.JAVASCRIPT', () => {
+    expect(getLinterExtension(ContentType.JAVASCRIPT, false)).toEqual([]);
+  });
+
+  it('returns no linter when hideLinter is true, regardless of contentType', () => {
+    expect(getLinterExtension(ContentType.JSON, true)).toEqual([]);
+    expect(getLinterExtension(ContentType.JSONL, true)).toEqual([]);
+    expect(getLinterExtension(ContentType.YAML, true)).toEqual([]);
+  });
+});

--- a/web/packages/common/src/components/CodeEditor/extensions/useLinter.ts
+++ b/web/packages/common/src/components/CodeEditor/extensions/useLinter.ts
@@ -26,7 +26,7 @@ export function useLinter(view: EditorView | null, contentType: ContentType, hid
   return extension;
 }
 
-const getLinterExtension = (contentType: ContentType, hideLinter: boolean): Extension => {
+export const getLinterExtension = (contentType: ContentType, hideLinter: boolean): Extension => {
   if (hideLinter) return [];
   switch (contentType) {
     case ContentType.YAML:
@@ -35,7 +35,8 @@ const getLinterExtension = (contentType: ContentType, hideLinter: boolean): Exte
       return jsonLinter;
     case ContentType.JSONL:
       return jsonlLinter;
+    case ContentType.TEXT:
     default:
-      return jsonLinter;
+      return [];
   }
 };

--- a/web/packages/common/src/components/FileContentPreview/FileContentPreview.spec.tsx
+++ b/web/packages/common/src/components/FileContentPreview/FileContentPreview.spec.tsx
@@ -4,16 +4,44 @@
 import { FileContentPreview } from '@nemo/common/src/components/FileContentPreview/index';
 import { render, screen } from '@testing-library/react';
 
+// Mock CodeEditor: avoids ToastProvider requirement and lets us assert
+// branch dispatch (contentType, hideCopyButton, content) directly.
+vi.mock('@nemo/common/src/components/CodeEditor', () => ({
+  CodeEditor: ({
+    content,
+    contentType,
+    hideCopyButton,
+  }: {
+    content: string;
+    contentType: string;
+    hideCopyButton?: boolean;
+  }) => (
+    <div
+      data-testid="code-editor"
+      data-content-type={contentType}
+      data-hide-copy-button={hideCopyButton ? 'true' : 'false'}
+    >
+      {content}
+    </div>
+  ),
+}));
+
+// Mock MarkdownContent so we can assert the markdown branch without exercising
+// the real react-markdown pipeline.
+vi.mock('@nemo/common/src/components/MarkdownContent', () => ({
+  MarkdownContent: ({ content }: { content: string }) => (
+    <div data-testid="markdown-content">{content}</div>
+  ),
+}));
+
 // Mock papaparse
 vi.mock('papaparse', () => ({
   default: {
     parse: vi.fn((content: string) => {
-      // Simple CSV parser mock
       const lines = content.trim().split('\n');
       if (lines.length === 0) {
         return { data: [], meta: { fields: [] }, errors: [] };
       }
-
       const headers = lines[0].split(',');
       const data = lines.slice(1).map((line) => {
         const values = line.split(',');
@@ -23,12 +51,7 @@ vi.mock('papaparse', () => ({
         });
         return row;
       });
-
-      return {
-        data,
-        meta: { fields: headers },
-        errors: [],
-      };
+      return { data, meta: { fields: headers }, errors: [] };
     }),
   },
 }));
@@ -36,193 +59,168 @@ vi.mock('papaparse', () => ({
 describe('FileContentPreview', () => {
   const defaultFile = { path: 'test.txt', url: '' };
 
-  describe('loading state', () => {
+  describe('loading / error / empty states', () => {
     it('renders spinner when loading', () => {
       render(<FileContentPreview file={defaultFile} isLoading error={null} content={undefined} />);
-
       expect(screen.getByLabelText('Loading...')).toBeInTheDocument();
     });
-  });
 
-  describe('error state', () => {
     it('renders error message when error is provided', () => {
-      const error = new Error('Failed to fetch file');
-
-      render(<FileContentPreview file={defaultFile} isLoading={false} error={error} />);
-
+      render(
+        <FileContentPreview
+          file={defaultFile}
+          isLoading={false}
+          error={new Error('Failed to fetch file')}
+        />
+      );
       expect(screen.getByText('Error: Failed to fetch file')).toBeInTheDocument();
     });
 
-    it('renders generic error message when error has no message', () => {
+    it('renders fallback message when error has no message', () => {
       const error = new Error();
       error.message = '';
-
       render(<FileContentPreview file={defaultFile} isLoading={false} error={error} />);
-
       expect(screen.getByText('Error: Failed to load file')).toBeInTheDocument();
     });
-  });
 
-  describe('no content state', () => {
-    it('renders "No content available" when content is undefined', () => {
-      render(
+    it('renders "No content available" when content is missing or empty', () => {
+      const { rerender } = render(
         <FileContentPreview file={defaultFile} isLoading={false} error={null} content={undefined} />
       );
-
       expect(screen.getByText('No content available')).toBeInTheDocument();
-    });
 
-    it('renders "No content available" when content is empty string', () => {
-      render(<FileContentPreview file={defaultFile} isLoading={false} error={null} content="" />);
-
+      rerender(<FileContentPreview file={defaultFile} isLoading={false} error={null} content="" />);
       expect(screen.getByText('No content available')).toBeInTheDocument();
     });
   });
 
-  describe('JSON files', () => {
-    it('renders JSON content with CodeSnippet', () => {
-      const jsonFile = { path: 'data.json', url: '' };
-      const content = '{"key": "value"}';
-
+  describe('JSON / JSONL dispatch', () => {
+    it('routes .json through CodeEditor with contentType=json', () => {
       render(
-        <FileContentPreview file={jsonFile} isLoading={false} error={null} content={content} />
+        <FileContentPreview
+          file={{ path: 'data.json' }}
+          isLoading={false}
+          error={null}
+          content='{"key": "value"}'
+        />
       );
-
-      // CodeSnippet should render the content
-      expect(screen.getByText('{"key": "value"}')).toBeInTheDocument();
+      const editor = screen.getByTestId('code-editor');
+      expect(editor).toHaveAttribute('data-content-type', 'json');
+      expect(editor).toHaveTextContent('{"key": "value"}');
     });
 
-    it('renders JSONL content with CodeSnippet', () => {
-      const jsonlFile = { path: 'data.jsonl', url: '' };
-      const content = '{"line": 1}\n{"line": 2}';
-
+    it('routes .jsonl through CodeEditor with contentType=jsonl', () => {
       render(
-        <FileContentPreview file={jsonlFile} isLoading={false} error={null} content={content} />
+        <FileContentPreview
+          file={{ path: 'data.jsonl' }}
+          isLoading={false}
+          error={null}
+          content={'{"line": 1}\n{"line": 2}'}
+        />
       );
+      const editor = screen.getByTestId('code-editor');
+      expect(editor).toHaveAttribute('data-content-type', 'jsonl');
+      expect(editor).toHaveTextContent('{"line": 1}');
+    });
 
-      // Verify CodeSnippet renders with the content
-      const codeSnippet = screen.getByTestId('nv-code-snippet-root');
-      expect(codeSnippet).toBeInTheDocument();
-      expect(codeSnippet).toHaveTextContent('{"line": 1}');
-      expect(codeSnippet).toHaveTextContent('{"line": 2}');
+    it('handles nested file paths', () => {
+      render(
+        <FileContentPreview
+          file={{ path: 'folder/subfolder/data.json' }}
+          isLoading={false}
+          error={null}
+          content='{"nested": true}'
+        />
+      );
+      expect(screen.getByTestId('code-editor')).toHaveAttribute('data-content-type', 'json');
+    });
+  });
+
+  describe('Markdown dispatch', () => {
+    it('routes .md through MarkdownContent', () => {
+      render(
+        <FileContentPreview
+          file={{ path: 'README.md' }}
+          isLoading={false}
+          error={null}
+          content="# Heading"
+        />
+      );
+      const md = screen.getByTestId('markdown-content');
+      expect(md).toHaveTextContent('# Heading');
+      expect(screen.queryByTestId('code-editor')).toBeNull();
+    });
+
+    it('routes .markdown through MarkdownContent', () => {
+      render(
+        <FileContentPreview
+          file={{ path: 'notes.markdown' }}
+          isLoading={false}
+          error={null}
+          content="text"
+        />
+      );
+      expect(screen.getByTestId('markdown-content')).toHaveTextContent('text');
     });
   });
 
   describe('CSV files', () => {
     it('renders CSV content in a table', () => {
-      const csvFile = { path: 'data.csv', url: '' };
-      const content = 'name,age\nAlice,30\nBob,25';
-
       render(
-        <FileContentPreview file={csvFile} isLoading={false} error={null} content={content} />
+        <FileContentPreview
+          file={{ path: 'data.csv' }}
+          isLoading={false}
+          error={null}
+          content={'name,age\nAlice,30\nBob,25'}
+        />
       );
-
-      // Table headers
       expect(screen.getByText('name')).toBeInTheDocument();
       expect(screen.getByText('age')).toBeInTheDocument();
-
-      // Table data
       expect(screen.getByText('Alice')).toBeInTheDocument();
       expect(screen.getByText('30')).toBeInTheDocument();
-      expect(screen.getByText('Bob')).toBeInTheDocument();
-      expect(screen.getByText('25')).toBeInTheDocument();
     });
   });
 
-  describe('plain text fallback', () => {
-    it('renders plain text content with CodeSnippet', () => {
-      const txtFile = { path: 'readme.txt', url: '' };
-      const content = 'This is plain text content';
-
+  describe('Plain text fallback', () => {
+    it('routes unknown extensions through CodeEditor with contentType=text', () => {
       render(
-        <FileContentPreview file={txtFile} isLoading={false} error={null} content={content} />
+        <FileContentPreview
+          file={{ path: 'readme.txt' }}
+          isLoading={false}
+          error={null}
+          content="This is plain text content"
+        />
       );
-
-      expect(screen.getByText('This is plain text content')).toBeInTheDocument();
-    });
-
-    it('renders markdown content with CodeSnippet', () => {
-      const mdFile = { path: 'readme.md', url: '' };
-      const content = '# Heading\n\nSome text';
-
-      render(<FileContentPreview file={mdFile} isLoading={false} error={null} content={content} />);
-
-      // Verify CodeSnippet renders with the content
-      const codeSnippet = screen.getByTestId('nv-code-snippet-root');
-      expect(codeSnippet).toBeInTheDocument();
-      expect(codeSnippet).toHaveTextContent('# Heading');
-      expect(codeSnippet).toHaveTextContent('Some text');
+      const editor = screen.getByTestId('code-editor');
+      expect(editor).toHaveAttribute('data-content-type', 'text');
+      expect(editor).toHaveTextContent('This is plain text content');
     });
   });
 
-  describe('file type detection', () => {
-    it('detects JSON file by extension', () => {
-      const file = { path: 'config.json', url: '' };
-      const content = '{"setting": true}';
-
-      render(<FileContentPreview file={file} isLoading={false} error={null} content={content} />);
-
-      // JSON files render in CodeSnippet
-      expect(screen.getByText('{"setting": true}')).toBeInTheDocument();
-    });
-
-    it('detects JSONL file by extension', () => {
-      const file = { path: 'logs.jsonl', url: '' };
-      const content = '{"event": "login"}';
-
-      render(<FileContentPreview file={file} isLoading={false} error={null} content={content} />);
-
-      expect(screen.getByText('{"event": "login"}')).toBeInTheDocument();
-    });
-
-    it('handles nested file paths', () => {
-      const file = { path: 'folder/subfolder/data.json', url: '' };
-      const content = '{"nested": true}';
-
-      render(<FileContentPreview file={file} isLoading={false} error={null} content={content} />);
-
-      expect(screen.getByText('{"nested": true}')).toBeInTheDocument();
-    });
-  });
-
-  describe('with file content from FileListItem', () => {
-    it('renders content from file with dataset info', () => {
-      const file = {
-        path: 'train.jsonl',
-        url: 'fileset://org/dataset/train.jsonl',
-        dataset: {
-          id: 'org/dataset',
-          name: 'dataset',
-          workspace: 'org',
-          description: '',
-          purpose: 'dataset' as const,
-          storage: { type: 'local' as const, path: '/data' },
-          metadata: {},
-          custom_fields: {},
-          project: 'default',
-          created_at: '2024-01-01T00:00:00Z',
-          updated_at: '2024-01-01T00:00:00Z',
-        },
-      };
-      const content = '{"example": 1}';
-
-      render(<FileContentPreview file={file} isLoading={false} error={null} content={content} />);
-
-      expect(screen.getByText('{"example": 1}')).toBeInTheDocument();
-    });
-
-    it('renders content from file with local content', () => {
-      const file = {
-        path: 'uploaded.json',
-        url: 'blob:http://localhost/abc123',
-        content: '{"local": true}',
-      };
-
+  describe('hideCopyButton prop', () => {
+    it('forwards hideCopyButton=true to CodeEditor', () => {
       render(
-        <FileContentPreview file={file} isLoading={false} error={null} content={file.content} />
+        <FileContentPreview
+          file={{ path: 'data.json' }}
+          isLoading={false}
+          error={null}
+          content="{}"
+          hideCopyButton
+        />
       );
+      expect(screen.getByTestId('code-editor')).toHaveAttribute('data-hide-copy-button', 'true');
+    });
 
-      expect(screen.getByText('{"local": true}')).toBeInTheDocument();
+    it('defaults hideCopyButton to false', () => {
+      render(
+        <FileContentPreview
+          file={{ path: 'data.json' }}
+          isLoading={false}
+          error={null}
+          content="{}"
+        />
+      );
+      expect(screen.getByTestId('code-editor')).toHaveAttribute('data-hide-copy-button', 'false');
     });
   });
 });

--- a/web/packages/common/src/components/FileContentPreview/FileContentPreview.spec.tsx
+++ b/web/packages/common/src/components/FileContentPreview/FileContentPreview.spec.tsx
@@ -4,30 +4,14 @@
 import { FileContentPreview } from '@nemo/common/src/components/FileContentPreview/index';
 import { render, screen } from '@testing-library/react';
 
-// Mock CodeEditor: avoids ToastProvider requirement and lets us assert
-// branch dispatch (contentType, hideCopyButton, content) directly.
 vi.mock('@nemo/common/src/components/CodeEditor', () => ({
-  CodeEditor: ({
-    content,
-    contentType,
-    hideCopyButton,
-  }: {
-    content: string;
-    contentType: string;
-    hideCopyButton?: boolean;
-  }) => (
-    <div
-      data-testid="code-editor"
-      data-content-type={contentType}
-      data-hide-copy-button={hideCopyButton ? 'true' : 'false'}
-    >
+  CodeEditor: ({ content, contentType }: { content: string; contentType: string }) => (
+    <div data-testid="code-editor" data-content-type={contentType}>
       {content}
     </div>
   ),
 }));
 
-// Mock MarkdownContent so we can assert the markdown branch without exercising
-// the real react-markdown pipeline.
 vi.mock('@nemo/common/src/components/MarkdownContent', () => ({
   MarkdownContent: ({ content }: { content: string }) => (
     <div data-testid="markdown-content">{content}</div>
@@ -194,33 +178,6 @@ describe('FileContentPreview', () => {
       const editor = screen.getByTestId('code-editor');
       expect(editor).toHaveAttribute('data-content-type', 'text');
       expect(editor).toHaveTextContent('This is plain text content');
-    });
-  });
-
-  describe('hideCopyButton prop', () => {
-    it('forwards hideCopyButton=true to CodeEditor', () => {
-      render(
-        <FileContentPreview
-          file={{ path: 'data.json' }}
-          isLoading={false}
-          error={null}
-          content="{}"
-          hideCopyButton
-        />
-      );
-      expect(screen.getByTestId('code-editor')).toHaveAttribute('data-hide-copy-button', 'true');
-    });
-
-    it('defaults hideCopyButton to false', () => {
-      render(
-        <FileContentPreview
-          file={{ path: 'data.json' }}
-          isLoading={false}
-          error={null}
-          content="{}"
-        />
-      );
-      expect(screen.getByTestId('code-editor')).toHaveAttribute('data-hide-copy-button', 'false');
     });
   });
 });

--- a/web/packages/common/src/components/FileContentPreview/index.tsx
+++ b/web/packages/common/src/components/FileContentPreview/index.tsx
@@ -1,28 +1,32 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { CodeEditor } from '@nemo/common/src/components/CodeEditor';
+import { ContentType } from '@nemo/common/src/components/CodeEditor/constants';
 import {
   getFileExtension,
   inferJsonContentType,
   isJsonFile,
 } from '@nemo/common/src/components/DatasetFileSelect/utils';
 import type { FileListItem } from '@nemo/common/src/components/FileList';
+import { MarkdownContent } from '@nemo/common/src/components/MarkdownContent';
 import { ScrollTable } from '@nemo/common/src/components/ScrollTable';
-import {
-  CodeSnippet,
-  Flex,
-  Spinner,
-  TableRowDefinition,
-  Text,
-} from '@nvidia/foundations-react-core';
+import { Flex, Spinner, TableRowDefinition, Text } from '@nvidia/foundations-react-core';
 import Papa from 'papaparse';
 import { FC, useEffect, useMemo, useState } from 'react';
+
+const MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
 
 export interface FileContentPreviewProps {
   isLoading: boolean;
   error: Error | null;
   content?: string;
   file: FileListItem;
+  /**
+   * Hide the CodeEditor copy button. Useful when the host already renders
+   * its own file action affordances (e.g. DatasetFilePreviewContent's header).
+   */
+  hideCopyButton?: boolean;
 }
 
 export const FileContentPreview: FC<FileContentPreviewProps> = ({
@@ -30,6 +34,7 @@ export const FileContentPreview: FC<FileContentPreviewProps> = ({
   error,
   content,
   file,
+  hideCopyButton = false,
 }) => {
   const [parseError, setParseError] = useState<string | undefined>(undefined);
   const [csvData, setCsvData] = useState<{
@@ -40,7 +45,9 @@ export const FileContentPreview: FC<FileContentPreviewProps> = ({
   // Detect file types
   const jsonContentType = useMemo(() => inferJsonContentType(file.path), [file.path]);
   const isJson = useMemo(() => isJsonFile(jsonContentType), [jsonContentType]);
-  const isCsv = useMemo(() => getFileExtension(file.path) === '.csv', [file.path]);
+  const extension = useMemo(() => getFileExtension(file.path), [file.path]);
+  const isCsv = extension === '.csv';
+  const isMarkdown = extension !== null && MARKDOWN_EXTENSIONS.has(extension);
 
   // Parse CSV if applicable
   useEffect(() => {
@@ -102,11 +109,26 @@ export const FileContentPreview: FC<FileContentPreviewProps> = ({
     );
   }
 
-  // JSON/JSONL files - use CodeSnippet
+  // Markdown files - rendered
+  if (isMarkdown) {
+    return (
+      <div className="h-full overflow-auto p-4">
+        <MarkdownContent content={content} />
+      </div>
+    );
+  }
+
+  // JSON / JSONL files
   if (isJson && jsonContentType) {
     return (
-      <div className="h-full">
-        <CodeSnippet value={content} language="json" kind="block" />
+      <div className="h-full min-h-0">
+        <CodeEditor
+          content={content}
+          contentType={jsonContentType}
+          readOnly
+          hideCopyButton={hideCopyButton}
+          className="h-full min-h-0"
+        />
       </div>
     );
   }
@@ -131,10 +153,16 @@ export const FileContentPreview: FC<FileContentPreviewProps> = ({
     );
   }
 
-  // Plain text fallback
+  // Plain text fallback (incl. .txt, .log, anything we don't have a richer view for)
   return (
-    <div className="h-full">
-      <CodeSnippet value={content} language="markdown" kind="block" />
+    <div className="h-full min-h-0">
+      <CodeEditor
+        content={content}
+        contentType={ContentType.TEXT}
+        readOnly
+        hideCopyButton={hideCopyButton}
+        className="h-full min-h-0"
+      />
     </div>
   );
 };

--- a/web/packages/common/src/components/FileContentPreview/index.tsx
+++ b/web/packages/common/src/components/FileContentPreview/index.tsx
@@ -22,11 +22,6 @@ export interface FileContentPreviewProps {
   error: Error | null;
   content?: string;
   file: FileListItem;
-  /**
-   * Hide the CodeEditor copy button. Useful when the host already renders
-   * its own file action affordances (e.g. DatasetFilePreviewContent's header).
-   */
-  hideCopyButton?: boolean;
 }
 
 export const FileContentPreview: FC<FileContentPreviewProps> = ({
@@ -34,7 +29,6 @@ export const FileContentPreview: FC<FileContentPreviewProps> = ({
   error,
   content,
   file,
-  hideCopyButton = false,
 }) => {
   const [parseError, setParseError] = useState<string | undefined>(undefined);
   const [csvData, setCsvData] = useState<{
@@ -126,7 +120,6 @@ export const FileContentPreview: FC<FileContentPreviewProps> = ({
           content={content}
           contentType={jsonContentType}
           readOnly
-          hideCopyButton={hideCopyButton}
           className="h-full min-h-0"
         />
       </div>
@@ -160,7 +153,6 @@ export const FileContentPreview: FC<FileContentPreviewProps> = ({
         content={content}
         contentType={ContentType.TEXT}
         readOnly
-        hideCopyButton={hideCopyButton}
         className="h-full min-h-0"
       />
     </div>

--- a/web/packages/studio/src/api/datasets/constants.ts
+++ b/web/packages/studio/src/api/datasets/constants.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export const ALLOWED_CONTENT_FILE_TYPES = new Set(['csv', 'json', 'jsonl', 'parquet']); // File types that the platform parses as structured data (used by ICL import / form validation).
+export const ALLOWED_CONTENT_FILE_TYPES = new Set(['csv', 'json', 'jsonl', 'parquet']); // File types that the platform parses as structured data.
 
 // File types that Studio's FileContentPreview can render. Superset of ALLOWED_CONTENT_FILE_TYPES:
 // includes formats we can display but do not structurally manipulate.

--- a/web/packages/studio/src/api/datasets/constants.ts
+++ b/web/packages/studio/src/api/datasets/constants.ts
@@ -1,5 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export const ALLOWED_CONTENT_FILE_TYPES = new Set(['csv', 'json', 'jsonl', 'parquet']); // File types that are supported in-memory for manipulation.
+export const ALLOWED_CONTENT_FILE_TYPES = new Set(['csv', 'json', 'jsonl', 'parquet']); // File types that the platform parses as structured data (used by ICL import / form validation).
+
+// File types that Studio's FileContentPreview can render. Superset of ALLOWED_CONTENT_FILE_TYPES:
+// includes formats we can display but do not structurally manipulate.
+export const PREVIEWABLE_FILE_TYPES = new Set([
+  ...ALLOWED_CONTENT_FILE_TYPES,
+  'md',
+  'markdown',
+  'txt',
+]);
+
 export const COMPLETION_PROMPT_KEY_ORDER = ['prompt', 'instruction', 'question']; // Searches for a prompt in the following keys

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.spec.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.spec.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { datasetFileContentQueryOptions } from '@studio/api/datasets/useDatasetFileContent';
+
+vi.mock('@nemo/sdk/generated/platform/api', () => ({
+  filesHeadFile: vi.fn().mockResolvedValue(undefined),
+  filesDownloadFile: vi.fn().mockResolvedValue(new Blob(['# heading'])),
+}));
+
+describe('useDatasetFileContent gate', () => {
+  const baseParams = { workspace: 'ws', name: 'ds', path: 'README.md' };
+
+  it('allows .md files (preview superset)', async () => {
+    const { queryFn } = datasetFileContentQueryOptions(baseParams);
+    await expect((queryFn as () => Promise<string>)()).resolves.toBe('# heading');
+  });
+
+  it('rejects extensions outside PREVIEWABLE_FILE_TYPES', async () => {
+    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, path: 'app.exe' });
+    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/Unsupported file type/);
+  });
+
+  it('rejects files with no extension', async () => {
+    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, path: 'noextension' });
+    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/Unsupported file type/);
+  });
+});

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -3,7 +3,7 @@
 
 import { filesDownloadFile, filesHeadFile } from '@nemo/sdk/generated/platform/api';
 import { EntityIdentifier } from '@studio/api/common/types';
-import { ALLOWED_CONTENT_FILE_TYPES } from '@studio/api/datasets/constants';
+import { PREVIEWABLE_FILE_TYPES } from '@studio/api/datasets/constants';
 import { getDatasetFileContentQueryKey } from '@studio/api/datasets/invalidateDatasetCaches';
 import { queryOptions, useQuery, UseQueryOptions, useSuspenseQuery } from '@tanstack/react-query';
 import { parquetRead } from 'hyparquet';
@@ -29,9 +29,9 @@ export const datasetFileContentQueryOptions = ({
       ...(range ? range.map((bound) => String(bound)) : []),
     ],
     queryFn: async () => {
-      if (!path.includes('.') || !ALLOWED_CONTENT_FILE_TYPES.has(path.split('.').at(-1)!)) {
+      if (!path.includes('.') || !PREVIEWABLE_FILE_TYPES.has(path.split('.').at(-1)!)) {
         throw new Error(
-          `Unsupported file type. Currently supports: ${[...ALLOWED_CONTENT_FILE_TYPES].join(', ')}`
+          `Unsupported file type. Currently supports: ${[...PREVIEWABLE_FILE_TYPES].join(', ')}`
         );
       }
 

--- a/web/packages/studio/src/components/DatasetFilePreviewPanel/DatasetFilePreviewContent/index.spec.tsx
+++ b/web/packages/studio/src/components/DatasetFilePreviewPanel/DatasetFilePreviewContent/index.spec.tsx
@@ -58,7 +58,8 @@ describe('DatasetFilePreviewContent', () => {
         <DatasetFilePreviewContent {...baseProps} isLoading />
       </TestProviders>
     );
-    expect(screen.getByText('Loading content...')).toBeInTheDocument();
+    // Loading + error UI now lives inside FileContentPreview (the spinner has aria-label="Loading...").
+    expect(screen.getByLabelText('Loading...')).toBeInTheDocument();
   });
 
   it('shows the error state', () => {
@@ -67,8 +68,7 @@ describe('DatasetFilePreviewContent', () => {
         <DatasetFilePreviewContent {...baseProps} isLoading={false} error={new Error('boom')} />
       </TestProviders>
     );
-    expect(screen.getByText(/Error loading file/)).toBeInTheDocument();
-    expect(screen.getByText(/boom/)).toBeInTheDocument();
+    expect(screen.getByText('Error: boom')).toBeInTheDocument();
   });
 
   it('invokes onFolderClick with the cumulative folder path', () => {

--- a/web/packages/studio/src/components/DatasetFilePreviewPanel/DatasetFilePreviewContent/index.tsx
+++ b/web/packages/studio/src/components/DatasetFilePreviewPanel/DatasetFilePreviewContent/index.tsx
@@ -1,16 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { CodeEditor } from '@nemo/common/src/components/CodeEditor';
-import { ContentType } from '@nemo/common/src/components/CodeEditor/constants';
+import { FileContentPreview } from '@nemo/common/src/components/FileContentPreview';
 import { useFilesListFilesetFiles } from '@nemo/sdk/generated/platform/api';
-import { Flex, Stack } from '@nvidia/foundations-react-core';
+import { Stack } from '@nvidia/foundations-react-core';
 import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
-import { FileActions } from '@studio/components/DatasetFilePreviewPanel/components/FileActions';
-import { FileBreadcrumbs } from '@studio/components/DatasetFilePreviewPanel/components/FileBreadcrumbs';
+import { DatasetFilePreviewHeader } from '@studio/components/DatasetFilePreviewPanel/components/DatasetFilePreviewHeader';
 import type { FileSystemFile } from '@studio/components/FilesTable/utils';
-import { inferJsonContentType, isJsonFile } from '@studio/util/files';
-import { FolderOpen } from 'lucide-react';
 import { useMemo, type FC } from 'react';
 
 export interface DatasetFilePreviewContentProps {
@@ -91,35 +87,17 @@ export const DatasetFilePreviewContent: FC<DatasetFilePreviewContentProps> = ({
   const file =
     externalFile ?? (allFiles?.find((f) => f.path === filePath) as FileSystemFile | undefined);
 
-  const body = useMemo(() => {
-    if (error) {
-      return (
-        <div className="flex items-center justify-center h-full text-red-600">
-          Error loading file: {error.message}
-        </div>
-      );
-    }
-
-    if (isLoading) {
-      return (
-        <div className="flex items-center justify-center h-full">
-          <span>Loading content...</span>
-        </div>
-      );
-    }
-
-    const jsonContentType = inferJsonContentType(filePath);
-    const isJson = isJsonFile(jsonContentType);
-
-    return (
-      <CodeEditor
-        content={fileContent || ''}
-        contentType={isJson ? ContentType.JSON : ContentType.TEXT}
-        readOnly
-        className="h-full min-h-0"
+  const body = useMemo(
+    () => (
+      <FileContentPreview
+        file={{ path: filePath }}
+        content={fileContent}
+        isLoading={isLoading}
+        error={error ?? null}
       />
-    );
-  }, [fileContent, isLoading, error, filePath]);
+    ),
+    [filePath, fileContent, isLoading, error]
+  );
 
   if (hideHeader) {
     return body;
@@ -127,26 +105,16 @@ export const DatasetFilePreviewContent: FC<DatasetFilePreviewContentProps> = ({
 
   return (
     <Stack gap="density-sm" className="h-full min-h-0">
-      <Flex justify="between" align="center" gap="density-sm" className="shrink-0">
-        <Flex gap="density-sm" align="center">
-          <FolderOpen width={16} height={16} />
-          <FileBreadcrumbs
-            datasetName={datasetName}
-            filePath={filePath}
-            onDatasetClick={onDatasetClick}
-            onFolderClick={onFolderClick}
-          />
-        </Flex>
-        {file && (
-          <FileActions
-            file={file}
-            datasetWorkspace={datasetWorkspace}
-            datasetName={datasetName}
-            onDeleteSuccess={onDeleteSuccess}
-            onRenameSuccess={onRenameSuccess}
-          />
-        )}
-      </Flex>
+      <DatasetFilePreviewHeader
+        datasetWorkspace={datasetWorkspace}
+        datasetName={datasetName}
+        filePath={filePath}
+        file={file}
+        onDatasetClick={onDatasetClick}
+        onFolderClick={onFolderClick}
+        onDeleteSuccess={onDeleteSuccess}
+        onRenameSuccess={onRenameSuccess}
+      />
       <div className="flex-1 min-h-0">{body}</div>
     </Stack>
   );

--- a/web/packages/studio/src/components/DatasetFilePreviewPanel/components/DatasetFilePreviewHeader/index.tsx
+++ b/web/packages/studio/src/components/DatasetFilePreviewPanel/components/DatasetFilePreviewHeader/index.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flex } from '@nvidia/foundations-react-core';
+import { FileActions } from '@studio/components/DatasetFilePreviewPanel/components/FileActions';
+import { FileBreadcrumbs } from '@studio/components/DatasetFilePreviewPanel/components/FileBreadcrumbs';
+import type { FileSystemFile } from '@studio/components/FilesTable/utils';
+import { FolderOpen } from 'lucide-react';
+import type { FC } from 'react';
+
+export interface DatasetFilePreviewHeaderProps {
+  datasetWorkspace: string;
+  datasetName: string;
+  filePath: string;
+  /** Resolved file used to render delete/rename/split actions. Omit to hide actions. */
+  file?: FileSystemFile;
+  onDatasetClick?: () => void;
+  onFolderClick?: (folderPath: string) => void;
+  onDeleteSuccess?: () => void;
+  onRenameSuccess?: (newPath: string) => void;
+}
+
+export const DatasetFilePreviewHeader: FC<DatasetFilePreviewHeaderProps> = ({
+  datasetWorkspace,
+  datasetName,
+  filePath,
+  file,
+  onDatasetClick,
+  onFolderClick,
+  onDeleteSuccess,
+  onRenameSuccess,
+}) => (
+  <Flex justify="between" align="center" gap="density-sm" className="shrink-0 w-full">
+    <Flex gap="density-sm" align="center" className="min-w-0">
+      <FolderOpen width={16} height={16} />
+      <FileBreadcrumbs
+        datasetName={datasetName}
+        filePath={filePath}
+        onDatasetClick={onDatasetClick}
+        onFolderClick={onFolderClick}
+      />
+    </Flex>
+    {file && (
+      <FileActions
+        file={file}
+        datasetWorkspace={datasetWorkspace}
+        datasetName={datasetName}
+        onDeleteSuccess={onDeleteSuccess}
+        onRenameSuccess={onRenameSuccess}
+      />
+    )}
+  </Flex>
+);

--- a/web/packages/studio/src/components/DatasetFilePreviewPanel/index.spec.tsx
+++ b/web/packages/studio/src/components/DatasetFilePreviewPanel/index.spec.tsx
@@ -89,7 +89,8 @@ describe('DatasetFilePreviewPanel', () => {
         <DatasetFilePreviewPanel {...props} />
       </TestProviders>
     );
-    expect(screen.getByText('Loading content...')).toBeInTheDocument();
+    // Loading UI comes from FileContentPreview (spinner with aria-label="Loading...").
+    expect(screen.getByLabelText('Loading...')).toBeInTheDocument();
   });
 
   it('displays error state', () => {
@@ -104,8 +105,7 @@ describe('DatasetFilePreviewPanel', () => {
         <DatasetFilePreviewPanel {...props} />
       </TestProviders>
     );
-    expect(screen.getByText(/Error loading file/)).toBeInTheDocument();
-    expect(screen.getByText(/Failed to load file/)).toBeInTheDocument();
+    expect(screen.getByText('Error: Failed to load file')).toBeInTheDocument();
   });
 
   it('accepts pre-fetched data', () => {

--- a/web/packages/studio/src/components/DatasetFilePreviewPanel/index.tsx
+++ b/web/packages/studio/src/components/DatasetFilePreviewPanel/index.tsx
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useFilesListFilesetFiles } from '@nemo/sdk/generated/platform/api';
 import { SidePanel } from '@nvidia/foundations-react-core';
+import { DatasetFilePreviewHeader } from '@studio/components/DatasetFilePreviewPanel/components/DatasetFilePreviewHeader';
 import { DatasetFilePreviewContent } from '@studio/components/DatasetFilePreviewPanel/DatasetFilePreviewContent';
 import type { FileSystemFile } from '@studio/components/FilesTable/utils';
 import type { FC } from 'react';
@@ -43,7 +45,17 @@ export const DatasetFilePreviewPanel: FC<DatasetFilePreviewPanelProps> = ({
   open,
   onCloseClick,
   onOutsideClick,
-  ...contentProps
+  datasetWorkspace,
+  datasetName,
+  filePath,
+  onDatasetClick,
+  onFolderClick,
+  onDeleteSuccess,
+  onRenameSuccess,
+  file: externalFile,
+  fileContent,
+  isLoading,
+  error,
 }) => {
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) onCloseClick();
@@ -56,6 +68,16 @@ export const DatasetFilePreviewPanel: FC<DatasetFilePreviewPanelProps> = ({
       onCloseClick();
     }
   };
+
+  const { data: allFilesResponse } = useFilesListFilesetFiles(
+    datasetWorkspace,
+    datasetName,
+    undefined,
+    { query: { enabled: !externalFile && open } }
+  );
+  const file =
+    externalFile ??
+    (allFilesResponse?.data?.find((f) => f.path === filePath) as FileSystemFile | undefined);
 
   return (
     <SidePanel
@@ -70,6 +92,18 @@ export const DatasetFilePreviewPanel: FC<DatasetFilePreviewPanelProps> = ({
         e.preventDefault();
         handleOutside();
       }}
+      slotHeading={
+        <DatasetFilePreviewHeader
+          datasetWorkspace={datasetWorkspace}
+          datasetName={datasetName}
+          filePath={filePath}
+          file={file}
+          onDatasetClick={onDatasetClick}
+          onFolderClick={onFolderClick}
+          onDeleteSuccess={onDeleteSuccess}
+          onRenameSuccess={onRenameSuccess}
+        />
+      }
       attributes={{
         SidePanelHeading: { className: 'font-normal' },
       }}
@@ -77,7 +111,21 @@ export const DatasetFilePreviewPanel: FC<DatasetFilePreviewPanelProps> = ({
       modal
       className="max-w-[960px] w-full"
     >
-      <DatasetFilePreviewContent {...contentProps} enabled={open} />
+      <DatasetFilePreviewContent
+        datasetWorkspace={datasetWorkspace}
+        datasetName={datasetName}
+        filePath={filePath}
+        file={file}
+        fileContent={fileContent}
+        isLoading={isLoading}
+        error={error}
+        onDatasetClick={onDatasetClick}
+        onFolderClick={onFolderClick}
+        onDeleteSuccess={onDeleteSuccess}
+        onRenameSuccess={onRenameSuccess}
+        enabled={open}
+        hideHeader
+      />
     </SidePanel>
   );
 };


### PR DESCRIPTION
In this PR:
- Fixed a header issue with the file preview panel:
<img width="1715" height="373" alt="image" src="https://github.com/user-attachments/assets/4a8f4b31-c738-4b3d-97f5-f6aeac65477b" />

- Moved Fileset file preview to the existing FileContentPreview component that supports tabular data
- Added Markdown preview support to FilePreview
- Used the preferred <CodeEditor on FileContentPreview for performance on text highlighting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown files render with proper formatting; CSVs show as tables; JSON/JSONL open in a read-only editor; plain-text (.txt/.log) previews now use the text viewer.
  * File preview panel gains an improved header with breadcrumbs and contextual actions.

* **UX**
  * Loading and error states updated to clearer messages and accessible labels.

* **Tests**
  * Expanded test coverage for file-type validation, preview routing, and linter behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->