### PR TITLE
feat(agents): submit agent evaluate + optimize as jobs (AIRCORE-656)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,7 @@ docs/**/*.mp4 filter=lfs diff=lfs merge=lfs -text
 # Generated OpenAPI specifications
 openapi/**/*.yaml linguist-generated
 openapi/**/*.yaml.txt linguist-generated
+plugins/*/openapi/**/*.yaml linguist-generated
 # Generated Models service types
 services/core/infrastructure/models/src/models/nim_operator_types/*.py linguist-generated
 # Generated SDK client bindings

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: agents (plugin)
-  version: 0.1.3
+  version: 0.1.1
 paths:
   /apis/agents/v2/workspaces/{workspace}/agents:
     post:
@@ -377,6 +377,380 @@ paths:
           content:
             application/json:
               schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/analyze:
+    post:
+      tags:
+      - Agents
+      summary: Create Job
+      operationId: create_job_apis_agents_v2_workspaces__workspace__jobs_analyze_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnalyzeJobRequest'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalyzeJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Agents
+      summary: List Jobs
+      operationId: list_jobs_apis_agents_v2_workspaces__workspace__jobs_analyze_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page number.
+          default: 1
+          title: Page
+        description: Page number.
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page size.
+          default: 10
+          title: Page Size
+        description: Page size.
+      - name: sort
+        in: query
+        required: false
+        schema:
+          allOf:
+          - $ref: '#/components/schemas/AnalyzeJobsSortField'
+          description: The field to sort by. To sort in decreasing order, use `-`
+            in front of the field name.
+          default: -created_at
+        description: The field to sort by. To sort in decreasing order, use `-` in
+          front of the field name.
+      - in: query
+        name: filter
+        style: deepObject
+        required: false
+        explode: true
+        schema:
+          $ref: '#/components/schemas/AnalyzeJobsListFilter'
+        description: Filter jobs on various criteria.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalyzeJobsPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/analyze/{job}/results/{name}:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Result
+      operationId: get_job_result_apis_agents_v2_workspaces__workspace__jobs_analyze__job__results__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/analyze/{job}/results/{name}/download:
+    get:
+      tags:
+      - Agents
+      summary: Download Job Result
+      operationId: download_job_result_apis_agents_v2_workspaces__workspace__jobs_analyze__job__results__name__download_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Not Found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/analyze/{name}:
+    get:
+      tags:
+      - Agents
+      summary: Get Job
+      operationId: get_job_apis_agents_v2_workspaces__workspace__jobs_analyze__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalyzeJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Agents
+      summary: Delete Job
+      operationId: delete_job_apis_agents_v2_workspaces__workspace__jobs_analyze__name__delete
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/analyze/{name}/cancel:
+    post:
+      tags:
+      - Agents
+      summary: Cancel Job
+      operationId: cancel_job_apis_agents_v2_workspaces__workspace__jobs_analyze__name__cancel_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalyzeJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/analyze/{name}/logs:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Logs
+      operationId: get_job_logs_apis_agents_v2_workspaces__workspace__jobs_analyze__name__logs_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      - name: limit
+        in: query
+        required: false
+        schema:
+          title: Limit
+          type: integer
+      - name: page_cursor
+        in: query
+        required: false
+        schema:
+          title: Page Cursor
+          type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobLogPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/analyze/{name}/results:
+    get:
+      tags:
+      - Agents
+      summary: List Job Results
+      operationId: list_job_results_apis_agents_v2_workspaces__workspace__jobs_analyze__name__results_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobListResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/analyze/{name}/status:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Status
+      operationId: get_job_status_apis_agents_v2_workspaces__workspace__jobs_analyze__name__status_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobStatusResponse'
         '422':
           description: Validation Error
           content:
@@ -1131,6 +1505,102 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize:
+    post:
+      tags:
+      - Agents
+      summary: Create Job
+      operationId: create_job_apis_agents_v2_workspaces__workspace__jobs_optimize_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OptimizeJobRequest'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptimizeJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Agents
+      summary: List Jobs
+      operationId: list_jobs_apis_agents_v2_workspaces__workspace__jobs_optimize_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page number.
+          default: 1
+          title: Page
+        description: Page number.
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page size.
+          default: 10
+          title: Page Size
+        description: Page size.
+      - name: sort
+        in: query
+        required: false
+        schema:
+          allOf:
+          - $ref: '#/components/schemas/OptimizeJobsSortField'
+          description: The field to sort by. To sort in decreasing order, use `-`
+            in front of the field name.
+          default: -created_at
+        description: The field to sort by. To sort in decreasing order, use `-` in
+          front of the field name.
+      - in: query
+        name: filter
+        style: deepObject
+        required: false
+        explode: true
+        schema:
+          $ref: '#/components/schemas/OptimizeJobsListFilter'
+        description: Filter jobs on various criteria.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptimizeJobsPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/agents/v2/workspaces/{workspace}/jobs/optimize-skills:
     post:
       tags:
@@ -1505,6 +1975,284 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize/{job}/results/{name}:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Result
+      operationId: get_job_result_apis_agents_v2_workspaces__workspace__jobs_optimize__job__results__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize/{job}/results/{name}/download:
+    get:
+      tags:
+      - Agents
+      summary: Download Job Result
+      operationId: download_job_result_apis_agents_v2_workspaces__workspace__jobs_optimize__job__results__name__download_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Not Found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize/{name}:
+    get:
+      tags:
+      - Agents
+      summary: Get Job
+      operationId: get_job_apis_agents_v2_workspaces__workspace__jobs_optimize__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptimizeJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Agents
+      summary: Delete Job
+      operationId: delete_job_apis_agents_v2_workspaces__workspace__jobs_optimize__name__delete
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize/{name}/cancel:
+    post:
+      tags:
+      - Agents
+      summary: Cancel Job
+      operationId: cancel_job_apis_agents_v2_workspaces__workspace__jobs_optimize__name__cancel_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptimizeJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize/{name}/logs:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Logs
+      operationId: get_job_logs_apis_agents_v2_workspaces__workspace__jobs_optimize__name__logs_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      - name: limit
+        in: query
+        required: false
+        schema:
+          title: Limit
+          type: integer
+      - name: page_cursor
+        in: query
+        required: false
+        schema:
+          title: Page Cursor
+          type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobLogPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize/{name}/results:
+    get:
+      tags:
+      - Agents
+      summary: List Job Results
+      operationId: list_job_results_apis_agents_v2_workspaces__workspace__jobs_optimize__name__results_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobListResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize/{name}/status:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Status
+      operationId: get_job_status_apis_agents_v2_workspaces__workspace__jobs_optimize__name__status_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobStatusResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
     Agent:
@@ -1697,6 +2445,173 @@ components:
         \ ``agent_deployment``\nLifecycle: pending \u2192 starting \u2192 running\
         \ | failed.\nThe :class:`~nemo_agents_plugin.runner.controller.AgentDeploymentController`\n\
         drives state transitions by reconciling this entity against the\n:class:`~nemo_agents_plugin.runner.backend.RunnerBackend`."
+    AnalyzeBatchConfig:
+      properties:
+        batch:
+          type: string
+          title: Batch
+          description: Path to a batch directory produced by evaluate-suite.
+        format:
+          type: string
+          enum:
+          - md
+          - json
+          title: Format
+          description: 'Output format: md or json.'
+          default: md
+        mechanical_only:
+          type: boolean
+          title: Mechanical Only
+          description: Skip the LLM analysis pass.
+          default: false
+        anthropic_api_key_secret:
+          title: Anthropic Api Key Secret
+          description: Name of a platform Secret holding the Anthropic API key.  When
+            set on a submit, the value is injected as ``ANTHROPIC_API_KEY`` into the
+            dispatched subprocess so the LLM gap-analysis pass can call Anthropic.  Ignored
+            when ``mechanical_only=True``.  Local (in-process) runs read ``ANTHROPIC_API_KEY``
+            from the calling shell as before.
+          type: string
+      type: object
+      required:
+      - batch
+      title: AnalyzeBatchConfig
+    AnalyzeJob:
+      properties:
+        id:
+          title: Id
+          type: string
+        name:
+          type: string
+          title: Name
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        workspace:
+          title: Workspace
+          type: string
+        created_at:
+          title: Created At
+          type: string
+          format: date-time
+        updated_at:
+          title: Updated At
+          type: string
+          format: date-time
+        spec:
+          $ref: '#/components/schemas/AnalyzeBatchConfig'
+        status:
+          $ref: '#/components/schemas/PlatformJobStatus'
+        status_details:
+          title: Status Details
+          additionalProperties: true
+          type: object
+        error_details:
+          title: Error Details
+          additionalProperties: true
+          type: object
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - name
+      - spec
+      title: AnalyzeJob
+    AnalyzeJobRequest:
+      properties:
+        name:
+          title: Name
+          type: string
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        spec:
+          $ref: '#/components/schemas/AnalyzeBatchConfig'
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - spec
+      title: AnalyzeJobRequest
+    AnalyzeJobsListFilter:
+      additionalProperties: false
+      properties:
+        created_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs created at 'gte' datetime or 'lte' datetime.
+        name:
+          description: Name of the job.
+          title: Name
+          type: string
+        workspace:
+          description: Workspace of the job.
+          title: Workspace
+          type: string
+        project:
+          description: Project containing the job.
+          title: Project
+          type: string
+        status:
+          allOf:
+          - $ref: '#/components/schemas/PlatformJobStatus'
+          description: The current status.
+        updated_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs updated at 'gte' datetime or 'lte' datetime.
+      title: AnalyzeJobsListFilter
+      type: object
+    AnalyzeJobsPage:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/AnalyzeJob'
+          type: array
+          title: Data
+        pagination:
+          allOf:
+          - $ref: '#/components/schemas/PaginationData'
+          description: Pagination information.
+        sort:
+          title: Sort
+          description: The field on which the results are sorted.
+          type: string
+        filter:
+          title: Filter
+          description: Filtering information.
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - data
+      title: AnalyzeJobsPage
+    AnalyzeJobsSortField:
+      type: string
+      enum:
+      - created_at
+      - -created_at
+      - updated_at
+      - -updated_at
+      title: AnalyzeJobsSortField
     CreateAgentRequest:
       properties:
         name:
@@ -1755,29 +2670,6 @@ components:
           type: string
       title: DatetimeFilter
       type: object
-    DeploymentLogsResponse:
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/LogLine'
-          type: array
-          title: Data
-        total_lines:
-          type: integer
-          title: Total Lines
-          description: Number of lines actually returned.
-        next_offset:
-          type: integer
-          title: Next Offset
-          description: Byte offset just past the returned tail; pass as Last-Event-ID
-            to resume the stream without gaps.
-      type: object
-      required:
-      - data
-      - total_lines
-      - next_offset
-      title: DeploymentLogsResponse
-      description: Response body for ``GET /deployments/{name}/logs``.
     EvaluateAgentSpec:
       properties:
         agent:
@@ -2198,38 +3090,6 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
-    LogLine:
-      properties:
-        timestamp:
-          type: string
-          title: Timestamp
-          description: ISO-8601 timestamp parsed from the line; empty when absent.
-        job:
-          type: string
-          title: Job
-          description: "Empty \u2014 kept for shape compatibility with jobs logs."
-          default: ''
-        job_step:
-          type: string
-          title: Job Step
-          description: "Empty \u2014 kept for shape compatibility."
-          default: ''
-        job_task:
-          type: string
-          title: Job Task
-          description: "Empty \u2014 kept for shape compatibility."
-          default: ''
-        message:
-          type: string
-          title: Message
-          description: The raw log line minus any parsed timestamp prefix.
-      type: object
-      required:
-      - timestamp
-      - message
-      title: LogLine
-      description: One line shaped to match ``PlatformJobLog`` so Studio's LogViewer
-        renders it as-is.
     NemoListResponse_AgentDeployment_:
       properties:
         data:
@@ -2276,6 +3136,185 @@ components:
       required:
       - data
       title: NemoListResponse_Agent_
+    OptimizeAgentSpec:
+      properties:
+        agent:
+          title: Agent
+          description: "Agent to optimize \u2014 either a platform-managed agent reference\
+            \ (e.g. 'react-agent', 'workspace/react-agent') or an HTTP(S) endpoint\
+            \ URL (e.g. 'http://localhost:8080').  Bare names fetch the agent's stored\
+            \ config and merge it with the optimize config so trials run the agent's\
+            \ workflow locally with swept parameters; URLs are passed through to 'nat\
+            \ optimize --endpoint' verbatim (opaque service mode \u2014 local parameter\
+            \ sweeps don't reach the remote agent).  When omitted, the optimize config\
+            \ must include an inline agent workflow."
+          type: string
+        optimize_config:
+          type: string
+          title: Optimize Config
+          description: Path to the NAT optimization YAML config file.
+        workspace:
+          type: string
+          title: Workspace
+          description: Workspace name used to fetch the agent's stored config when
+            --agent is a bare name, and to construct the Inference Gateway URL when
+            injecting base_url into LLMs that have none set.
+          default: default
+      type: object
+      required:
+      - optimize_config
+      title: OptimizeAgentSpec
+      description: "Spec for an agent optimization job.\n\nField declaration order\
+        \ also drives the auto-generated CLI flag\norder \u2014 keep the most-frequently-set\
+        \ knobs first.\n\nAttributes:\n    agent: The agent to optimize.  Accepts\
+        \ either a platform-managed\n        agent reference (``\"name\"`` or ``\"\
+        workspace/name\"``) or a\n        literal HTTP(S) endpoint URL.  Bare names\
+        \ cause the job to\n        fetch the agent's stored config from the platform\
+        \ and merge\n        it with the optimize config so trials run the agent's\n\
+        \        workflow locally with the swept parameters; URLs are\n        forwarded\
+        \ to ``nat optimize --endpoint`` and treated as an\n        opaque service\
+        \ (sweeps don't affect the remote agent \u2014 see\n        module docstring).\
+        \  When ``None`` the optimize config is\n        expected to include an inline\
+        \ agent workflow.\n    optimize_config: Path to the NAT optimization YAML\
+        \ config file.\n        The output path is controlled by ``optimizer.output_path``\n\
+        \        inside the YAML.\n    workspace: NeMo Platform workspace used to\
+        \ scope the agent fetch and the\n        gateway URL injection."
+    OptimizeJob:
+      properties:
+        id:
+          title: Id
+          type: string
+        name:
+          type: string
+          title: Name
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        workspace:
+          title: Workspace
+          type: string
+        created_at:
+          title: Created At
+          type: string
+          format: date-time
+        updated_at:
+          title: Updated At
+          type: string
+          format: date-time
+        spec:
+          $ref: '#/components/schemas/OptimizeAgentSpec'
+        status:
+          $ref: '#/components/schemas/PlatformJobStatus'
+        status_details:
+          title: Status Details
+          additionalProperties: true
+          type: object
+        error_details:
+          title: Error Details
+          additionalProperties: true
+          type: object
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - name
+      - spec
+      title: OptimizeJob
+    OptimizeJobRequest:
+      properties:
+        name:
+          title: Name
+          type: string
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        spec:
+          $ref: '#/components/schemas/OptimizeAgentSpec'
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - spec
+      title: OptimizeJobRequest
+    OptimizeJobsListFilter:
+      additionalProperties: false
+      properties:
+        created_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs created at 'gte' datetime or 'lte' datetime.
+        name:
+          description: Name of the job.
+          title: Name
+          type: string
+        workspace:
+          description: Workspace of the job.
+          title: Workspace
+          type: string
+        project:
+          description: Project containing the job.
+          title: Project
+          type: string
+        status:
+          allOf:
+          - $ref: '#/components/schemas/PlatformJobStatus'
+          description: The current status.
+        updated_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs updated at 'gte' datetime or 'lte' datetime.
+      title: OptimizeJobsListFilter
+      type: object
+    OptimizeJobsPage:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/OptimizeJob'
+          type: array
+          title: Data
+        pagination:
+          allOf:
+          - $ref: '#/components/schemas/PaginationData'
+          description: Pagination information.
+        sort:
+          title: Sort
+          description: The field on which the results are sorted.
+          type: string
+        filter:
+          title: Filter
+          description: Filtering information.
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - data
+      title: OptimizeJobsPage
+    OptimizeJobsSortField:
+      type: string
+      enum:
+      - created_at
+      - -created_at
+      - updated_at
+      - -updated_at
+      title: OptimizeJobsSortField
     OptimizeSkillsConfig:
       properties:
         evals:

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -2884,7 +2884,7 @@ components:
           description: Path to the directory of eval tasks.
         agent:
           title: Agent
-          description: Agent root (defaults to repo root).
+          description: Agent root (defaults to repo root in local run).
           type: string
         runner:
           type: string
@@ -2916,7 +2916,8 @@ components:
           default: false
         output:
           title: Output
-          description: Output dir for batch artifacts.
+          description: Output dir for batch artifacts (defaults to cwd/runs in local
+            run).
           type: string
         filter_glob:
           title: Filter Glob
@@ -2940,6 +2941,18 @@ components:
       required:
       - evals
       title: EvaluateSuiteConfig
+      description: 'Canonical config consumed by ``EvaluateSuiteJob.run``.
+
+
+        ``agent`` and ``output`` are optional here so the local run path can
+
+        fall back to ``Path.cwd()`` / ``Path.cwd()/runs/batch-<ts>``.  The
+
+        submit path uses :class:`EvaluateSuiteSubmitConfig` (where both are
+
+        required) as its wire schema, and ``compile()`` re-validates that
+
+        both ended up non-``None`` before dispatch.'
     EvaluateSuiteJob:
       properties:
         id:
@@ -3002,7 +3015,7 @@ components:
           title: Project
           type: string
         spec:
-          $ref: '#/components/schemas/EvaluateSuiteConfig'
+          $ref: '#/components/schemas/EvaluateSuiteSubmitConfig'
         ownership:
           title: Ownership
           additionalProperties: true
@@ -3076,6 +3089,88 @@ components:
       - updated_at
       - -updated_at
       title: EvaluateSuiteJobsSortField
+    EvaluateSuiteSubmitConfig:
+      properties:
+        evals:
+          type: string
+          title: Evals
+          description: Path to the directory of eval tasks.
+        agent:
+          type: string
+          title: Agent
+          description: Agent root (required on submit).
+        runner:
+          type: string
+          enum:
+          - auto
+          - harbor
+          - nat
+          title: Runner
+          description: Eval runner.
+          default: auto
+        prefer:
+          type: string
+          enum:
+          - harbor
+          - nat
+          title: Prefer
+          description: Tiebreaker when both markers present.
+          default: nat
+        concurrency:
+          type: integer
+          minimum: 1.0
+          title: Concurrency
+          description: Parallel eval concurrency.
+          default: 4
+        skip_build:
+          type: boolean
+          title: Skip Build
+          description: Skip docker build (Harbor only).
+          default: false
+        output:
+          type: string
+          title: Output
+          description: Output dir for batch artifacts (required on submit).
+        filter_glob:
+          title: Filter Glob
+          description: Glob filter on eval names.
+          type: string
+        repeats:
+          type: integer
+          minimum: 1.0
+          title: Repeats
+          description: Trials per eval (median aggregation when >1).
+          default: 1
+        anthropic_api_key_secret:
+          title: Anthropic Api Key Secret
+          description: Name of a platform Secret holding the Anthropic API key.  When
+            set on a submit, the value is injected as ``ANTHROPIC_API_KEY`` into the
+            dispatched subprocess so the Harbor eval tasks' LLM-judge calls reach
+            Anthropic.  Local (in-process) runs read ``ANTHROPIC_API_KEY`` from the
+            calling shell as before.
+          type: string
+      type: object
+      required:
+      - evals
+      - agent
+      - output
+      title: EvaluateSuiteSubmitConfig
+      description: 'Submit-side wire schema for ``EvaluateSuiteJob``.
+
+
+        Narrows ``agent`` and ``output`` from ``str | None`` to ``str`` (no
+
+        default) so the OpenAPI contract matches the runtime behaviour: the
+
+        subprocess executor''s work dir is not the caller''s cwd, so the
+
+        canonical ``EvaluateSuiteConfig`` fallback to ``Path.cwd()`` would
+
+        silently land in ``/tmp/nmp-subprocess-jobs/.../task-*/``.  Making
+
+        them required at the schema layer surfaces the requirement as a
+
+        422 at submit time instead of a confusing dispatched-job failure.'
     FileStorageType:
       type: string
       enum:

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -479,6 +479,380 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/evaluate-suite:
+    post:
+      tags:
+      - Agents
+      summary: Create Job
+      operationId: create_job_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvaluateSuiteJobRequest'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateSuiteJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Agents
+      summary: List Jobs
+      operationId: list_jobs_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page number.
+          default: 1
+          title: Page
+        description: Page number.
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page size.
+          default: 10
+          title: Page Size
+        description: Page size.
+      - name: sort
+        in: query
+        required: false
+        schema:
+          allOf:
+          - $ref: '#/components/schemas/EvaluateSuiteJobsSortField'
+          description: The field to sort by. To sort in decreasing order, use `-`
+            in front of the field name.
+          default: -created_at
+        description: The field to sort by. To sort in decreasing order, use `-` in
+          front of the field name.
+      - in: query
+        name: filter
+        style: deepObject
+        required: false
+        explode: true
+        schema:
+          $ref: '#/components/schemas/EvaluateSuiteJobsListFilter'
+        description: Filter jobs on various criteria.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateSuiteJobsPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/evaluate-suite/{job}/results/{name}:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Result
+      operationId: get_job_result_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite__job__results__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/evaluate-suite/{job}/results/{name}/download:
+    get:
+      tags:
+      - Agents
+      summary: Download Job Result
+      operationId: download_job_result_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite__job__results__name__download_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Not Found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/evaluate-suite/{name}:
+    get:
+      tags:
+      - Agents
+      summary: Get Job
+      operationId: get_job_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateSuiteJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Agents
+      summary: Delete Job
+      operationId: delete_job_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite__name__delete
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/evaluate-suite/{name}/cancel:
+    post:
+      tags:
+      - Agents
+      summary: Cancel Job
+      operationId: cancel_job_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite__name__cancel_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateSuiteJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/evaluate-suite/{name}/logs:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Logs
+      operationId: get_job_logs_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite__name__logs_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      - name: limit
+        in: query
+        required: false
+        schema:
+          title: Limit
+          type: integer
+      - name: page_cursor
+        in: query
+        required: false
+        schema:
+          title: Page Cursor
+          type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobLogPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/evaluate-suite/{name}/results:
+    get:
+      tags:
+      - Agents
+      summary: List Job Results
+      operationId: list_job_results_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite__name__results_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobListResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/evaluate-suite/{name}/status:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Status
+      operationId: get_job_status_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite__name__status_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobStatusResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/agents/v2/workspaces/{workspace}/jobs/evaluate/{job}/results/{name}:
     get:
       tags:
