### PR TITLE
fix(models): Prefix digit-leading upstream model ids

### DIFF
--- a/services/core/models/src/nmp/core/models/app/utils.py
+++ b/services/core/models/src/nmp/core/models/app/utils.py
@@ -186,6 +186,12 @@ def normalize_model_entity_name(model_name: str) -> str:
     normalizes when possible; if the result would not match, it raises ValueError
     so callers can skip or fail explicitly.
 
+    Names that would otherwise normalize cleanly but begin with a digit (e.g.
+    upstream catalog ids like ``01-ai/yi-large``) are prefixed with ``m-`` so they
+    satisfy the leading-letter requirement. The prefix is purely internal to the
+    entity store / routing layer; the original id is preserved as the
+    ``served_model_name`` and remains the user-facing handle.
+
     Args:
         model_name: The original model name (e.g., "meta/llama-3.2-1b-instruct")
 
@@ -194,13 +200,15 @@ def normalize_model_entity_name(model_name: str) -> str:
 
     Raises:
         ValueError: If the name cannot be normalized to a valid entity name (e.g. empty,
-            only invalid characters, starts with digit with no letter, or single character).
+            only invalid characters, or single character).
 
     Examples:
         >>> normalize_model_entity_name("meta/llama-3.2-1b-instruct")
         "meta-llama-3-2-1b-instruct"
         >>> normalize_model_entity_name("model:v1.0")
         "model-v1-0"
