### PR TITLE
feat: expose filter by trace_id for spans

### DIFF
--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -6790,9 +6790,9 @@ paths:
         explode: true
         schema:
           $ref: '#/components/schemas/SpanFilter'
-        description: Filter spans by session_id, parent_span_id, project, evaluation
-          context fields, source, kind, status, model, tool_name, provider, agent_id,
-          agent_name, prompt_name, prompt_version, and started_at.
+        description: Filter spans by session_id, trace_id, span_id, parent_span_id,
+          project, evaluation context fields, source, kind, status, model, tool_name,
+          provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27880,6 +27880,14 @@ components:
         session_id:
           description: Filter by span session id.
           title: Session Id
+          type: string
+        trace_id:
+          description: Filter by canonical trace id.
+          title: Trace Id
+          type: string
+        span_id:
+          description: Filter by external span id.
+          title: Span Id
           type: string
         project:
           description: Filter by project name.

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -6790,9 +6790,9 @@ paths:
         explode: true
         schema:
           $ref: '#/components/schemas/SpanFilter'
-        description: Filter spans by session_id, trace_id, span_id, parent_span_id,
-          project, evaluation context fields, source, kind, status, model, tool_name,
-          provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.
+        description: Filter spans by session_id, trace_id, parent_span_id, project,
+          evaluation context fields, source, kind, status, model, tool_name, provider,
+          agent_id, agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27884,10 +27884,6 @@ components:
         trace_id:
           description: Filter by canonical trace id.
           title: Trace Id
-          type: string
-        span_id:
-          description: Filter by external span id.
-          title: Span Id
           type: string
         project:
           description: Filter by project name.

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -6790,9 +6790,9 @@ paths:
         explode: true
         schema:
           $ref: '#/components/schemas/SpanFilter'
-        description: Filter spans by session_id, parent_span_id, project, evaluation
-          context fields, source, kind, status, model, tool_name, provider, agent_id,
-          agent_name, prompt_name, prompt_version, and started_at.
+        description: Filter spans by session_id, trace_id, span_id, parent_span_id,
+          project, evaluation context fields, source, kind, status, model, tool_name,
+          provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27880,6 +27880,14 @@ components:
         session_id:
           description: Filter by span session id.
           title: Session Id
+          type: string
+        trace_id:
+          description: Filter by canonical trace id.
+          title: Trace Id
+          type: string
+        span_id:
+          description: Filter by external span id.
+          title: Span Id
           type: string
         project:
           description: Filter by project name.

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -6790,9 +6790,9 @@ paths:
         explode: true
         schema:
           $ref: '#/components/schemas/SpanFilter'
-        description: Filter spans by session_id, trace_id, span_id, parent_span_id,
-          project, evaluation context fields, source, kind, status, model, tool_name,
-          provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.
+        description: Filter spans by session_id, trace_id, parent_span_id, project,
+          evaluation context fields, source, kind, status, model, tool_name, provider,
+          agent_id, agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27884,10 +27884,6 @@ components:
         trace_id:
           description: Filter by canonical trace id.
           title: Trace Id
-          type: string
-        span_id:
-          description: Filter by external span id.
-          title: Span Id
           type: string
         project:
           description: Filter by project name.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -6790,9 +6790,9 @@ paths:
         explode: true
         schema:
           $ref: '#/components/schemas/SpanFilter'
-        description: Filter spans by session_id, parent_span_id, project, evaluation
-          context fields, source, kind, status, model, tool_name, provider, agent_id,
-          agent_name, prompt_name, prompt_version, and started_at.
+        description: Filter spans by session_id, trace_id, span_id, parent_span_id,
+          project, evaluation context fields, source, kind, status, model, tool_name,
+          provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27880,6 +27880,14 @@ components:
         session_id:
           description: Filter by span session id.
           title: Session Id