@@ -731,6 +1105,380 @@ paths:
       - Agents
       summary: Get Job Status
       operationId: get_job_status_apis_agents_v2_workspaces__workspace__jobs_evaluate__name__status_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobStatusResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize-skills:
+    post:
+      tags:
+      - Agents
+      summary: Create Job
+      operationId: create_job_apis_agents_v2_workspaces__workspace__jobs_optimize_skills_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OptimizeSkillsJobRequest'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptimizeSkillsJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Agents
+      summary: List Jobs
+      operationId: list_jobs_apis_agents_v2_workspaces__workspace__jobs_optimize_skills_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page number.
+          default: 1
+          title: Page
+        description: Page number.
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page size.
+          default: 10
+          title: Page Size
+        description: Page size.
+      - name: sort
+        in: query
+        required: false
+        schema:
+          allOf:
+          - $ref: '#/components/schemas/OptimizeSkillsJobsSortField'
+          description: The field to sort by. To sort in decreasing order, use `-`
+            in front of the field name.
+          default: -created_at
+        description: The field to sort by. To sort in decreasing order, use `-` in
+          front of the field name.
+      - in: query
+        name: filter
+        style: deepObject
+        required: false
+        explode: true
+        schema:
+          $ref: '#/components/schemas/OptimizeSkillsJobsListFilter'
+        description: Filter jobs on various criteria.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptimizeSkillsJobsPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize-skills/{job}/results/{name}:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Result
+      operationId: get_job_result_apis_agents_v2_workspaces__workspace__jobs_optimize_skills__job__results__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize-skills/{job}/results/{name}/download:
+    get:
+      tags:
+      - Agents
+      summary: Download Job Result
+      operationId: download_job_result_apis_agents_v2_workspaces__workspace__jobs_optimize_skills__job__results__name__download_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Not Found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize-skills/{name}:
+    get:
+      tags:
+      - Agents
+      summary: Get Job
+      operationId: get_job_apis_agents_v2_workspaces__workspace__jobs_optimize_skills__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptimizeSkillsJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Agents
+      summary: Delete Job
+      operationId: delete_job_apis_agents_v2_workspaces__workspace__jobs_optimize_skills__name__delete
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize-skills/{name}/cancel:
+    post:
+      tags:
+      - Agents
+      summary: Cancel Job
+      operationId: cancel_job_apis_agents_v2_workspaces__workspace__jobs_optimize_skills__name__cancel_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptimizeSkillsJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize-skills/{name}/logs:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Logs
+      operationId: get_job_logs_apis_agents_v2_workspaces__workspace__jobs_optimize_skills__name__logs_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      - name: limit
+        in: query
+        required: false
+        schema:
+          title: Limit
+          type: integer
+      - name: page_cursor
+        in: query
+        required: false
+        schema:
+          title: Page Cursor
+          type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobLogPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize-skills/{name}/results:
+    get:
+      tags:
+      - Agents
+      summary: List Job Results
+      operationId: list_job_results_apis_agents_v2_workspaces__workspace__jobs_optimize_skills__name__results_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobListResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/optimize-skills/{name}/status:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Status
+      operationId: get_job_status_apis_agents_v2_workspaces__workspace__jobs_optimize_skills__name__status_get
       parameters:
       - name: workspace
         in: path
@@ -1236,6 +1984,206 @@ components:
       - updated_at
       - -updated_at
       title: EvaluateJobsSortField
