### PR TITLE
feat(evaluator): add metric type name alias

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/__init__.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/__init__.py
@@ -19,6 +19,7 @@ from nemo_evaluator_sdk.metrics.llm_judge import LLMJudgeMetric
 from nemo_evaluator_sdk.metrics.number_check import NumberCheckMetric
 from nemo_evaluator_sdk.metrics.protocol import (
     Metric,
+    MetricTypeName,
     validate_metric_result,
 )
 from nemo_evaluator_sdk.metrics.remote import NemoAgentToolkitRemoteMetric, RemoteMetric
@@ -85,6 +86,7 @@ __all__ = [
     "InferenceStructuredOutput",
     "JSONScoreParser",
     "Metric",
+    "MetricTypeName",
     "MetricDescriptor",
     "MetricInput",
     "MetricOutput",

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/protocol.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/protocol.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 
 import math
 from collections.abc import Awaitable, Callable
-from typing import Any, Protocol, runtime_checkable
+from typing import Annotated, Any, Protocol, runtime_checkable
 
 from nemo_evaluator_sdk.values.common import SecretRef
-from pydantic import BaseModel, ConfigDict, Field, RootModel, field_serializer, field_validator
+from pydantic import BaseModel, ConfigDict, Field, RootModel, StringConstraints, field_serializer, field_validator
 
 SecretResolver = Callable[[str], Awaitable[str | None]]
+MetricTypeName = Annotated[str, StringConstraints(min_length=1)]
 
 
 class DatasetRow(BaseModel):
@@ -126,15 +127,8 @@ class MetricDescriptor(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    type: str
+    type: MetricTypeName
     outputs: list[MetricOutputSpec] = Field(min_length=1)
-
-    @field_validator("type")
-    @classmethod
-    def _type_must_not_be_empty(cls, value: str) -> str:
-        if not value:
-            raise ValueError("metric type must not be empty")
-        return value
 
     @field_validator("outputs")
     @classmethod
@@ -174,7 +168,7 @@ class Metric(Protocol):
     """Shared row-scoring primitive for SDK runtime metrics."""
 
     @property
-    def type(self) -> str:
+    def type(self) -> MetricTypeName:
         """Return the public metric key/type identifier."""
         ...
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/__init__.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/__init__.py
@@ -15,6 +15,7 @@ from nemo_evaluator_sdk.metrics.protocol import (
     MetricOutput,
     MetricOutputSpec,
     MetricResult,
+    MetricTypeName,
 )
 from nemo_evaluator_sdk.values.agents import Agent
 from nemo_evaluator_sdk.values.common import SecretRef, SupportedJobTypes
@@ -114,6 +115,7 @@ __all__ = [
     "MetricOutput",
     "MetricOutputSpec",
     "MetricResult",
+    "MetricTypeName",
     "MetricScore",
     "Model",
     "DatasetInput",

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/metrics.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/metrics.py
@@ -20,6 +20,7 @@ from nemo_evaluator_sdk.dataset_schemas.common import empty_object_schema
 from nemo_evaluator_sdk.dataset_schemas.compatibility import merge_metric_required_schemas
 from nemo_evaluator_sdk.dataset_schemas.templates import infer_required_schema_from_template
 from nemo_evaluator_sdk.enums import MetricType
+from nemo_evaluator_sdk.metrics.protocol import MetricTypeName
 from nemo_evaluator_sdk.values.common import SecretRef, SupportedJobTypes
 from nemo_evaluator_sdk.values.dataset_schemas import InputSchema
 from nemo_evaluator_sdk.values.models import Model, ReasoningParams
@@ -129,7 +130,7 @@ class MetricBase(BaseModel):
 
     __entity_type__: ClassVar[str] = "metric"
 
-    type: str = Field(description="The type of metric. Used as a discriminator for the metric type.")
+    type: MetricTypeName = Field(description="The type of metric. Used as a discriminator for the metric type.")
     description: str | None = Field(default=None, description="Human-readable description of the metric.")
     labels: dict[str, str] = Field(
         default_factory=dict, description="Labels are key-value pairs that can be used for grouping and filtering."

--- a/packages/nemo_evaluator_sdk/tests/metrics/test_metric_contract.py
+++ b/packages/nemo_evaluator_sdk/tests/metrics/test_metric_contract.py
@@ -85,6 +85,11 @@ def test_metric_descriptor_rejects_duplicate_outputs() -> None:
         )
 
 
+def test_metric_descriptor_rejects_empty_type() -> None:
+    with pytest.raises(ValidationError):
+        MetricDescriptor(type="", outputs=[MetricOutputSpec.continuous_score("reward")])
+
+
 def test_validate_metric_result_accepts_declared_outputs() -> None:
     outputs = [
         MetricOutputSpec.continuous_score("reward"),

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/__init__.py
@@ -19,6 +19,7 @@ from nemo_platform.beta.evaluator.metrics.llm_judge import LLMJudgeMetric
 from nemo_platform.beta.evaluator.metrics.number_check import NumberCheckMetric
 from nemo_platform.beta.evaluator.metrics.protocol import (
     Metric,
+    MetricTypeName,
     validate_metric_result,
 )
 from nemo_platform.beta.evaluator.metrics.remote import NemoAgentToolkitRemoteMetric, RemoteMetric
@@ -85,6 +86,7 @@ __all__ = [
     "InferenceStructuredOutput",
     "JSONScoreParser",
     "Metric",
+    "MetricTypeName",
     "MetricDescriptor",
     "MetricInput",
     "MetricOutput",

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/protocol.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/protocol.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 
 import math
 from collections.abc import Awaitable, Callable
-from typing import Any, Protocol, runtime_checkable
+from typing import Annotated, Any, Protocol, runtime_checkable
 
 from nemo_platform.beta.evaluator.values.common import SecretRef
-from pydantic import BaseModel, ConfigDict, Field, RootModel, field_serializer, field_validator
+from pydantic import BaseModel, ConfigDict, Field, RootModel, StringConstraints, field_serializer, field_validator
 
 SecretResolver = Callable[[str], Awaitable[str | None]]
+MetricTypeName = Annotated[str, StringConstraints(min_length=1)]
 
 
 class DatasetRow(BaseModel):
@@ -126,15 +127,8 @@ class MetricDescriptor(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    type: str
+    type: MetricTypeName
     outputs: list[MetricOutputSpec] = Field(min_length=1)
-
-    @field_validator("type")
-    @classmethod
-    def _type_must_not_be_empty(cls, value: str) -> str:
-        if not value:
-            raise ValueError("metric type must not be empty")
-        return value
 
     @field_validator("outputs")
     @classmethod
@@ -174,7 +168,7 @@ class Metric(Protocol):
     """Shared row-scoring primitive for SDK runtime metrics."""
 
     @property
-    def type(self) -> str:
+    def type(self) -> MetricTypeName:
         """Return the public metric key/type identifier."""
         ...
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/__init__.py
@@ -15,6 +15,7 @@ from nemo_platform.beta.evaluator.metrics.protocol import (
     MetricOutput,
     MetricOutputSpec,
     MetricResult,
+    MetricTypeName,
 )
 from nemo_platform.beta.evaluator.values.agents import Agent
 from nemo_platform.beta.evaluator.values.common import SecretRef, SupportedJobTypes
@@ -114,6 +115,7 @@ __all__ = [
     "MetricOutput",
     "MetricOutputSpec",
     "MetricResult",
+    "MetricTypeName",
     "MetricScore",
     "Model",
     "DatasetInput",

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/metrics.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/metrics.py
@@ -20,6 +20,7 @@ from nemo_platform.beta.evaluator.dataset_schemas.common import empty_object_sch
 from nemo_platform.beta.evaluator.dataset_schemas.compatibility import merge_metric_required_schemas
 from nemo_platform.beta.evaluator.dataset_schemas.templates import infer_required_schema_from_template
 from nemo_platform.beta.evaluator.enums import MetricType
+from nemo_platform.beta.evaluator.metrics.protocol import MetricTypeName
 from nemo_platform.beta.evaluator.values.common import SecretRef, SupportedJobTypes
 from nemo_platform.beta.evaluator.values.dataset_schemas import InputSchema
 from nemo_platform.beta.evaluator.values.models import Model, ReasoningParams
@@ -129,7 +130,7 @@ class MetricBase(BaseModel):
 
     __entity_type__: ClassVar[str] = "metric"
 
-    type: str = Field(description="The type of metric. Used as a discriminator for the metric type.")
+    type: MetricTypeName = Field(description="The type of metric. Used as a discriminator for the metric type.")
     description: str | None = Field(default=None, description="Human-readable description of the metric.")
     labels: dict[str, str] = Field(
         default_factory=dict, description="Labels are key-value pairs that can be used for grouping and filtering."


### PR DESCRIPTION
## Summary
- add a shared non-empty MetricTypeName alias for evaluator SDK metric identifiers
- use it in Metric, MetricDescriptor, and inline metric values
- cover empty descriptor type validation in the metric contract tests

## Testing
- uv run --frozen ruff check packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/protocol.py packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/metrics.py packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/__init__.py packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/__init__.py packages/nemo_evaluator_sdk/tests/metrics/test_metric_contract.py
- uv run --frozen ruff format --check packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/protocol.py packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/metrics.py packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/__init__.py packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/__init__.py packages/nemo_evaluator_sdk/tests/metrics/test_metric_contract.py
- uv run --frozen --extra cpu ty check packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/protocol.py packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/metrics.py packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/__init__.py packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/__init__.py packages/nemo_evaluator_sdk/tests/metrics/test_metric_contract.py
- uv run --frozen pytest packages/nemo_evaluator_sdk/tests/metrics/test_metric_contract.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `MetricTypeName` is now available in the public API, providing a unified type definition for all metric type identifiers.

* **Bug Fixes**
  * Metric descriptors and metrics now consistently validate and enforce non-empty type identifiers across the entire SDK with standardized constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->