### PR TITLE
fix(studio): Operators type for query filter

### DIFF
--- a/web/packages/common/src/api/entity-store/useBaseModels.ts
+++ b/web/packages/common/src/api/entity-store/useBaseModels.ts
@@ -14,6 +14,7 @@ import { useCallback, useMemo } from 'react';
 import { DEFAULT_NAMESPACE } from '../../constants';
 import { DEFAULT_PAGE_SIZE, QUERY_PREFIX_ENTITY_STORE } from '../../constants/api';
 import { isBaseModel } from '../../utils/models';
+import type { WithFilterOperators } from '../filterOperators';
 
 const SORT_COMPARATORS: Record<ModelEntitySortField, (a: ModelEntity, b: ModelEntity) => number> = {
   [ModelEntitySortField.name]: (a, b) => (a.name ?? '').localeCompare(b.name ?? ''),
@@ -29,16 +30,13 @@ const SORT_COMPARATORS: Record<ModelEntitySortField, (a: ModelEntity, b: ModelEn
 };
 
 /**
- * Widened input type for `useBaseModels({ filter })`. The generated SDK types
- * `ModelEntityFilter.name` as `string` only, but the NeMo Platform API documents support
- * for filter-operator objects (`{ $like, $eq }`) on `name` via the same unified
- * filter syntax used for `created_at` / `updated_at`. We widen here so call sites
- * can build text-search filters without bypassing the type system; the coercion
- * back to `ModelEntityFilter` happens once at the SDK boundary below.
+ * Widened input type for `useBaseModels({ filter })`. The generated SDK models
+ * filter fields as bare scalars, but the NeMo Platform API accepts operator
+ * objects on every field via the same unified filter syntax (`$like`, `$gte`,
+ * etc). Coercion back to `ModelEntityFilter` happens once at the SDK boundary
+ * below.
  */
-export type ModelEntityFilterInput = Omit<ModelEntityFilter, 'name'> & {
-  name?: string | { $like?: string; $eq?: string };
-};
+export type ModelEntityFilterInput = WithFilterOperators<ModelEntityFilter>;
 
 export interface UseBaseModelsOptions {
   workspace: string;
@@ -92,7 +90,7 @@ export function useBaseModels({
   const isDefaultWorkspace = workspace === DEFAULT_NAMESPACE;
 
   const baseQuery = {
-    // Cast reflects the SDK's under-typing of `name`; see ModelEntityFilterInput doc above.
+    // Cast reflects the SDK's scalar-only modeling of filter fields; see ModelEntityFilterInput.
     filter: { base_model: false, ...filter } as ModelEntityFilter,
     page_size: DEFAULT_PAGE_SIZE,
   };

--- a/web/packages/common/src/api/entity-store/useBaseModels.ts
+++ b/web/packages/common/src/api/entity-store/useBaseModels.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { WithFilterOperators } from '@nemo/common/src/api/filterOperators';
 import { modelsListModels } from '@nemo/sdk/generated/platform/api';
 import {
   ModelEntity,
@@ -14,7 +15,6 @@ import { useCallback, useMemo } from 'react';
 import { DEFAULT_NAMESPACE } from '../../constants';
 import { DEFAULT_PAGE_SIZE, QUERY_PREFIX_ENTITY_STORE } from '../../constants/api';
 import { isBaseModel } from '../../utils/models';
-import type { WithFilterOperators } from '../filterOperators';
 
 const SORT_COMPARATORS: Record<ModelEntitySortField, (a: ModelEntity, b: ModelEntity) => number> = {
   [ModelEntitySortField.name]: (a, b) => (a.name ?? '').localeCompare(b.name ?? ''),

--- a/web/packages/common/src/api/filterOperators.ts
+++ b/web/packages/common/src/api/filterOperators.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Mongo-style comparison operators accepted by NeMo Platform's unified filter
+ * syntax (e.g. `{ name: { $like: '%foo%' } }`, `{ created_at: { $gte, $lte } }`).
+ *
+ * The OpenAPI-generated SDK types model filter fields as bare scalars
+ * (`name?: string`) and do not expose the operator-object form. Use
+ * {@link WithFilterOperators} to widen a generated filter shape so call sites
+ * can build operator filters without `as unknown as` casts.
+ */
+export interface FilterOperators<V> {
+  $eq?: V;
+  $ne?: V;
+  $in?: readonly V[];
+  $nin?: readonly V[];
+  $gt?: V;
+  $gte?: V;
+  $lt?: V;
+  $lte?: V;
+  /** Substring match (e.g. `%foo%`). String-typed regardless of `V`. */
+  $like?: string;
+}
+
+/**
+ * Widens each field of `F` so it accepts either its original scalar value or
+ * a {@link FilterOperators} object. Intended for API call sites that need
+ * operator-object filters; coerce back to the generated filter type once at
+ * the SDK boundary.
+ *
+ * @example
+ * type ModelFilterInput = WithFilterOperators<ModelEntityFilter>;
+ * const filter: ModelFilterInput = { name: { $like: '%foo%' } };
+ */
+export type WithFilterOperators<F> = {
+  [K in keyof F]?: F[K] | FilterOperators<NonNullable<F[K]>>;
+};
+
+/**
+ * Build a typed operator-filter and coerce it to the generated SDK filter type
+ * in one step. Centralizes the unavoidable cast at the SDK boundary so call
+ * sites can be written with full type-checking on operator objects.
+ *
+ * @example
+ * filter: withOperators<FilesetFilter>({ name: { $like: `%${search}%` } })
+ */
+export const withOperators = <F>(filter: WithFilterOperators<F>): F => filter as F;

--- a/web/packages/common/src/hooks/useStudioDataViewState/index.ts
+++ b/web/packages/common/src/hooks/useStudioDataViewState/index.ts
@@ -39,15 +39,23 @@ export interface UseStudioDataViewStateOptions extends Omit<
   defaultSort?: { id: string; desc: boolean };
 }
 
-export interface ApiFilter {
+/**
+ * API filter object exposed by the hook. The `filter` shape is parameterized by
+ * `FilterType` so consumers get type-checked filter keys and values without
+ * needing `as` casts at the call site.
+ *
+ * Defaults to `Record<string, unknown>` for callers that don't supply a type.
+ */
+export interface ApiFilter<FilterType = Record<string, unknown>> {
   searchText?: string;
-  filter?: Record<string, unknown>;
+  filter?: Partial<FilterType>;
 }
 
 /**
  * Extended DataView state that includes helper functions for common table operations.
  */
-export interface StudioDataViewState extends DataView.DataViewState {
+export interface StudioDataViewState<FilterType = Record<string, unknown>>
+  extends DataView.DataViewState {
   /**
    * Resets pagination to page 1 and clears row selection.
    * Call this when search/filter criteria change to ensure users see results from the beginning.
@@ -64,7 +72,7 @@ export interface StudioDataViewState extends DataView.DataViewState {
    *   mapping `searchText` onto the appropriate filter field (and wrapping it in an operator
    *   like `$like` if fuzzy matching is desired).
    */
-  apiFilter: ApiFilter;
+  apiFilter: ApiFilter<FilterType>;
   /** Clears searchBar, columnFilters, and resets pagination. */
   resetFilters: () => void;
 }
@@ -91,9 +99,9 @@ export interface StudioDataViewState extends DataView.DataViewState {
  * - Use `resetPagination()` when search/filter criteria change.
  * - Intended for table/data grid views where browser-driven navigation is desirable.
  */
-export const useStudioDataViewState = (
+export const useStudioDataViewState = <FilterType = Record<string, unknown>>(
   options?: UseStudioDataViewStateOptions
-): StudioDataViewState => {
+): StudioDataViewState<FilterType> => {
   const {
     defaultPage = DEFAULT_PAGE,
     defaultPageSize = DEFAULT_PAGE_SIZE,
@@ -453,9 +461,12 @@ export const useStudioDataViewState = (
     }
   }, [dataViewState.columnFiltering, urlColumnFilters, urlFiltersParam, updateUrlParams]);
 
-  // Convention-mapped API filter object
-  const apiFilter = useMemo<ApiFilter>(() => {
-    const result: ApiFilter = {};
+  // Convention-mapped API filter object.
+  // The narrowing from TanStack's untyped `ColumnFiltersState` ({id: string, value: unknown}[])
+  // to `Partial<FilterType>` happens here in one place, so call sites get a typed
+  // `apiFilter.filter` and don't need their own `as` casts.
+  const apiFilter = useMemo<ApiFilter<FilterType>>(() => {
+    const result: ApiFilter<FilterType> = {};
 
     if (debouncedSearchBar) {
       result.searchText = debouncedSearchBar;
@@ -475,7 +486,7 @@ export const useStudioDataViewState = (
             return true;
           })
           .map((f) => [f.id, f.value])
-      );
+      ) as Partial<FilterType>;
     }
 
     return result;

--- a/web/packages/studio/src/api/intake/utils.ts
+++ b/web/packages/studio/src/api/intake/utils.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { EntryFilter } from '@nemo/sdk/generated/platform/schema';
+import type { EntryFilter } from '@nemo/sdk/generated/platform/schema';
 import { QUERY_PARAMETERS } from '@studio/routes/constants';
 import { ChatCompletionMessageParam } from 'openai/resources/index.mjs';
 

--- a/web/packages/studio/src/api/intake/utils.ts
+++ b/web/packages/studio/src/api/intake/utils.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { EntryFilter } from '@nemo/sdk/generated/platform/schema';
 import { QUERY_PARAMETERS } from '@studio/routes/constants';
 import { ChatCompletionMessageParam } from 'openai/resources/index.mjs';
 
@@ -12,11 +13,7 @@ import { ChatCompletionMessageParam } from 'openai/resources/index.mjs';
  * @param params - The URLSearchParams instance to populate
  * @param prefix - The current key prefix for nested properties (e.g., 'context', 'created_at')
  */
-const processFilterObject = (
-  obj: Record<string, unknown>,
-  params: URLSearchParams,
-  prefix = ''
-): void => {
+const processFilterObject = (obj: EntryFilter, params: URLSearchParams, prefix = ''): void => {
   for (const [key, value] of Object.entries(obj)) {
     // Skip undefined and null values
     if (value === undefined || value === null) {
@@ -36,7 +33,7 @@ const processFilterObject = (
     }
     // Handle nested objects recursively
     else if (typeof value === 'object' && value !== null) {
-      processFilterObject(value as Record<string, unknown>, params, paramKey);
+      processFilterObject(value, params, paramKey);
     }
     // Handle primitive values (string, number, boolean)
     else {
@@ -45,7 +42,7 @@ const processFilterObject = (
   }
 };
 
-export const generateFilterParam = (filter?: Record<string, unknown>): string => {
+export const generateFilterParam = (filter?: EntryFilter): string => {
   if (!filter) {
     return '';
   }
@@ -57,7 +54,7 @@ export const generateFilterParam = (filter?: Record<string, unknown>): string =>
     const withoutProject = { ...filter, project: undefined };
     processFilterObject(withoutProject, params);
   } else {
-    processFilterObject(filter as Record<string, unknown>, params);
+    processFilterObject(filter, params);
   }
 
   return params.toString();

--- a/web/packages/studio/src/components/dataViews/DataDesignerJobsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/DataDesignerJobsDataView/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { withOperators } from '@nemo/common/src/api/filterOperators';
 import { dateTimeFilter } from '@nemo/common/src/components/DataView/dateTimeFilter';
 import {
   ROW_SELECTION_COLUMN_SIZE,
@@ -86,9 +87,11 @@ export const DataDesignerJobsDataView: FC = () => {
       filter: {
         ...((dataViewState.apiFilter.filter ?? {}) as DataDesignerJobsListFilter),
         ...(dataViewState.apiFilter.searchText
-          ? { name: { $like: dataViewState.apiFilter.searchText } }
+          ? withOperators<DataDesignerJobsListFilter>({
+              name: { $like: dataViewState.apiFilter.searchText },
+            })
           : {}),
-      } as DataDesignerJobsListFilter | undefined,
+      },
     },
     {
       query: {

--- a/web/packages/studio/src/components/dataViews/DeploymentsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/DeploymentsDataView/index.tsx
@@ -10,6 +10,7 @@
  * its affiliates is strictly prohibited.
  */
 
+import { withOperators } from '@nemo/common/src/api/filterOperators';
 import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
@@ -68,9 +69,11 @@ export const DeploymentsDataView: FC<DeploymentsDataViewProps> = ({
       filter: {
         ...dataViewState.apiFilter.filter,
         ...(dataViewState.apiFilter.searchText
-          ? { name: { $like: dataViewState.apiFilter.searchText } as unknown as string }
+          ? withOperators<ModelDeploymentFilter>({
+              name: { $like: dataViewState.apiFilter.searchText },
+            })
           : {}),
-      } as ModelDeploymentFilter,
+      },
     },
     {
       query: {

--- a/web/packages/studio/src/components/dataViews/EvaluationBenchmarksDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/EvaluationBenchmarksDataView/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { withOperators, type WithFilterOperators } from '@nemo/common/src/api/filterOperators';
 import { dateTimeFilter } from '@nemo/common/src/components/DataView/dateTimeFilter';
 import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
@@ -9,7 +10,10 @@ import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
 import { getSortParam } from '@nemo/common/src/utils/query';
 import { useEvaluationListBenchmarks } from '@nemo/sdk/generated/platform/api';
-import type { EvaluationListBenchmarksSort } from '@nemo/sdk/generated/platform/schema';
+import type {
+  EvaluationListBenchmarksParams,
+  EvaluationListBenchmarksSort,
+} from '@nemo/sdk/generated/platform/schema';
 import { Button, Stack, Text } from '@nvidia/foundations-react-core';
 import type {
   BenchmarkItemWithId,
@@ -31,11 +35,12 @@ export const EvaluationBenchmarksDataView: FC<EvaluationBenchmarksDataViewProps>
   });
 
   const benchmarksFilter = useMemo(() => {
-    const filterObj: Record<string, unknown> = {};
+    type BenchmarksFilter = NonNullable<EvaluationListBenchmarksParams['filter']>;
+    const filterObj: WithFilterOperators<BenchmarksFilter> = {};
 
     const nameFilter = dataViewState.apiFilter.searchText;
     if (nameFilter) {
-      filterObj.name = { $like: nameFilter } as unknown as string;
+      filterObj.name = { $like: nameFilter };
     }
 
     const createdAtFilter = dataViewState.apiFilter.filter?.created_at;
@@ -44,11 +49,11 @@ export const EvaluationBenchmarksDataView: FC<EvaluationBenchmarksDataViewProps>
       typeof createdAtFilter === 'object' &&
       Object.keys(createdAtFilter).length > 0
     ) {
-      filterObj.created_at = createdAtFilter;
+      filterObj.created_at = createdAtFilter as BenchmarksFilter['created_at'];
     }
 
     if (Object.keys(filterObj).length === 0) return undefined;
-    return filterObj;
+    return withOperators<BenchmarksFilter>(filterObj);
   }, [dataViewState.apiFilter]);
 
   const {

--- a/web/packages/studio/src/components/dataViews/EvaluationMetricsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/EvaluationMetricsDataView/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { withOperators, type WithFilterOperators } from '@nemo/common/src/api/filterOperators';
 import { dateTimeFilter } from '@nemo/common/src/components/DataView/dateTimeFilter';
 import {
   ROW_ACTIONS_COLUMN_SIZE,
@@ -17,7 +18,10 @@ import {
   useEvaluationDeleteMetric,
   useEvaluationListMetrics,
 } from '@nemo/sdk/generated/platform/api';
-import type { EvaluationListMetricsSort } from '@nemo/sdk/generated/platform/schema';
+import type {
+  EvaluationListMetricsParams,
+  EvaluationListMetricsSort,
+} from '@nemo/sdk/generated/platform/schema';
 import { Badge, Button, Flex, Stack, Text } from '@nvidia/foundations-react-core';
 import type {
   EvaluationMetricsDataViewProps,
@@ -73,11 +77,12 @@ export const EvaluationMetricsDataView: FC<EvaluationMetricsDataViewProps> = ({
 
   // Build filter object from the dataview filter state
   const metricsFilter = useMemo(() => {
-    const filterObj: Record<string, unknown> = {};
+    type MetricsFilter = NonNullable<EvaluationListMetricsParams['filter']>;
+    const filterObj: WithFilterOperators<MetricsFilter> = {};
 
     const nameFilter = dataViewState.apiFilter.searchText;
     if (nameFilter) {
-      filterObj.name = { $like: nameFilter } as unknown as string;
+      filterObj.name = { $like: nameFilter };
     }
 
     const createdAtFilter = dataViewState.apiFilter.filter?.created_at;
@@ -86,11 +91,11 @@ export const EvaluationMetricsDataView: FC<EvaluationMetricsDataViewProps> = ({
       typeof createdAtFilter === 'object' &&
       Object.keys(createdAtFilter).length > 0
     ) {
-      filterObj.created_at = createdAtFilter;
+      filterObj.created_at = createdAtFilter as MetricsFilter['created_at'];
     }
 
     if (Object.keys(filterObj).length === 0) return undefined;
-    return filterObj;
+    return withOperators<MetricsFilter>(filterObj);
   }, [dataViewState.apiFilter]);
 
   const {

--- a/web/packages/studio/src/components/dataViews/ExportJobsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExportJobsDataView/index.tsx
@@ -31,7 +31,7 @@ export const ExportJobsDataView = () => {
   const { getQueryParam, setQueryParam } = useQueryParams();
   const exportJobId = getQueryParam(QUERY_PARAMETERS.exportJobId);
 
-  const dataViewState = useStudioDataViewState({
+  const dataViewState = useStudioDataViewState<ExportJobFilter>({
     defaultSort: { id: 'created_at', desc: true },
   });
 
@@ -49,9 +49,9 @@ export const ExportJobsDataView = () => {
       page_size: dataViewState.pagination.state.pageSize,
       sort: getSortParam(dataViewState.sorting.state) as ExportJobSortField,
       filter: {
-        ...(dataViewState.apiFilter.filter as ExportJobFilter | undefined),
+        ...dataViewState.apiFilter.filter,
         ...(dataViewState.apiFilter.searchText ? { id: dataViewState.apiFilter.searchText } : {}),
-      } as ExportJobFilter | undefined,
+      },
     },
     {
       query: {

--- a/web/packages/studio/src/components/dataViews/InferenceProvidersDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/InferenceProvidersDataView/index.tsx
@@ -10,6 +10,7 @@
  * its affiliates is strictly prohibited.
  */
 
+import { withOperators } from '@nemo/common/src/api/filterOperators';
 import {
   ROW_ACTIONS_COLUMN_SIZE,
   StudioDataView,
@@ -89,9 +90,11 @@ export const InferenceProvidersDataView: FC<InferenceProvidersDataViewProps> = (
       filter: {
         ...dataViewState.apiFilter.filter,
         ...(dataViewState.apiFilter.searchText
-          ? { name: { $like: dataViewState.apiFilter.searchText } as unknown as string }
+          ? withOperators<ModelProviderFilter>({
+              name: { $like: dataViewState.apiFilter.searchText },
+            })
           : {}),
-      } as ModelProviderFilter,
+      },
     },
     {
       query: {

--- a/web/packages/studio/src/components/dataViews/JobsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/JobsDataView/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { withOperators } from '@nemo/common/src/api/filterOperators';
 import { dateTimeFilter } from '@nemo/common/src/components/DataView/dateTimeFilter';
 import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
@@ -12,6 +13,7 @@ import { useJobsListJobs } from '@nemo/sdk/generated/platform/api';
 import type {
   PlatformJobResponse,
   PlatformJobSortField,
+  PlatformJobsListFilter,
 } from '@nemo/sdk/generated/platform/schema';
 import { Button, Flex, StatusMessage } from '@nvidia/foundations-react-core';
 import { getErrorMessage } from '@studio/api/common/utils';
@@ -126,9 +128,13 @@ export const JobsDataView = () => {
       sort: getSortParam(dataViewState.sorting.state) as PlatformJobSortField,
       filter: {
         ...userFilter,
-        ...(hasUserSourceFilter ? {} : { source: { $nin: hiddenJobSources } as unknown as string }),
+        ...(hasUserSourceFilter
+          ? {}
+          : withOperators<PlatformJobsListFilter>({ source: { $nin: hiddenJobSources } })),
         ...(dataViewState.apiFilter.searchText
-          ? { name: { $like: dataViewState.apiFilter.searchText } as unknown as string }
+          ? withOperators<PlatformJobsListFilter>({
+              name: { $like: dataViewState.apiFilter.searchText },
+            })
           : {}),
       },
     },

--- a/web/packages/studio/src/components/dataViews/SafeSynthesizerJobsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/SafeSynthesizerJobsDataView/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { withOperators } from '@nemo/common/src/api/filterOperators';
 import { dateTimeFilter } from '@nemo/common/src/components/DataView/dateTimeFilter';
 import * as DataView from '@nemo/common/src/components/DataView/internal';
 import {
@@ -98,9 +99,11 @@ export const SafeSynthesizerJobsDataView: FC = () => {
       filter: {
         ...((dataViewState.apiFilter.filter ?? {}) as SafeSynthesizerJobsListFilter),
         ...(dataViewState.apiFilter.searchText
-          ? { name: { $like: dataViewState.apiFilter.searchText } }
+          ? withOperators<SafeSynthesizerJobsListFilter>({
+              name: { $like: dataViewState.apiFilter.searchText },
+            })
           : {}),
-      } as SafeSynthesizerJobsListFilter | undefined,
+      },
     },
     {
       query: {

--- a/web/packages/studio/src/components/sidePanels/MetricRunSidePanel/index.tsx
+++ b/web/packages/studio/src/components/sidePanels/MetricRunSidePanel/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { withOperators } from '@nemo/common/src/api/filterOperators';
 import { BASIC_ALL_MODELS_DROPDOWN_FILTER } from '@nemo/common/src/api/models/useModels';
 import { useModelsFromWorkspace } from '@nemo/common/src/api/models/useModelsFromWorkspace';
 import { VariableButton } from '@nemo/common/src/components/buttons/VariableButton';
@@ -17,7 +18,10 @@ import {
   useEvaluationCreateMetricJob,
   useEvaluationListMetrics,
 } from '@nemo/sdk/generated/platform/api';
-import type { EvaluatorModel } from '@nemo/sdk/generated/platform/schema';
+import type {
+  EvaluationListMetricsParams,
+  EvaluatorModel,
+} from '@nemo/sdk/generated/platform/schema';
 import type { MetricEvaluationJobRequest } from '@nemo/sdk/generated/platform/schema/MetricEvaluationJobRequest';
 import {
   Button,
@@ -186,7 +190,9 @@ export const MetricRunSidePanel: FC<MetricRunSidePanelProps> = ({
       page: 1,
       page_size: 50,
       filter: metricSearch
-        ? ({ name: { $like: metricSearch } } as Record<string, unknown>)
+        ? withOperators<NonNullable<EvaluationListMetricsParams['filter']>>({
+            name: { $like: metricSearch },
+          })
         : undefined,
     },
     { query: { enabled: !metric && open } }

--- a/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/FilesetSearchableSelect.tsx
+++ b/web/packages/studio/src/routes/DeploymentsListRoute/CreateDeploymentSidePanel/FilesetSearchableSelect.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { withOperators } from '@nemo/common/src/api/filterOperators';
 import {
   ControlledSearchableSelect,
   type SelectItemOption,
@@ -39,9 +40,9 @@ export function FilesetSearchableSelect<T extends FieldValues>({
   const [search, setSearch] = useState('');
   const filter = useMemo<FilesListFilesetsParams['filter'] | undefined>(() => {
     if (!search) return undefined;
-    // `$like` enables substring search; the generated `name?: string` type doesn't expose
-    // the operator object form so we cast — same pattern as CustomModelsDataView.
-    return { name: { $like: `%${search}%` } } as unknown as FilesListFilesetsParams['filter'];
+    return withOperators<FilesListFilesetsParams['filter']>({
+      name: { $like: `%${search}%` },
+    });
   }, [search]);
 
   const {

--- a/web/packages/studio/src/routes/WorkspaceBaseModelsRoute/index.tsx
+++ b/web/packages/studio/src/routes/WorkspaceBaseModelsRoute/index.tsx
@@ -120,7 +120,9 @@ export const WorkspaceBaseModelsRoute: FC = () => {
     items: [{ slotLabel: 'Base Models' }],
   });
 
-  const dataViewState = useStudioDataViewState({
+  const dataViewState = useStudioDataViewState<
+    Partial<ModelEntityFilterInput> & { [CUSTOMIZABLE_FILTER_ID]?: CustomizableFilterState }
+  >({
     defaultSort: { id: 'name', desc: false },
   });
 
@@ -130,9 +132,7 @@ export const WorkspaceBaseModelsRoute: FC = () => {
   const modelNameFromPath = decodeURIComponent(modelNameParam ?? '');
 
   const nameSearch = dataViewState.apiFilter.searchText;
-  const allColumnFilters = dataViewState.apiFilter.filter as
-    | (Partial<ModelEntityFilterInput> & { [CUSTOMIZABLE_FILTER_ID]?: CustomizableFilterState })
-    | undefined;
+  const allColumnFilters = dataViewState.apiFilter.filter;
   const customizableFilter = CUSTOMIZER_ENABLED
     ? allColumnFilters?.[CUSTOMIZABLE_FILTER_ID]
     : undefined;

--- a/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/index.tsx
@@ -70,6 +70,12 @@ import {
 import { useLocation } from 'react-router-dom';
 
 type MultiState = Record<string, true>;
+type SuggestionFilter = {
+  agent?: MultiState;
+  severity?: MultiState;
+  type?: MultiState;
+  scope?: MultiState;
+};
 
 export const AgentOptimizationsRoute: FC = () => {
   const workspace = useWorkspaceFromPath();
@@ -161,7 +167,7 @@ export const AgentOptimizationsRoute: FC = () => {
   // Suggestion the user just clicked Apply on — drives the eval-config
   // chooser modal. ``null`` keeps the modal closed.
   const [pendingApply, setPendingApply] = useState<OptimizationSuggestion | null>(null);
-  const dataViewState = useStudioDataViewState({});
+  const dataViewState = useStudioDataViewState<SuggestionFilter>({});
 
   const handleApplyClicked = useCallback(
     (suggestion: OptimizationSuggestion) => {
@@ -272,9 +278,7 @@ export const AgentOptimizationsRoute: FC = () => {
     [typeOptions, severityOptions, scopeOptions, agentOptions]
   );
 
-  const filterState = dataViewState.apiFilter.filter as
-    | { agent?: MultiState; severity?: MultiState; type?: MultiState; scope?: MultiState }
-    | undefined;
+  const filterState = dataViewState.apiFilter.filter;
   const agentFilter = filterState?.agent;
   const severityFilter = filterState?.severity;
   const typeFilter = filterState?.type;

--- a/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/index.tsx
@@ -70,12 +70,12 @@ import {
 import { useLocation } from 'react-router-dom';
 
 type MultiState = Record<string, true>;
-type SuggestionFilter = {
+interface SuggestionFilter {
   agent?: MultiState;
   severity?: MultiState;
   type?: MultiState;
   scope?: MultiState;
-};
+}
 
 export const AgentOptimizationsRoute: FC = () => {
   const workspace = useWorkspaceFromPath();

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -389,7 +389,8 @@ export const getIntakeRoute = (workspace: string) => {
 };
 
 export const getIntakeEntriesRoute = (workspace: string, options?: ListEntriesParams) => {
-  const queryParamStr = options ? `?${generateFilterParam(options.filter)}` : '';
+  const filterQuery = options ? generateFilterParam(options.filter) : '';
+  const queryParamStr = filterQuery ? `?${filterQuery}` : '';
   return generatePath(ROUTES.workspace.intakeEntries, { workspace }) + queryParamStr;
 };
 

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -389,9 +389,7 @@ export const getIntakeRoute = (workspace: string) => {
 };
 
 export const getIntakeEntriesRoute = (workspace: string, options?: ListEntriesParams) => {
-  const queryParamStr = options
-    ? `?${generateFilterParam(options?.filter as Record<string, unknown>)}`
-    : '';
+  const queryParamStr = options ? `?${generateFilterParam(options.filter)}` : '';
   return generatePath(ROUTES.workspace.intakeEntries, { workspace }) + queryParamStr;
 };
 


### PR DESCRIPTION
This PR addresses https://linear.app/nvidia/issue/ASTD-87/improve-filter-typing-for-dataview by adding a type that captures the mongo like operators that are supported by the backend but not included in the openapi definition. There is a new utility that creates a type union between string and the operator type.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized filtering across the app: introduced operator-based filters and a central helper, and made data-view hooks and many components accept typed filter shapes.
  * Improved filter typing for lists, searches and route query generation (jobs, deployments, evaluations, metrics, benchmarks, models, filesets, providers, exports, etc.), increasing consistency and reliability of search/filter behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->