+    EvaluateSuiteConfig:
+      properties:
+        evals:
+          type: string
+          title: Evals
+          description: Path to the directory of eval tasks.
+        agent:
+          title: Agent
+          description: Agent root (defaults to repo root).
+          type: string
+        runner:
+          type: string
+          enum:
+          - auto
+          - harbor
+          - nat
+          title: Runner
+          description: Eval runner.
+          default: auto
+        prefer:
+          type: string
+          enum:
+          - harbor
+          - nat
+          title: Prefer
+          description: Tiebreaker when both markers present.
+          default: nat
+        concurrency:
+          type: integer
+          minimum: 1.0
+          title: Concurrency
+          description: Parallel eval concurrency.
+          default: 4
+        skip_build:
+          type: boolean
+          title: Skip Build
+          description: Skip docker build (Harbor only).
+          default: false
+        output:
+          title: Output
+          description: Output dir for batch artifacts.
+          type: string
+        filter_glob:
+          title: Filter Glob
+          description: Glob filter on eval names.
+          type: string
+        repeats:
+          type: integer
+          minimum: 1.0
+          title: Repeats
+          description: Trials per eval (median aggregation when >1).
+          default: 1
+        anthropic_api_key_secret:
+          title: Anthropic Api Key Secret
+          description: Name of a platform Secret holding the Anthropic API key.  When
+            set on a submit, the value is injected as ``ANTHROPIC_API_KEY`` into the
+            dispatched subprocess so the Harbor eval tasks' LLM-judge calls reach
+            Anthropic.  Local (in-process) runs read ``ANTHROPIC_API_KEY`` from the
+            calling shell as before.
+          type: string
+      type: object
+      required:
+      - evals
+      title: EvaluateSuiteConfig
+    EvaluateSuiteJob:
+      properties:
+        id:
+          title: Id
+          type: string
+        name:
+          type: string
+          title: Name
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        workspace:
+          title: Workspace
+          type: string
+        created_at:
+          title: Created At
+          type: string
+          format: date-time
+        updated_at:
+          title: Updated At
+          type: string
+          format: date-time
+        spec:
+          $ref: '#/components/schemas/EvaluateSuiteConfig'
+        status:
+          $ref: '#/components/schemas/PlatformJobStatus'
+        status_details:
+          title: Status Details
+          additionalProperties: true
+          type: object
+        error_details:
+          title: Error Details
+          additionalProperties: true
+          type: object
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - name
+      - spec
+      title: EvaluateSuiteJob
+    EvaluateSuiteJobRequest:
+      properties:
+        name:
+          title: Name
+          type: string
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        spec:
+          $ref: '#/components/schemas/EvaluateSuiteConfig'
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - spec
+      title: EvaluateSuiteJobRequest
+    EvaluateSuiteJobsListFilter:
+      additionalProperties: false
+      properties:
+        created_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs created at 'gte' datetime or 'lte' datetime.
+        name:
+          description: Name of the job.
+          title: Name
+          type: string
+        workspace:
+          description: Workspace of the job.
+          title: Workspace
+          type: string
+        project:
+          description: Project containing the job.
+          title: Project
+          type: string
+        status:
+          allOf:
+          - $ref: '#/components/schemas/PlatformJobStatus'
+          description: The current status.
+        updated_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs updated at 'gte' datetime or 'lte' datetime.
+      title: EvaluateSuiteJobsListFilter
+      type: object
+    EvaluateSuiteJobsPage:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/EvaluateSuiteJob'
+          type: array
+          title: Data
+        pagination:
+          allOf:
+          - $ref: '#/components/schemas/PaginationData'
+          description: Pagination information.
+        sort:
+          title: Sort
+          description: The field on which the results are sorted.
+          type: string
+        filter:
+          title: Filter
+          description: Filtering information.
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - data
+      title: EvaluateSuiteJobsPage
+    EvaluateSuiteJobsSortField:
+      type: string
+      enum:
+      - created_at
+      - -created_at
+      - updated_at
+      - -updated_at
+      title: EvaluateSuiteJobsSortField
     FileStorageType:
       type: string
       enum:
@@ -1328,6 +2276,220 @@ components:
       required:
       - data
       title: NemoListResponse_Agent_
+    OptimizeSkillsConfig:
+      properties:
+        evals:
+          type: string
+          title: Evals
+          description: Path to the directory of eval tasks.
+        agent:
+          type: string
+          title: Agent
+          description: Agent root (where the loop runs from; skills live under it).
+        skills_path:
+          type: string
+          title: Skills Path
+          description: Relative path inside agent where skills live.
+          default: .agents/skills
+        filter_glob:
+          title: Filter Glob
+          description: Glob filter on eval names (e.g. 'files-*').
+          type: string
+        iterations:
+          type: integer
+          minimum: 1.0
+          title: Iterations
+          default: 3
+        concurrency:
+          type: integer
+          minimum: 1.0
+          title: Concurrency
+          default: 2
+        state:
+          title: State
+          description: 'Path to loop_state.json; default: <agent>/loop_state.json.'
+          type: string
+        initial_batch:
+          title: Initial Batch
+          description: Existing batch dir to seed from.
+          type: string
+        full_verification:
+          type: boolean
+          title: Full Verification
+          default: false
+        open_pr:
+          type: boolean
+          title: Open Pr
+          default: false
+        repeats:
+          type: integer
+          minimum: 1.0
+          title: Repeats
+          default: 1
+        analyze_only:
+          type: boolean
+          title: Analyze Only
+          description: 'Analyze-only mode: consume an existing --initial-batch, generate
+            suggestions, exit. Skips worktree, apply, verify, MR. Works with any AUT
+            (Harbor or NAT).'
+          default: false
+        trace_parser:
+          type: string
+          const: claude-code
+          title: Trace Parser
+          description: "Trace parser for the agent's traces. Today only 'claude-code'\
+            \ is registered (parses Claude Code session.jsonl). Future parsers \u2014\
+            \ e.g. for NAT IntermediateStep records \u2014 extend this Literal."
+          default: claude-code
+        anthropic_api_key_secret:
+          title: Anthropic Api Key Secret
+          description: Name of a platform Secret holding the Anthropic API key.  When
+            set on a submit, the value is injected as ``ANTHROPIC_API_KEY`` into the
+            dispatched subprocess so the loop's ``check_anthropic_api`` / Claude analyzer
+            preflights pass.  Local (in-process) runs read ``ANTHROPIC_API_KEY`` from
+            the calling shell as before.
+          type: string
+      type: object
+      required:
+      - evals
+      - agent
+      title: OptimizeSkillsConfig
+    OptimizeSkillsJob:
+      properties:
+        id:
+          title: Id
+          type: string
+        name:
+          type: string
+          title: Name
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        workspace:
+          title: Workspace
+          type: string
+        created_at:
+          title: Created At
+          type: string
+          format: date-time
+        updated_at:
+          title: Updated At
+          type: string
+          format: date-time
+        spec:
+          $ref: '#/components/schemas/OptimizeSkillsConfig'
+        status:
+          $ref: '#/components/schemas/PlatformJobStatus'
+        status_details:
+          title: Status Details
+          additionalProperties: true
+          type: object
+        error_details:
+          title: Error Details
+          additionalProperties: true
+          type: object
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - name
+      - spec
+      title: OptimizeSkillsJob
+    OptimizeSkillsJobRequest:
+      properties:
+        name:
+          title: Name
+          type: string
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        spec:
+          $ref: '#/components/schemas/OptimizeSkillsConfig'
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - spec
+      title: OptimizeSkillsJobRequest
+    OptimizeSkillsJobsListFilter:
+      additionalProperties: false
+      properties:
+        created_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs created at 'gte' datetime or 'lte' datetime.
+        name:
+          description: Name of the job.
+          title: Name
+          type: string
+        workspace:
+          description: Workspace of the job.
+          title: Workspace
+          type: string
+        project:
+          description: Project containing the job.
+          title: Project
+          type: string
+        status:
+          allOf:
+          - $ref: '#/components/schemas/PlatformJobStatus'
+          description: The current status.
+        updated_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs updated at 'gte' datetime or 'lte' datetime.
+      title: OptimizeSkillsJobsListFilter
+      type: object
+    OptimizeSkillsJobsPage:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/OptimizeSkillsJob'
+          type: array
+          title: Data
+        pagination:
+          allOf:
+          - $ref: '#/components/schemas/PaginationData'
+          description: Pagination information.
+        sort:
+          title: Sort
+          description: The field on which the results are sorted.
+          type: string
+        filter:
+          title: Filter
+          description: Filtering information.
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - data
+      title: OptimizeSkillsJobsPage
+    OptimizeSkillsJobsSortField:
+      type: string
+      enum:
+      - created_at
+      - -created_at
+      - updated_at
+      - -updated_at
+      title: OptimizeSkillsJobsSortField
     PaginationData:
       properties:
         page:

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -3121,7 +3121,7 @@ components:
         agent:
           type: string
           title: Agent
-          description: Agent root (required on submit).
+          description: Agent root.
         runner:
           type: string
           enum:
@@ -3153,7 +3153,7 @@ components:
         output:
           type: string
           title: Output
-          description: Output dir for batch artifacts (required on submit).
+          description: Output dir for batch artifacts.
         filter_glob:
           title: Filter Glob
           description: Glob filter on eval names.

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: agents (plugin)
-  version: 0.1.1
+  version: 0.1.3
 paths:
   /apis/agents/v2/workspaces/{workspace}/agents:
     post:
@@ -2670,6 +2670,29 @@ components:
           type: string
       title: DatetimeFilter
       type: object
+    DeploymentLogsResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/LogLine'
+          type: array
+          title: Data
+        total_lines:
+          type: integer
+          title: Total Lines
+          description: Number of lines actually returned.
+        next_offset:
+          type: integer
+          title: Next Offset
+          description: Byte offset just past the returned tail; pass as Last-Event-ID
+            to resume the stream without gaps.
+      type: object
+      required:
+      - data
+      - total_lines
+      - next_offset
+      title: DeploymentLogsResponse
+      description: Response body for ``GET /deployments/{name}/logs``.
     EvaluateAgentSpec:
       properties:
         agent:
@@ -3185,6 +3208,38 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
+    LogLine:
+      properties:
+        timestamp:
+          type: string
+          title: Timestamp
+          description: ISO-8601 timestamp parsed from the line; empty when absent.
+        job:
+          type: string
+          title: Job
+          description: "Empty \u2014 kept for shape compatibility with jobs logs."
+          default: ''
+        job_step:
+          type: string
+          title: Job Step
+          description: "Empty \u2014 kept for shape compatibility."
+          default: ''
+        job_task:
+          type: string
+          title: Job Task
+          description: "Empty \u2014 kept for shape compatibility."
+          default: ''
+        message:
+          type: string
+          title: Message
+          description: The raw log line minus any parsed timestamp prefix.
+      type: object
+      required:
+      - timestamp
+      - message
+      title: LogLine
+      description: One line shaped to match ``PlatformJobLog`` so Studio's LogViewer
+        renders it as-is.
     NemoListResponse_AgentDeployment_:
       properties:
         data:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/analyze_batch.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/analyze_batch.py
@@ -4,6 +4,14 @@
 """AnalyzeBatchJob — analyze a batch of eval-suite results.
 
 Registered under ``nemo.jobs`` as ``agents.analyze``.
+
+Two invocation paths share the same ``run(config)`` body:
+
+* ``nemo agents analyze run --spec '{...}'`` — local, in-process, no
+  platform job row.
+* ``nemo agents analyze submit --spec '{...}'`` — POSTs to the platform;
+  the jobs controller dispatches a subprocess on the same host and the
+  result lands in ``nemo jobs list`` / Studio's Jobs view.
 """
 
 from __future__ import annotations
@@ -13,7 +21,11 @@ import logging
 from pathlib import Path
 from typing import ClassVar, Literal
 
+from nemo_agents_plugin.jobs.evaluate_suite import _require_absolute
 from nemo_platform_plugin.job import NemoJob
+from nemo_platform_plugin.job_context import JobContext
+from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
+from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -23,6 +35,16 @@ class AnalyzeBatchConfig(BaseModel):
     batch: str = Field(description="Path to a batch directory produced by evaluate-suite.")
     format: Literal["md", "json"] = Field(default="md", description="Output format: md or json.")
     mechanical_only: bool = Field(default=False, description="Skip the LLM analysis pass.")
+    anthropic_api_key_secret: str | None = Field(
+        default=None,
+        description=(
+            "Name of a platform Secret holding the Anthropic API key.  When set on a submit, "
+            "the value is injected as ``ANTHROPIC_API_KEY`` into the dispatched subprocess "
+            "so the LLM gap-analysis pass can call Anthropic.  Ignored when "
+            "``mechanical_only=True``.  Local (in-process) runs read ``ANTHROPIC_API_KEY`` "
+            "from the calling shell as before."
+        ),
+    )
 
 
 class AnalyzeBatchJob(NemoJob):
@@ -31,8 +53,73 @@ class AnalyzeBatchJob(NemoJob):
     name: ClassVar[str] = "analyze"
     description: ClassVar[str] = "Analyze a batch of eval-suite results (clusters, regressions, hypotheses)."
     container: ClassVar[str] = "cpu-tasks"
+    spec_schema: ClassVar[type[BaseModel]] = AnalyzeBatchConfig
 
