### PR TITLE
chore(release): bump platform version to 0.1.1

### DIFF
--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Nemo Platform API
   description: API for Nemo Platform services
-  version: 0.1.0
+  version: 0.1.1
 paths:
   /apis/auth/discovery:
     get:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Nemo Platform API
   description: API for Nemo Platform services
-  version: 0.1.0
+  version: 0.1.1
 paths:
   /apis/auth/discovery:
     get:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Nemo Platform API
   description: API for Nemo Platform services
-  version: 0.1.0
+  version: 0.1.1
 paths:
   /apis/auth/discovery:
     get:

--- a/packages/nmp_common/src/nmp/common/version.py
+++ b/packages/nmp_common/src/nmp/common/version.py
@@ -6,7 +6,7 @@
 For now, this needs to be updated manually, whenever we move to a new version (typically after release).
 """
 
-platform_api_version = "0.1.0"
+platform_api_version = "0.1.1"
 
 # NOTE: the SDK version will follow the major.minor API version, with the patch version potentially differing.
-platform_sdk_version = "0.1.0"
+platform_sdk_version = "0.1.1"

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: agents (plugin)
-  version: 0.1.0
+  version: 0.1.1
 paths:
   /apis/agents/v2/workspaces/{workspace}/agents:
     post:

--- a/plugins/nemo-auditor/openapi/openapi.yaml
+++ b/plugins/nemo-auditor/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: auditor (plugin)
-  version: 0.1.0
+  version: 0.1.1
 paths:
   /apis/auditor/v1/healthz:
     get:

--- a/plugins/nemo-data-designer/openapi/openapi.yaml
+++ b/plugins/nemo-data-designer/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: data-designer (plugin)
-  version: 0.1.0
+  version: 0.1.1
 paths:
   /apis/data-designer/v2/workspaces/{workspace}/jobs/create:
     post:

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Nemo Platform API
   description: API for Nemo Platform services
-  version: 0.1.0
+  version: 0.1.1
 paths:
   /apis/auth/discovery:
     get:

--- a/sdk/python/nemo-platform/.nmpcontext/stainless.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/stainless.yaml
@@ -260,8 +260,8 @@ resources:
       json_score_parser: JSONScoreParser
       llm_judge_metric: LLMJudgeMetric
       llm_judge_metric_param: LLMJudgeMetricInput
+      metric: MetricOutput
       metric_ref: MetricRef
-      metric_score: MetricScore
       model: Evaluator.Model
       nemo_agent_toolkit_remote_metric: NemoAgentToolkitRemoteMetric
       nemo_agent_toolkit_remote_metric_param: NemoAgentToolkitRemoteMetricInput
@@ -288,7 +288,6 @@ resources:
       run_config: RunConfig
       run_config_online: RunConfigOnline
       run_config_online_model: RunConfigOnlineModel
-      score_stats: ScoreStats
       string_check_metric: StringCheckMetric
       string_check_metric_param: StringCheckMetricInput
       tool_call_accuracy_metric: ToolCallAccuracyMetric

--- a/sdk/python/nemo-platform/src/nemo_platform/_version.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/_version.py
@@ -16,6 +16,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 __title__ = "nemo_platform"
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 # Injected at release time for non-production builds; None for RC and production releases.
 __image_tag__: str | None = None

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/evaluation/api.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/evaluation/api.md
@@ -33,7 +33,7 @@ from nemo_platform.types.evaluation import (
     JsonScoreParser,
     LLMJudgeMetric,
     LLMJudgeMetricParam,
-    MetricOutput,
+    Metric,
     MetricRef,
     Model,
     NeMoAgentToolkitRemoteMetric,

--- a/sdk/python/nemo-platform/src/nemo_platform/types/evaluation/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/evaluation/__init__.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from .agent import Agent as Agent
 from .model import Model as Model
+from .metric import Metric as Metric
 from .rubric import Rubric as Rubric
 from .fileset import Fileset as Fileset
 from .benchmark import Benchmark as Benchmark
@@ -37,7 +38,6 @@ from .model_param import ModelParam as ModelParam
 from .percentiles import Percentiles as Percentiles
 from .range_score import RangeScore as RangeScore
 from .dataset_rows import DatasetRows as DatasetRows
-from .metric_output import MetricOutput as MetricOutput
 from .remote_score import RemoteScore as RemoteScore
 from .rouge_metric import RougeMetric as RougeMetric
 from .rubric_param import RubricParam as RubricParam

--- a/sdk/python/nemo-platform/src/nemo_platform/types/evaluation/metric.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/evaluation/metric.py
@@ -15,16 +15,14 @@
 
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import Any
-
 from ..._models import BaseModel
 
-__all__ = ["MetricOutput"]
+__all__ = ["Metric"]
 
 
-class MetricOutput(BaseModel):
+class Metric(BaseModel):
     """One named value emitted by a metric."""
 
     name: str
 
-    value: Any
+    value: object

--- a/sdk/python/nemo-platform/src/nemo_platform/types/evaluation/row_score.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/evaluation/row_score.py
@@ -19,8 +19,8 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 from pydantic import Field as FieldInfo
 
+from .metric import Metric
 from ..._models import BaseModel
-from .metric_output import MetricOutput
 
 __all__ = ["RowScore"]
 
@@ -31,7 +31,7 @@ class RowScore(BaseModel):
     item: Dict[str, object]
     """Input item metadata for the evaluated row."""
 
-    metrics: Dict[str, List[MetricOutput]]
+    metrics: Dict[str, List[Metric]]
     """Metric-level row outputs by metric key."""
 
     requests: List[Dict[str, object]]

--- a/sdk/stainless.yaml
+++ b/sdk/stainless.yaml
@@ -260,8 +260,8 @@ resources:
       json_score_parser: JSONScoreParser
       llm_judge_metric: LLMJudgeMetric
       llm_judge_metric_param: LLMJudgeMetricInput
+      metric: MetricOutput
       metric_ref: MetricRef
-      metric_score: MetricScore
       model: Evaluator.Model
       nemo_agent_toolkit_remote_metric: NemoAgentToolkitRemoteMetric
       nemo_agent_toolkit_remote_metric_param: NemoAgentToolkitRemoteMetricInput
@@ -288,7 +288,6 @@ resources:
       run_config: RunConfig
       run_config_online: RunConfigOnline
       run_config_online_model: RunConfigOnlineModel
-      score_stats: ScoreStats
       string_check_metric: StringCheckMetric
       string_check_metric_param: StringCheckMetricInput
       tool_call_accuracy_metric: ToolCallAccuracyMetric


### PR DESCRIPTION
## Summary

Bumps the platform version in `packages/nmp_common/src/nmp/common/version.py` from `0.1.0` to `0.1.1`:

- `platform_sdk_version` → `0.1.1`
- `platform_api_version` → `0.1.1`

Also regenerates the OpenAPI specs (`make refresh-openapi`) so `info.version` stays in sync — both the platform-level specs (`openapi/openapi.yaml`, `openapi/ga/openapi.yaml`, `openapi/ga/individual/platform.openapi.yaml`) and the plugin specs (`plugins/nemo-agents/openapi/openapi.yaml`, `plugins/nemo-auditor/openapi/openapi.yaml`, `plugins/nemo-data-designer/openapi/openapi.yaml`).

## Why

- The Platform-Deploy stable release workflow (`release-sdk.yaml`) reads `platform_sdk_version` verbatim for `release` cadence and stamps both bundled wheels (`nemo-platform`, `nemo-platform-plugin`) with that value. `0.1.0` matches the existing public release, so `0.1.1` is required before kicking off the next stable release.
- Keeps SDK and API patch versions in lockstep. The comment on `version.py:11` previously suggested the patch numbers could drift, but we have not used that flexibility in practice and there is no clear policy yet for when they should diverge — keeping them aligned for now is simpler and easier to reason about.

## Notes

- `sdk/python/nemo-platform/src/nemo_platform/_version.py` is intentionally **not** edited here — it is vendored/generated and the release workflow re-stamps it from `version.py` at build time (see `Platform-Deploy/.github/workflows/release-sdk.yaml`, "Stamp SDK version and build wheel" step).
- Branch is `release/0.1.1` (off `3728e07`) so `Platform-Deploy/release-stable.yaml` will accept its tip as a valid `ref` (it requires a SHA on a `release/*` branch).

## Follow-ups (not in this PR)

- Platform-Deploy needs the `nemo-plugin` → `nemo-platform-plugin` naming fix in `release/sdk-publish-config.yaml` and a Kitmaker upload toggle on `release-stable.yaml` before the stable run can publish to public PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped platform SDK and platform API versions from 0.1.0 to 0.1.1 across the project.
* **Documentation**
  * Updated OpenAPI/API specification metadata in all relevant API documents to reflect version 0.1.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->