+        >>> normalize_model_entity_name("01-ai/yi-large")
+        "m-01-ai-yi-large"
         >>> normalize_model_entity_name("")
         ValueError: ... cannot be normalized to a valid entity name
     """
@@ -216,6 +224,15 @@ def normalize_model_entity_name(model_name: str) -> str:
             f"Model name {model_name!r} cannot be normalized to a valid entity name: "
             "result is empty (use at least one letter or digit)."
         )
+    # Entity store NAME_PATTERN requires a leading [a-z]. Upstream catalogs sometimes
+    # publish digit-leading ids (e.g. "01-ai/yi-large"); prefix them with "m-" so they
+    # become routable as internal entity names. The prefix is added *before* the 63-char
+    # truncation step so the existing truncate+hash machinery still produces a valid
+    # length-bounded result for long digit-leading names. Idempotent: names that already
+    # start with a letter are left untouched, so re-normalizing "m-01-ai-yi-large" stays
+    # "m-01-ai-yi-large".
+    if normalized[0].isdigit():
+        normalized = f"m-{normalized}"
     # If over 63 chars, truncate with deterministic hash suffix to avoid collisions (before validating)
     if len(normalized) > 63:
         hash_suffix = hashlib.sha256(model_name.encode()).hexdigest()[:8]

--- a/services/core/models/tests/unit/common/test_utils.py
+++ b/services/core/models/tests/unit/common/test_utils.py
@@ -800,6 +800,12 @@ def test_is_multi_llm_image_random_image_returns_false():
             "org-model-v1-0-main-with-spaces",
             id="mixed_invalid_chars",
         ),
+        # Digit-leading upstream ids (e.g. NVIDIA Build's "01-ai/yi-large") get an
+        # internal "m-" prefix so they satisfy NAME_PATTERN's leading-letter rule.
+        pytest.param("01-ai/yi-large", "m-01-ai-yi-large", id="digit_leading_with_slash"),
+        pytest.param("9model", "m-9model", id="digit_leading_simple"),
+        pytest.param("123", "m-123", id="digit_only"),
+        pytest.param("2pac/rapper-model", "m-2pac-rapper-model", id="digit_leading_alphanumeric"),
     ],
 )
 def test_normalize_model_entity_name_output(input_name, expected):
@@ -812,8 +818,6 @@ def test_normalize_model_entity_name_output(input_name, expected):
     [
         pytest.param("", "cannot be normalized to a valid entity name", id="empty_string"),
         pytest.param("///:::", "cannot be normalized to a valid entity name", id="only_invalid_chars"),
-        pytest.param("123", "not valid", id="starts_with_digit_only"),
-        pytest.param("9model", "not valid", id="starts_with_digit_then_letters"),
         pytest.param("a", "not valid", id="single_char"),
     ],
 )
@@ -875,6 +879,29 @@ def test_normalize_model_entity_name_long_different_names_different_hashes():
     r2 = normalize_model_entity_name(name2)
     assert r1 != r2
     assert len(r1) <= 63 and len(r2) <= 63
+
+
+def test_normalize_model_entity_name_digit_leading_idempotent():
+    """The 'm-' prefix is only added when the result starts with a digit, so re-normalizing
+    a previously normalized digit-leading name is a no-op."""
+    original = "01-ai/yi-large"
+    once = normalize_model_entity_name(original)
+    twice = normalize_model_entity_name(once)
+    assert once == "m-01-ai-yi-large"
+    assert once == twice
+
+
+def test_normalize_model_entity_name_digit_leading_long_truncates():
+    """Digit-leading names that exceed 63 chars after the 'm-' prefix still truncate cleanly
+    via the existing hash-suffix path."""
+    # 70-char digit-leading raw name -> with 'm-' prefix would be 72; truncation must kick in.
+    long_digit_name = "0" + "1" * 69
+    result = normalize_model_entity_name(long_digit_name)
+    assert len(result) <= 63
+    assert result.startswith("m-")
+    # Trailing 8 hex chars after final '-' (the deterministic hash suffix).
+    parts = result.rsplit("-", 1)
+    assert len(parts[1]) == 8 and all(c in "0123456789abcdef" for c in parts[1])
 
 
 # ============================================================================

--- a/services/core/models/tests/unit/controllers/test_provider_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_provider_reconciler.py
@@ -332,10 +332,16 @@ def test_entity_name_from_discovered_model_different_workspace_prefix_normalizes
 
 def test_entity_name_from_discovered_model_invalid_raises():
     """When model_id normalizes to an invalid entity name, ValueError is raised."""
-    with pytest.raises(ValueError, match="not valid"):
-        _entity_name_from_discovered_model("123", "test-ns")
+    # Single-character id still fails NAME_PATTERN's 2-char minimum length.
     with pytest.raises(ValueError, match="not valid"):
         _entity_name_from_discovered_model("a", "test-ns")
+
+
+def test_entity_name_from_discovered_model_digit_leading_gets_prefix():
+    """Digit-leading upstream ids (e.g. NVIDIA Build's '01-ai/yi-large') get an
+    internal 'm-' prefix from normalize_model_entity_name and become routable."""
+    assert _entity_name_from_discovered_model("01-ai/yi-large", "default") == "m-01-ai-yi-large"
+    assert _entity_name_from_discovered_model("123", "test-ns") == "m-123"
 
 
 # ============================================================================


### PR DESCRIPTION
## What

When the models controller reconciler discovers models from an external provider, it normalizes each upstream id to an internal entity name that satisfies the entity store's RFC 1035-style `NAME_PATTERN` (leading `[a-z]`, length 2-63, only `[a-z0-9-]`). Upstream catalogs occasionally publish digit-leading ids — e.g. NVIDIA Build's `01-ai/yi-large` — which the normalizer rejects because `01-ai-yi-large` doesn't start with a letter. The reconciler then logs `Skipped 1 model(s) with invalid names ...` on every cycle (~every 5s) and the model never becomes routable.

This PR teaches `normalize_model_entity_name` to prepend an internal `m-` prefix when the cleaned form starts with a digit, so digit-leading upstream ids become valid entity names instead of being skipped.

## Why this approach

* **Internal-only, not user-facing.** The normalized string is the entity store's `model_entity_id`. The `served_model_name` mapping still preserves the original id (`provider_reconciler.py:707`), so the IGW continues to forward `01-ai/yi-large` (the original) to the backend. End users keep calling the model exactly as the upstream advertises it.
* **Minimal & deterministic.** A constant `m-` prefix is mechanical, idempotent (`m-01-ai-yi-large` → `m-01-ai-yi-large`), and preserves the source id verbatim after the prefix, so the entity name still reads like the upstream id.
* **Length-safe.** The prefix is applied *before* the existing 63-char truncate-with-hash step, so long digit-leading names still produce length-bounded results via the existing machinery.

Considered and rejected: provider-derived prefixes (collide with the existing `workspace/name` convention, lengthen names), spelling out leading digits (lossy/weird), dropping leading digits (collisions across ids that differ only in the digit segment), hash prefixes (ugly, inconsistent with the existing policy of hashing only on overflow).

## Verification

* New positive test cases for `01-ai/yi-large`, `9model`, `123`, `2pac/rapper-model`.
* New dedicated tests for idempotence and the digit-leading + 63-char-overflow interaction.
* Updated `test_entity_name_from_discovered_model_invalid_raises` and added `test_entity_name_from_discovered_model_digit_leading_gets_prefix` so the reconciler's caller-side contract is also pinned.
* Full `services/core/models/tests/unit` suite: 992 passed, 1 skipped.
* `ruff check` / `ruff format --check` clean. `ty` clean for the change (5 pre-existing diagnostics in unrelated functions in the same file).

## Tracking

* Linear: [AIRCORE-678](https://linear.app/nvidia/issue/AIRCORE-678/models-controller-prefix-digit-leading-upstream-model-ids-so-they)
* NVBug: [6215677](https://nvbugspro.nvidia.com/bug/6215677/1)

Signed-off-by: Matthew Grossman <mgrossman@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of model identifiers that start with digits to ensure proper system compatibility.
  * Updated validation logic to handle digit-leading model IDs with automatic prefix handling.

* **Tests**
  * Added test coverage for digit-leading model identifier normalization and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
