### PR TITLE
fix(dependencies): 0.1.1 fixes; upperbound typer and fix `nat` PATH issues

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -370,7 +370,7 @@ nemo-platform-plugin = [
   "pydantic>=2.10.3",
   "pydantic-settings>=2.8.1",
   "pyyaml>=6.0.2",
-  "typer>=0.20.0",
+  "typer>=0.20.0,<0.26",
 ]
 
 # Generated from [tool.bundle-package]; do not edit by hand.

--- a/packages/nemo_platform_plugin/pyproject.toml
+++ b/packages/nemo_platform_plugin/pyproject.toml
@@ -25,7 +25,11 @@ dependencies = [
     "pydantic>=2.10.3",
     "pydantic-settings>=2.8.1",
     "pyyaml>=6.0.2",
-    "typer>=0.20.0",
+    # Upper bound: typer 0.26.x has a regression where Click sentinel defaults
+    # for boolean options surface as `AttributeError: 'Sentinel' object has no
+    # attribute 'strip'` from `BoolParamType.str_to_bool`, breaking commands
+    # like `nemo services run`. Drop the upper bound once typer ships a fix.
+    "typer>=0.20.0,<0.26",
 ]
 license = "Apache-2.0"
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py
@@ -28,6 +28,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -53,6 +54,32 @@ def _sanitize_filename(name: str) -> str:
     """
     cleaned = _FILENAME_UNSAFE_RE.sub("_", name).strip("._-") or "deployment"
     return cleaned
+
+
+def _resolve_nat_bin() -> str:
+    """Locate the ``nat`` executable to spawn for an agent deployment.
+
+    Resolution order:
+
+    1. ``shutil.which("nat")`` — handles activated venvs, the agentic
+       container (which prepends ``/app/.venv/bin`` to ``PATH``), and any
+       setup where the user has ``nat`` on their shell ``PATH``.
+    2. Sibling of ``sys.executable`` — covers ``uv tool install
+       nemo-platform``, where the tool venv's ``bin/`` is **not** prepended
+       to ``PATH`` (uv only symlinks the declared ``[project.scripts]`` into
+       ``~/.local/bin``; the rest of the tool venv stays off ``PATH``).
+       ``nat`` is co-installed with ``nemo`` in that same venv, so picking
+       it up next to ``sys.executable`` is the canonical way to find it.
+    3. ``/app/.venv/bin/nat`` — last-resort fallback for the official
+       agentic container if the ``PATH`` lookup somehow fails. Kept for
+       backwards compatibility with prior behavior.
+    """
+    if found := shutil.which("nat"):
+        return found
+    sibling = Path(sys.executable).parent / "nat"
+    if sibling.is_file():
+        return str(sibling)
+    return "/app/.venv/bin/nat"
 
 
 def system_dir(workspace_dir: Path | None = None) -> Path:
@@ -297,7 +324,7 @@ class InMemoryRunnerBackend(RunnerBackend):
         """
         # config_path is an absolute path — pass it as-is so nat can find it
         # regardless of the working directory it inherits.
