### PR TITLE
docs(evaluator): update BYOB evaluator skill

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/SKILL.md
@@ -1,140 +1,125 @@
 ---
 name: nemo-evaluator
 description: >
-  NeMo evaluator CLI reference for metrics, evaluations, metric jobs, and benchmarks.
-  Use when the task involves evaluation metrics, string-check, llm-judge, tool-calling
-  metrics, sync/async evaluations, benchmark jobs, or `nemo evaluation` CLI commands.
-user-invocable: true
-allowed-tools: Bash, Read, Grep
+  NeMo Evaluator SDK-first rubric-to-eval guide for BYOB (Bring Your Own
+  Benchmark): parse domain expert rubrics, choose composable evaluation
+  primitives, generate human-reviewable eval configs/artifacts, and run
+  reproducible exact, numeric, LLM-as-judge, code/custom, composite,
+  RAG/agentic, and tool-calling evaluations. Use when a task involves
+  questions/rubrics/responses files, rubric criteria, benchmark scoring,
+  evaluator primitive selection, or reusable evaluation artifacts.
+compatibility: Designed for installed NeMo Platform skill use; repo-relative SDK paths are developer fallbacks when a checkout is available.
+metadata:
+  user-invocable: true
 ---
 
-# NeMo Evaluator CLI Reference
+# NeMo Evaluator
 
-## Environment
+Use this skill to turn a domain-specific benchmark and expert-written rubric
+into a reproducible evaluation. The agent should parse the rubric, choose the
+simplest correct composable primitive for each criterion, generate
+human-reviewable config/artifacts, run the evaluation, and explain both scores
+and reasoning.
 
-- **CLI path**: `/app/.venv/bin/nemo`
-- **API server**: `http://localhost:8080` (default)
+Use the NeMo Evaluator SDK as the source of truth for metric names, fields,
+templates, execution modes, result shapes, and failure behavior. Keep this skill
+focused on SDK guidance. Use CLI commands only when the user explicitly needs a
+remote platform job or an existing platform resource.
 
-## Metric Commands
+## Runtime Context
 
-```bash
-# Create a string-check metric
-nemo evaluation metrics create <name> \
-  --type string-check \
-  --params '{"field": "output", "expected_field": "expected", "operation": "equals"}' \
-  --workspace <workspace>
+This skill can run in two contexts:
 
-# Create a metric from a JSON file (for complex types like llm-judge)
-nemo evaluation metrics create <name> \
-  --workspace <workspace> \
-  --input-file <path-to-json>
+- In the NeMo Platform repo, expect the SDK to be importable through the repo
+  environment, for example with `uv run` commands from the repo root. Use the
+  repo-relative SDK reference paths in `references/sdk-execution.md` when
+  checking exact schemas or tests.
+- As an installed skill outside the repo, do not assume the source tree is
+  present. Use installed Python imports, package metadata, CLI help, or
+  user-provided files first; treat repo paths as developer fallback references.
 
-# List metrics
-nemo evaluation metrics list --workspace <workspace>
+Prefer local SDK runs for iteration and smoke tests. Use remote platform jobs
+only when the user needs platform-managed execution, existing platform
+resources, or a job result from a deployed environment. For local SDK runs,
+`api_key_secret` resolves through the local environment; for remote jobs, the
+same name should refer to a platform secret in the job workspace.
 
-# Get a metric
-nemo evaluation metrics get <name> --workspace <workspace>
-```
+## Reference Files
 
-## Sync Evaluation Commands
+Load these files only when the task needs the detail:
 
-```bash
-# Run sync evaluation with inline data
-nemo evaluation metrics run \
-  --name <metric_name> \
-  --data '<jsonl_rows>' \
-  --workspace <workspace>
-```
+- Metric selection: `references/metric-selection.md`
+  - Read when mapping rubric criteria to SDK metrics, choosing deterministic vs
+    LLM judges, or working with RAG/agentic/tool-calling metrics.
+- SDK execution: `references/sdk-execution.md`
+  - Read before guessing a metric schema, execution parameter, online/offline
+    setup, parser, template, or SDK result shape.
+- Benchmark reproduction: `references/benchmark-reproduction.md`
+  - Read for BYOB protocol, long-running benchmark reproduction, artifact
+    contracts, and external-safe output requirements.
+- Troubleshooting: `references/troubleshooting.md`
+  - Read when SDK runs fail, judge outputs do not parse, provider calls time
+    out, or generated artifacts need recovery.
 
-Each row in `--data` is a JSON object with fields the metric references.
+## Default Loop
 
-## Async Metric Job Commands
+1. Identify the BYOB inputs: questions, rubric criteria, responses or live
+   model endpoints, weights, pass threshold, and desired summary breakdowns.
+2. Clarify the evaluation target: model output quality, judge quality, RAG
+   quality, tool use, benchmark regression, or bring-your-own benchmark
+   reproduction.
+   - Judge-quality evaluation checks whether a judge agrees with labels for
+     existing responses.
+   - Generator-quality evaluation creates fresh responses and scores those
+     responses with a fixed judge or deterministic checker.
+3. Choose the simplest correct SDK metric class or composed set of classes for
+   each criterion. See `references/metric-selection.md`.
+4. Generate a small, human-reviewable config or code artifact instead of
+   burying criterion logic in one-off scripts.
+5. Build a tiny inline dataset with at least one expected pass and one expected
+   fail.
+6. Run locally with `Evaluator().run_sync(...)` or `await Evaluator().run(...)`.
+   See `references/sdk-execution.md`.
+7. Inspect `result.print_summary()`, `row_scores`, and `aggregate_scores`.
+8. When errors arise, fix dataset shape, Jinja templates, parser paths,
+   prompts, model config, or secrets. See `references/troubleshooting.md`.
+9. Move to remote platform jobs only after the local SDK run behaves as
+   expected.
 
-```bash
-# Create an async metric job
-nemo evaluation metric-jobs create <job_name> \
-  --metric-name <metric_name> \
-  --dataset-fileset <fileset_name> \
-  --workspace <workspace>
+Do not stop at "the score is bad." Explain what failed and what evidence
+supports that conclusion.
 
-# Check job status
-nemo evaluation metric-jobs get <job_name> --workspace <workspace>
+## Core Selection Rules
 
-# List jobs
-nemo evaluation metric-jobs list --workspace <workspace>
-```
+Prefer deterministic primitives before LLM calls. Use LLM judges for nuance,
+not for checks that can be expressed as exact, string, numeric, or code logic.
 
-**Note**: Jobs may stay in "created" status if the job controller is not running — that is expected.
+Use online generation only when the evaluator should call a model or agent
+before scoring. Pass `target=Model(...)` or `target=Agent(...)` and a
+`prompt_template`; otherwise keep evaluation offline and put outputs in the
+dataset rows.
 
-## Benchmark Commands
+For external, custom, or bring-your-own benchmarks, keep the protocol explicit
+and reproducible.
 
-```bash
-# List system benchmarks (from system workspace)
-nemo evaluation benchmarks list --workspace system
+Separate judge-quality evaluation from generation-quality evaluation. If the
+target is report generation, generate fresh model responses, score them with a
+fixed judge, and aggregate fulfilment. Do not treat human labels for existing
+baseline responses as labels for new model outputs.
 
-# Get benchmark details
-nemo evaluation benchmarks get <name> --workspace system
+For public or broadly shared skills and reports, avoid internal endpoint names,
+internal model IDs, authentication details, and secret paths. Use placeholders
+such as `<provider-base-url>`, `<generator-model-id>`, `<judge-model-id>`, and
+`<secret-reference>`. Report parameter categories and aliases instead of
+revealing private infrastructure.
 
-# Create a benchmark eval job
-nemo evaluation benchmark-jobs create <job_name> \
-  --benchmark <benchmark_spec_json> \
-  --workspace <workspace>
+## Completion Criteria
 
-# Check benchmark job status
-nemo evaluation benchmark-jobs get <job_name> --workspace <workspace>
-```
+A good evaluator answer includes:
 