-    def run(self, config: dict) -> dict:
+    @classmethod
+    async def compile(  # type: ignore[override]
+        cls,
+        *,
+        workspace: str,
+        spec: AnalyzeBatchConfig,
+        entity_client: object,
+        job_name: str | None,
+        async_sdk: object,
+        profile: str | None = None,
+        options: dict | None = None,
+    ) -> PlatformJobSpec:
+        """Single-step PlatformJobSpec running ``nemo_agents_plugin.tasks.analyze``."""
+        from nemo_platform_plugin.jobs.api_factory import (
+            EnvironmentVariable,
+            EnvironmentVariableFromSecret,
+            PlatformJobStep,
+            SubprocessExecutionProviderSpec,
+        )
+        from nmp.common.jobs.constants import (
+            DEFAULT_JOB_STORAGE_PATH,
+            PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+        )
+
+        _require_absolute(spec.batch, "batch")
+        if not spec.mechanical_only and not spec.anthropic_api_key_secret:
+            raise PlatformJobCompilationError(
+                "'anthropic_api_key_secret' is required when submitting unless "
+                "'mechanical_only' is True (the LLM analysis pass calls Anthropic, "
+                "and the subprocess backend's sanitized env does not inherit "
+                "ANTHROPIC_API_KEY)."
+            )
+
+        spec_dict = spec.model_dump(mode="json")
+        spec_dict["workspace"] = workspace
+
+        environment: list[EnvironmentVariable] = [
+            EnvironmentVariable(name=PERSISTENT_JOB_STORAGE_PATH_ENVVAR, value=DEFAULT_JOB_STORAGE_PATH),
+        ]
+        if spec.anthropic_api_key_secret:
+            environment.append(
+                EnvironmentVariable(
+                    name="ANTHROPIC_API_KEY",
+                    from_secret=EnvironmentVariableFromSecret(name=spec.anthropic_api_key_secret),
+                )
+            )
+
+        return PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="analyze",
+                    executor=SubprocessExecutionProviderSpec(
+                        provider="subprocess",
+                        command=["python", "-m", "nemo_agents_plugin.tasks.analyze"],
+                    ),
+                    config=spec_dict,
+                    environment=environment,
+                ),
+            ],
+        )
+
+    def run(self, config: dict, *, ctx: JobContext | None = None) -> dict:
+        # ``ctx`` is signature-typed so the framework's DI populates it on the
+        # submit path; the friendly CLI calls ``run(spec)`` directly without one.
+        del ctx
         from nemo_agents_plugin.improvement.analysis.llm import generate_gap_analysis
         from nemo_agents_plugin.improvement.analysis.mechanical import cluster_evals, mechanical_analysis
         from nemo_agents_plugin.improvement.baselines import load_baselines

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
@@ -210,7 +210,7 @@ class EvaluateSuiteJob(NemoJob):
             ],
         )
 
-    def run(self, config: dict, *, _ctx: JobContext | None = None) -> dict:
+    def run(self, config: dict, *, ctx: JobContext | None = None) -> dict:
         from nemo_agents_plugin.improvement import preflight
         from nemo_agents_plugin.improvement.runners.detect import detect_runner, get_runner
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
@@ -101,8 +101,8 @@ class EvaluateSuiteSubmitConfig(EvaluateSuiteConfig):
     422 at submit time instead of a confusing dispatched-job failure.
     """
 
-    agent: str = Field(description="Agent root (required on submit).")
-    output: str = Field(description="Output dir for batch artifacts (required on submit).")
+    agent: str = Field(description="Agent root.")
+    output: str = Field(description="Output dir for batch artifacts.")
 
 
 class EvaluateSuiteJob(NemoJob):

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
@@ -210,16 +210,9 @@ class EvaluateSuiteJob(NemoJob):
             ],
         )
 
-    def run(self, config: dict, *, ctx: JobContext | None = None) -> dict:
+    def run(self, config: dict, *, _ctx: JobContext | None = None) -> dict:
         from nemo_agents_plugin.improvement import preflight
         from nemo_agents_plugin.improvement.runners.detect import detect_runner, get_runner
-
-        # ``ctx`` is signature-typed so the framework's DI populates it on the
-        # submit path; the friendly CLI in ``cli.py`` calls ``run(spec)`` directly
-        # without one (and ``EvaluateSuiteJob`` is also constructed from tests
-        # and other in-process callers).  Today the body doesn't consume it —
-        # fileset-write helpers that need ``ctx.storage`` land in a follow-up.
-        del ctx
 
         cfg = EvaluateSuiteConfig.model_validate(config)
         evals_dir = Path(cfg.evals).resolve()

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
@@ -58,13 +58,24 @@ def _require_absolute(value: str | None, field: str) -> None:
 
 
 class EvaluateSuiteConfig(BaseModel):
+    """Canonical config consumed by ``EvaluateSuiteJob.run``.
+
+    ``agent`` and ``output`` are optional here so the local run path can
+    fall back to ``Path.cwd()`` / ``Path.cwd()/runs/batch-<ts>``.  The
+    submit path uses :class:`EvaluateSuiteSubmitConfig` (where both are
+    required) as its wire schema, and ``compile()`` re-validates that
+    both ended up non-``None`` before dispatch.
+    """
+
     evals: str = Field(description="Path to the directory of eval tasks.")
-    agent: str | None = Field(default=None, description="Agent root (defaults to repo root).")
+    agent: str | None = Field(default=None, description="Agent root (defaults to repo root in local run).")
     runner: Literal["auto", "harbor", "nat"] = Field(default="auto", description="Eval runner.")
     prefer: Literal["harbor", "nat"] = Field(default="nat", description="Tiebreaker when both markers present.")
     concurrency: int = Field(default=4, ge=1, description="Parallel eval concurrency.")
     skip_build: bool = Field(default=False, description="Skip docker build (Harbor only).")
-    output: str | None = Field(default=None, description="Output dir for batch artifacts.")
+    output: str | None = Field(
+        default=None, description="Output dir for batch artifacts (defaults to cwd/runs in local run)."
+    )
     filter_glob: str | None = Field(default=None, description="Glob filter on eval names.")
     repeats: int = Field(default=1, ge=1, description="Trials per eval (median aggregation when >1).")
     anthropic_api_key_secret: str | None = Field(
@@ -78,6 +89,22 @@ class EvaluateSuiteConfig(BaseModel):
     )
 
 
+class EvaluateSuiteSubmitConfig(EvaluateSuiteConfig):
+    """Submit-side wire schema for ``EvaluateSuiteJob``.
+
+    Narrows ``agent`` and ``output`` from ``str | None`` to ``str`` (no
+    default) so the OpenAPI contract matches the runtime behaviour: the
+    subprocess executor's work dir is not the caller's cwd, so the
+    canonical ``EvaluateSuiteConfig`` fallback to ``Path.cwd()`` would
+    silently land in ``/tmp/nmp-subprocess-jobs/.../task-*/``.  Making
+    them required at the schema layer surfaces the requirement as a
+    422 at submit time instead of a confusing dispatched-job failure.
+    """
+
+    agent: str = Field(description="Agent root (required on submit).")
+    output: str = Field(description="Output dir for batch artifacts (required on submit).")
+
+
 class EvaluateSuiteJob(NemoJob):
     """Run a suite of containerized eval tasks against an agent."""
 
@@ -85,6 +112,21 @@ class EvaluateSuiteJob(NemoJob):
     description: ClassVar[str] = "Run a directory of containerized eval tasks (Harbor or NAT) against an agent."
     container: ClassVar[str] = "cpu-tasks"
     spec_schema: ClassVar[type[BaseModel]] = EvaluateSuiteConfig
+    input_spec_schema: ClassVar[type[BaseModel]] = EvaluateSuiteSubmitConfig
+
+    @classmethod
+    async def to_spec(  # type: ignore[override]
+        cls,
+        input_spec: EvaluateSuiteSubmitConfig,
+        *,
+        workspace: str,
+        entity_client: object,
+        async_sdk: object,
+        is_local: bool,
+    ) -> EvaluateSuiteConfig:
+        # input_spec_schema is a strict subclass — re-pack to drop the input
+        # label so downstream consumers (compile, run) see the canonical type.
+        return EvaluateSuiteConfig.model_validate(input_spec.model_dump())
 
     @classmethod
     async def compile(  # type: ignore[override]

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
@@ -5,7 +5,14 @@
 
 Registered under ``nemo.jobs`` as ``agents.evaluate-suite``. Invoke as
 
-    nemo agents evaluate-suite run --spec '{"evals": "./my-evals", "concurrency": 4}'
+Two invocation paths share the same ``run(config)`` body:
+
+* ``nemo agents evaluate-suite run --spec '{...}'`` — local, in-process, no
+  platform job row (good for offline iteration / no platform required).
+* ``nemo agents evaluate-suite submit --spec '{...}'`` — POSTs to the
+  platform; the jobs controller dispatches a subprocess on the same host that
+  runs the platform (today: the user's laptop) and the result lands in
+  ``nemo jobs list`` / Studio's Jobs view.
 
 or, preferred for repeatable runs, with a YAML spec file:
 
@@ -21,6 +28,7 @@ from pathlib import Path
 from typing import ClassVar, Literal
 
 from nemo_platform_plugin.job import NemoJob
+from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -44,6 +52,42 @@ class EvaluateSuiteJob(NemoJob):
     name: ClassVar[str] = "evaluate-suite"
     description: ClassVar[str] = "Run a directory of containerized eval tasks (Harbor or NAT) against an agent."
     container: ClassVar[str] = "cpu-tasks"
+    spec_schema: ClassVar[type[BaseModel]] = EvaluateSuiteConfig
+
+    @classmethod
+    async def compile(  # type: ignore[override]
+        cls,
+        *,
+        workspace: str,
+        spec: EvaluateSuiteConfig,
+        entity_client: object,
+        job_name: str | None,
+        async_sdk: object,
+        profile: str | None = None,
+        options: dict | None = None,
+    ) -> PlatformJobSpec:
+        """Single-step PlatformJobSpec running ``nemo_agents_plugin.tasks.evaluate_suite``.
+
+        Dispatched by the platform's host-subprocess executor — same machine as the
+        platform (and the user's docker daemon).  No dedicated container image.
+        """
+        from nemo_platform_plugin.jobs.api_factory import (
+            PlatformJobStep,
+            SubprocessExecutionProviderSpec,
+        )
+
+        return PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="evaluate-suite",
+                    executor=SubprocessExecutionProviderSpec(
+                        provider="subprocess",
+                        command=["python", "-m", "nemo_agents_plugin.tasks.evaluate_suite"],
+                    ),
+                    config=spec.model_dump(mode="json"),
+                ),
+            ],
+        )
 
     def run(self, config: dict) -> dict:
         from nemo_agents_plugin.improvement import preflight

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
@@ -28,10 +28,33 @@ from pathlib import Path
 from typing import ClassVar, Literal
 
 from nemo_platform_plugin.job import NemoJob
+from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
+from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
+
+
+def _require_absolute(value: str | None, field: str) -> None:
+    """Raise PlatformJobCompilationError if *value* is set and not absolute.
+
+    The platform's host-subprocess executor runs each step in an ephemeral
+    work dir under ``/tmp/nmp-subprocess-jobs/<job>/<attempt>/<step>/task-<id>``,
+    not the caller's project root.  Relative paths on the submit path resolve
+    against that work dir, which is empty, and the job silently fails preflight
+    (or worse, writes outputs to the work dir that get reaped after the job's
+    TTL).  Reject relative paths up front with a clear error so a 422 surfaces
+    at submit time instead.
+    """
+    if value is None:
+        return
+    if not Path(value).is_absolute():
+        raise PlatformJobCompilationError(
+            f"{field!r} must be an absolute path when submitting via the platform "
+            f"(got {value!r}); the subprocess executor's work dir is not the caller's "
+            f"cwd. Re-submit with an absolute path."
+        )
 
 
 class EvaluateSuiteConfig(BaseModel):
@@ -72,9 +95,28 @@ class EvaluateSuiteJob(NemoJob):
         platform (and the user's docker daemon).  No dedicated container image.
         """
         from nemo_platform_plugin.jobs.api_factory import (
+            EnvironmentVariable,
             PlatformJobStep,
             SubprocessExecutionProviderSpec,
         )
+        from nmp.common.jobs.constants import (
+            DEFAULT_JOB_STORAGE_PATH,
+            PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+        )
+
+        # Subprocess work dir is /tmp/nmp-subprocess-jobs/.../task-..., not the
+        # caller's cwd.  Relative paths silently fail at preflight or stash
+        # outputs in the ephemeral work dir.
+        _require_absolute(spec.evals, "evals")
+        _require_absolute(spec.agent, "agent")
+        _require_absolute(spec.output, "output")
+
+        # URL workspace is the auth boundary; overwrite any spec workspace
+        # field if one is added later.  Today the config has no `workspace`
+        # field so this just adds the key (Pydantic ``extra="ignore"`` on
+        # the subprocess-side validate drops it).
+        spec_dict = spec.model_dump(mode="json")
+        spec_dict["workspace"] = workspace
 
         return PlatformJobSpec(
             steps=[
@@ -84,14 +126,22 @@ class EvaluateSuiteJob(NemoJob):
                         provider="subprocess",
                         command=["python", "-m", "nemo_agents_plugin.tasks.evaluate_suite"],
                     ),
-                    config=spec.model_dump(mode="json"),
+                    config=spec_dict,
+                    environment=[
+                        EnvironmentVariable(
+                            name=PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+                            value=DEFAULT_JOB_STORAGE_PATH,
+                        ),
+                    ],
                 ),
             ],
         )
 
-    def run(self, config: dict) -> dict:
+    def run(self, config: dict, *, ctx: JobContext) -> dict:
         from nemo_agents_plugin.improvement import preflight
         from nemo_agents_plugin.improvement.runners.detect import detect_runner, get_runner
+
+        del ctx  # framework-injected for future fileset writes; not consumed yet
 
         cfg = EvaluateSuiteConfig.model_validate(config)
         evals_dir = Path(cfg.evals).resolve()
