### PR TITLE
ci: add Trufflehog OSS secrets scan to PRs

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -38,7 +38,6 @@ jobs:
         with:
           path: ./
           version: 3.95.3
-          extra_args: --debug
 
       - name: Scan Results Status
         if: ${{ github.event_name != 'merge_group' && steps.trufflehog.outcome == 'failure' }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,45 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  secrets-scan:
+    name: Secrets Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip merge queue scan
+        if: ${{ github.event_name == 'merge_group' }}
+        run: echo "Skipping secrets scan for merge queue"
+
+      - uses: actions/checkout@v6
+        if: ${{ github.event_name != 'merge_group' }}
+        with:
+          fetch-depth: 0
+      - name: TruffleHog OSS
+        if: ${{ github.event_name != 'merge_group' }}
+        id: trufflehog
+        uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab # v3.95.3
+        continue-on-error: true
+        with:
+          path: ./
+          version: 3.95.3
+          extra_args: --debug
+
+      - name: Scan Results Status
+        if: ${{ github.event_name != 'merge_group' && steps.trufflehog.outcome == 'failure' }}
+        run: exit 1


### PR DESCRIPTION
This adds a secrets scan to PRs for early detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated Security workflow to CI that scans commits and PRs for exposed secrets on pushes, pull requests, merge-group checks, and manual runs. It reduces redundant runs via concurrency controls, restricts scan permissions, skips or logs merge-group events, and surfaces detected issues—failing the run for standard events while allowing non-blocking behavior for merge-group scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->