-## Metric Types
-
-### string-check
-Compares fields using an operation (equals, contains, etc.):
-```json
-{"field": "output", "expected_field": "expected", "operation": "equals"}
-```
-Dataset rows need `output` and `expected` fields.
-
-### llm-judge
-Uses an LLM to score responses. Create via `--input-file` with this JSON structure:
-```json
-{
-  "type": "llm-judge",
-  "name": "quality-judge",
-  "model": {
-    "url": "https://integrate.api.nvidia.com/v1",
-    "name": "openai/gpt-oss-20b",
-    "format": "openai",
-    "api_key_secret": "<secret-name>"
-  },
-  "scores": [
-    {
-      "name": "relevance",
-      "description": "Relevance score from 1 to 5",
-      "minimum": 1,
-      "maximum": 5,
-      "parser": {"type": "json", "json_path": "relevance"}
-    }
-  ],
-  "prompt_template": {
-    "messages": [
-      {"role": "system", "content": "Rate the response on relevance 1-5. Return JSON: {\"relevance\": <score>}"},
-      {"role": "user", "content": "Question: {{item.input}}\nResponse: {{item.output}}"}
-    ]
-  }
-}
-```
-Requires a secret with the API key (use `nemo-secrets` skill).
-
-### zero-config llm-judge
-Same as llm-judge but without `prompt_template` and score `parser` — the system auto-generates them. Just provide `scores` with `name`, `description`, `minimum`, `maximum`, and a rubric.
-
-### tool-calling
-Evaluates function call accuracy. Dataset rows need `messages`, `tools`, `expected_tool_calls`, `response` fields in OpenAI format.
-
-## Typical Workflow
-
-1. Create workspace: `nemo workspaces create <ws>`
-2. Upload dataset: create fileset + upload JSONL file (use `nemo-files` skill)
-3. Create metric (string-check, llm-judge, etc.)
-4. Run sync eval with inline data to test
-5. Create async metric job against the uploaded dataset
-6. Check job status
+- The evaluation goal and chosen SDK metric class or benchmark shape.
+- The dataset shape and any templates or parser paths.
+- The exact SDK snippet or evaluation spec used.
+- Row-level and aggregate evidence for local runs, or job status/result
+  evidence for remote runs.
+- Any caveats about reproducibility, provider config, or calibration.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/references/benchmark-reproduction.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/references/benchmark-reproduction.md
@@ -1,0 +1,101 @@
+# Benchmark Reproduction
+
+Read this file for BYOB protocol, long-running benchmark reproduction, artifact
+contracts, and external-safe output requirements.
+
+## Bring Your Own Benchmark
+
+For external, custom, or bring-your-own benchmarks, keep the protocol explicit
+and reproducible.
+
+- Separate judge-quality evaluation from generation-quality evaluation. If the
+  target is report generation, generate fresh model responses, score them with
+  a fixed judge, and aggregate fulfilment. Do not treat human labels for
+  existing baseline responses as labels for new model outputs.
+- Use provider-agnostic configuration. Require users or harness config to
+  provide generator and judge base URLs, model IDs, and secret references.
+- Validate model IDs with a `/v1/models`-style endpoint when the provider
+  supports it. Do not assume a web catalog equals runnable API model IDs.
+- Run a tiny smoke prompt before the full benchmark to confirm authentication,
+  response shape, parser behavior, and unsupported generation parameters.
+- Record artifacts that make the run replayable: `README.md`, `manifest.yaml`,
+  `scoring_protocol.md`, `results_report.md`, `generations.jsonl`,
+  `judge_predictions.jsonl`, and `scores.json`.
+- Store secret variable names or secret file paths in manifests, never secret
+  values.
+- Report calibration deltas transparently. Do not apply hidden correction
+  factors; inspect endpoint/model ID, generation params, sampling plan, judge
+  prompt, reasoning policy, parser, and aggregation if deltas are large.
+
+## Long-Running Benchmark Reproduction
+
+Use this pattern when a BYOB run is too large for a single in-memory SDK
+example.
+
+1. Freeze the dataset, rubric, sample plan, generator parameters, judge
+   parameters, and any external scoring weights used by the benchmark protocol
+   before starting the full run.
+2. Smoke-test one or two rows end to end: generate, judge, parse, aggregate,
+   and write artifacts.
+3. Use one run directory per generator model or model configuration. Do not mix
+   outputs from different generator settings in the same checkpoint files.
+4. Checkpoint generation and judging separately so either stage can resume.
+   Prefer append-only JSONL with stable row IDs, external criterion IDs from
+   the expanded BYOB artifact, status, parsed values, and error fields.
+5. For external harness JSONL recovery, recover by stable IDs, validate each
+   line before reuse, rewrite a clean compacted file after recovery, and keep
+   the corrupted fragment for audit.
+6. Retry failed rows individually with bounded attempts. Fail closed on missing
+   rows, missing criteria, or unparsable judge outputs; do not silently drop
+   them from benchmark-protocol scoring counts.
+7. Write final task, domain, and overall scores only after every required
+   criterion row is present and parseable, or after failures are explicitly
+   counted according to the scoring protocol.
+8. Report progress periodically by stage: generated rows, judged criterion
+   rows, parse failures, retry queue, rate-limit sleeps, and estimated
+   remaining work.
+
+ProfBench-style rubric-to-leaderboard shape:
+
+```text
+dataset rows
+-> generated responses per model
+-> criterion-level judge rows per response
+-> fixed binary judge with parser-compatible yes/no output
+-> weighted criterion fulfilment
+-> task, domain, and overall scores
+```
+
+Keep the fixed judge, rubric text, parser, and any external benchmark weights
+constant when comparing generator models. If the judge itself is being
+evaluated, run a separate judge-quality experiment against labeled existing
+responses.
+
+## Artifact Contract
+
+For an external BYOB handoff or checkpointed benchmark harness, these artifacts
+make the run inspectable and rerunnable. The SDK does not generate this full
+contract automatically; teams that need strict enforcement should implement a
+typed artifact contract outside the skill.
+
+- `manifest.yaml`: dataset version, rubric version, sample plan, model aliases,
+  parameter summaries, scoring protocol, and artifact paths.
+- `expanded_dataset.jsonl`: immutable rows after sampling and task expansion.
+- `generations.jsonl`: generator outputs with row IDs, model alias, params
+  summary, status, output text, and errors.
+- `criterion_rows.jsonl`: one row per generated response and rubric criterion.
+- `judge_predictions.jsonl`: raw and parsed judge outputs with retry metadata.
+- `failure_log.jsonl`: failures, skipped rows, parser errors, and retry
+  exhaustion.
+- `scores.json`: task, domain, and overall aggregates with scoring counts
+  defined by the benchmark protocol.
+- `results_report.md`: concise explanation of setup, scores, caveats, and
+  interpretation.
+
+## External-Safe Outputs
+
+For public or broadly shared skills and reports, avoid internal endpoint names,
+internal model IDs, authentication details, and secret paths. Use placeholders
+such as `<provider-base-url>`, `<generator-model-id>`, `<judge-model-id>`, and
+`<secret-reference>`. Report parameter categories and aliases instead of
+revealing private infrastructure.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/references/metric-selection.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/references/metric-selection.md
@@ -1,0 +1,55 @@
+# Metric Selection
+
+Read this file when mapping rubric criteria to SDK metrics, choosing
+deterministic vs LLM judges, or working with RAG/agentic/tool-calling metrics.
+
+## Choosing The Right Metric
+
+| Evaluation goal | Prefer | SDK class | Watch for |
+| --- | --- | --- | --- |
+| Exact label, enum, or string regression | `exact-match` or `string-check` | `ExactMatchMetric`, `StringCheckMetric` | Normalize whitespace/case with Jinja filters if needed |
+| Numeric correctness or thresholds | `number-check` | `NumberCheckMetric` | Non-numeric values score `NaN` |
+| Reference text similarity | `f1`, `bleu`, or `rouge` | `F1Metric`, `BLEUMetric`, `ROUGEMetric` | Similarity is not factual correctness |
+| Flexible semantic quality | `llm-judge` | `LLMJudgeMetric` | Use explicit rubrics and parser-compatible judge output |
+| Zero-config semantic quality | `llm-judge` without custom prompt/parsers | `LLMJudgeMetric` with score definitions only | Validate default prompt and parser behavior on tiny data |
+| RAG retrieval coverage | `context_recall`, `context_precision`, `context_relevance`, `context_entity_recall` | RAGAS metric classes | Required columns differ by metric |
+| RAG grounding or hallucination | `faithfulness`, `response_groundedness`, `noise_sensitivity` | RAGAS metric classes | Requires judge model config |
+| RAG answer relevance | `response_relevancy` | `ResponseRelevancyMetric` | Requires judge and embeddings model config |
+| Agent final outcome | `agent_goal_accuracy`, `answer_accuracy`, `topic_adherence` | RAGAS agentic metric classes | Most require a judge model |
+| Agent tool/function calls | `tool_call_accuracy` or `tool-calling` | `ToolCallAccuracyMetric`, `ToolCallingMetric` | Ground truth and response shape must match the metric |
+| Custom business scoring | `remote` or `nemo-agent-toolkit-remote` | `RemoteMetric`, `NemoAgentToolkitRemoteMetric` | Smoke test endpoint auth, payload, timeout, and parser path |
+| Repeatable model comparison | Multi-metric SDK run or platform benchmark job | `Evaluator.run(metrics=[...])` or benchmark APIs | Record metric list, dataset, model config, params, and results |
+| Bring-your-own benchmark reproduction | Fixed judge plus explicit artifact protocol | SDK harness around generation, judge predictions, and aggregation | Keep generation quality separate from judge-quality evaluation |
+
+## Composable Primitive Mapping
+
+When converting rubric criteria into an eval, use the PRD's primitive mindset
+and map it onto the current SDK surface:
+
+| PRD primitive | Use when | Current SDK surface |
+| --- | --- | --- |
+| `exact` | Criterion checks for a term, phrase, regex-like pattern, or exact output | `ExactMatchMetric`, `StringCheckMetric` |
+| `numeric` | Criterion expects a calculated value, threshold, tolerance, or count | `NumberCheckMetric` |
+| `llm` | Criterion needs semantic reasoning, style judgment, communication quality, or subjective quality | `LLMJudgeMetric` with `RangeScore` or `RubricScore` |
+| `code` | Criterion needs domain-specific computation or validation logic | Custom harness code, `RemoteMetric`, or a reviewed Python checker around SDK results |
+| `composite` | One criterion benefits from deterministic checks plus an LLM fallback or weighted subchecks | Multiple SDK metrics plus agent-owned aggregation, or a custom wrapper until a native composite primitive exists |
+
+Prefer deterministic primitives before LLM calls. Use LLM judges for nuance,
+not for checks that can be expressed as exact, string, numeric, or code logic.
+
+## RAG And Agentic Metrics
+
+Use RAGAS-backed metric classes from `nemo_evaluator_sdk.metrics.ragas` when the
+task is about retrieval, grounding, or agent behavior. Keep dataset columns
+aligned with the metric:
+
+| Metric family | Common required fields |
+| --- | --- |
+| Retrieval quality | `user_input`, `retrieved_contexts`, often `reference` |
+| Grounding/hallucination | `user_input`, `response`, `retrieved_contexts`, sometimes `reference` |
+| Response relevancy | `user_input`, `response`, `retrieved_contexts` plus embeddings model config |
+| Tool call accuracy | `user_input`, `reference_tool_calls` or metric-specific tool-call fields |
+| Agent goal/answer/topic | Conversation or final response fields plus judge model config |
+
+When unsure, read the SDK metric class and its tests before creating a large
+run.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/references/sdk-execution.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/references/sdk-execution.md
@@ -1,0 +1,247 @@
+# SDK Execution
+
+Read this file before guessing a metric schema, execution parameter,
+online/offline setup, parser, template, or SDK result shape.
+
+## SDK Reference Points
+
+Assume the skill is usually installed with the plugin rather than running from
+a NeMo Platform repo checkout. Prefer installed SDK inspection before using
+repo-relative source paths:
+
+- Import SDK classes and inspect their signatures, docstrings, and exported
+  field names.
+- Use package metadata, installed examples, and CLI help when available.
+- Prefer the public import surface, such as `nemo_evaluator_sdk.Evaluator`,
+  metric classes, `RunConfig`, `RunConfigOnlineModel`, `Model`, and parser
+  classes, over private paths.
+- If the user provides a repo checkout or you are already working inside one,
+  use the source paths below as developer fallbacks before guessing a metric
+  schema or execution parameter.
+
+- Metric config schemas: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/metrics.py`
+- Metric type names: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/enums.py`
+- Runtime metric behavior: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/`
+- RAGAS runtime metrics: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/metrics.py`
+- Execution API: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/evaluator.py`
+- Run config types: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/params.py`
+- Request config normalization: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/config.py`
+- Public examples: `packages/nemo_evaluator_sdk/examples/examples.py`
+- Focused tests: `packages/nemo_evaluator_sdk/tests/metrics/` and
+  `packages/nemo_evaluator_sdk/tests/execution/`
+
+Prefer the SDK class field names. For example, `StringCheckMetric` uses
+`operation`, `left_template`, and `right_template`; do not invent `field` or
+`expected_field`.
+
+## Online Vs Offline Evaluation
+
+Use offline evaluation when dataset rows already contain the output or response
+to score. This is the default for reproducing a benchmark, validating known
+responses, checking judge agreement against labels, or debugging metric
+templates.
+
+Use online evaluation when the evaluator should call a live model or agent
+before scoring. In online mode, pass `target=Model(...)` or `target=Agent(...)`
+and a `prompt_template`; metrics can then score the generated output through
+the SDK's online result fields. Use this for generation-quality workflows,
+live model comparisons, or platform-managed jobs that need fresh generations.
+
+Keep these workflows separate. Do not use labels for existing baseline
+responses as labels for newly generated outputs unless the benchmark protocol
+explicitly defines that mapping.
+
+## Good Loop Examples
+
+Offline judge-quality loop: start with rows that already contain `input`,
+`output`, and `expected`; choose `ExactMatchMetric`, `StringCheckMetric`, or
+`LLMJudgeMetric` depending on the rubric; smoke-test one expected pass and one
+expected fail; inspect `row_scores` before trusting aggregate scores.
+
+Online generation-quality loop: start with rows that contain prompts and
+references; pass `target=Model(...)` or `target=Agent(...)` plus a
+`prompt_template`; score fresh generations with fixed deterministic metrics or
+a fixed judge; inspect generated outputs, judge predictions, and aggregate
+scores separately.
+
+## SDK Execution Patterns
+
+Use `Evaluator` directly for local, completed-result evaluation. It accepts one
+metric or a sequence of metrics and returns either `EvaluationResult` or a
+multi-metric benchmark result.
+
+```python
+from nemo_evaluator_sdk import Evaluator, RunConfig, StringCheckMetric
+
+
+metric = StringCheckMetric(
+    operation="equals",
+    left_template="{{item.output | trim}}",
+    right_template="{{item.expected | trim}}",
+)
+
+result = Evaluator().run_sync(
+    metrics=metric,
+    dataset=[
+        {"output": "hello", "expected": "hello"},
+        {"output": "foo", "expected": "bar"},
+    ],
+    config=RunConfig(parallelism=4),
+)
+
+result.print_summary()
+print(result.aggregate_scores)
+print(result.row_scores)
+```
+
+Run multiple metrics together when evaluating multiple dimensions of the same
+dataset:
+
+```python
+from nemo_evaluator_sdk import Evaluator, ExactMatchMetric, StringCheckMetric
+
+
+metrics = [
+    ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.output}}"),
+    StringCheckMetric(
+        operation="contains",
+        left_template="{{item.output}}",
+        right_template="{{item.required_phrase}}",
+    ),
+]
+
+result = Evaluator().run_sync(metrics=metrics, dataset=rows)
+result.print_summary()
+print(result.per_metric)
+```
+
+Use online generation only when the evaluator should call a model or agent
+before scoring. Pass `target=Model(...)` or `target=Agent(...)` and a
+`prompt_template`; otherwise keep evaluation offline and put outputs in the
+dataset rows.
+
+```python
+from nemo_evaluator_sdk import (
+    Evaluator,
+    ExactMatchMetric,
+    InferenceParams,
+    Model,
+    RunConfigOnlineModel,
+)
+
+
+metric = ExactMatchMetric(reference="{{item.expected}}")
+target = Model(
+    url="https://provider.example/v1",
+    name="<model-id>",
+    format="openai",
+    api_key_secret="<secret-or-env-name>",
+)
+
+result = Evaluator().run_sync(
+    metrics=metric,
+    target=target,
+    dataset=[{"prompt": "What is 2+2?", "expected": "4"}],
+    prompt_template={"messages": [{"role": "user", "content": "{{item.prompt}}"}]},
+    config=RunConfigOnlineModel(
+        parallelism=2,
+        inference=InferenceParams(max_tokens=128),
+    ),
+)
+```
+
+In `Model(...)`, `format` selects the provider/API protocol shape, such as
+OpenAI-compatible request and response handling. `api_key_secret` is a secret
+reference name, not a literal secret value. For local SDK runs, ensure the
+matching local environment variable exists; for remote platform jobs, create a
+platform secret with the same name in the job workspace.
+
+## LLM Judge Pattern
+
+Use `LLMJudgeMetric` when deterministic metrics cannot capture the behavior.
+Define score names, descriptions, ranges or rubrics, parser behavior, judge
+model, and prompt template. Score names must use lowercase letters, numbers,
+and underscores.
+
+```python
+from nemo_evaluator_sdk import Evaluator, JSONScoreParser, LLMJudgeMetric, Model, RangeScore
+
+
+judge_model = Model(
+    url="https://provider.example/v1",
+    name="<judge-model-id>",
+    format="openai",
+    api_key_secret="<secret-or-env-name>",
+)
+
+metric = LLMJudgeMetric(
+    model=judge_model,
+    scores=[
+        RangeScore(
+            name="quality",
+            description="Overall response quality from 1 to 5",
+            minimum=1,
+            maximum=5,
+            parser=JSONScoreParser(json_path="quality"),
+        )
+    ],
+    prompt_template={
+        "messages": [
+            {
+                "role": "system",
+                "content": 'Rate response quality from 1 to 5. Return JSON: {"quality": <score>}',
+            },
+            {
+                "role": "user",
+                "content": "Input: {{item.input}}\nResponse: {{item.output}}",
+            },
+        ]
+    },
+)
+
+result = Evaluator().run_sync(
+    metrics=metric,
+    dataset=[
+        {"input": "Explain photosynthesis.", "output": "Plants use sunlight to make sugars."},
+        {"input": "Explain photosynthesis.", "output": "I cannot help."},
+    ],
+)
+```
+
+For zero-config judge metrics, provide `model` and rubric/range `scores`, then
+omit `prompt_template` and explicit parsers. Run a tiny local evaluation before
+using a full dataset.
+
+## Tool Calling Pattern
+
+Use `ToolCallingMetric` when rows contain OpenAI-style tool responses and
+ground truth tool calls. It emits:
+
+- `function_name_accuracy`
+- `function_name_and_args_accuracy`
+
+```python
+from nemo_evaluator_sdk import Evaluator, ToolCallingMetric
+
+
+metric = ToolCallingMetric(reference="{{item.expected_tool_calls}}")
+result = Evaluator().run_sync(metrics=metric, dataset=rows)
+```
+
+Each row should include a `response` object shaped like an OpenAI chat
+completion with `choices[0].message.tool_calls`. Ground truth should be a list
+of OpenAI-style tool call objects with `function.name` and
+`function.arguments`. The runtime is case sensitive, order insensitive for
+parallel calls, and expects function arguments to be valid JSON strings in the
+predicted response.
+
+## Dataset And Template Checks
+
+- Templates read dataset columns through `item`, for example
+  `{{item.expected}}`.
+- Online evaluations can read generated output through `sample.output_text`.
+- Offline evaluations need response/output fields already present in each row.
+- Keep field names identical between dataset rows and templates.
+- Include at least one expected pass and one expected fail in smoke data.
+- If a row fails to render a template, fix the dataset shape before changing
+  the metric.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/references/troubleshooting.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/references/troubleshooting.md
@@ -1,0 +1,48 @@
+# Troubleshooting
+
+Read this file when SDK runs fail, judge outputs do not parse, provider calls
+time out, or generated artifacts need recovery.
+
+## Failure Modes
+
+- Empty completions: record the raw provider response, prompt, params, finish
+  reason, and provider token/request metadata when available. In SDK results,
+  look for request metadata in row-level request details rather than aggregate
+  scores. Retry only if the provider response indicates a transient failure.
+- All-reasoning outputs: inspect completion token use and final-answer length;
+  record token budget and reasoning settings separately from benchmark
+  semantics.
+- Unparsable judge rows: store raw judge text, parser error, row ID, external
+  criterion ID from the expanded BYOB artifact if present, and retry count;
+  count unresolved rows as failures unless the protocol defines different
+  failure accounting.
+- SDK row failures: by default, request or scoring failures abort the run. Use
+  `ignore_request_failure=True` only when the benchmark protocol allows failed
+  rows to be marked as `NaN` and carried into reporting.
+- SDK provider timeouts and rate limits: configure SDK request behavior with
+  fields such as `request_timeout` and `max_retries`; the SDK handles retry
+  attempts internally and does not expose a persistent retry queue.
+- External BYOB harness timeouts and rate limits: if building a checkpointed
+  harness outside the SDK, use bounded retries with backoff, persist the retry
+  queue, and keep progress artifacts valid after interruption.
+- Failed-row retries: retry the smallest failed unit, usually one generation
+  row or one criterion judge row, rather than rerunning completed work.
+
+## Debugging Checklist
+
+- Wrong schema: compare the metric constructor fields against
+  `values/metrics.py`.
+- Missing field: compare dataset row keys with Jinja templates.
+- Bad parser: make the judge return exactly the JSON or regex format the parser
+  expects.
+- Judge produced reasoning but no final answer: increase final-answer token
+  budget or adjust reasoning params if the provider supports them.
+- Secret error: for local SDK runs, ensure the environment variable resolved
+  from `api_key_secret` exists; for remote platform jobs, create the platform
+  secret in the job workspace.
+- Unsupported provider parameter: remove optional params first, then add them
+  back one at a time.
+- Tool-calling mismatch: check case sensitivity, function name normalization,
+  argument JSON validity, and response shape.
+- SDK mismatch: verify the request/config payload uses current SDK metric
+  fields.

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/SKILL.md
@@ -1,140 +1,125 @@
 ---
 name: nemo-evaluator
 description: >
-  NeMo evaluator CLI reference for metrics, evaluations, metric jobs, and benchmarks.
-  Use when the task involves evaluation metrics, string-check, llm-judge, tool-calling
-  metrics, sync/async evaluations, benchmark jobs, or `nemo evaluation` CLI commands.
-user-invocable: true
-allowed-tools: Bash, Read, Grep
+  NeMo Evaluator SDK-first rubric-to-eval guide for BYOB (Bring Your Own
+  Benchmark): parse domain expert rubrics, choose composable evaluation
+  primitives, generate human-reviewable eval configs/artifacts, and run
+  reproducible exact, numeric, LLM-as-judge, code/custom, composite,
+  RAG/agentic, and tool-calling evaluations. Use when a task involves
+  questions/rubrics/responses files, rubric criteria, benchmark scoring,
+  evaluator primitive selection, or reusable evaluation artifacts.
+compatibility: Designed for installed NeMo Platform skill use; repo-relative SDK paths are developer fallbacks when a checkout is available.
+metadata:
+  user-invocable: true
 ---
 
-# NeMo Evaluator CLI Reference
+# NeMo Evaluator
 
-## Environment
+Use this skill to turn a domain-specific benchmark and expert-written rubric
+into a reproducible evaluation. The agent should parse the rubric, choose the
+simplest correct composable primitive for each criterion, generate
+human-reviewable config/artifacts, run the evaluation, and explain both scores
+and reasoning.
 
-- **CLI path**: `/app/.venv/bin/nemo`
-- **API server**: `http://localhost:8080` (default)
+Use the NeMo Evaluator SDK as the source of truth for metric names, fields,
+templates, execution modes, result shapes, and failure behavior. Keep this skill
+focused on SDK guidance. Use CLI commands only when the user explicitly needs a
+remote platform job or an existing platform resource.
 