+          type: string
+        trace_id:
+          description: Filter by canonical trace id.
+          title: Trace Id
+          type: string
+        span_id:
+          description: Filter by external span id.
+          title: Span Id
           type: string
         project:
           description: Filter by project name.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -6790,9 +6790,9 @@ paths:
         explode: true
         schema:
           $ref: '#/components/schemas/SpanFilter'
-        description: Filter spans by session_id, trace_id, span_id, parent_span_id,
-          project, evaluation context fields, source, kind, status, model, tool_name,
-          provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.
+        description: Filter spans by session_id, trace_id, parent_span_id, project,
+          evaluation context fields, source, kind, status, model, tool_name, provider,
+          agent_id, agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27884,10 +27884,6 @@ components:
         trace_id:
           description: Filter by canonical trace id.
           title: Trace Id
-          type: string
-        span_id:
-          description: Filter by external span id.
-          title: Span Id
           type: string
         project:
           description: Filter by project name.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/__init__.py
@@ -39,7 +39,7 @@ def list_spans(
         typer.Option(
             "--filter",
             metavar="FILTER_JSON",
-            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.",
+            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, trace_id, span_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.",
             rich_help_panel="Filter Options",
         ),
     ] = None,
@@ -82,6 +82,7 @@ def list_spans(
         str | None, typer.Option("--filter.session-id", rich_help_panel="Filter Options")
     ] = None,
     filter_source: Annotated[str | None, typer.Option("--filter.source", rich_help_panel="Filter Options")] = None,
