### PR TITLE
ci: add codeql scanning

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -42,3 +42,30 @@ jobs:
       - name: Scan Results Status
         if: ${{ github.event_name != 'merge_group' && steps.trufflehog.outcome == 'failure' }}
         run: exit 1
+  codeql:
+    name: CodeQL Analyze Codebase
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python', 'javascript-typescript' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+            languages: ${{matrix.language}}
+            queries: +security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+            category: "/language:${{matrix.language}}"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@6
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
A common solution for finding code security and quality issues in PRs is to use codeql in our Github repos. This adds it to our PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI to run automated CodeQL analysis across Python and JavaScript/TypeScript in addition to the existing secrets scan, using a language matrix so analyses run per language.
  * Adjusted CI job-level settings to support the new analysis steps; no changes to public APIs or exported interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->