-## Metric Commands
+## Runtime Context
 
-```bash
-# Create a string-check metric
-nemo evaluation metrics create <name> \
-  --type string-check \
-  --params '{"field": "output", "expected_field": "expected", "operation": "equals"}' \
-  --workspace <workspace>
+This skill can run in two contexts:
 
-# Create a metric from a JSON file (for complex types like llm-judge)
-nemo evaluation metrics create <name> \
-  --workspace <workspace> \
-  --input-file <path-to-json>
+- In the NeMo Platform repo, expect the SDK to be importable through the repo
+  environment, for example with `uv run` commands from the repo root. Use the
+  repo-relative SDK reference paths in `references/sdk-execution.md` when
+  checking exact schemas or tests.
+- As an installed skill outside the repo, do not assume the source tree is
+  present. Use installed Python imports, package metadata, CLI help, or
+  user-provided files first; treat repo paths as developer fallback references.
 
-# List metrics
-nemo evaluation metrics list --workspace <workspace>
+Prefer local SDK runs for iteration and smoke tests. Use remote platform jobs
+only when the user needs platform-managed execution, existing platform
+resources, or a job result from a deployed environment. For local SDK runs,
+`api_key_secret` resolves through the local environment; for remote jobs, the
+same name should refer to a platform secret in the job workspace.
 
-# Get a metric
-nemo evaluation metrics get <name> --workspace <workspace>
-```
+## Reference Files
 