+    filter_span_id: Annotated[str | None, typer.Option("--filter.span-id", rich_help_panel="Filter Options")] = None,
     filter_status: Annotated[str | None, typer.Option("--filter.status", rich_help_panel="Filter Options")] = None,
     filter_test_case_id: Annotated[
         str | None, typer.Option("--filter.test-case-id", rich_help_panel="Filter Options")
@@ -89,6 +90,7 @@ def list_spans(
     filter_tool_name: Annotated[
         str | None, typer.Option("--filter.tool-name", rich_help_panel="Filter Options")
     ] = None,
+    filter_trace_id: Annotated[str | None, typer.Option("--filter.trace-id", rich_help_panel="Filter Options")] = None,
     mode: Annotated[Literal["summary", "detailed"] | None, typer.Option("--mode")] = None,
     page: Annotated[int | None, typer.Option("--page", help="Page number.")] = None,
     page_size: Annotated[int | None, typer.Option("--page-size", help="Page size.")] = None,
@@ -133,9 +135,11 @@ def list_spans(
             provider=filter_provider,
             session_id=filter_session_id,
             source=filter_source,
+            span_id=filter_span_id,
             status=filter_status,
             test_case_id=filter_test_case_id,
             tool_name=filter_tool_name,
+            trace_id=filter_trace_id,
         ),
         mode=mode,
         page=page,

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/__init__.py
@@ -39,7 +39,7 @@ def list_spans(
         typer.Option(
             "--filter",
             metavar="FILTER_JSON",
-            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, trace_id, span_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.",
+            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, trace_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.",
             rich_help_panel="Filter Options",
         ),
     ] = None,
@@ -82,7 +82,6 @@ def list_spans(
         str | None, typer.Option("--filter.session-id", rich_help_panel="Filter Options")
     ] = None,
     filter_source: Annotated[str | None, typer.Option("--filter.source", rich_help_panel="Filter Options")] = None,
-    filter_span_id: Annotated[str | None, typer.Option("--filter.span-id", rich_help_panel="Filter Options")] = None,
     filter_status: Annotated[str | None, typer.Option("--filter.status", rich_help_panel="Filter Options")] = None,
     filter_test_case_id: Annotated[
         str | None, typer.Option("--filter.test-case-id", rich_help_panel="Filter Options")
@@ -135,7 +134,6 @@ def list_spans(
             provider=filter_provider,
             session_id=filter_session_id,
             source=filter_source,
-            span_id=filter_span_id,
             status=filter_status,
             test_case_id=filter_test_case_id,
             tool_name=filter_tool_name,

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -6790,9 +6790,9 @@ paths:
         explode: true
         schema:
           $ref: '#/components/schemas/SpanFilter'
-        description: Filter spans by session_id, parent_span_id, project, evaluation
-          context fields, source, kind, status, model, tool_name, provider, agent_id,
-          agent_name, prompt_name, prompt_version, and started_at.
+        description: Filter spans by session_id, trace_id, span_id, parent_span_id,
+          project, evaluation context fields, source, kind, status, model, tool_name,
+          provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27880,6 +27880,14 @@ components:
         session_id:
           description: Filter by span session id.
           title: Session Id
+          type: string
+        trace_id:
+          description: Filter by canonical trace id.
+          title: Trace Id
+          type: string
+        span_id:
+          description: Filter by external span id.
+          title: Span Id
           type: string
         project:
           description: Filter by project name.

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -6790,9 +6790,9 @@ paths:
         explode: true
         schema:
           $ref: '#/components/schemas/SpanFilter'
-        description: Filter spans by session_id, trace_id, span_id, parent_span_id,
-          project, evaluation context fields, source, kind, status, model, tool_name,
-          provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.
+        description: Filter spans by session_id, trace_id, parent_span_id, project,
+          evaluation context fields, source, kind, status, model, tool_name, provider,
+          agent_id, agent_name, prompt_name, prompt_version, and started_at.
       responses:
         '200':
           description: Successful Response
@@ -27884,10 +27884,6 @@ components:
         trace_id:
           description: Filter by canonical trace id.
           title: Trace Id
-          type: string
-        span_id:
-          description: Filter by external span id.
-          title: Span Id
           type: string
         project:
           description: Filter by project name.

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/__init__.py
@@ -39,7 +39,7 @@ def list_spans(
         typer.Option(
             "--filter",
             metavar="FILTER_JSON",
-            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.",
+            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, trace_id, span_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.",
             rich_help_panel="Filter Options",
         ),
     ] = None,
@@ -82,6 +82,7 @@ def list_spans(
         str | None, typer.Option("--filter.session-id", rich_help_panel="Filter Options")
     ] = None,
     filter_source: Annotated[str | None, typer.Option("--filter.source", rich_help_panel="Filter Options")] = None,
+    filter_span_id: Annotated[str | None, typer.Option("--filter.span-id", rich_help_panel="Filter Options")] = None,
     filter_status: Annotated[str | None, typer.Option("--filter.status", rich_help_panel="Filter Options")] = None,
     filter_test_case_id: Annotated[
         str | None, typer.Option("--filter.test-case-id", rich_help_panel="Filter Options")
@@ -89,6 +90,7 @@ def list_spans(
     filter_tool_name: Annotated[
         str | None, typer.Option("--filter.tool-name", rich_help_panel="Filter Options")
     ] = None,
+    filter_trace_id: Annotated[str | None, typer.Option("--filter.trace-id", rich_help_panel="Filter Options")] = None,
     mode: Annotated[Literal["summary", "detailed"] | None, typer.Option("--mode")] = None,
     page: Annotated[int | None, typer.Option("--page", help="Page number.")] = None,
     page_size: Annotated[int | None, typer.Option("--page-size", help="Page size.")] = None,
@@ -133,9 +135,11 @@ def list_spans(
             provider=filter_provider,
             session_id=filter_session_id,
             source=filter_source,
+            span_id=filter_span_id,
             status=filter_status,
             test_case_id=filter_test_case_id,
             tool_name=filter_tool_name,
+            trace_id=filter_trace_id,
         ),
         mode=mode,
         page=page,

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/__init__.py
@@ -39,7 +39,7 @@ def list_spans(
         typer.Option(
             "--filter",
             metavar="FILTER_JSON",
-            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, trace_id, span_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.",
+            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  started_at: {gte: str, lte: str}\n\nFilter spans by session_id, trace_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.",
             rich_help_panel="Filter Options",
         ),
     ] = None,
@@ -82,7 +82,6 @@ def list_spans(
         str | None, typer.Option("--filter.session-id", rich_help_panel="Filter Options")
     ] = None,
     filter_source: Annotated[str | None, typer.Option("--filter.source", rich_help_panel="Filter Options")] = None,
-    filter_span_id: Annotated[str | None, typer.Option("--filter.span-id", rich_help_panel="Filter Options")] = None,
     filter_status: Annotated[str | None, typer.Option("--filter.status", rich_help_panel="Filter Options")] = None,
     filter_test_case_id: Annotated[
         str | None, typer.Option("--filter.test-case-id", rich_help_panel="Filter Options")
@@ -135,7 +134,6 @@ def list_spans(
             provider=filter_provider,
             session_id=filter_session_id,
             source=filter_source,
-            span_id=filter_span_id,
             status=filter_status,
             test_case_id=filter_test_case_id,
             tool_name=filter_tool_name,

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/intake/spans/spans.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/intake/spans/spans.py
@@ -133,9 +133,9 @@ class SpansResource(SyncAPIResource):
         List Spans
 
         Args:
-          filter: Filter spans by session_id, parent_span_id, project, evaluation context fields,
-              source, kind, status, model, tool_name, provider, agent_id, agent_name,
-              prompt_name, prompt_version, and started_at.
+          filter: Filter spans by session_id, trace_id, span_id, parent_span_id, project,
+              evaluation context fields, source, kind, status, model, tool_name, provider,
+              agent_id, agent_name, prompt_name, prompt_version, and started_at.
 
           page: Page number.
 
@@ -260,9 +260,9 @@ class AsyncSpansResource(AsyncAPIResource):
         List Spans
 
         Args:
-          filter: Filter spans by session_id, parent_span_id, project, evaluation context fields,
-              source, kind, status, model, tool_name, provider, agent_id, agent_name,
-              prompt_name, prompt_version, and started_at.
+          filter: Filter spans by session_id, trace_id, span_id, parent_span_id, project,
+              evaluation context fields, source, kind, status, model, tool_name, provider,
+              agent_id, agent_name, prompt_name, prompt_version, and started_at.
 
           page: Page number.
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/intake/spans/spans.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/intake/spans/spans.py
@@ -133,9 +133,9 @@ class SpansResource(SyncAPIResource):
         List Spans
 
         Args:
-          filter: Filter spans by session_id, trace_id, span_id, parent_span_id, project,
-              evaluation context fields, source, kind, status, model, tool_name, provider,
-              agent_id, agent_name, prompt_name, prompt_version, and started_at.
+          filter: Filter spans by session_id, trace_id, parent_span_id, project, evaluation
+              context fields, source, kind, status, model, tool_name, provider, agent_id,
+              agent_name, prompt_name, prompt_version, and started_at.
 
           page: Page number.
 
@@ -260,9 +260,9 @@ class AsyncSpansResource(AsyncAPIResource):
         List Spans
 
         Args:
-          filter: Filter spans by session_id, trace_id, span_id, parent_span_id, project,
-              evaluation context fields, source, kind, status, model, tool_name, provider,
-              agent_id, agent_name, prompt_name, prompt_version, and started_at.
+          filter: Filter spans by session_id, trace_id, parent_span_id, project, evaluation
+              context fields, source, kind, status, model, tool_name, provider, agent_id,
+              agent_name, prompt_name, prompt_version, and started_at.
 
           page: Page number.
 

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_filter_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_filter_param.py
@@ -82,9 +82,6 @@ class SpanFilterParam(TypedDict, total=False):
     source: str
     """Filter by ingest source (e.g. 'otel', 'atif', 'chat_completions')."""
 
-    span_id: str
-    """Filter by external span id."""
-
     started_at: DatetimeFilter
     """Filter by span start timestamp."""
 

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_filter_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_filter_param.py
@@ -82,6 +82,9 @@ class SpanFilterParam(TypedDict, total=False):
     source: str
     """Filter by ingest source (e.g. 'otel', 'atif', 'chat_completions')."""
 
+    span_id: str
+    """Filter by external span id."""
+
     started_at: DatetimeFilter
     """Filter by span start timestamp."""
 
@@ -93,3 +96,6 @@ class SpanFilterParam(TypedDict, total=False):
 
     tool_name: str
     """Filter by tool name."""
+
+    trace_id: str
+    """Filter by canonical trace id."""

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_list_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_list_params.py
@@ -30,9 +30,9 @@ class SpanListParams(TypedDict, total=False):
 
     filter: SpanFilterParam
     """
-    Filter spans by session_id, trace_id, span_id, parent_span_id, project,
-    evaluation context fields, source, kind, status, model, tool_name, provider,
-    agent_id, agent_name, prompt_name, prompt_version, and started_at.
+    Filter spans by session_id, trace_id, parent_span_id, project, evaluation
+    context fields, source, kind, status, model, tool_name, provider, agent_id,
+    agent_name, prompt_name, prompt_version, and started_at.
     """
 
     mode: Literal["summary", "detailed"]

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_list_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/span_list_params.py
@@ -30,9 +30,9 @@ class SpanListParams(TypedDict, total=False):
 
     filter: SpanFilterParam
     """
-    Filter spans by session_id, parent_span_id, project, evaluation context fields,
-    source, kind, status, model, tool_name, provider, agent_id, agent_name,
-    prompt_name, prompt_version, and started_at.
+    Filter spans by session_id, trace_id, span_id, parent_span_id, project,
+    evaluation context fields, source, kind, status, model, tool_name, provider,
+    agent_id, agent_name, prompt_name, prompt_version, and started_at.
     """
 
     mode: Literal["summary", "detailed"]

--- a/sdk/python/nemo-platform/tests/api_resources/intake/test_spans.py
+++ b/sdk/python/nemo-platform/tests/api_resources/intake/test_spans.py
@@ -117,6 +117,7 @@ class TestSpans:
                 "provider": "provider",
                 "session_id": "session_id",
                 "source": "source",
+                "span_id": "span_id",
                 "started_at": {
                     "gte": parse_datetime("2019-12-27T18:11:19.117Z"),
                     "lte": parse_datetime("2019-12-27T18:11:19.117Z"),
@@ -124,6 +125,7 @@ class TestSpans:
                 "status": "success",
                 "test_case_id": "test_case_id",
                 "tool_name": "tool_name",
+                "trace_id": "trace_id",
             },
             mode="summary",
             page=1,
@@ -255,6 +257,7 @@ class TestAsyncSpans:
                 "provider": "provider",
                 "session_id": "session_id",
                 "source": "source",
+                "span_id": "span_id",
                 "started_at": {
                     "gte": parse_datetime("2019-12-27T18:11:19.117Z"),
                     "lte": parse_datetime("2019-12-27T18:11:19.117Z"),
@@ -262,6 +265,7 @@ class TestAsyncSpans:
                 "status": "success",
                 "test_case_id": "test_case_id",
                 "tool_name": "tool_name",
+                "trace_id": "trace_id",
             },
             mode="summary",
             page=1,

--- a/sdk/python/nemo-platform/tests/api_resources/intake/test_spans.py
+++ b/sdk/python/nemo-platform/tests/api_resources/intake/test_spans.py
@@ -117,7 +117,6 @@ class TestSpans:
                 "provider": "provider",
                 "session_id": "session_id",
                 "source": "source",
-                "span_id": "span_id",
                 "started_at": {
                     "gte": parse_datetime("2019-12-27T18:11:19.117Z"),
                     "lte": parse_datetime("2019-12-27T18:11:19.117Z"),
@@ -257,7 +256,6 @@ class TestAsyncSpans:
                 "provider": "provider",
                 "session_id": "session_id",
                 "source": "source",
-                "span_id": "span_id",
                 "started_at": {
                     "gte": parse_datetime("2019-12-27T18:11:19.117Z"),
                     "lte": parse_datetime("2019-12-27T18:11:19.117Z"),

--- a/services/intake/src/nmp/intake/spans/api/spans.py
+++ b/services/intake/src/nmp/intake/spans/api/spans.py
@@ -56,7 +56,7 @@ ATTRIBUTE_EQ_FILTER_FIELDS = frozenset(
     openapi_extra=generate_openapi_extra_params(
         filter_schema=SpanFilter,
         filter_description=(
-            "Filter spans by session_id, parent_span_id, project, evaluation context fields, "
+            "Filter spans by session_id, trace_id, span_id, parent_span_id, project, evaluation context fields, "
             "source, kind, status, model, tool_name, provider, agent_id, agent_name, "
             "prompt_name, prompt_version, and started_at."
         ),
@@ -113,6 +113,10 @@ def _span_filter(workspace: str, parsed: ParsedFilter) -> SpanListFilter:
     for comparison in filter_comparisons(parsed):
         if comparison.field == "session_id":
             filters.session_id = require_string_value(comparison)
+        elif comparison.field == "trace_id":
+            filters.trace_id = require_string_value(comparison)
+        elif comparison.field == "span_id":
+            filters.span_id = require_string_value(comparison)
         elif comparison.field == "parent_span_id":
             filters.external_parent_span_id = require_string_value(comparison)
         elif comparison.field in ATTRIBUTE_EQ_FILTER_FIELDS:

--- a/services/intake/src/nmp/intake/spans/api/spans.py
+++ b/services/intake/src/nmp/intake/spans/api/spans.py
@@ -56,7 +56,7 @@ ATTRIBUTE_EQ_FILTER_FIELDS = frozenset(
     openapi_extra=generate_openapi_extra_params(
         filter_schema=SpanFilter,
         filter_description=(
-            "Filter spans by session_id, trace_id, span_id, parent_span_id, project, evaluation context fields, "
+            "Filter spans by session_id, trace_id, parent_span_id, project, evaluation context fields, "
             "source, kind, status, model, tool_name, provider, agent_id, agent_name, "
             "prompt_name, prompt_version, and started_at."
         ),
@@ -115,8 +115,6 @@ def _span_filter(workspace: str, parsed: ParsedFilter) -> SpanListFilter:
             filters.session_id = require_string_value(comparison)
         elif comparison.field == "trace_id":
             filters.trace_id = require_string_value(comparison)
-        elif comparison.field == "span_id":
-            filters.span_id = require_string_value(comparison)
         elif comparison.field == "parent_span_id":
             filters.external_parent_span_id = require_string_value(comparison)
         elif comparison.field in ATTRIBUTE_EQ_FILTER_FIELDS:

--- a/services/intake/src/nmp/intake/spans/api/spans_schemas.py
+++ b/services/intake/src/nmp/intake/spans/api/spans_schemas.py
@@ -28,7 +28,6 @@ SpanMode = Literal["summary", "detailed"]
 class SpanFilter(BaseModel):
     session_id: str | None = Field(default=None, description="Filter by span session id.")
     trace_id: str | None = Field(default=None, description="Filter by canonical trace id.")
-    span_id: str | None = Field(default=None, description="Filter by external span id.")
     project: str | None = Field(default=None, description="Filter by project name.")
     evaluation_id: str | None = Field(default=None, description="Filter by evaluation id.")
     evaluation_sha: str | None = Field(default=None, description="Filter by evaluation sha.")

--- a/services/intake/src/nmp/intake/spans/api/spans_schemas.py
+++ b/services/intake/src/nmp/intake/spans/api/spans_schemas.py
@@ -27,6 +27,8 @@ SpanMode = Literal["summary", "detailed"]
 
 class SpanFilter(BaseModel):
     session_id: str | None = Field(default=None, description="Filter by span session id.")
+    trace_id: str | None = Field(default=None, description="Filter by canonical trace id.")
+    span_id: str | None = Field(default=None, description="Filter by external span id.")
     project: str | None = Field(default=None, description="Filter by project name.")
     evaluation_id: str | None = Field(default=None, description="Filter by evaluation id.")
     evaluation_sha: str | None = Field(default=None, description="Filter by evaluation sha.")

--- a/services/intake/src/nmp/intake/spans/domain.py
+++ b/services/intake/src/nmp/intake/spans/domain.py
@@ -73,6 +73,7 @@ class SpanListFilter(BaseModel):
     workspace: str
     session_id: str | None = None
     trace_id: str | None = None
+    span_id: str | None = None
     external_parent_span_id: str | None = None
     source_format: str | None = None
     kind: SpanKind | None = None

--- a/services/intake/src/nmp/intake/spans/domain.py
+++ b/services/intake/src/nmp/intake/spans/domain.py
@@ -73,7 +73,6 @@ class SpanListFilter(BaseModel):
     workspace: str
     session_id: str | None = None
     trace_id: str | None = None
-    span_id: str | None = None
     external_parent_span_id: str | None = None
     source_format: str | None = None
     kind: SpanKind | None = None

--- a/services/intake/src/nmp/intake/spans/span_repository.py
+++ b/services/intake/src/nmp/intake/spans/span_repository.py
@@ -119,9 +119,6 @@ def _span_where(filters: SpanListFilter) -> tuple[str, dict[str, Any]]:
     if filters.trace_id is not None:
         clauses.append("trace_id = %(trace_id)s")
         parameters["trace_id"] = filters.trace_id
-    if filters.span_id is not None:
-        clauses.append("external_span_id = %(external_span_id)s")
-        parameters["external_span_id"] = filters.span_id
     if filters.external_parent_span_id is not None:
         clauses.append("external_parent_span_id = %(external_parent_span_id)s")
         parameters["external_parent_span_id"] = filters.external_parent_span_id

--- a/services/intake/src/nmp/intake/spans/span_repository.py
+++ b/services/intake/src/nmp/intake/spans/span_repository.py
@@ -95,7 +95,7 @@ class SpanRepository:
 
     async def get_span(self, *, workspace: str, span_id: str) -> IntakeSpan | None:
         columns_sql = ", ".join(SPAN_COLUMNS)
-        external_result = await self._client.query(
+        result = await self._client.query(
             f"""
             SELECT {columns_sql}
             FROM {self._client.table("spans")} FINAL
@@ -104,28 +104,10 @@ class SpanRepository:
             """,
             parameters={"workspace": workspace, "span_id": span_id},
         )
-        external_rows = result_rows(external_result)
-        if external_rows:
-            return _row_to_span(external_rows[0])
-
-        try:
-            internal_id = int(span_id)
-        except ValueError:
+        rows = result_rows(result)
+        if not rows:
             return None
-
-        internal_result = await self._client.query(
-            f"""
-            SELECT {columns_sql}
-            FROM {self._client.table("spans")} FINAL
-            WHERE workspace = %(workspace)s AND id = %(id)s AND is_deleted = 0
-            LIMIT 1
-            """,
-            parameters={"workspace": workspace, "id": internal_id},
-        )
-        internal_rows = result_rows(internal_result)
-        if not internal_rows:
-            return None
-        return _row_to_span(internal_rows[0])
+        return _row_to_span(rows[0])
 
 
 def _span_where(filters: SpanListFilter) -> tuple[str, dict[str, Any]]:
@@ -137,6 +119,9 @@ def _span_where(filters: SpanListFilter) -> tuple[str, dict[str, Any]]:
     if filters.trace_id is not None:
         clauses.append("trace_id = %(trace_id)s")
         parameters["trace_id"] = filters.trace_id
+    if filters.span_id is not None:
+        clauses.append("external_span_id = %(external_span_id)s")
+        parameters["external_span_id"] = filters.span_id
     if filters.external_parent_span_id is not None:
         clauses.append("external_parent_span_id = %(external_parent_span_id)s")
         parameters["external_parent_span_id"] = filters.external_parent_span_id

--- a/services/intake/tests/integration/spans/test_spans_read_filters.py
+++ b/services/intake/tests/integration/spans/test_spans_read_filters.py
@@ -68,6 +68,22 @@ def test_spans_read_filters(client: TestClient, make_otlp_request):
     assert session_response.json()["pagination"]["total_results"] == 5
     assert {span["session_id"] for span in session_response.json()["data"]} == {"conv-a"}
 
+    trace_response = client.get(
+        "/apis/intake/v2/workspaces/default/spans",
+        params={"filter[trace_id]": "0" * 31 + "1", "page_size": 20},
+    )
+    assert trace_response.status_code == 200, trace_response.text
+    assert trace_response.json()["pagination"]["total_results"] == 10
+    assert {span["trace_id"] for span in trace_response.json()["data"]} == {"0" * 31 + "1"}
+
+    span_response = client.get(
+        "/apis/intake/v2/workspaces/default/spans",
+        params={"filter[span_id]": f"{4:016x}", "page_size": 20},
+    )
+    assert span_response.status_code == 200, span_response.text
+    assert span_response.json()["pagination"]["total_results"] == 1
+    assert span_response.json()["data"][0]["span_id"] == f"{4:016x}"
+
     source_format_response = client.get(
         "/apis/intake/v2/workspaces/default/spans",
         params={"filter[source]": "otel", "page_size": 20},

--- a/services/intake/tests/integration/spans/test_spans_read_filters.py
+++ b/services/intake/tests/integration/spans/test_spans_read_filters.py
@@ -76,14 +76,6 @@ def test_spans_read_filters(client: TestClient, make_otlp_request):
     assert trace_response.json()["pagination"]["total_results"] == 10
     assert {span["trace_id"] for span in trace_response.json()["data"]} == {"0" * 31 + "1"}
 
-    span_response = client.get(
-        "/apis/intake/v2/workspaces/default/spans",
-        params={"filter[span_id]": f"{4:016x}", "page_size": 20},
-    )
-    assert span_response.status_code == 200, span_response.text
-    assert span_response.json()["pagination"]["total_results"] == 1
-    assert span_response.json()["data"][0]["span_id"] == f"{4:016x}"
-
     source_format_response = client.get(
         "/apis/intake/v2/workspaces/default/spans",
         params={"filter[source]": "otel", "page_size": 20},

--- a/services/intake/tests/test_spans_clickhouse_repository.py
+++ b/services/intake/tests/test_spans_clickhouse_repository.py
@@ -129,21 +129,16 @@ async def test_get_span_prefers_external_span_id_over_numeric_internal_id():
 
 
 @pytest.mark.asyncio
-async def test_get_span_falls_back_to_internal_id_after_external_miss():
-    row = _span_row(internal_id=123, external_span_id="external-123")
-    client = _Client(query_results=[_QueryResult([], SPAN_COLUMNS), _QueryResult([row], SPAN_COLUMNS)])
+async def test_get_span_does_not_fall_back_to_internal_id_after_external_miss():
+    client = _Client(query_results=[_QueryResult([], SPAN_COLUMNS)])
     repository = _repository(client)
 
     span = await repository.get_span(workspace="workspace-a", span_id="123")
 
-    assert span is not None
-    assert span.id == 123
-    assert span.external_span_id == "external-123"
-    assert len(client.queries) == 2
+    assert span is None
+    assert len(client.queries) == 1
     assert "external_span_id = %(span_id)s" in client.queries[0]
-    assert "id = %(id)s" in client.queries[1]
     assert client.parameters[0] == {"workspace": "workspace-a", "span_id": "123"}
-    assert client.parameters[1] == {"workspace": "workspace-a", "id": 123}
 
 
 def _span_row(*, internal_id: int, external_span_id: str) -> tuple[object, ...]:


### PR DESCRIPTION
We didn't yet expose a way to get spans by their trace_id, this does that via our filtering pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support filtering spans by canonical trace ID via API filter[trace_id] and CLI --filter.trace-id.

* **Bug Fixes**
  * Span retrieval no longer performs an extra fallback lookup, improving consistency and performance.

* **Documentation**
  * API and CLI help updated to list trace_id as a supported span filter field.

* **Tests**
  * Added/updated tests validating trace_id filtering and the updated retrieval behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->