@@ -123,7 +173,11 @@ class EvaluateSuiteJob(NemoJob):
 
             evals = [e for e in evals if _fn(e.name, cfg.filter_glob)]
         if not evals:
-            return {"status": "no-evals-found", "runner": runner.name, "evals_dir": str(evals_dir)}
+            # Raising instead of returning {"status": "no-evals-found"} so the
+            # platform dispatcher marks the job as error rather than completed.
+            # A silent success here is invisible in Studio's Jobs view.
+            filter_clause = f" matching {cfg.filter_glob!r}" if cfg.filter_glob else ""
+            raise RuntimeError(f"No evals found in {evals_dir} (runner={runner.name}){filter_clause}.")
 
         batch = asyncio.run(
             runner.run_batch(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/evaluate_suite.py
@@ -67,6 +67,15 @@ class EvaluateSuiteConfig(BaseModel):
     output: str | None = Field(default=None, description="Output dir for batch artifacts.")
     filter_glob: str | None = Field(default=None, description="Glob filter on eval names.")
     repeats: int = Field(default=1, ge=1, description="Trials per eval (median aggregation when >1).")
+    anthropic_api_key_secret: str | None = Field(
+        default=None,
+        description=(
+            "Name of a platform Secret holding the Anthropic API key.  When set on a submit, "
+            "the value is injected as ``ANTHROPIC_API_KEY`` into the dispatched subprocess so "
+            "the Harbor eval tasks' LLM-judge calls reach Anthropic.  Local (in-process) runs "
+            "read ``ANTHROPIC_API_KEY`` from the calling shell as before."
+        ),
+    )
 
 
 class EvaluateSuiteJob(NemoJob):
@@ -96,6 +105,7 @@ class EvaluateSuiteJob(NemoJob):
         """
         from nemo_platform_plugin.jobs.api_factory import (
             EnvironmentVariable,
+            EnvironmentVariableFromSecret,
             PlatformJobStep,
             SubprocessExecutionProviderSpec,
         )
@@ -106,8 +116,19 @@ class EvaluateSuiteJob(NemoJob):
 
         # Subprocess work dir is /tmp/nmp-subprocess-jobs/.../task-..., not the
         # caller's cwd.  Relative paths silently fail at preflight or stash
-        # outputs in the ephemeral work dir.
+        # outputs in the ephemeral work dir; None defaults fall back to
+        # ``Path.cwd()`` inside run() — same hazard.  Require both up front.
         _require_absolute(spec.evals, "evals")
+        if spec.agent is None:
+            raise PlatformJobCompilationError(
+                "'agent' is required when submitting (defaults to Path.cwd() in run(), "
+                "which inside the subprocess executor is the empty task scratch dir)."
+            )
+        if spec.output is None:
+            raise PlatformJobCompilationError(
+                "'output' is required when submitting (defaults to Path.cwd()/runs/... in "
+                "run(), writing artifacts to the ephemeral subprocess scratch dir)."
+            )
         _require_absolute(spec.agent, "agent")
         _require_absolute(spec.output, "output")
 
@@ -118,6 +139,21 @@ class EvaluateSuiteJob(NemoJob):
         spec_dict = spec.model_dump(mode="json")
         spec_dict["workspace"] = workspace
 
+        environment: list[EnvironmentVariable] = [
+            EnvironmentVariable(name=PERSISTENT_JOB_STORAGE_PATH_ENVVAR, value=DEFAULT_JOB_STORAGE_PATH),
+        ]
+        if spec.anthropic_api_key_secret:
+            # The subprocess backend's sanitized environment does not inherit
+            # ANTHROPIC_API_KEY from the platform process.  Harbor eval tasks
+            # call Anthropic for LLM-judge scoring, so inject from a Secret
+            # to keep submitted jobs functional.
+            environment.append(
+                EnvironmentVariable(
+                    name="ANTHROPIC_API_KEY",
+                    from_secret=EnvironmentVariableFromSecret(name=spec.anthropic_api_key_secret),
+                )
+            )
+
         return PlatformJobSpec(
             steps=[
                 PlatformJobStep(
@@ -127,21 +163,21 @@ class EvaluateSuiteJob(NemoJob):
                         command=["python", "-m", "nemo_agents_plugin.tasks.evaluate_suite"],
                     ),
                     config=spec_dict,
-                    environment=[
-                        EnvironmentVariable(
-                            name=PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
-                            value=DEFAULT_JOB_STORAGE_PATH,
-                        ),
-                    ],
+                    environment=environment,
                 ),
             ],
         )
 
-    def run(self, config: dict, *, ctx: JobContext) -> dict:
+    def run(self, config: dict, *, ctx: JobContext | None = None) -> dict:
         from nemo_agents_plugin.improvement import preflight
         from nemo_agents_plugin.improvement.runners.detect import detect_runner, get_runner
 
-        del ctx  # framework-injected for future fileset writes; not consumed yet
+        # ``ctx`` is signature-typed so the framework's DI populates it on the
+        # submit path; the friendly CLI in ``cli.py`` calls ``run(spec)`` directly
+        # without one (and ``EvaluateSuiteJob`` is also constructed from tests
+        # and other in-process callers).  Today the body doesn't consume it —
+        # fileset-write helpers that need ``ctx.storage`` land in a follow-up.
+        del ctx
 
         cfg = EvaluateSuiteConfig.model_validate(config)
         evals_dir = Path(cfg.evals).resolve()

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_agent.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_agent.py
@@ -63,6 +63,7 @@ from nemo_agents_plugin.utils import (
 from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
+from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
 from nemo_platform_plugin.refs import EndpointURL
 from nemo_platform_plugin.run_dependencies import LocalRunError
 from pydantic import BaseModel, Field
@@ -127,6 +128,55 @@ class OptimizeAgentJob(NemoJob):
     description: ClassVar[str] = "Optimize an agent workflow (prompt tuning, HPO) as a scheduled platform job."
     container: ClassVar[str] = "cpu-tasks"
     spec_schema: ClassVar[type[BaseModel]] = OptimizeAgentSpec
+
+    @classmethod
+    async def compile(  # type: ignore[override]
+        cls,
+        *,
+        workspace: str,
+        spec: OptimizeAgentSpec,
+        entity_client: object,
+        job_name: str | None,
+        async_sdk: object,
+        profile: str | None = None,
+        options: dict | None = None,
+    ) -> PlatformJobSpec:
+        """Single-step PlatformJobSpec running ``nemo_agents_plugin.tasks.optimize``."""
+        from nemo_agents_plugin.jobs.evaluate_suite import _require_absolute
+        from nemo_platform_plugin.jobs.api_factory import (
+            EnvironmentVariable,
+            PlatformJobStep,
+            SubprocessExecutionProviderSpec,
+        )
+        from nmp.common.jobs.constants import (
+            DEFAULT_JOB_STORAGE_PATH,
+            PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+        )
+
+        _require_absolute(spec.optimize_config, "optimize_config")
+
+        spec_dict = spec.model_dump(mode="json")
+        # URL workspace is the auth boundary; overwrites any spec workspace.
+        spec_dict["workspace"] = workspace
+
+        return PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="optimize-agent",
+                    executor=SubprocessExecutionProviderSpec(
+                        provider="subprocess",
+                        command=["python", "-m", "nemo_agents_plugin.tasks.optimize"],
+                    ),
+                    config=spec_dict,
+                    environment=[
+                        EnvironmentVariable(
+                            name=PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+                            value=DEFAULT_JOB_STORAGE_PATH,
+                        ),
+                    ],
+                ),
+            ],
+        )
 
     def run(self, config: dict, *, ctx: JobContext, sdk: NeMoPlatform | None = None) -> dict:
         """Run optimization by delegating to the ``nat optimize`` CLI.

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
@@ -147,13 +147,17 @@ class OptimizeSkillsJob(NemoJob):
             ],
         )
 
-    def run(self, config: dict, *, ctx: JobContext) -> dict:
+    def run(self, config: dict, *, ctx: JobContext | None = None) -> dict:
         from nemo_agents_plugin.improvement import preflight
         from nemo_agents_plugin.improvement.coding_agents.claude import ClaudeCodingAgent
         from nemo_agents_plugin.improvement.loop import run_analyze_only, run_loop
         from nemo_agents_plugin.improvement.models import _serialize
 
-        del ctx  # framework-injected for future fileset writes; not consumed yet
+        # ``ctx`` is signature-typed so the framework's DI populates it on the
+        # submit path; the friendly CLI in ``cli.py`` calls ``run(spec)`` directly
+        # without one.  Today the body doesn't consume it — fileset-write helpers
+        # that need ``ctx.storage`` land in a follow-up.
+        del ctx
 
         cfg = OptimizeSkillsConfig.model_validate(config)
         agent_root = Path(cfg.agent).resolve()

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
@@ -156,7 +156,7 @@ class OptimizeSkillsJob(NemoJob):
             ],
         )
 
-    def run(self, config: dict, *, _ctx: JobContext | None = None) -> dict:
+    def run(self, config: dict, *, ctx: JobContext | None = None) -> dict:
         from nemo_agents_plugin.improvement import preflight
         from nemo_agents_plugin.improvement.coding_agents.claude import ClaudeCodingAgent
         from nemo_agents_plugin.improvement.loop import run_analyze_only, run_loop

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
@@ -156,17 +156,11 @@ class OptimizeSkillsJob(NemoJob):
             ],
         )
 
-    def run(self, config: dict, *, ctx: JobContext | None = None) -> dict:
+    def run(self, config: dict, *, _ctx: JobContext | None = None) -> dict:
         from nemo_agents_plugin.improvement import preflight
         from nemo_agents_plugin.improvement.coding_agents.claude import ClaudeCodingAgent
         from nemo_agents_plugin.improvement.loop import run_analyze_only, run_loop
         from nemo_agents_plugin.improvement.models import _serialize
-
-        # ``ctx`` is signature-typed so the framework's DI populates it on the
-        # submit path; the friendly CLI in ``cli.py`` calls ``run(spec)`` directly
-        # without one.  Today the body doesn't consume it — fileset-write helpers
-        # that need ``ctx.storage`` land in a follow-up.
-        del ctx
 
         cfg = OptimizeSkillsConfig.model_validate(config)
         agent_root = Path(cfg.agent).resolve()

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
@@ -22,7 +22,9 @@ import logging
 from pathlib import Path
 from typing import ClassVar, Literal
 
+from nemo_agents_plugin.jobs.evaluate_suite import _require_absolute
 from nemo_platform_plugin.job import NemoJob
+from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
 from pydantic import BaseModel, Field
 
@@ -56,6 +58,15 @@ class OptimizeSkillsConfig(BaseModel):
             "records — extend this Literal."
         ),
     )
+    anthropic_api_key_secret: str | None = Field(
+        default=None,
+        description=(
+            "Name of a platform Secret holding the Anthropic API key.  When set on a submit, "
+            "the value is injected as ``ANTHROPIC_API_KEY`` into the dispatched subprocess so "
+            "the loop's ``check_anthropic_api`` / Claude analyzer preflights pass.  Local "
+            "(in-process) runs read ``ANTHROPIC_API_KEY`` from the calling shell as before."
+        ),
+    )
 
 
 class OptimizeSkillsJob(NemoJob):