-## Sync Evaluation Commands
+Load these files only when the task needs the detail:
 
-```bash
-# Run sync evaluation with inline data
-nemo evaluation metrics run \
-  --name <metric_name> \
-  --data '<jsonl_rows>' \
-  --workspace <workspace>
-```
+- Metric selection: `references/metric-selection.md`
+  - Read when mapping rubric criteria to SDK metrics, choosing deterministic vs
+    LLM judges, or working with RAG/agentic/tool-calling metrics.
+- SDK execution: `references/sdk-execution.md`
+  - Read before guessing a metric schema, execution parameter, online/offline
+    setup, parser, template, or SDK result shape.
+- Benchmark reproduction: `references/benchmark-reproduction.md`
+  - Read for BYOB protocol, long-running benchmark reproduction, artifact
+    contracts, and external-safe output requirements.
+- Troubleshooting: `references/troubleshooting.md`
+  - Read when SDK runs fail, judge outputs do not parse, provider calls time
+    out, or generated artifacts need recovery.
 
-Each row in `--data` is a JSON object with fields the metric references.
+## Default Loop
 
-## Async Metric Job Commands
+1. Identify the BYOB inputs: questions, rubric criteria, responses or live
+   model endpoints, weights, pass threshold, and desired summary breakdowns.
+2. Clarify the evaluation target: model output quality, judge quality, RAG
+   quality, tool use, benchmark regression, or bring-your-own benchmark
+   reproduction.
+   - Judge-quality evaluation checks whether a judge agrees with labels for
+     existing responses.
+   - Generator-quality evaluation creates fresh responses and scores those
+     responses with a fixed judge or deterministic checker.
+3. Choose the simplest correct SDK metric class or composed set of classes for
+   each criterion. See `references/metric-selection.md`.
+4. Generate a small, human-reviewable config or code artifact instead of
+   burying criterion logic in one-off scripts.
+5. Build a tiny inline dataset with at least one expected pass and one expected
+   fail.
+6. Run locally with `Evaluator().run_sync(...)` or `await Evaluator().run(...)`.
+   See `references/sdk-execution.md`.
+7. Inspect `result.print_summary()`, `row_scores`, and `aggregate_scores`.
+8. When errors arise, fix dataset shape, Jinja templates, parser paths,
+   prompts, model config, or secrets. See `references/troubleshooting.md`.
+9. Move to remote platform jobs only after the local SDK run behaves as
+   expected.
 
