### PR TITLE
fix(studio): Feedback on deployed agent deletion

### DIFF
--- a/web/packages/studio/src/components/DeleteConfirmationModal/index.tsx
+++ b/web/packages/studio/src/components/DeleteConfirmationModal/index.tsx
@@ -13,6 +13,7 @@ interface DeleteModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
   simpleConfirm?: boolean;
   successText?: string;
   errorText?: string;
+  suppressResultToasts?: boolean;
 }
 
 export const DeleteConfirmationModal: FC<DeleteModalProps> = ({
@@ -22,6 +23,7 @@ export const DeleteConfirmationModal: FC<DeleteModalProps> = ({
   simpleConfirm = true,
   successText = 'Successfully deleted!',
   errorText = 'Something went wrong. Please try again.',
+  suppressResultToasts,
   ...rest
 }) => {
   const confirmationDescription =
@@ -41,6 +43,7 @@ export const DeleteConfirmationModal: FC<DeleteModalProps> = ({
       simpleConfirm={simpleConfirm}
       successText={successText}
       errorText={errorText}
+      suppressResultToasts={suppressResultToasts}
     />
   );
 };

--- a/web/packages/studio/src/components/dataViews/AgentsDataView/index.spec.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentsDataView/index.spec.tsx
@@ -343,7 +343,7 @@ describe('CombinedAgentsTable', () => {
 
       const errorToast = await screen.findByTestId('mock-toast-error');
       expect(errorToast).toHaveTextContent(
-        'Agent has active deployments. Please delete all deployments before deleting.'
+        'Agent has active deployments. Please delete all deployments before deleting agent.'
       );
       // The generic fallback toast should not appear.
       expect(screen.queryByText(/Something went wrong\. Please try again\./i)).toBeNull();

--- a/web/packages/studio/src/components/dataViews/AgentsDataView/index.spec.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentsDataView/index.spec.tsx
@@ -315,5 +315,38 @@ describe('CombinedAgentsTable', () => {
 
       expect(await screen.findByText('Delete Agent')).toBeInTheDocument();
     });
+
+    it('shows a friendly toast when delete is blocked by active deployments (409)', async () => {
+      server.use(
+        http.delete(`${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/:workspace/agents/:name`, () =>
+          HttpResponse.json(
+            {
+              detail:
+                "Agent 'react-agent' has active deployments that must be removed first: rag-agent-prod. Use DELETE /deployments/{name} to remove them.",
+            },
+            { status: 409 }
+          )
+        )
+      );
+
+      const user = userEvent.setup();
+      renderTable();
+
+      await screen.findByText(MOCK_AGENTS[0].name);
+
+      const menuButtons = screen.getAllByRole('button', { name: /actions/i });
+      await user.click(menuButtons[0]);
+      await user.click(await screen.findByRole('menuitem', { name: 'Delete' }));
+
+      const confirmDialog = await screen.findByRole('dialog');
+      await user.click(within(confirmDialog).getByRole('button', { name: 'Delete' }));
+
+      const errorToast = await screen.findByTestId('mock-toast-error');
+      expect(errorToast).toHaveTextContent(
+        'Agent has active deployments. Please delete all deployments before deleting.'
+      );
+      // The generic fallback toast should not appear.
+      expect(screen.queryByText(/Something went wrong\. Please try again\./i)).toBeNull();
+    });
   });
 });

--- a/web/packages/studio/src/components/dataViews/AgentsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentsDataView/index.tsx
@@ -22,6 +22,7 @@ import {
 import type { Agent } from '@nemo/sdk/generated/agents/schema/Agent';
 import type { AgentDeployment } from '@nemo/sdk/generated/agents/schema/AgentDeployment';
 import { Text } from '@nvidia/foundations-react-core';
+import { getErrorMessage } from '@studio/api/common/utils';
 import { getAgentModelNames } from '@studio/components/dataViews/AgentsDataView/utils';
 import { DeleteConfirmationModal } from '@studio/components/DeleteConfirmationModal';
 import { DocumentationButton } from '@studio/components/DocumentationButton';
@@ -162,12 +163,19 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
   const deleteAgentMutation = useAgentsDeleteAgent({
     mutation: {
       onSuccess: () => {
+        toast.success('Agent deleted.');
         void queryClient.refetchQueries({
           queryKey: getAgentsListAgentsQueryKey(workspace),
         });
       },
       onError: (error) => {
-        toast.error(error.message);
+        if (error.response?.status === 409) {
+          toast.error(
+            'Agent has active deployments. Please delete all deployments before deleting agent.'
+          );
+          return;
+        }
+        toast.error(getErrorMessage(error, 'Failed to delete agent.'));
       },
     },
   });
@@ -281,6 +289,7 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
           onDelete={handleDelete}
           onClose={() => setDeleteState(null)}
           simpleConfirm
+          suppressResultToasts
         />
       )}
     </>


### PR DESCRIPTION
Addresses https://nvbugspro.nvidia.com/bug/6221288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when deleting agents with active deployments (specific “active deployments” error shown instead of a generic failure).

* **Improvements**
  * Success notification shown on successful agent deletion.
  * Agent list automatically refreshes after deletion.
  * Option added to suppress result toasts for delete flows.

* **Tests**
  * Added a test covering the delete-agent conflict scenario and its error toast behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->