### PR TITLE
chore: add workaround for DCO in merge queues

### DIFF
--- a/.github/workflows/dco-war.yaml
+++ b/.github/workflows/dco-war.yaml
@@ -1,0 +1,16 @@
+name: DCO
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  DCO:
+    runs-on: ubuntu-lateset
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - run: echo "DCO app doesn't support merge groups, so this allows them until it does. See https://github.com/dcoapp/app/issues/199"
+        shell: bash
+

--- a/.github/workflows/dco-war.yaml
+++ b/.github/workflows/dco-war.yaml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   DCO:
-    runs-on: ubuntu-lateset
+    runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - run: echo "DCO app doesn't support merge groups, so this allows them until it does. See https://github.com/dcoapp/app/issues/199"


### PR DESCRIPTION
A lot is explained in  https://github.com/dcoapp/app/issues/199
Basically DCO app doesn't work in merge queues, so to require it for PRs, we need it to pass in the merge group workflow. This makes it so that it will, in fact, pass by not actually running there with a similarly named job/workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a DCO validation workflow for merge-group events to surface DCO status.
  * Workflow performs a check that reports DCO currently does not support merge groups and references the tracking issue.
  * Workflow skips automated bot actors (e.g., Dependabot) to avoid noise.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->