-```bash
-# Create an async metric job
-nemo evaluation metric-jobs create <job_name> \
-  --metric-name <metric_name> \
-  --dataset-fileset <fileset_name> \
-  --workspace <workspace>
+Do not stop at "the score is bad." Explain what failed and what evidence
+supports that conclusion.
 
-# Check job status
-nemo evaluation metric-jobs get <job_name> --workspace <workspace>
+## Core Selection Rules
 
-# List jobs
-nemo evaluation metric-jobs list --workspace <workspace>
-```
+Prefer deterministic primitives before LLM calls. Use LLM judges for nuance,
+not for checks that can be expressed as exact, string, numeric, or code logic.
 
-**Note**: Jobs may stay in "created" status if the job controller is not running — that is expected.
+Use online generation only when the evaluator should call a model or agent
+before scoring. Pass `target=Model(...)` or `target=Agent(...)` and a
+`prompt_template`; otherwise keep evaluation offline and put outputs in the
+dataset rows.
 
-## Benchmark Commands
+For external, custom, or bring-your-own benchmarks, keep the protocol explicit
+and reproducible.
 
-```bash
-# List system benchmarks (from system workspace)
-nemo evaluation benchmarks list --workspace system
+Separate judge-quality evaluation from generation-quality evaluation. If the
+target is report generation, generate fresh model responses, score them with a
+fixed judge, and aggregate fulfilment. Do not treat human labels for existing
+baseline responses as labels for new model outputs.
 
-# Get benchmark details
-nemo evaluation benchmarks get <name> --workspace system
+For public or broadly shared skills and reports, avoid internal endpoint names,
+internal model IDs, authentication details, and secret paths. Use placeholders
+such as `<provider-base-url>`, `<generator-model-id>`, `<judge-model-id>`, and
+`<secret-reference>`. Report parameter categories and aliases instead of
+revealing private infrastructure.
 
-# Create a benchmark eval job
-nemo evaluation benchmark-jobs create <job_name> \
-  --benchmark <benchmark_spec_json> \
-  --workspace <workspace>
+## Completion Criteria
 
-# Check benchmark job status
-nemo evaluation benchmark-jobs get <job_name> --workspace <workspace>
-```
+A good evaluator answer includes:
 