-        nat_bin = shutil.which("nat") or "/app/.venv/bin/nat"
+        nat_bin = _resolve_nat_bin()
         cmd = [
             nat_bin,
             "start",

--- a/plugins/nemo-agents/tests/unit/test_runner_in_memory.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_in_memory.py
@@ -28,7 +28,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 from nemo_agents_plugin.config import AgentsConfig, ControllerConfig
-from nemo_agents_plugin.runner.in_memory import InMemoryRunnerBackend
+from nemo_agents_plugin.runner.in_memory import InMemoryRunnerBackend, _resolve_nat_bin
 from nmp.common.config import Configuration, nmp_user_data_dir
 
 
@@ -291,3 +291,55 @@ async def test_real_subprocess_exit_writes_log_at_recorded_path(tmp_path: Path) 
     assert status is not None
     assert status.status == "failed"
     assert "exited with code 1" in status.error
+
+
+# ---------------------------------------------------------------------------
+# _resolve_nat_bin: how the runner finds the `nat` executable.
+#
+# The runner spawns `nat start fastapi` per deployment.  Resolution must work
+# under every supported install path (activated venv, agentic container,
+# `uv tool install`, and explicit override) without requiring users to massage
+# PATH themselves.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_nat_bin_uses_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`shutil.which` is preferred — covers activated venvs and the container."""
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/local/bin/{name}")
+    assert _resolve_nat_bin() == "/usr/local/bin/nat"
+
+
+def test_resolve_nat_bin_uses_sibling_of_sys_executable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When `nat` is not on PATH, look next to `sys.executable`.
+
+    This is the `uv tool install nemo-platform` case: the tool venv contains
+    `nat` (it's co-installed with `nemo` via the `[services]` chain), but the
+    venv's `bin/` is not prepended to PATH, so `shutil.which` returns None.
+    """
+    monkeypatch.setattr("shutil.which", lambda _: None)
+
+    fake_venv_bin = tmp_path / "bin"
+    fake_venv_bin.mkdir()
+    fake_python = fake_venv_bin / "python"
+    fake_python.touch()
+    fake_nat = fake_venv_bin / "nat"
+    fake_nat.write_text("#!/bin/sh\necho nat-stub\n")
+    monkeypatch.setattr(sys, "executable", str(fake_python))
+
+    assert _resolve_nat_bin() == str(fake_nat)
+
+
+def test_resolve_nat_bin_falls_back_to_container_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When nothing else matches, return the container path. This preserves
+    backwards-compatible behavior in the agentic container even if the PATH
+    lookup somehow fails inside it."""
+    monkeypatch.setattr("shutil.which", lambda _: None)
+
+    # sys.executable points somewhere with no sibling `nat`.
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python"
+    fake_python.touch()
+    monkeypatch.setattr(sys, "executable", str(fake_python))
+
+    assert _resolve_nat_bin() == "/app/.venv/bin/nat"

--- a/plugins/nemo-data-designer/pyproject.toml
+++ b/plugins/nemo-data-designer/pyproject.toml
@@ -93,7 +93,7 @@ nemo-platform-plugin = [
   "pydantic>=2.10.3",
   "pydantic-settings>=2.8.1",
   "pyyaml>=6.0.2",
-  "typer>=0.20.0",
+  "typer>=0.20.0,<0.26",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -4902,7 +4902,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'nmp-common'", specifier = ">=6.0.2" },
     { name = "sqlalchemy", marker = "extra == 'nmp-common'", specifier = ">=2.0.0" },
     { name = "structlog", marker = "extra == 'nmp-common'", specifier = ">=24.1.0" },
-    { name = "typer", marker = "extra == 'nemo-platform-plugin'", specifier = ">=0.20.0" },
+    { name = "typer", marker = "extra == 'nemo-platform-plugin'", specifier = ">=0.20.0,<0.26" },
 ]
 provides-extras = ["test", "data-designer-nemo", "nmp-common", "nemo-platform-plugin"]
 
@@ -6027,7 +6027,7 @@ requires-dist = [
     { name = "tenacity", marker = "extra == 'services'", specifier = ">=8.5.0" },
     { name = "typer", marker = "extra == 'nemo-auditor-plugin'", specifier = ">=0.20.0" },
     { name = "typer", marker = "extra == 'nemo-evaluator-plugin'", specifier = ">=0.20.0" },
-    { name = "typer", marker = "extra == 'nemo-platform-plugin'", specifier = ">=0.20.0" },
+    { name = "typer", marker = "extra == 'nemo-platform-plugin'", specifier = ">=0.20.0,<0.26" },
     { name = "typer", marker = "extra == 'nemo-platform-sdk'", specifier = ">=0.20.0" },
     { name = "typer", marker = "extra == 'plugins'", specifier = ">=0.20.0" },
     { name = "typer", marker = "extra == 'services'", specifier = ">=0.20.0" },
@@ -6191,7 +6191,7 @@ requires-dist = [
     { name = "requests", marker = "extra == 'nemo-platform-sdk'", specifier = ">=2.31.0" },
     { name = "rich", marker = "extra == 'nemo-platform-sdk'", specifier = ">=13.7.1" },
     { name = "sniffio", marker = "extra == 'nemo-platform-sdk'" },
-    { name = "typer", specifier = ">=0.20.0" },
+    { name = "typer", specifier = ">=0.20.0,<0.26" },
     { name = "typer", marker = "extra == 'nemo-platform-sdk'", specifier = ">=0.20.0" },
     { name = "typing-extensions", marker = "extra == 'nemo-platform-sdk'", specifier = ">=4.14,<5" },
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced `typer` version range across platform packages to `>=0.20.0,<0.26`.
* **Bug Fixes**
  * Improved runtime executable resolution for the local runner, reducing failures when starting the bundled service.
* **Tests**
  * Added unit tests covering executable resolution paths to ensure consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->