@@ -84,9 +95,43 @@ class OptimizeSkillsJob(NemoJob):
         platform (and the user's docker daemon / Claude CLI).  No dedicated container image.
         """
         from nemo_platform_plugin.jobs.api_factory import (
+            EnvironmentVariable,
+            EnvironmentVariableFromSecret,
             PlatformJobStep,
             SubprocessExecutionProviderSpec,
         )
+        from nmp.common.jobs.constants import (
+            DEFAULT_JOB_STORAGE_PATH,
+            PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+        )
+
+        # Subprocess work dir is /tmp/nmp-subprocess-jobs/.../task-..., not the
+        # caller's cwd; reject relative paths up front.
+        _require_absolute(spec.evals, "evals")
+        _require_absolute(spec.agent, "agent")
+        _require_absolute(spec.state, "state")
+        _require_absolute(spec.initial_batch, "initial_batch")
+
+        # URL workspace is the auth boundary.  Config has no ``workspace``
+        # field today; injecting the key is a no-op now and a guard against
+        # future workspace-scoped fields.
+        spec_dict = spec.model_dump(mode="json")
+        spec_dict["workspace"] = workspace
+
+        environment: list[EnvironmentVariable] = [
+            EnvironmentVariable(name=PERSISTENT_JOB_STORAGE_PATH_ENVVAR, value=DEFAULT_JOB_STORAGE_PATH),
+        ]
+        if spec.anthropic_api_key_secret:
+            # The subprocess backend's sanitized environment does not inherit
+            # ANTHROPIC_API_KEY from the platform process.  Inject from a
+            # platform Secret so ``preflight.check_anthropic_api`` and the
+            # Claude coding-agent preflight pass inside the dispatched step.
+            environment.append(
+                EnvironmentVariable(
+                    name="ANTHROPIC_API_KEY",
+                    from_secret=EnvironmentVariableFromSecret(name=spec.anthropic_api_key_secret),
+                )
+            )
 
         return PlatformJobSpec(
             steps=[
@@ -96,16 +141,19 @@ class OptimizeSkillsJob(NemoJob):
                         provider="subprocess",
                         command=["python", "-m", "nemo_agents_plugin.tasks.optimize_skills"],
                     ),
-                    config=spec.model_dump(mode="json"),
+                    config=spec_dict,
+                    environment=environment,
                 ),
             ],
         )
 
-    def run(self, config: dict) -> dict:
+    def run(self, config: dict, *, ctx: JobContext) -> dict:
         from nemo_agents_plugin.improvement import preflight
         from nemo_agents_plugin.improvement.coding_agents.claude import ClaudeCodingAgent
         from nemo_agents_plugin.improvement.loop import run_analyze_only, run_loop
         from nemo_agents_plugin.improvement.models import _serialize
+
+        del ctx  # framework-injected for future fileset writes; not consumed yet
 
         cfg = OptimizeSkillsConfig.model_validate(config)
         agent_root = Path(cfg.agent).resolve()

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
@@ -26,6 +26,7 @@ from nemo_agents_plugin.jobs.evaluate_suite import _require_absolute
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
+from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -111,6 +112,14 @@ class OptimizeSkillsJob(NemoJob):
         _require_absolute(spec.agent, "agent")
         _require_absolute(spec.state, "state")
         _require_absolute(spec.initial_batch, "initial_batch")
+
+        # Mirror the run() guard so submit fails fast with a 422 instead of
+        # spawning a doomed subprocess that errors inside analyze_only.
+        if spec.analyze_only and not spec.initial_batch:
+            raise PlatformJobCompilationError(
+                "'analyze_only' requires 'initial_batch' to point at an existing batch "
+                "directory; the analyze-only path has no batch to consume otherwise."
+            )
 
         # URL workspace is the auth boundary.  Config has no ``workspace``
         # field today; injecting the key is a no-op now and a guard against

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_skills.py
@@ -4,6 +4,15 @@
 """OptimizeSkillsJob — the optimize-skills loop.
 
 Registered under ``nemo.jobs`` as ``agents.optimize-skills``.
+
+Two invocation paths share the same ``run(config)`` body:
+
+* ``nemo agents optimize-skills run --spec '{...}'`` — local, in-process, no
+  platform job row (good for offline iteration / no platform required).
+* ``nemo agents optimize-skills submit --spec '{...}'`` — POSTs to the
+  platform; the jobs controller dispatches a subprocess on the same host that
+  runs the platform and the result lands in ``nemo jobs list`` / Studio's
+  Jobs view.
 """
 
 from __future__ import annotations
@@ -14,6 +23,7 @@ from pathlib import Path
 from typing import ClassVar, Literal
 
 from nemo_platform_plugin.job import NemoJob
+from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -54,6 +64,42 @@ class OptimizeSkillsJob(NemoJob):
     name: ClassVar[str] = "optimize-skills"
     description: ClassVar[str] = "Optimize an agent's skills against eval failures via a coding agent (Claude)."
     container: ClassVar[str] = "cpu-tasks"
+    spec_schema: ClassVar[type[BaseModel]] = OptimizeSkillsConfig
+
+    @classmethod
+    async def compile(  # type: ignore[override]
+        cls,
+        *,
+        workspace: str,
+        spec: OptimizeSkillsConfig,
+        entity_client: object,
+        job_name: str | None,
+        async_sdk: object,
+        profile: str | None = None,
+        options: dict | None = None,
+    ) -> PlatformJobSpec:
+        """Single-step PlatformJobSpec running ``nemo_agents_plugin.tasks.optimize_skills``.
+
+        Dispatched by the platform's host-subprocess executor — same machine as the
+        platform (and the user's docker daemon / Claude CLI).  No dedicated container image.
+        """
+        from nemo_platform_plugin.jobs.api_factory import (
+            PlatformJobStep,
+            SubprocessExecutionProviderSpec,
+        )
+
+        return PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="optimize-skills",
+                    executor=SubprocessExecutionProviderSpec(
+                        provider="subprocess",
+                        command=["python", "-m", "nemo_agents_plugin.tasks.optimize_skills"],
+                    ),
+                    config=spec.model_dump(mode="json"),
+                ),
+            ],
+        )
 
     def run(self, config: dict) -> dict:
         from nemo_agents_plugin.improvement import preflight

--- a/plugins/nemo-agents/src/nemo_agents_plugin/service.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/service.py
@@ -37,8 +37,10 @@ class AgentsService(NemoService):
             deployments,
             gateway,
         )
+        from nemo_agents_plugin.jobs.analyze_batch import AnalyzeBatchJob
         from nemo_agents_plugin.jobs.evaluate_agent import EvaluateAgentJob
         from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteJob
+        from nemo_agents_plugin.jobs.optimize_agent import OptimizeAgentJob
         from nemo_agents_plugin.jobs.optimize_skills import OptimizeSkillsJob
 
         _prefix = "/v2/workspaces/{workspace}"
@@ -60,6 +62,12 @@ class AgentsService(NemoService):
                 description="Submit and track agent evaluation jobs",
                 prefix=_prefix,
             ),
+            # Distinct service_name per job type so each list endpoint filters
+            # to rows of its own type only.  add_job_routes filters by
+            # source=service_name; if all jobs shared the default service_name
+            # ("nemo-agents-plugin"), listing /jobs/evaluate would pull in rows
+            # from sibling types and 500 on Pydantic validation against the
+            # wrong schema.
             RouterSpec(
                 add_job_routes(EvaluateSuiteJob, service_name="nemo-agents-plugin-evaluate-suite"),
                 tag="Agents",
@@ -70,6 +78,18 @@ class AgentsService(NemoService):
                 add_job_routes(OptimizeSkillsJob, service_name="nemo-agents-plugin-optimize-skills"),
                 tag="Agents",
                 description="Submit and track optimize-skills jobs (skills-improvement loop).",
+                prefix=_prefix,
+            ),
+            RouterSpec(
+                add_job_routes(AnalyzeBatchJob, service_name="nemo-agents-plugin-analyze"),
+                tag="Agents",
+                description="Submit and track analyze jobs (eval-suite batch analysis).",
+                prefix=_prefix,
+            ),
+            RouterSpec(
+                add_job_routes(OptimizeAgentJob, service_name="nemo-agents-plugin-optimize"),
+                tag="Agents",
+                description="Submit and track optimize jobs (prompt tuning, HPO).",
                 prefix=_prefix,
             ),
         ]

--- a/plugins/nemo-agents/src/nemo_agents_plugin/service.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/service.py
@@ -38,6 +38,8 @@ class AgentsService(NemoService):
             gateway,
         )
         from nemo_agents_plugin.jobs.evaluate_agent import EvaluateAgentJob
+        from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteJob
+        from nemo_agents_plugin.jobs.optimize_skills import OptimizeSkillsJob
 
         _prefix = "/v2/workspaces/{workspace}"
         return [
@@ -56,6 +58,18 @@ class AgentsService(NemoService):
                 add_job_routes(EvaluateAgentJob),
                 tag="Agents",
                 description="Submit and track agent evaluation jobs",
+                prefix=_prefix,
+            ),
+            RouterSpec(
+                add_job_routes(EvaluateSuiteJob, service_name="nemo-agents-plugin-evaluate-suite"),
+                tag="Agents",
+                description="Submit and track evaluate-suite jobs (Harbor / NAT eval runner).",
+                prefix=_prefix,
+            ),
+            RouterSpec(
+                add_job_routes(OptimizeSkillsJob, service_name="nemo-agents-plugin-optimize-skills"),
+                tag="Agents",
+                description="Submit and track optimize-skills jobs (skills-improvement loop).",
                 prefix=_prefix,
             ),
         ]

--- a/plugins/nemo-agents/src/nemo_agents_plugin/tasks/analyze/__main__.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/tasks/analyze/__main__.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task entrypoint for ``agents.analyze`` (``python -m nemo_agents_plugin.tasks.analyze``).
+
+See :mod:`nemo_agents_plugin.tasks.evaluate_suite` for the shared pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import sys
+from types import FrameType
+
+from nemo_agents_plugin.jobs.analyze_batch import AnalyzeBatchJob
+from nemo_platform_plugin.tasks.dispatcher import run_task
+from nmp.common.sdk_factory import get_task_sdk
+
+logger = logging.getLogger(__name__)
+
+
+def _shutdown_handler(signum: int, frame: FrameType | None) -> None:
+    logger.warning("Received shutdown signal (%d).  Exiting.", signum)
+    raise SystemExit(128 + signum)
+
+
+def main() -> int:
+    signal.signal(signal.SIGTERM, _shutdown_handler)
+    try:
+        sdk = get_task_sdk("agents")
+    except Exception:
+        logger.exception("Failed to build task SDK for agents")
+        return 2
+    return run_task(AnalyzeBatchJob, sdk=sdk)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/nemo-agents/src/nemo_agents_plugin/tasks/evaluate_suite/__main__.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/tasks/evaluate_suite/__main__.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task entrypoint for ``agents.evaluate-suite`` (``python -m nemo_agents_plugin.tasks.evaluate_suite``).
+
+Mirrors :mod:`nemo_agents_plugin.tasks.evaluate`: delegates to
+:func:`nemo_platform_plugin.tasks.dispatcher.run_task` so step config loading,
+:class:`~nemo_platform_plugin.job_context.JobContext` construction, and
+signature-based DI into :meth:`EvaluateSuiteJob.run` are all handled by the
+framework.
+
+This module is invoked by the platform's host-subprocess executor when a
+caller submits an evaluate-suite job (``POST /apis/agents/.../jobs`` →
+``sdk.jobs.create`` → controller dispatches ``python -m
+nemo_agents_plugin.tasks.evaluate_suite``).
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import sys
+from types import FrameType
+
+from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteJob
+from nemo_platform_plugin.tasks.dispatcher import run_task
+from nmp.common.sdk_factory import get_task_sdk
+
+logger = logging.getLogger(__name__)
+
+
+def _shutdown_handler(signum: int, frame: FrameType | None) -> None:
+    logger.warning("Received shutdown signal (%d).  Exiting.", signum)
+    raise SystemExit(128 + signum)
+
+
+def main() -> int:
+    signal.signal(signal.SIGTERM, _shutdown_handler)
+    try:
+        sdk = get_task_sdk("agents")
+    except Exception:
+        logger.exception("Failed to build task SDK for agents")
+        return 2
+    return run_task(EvaluateSuiteJob, sdk=sdk)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/nemo-agents/src/nemo_agents_plugin/tasks/optimize/__main__.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/tasks/optimize/__main__.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task entrypoint for ``agents.optimize`` (``python -m nemo_agents_plugin.tasks.optimize``).
+
+See :mod:`nemo_agents_plugin.tasks.evaluate` for the shared pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import sys
+from types import FrameType
+
+from nemo_agents_plugin.jobs.optimize_agent import OptimizeAgentJob
+from nemo_platform_plugin.tasks.dispatcher import run_task
+from nmp.common.sdk_factory import get_task_sdk
+
+logger = logging.getLogger(__name__)
+
+
+def _shutdown_handler(signum: int, frame: FrameType | None) -> None:
+    logger.warning("Received shutdown signal (%d).  Exiting.", signum)
+    raise SystemExit(128 + signum)
+
+
+def main() -> int:
+    signal.signal(signal.SIGTERM, _shutdown_handler)
+    try:
+        sdk = get_task_sdk("agents")
+    except Exception:
+        logger.exception("Failed to build task SDK for agents")
+        return 2
+    return run_task(OptimizeAgentJob, sdk=sdk)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/nemo-agents/src/nemo_agents_plugin/tasks/optimize_skills/__main__.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/tasks/optimize_skills/__main__.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task entrypoint for ``agents.optimize-skills`` (``python -m nemo_agents_plugin.tasks.optimize_skills``).
+
+See :mod:`nemo_agents_plugin.tasks.evaluate_suite` for the shared pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import sys
+from types import FrameType
+
+from nemo_agents_plugin.jobs.optimize_skills import OptimizeSkillsJob
+from nemo_platform_plugin.tasks.dispatcher import run_task
+from nmp.common.sdk_factory import get_task_sdk
+
+logger = logging.getLogger(__name__)
+
+
+def _shutdown_handler(signum: int, frame: FrameType | None) -> None:
+    logger.warning("Received shutdown signal (%d).  Exiting.", signum)
+    raise SystemExit(128 + signum)
+
+
+def main() -> int:
+    signal.signal(signal.SIGTERM, _shutdown_handler)
+    try:
+        sdk = get_task_sdk("agents")
+    except Exception:
+        logger.exception("Failed to build task SDK for agents")
+        return 2
+    return run_task(OptimizeSkillsJob, sdk=sdk)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/nemo-agents/tests/unit/test_improvement_jobs.py
+++ b/plugins/nemo-agents/tests/unit/test_improvement_jobs.py
@@ -5,6 +5,11 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
+import pytest
+from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
+
 
 def test_jobs_discovered_via_entry_points() -> None:
     from nemo_platform_plugin.discovery import discover_jobs
@@ -54,3 +59,134 @@ def test_optimize_skills_config_validation() -> None:
     assert cfg.iterations == 3
     assert cfg.repeats == 1
     assert cfg.open_pr is False
+
+
+# ---------------------------------------------------------------------------
+# compile() — platform-job dispatch shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_suite_compile_produces_single_subprocess_step() -> None:
+    from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteConfig, EvaluateSuiteJob
+    from nmp.common.jobs.constants import (
+        DEFAULT_JOB_STORAGE_PATH,
+        PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+    )
+
+    spec = EvaluateSuiteConfig(evals="/abs/evals", agent="/abs/agent", output="/abs/out")
+    platform_spec = await EvaluateSuiteJob.compile(
+        workspace="default",
+        spec=spec,
+        entity_client=MagicMock(),
+        job_name=None,
+        async_sdk=MagicMock(),
+    )
+    steps = list(platform_spec["steps"])
+    assert len(steps) == 1
+    step = steps[0]
+    assert step["name"] == "evaluate-suite"
+    assert step["executor"]["provider"] == "subprocess"
+    assert step["executor"]["command"] == ["python", "-m", "nemo_agents_plugin.tasks.evaluate_suite"]
+    assert step["config"]["evals"] == "/abs/evals"
+    assert step["config"]["agent"] == "/abs/agent"
+
+    env = {e["name"]: e.get("value") for e in step["environment"]}
+    assert env[PERSISTENT_JOB_STORAGE_PATH_ENVVAR] == DEFAULT_JOB_STORAGE_PATH
+
+
+@pytest.mark.asyncio
+async def test_evaluate_suite_compile_url_workspace_overrides_spec_workspace() -> None:
+    from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteConfig, EvaluateSuiteJob
+
+    spec = EvaluateSuiteConfig(evals="/abs/evals", agent="/abs/agent")
+    platform_spec = await EvaluateSuiteJob.compile(
+        workspace="staging",
+        spec=spec,
+        entity_client=MagicMock(),
+        job_name=None,
+        async_sdk=MagicMock(),
+    )
+    config = next(iter(platform_spec["steps"]))["config"]
+    assert config["workspace"] == "staging"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_suite_compile_rejects_relative_paths() -> None:
+    from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteConfig, EvaluateSuiteJob
+
+    spec = EvaluateSuiteConfig(evals="./my-evals", agent="/abs/agent")
+    with pytest.raises(PlatformJobCompilationError, match="'evals' must be an absolute path"):
+        await EvaluateSuiteJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_optimize_skills_compile_produces_single_subprocess_step() -> None:
+    from nemo_agents_plugin.jobs.optimize_skills import OptimizeSkillsConfig, OptimizeSkillsJob
+    from nmp.common.jobs.constants import (
+        DEFAULT_JOB_STORAGE_PATH,
+        PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+    )
+
+    spec = OptimizeSkillsConfig(evals="/abs/evals", agent="/abs/agent")
+    platform_spec = await OptimizeSkillsJob.compile(
+        workspace="default",
+        spec=spec,
+        entity_client=MagicMock(),
+        job_name=None,
+        async_sdk=MagicMock(),
+    )
+    steps = list(platform_spec["steps"])
+    assert len(steps) == 1
+    step = steps[0]
+    assert step["name"] == "optimize-skills"
+    executor = step["executor"]
+    assert executor.get("provider") == "subprocess"
+    assert executor.get("command") == ["python", "-m", "nemo_agents_plugin.tasks.optimize_skills"]
+
+    env = {e["name"]: e for e in step["environment"]}
+    assert env[PERSISTENT_JOB_STORAGE_PATH_ENVVAR]["value"] == DEFAULT_JOB_STORAGE_PATH
+    # When ``anthropic_api_key_secret`` is unset, no ANTHROPIC_API_KEY env is declared.
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+@pytest.mark.asyncio
+async def test_optimize_skills_compile_injects_anthropic_secret_when_set() -> None:
+    from nemo_agents_plugin.jobs.optimize_skills import OptimizeSkillsConfig, OptimizeSkillsJob
+
+    spec = OptimizeSkillsConfig(
+        evals="/abs/evals",
+        agent="/abs/agent",
+        anthropic_api_key_secret="anthropic-api-key",
+    )
+    platform_spec = await OptimizeSkillsJob.compile(
+        workspace="default",
+        spec=spec,
+        entity_client=MagicMock(),
+        job_name=None,
+        async_sdk=MagicMock(),
+    )
+    step = next(iter(platform_spec["steps"]))
+    env = {e["name"]: e for e in step["environment"]}
+    assert env["ANTHROPIC_API_KEY"]["from_secret"]["name"] == "anthropic-api-key"
+
+
+@pytest.mark.asyncio
+async def test_optimize_skills_compile_rejects_relative_paths() -> None:
+    from nemo_agents_plugin.jobs.optimize_skills import OptimizeSkillsConfig, OptimizeSkillsJob
+
+    spec = OptimizeSkillsConfig(evals="/abs/evals", agent="./my-agent")
+    with pytest.raises(PlatformJobCompilationError, match="'agent' must be an absolute path"):
+        await OptimizeSkillsJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )

--- a/plugins/nemo-agents/tests/unit/test_improvement_jobs.py
+++ b/plugins/nemo-agents/tests/unit/test_improvement_jobs.py
@@ -242,3 +242,92 @@ async def test_optimize_skills_compile_rejects_relative_paths() -> None:
             job_name=None,
             async_sdk=MagicMock(),
         )
+
+
+# ---------------------------------------------------------------------------
+# AnalyzeBatchJob + OptimizeAgentJob — newly added compile() paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_analyze_compile_produces_single_subprocess_step() -> None:
+    from nemo_agents_plugin.jobs.analyze_batch import AnalyzeBatchConfig, AnalyzeBatchJob
+
+    spec = AnalyzeBatchConfig(batch="/abs/batch", mechanical_only=True)
+    platform_spec = await AnalyzeBatchJob.compile(
+        workspace="default",
+        spec=spec,
+        entity_client=MagicMock(),
+        job_name=None,
+        async_sdk=MagicMock(),
+    )
+    step = next(iter(platform_spec["steps"]))
+    assert step["name"] == "analyze"
+    executor = step["executor"]
+    assert executor.get("provider") == "subprocess"
+    assert executor.get("command") == ["python", "-m", "nemo_agents_plugin.tasks.analyze"]
+
+
+@pytest.mark.asyncio
+async def test_analyze_compile_requires_anthropic_secret_unless_mechanical_only() -> None:
+    from nemo_agents_plugin.jobs.analyze_batch import AnalyzeBatchConfig, AnalyzeBatchJob
+
+    spec = AnalyzeBatchConfig(batch="/abs/batch")  # mechanical_only defaults False, secret unset
+    with pytest.raises(PlatformJobCompilationError, match="anthropic_api_key_secret"):
+        await AnalyzeBatchJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_analyze_compile_rejects_relative_batch_path() -> None:
+    from nemo_agents_plugin.jobs.analyze_batch import AnalyzeBatchConfig, AnalyzeBatchJob
+
+    spec = AnalyzeBatchConfig(batch="./my-batch", mechanical_only=True)
+    with pytest.raises(PlatformJobCompilationError, match="'batch' must be an absolute path"):
+        await AnalyzeBatchJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_optimize_agent_compile_produces_single_subprocess_step() -> None:
+    from nemo_agents_plugin.jobs.optimize_agent import OptimizeAgentJob, OptimizeAgentSpec
+
+    spec = OptimizeAgentSpec(agent=None, optimize_config="/abs/optimize.yml")
+    platform_spec = await OptimizeAgentJob.compile(
+        workspace="staging",
+        spec=spec,
+        entity_client=MagicMock(),
+        job_name=None,
+        async_sdk=MagicMock(),
+    )
+    step = next(iter(platform_spec["steps"]))
+    assert step["name"] == "optimize-agent"
+    executor = step["executor"]
+    assert executor.get("provider") == "subprocess"
+    assert executor.get("command") == ["python", "-m", "nemo_agents_plugin.tasks.optimize"]
+    assert step["config"]["workspace"] == "staging"
+
+
+@pytest.mark.asyncio
+async def test_optimize_agent_compile_rejects_relative_optimize_config() -> None:
+    from nemo_agents_plugin.jobs.optimize_agent import OptimizeAgentJob, OptimizeAgentSpec
+
+    spec = OptimizeAgentSpec(agent=None, optimize_config="./relative.yml")
+    with pytest.raises(PlatformJobCompilationError, match="'optimize_config' must be an absolute path"):
+        await OptimizeAgentJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )

--- a/plugins/nemo-agents/tests/unit/test_improvement_jobs.py
+++ b/plugins/nemo-agents/tests/unit/test_improvement_jobs.py
@@ -244,6 +244,21 @@ async def test_optimize_skills_compile_rejects_relative_paths() -> None:
         )
 
 
+@pytest.mark.asyncio
+async def test_optimize_skills_compile_rejects_analyze_only_without_initial_batch() -> None:
+    from nemo_agents_plugin.jobs.optimize_skills import OptimizeSkillsConfig, OptimizeSkillsJob
+
+    spec = OptimizeSkillsConfig(evals="/abs/evals", agent="/abs/agent", analyze_only=True)
+    with pytest.raises(PlatformJobCompilationError, match="'analyze_only' requires 'initial_batch'"):
+        await OptimizeSkillsJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )
+
+
 # ---------------------------------------------------------------------------
 # AnalyzeBatchJob + OptimizeAgentJob — newly added compile() paths
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-agents/tests/unit/test_improvement_jobs.py
+++ b/plugins/nemo-agents/tests/unit/test_improvement_jobs.py
@@ -99,7 +99,7 @@ async def test_evaluate_suite_compile_produces_single_subprocess_step() -> None:
 async def test_evaluate_suite_compile_url_workspace_overrides_spec_workspace() -> None:
     from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteConfig, EvaluateSuiteJob
 
-    spec = EvaluateSuiteConfig(evals="/abs/evals", agent="/abs/agent")
+    spec = EvaluateSuiteConfig(evals="/abs/evals", agent="/abs/agent", output="/abs/out")
     platform_spec = await EvaluateSuiteJob.compile(
         workspace="staging",
         spec=spec,
@@ -115,7 +115,7 @@ async def test_evaluate_suite_compile_url_workspace_overrides_spec_workspace() -
 async def test_evaluate_suite_compile_rejects_relative_paths() -> None:
     from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteConfig, EvaluateSuiteJob
 
-    spec = EvaluateSuiteConfig(evals="./my-evals", agent="/abs/agent")
+    spec = EvaluateSuiteConfig(evals="./my-evals", agent="/abs/agent", output="/abs/out")
     with pytest.raises(PlatformJobCompilationError, match="'evals' must be an absolute path"):
         await EvaluateSuiteJob.compile(
             workspace="default",
@@ -124,6 +124,58 @@ async def test_evaluate_suite_compile_rejects_relative_paths() -> None:
             job_name=None,
             async_sdk=MagicMock(),
         )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_suite_compile_rejects_none_agent() -> None:
+    from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteConfig, EvaluateSuiteJob
+
+    spec = EvaluateSuiteConfig(evals="/abs/evals", output="/abs/out")  # agent defaults to None
+    with pytest.raises(PlatformJobCompilationError, match="'agent' is required"):
+        await EvaluateSuiteJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_suite_compile_rejects_none_output() -> None:
+    from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteConfig, EvaluateSuiteJob
+
+    spec = EvaluateSuiteConfig(evals="/abs/evals", agent="/abs/agent")  # output defaults to None
+    with pytest.raises(PlatformJobCompilationError, match="'output' is required"):
+        await EvaluateSuiteJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_suite_compile_injects_anthropic_secret_when_set() -> None:
+    from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteConfig, EvaluateSuiteJob
+
+    spec = EvaluateSuiteConfig(
+        evals="/abs/evals",
+        agent="/abs/agent",
+        output="/abs/out",
+        anthropic_api_key_secret="anthropic-api-key",
+    )
+    platform_spec = await EvaluateSuiteJob.compile(
+        workspace="default",
+        spec=spec,
+        entity_client=MagicMock(),
+        job_name=None,
+        async_sdk=MagicMock(),
+    )
+    step = next(iter(platform_spec["steps"]))
+    env = {e["name"]: e for e in step["environment"]}
+    assert env["ANTHROPIC_API_KEY"]["from_secret"]["name"] == "anthropic-api-key"
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-agents/tests/unit/test_optimize_skills_analyze_only.py
+++ b/plugins/nemo-agents/tests/unit/test_optimize_skills_analyze_only.py
@@ -15,7 +15,7 @@ import asyncio
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -225,4 +225,38 @@ def test_optimize_skills_job_analyze_only_requires_initial_batch() -> None:
         "initial_batch": None,
     }
     with pytest.raises(ValueError, match="initial_batch"):
-        OptimizeSkillsJob().run(cfg)
+        OptimizeSkillsJob().run(cfg, ctx=MagicMock())
+
+
+def test_cli_analyze_only_requires_initial_batch_flag() -> None:
+    """The CLI handler rejects --analyze-only without --initial-batch."""
+    from nemo_agents_plugin.cli import AgentsCLI
+    from typer.testing import CliRunner
+
+    app = AgentsCLI().get_cli()
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "optimize-skills",
+            "--evals",
+            "/tmp/x",
+            "--analyze-only",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "initial-batch" in result.output or "initial_batch" in result.output
+
+
+def test_cli_analyze_only_from_config_file_requires_initial_batch(tmp_path: Path) -> None:
+    """analyze_only=true in a --config YAML must also be guarded (not just the CLI flag)."""
+    from nemo_agents_plugin.cli import AgentsCLI
+    from typer.testing import CliRunner
+
+    config = tmp_path / "config.yml"
+    config.write_text("analyze_only: true\nevals: /tmp/x\n")
+
+    app = AgentsCLI().get_cli()
+    result = CliRunner().invoke(app, ["optimize-skills", "--config", str(config)])
+    assert result.exit_code == 1
+    assert "initial-batch" in result.output or "initial_batch" in result.output

--- a/plugins/nemo-agents/tests/unit/test_optimize_skills_analyze_only.py
+++ b/plugins/nemo-agents/tests/unit/test_optimize_skills_analyze_only.py
@@ -225,7 +225,7 @@ def test_optimize_skills_job_analyze_only_requires_initial_batch() -> None:
         "initial_batch": None,
     }
     with pytest.raises(ValueError, match="initial_batch"):
-        OptimizeSkillsJob().run(cfg, ctx=MagicMock())
+        OptimizeSkillsJob().run(cfg, _ctx=MagicMock())
 
 
 def test_cli_analyze_only_requires_initial_batch_flag() -> None:

--- a/plugins/nemo-agents/tests/unit/test_optimize_skills_analyze_only.py
+++ b/plugins/nemo-agents/tests/unit/test_optimize_skills_analyze_only.py
@@ -225,7 +225,7 @@ def test_optimize_skills_job_analyze_only_requires_initial_batch() -> None:
         "initial_batch": None,
     }
     with pytest.raises(ValueError, match="initial_batch"):
-        OptimizeSkillsJob().run(cfg, _ctx=MagicMock())
+        OptimizeSkillsJob().run(cfg, ctx=MagicMock())
 
 
 def test_cli_analyze_only_requires_initial_batch_flag() -> None:

--- a/plugins/nemo-agents/tests/unit/test_service.py
+++ b/plugins/nemo-agents/tests/unit/test_service.py
@@ -7,20 +7,32 @@ from __future__ import annotations
 
 from fastapi.routing import APIRoute
 from nemo_agents_plugin.jobs.evaluate_agent import EvaluateAgentJob
+from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteJob
+from nemo_agents_plugin.jobs.optimize_skills import OptimizeSkillsJob
 from nemo_agents_plugin.service import AgentsService
 from nemo_platform_plugin.scheduler import submit_path_for
 
 
-def test_evaluate_job_route_matches_generated_submit_path() -> None:
+def _mounted_post_paths_for(description: str) -> set[str]:
     service = AgentsService()
-    evaluate_router_spec = next(
-        spec for spec in service.get_routers() if spec.description == "Submit and track agent evaluation jobs"
-    )
-
-    mounted_paths = {
-        f"/apis/agents{evaluate_router_spec.prefix}{route.path}"
-        for route in evaluate_router_spec.router.routes
+    router_spec = next(spec for spec in service.get_routers() if spec.description == description)
+    return {
+        f"/apis/agents{router_spec.prefix}{route.path}"
+        for route in router_spec.router.routes
         if isinstance(route, APIRoute) and "POST" in route.methods
     }
 
-    assert submit_path_for(EvaluateAgentJob, workspace="{workspace}") in mounted_paths
+
+def test_evaluate_job_route_matches_generated_submit_path() -> None:
+    mounted = _mounted_post_paths_for("Submit and track agent evaluation jobs")
+    assert submit_path_for(EvaluateAgentJob, workspace="{workspace}") in mounted
+
+
+def test_evaluate_suite_job_route_matches_generated_submit_path() -> None:
+    mounted = _mounted_post_paths_for("Submit and track evaluate-suite jobs (Harbor / NAT eval runner).")
+    assert submit_path_for(EvaluateSuiteJob, workspace="{workspace}") in mounted
+
+
+def test_optimize_skills_job_route_matches_generated_submit_path() -> None:
+    mounted = _mounted_post_paths_for("Submit and track optimize-skills jobs (skills-improvement loop).")
+    assert submit_path_for(OptimizeSkillsJob, workspace="{workspace}") in mounted

--- a/plugins/nemo-agents/tests/unit/test_service.py
+++ b/plugins/nemo-agents/tests/unit/test_service.py
@@ -6,8 +6,10 @@
 from __future__ import annotations
 
 from fastapi.routing import APIRoute
+from nemo_agents_plugin.jobs.analyze_batch import AnalyzeBatchJob
 from nemo_agents_plugin.jobs.evaluate_agent import EvaluateAgentJob
 from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteJob
+from nemo_agents_plugin.jobs.optimize_agent import OptimizeAgentJob
 from nemo_agents_plugin.jobs.optimize_skills import OptimizeSkillsJob
 from nemo_agents_plugin.service import AgentsService
 from nemo_platform_plugin.scheduler import submit_path_for
@@ -36,3 +38,13 @@ def test_evaluate_suite_job_route_matches_generated_submit_path() -> None:
 def test_optimize_skills_job_route_matches_generated_submit_path() -> None:
     mounted = _mounted_post_paths_for("Submit and track optimize-skills jobs (skills-improvement loop).")
     assert submit_path_for(OptimizeSkillsJob, workspace="{workspace}") in mounted
+
+
+def test_analyze_job_route_matches_generated_submit_path() -> None:
+    mounted = _mounted_post_paths_for("Submit and track analyze jobs (eval-suite batch analysis).")
+    assert submit_path_for(AnalyzeBatchJob, workspace="{workspace}") in mounted
+
+
+def test_optimize_job_route_matches_generated_submit_path() -> None:
+    mounted = _mounted_post_paths_for("Submit and track optimize jobs (prompt tuning, HPO).")
+    assert submit_path_for(OptimizeAgentJob, workspace="{workspace}") in mounted

--- a/plugins/nemo-agents/tests/unit/test_service.py
+++ b/plugins/nemo-agents/tests/unit/test_service.py
@@ -15,36 +15,36 @@ from nemo_agents_plugin.service import AgentsService
 from nemo_platform_plugin.scheduler import submit_path_for
 
 
-def _mounted_post_paths_for(description: str) -> set[str]:
+def _mounted_post_paths() -> set[str]:
+    """All POST paths mounted by AgentsService, regardless of which router owns them.
+
+    Avoids the description-string filter that earlier revisions used — copy-only
+    docstring edits in service.py should not break route-shape tests.
+    """
     service = AgentsService()
-    router_spec = next(spec for spec in service.get_routers() if spec.description == description)
     return {
-        f"/apis/agents{router_spec.prefix}{route.path}"
-        for route in router_spec.router.routes
+        f"/apis/agents{spec.prefix}{route.path}"
+        for spec in service.get_routers()
+        for route in spec.router.routes
         if isinstance(route, APIRoute) and "POST" in route.methods
     }
 
 
 def test_evaluate_job_route_matches_generated_submit_path() -> None:
-    mounted = _mounted_post_paths_for("Submit and track agent evaluation jobs")
-    assert submit_path_for(EvaluateAgentJob, workspace="{workspace}") in mounted
+    assert submit_path_for(EvaluateAgentJob, workspace="{workspace}") in _mounted_post_paths()
 
 
 def test_evaluate_suite_job_route_matches_generated_submit_path() -> None:
-    mounted = _mounted_post_paths_for("Submit and track evaluate-suite jobs (Harbor / NAT eval runner).")
-    assert submit_path_for(EvaluateSuiteJob, workspace="{workspace}") in mounted
+    assert submit_path_for(EvaluateSuiteJob, workspace="{workspace}") in _mounted_post_paths()
 
 
 def test_optimize_skills_job_route_matches_generated_submit_path() -> None:
-    mounted = _mounted_post_paths_for("Submit and track optimize-skills jobs (skills-improvement loop).")
-    assert submit_path_for(OptimizeSkillsJob, workspace="{workspace}") in mounted
+    assert submit_path_for(OptimizeSkillsJob, workspace="{workspace}") in _mounted_post_paths()
 
 
 def test_analyze_job_route_matches_generated_submit_path() -> None:
-    mounted = _mounted_post_paths_for("Submit and track analyze jobs (eval-suite batch analysis).")
-    assert submit_path_for(AnalyzeBatchJob, workspace="{workspace}") in mounted
+    assert submit_path_for(AnalyzeBatchJob, workspace="{workspace}") in _mounted_post_paths()
 
 
 def test_optimize_job_route_matches_generated_submit_path() -> None:
-    mounted = _mounted_post_paths_for("Submit and track optimize jobs (prompt tuning, HPO).")
-    assert submit_path_for(OptimizeAgentJob, workspace="{workspace}") in mounted
+    assert submit_path_for(OptimizeAgentJob, workspace="{workspace}") in _mounted_post_paths()


### PR DESCRIPTION
Adds submit which adds job entries, run does not by design.

## Summary

Wire `nemo agents evaluate-suite` and `nemo agents optimize-skills` into the platform jobs table so their results stop being invisible to Studio. Per AIRCORE-656.

Before: both verbs ran their `NemoJob` in-process via `_run_with_clean_errors(...).run(spec)`, left artifacts under `runs/batch-<ts>/` plus a fileset, but no row in the jobs table → Studio's `JobsRoute` can't see them.

After: both verbs gain a `submit` path (auto-injected `nemo agents <verb> submit --spec '{...}'`) that POSTs to the platform, which dispatches a subprocess on the host via the existing `SubprocessExecutionProviderSpec`. Row lands in `nemo jobs list` and Studio.

### What changed

- **`EvaluateSuiteJob` / `OptimizeSkillsJob`** — declare `spec_schema` and an async `compile()` returning a `PlatformJobSpec` with one subprocess step.
- **New task entrypoints** — `nemo_agents_plugin.tasks.evaluate_suite` and `.tasks.optimize_skills`, mirroring `.tasks.evaluate`. Install SIGTERM handler, build an `agents` task SDK, delegate to `run_task(JobCls, sdk=sdk)`.
- **`AgentsService.get_routers`** — register `add_job_routes(...)` for both jobs.
- **Per-job `service_name`** — explicit `nemo-agents-plugin-evaluate-suite` and `nemo-agents-plugin-optimize-skills` so `add_job_routes`'s list endpoint filters cleanly by source per job type. Without this, listing `/jobs/evaluate` would pull in suite/skills rows and 500 on Pydantic validation against `EvaluateAgentSpec`.

### Hardening from review (roundtable + Codex)

- `compile()` rejects relative paths, `agent=None`, and `output=None` (`PlatformJobCompilationError` at submit time, not silent failure in the subprocess scratch dir).
- Mirrors `EvaluateAgentJob.compile()`'s `spec_dict["workspace"] = workspace` override (URL workspace is the auth boundary; landmine guard for future workspace-scoped config fields).
- Declares `PERSISTENT_JOB_STORAGE_PATH_ENVVAR` on each compiled step so the K8s backend can wire volume mounts when GPU-side execution lands.
- New optional `anthropic_api_key_secret` field on both `EvaluateSuiteConfig` and `OptimizeSkillsConfig`. When set, injects `ANTHROPIC_API_KEY` via `EnvironmentVariableFromSecret` so the subprocess can reach the LLM judge / Claude analyzer (the subprocess backend's sanitized env doesn't inherit `ANTHROPIC_API_KEY` from the platform process).
- Promotes `no-evals-found` to a `RuntimeError` so the platform reports `error` instead of `completed`.
- Adds `*, ctx: JobContext | None = None` to both `run()` signatures so the framework's DI populates storage context on the submit path. Optional so the friendly CLI's direct `JobCls().run(spec)` calls still work.

### Out of scope (deferred)

- **`LocalOnlyJob` mixin / canonical `source_name` on `NemoJob` base** — Devon's 12-month reflection point. Touches platform package; own PR.
- **Studio source-enum entries** — `JOB_SOURCE` / `SOURCE_DISPLAY` in `web/packages/studio/src/components/dataViews/JobsDataView/constants.ts` don't yet enumerate `nemo-agents-plugin-evaluate-suite` or `-optimize-skills`. Job rows render unlabeled in the UI until that lands. Per AIRCORE-656 step 3.
- **SIGINT handler in task entrypoints** — sibling `tasks/evaluate/__main__.py` has the same gap.

## Test plan

- [x] `pytest plugins/nemo-agents/tests/unit/test_improvement_jobs.py plugins/nemo-agents/tests/unit/test_service.py plugins/nemo-agents/tests/unit/test_optimize_skills_analyze_only.py` — 24/24 passing
- [x] `ruff check` + `ty check` — clean on touched files
- [x] Manual end-to-end against local platform:
  - `nemo agents evaluate-suite submit --evals /abs/dir --spec '{"runner":"nat"}'` → job row created, status transitions `created → active → error` (fake dir, expected)
  - `nemo agents evaluate submit --agent react-agent --eval-config /abs/.../react-eval.yml` → status `completed`, accuracy 0.73, artifacts at `/tmp/nmp-subprocess-jobs/.../job-storage/results/eval/react-agent/`
- [x] OpenAPI spec regenerated (`make refresh-openapi`); Studio TS SDK will see the new endpoints + `anthropic_api_key_secret` field once `pnpm gen` runs.
- [ ] Verify Studio's Jobs page renders the new source label after the parallel Studio PR adds `JOB_SOURCE` entries.

## Related

- AIRCORE-591 (evaluate-suite → evaluation rename) — follow-up will need to migrate the `service_name` strings here.
- AIRCORE-594 (folder-based eval suite under unified verb) — forward-looking redesign on top of this work.
- AIRCORE-400 (local-jobs typed-client DI for evaluator) — adjacent infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added evaluate-suite and optimize-skills job APIs (create/list/get/cancel/delete/logs/results/download/status) and CLI entrypoints for evaluate-suite, optimize-skills, analyze, and optimize.

* **Enhancements**
  * Jobs can be submitted as platform subprocesses so results appear in job listings/Studio.
  * Optional Anthropic API key secret injection for submitted runs; stricter absolute-path and required-field validation; workspace and persistent job storage enforced.
  
* **Tests**
  * Expanded unit tests for compilation, submission, validation, secret handling, and route registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->