-## Metric Types
-
-### string-check
-Compares fields using an operation (equals, contains, etc.):
-```json
-{"field": "output", "expected_field": "expected", "operation": "equals"}
-```
-Dataset rows need `output` and `expected` fields.
-
-### llm-judge
-Uses an LLM to score responses. Create via `--input-file` with this JSON structure:
-```json
-{
-  "type": "llm-judge",
-  "name": "quality-judge",
-  "model": {
-    "url": "https://integrate.api.nvidia.com/v1",
-    "name": "openai/gpt-oss-20b",
-    "format": "openai",
-    "api_key_secret": "<secret-name>"
-  },
-  "scores": [
-    {
-      "name": "relevance",
-      "description": "Relevance score from 1 to 5",
-      "minimum": 1,
-      "maximum": 5,
-      "parser": {"type": "json", "json_path": "relevance"}
-    }
-  ],
-  "prompt_template": {
-    "messages": [
-      {"role": "system", "content": "Rate the response on relevance 1-5. Return JSON: {\"relevance\": <score>}"},
-      {"role": "user", "content": "Question: {{item.input}}\nResponse: {{item.output}}"}
-    ]
-  }
-}
-```
-Requires a secret with the API key (use `nemo-secrets` skill).
-
-### zero-config llm-judge
-Same as llm-judge but without `prompt_template` and score `parser` — the system auto-generates them. Just provide `scores` with `name`, `description`, `minimum`, `maximum`, and a rubric.
-
-### tool-calling
-Evaluates function call accuracy. Dataset rows need `messages`, `tools`, `expected_tool_calls`, `response` fields in OpenAI format.
-
-## Typical Workflow
-
-1. Create workspace: `nemo workspaces create <ws>`
-2. Upload dataset: create fileset + upload JSONL file (use `nemo-files` skill)
-3. Create metric (string-check, llm-judge, etc.)
-4. Run sync eval with inline data to test
-5. Create async metric job against the uploaded dataset
-6. Check job status
+- The evaluation goal and chosen SDK metric class or benchmark shape.
+- The dataset shape and any templates or parser paths.
+- The exact SDK snippet or evaluation spec used.
+- Row-level and aggregate evidence for local runs, or job status/result
+  evidence for remote runs.
+- Any caveats about reproducibility, provider config, or calibration.

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/references/benchmark-reproduction.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/references/benchmark-reproduction.md
@@ -1,0 +1,101 @@
+# Benchmark Reproduction
+
+Read this file for BYOB protocol, long-running benchmark reproduction, artifact
+contracts, and external-safe output requirements.
+
+## Bring Your Own Benchmark
+
+For external, custom, or bring-your-own benchmarks, keep the protocol explicit
+and reproducible.
+
+- Separate judge-quality evaluation from generation-quality evaluation. If the
+  target is report generation, generate fresh model responses, score them with
+  a fixed judge, and aggregate fulfilment. Do not treat human labels for
+  existing baseline responses as labels for new model outputs.
+- Use provider-agnostic configuration. Require users or harness config to
+  provide generator and judge base URLs, model IDs, and secret references.
+- Validate model IDs with a `/v1/models`-style endpoint when the provider
+  supports it. Do not assume a web catalog equals runnable API model IDs.
+- Run a tiny smoke prompt before the full benchmark to confirm authentication,
+  response shape, parser behavior, and unsupported generation parameters.
+- Record artifacts that make the run replayable: `README.md`, `manifest.yaml`,
+  `scoring_protocol.md`, `results_report.md`, `generations.jsonl`,
+  `judge_predictions.jsonl`, and `scores.json`.
+- Store secret variable names or secret file paths in manifests, never secret
+  values.
+- Report calibration deltas transparently. Do not apply hidden correction
+  factors; inspect endpoint/model ID, generation params, sampling plan, judge
+  prompt, reasoning policy, parser, and aggregation if deltas are large.
+
+## Long-Running Benchmark Reproduction
+
+Use this pattern when a BYOB run is too large for a single in-memory SDK
+example.
+
+1. Freeze the dataset, rubric, sample plan, generator parameters, judge
+   parameters, and any external scoring weights used by the benchmark protocol
+   before starting the full run.
+2. Smoke-test one or two rows end to end: generate, judge, parse, aggregate,
+   and write artifacts.
+3. Use one run directory per generator model or model configuration. Do not mix
+   outputs from different generator settings in the same checkpoint files.
+4. Checkpoint generation and judging separately so either stage can resume.
+   Prefer append-only JSONL with stable row IDs, external criterion IDs from
+   the expanded BYOB artifact, status, parsed values, and error fields.
+5. For external harness JSONL recovery, recover by stable IDs, validate each
+   line before reuse, rewrite a clean compacted file after recovery, and keep
+   the corrupted fragment for audit.
+6. Retry failed rows individually with bounded attempts. Fail closed on missing
+   rows, missing criteria, or unparsable judge outputs; do not silently drop
+   them from benchmark-protocol scoring counts.
+7. Write final task, domain, and overall scores only after every required
+   criterion row is present and parseable, or after failures are explicitly
+   counted according to the scoring protocol.
+8. Report progress periodically by stage: generated rows, judged criterion
+   rows, parse failures, retry queue, rate-limit sleeps, and estimated
+   remaining work.
+
+ProfBench-style rubric-to-leaderboard shape:
+
+```text
+dataset rows
+-> generated responses per model
+-> criterion-level judge rows per response
+-> fixed binary judge with parser-compatible yes/no output
+-> weighted criterion fulfilment
+-> task, domain, and overall scores
+```
+
+Keep the fixed judge, rubric text, parser, and any external benchmark weights
+constant when comparing generator models. If the judge itself is being
+evaluated, run a separate judge-quality experiment against labeled existing
+responses.
+
+## Artifact Contract
+
+For an external BYOB handoff or checkpointed benchmark harness, these artifacts
+make the run inspectable and rerunnable. The SDK does not generate this full
+contract automatically; teams that need strict enforcement should implement a
+typed artifact contract outside the skill.
+
+- `manifest.yaml`: dataset version, rubric version, sample plan, model aliases,
+  parameter summaries, scoring protocol, and artifact paths.
+- `expanded_dataset.jsonl`: immutable rows after sampling and task expansion.
+- `generations.jsonl`: generator outputs with row IDs, model alias, params
+  summary, status, output text, and errors.
+- `criterion_rows.jsonl`: one row per generated response and rubric criterion.
+- `judge_predictions.jsonl`: raw and parsed judge outputs with retry metadata.
+- `failure_log.jsonl`: failures, skipped rows, parser errors, and retry
+  exhaustion.
+- `scores.json`: task, domain, and overall aggregates with scoring counts
+  defined by the benchmark protocol.
+- `results_report.md`: concise explanation of setup, scores, caveats, and
+  interpretation.
+
+## External-Safe Outputs
+
+For public or broadly shared skills and reports, avoid internal endpoint names,
+internal model IDs, authentication details, and secret paths. Use placeholders
+such as `<provider-base-url>`, `<generator-model-id>`, `<judge-model-id>`, and
+`<secret-reference>`. Report parameter categories and aliases instead of
+revealing private infrastructure.

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/references/metric-selection.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/references/metric-selection.md
@@ -1,0 +1,55 @@
+# Metric Selection
+
+Read this file when mapping rubric criteria to SDK metrics, choosing
+deterministic vs LLM judges, or working with RAG/agentic/tool-calling metrics.
+
+## Choosing The Right Metric
+
+| Evaluation goal | Prefer | SDK class | Watch for |
+| --- | --- | --- | --- |
+| Exact label, enum, or string regression | `exact-match` or `string-check` | `ExactMatchMetric`, `StringCheckMetric` | Normalize whitespace/case with Jinja filters if needed |
+| Numeric correctness or thresholds | `number-check` | `NumberCheckMetric` | Non-numeric values score `NaN` |
+| Reference text similarity | `f1`, `bleu`, or `rouge` | `F1Metric`, `BLEUMetric`, `ROUGEMetric` | Similarity is not factual correctness |
+| Flexible semantic quality | `llm-judge` | `LLMJudgeMetric` | Use explicit rubrics and parser-compatible judge output |
+| Zero-config semantic quality | `llm-judge` without custom prompt/parsers | `LLMJudgeMetric` with score definitions only | Validate default prompt and parser behavior on tiny data |
+| RAG retrieval coverage | `context_recall`, `context_precision`, `context_relevance`, `context_entity_recall` | RAGAS metric classes | Required columns differ by metric |
+| RAG grounding or hallucination | `faithfulness`, `response_groundedness`, `noise_sensitivity` | RAGAS metric classes | Requires judge model config |
+| RAG answer relevance | `response_relevancy` | `ResponseRelevancyMetric` | Requires judge and embeddings model config |
+| Agent final outcome | `agent_goal_accuracy`, `answer_accuracy`, `topic_adherence` | RAGAS agentic metric classes | Most require a judge model |
+| Agent tool/function calls | `tool_call_accuracy` or `tool-calling` | `ToolCallAccuracyMetric`, `ToolCallingMetric` | Ground truth and response shape must match the metric |
+| Custom business scoring | `remote` or `nemo-agent-toolkit-remote` | `RemoteMetric`, `NemoAgentToolkitRemoteMetric` | Smoke test endpoint auth, payload, timeout, and parser path |
+| Repeatable model comparison | Multi-metric SDK run or platform benchmark job | `Evaluator.run(metrics=[...])` or benchmark APIs | Record metric list, dataset, model config, params, and results |
+| Bring-your-own benchmark reproduction | Fixed judge plus explicit artifact protocol | SDK harness around generation, judge predictions, and aggregation | Keep generation quality separate from judge-quality evaluation |
+
+## Composable Primitive Mapping
+
+When converting rubric criteria into an eval, use the PRD's primitive mindset
+and map it onto the current SDK surface:
+
+| PRD primitive | Use when | Current SDK surface |
+| --- | --- | --- |
+| `exact` | Criterion checks for a term, phrase, regex-like pattern, or exact output | `ExactMatchMetric`, `StringCheckMetric` |
+| `numeric` | Criterion expects a calculated value, threshold, tolerance, or count | `NumberCheckMetric` |
+| `llm` | Criterion needs semantic reasoning, style judgment, communication quality, or subjective quality | `LLMJudgeMetric` with `RangeScore` or `RubricScore` |
+| `code` | Criterion needs domain-specific computation or validation logic | Custom harness code, `RemoteMetric`, or a reviewed Python checker around SDK results |
+| `composite` | One criterion benefits from deterministic checks plus an LLM fallback or weighted subchecks | Multiple SDK metrics plus agent-owned aggregation, or a custom wrapper until a native composite primitive exists |
+
+Prefer deterministic primitives before LLM calls. Use LLM judges for nuance,
+not for checks that can be expressed as exact, string, numeric, or code logic.
+
+## RAG And Agentic Metrics
+
+Use RAGAS-backed metric classes from `nemo_evaluator_sdk.metrics.ragas` when the
+task is about retrieval, grounding, or agent behavior. Keep dataset columns
+aligned with the metric:
+
+| Metric family | Common required fields |
+| --- | --- |
+| Retrieval quality | `user_input`, `retrieved_contexts`, often `reference` |
+| Grounding/hallucination | `user_input`, `response`, `retrieved_contexts`, sometimes `reference` |
+| Response relevancy | `user_input`, `response`, `retrieved_contexts` plus embeddings model config |
+| Tool call accuracy | `user_input`, `reference_tool_calls` or metric-specific tool-call fields |
+| Agent goal/answer/topic | Conversation or final response fields plus judge model config |
+
+When unsure, read the SDK metric class and its tests before creating a large
+run.

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/references/sdk-execution.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/references/sdk-execution.md
@@ -1,0 +1,247 @@
+# SDK Execution
+
+Read this file before guessing a metric schema, execution parameter,
+online/offline setup, parser, template, or SDK result shape.
+
+## SDK Reference Points
+
+Assume the skill is usually installed with the plugin rather than running from
+a NeMo Platform repo checkout. Prefer installed SDK inspection before using
+repo-relative source paths:
+
+- Import SDK classes and inspect their signatures, docstrings, and exported
+  field names.
+- Use package metadata, installed examples, and CLI help when available.
+- Prefer the public import surface, such as `nemo_evaluator_sdk.Evaluator`,
+  metric classes, `RunConfig`, `RunConfigOnlineModel`, `Model`, and parser
+  classes, over private paths.
+- If the user provides a repo checkout or you are already working inside one,
+  use the source paths below as developer fallbacks before guessing a metric
+  schema or execution parameter.
+
+- Metric config schemas: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/metrics.py`
+- Metric type names: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/enums.py`
+- Runtime metric behavior: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/`
+- RAGAS runtime metrics: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/metrics.py`
+- Execution API: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/evaluator.py`
+- Run config types: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/params.py`
+- Request config normalization: `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/config.py`
+- Public examples: `packages/nemo_evaluator_sdk/examples/examples.py`
+- Focused tests: `packages/nemo_evaluator_sdk/tests/metrics/` and
+  `packages/nemo_evaluator_sdk/tests/execution/`
+
+Prefer the SDK class field names. For example, `StringCheckMetric` uses
+`operation`, `left_template`, and `right_template`; do not invent `field` or
+`expected_field`.
+
+## Online Vs Offline Evaluation
+
+Use offline evaluation when dataset rows already contain the output or response
+to score. This is the default for reproducing a benchmark, validating known
+responses, checking judge agreement against labels, or debugging metric
+templates.
+
+Use online evaluation when the evaluator should call a live model or agent
+before scoring. In online mode, pass `target=Model(...)` or `target=Agent(...)`
+and a `prompt_template`; metrics can then score the generated output through
+the SDK's online result fields. Use this for generation-quality workflows,
+live model comparisons, or platform-managed jobs that need fresh generations.
+
+Keep these workflows separate. Do not use labels for existing baseline
+responses as labels for newly generated outputs unless the benchmark protocol
+explicitly defines that mapping.
+
+## Good Loop Examples
+
+Offline judge-quality loop: start with rows that already contain `input`,
+`output`, and `expected`; choose `ExactMatchMetric`, `StringCheckMetric`, or
+`LLMJudgeMetric` depending on the rubric; smoke-test one expected pass and one
+expected fail; inspect `row_scores` before trusting aggregate scores.
+
+Online generation-quality loop: start with rows that contain prompts and
+references; pass `target=Model(...)` or `target=Agent(...)` plus a
+`prompt_template`; score fresh generations with fixed deterministic metrics or
+a fixed judge; inspect generated outputs, judge predictions, and aggregate
+scores separately.
+
+## SDK Execution Patterns
+
+Use `Evaluator` directly for local, completed-result evaluation. It accepts one
+metric or a sequence of metrics and returns either `EvaluationResult` or a
+multi-metric benchmark result.
+
+```python
+from nemo_evaluator_sdk import Evaluator, RunConfig, StringCheckMetric
+
+
+metric = StringCheckMetric(
+    operation="equals",
+    left_template="{{item.output | trim}}",
+    right_template="{{item.expected | trim}}",
+)
+
+result = Evaluator().run_sync(
+    metrics=metric,
+    dataset=[
+        {"output": "hello", "expected": "hello"},
+        {"output": "foo", "expected": "bar"},
+    ],
+    config=RunConfig(parallelism=4),
+)
+
+result.print_summary()
+print(result.aggregate_scores)
+print(result.row_scores)
+```
+
+Run multiple metrics together when evaluating multiple dimensions of the same
+dataset:
+
+```python
+from nemo_evaluator_sdk import Evaluator, ExactMatchMetric, StringCheckMetric
+
+
+metrics = [
+    ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.output}}"),
+    StringCheckMetric(
+        operation="contains",
+        left_template="{{item.output}}",
+        right_template="{{item.required_phrase}}",
+    ),
+]
+
+result = Evaluator().run_sync(metrics=metrics, dataset=rows)
+result.print_summary()
+print(result.per_metric)
+```
+
+Use online generation only when the evaluator should call a model or agent
+before scoring. Pass `target=Model(...)` or `target=Agent(...)` and a
+`prompt_template`; otherwise keep evaluation offline and put outputs in the
+dataset rows.
+
+```python
+from nemo_evaluator_sdk import (
+    Evaluator,
+    ExactMatchMetric,
+    InferenceParams,
+    Model,
+    RunConfigOnlineModel,
+)
+
+
+metric = ExactMatchMetric(reference="{{item.expected}}")
+target = Model(
+    url="https://provider.example/v1",
+    name="<model-id>",
+    format="openai",
+    api_key_secret="<secret-or-env-name>",
+)
+
+result = Evaluator().run_sync(
+    metrics=metric,
+    target=target,
+    dataset=[{"prompt": "What is 2+2?", "expected": "4"}],
+    prompt_template={"messages": [{"role": "user", "content": "{{item.prompt}}"}]},
+    config=RunConfigOnlineModel(
+        parallelism=2,
+        inference=InferenceParams(max_tokens=128),
+    ),
+)
+```
+
+In `Model(...)`, `format` selects the provider/API protocol shape, such as
+OpenAI-compatible request and response handling. `api_key_secret` is a secret
+reference name, not a literal secret value. For local SDK runs, ensure the
+matching local environment variable exists; for remote platform jobs, create a
+platform secret with the same name in the job workspace.
+
+## LLM Judge Pattern
+
+Use `LLMJudgeMetric` when deterministic metrics cannot capture the behavior.
+Define score names, descriptions, ranges or rubrics, parser behavior, judge
+model, and prompt template. Score names must use lowercase letters, numbers,
+and underscores.
+
+```python
+from nemo_evaluator_sdk import Evaluator, JSONScoreParser, LLMJudgeMetric, Model, RangeScore
+
+
+judge_model = Model(
+    url="https://provider.example/v1",
+    name="<judge-model-id>",
+    format="openai",
+    api_key_secret="<secret-or-env-name>",
+)
+
+metric = LLMJudgeMetric(
+    model=judge_model,
+    scores=[
+        RangeScore(
+            name="quality",
+            description="Overall response quality from 1 to 5",
+            minimum=1,
+            maximum=5,
+            parser=JSONScoreParser(json_path="quality"),
+        )
+    ],
+    prompt_template={
+        "messages": [
+            {
+                "role": "system",
+                "content": 'Rate response quality from 1 to 5. Return JSON: {"quality": <score>}',
+            },
+            {
+                "role": "user",
+                "content": "Input: {{item.input}}\nResponse: {{item.output}}",
+            },
+        ]
+    },
+)
+
+result = Evaluator().run_sync(
+    metrics=metric,
+    dataset=[
+        {"input": "Explain photosynthesis.", "output": "Plants use sunlight to make sugars."},
+        {"input": "Explain photosynthesis.", "output": "I cannot help."},
+    ],
+)
+```
+
+For zero-config judge metrics, provide `model` and rubric/range `scores`, then
+omit `prompt_template` and explicit parsers. Run a tiny local evaluation before
+using a full dataset.
+
+## Tool Calling Pattern
+
+Use `ToolCallingMetric` when rows contain OpenAI-style tool responses and
+ground truth tool calls. It emits:
+
+- `function_name_accuracy`
+- `function_name_and_args_accuracy`
+
+```python
+from nemo_evaluator_sdk import Evaluator, ToolCallingMetric
+
+
+metric = ToolCallingMetric(reference="{{item.expected_tool_calls}}")
+result = Evaluator().run_sync(metrics=metric, dataset=rows)
+```
+
+Each row should include a `response` object shaped like an OpenAI chat
+completion with `choices[0].message.tool_calls`. Ground truth should be a list
+of OpenAI-style tool call objects with `function.name` and
+`function.arguments`. The runtime is case sensitive, order insensitive for
+parallel calls, and expects function arguments to be valid JSON strings in the
+predicted response.
+
+## Dataset And Template Checks
+
+- Templates read dataset columns through `item`, for example
+  `{{item.expected}}`.
+- Online evaluations can read generated output through `sample.output_text`.
+- Offline evaluations need response/output fields already present in each row.
+- Keep field names identical between dataset rows and templates.
+- Include at least one expected pass and one expected fail in smoke data.
+- If a row fails to render a template, fix the dataset shape before changing
+  the metric.

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/references/troubleshooting.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/references/troubleshooting.md
@@ -1,0 +1,48 @@
+# Troubleshooting
+
+Read this file when SDK runs fail, judge outputs do not parse, provider calls
+time out, or generated artifacts need recovery.
+
+## Failure Modes
+
+- Empty completions: record the raw provider response, prompt, params, finish
+  reason, and provider token/request metadata when available. In SDK results,
+  look for request metadata in row-level request details rather than aggregate
+  scores. Retry only if the provider response indicates a transient failure.
+- All-reasoning outputs: inspect completion token use and final-answer length;
+  record token budget and reasoning settings separately from benchmark
+  semantics.
+- Unparsable judge rows: store raw judge text, parser error, row ID, external
+  criterion ID from the expanded BYOB artifact if present, and retry count;
+  count unresolved rows as failures unless the protocol defines different
+  failure accounting.
+- SDK row failures: by default, request or scoring failures abort the run. Use
+  `ignore_request_failure=True` only when the benchmark protocol allows failed
+  rows to be marked as `NaN` and carried into reporting.
+- SDK provider timeouts and rate limits: configure SDK request behavior with
+  fields such as `request_timeout` and `max_retries`; the SDK handles retry
+  attempts internally and does not expose a persistent retry queue.
+- External BYOB harness timeouts and rate limits: if building a checkpointed
+  harness outside the SDK, use bounded retries with backoff, persist the retry
+  queue, and keep progress artifacts valid after interruption.
+- Failed-row retries: retry the smallest failed unit, usually one generation
+  row or one criterion judge row, rather than rerunning completed work.
+
+## Debugging Checklist
+
+- Wrong schema: compare the metric constructor fields against
+  `values/metrics.py`.
+- Missing field: compare dataset row keys with Jinja templates.
+- Bad parser: make the judge return exactly the JSON or regex format the parser
+  expects.
+- Judge produced reasoning but no final answer: increase final-answer token
+  budget or adjust reasoning params if the provider supports them.
+- Secret error: for local SDK runs, ensure the environment variable resolved
+  from `api_key_secret` exists; for remote platform jobs, create the platform
+  secret in the job workspace.
+- Unsupported provider parameter: remove optional params first, then add them
+  back one at a time.
+- Tool-calling mismatch: check case sensitivity, function name normalization,
+  argument JSON validity, and response shape.
+- SDK mismatch: verify the request/config payload uses current SDK metric
+  fields.


### PR DESCRIPTION
## Summary

- Reimplement NVIDIA-NeMo/Platform#506 in the current repo layout.
- Update the bundled nemo-evaluator skill from a CLI cheat sheet to an SDK-first BYOB/rubric-to-eval guide.
- Mirror the same skill content into the vendored Python SDK copy and adjust examples for the current SDK config types.

## Validation

- uv run --frozen pytest packages/nemo_platform_ext/tests/cli/commands/skills/test_skill_content.py -v
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote Evaluator skill docs to an SDK-first, rubric-to-eval guide and updated frontmatter for clarity
  * Added benchmark-reproduction guidance with reproducible artifact rules, checkpointing, retries, and redaction guidance
  * Added metric-selection guidance mapping goals to metric families and composition rules
  * Added SDK execution patterns for online vs offline runs and metric usage
  * Added troubleshooting guide with failure modes and debugging checklist

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->