### PR TITLE
fix: register model providers with leading digits

### DIFF
--- a/services/core/models/src/nmp/core/models/app/utils.py
+++ b/services/core/models/src/nmp/core/models/app/utils.py
@@ -183,8 +183,10 @@ def normalize_model_entity_name(model_name: str) -> str:
 
     Entity store requires: start with [a-z], length 2-63, only [a-z0-9-] (and
     temporarily @ . + _), no consecutive hyphens, no trailing hyphen. This function
-    normalizes when possible; if the result would not match, it raises ValueError
-    so callers can skip or fail explicitly.
+    normalizes when possible; digit-leading names are prefixed with ``md-`` so
+    provider model IDs like ``01-ai/yi-large`` can still be registered without
+    dropping meaningful leading digits. If the result would not match, it raises
+    ValueError so callers can skip or fail explicitly.
 
     Args:
         model_name: The original model name (e.g., "meta/llama-3.2-1b-instruct")
@@ -194,13 +196,15 @@ def normalize_model_entity_name(model_name: str) -> str:
 
     Raises:
         ValueError: If the name cannot be normalized to a valid entity name (e.g. empty,
-            only invalid characters, starts with digit with no letter, or single character).
+            only invalid characters, or single character).
 
     Examples:
         >>> normalize_model_entity_name("meta/llama-3.2-1b-instruct")
         "meta-llama-3-2-1b-instruct"
         >>> normalize_model_entity_name("model:v1.0")
         "model-v1-0"
+        >>> normalize_model_entity_name("01-ai/yi-large")
+        "md-01-ai-yi-large"
         >>> normalize_model_entity_name("")
         ValueError: ... cannot be normalized to a valid entity name
     """
@@ -216,6 +220,8 @@ def normalize_model_entity_name(model_name: str) -> str:
             f"Model name {model_name!r} cannot be normalized to a valid entity name: "
             "result is empty (use at least one letter or digit)."
         )
+    if normalized[0].isdigit():
+        normalized = f"md-{normalized}"
     # If over 63 chars, truncate with deterministic hash suffix to avoid collisions (before validating)
     if len(normalized) > 63:
         hash_suffix = hashlib.sha256(model_name.encode()).hexdigest()[:8]

--- a/services/core/models/tests/unit/common/test_utils.py
+++ b/services/core/models/tests/unit/common/test_utils.py
@@ -795,6 +795,9 @@ def test_is_multi_llm_image_random_image_returns_false():
         pytest.param("model(version)", "model-version", id="parentheses"),
         pytest.param("already-valid-model-name", "already-valid-model-name", id="already_valid"),
         pytest.param("model123-v4.5.6", "model123-v4-5-6", id="numbers"),
+        pytest.param("01-ai/yi-large", "md-01-ai-yi-large", id="digit_leading_org"),
+        pytest.param("9model", "md-9model", id="digit_leading_model"),
+        pytest.param("123", "md-123", id="digits_only"),
         pytest.param(
             "org/model:v1.0@main with spaces",
             "org-model-v1-0-main-with-spaces",
@@ -812,8 +815,6 @@ def test_normalize_model_entity_name_output(input_name, expected):
     [
         pytest.param("", "cannot be normalized to a valid entity name", id="empty_string"),
         pytest.param("///:::", "cannot be normalized to a valid entity name", id="only_invalid_chars"),
-        pytest.param("123", "not valid", id="starts_with_digit_only"),
-        pytest.param("9model", "not valid", id="starts_with_digit_then_letters"),
         pytest.param("a", "not valid", id="single_char"),
     ],
 )

--- a/services/core/models/tests/unit/controllers/test_provider_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_provider_reconciler.py
@@ -323,6 +323,7 @@ def test_entity_name_from_discovered_model_no_prefix_normalizes_whole_id():
     """When model_id has no provider-workspace prefix, normalize the whole id (existing behavior)."""
     assert _entity_name_from_discovered_model("meta/llama-3.2-1b-instruct", "other-ns") == "meta-llama-3-2-1b-instruct"
     assert _entity_name_from_discovered_model("model:with:colons", "test-ns") == "model-with-colons"
+    assert _entity_name_from_discovered_model("01-ai/yi-large", "system") == "md-01-ai-yi-large"
 
 
 def test_entity_name_from_discovered_model_different_workspace_prefix_normalizes_whole():
@@ -332,8 +333,6 @@ def test_entity_name_from_discovered_model_different_workspace_prefix_normalizes
 
 def test_entity_name_from_discovered_model_invalid_raises():
     """When model_id normalizes to an invalid entity name, ValueError is raised."""
-    with pytest.raises(ValueError, match="not valid"):
-        _entity_name_from_discovered_model("123", "test-ns")
     with pytest.raises(ValueError, match="not valid"):
         _entity_name_from_discovered_model("a", "test-ns")
 
@@ -1083,6 +1082,49 @@ async def test_update_model_providers_normalizes_model_names(reconciler):
     assert len(served_models) == 1
     assert served_models[0].served_model_name == "model:with:colons"  # Original
     assert "model-with-colons" in served_models[0].model_entity_id  # Normalized
+
+
+@pytest.mark.asyncio
+async def test_update_model_providers_prefixes_digit_leading_external_model_id(reconciler, caplog):
+    """Digit-leading external model ids are prefixed so entity-store validation accepts them."""
+    provider = MagicMock()
+    provider.workspace = "system"
+    provider.name = "nvidia-build"
+    provider.model_deployment_id = None
+    provider.enabled_models = None
+    provider.served_models = []
+
+    ctx = ModelContext(
+        model_provider=provider,
+        model_deployment=None,
+        model_deployment_config=None,
+        model_entity=None,
+    )
+
+    reconciler._models_sdk.inference.providers.update_status = AsyncMock()
+
+    with (
+        patch.object(
+            reconciler,
+            "_discover_models",
+            return_value=DiscoverySuccess(_discovery_models_from_ids(["01-ai/yi-large"])),
+        ),
+        patch.object(reconciler, "_ensure_model_entity_for_provider") as mock_ensure,
+        caplog.at_level("INFO"),
+    ):
+        await reconciler.reconcile_model_providers([ctx])
+
+    mock_ensure.assert_called_once()
+    assert mock_ensure.call_args.kwargs["model_name"] == "md-01-ai-yi-large"
+
+    call_kwargs = reconciler._models_sdk.inference.providers.update_status.call_args.kwargs
+    served_models = call_kwargs["served_models"]
+    assert len(served_models) == 1
+    assert served_models[0].model_entity_id == "system/md-01-ai-yi-large"
+    assert served_models[0].served_model_name == "01-ai/yi-large"
+    assert not any(
+        "Skipped" in record.message and "01-ai/yi-large" in record.message for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model identifiers beginning with digits (e.g., "01-ai/yi-large") are now normalized and accepted for registration.

* **Documentation**
  * Clarified normalization behavior with improved examples and validation details.

* **Tests**
  * Unit tests updated to cover digit-leading and digit-only identifier normalization and related reconciliation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->