### PR TITLE
feat(skills): add nemo-help entry-point skill

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-help/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-help/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: nemo-help
+description: Exploratory entry point for users who don't know what NeMo Platform does yet. Catches open-ended questions like "what can you do", "where do I start", "tour", "show me the menu". Presents the menu of capabilities and hands off to nemo-skill-selection once the user picks a direction.
+triggers:
+  - what can you do
+  - how can you help
+  - what can I do here
+  - where do I start
+  - show me what's possible
+  - what is this
+  - what's in here
+  - tour
+  - menu
+  - help me explore
+  - I don't know what I want
+not-for:
+  - nemo-skill-selection (use once the user has picked a direction — build, optimize, evaluate, secure, status, teardown)
+  - setup (use to verify install or to be told how to run the CLI install)
+  - nemo-explore (use to reason about a specific agent's design)
+  - superpowers:brainstorming (use for design work unrelated to NeMo Platform)
+compatibility: nemo-platform >= 0.1.0; pure presentation (no commands run from this skill); safe under macOS or Linux sandbox; works without an installed CLI.
+maturity: active
+license: Apache-2.0
+user-invocable: true
+allowed-tools: [Read]
+---
+
+# NeMo Platform: where to start
+
+You are helping a user who landed in a NeMo Platform repo and asked open-endedly what's possible. They have not yet picked a direction. Your job is to give them a short tour of what the platform does and route them to the right downstream skill once they commit.
+
+This skill never runs commands. It presents options, asks a clarifying question, and hands off.
+
+## What NeMo Platform does
+
+NeMo Platform brings NVIDIA NeMo libraries together under one CLI, Python SDK, and web UI. The shipping value props:
+
+- **Build agents** — scaffold a LangGraph agent wrapped in NVIDIA NeMo Agent Toolkit (NAT), deploy locally, iterate.
+- **Harden agents** — add guardrails (content safety, jailbreak detection, PII redaction), red-team via the auditor, anonymize training data.
+- **Evaluate agents** — LLM-as-judge, deterministic checks, agentic and RAG benchmarks via Harbor-backed eval suites.
+- **Tune agents** — skill optimization, prompt and hyperparameter tuning, Switchyard model routing. Fine-tuning coming soon.
+
+The platform optimizes LangGraph agents wrapped in NAT today. If the user has an agent in another framework (CrewAI, AutoGen, plain LangChain, Pydantic AI), the build and optimize paths need a NAT wrapper they write themselves. Be honest about this if it comes up.
+
+## Tour script
+
+Present the four journeys in one short message, then ask the user which fits. Do not dump every detail at once.
+
+> NeMo Platform has four main journeys. Which one fits where you are?
+>
+> 1. **Build a new agent** — design it, scaffold a NAT workflow, deploy locally.
+> 2. **Improve an existing agent** — harden with guardrails, evaluate accuracy, optimize cost or routing.
+> 3. **Check what's running** — read-only health dashboard for the platform and any deployed agents.
+> 4. **Set up or tear down** — first-time install, or shut down a local platform.
+>
+> If you're not sure yet, tell me what you're working on and I'll suggest a starting point.
+
+## Routing once they pick
+
+After the user answers, hand off to `nemo-skill-selection`. Do not try to handle the downstream flow yourself. `nemo-skill-selection` owns the full decision table and will pick the right next skill (`setup`, `nemo-explore`, `nemo-spec`, `nemo-build-agent`, `nemo-try-agent`, `nemo-status`, `nemo-teardown`, `nemo-fine-tune`, or a plugin skill like `agents-secure` or `agents-optimize`).
+
+If the user says something off-topic (general LLM question, unrelated code task, weather, etc.), do not route to a NeMo skill. Defer to your default behavior.
+
+## What not to do
+
+- Do not run `nemo` CLI commands from this skill. Hand off first.
+- Do not explain every capability in detail upfront. Tour, then ask, then route.
+- Do not invent journeys that don't exist. If the user wants something NeMo Platform doesn't ship (e.g., training a base model from scratch), say so plainly.
+- Do not skip the handoff to `nemo-skill-selection` once the user has picked a direction. The decision table lives there, not here.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-help/tests.json
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-help/tests.json
@@ -1,0 +1,65 @@
+{
+  "skill": "nemo-help",
+  "tests": [
+    {
+      "type": "explicit",
+      "prompt": "Use the nemo-help skill to tell me what's possible here.",
+      "expected_skill": "nemo-help"
+    },
+    {
+      "type": "explicit",
+      "prompt": "Run nemo-help. I just opened this repo.",
+      "expected_skill": "nemo-help"
+    },
+    {
+      "type": "explicit",
+      "prompt": "Invoke nemo-help so I can see the menu of journeys.",
+      "expected_skill": "nemo-help"
+    },
+    {
+      "type": "implicit",
+      "prompt": "What can you do?",
+      "expected_skill": "nemo-help"
+    },
+    {
+      "type": "implicit",
+      "prompt": "Where do I start?",
+      "expected_skill": "nemo-help"
+    },
+    {
+      "type": "implicit",
+      "prompt": "I just cloned this repo. Never used NeMo before. What's in here?",
+      "expected_skill": "nemo-help"
+    },
+    {
+      "type": "contextual",
+      "prompt": "Build me an agent that classifies support tickets by urgency.",
+      "expected_skill_not": "nemo-help"
+    },
+    {
+      "type": "contextual",
+      "prompt": "My agent is deployed and I want to make it cheaper to run.",
+      "expected_skill_not": "nemo-help"
+    },
+    {
+      "type": "contextual",
+      "prompt": "Tear down the local NeMo Platform.",
+      "expected_skill_not": "nemo-help"
+    },
+    {
+      "type": "negative-control",
+      "prompt": "What's the weather in San Francisco today?",
+      "expected_skill_not": "nemo-help"
+    },
+    {
+      "type": "negative-control",
+      "prompt": "Help me set up a Postgres database on my laptop.",
+      "expected_skill_not": "nemo-help"
+    },
+    {
+      "type": "negative-control",
+      "prompt": "Write a recursive function in Rust to flatten a nested list.",
+      "expected_skill_not": "nemo-help"
+    }
+  ]
+}

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-help/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-help/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: nemo-help
+description: Exploratory entry point for users who don't know what NeMo Platform does yet. Catches open-ended questions like "what can you do", "where do I start", "tour", "show me the menu". Presents the menu of capabilities and hands off to nemo-skill-selection once the user picks a direction.
+triggers:
+  - what can you do
+  - how can you help
+  - what can I do here
+  - where do I start
+  - show me what's possible
+  - what is this
+  - what's in here
+  - tour
+  - menu
+  - help me explore
+  - I don't know what I want
+not-for:
+  - nemo-skill-selection (use once the user has picked a direction — build, optimize, evaluate, secure, status, teardown)
+  - setup (use to verify install or to be told how to run the CLI install)
+  - nemo-explore (use to reason about a specific agent's design)
+  - superpowers:brainstorming (use for design work unrelated to NeMo Platform)
+compatibility: nemo-platform >= 0.1.0; pure presentation (no commands run from this skill); safe under macOS or Linux sandbox; works without an installed CLI.
+maturity: active
+license: Apache-2.0
+user-invocable: true
+allowed-tools: [Read]
+---
+
+# NeMo Platform: where to start
+
+You are helping a user who landed in a NeMo Platform repo and asked open-endedly what's possible. They have not yet picked a direction. Your job is to give them a short tour of what the platform does and route them to the right downstream skill once they commit.
+
+This skill never runs commands. It presents options, asks a clarifying question, and hands off.
+
+## What NeMo Platform does
+
+NeMo Platform brings NVIDIA NeMo libraries together under one CLI, Python SDK, and web UI. The shipping value props:
+
+- **Build agents** — scaffold a LangGraph agent wrapped in NVIDIA NeMo Agent Toolkit (NAT), deploy locally, iterate.
+- **Harden agents** — add guardrails (content safety, jailbreak detection, PII redaction), red-team via the auditor, anonymize training data.
+- **Evaluate agents** — LLM-as-judge, deterministic checks, agentic and RAG benchmarks via Harbor-backed eval suites.
+- **Tune agents** — skill optimization, prompt and hyperparameter tuning, Switchyard model routing. Fine-tuning coming soon.
+
+The platform optimizes LangGraph agents wrapped in NAT today. If the user has an agent in another framework (CrewAI, AutoGen, plain LangChain, Pydantic AI), the build and optimize paths need a NAT wrapper they write themselves. Be honest about this if it comes up.
+
+## Tour script
+
+Present the four journeys in one short message, then ask the user which fits. Do not dump every detail at once.
+
+> NeMo Platform has four main journeys. Which one fits where you are?
+>
+> 1. **Build a new agent** — design it, scaffold a NAT workflow, deploy locally.
+> 2. **Improve an existing agent** — harden with guardrails, evaluate accuracy, optimize cost or routing.
+> 3. **Check what's running** — read-only health dashboard for the platform and any deployed agents.
+> 4. **Set up or tear down** — first-time install, or shut down a local platform.
+>
+> If you're not sure yet, tell me what you're working on and I'll suggest a starting point.
+
+## Routing once they pick
+
+After the user answers, hand off to `nemo-skill-selection`. Do not try to handle the downstream flow yourself. `nemo-skill-selection` owns the full decision table and will pick the right next skill (`setup`, `nemo-explore`, `nemo-spec`, `nemo-build-agent`, `nemo-try-agent`, `nemo-status`, `nemo-teardown`, `nemo-fine-tune`, or a plugin skill like `agents-secure` or `agents-optimize`).
+
+If the user says something off-topic (general LLM question, unrelated code task, weather, etc.), do not route to a NeMo skill. Defer to your default behavior.
+
+## What not to do
+
+- Do not run `nemo` CLI commands from this skill. Hand off first.
+- Do not explain every capability in detail upfront. Tour, then ask, then route.
+- Do not invent journeys that don't exist. If the user wants something NeMo Platform doesn't ship (e.g., training a base model from scratch), say so plainly.
+- Do not skip the handoff to `nemo-skill-selection` once the user has picked a direction. The decision table lives there, not here.


### PR DESCRIPTION
## Summary
- Adds `nemo-help` skill at `packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-help/`
- Catches exploratory intents ("what can you do", "where do I start", "tour", "menu") that none of the existing lifecycle skills match
- Presents the four NeMo Platform journeys, asks which fits, then hands off to `nemo-skill-selection`
- Ships `tests.json` with NV-BASE four-mode coverage (explicit / implicit / contextual / negative-control)

## Why
Per AIRCORE-634, a first-time user who opens the repo and asks "what can you do?" gets no skill match today. `nemo-skill-selection` triggers require the word "nemo" or a task verb. This skill catches the gap and routes once the user picks a direction.

## Test plan
- [x] `uv run --frozen --active nemo skills list` shows `nemo-help`
- [x] `uv run --frozen --active pytest packages/nemo_platform_ext/tests/cli/commands/skills/test_cli.py` — 31/31 passing
- [x] `ruff check` clean
- [ ] Spot-check via a coding agent in a fresh clone: "what can you do?" should route to `nemo-help`

Closes AIRCORE-634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "help" skill that provides an exploratory entry point and guided starting journeys.

* **Documentation**
  * Added guidance on trigger phrases, exclusions, routing rules, compatibility/safety notes, licensing/maturity, and allowed tool usage.

* **Tests**
  * Added a prompt-based test suite covering positive selection scenarios and negative-control cases to validate correct skill routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->