### PR TITLE
feat(intake): accept chat completion cost metrics

### DIFF
--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -13350,12 +13350,8 @@ components:
           type: string
         cost_usd:
           title: Cost Usd
-          description: Total estimated cost of this model call in USD. Alias for cost_total_usd.
-          type: number
-          minimum: 0.0
-        cost_total_usd:
-          title: Cost Total Usd
-          description: Total estimated cost of this model call in USD.
+          description: Total estimated cost of this model call in USD. This matches
+            ATIF step metrics; Intake stores it as semantic cost_total_usd on spans.
           type: number
           minimum: 0.0
         cost_input_usd:

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -13348,6 +13348,33 @@ components:
         provider:
           title: Provider
           type: string
+        cost_usd:
+          title: Cost Usd
+          description: Total estimated cost of this model call in USD. Alias for cost_total_usd.
+          type: number
+          minimum: 0.0
+        cost_total_usd:
+          title: Cost Total Usd
+          description: Total estimated cost of this model call in USD.
+          type: number
+          minimum: 0.0
+        cost_input_usd:
+          title: Cost Input Usd
+          description: Estimated input-token cost of this model call in USD.
+          type: number
+          minimum: 0.0
+        cost_output_usd:
+          title: Cost Output Usd
+          description: Estimated output-token cost of this model call in USD.
+          type: number
+          minimum: 0.0
+        cost_details:
+          additionalProperties:
+            type: number
+            minimum: 0.0
+          type: object
+          title: Cost Details
+          description: Additional estimated cost breakdown fields in USD.
       additionalProperties: false
       type: object
       required:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -13350,12 +13350,8 @@ components:
           type: string
         cost_usd:
           title: Cost Usd
-          description: Total estimated cost of this model call in USD. Alias for cost_total_usd.
-          type: number
-          minimum: 0.0
-        cost_total_usd:
-          title: Cost Total Usd
-          description: Total estimated cost of this model call in USD.
+          description: Total estimated cost of this model call in USD. This matches
+            ATIF step metrics; Intake stores it as semantic cost_total_usd on spans.
           type: number
           minimum: 0.0
         cost_input_usd:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -13348,6 +13348,33 @@ components:
         provider:
           title: Provider
           type: string
+        cost_usd:
+          title: Cost Usd
+          description: Total estimated cost of this model call in USD. Alias for cost_total_usd.
+          type: number
+          minimum: 0.0
+        cost_total_usd:
+          title: Cost Total Usd
+          description: Total estimated cost of this model call in USD.
+          type: number
+          minimum: 0.0
+        cost_input_usd:
+          title: Cost Input Usd
+          description: Estimated input-token cost of this model call in USD.
+          type: number
+          minimum: 0.0
+        cost_output_usd:
+          title: Cost Output Usd
+          description: Estimated output-token cost of this model call in USD.
+          type: number
+          minimum: 0.0
+        cost_details:
+          additionalProperties:
+            type: number
+            minimum: 0.0
+          type: object
+          title: Cost Details
+          description: Additional estimated cost breakdown fields in USD.
       additionalProperties: false
       type: object
       required:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -13350,12 +13350,8 @@ components:
           type: string
         cost_usd:
           title: Cost Usd
-          description: Total estimated cost of this model call in USD. Alias for cost_total_usd.
-          type: number
-          minimum: 0.0
-        cost_total_usd:
-          title: Cost Total Usd
-          description: Total estimated cost of this model call in USD.
+          description: Total estimated cost of this model call in USD. This matches
+            ATIF step metrics; Intake stores it as semantic cost_total_usd on spans.
           type: number
           minimum: 0.0
         cost_input_usd:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -13348,6 +13348,33 @@ components:
         provider:
           title: Provider
           type: string
+        cost_usd:
+          title: Cost Usd
+          description: Total estimated cost of this model call in USD. Alias for cost_total_usd.
+          type: number
+          minimum: 0.0
+        cost_total_usd:
+          title: Cost Total Usd
+          description: Total estimated cost of this model call in USD.
+          type: number
+          minimum: 0.0
+        cost_input_usd:
+          title: Cost Input Usd
+          description: Estimated input-token cost of this model call in USD.
+          type: number
+          minimum: 0.0
+        cost_output_usd:
+          title: Cost Output Usd
+          description: Estimated output-token cost of this model call in USD.
+          type: number
+          minimum: 0.0
+        cost_details:
+          additionalProperties:
+            type: number
+            minimum: 0.0
+          type: object
+          title: Cost Details
+          description: Additional estimated cost breakdown fields in USD.
       additionalProperties: false
       type: object
       required:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/chat_completions.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/chat_completions.py
@@ -39,6 +39,23 @@ def create_chat_completions(
             help="Flexible entry response that accepts any object shape.This flexibility enables the Intake service to store responses from various LLM providers and future model types without requiring schema updates.Required: either `choices` (successful response) or `error` (failed call). Common optional fields: `id`, `created`, `model`, `usage`, `system_fingerprint`, etc. (JSON string) (required)",
         ),
     ] = None,
+    cost_details: Annotated[
+        str | None,
+        typer.Option("--cost-details", help="Additional estimated cost breakdown fields in USD. (JSON string)"),
+    ] = None,
+    cost_input_usd: Annotated[
+        float | None, typer.Option("--cost-input-usd", help="Estimated input-token cost of this model call in USD.")
+    ] = None,
+    cost_output_usd: Annotated[
+        float | None, typer.Option("--cost-output-usd", help="Estimated output-token cost of this model call in USD.")
+    ] = None,
+    cost_usd: Annotated[
+        float | None,
+        typer.Option(
+            "--cost-usd",
+            help="Total estimated cost of this model call in USD. This matches ATIF step metrics; Intake stores it as semantic cost_total_usd on spans.",
+        ),
+    ] = None,
     evaluation_context: Annotated[str | None, typer.Option("--evaluation-context", help="JSON string")] = None,
     provider: Annotated[str | None, typer.Option("--provider")] = None,
     session_id: Annotated[
@@ -87,6 +104,14 @@ def create_chat_completions(
         input_payload["request"] = read_payload("request", request)
     if response is not None:
         input_payload["response"] = read_payload("response", response)
+    if cost_details is not None:
+        input_payload["cost_details"] = read_payload("cost_details", cost_details)
+    if cost_input_usd is not None:
+        input_payload["cost_input_usd"] = cost_input_usd
+    if cost_output_usd is not None:
+        input_payload["cost_output_usd"] = cost_output_usd
+    if cost_usd is not None:
+        input_payload["cost_usd"] = cost_usd
     if evaluation_context is not None:
         input_payload["evaluation_context"] = read_payload("evaluation_context", evaluation_context)
     if provider is not None:

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -13348,6 +13348,29 @@ components:
         provider:
           title: Provider
           type: string
+        cost_usd:
+          title: Cost Usd
+          description: Total estimated cost of this model call in USD. This matches
+            ATIF step metrics; Intake stores it as semantic cost_total_usd on spans.
+          type: number
+          minimum: 0.0
+        cost_input_usd:
+          title: Cost Input Usd
+          description: Estimated input-token cost of this model call in USD.
+          type: number
+          minimum: 0.0
+        cost_output_usd:
+          title: Cost Output Usd
+          description: Estimated output-token cost of this model call in USD.
+          type: number
+          minimum: 0.0
+        cost_details:
+          additionalProperties:
+            type: number
+            minimum: 0.0
+          type: object
+          title: Cost Details
+          description: Additional estimated cost breakdown fields in USD.
       additionalProperties: false
       type: object
       required:

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/chat_completions.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/chat_completions.py
@@ -39,6 +39,23 @@ def create_chat_completions(
             help="Flexible entry response that accepts any object shape.This flexibility enables the Intake service to store responses from various LLM providers and future model types without requiring schema updates.Required: either `choices` (successful response) or `error` (failed call). Common optional fields: `id`, `created`, `model`, `usage`, `system_fingerprint`, etc. (JSON string) (required)",
         ),
     ] = None,
+    cost_details: Annotated[
+        str | None,
+        typer.Option("--cost-details", help="Additional estimated cost breakdown fields in USD. (JSON string)"),
+    ] = None,
+    cost_input_usd: Annotated[
+        float | None, typer.Option("--cost-input-usd", help="Estimated input-token cost of this model call in USD.")
+    ] = None,
+    cost_output_usd: Annotated[
+        float | None, typer.Option("--cost-output-usd", help="Estimated output-token cost of this model call in USD.")
+    ] = None,
+    cost_usd: Annotated[
+        float | None,
+        typer.Option(
+            "--cost-usd",
+            help="Total estimated cost of this model call in USD. This matches ATIF step metrics; Intake stores it as semantic cost_total_usd on spans.",
+        ),
+    ] = None,
     evaluation_context: Annotated[str | None, typer.Option("--evaluation-context", help="JSON string")] = None,
     provider: Annotated[str | None, typer.Option("--provider")] = None,
     session_id: Annotated[
@@ -87,6 +104,14 @@ def create_chat_completions(
         input_payload["request"] = read_payload("request", request)
     if response is not None:
         input_payload["response"] = read_payload("response", response)
+    if cost_details is not None:
+        input_payload["cost_details"] = read_payload("cost_details", cost_details)
+    if cost_input_usd is not None:
+        input_payload["cost_input_usd"] = cost_input_usd
+    if cost_output_usd is not None:
+        input_payload["cost_output_usd"] = cost_output_usd
+    if cost_usd is not None:
+        input_payload["cost_usd"] = cost_usd
     if evaluation_context is not None:
         input_payload["evaluation_context"] = read_payload("evaluation_context", evaluation_context)
     if provider is not None:

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/intake/ingest/chat_completions.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/intake/ingest/chat_completions.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from typing import Dict
+
 import httpx
 
 from ...._types import Body, Omit, Query, Headers, NotGiven, omit, not_given
@@ -66,6 +68,10 @@ class ChatCompletionsResource(SyncAPIResource):
         workspace: str | None = None,
         request: FlexibleEntryRequestParam,
         response: FlexibleEntryResponseParam,
+        cost_details: Dict[str, float] | Omit = omit,
+        cost_input_usd: float | Omit = omit,
+        cost_output_usd: float | Omit = omit,
+        cost_usd: float | Omit = omit,
         evaluation_context: EvaluationContextParam | Omit = omit,
         provider: str | Omit = omit,
         session_id: str | Omit = omit,
@@ -99,6 +105,15 @@ class ChatCompletionsResource(SyncAPIResource):
               Common optional fields: `id`, `created`, `model`, `usage`, `system_fingerprint`,
               etc.
 
+          cost_details: Additional estimated cost breakdown fields in USD.
+
+          cost_input_usd: Estimated input-token cost of this model call in USD.
+
+          cost_output_usd: Estimated output-token cost of this model call in USD.
+
+          cost_usd: Total estimated cost of this model call in USD. This matches ATIF step metrics;
+              Intake stores it as semantic cost_total_usd on spans.
+
           session_id: Groups related chat-completions calls without forcing them into the same trace.
 
           trace_id: Opt into joining an existing trace built via OTel or ATIF. This is not a
@@ -123,6 +138,10 @@ class ChatCompletionsResource(SyncAPIResource):
                 {
                     "request": request,
                     "response": response,
+                    "cost_details": cost_details,
+                    "cost_input_usd": cost_input_usd,
+                    "cost_output_usd": cost_output_usd,
+                    "cost_usd": cost_usd,
                     "evaluation_context": evaluation_context,
                     "provider": provider,
                     "session_id": session_id,
@@ -163,6 +182,10 @@ class AsyncChatCompletionsResource(AsyncAPIResource):
         workspace: str | None = None,
         request: FlexibleEntryRequestParam,
         response: FlexibleEntryResponseParam,
+        cost_details: Dict[str, float] | Omit = omit,
+        cost_input_usd: float | Omit = omit,
+        cost_output_usd: float | Omit = omit,
+        cost_usd: float | Omit = omit,
         evaluation_context: EvaluationContextParam | Omit = omit,
         provider: str | Omit = omit,
         session_id: str | Omit = omit,
@@ -196,6 +219,15 @@ class AsyncChatCompletionsResource(AsyncAPIResource):
               Common optional fields: `id`, `created`, `model`, `usage`, `system_fingerprint`,
               etc.
 
+          cost_details: Additional estimated cost breakdown fields in USD.
+
+          cost_input_usd: Estimated input-token cost of this model call in USD.
+
+          cost_output_usd: Estimated output-token cost of this model call in USD.
+
+          cost_usd: Total estimated cost of this model call in USD. This matches ATIF step metrics;
+              Intake stores it as semantic cost_total_usd on spans.
+
           session_id: Groups related chat-completions calls without forcing them into the same trace.
 
           trace_id: Opt into joining an existing trace built via OTel or ATIF. This is not a
@@ -220,6 +252,10 @@ class AsyncChatCompletionsResource(AsyncAPIResource):
                 {
                     "request": request,
                     "response": response,
+                    "cost_details": cost_details,
+                    "cost_input_usd": cost_input_usd,
+                    "cost_output_usd": cost_output_usd,
+                    "cost_usd": cost_usd,
                     "evaluation_context": evaluation_context,
                     "provider": provider,
                     "session_id": session_id,

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/ingest/chat_completion_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/ingest/chat_completion_create_params.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from typing import Dict
 from typing_extensions import Required, TypedDict
 
 from ..evaluation_context_param import EvaluationContextParam
@@ -49,6 +50,22 @@ class ChatCompletionCreateParams(TypedDict, total=False):
     Required: either `choices` (successful response) or `error` (failed call).
     Common optional fields: `id`, `created`, `model`, `usage`, `system_fingerprint`,
     etc.
+    """
+
+    cost_details: Dict[str, float]
+    """Additional estimated cost breakdown fields in USD."""
+
+    cost_input_usd: float
+    """Estimated input-token cost of this model call in USD."""
+
+    cost_output_usd: float
+    """Estimated output-token cost of this model call in USD."""
+
+    cost_usd: float
+    """Total estimated cost of this model call in USD.
+
+    This matches ATIF step metrics; Intake stores it as semantic cost_total_usd on
+    spans.
     """
 
     evaluation_context: EvaluationContextParam

--- a/sdk/python/nemo-platform/tests/api_resources/intake/ingest/test_chat_completions.py
+++ b/sdk/python/nemo-platform/tests/api_resources/intake/ingest/test_chat_completions.py
@@ -58,6 +58,10 @@ class TestChatCompletions:
                 "choices": [{"foo": "bar"}],
                 "error": {"foo": "bar"},
             },
+            cost_details={"foo": 0},
+            cost_input_usd=0,
+            cost_output_usd=0,
+            cost_usd=0,
             evaluation_context={
                 "dataset_id": "dataset_id",
                 "dataset_name": "dataset_name",
@@ -155,6 +159,10 @@ class TestAsyncChatCompletions:
                 "choices": [{"foo": "bar"}],
                 "error": {"foo": "bar"},
             },
+            cost_details={"foo": 0},
+            cost_input_usd=0,
+            cost_output_usd=0,
+            cost_usd=0,
             evaluation_context={
                 "dataset_id": "dataset_id",
                 "dataset_name": "dataset_name",

--- a/services/intake/src/nmp/intake/spans/ingest/chat_completions.py
+++ b/services/intake/src/nmp/intake/spans/ingest/chat_completions.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import math
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
-from typing import Annotated, Any, Self
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, status
 from nmp.intake.entities.values import FlexibleEntryRequest, FlexibleEntryResponse
@@ -24,7 +24,7 @@ from nmp.intake.spans.ingest.evaluation_context import EvaluationContext
 from nmp.intake.spans.span_attribute_bags import SpanAttributeBags
 from nmp.intake.spans.span_semantic_attributes import SpanSemanticAttributes
 from nmp.intake.spans.storage import json_dumps_preserve, stable_id, utc_now
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 router = APIRouter(dependencies=[Depends(require_workspace_access)])
 API_TAG = "Ingest"
@@ -54,11 +54,10 @@ class ChatCompletionsIngestRequest(BaseModel):
     provider: str | None = None
     cost_usd: NonNegativeFloat | None = Field(
         default=None,
-        description="Total estimated cost of this model call in USD. Alias for cost_total_usd.",
-    )
-    cost_total_usd: NonNegativeFloat | None = Field(
-        default=None,
-        description="Total estimated cost of this model call in USD.",
+        description=(
+            "Total estimated cost of this model call in USD. This matches ATIF step "
+            "metrics; Intake stores it as semantic cost_total_usd on spans."
+        ),
     )
     cost_input_usd: NonNegativeFloat | None = Field(
         default=None,
@@ -72,16 +71,6 @@ class ChatCompletionsIngestRequest(BaseModel):
         default_factory=dict,
         description="Additional estimated cost breakdown fields in USD.",
     )
-
-    @model_validator(mode="after")
-    def validate_cost_aliases(self) -> Self:
-        if (
-            self.cost_usd is not None
-            and self.cost_total_usd is not None
-            and not math.isclose(self.cost_usd, self.cost_total_usd, rel_tol=0.0, abs_tol=1e-12)
-        ):
-            raise ValueError("cost_usd and cost_total_usd must match when both are set")
-        return self
 
 
 class ChatCompletionsIngestResponse(BaseModel):
@@ -309,9 +298,7 @@ def _decimal_or_none(value: float | None) -> Decimal | None:
 
 def _cost_total_usd(body: ChatCompletionsIngestRequest) -> float | None:
     return (
-        body.cost_total_usd
-        if body.cost_total_usd is not None
-        else body.cost_usd
+        body.cost_usd
         if body.cost_usd is not None
         else body.cost_details.get("total_cost")
         if body.cost_details.get("total_cost") is not None

--- a/services/intake/src/nmp/intake/spans/ingest/chat_completions.py
+++ b/services/intake/src/nmp/intake/spans/ingest/chat_completions.py
@@ -148,11 +148,10 @@ def _build_attribute_bags(
     error: dict[str, Any] | None,
 ) -> SpanAttributeBags:
     prompt_details = _dict_or_empty(usage.get("prompt_tokens_details"))
-    input_details = _dict_or_empty(usage.get("input_tokens_details"))
     completion_details = _dict_or_empty(usage.get("completion_tokens_details"))
-    output_details = _dict_or_empty(usage.get("output_tokens_details"))
-    input_tokens = _first_clean_int(usage, "prompt_tokens", "input_tokens")
-    output_tokens = _first_clean_int(usage, "completion_tokens", "output_tokens")
+    input_tokens = _clean_int(usage.get("prompt_tokens"))
+    output_tokens = _clean_int(usage.get("completion_tokens"))
+    total_tokens = input_tokens + output_tokens if input_tokens is not None and output_tokens is not None else None
 
     error_type: str | None = None
     error_message: str | None = None
@@ -175,40 +174,21 @@ def _build_attribute_bags(
         error_message=error_message,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
-        total_tokens=_coalesce_int(
-            _first_clean_int(usage, "total_tokens"), _sum_optional_ints(input_tokens, output_tokens)
-        ),
-        cached_tokens=_coalesce_int(
-            _first_clean_int(prompt_details, "cached_tokens"),
-            _first_clean_int(input_details, "cached_tokens"),
-            _first_clean_int(usage, "cache_read_input_tokens"),
-        ),
-        prompt_cache_write_tokens=_coalesce_int(
-            _first_clean_int(prompt_details, "cache_creation_tokens"),
-            _first_clean_int(input_details, "cache_creation_tokens"),
-            _first_clean_int(usage, "cache_creation_input_tokens"),
-        ),
-        prompt_audio_tokens=_coalesce_int(
-            _first_clean_int(prompt_details, "audio_tokens"),
-            _first_clean_int(input_details, "audio_tokens"),
-        ),
-        completion_reasoning_tokens=_coalesce_int(
-            _first_clean_int(completion_details, "reasoning_tokens"),
-            _first_clean_int(output_details, "reasoning_tokens"),
-            _first_clean_int(usage, "reasoning_tokens"),
-        ),
-        completion_audio_tokens=_coalesce_int(
-            _first_clean_int(completion_details, "audio_tokens"),
-            _first_clean_int(output_details, "audio_tokens"),
-        ),
-        cost_total_usd=_decimal_or_none(_cost_total_usd(body)),
-        cost_input_usd=_decimal_or_none(_cost_input_usd(body)),
-        cost_output_usd=_decimal_or_none(_cost_output_usd(body)),
+        total_tokens=total_tokens,
+        cached_tokens=_clean_int(prompt_details.get("cached_tokens")),
+        prompt_audio_tokens=_clean_int(prompt_details.get("audio_tokens")),
+        completion_reasoning_tokens=_clean_int(completion_details.get("reasoning_tokens")),
+        completion_audio_tokens=_clean_int(completion_details.get("audio_tokens")),
+        cost_total_usd=_decimal_or_none(body.cost_usd),
+        cost_input_usd=_decimal_or_none(body.cost_input_usd),
+        cost_output_usd=_decimal_or_none(body.cost_output_usd),
     )
     attribute_bags = semantic.to_bags()
     for key, value in body.cost_details.items():
-        if key not in {"total", "total_cost", "input", "input_cost", "prompt", "output", "output_cost", "completion"}:
-            attribute_bags.put_unhandled_source_attribute(f"llm.cost.{key}", value)
+        bag_key = f"cost.{key}"
+        if bag_key in attribute_bags.number:
+            continue
+        attribute_bags.put_unhandled_source_attribute(f"llm.cost.{key}", value)
     if evaluation_context is not None:
         attribute_bags.put_json("evaluation.metadata", evaluation_context.metadata)
     return attribute_bags
@@ -268,27 +248,6 @@ def _clean_int(value: Any) -> int | None:
     return value if value >= 0 else None
 
 
-def _first_clean_int(values: dict[str, Any], *keys: str) -> int | None:
-    for key in keys:
-        value = _clean_int(values.get(key))
-        if value is not None:
-            return value
-    return None
-
-
-def _sum_optional_ints(*values: int | None) -> int | None:
-    if any(value is None for value in values):
-        return None
-    return sum(value for value in values if value is not None)
-
-
-def _coalesce_int(*values: int | None) -> int | None:
-    for value in values:
-        if value is not None:
-            return value
-    return None
-
-
 def _decimal_or_none(value: float | None) -> Decimal | None:
     if value is None:
         return None
@@ -296,37 +255,3 @@ def _decimal_or_none(value: float | None) -> Decimal | None:
         return Decimal(str(value))
     except (InvalidOperation, ValueError):
         return None
-
-
-def _cost_total_usd(body: ChatCompletionsIngestRequest) -> float | None:
-    return (
-        body.cost_usd
-        if body.cost_usd is not None
-        else body.cost_details.get("total_cost")
-        if body.cost_details.get("total_cost") is not None
-        else body.cost_details.get("total")
-    )
-
-
-def _cost_input_usd(body: ChatCompletionsIngestRequest) -> float | None:
-    return (
-        body.cost_input_usd
-        if body.cost_input_usd is not None
-        else body.cost_details.get("input_cost")
-        if body.cost_details.get("input_cost") is not None
-        else body.cost_details.get("input")
-        if body.cost_details.get("input") is not None
-        else body.cost_details.get("prompt")
-    )
-
-
-def _cost_output_usd(body: ChatCompletionsIngestRequest) -> float | None:
-    return (
-        body.cost_output_usd
-        if body.cost_output_usd is not None
-        else body.cost_details.get("output_cost")
-        if body.cost_details.get("output_cost") is not None
-        else body.cost_details.get("output")
-        if body.cost_details.get("output") is not None
-        else body.cost_details.get("completion")
-    )

--- a/services/intake/src/nmp/intake/spans/ingest/chat_completions.py
+++ b/services/intake/src/nmp/intake/spans/ingest/chat_completions.py
@@ -175,7 +175,9 @@ def _build_attribute_bags(
         error_message=error_message,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
-        total_tokens=_coalesce_int(_first_clean_int(usage, "total_tokens"), _sum_optional_ints(input_tokens, output_tokens)),
+        total_tokens=_coalesce_int(
+            _first_clean_int(usage, "total_tokens"), _sum_optional_ints(input_tokens, output_tokens)
+        ),
         cached_tokens=_coalesce_int(
             _first_clean_int(prompt_details, "cached_tokens"),
             _first_clean_int(input_details, "cached_tokens"),

--- a/services/intake/src/nmp/intake/spans/ingest/chat_completions.py
+++ b/services/intake/src/nmp/intake/spans/ingest/chat_completions.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import math
 from datetime import datetime, timezone
-from typing import Any
+from decimal import Decimal, InvalidOperation
+from typing import Annotated, Any, Self
 
 from fastapi import APIRouter, Depends, status
 from nmp.intake.entities.values import FlexibleEntryRequest, FlexibleEntryResponse
@@ -23,12 +24,13 @@ from nmp.intake.spans.ingest.evaluation_context import EvaluationContext
 from nmp.intake.spans.span_attribute_bags import SpanAttributeBags
 from nmp.intake.spans.span_semantic_attributes import SpanSemanticAttributes
 from nmp.intake.spans.storage import json_dumps_preserve, stable_id, utc_now
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 router = APIRouter(dependencies=[Depends(require_workspace_access)])
 API_TAG = "Ingest"
 
 SOURCE_FORMAT = "chat_completions"
+NonNegativeFloat = Annotated[float, Field(ge=0)]
 
 
 class ChatCompletionsIngestRequest(BaseModel):
@@ -50,6 +52,36 @@ class ChatCompletionsIngestRequest(BaseModel):
     )
     evaluation_context: EvaluationContext | None = None
     provider: str | None = None
+    cost_usd: NonNegativeFloat | None = Field(
+        default=None,
+        description="Total estimated cost of this model call in USD. Alias for cost_total_usd.",
+    )
+    cost_total_usd: NonNegativeFloat | None = Field(
+        default=None,
+        description="Total estimated cost of this model call in USD.",
+    )
+    cost_input_usd: NonNegativeFloat | None = Field(
+        default=None,
+        description="Estimated input-token cost of this model call in USD.",
+    )
+    cost_output_usd: NonNegativeFloat | None = Field(
+        default=None,
+        description="Estimated output-token cost of this model call in USD.",
+    )
+    cost_details: dict[str, NonNegativeFloat] = Field(
+        default_factory=dict,
+        description="Additional estimated cost breakdown fields in USD.",
+    )
+
+    @model_validator(mode="after")
+    def validate_cost_aliases(self) -> Self:
+        if (
+            self.cost_usd is not None
+            and self.cost_total_usd is not None
+            and not math.isclose(self.cost_usd, self.cost_total_usd, rel_tol=0.0, abs_tol=1e-12)
+        ):
+            raise ValueError("cost_usd and cost_total_usd must match when both are set")
+        return self
 
 
 class ChatCompletionsIngestResponse(BaseModel):
@@ -127,7 +159,11 @@ def _build_attribute_bags(
     error: dict[str, Any] | None,
 ) -> SpanAttributeBags:
     prompt_details = _dict_or_empty(usage.get("prompt_tokens_details"))
+    input_details = _dict_or_empty(usage.get("input_tokens_details"))
     completion_details = _dict_or_empty(usage.get("completion_tokens_details"))
+    output_details = _dict_or_empty(usage.get("output_tokens_details"))
+    input_tokens = _first_clean_int(usage, "prompt_tokens", "input_tokens")
+    output_tokens = _first_clean_int(usage, "completion_tokens", "output_tokens")
 
     error_type: str | None = None
     error_message: str | None = None
@@ -148,15 +184,40 @@ def _build_attribute_bags(
         test_case_id=evaluation_context.test_case_id if evaluation_context is not None else None,
         error_type=error_type,
         error_message=error_message,
-        input_tokens=_clean_int(usage.get("prompt_tokens")),
-        output_tokens=_clean_int(usage.get("completion_tokens")),
-        total_tokens=_clean_int(usage.get("total_tokens")),
-        cached_tokens=_clean_int(prompt_details.get("cached_tokens")),
-        prompt_audio_tokens=_clean_int(prompt_details.get("audio_tokens")),
-        completion_reasoning_tokens=_clean_int(completion_details.get("reasoning_tokens")),
-        completion_audio_tokens=_clean_int(completion_details.get("audio_tokens")),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=_coalesce_int(_first_clean_int(usage, "total_tokens"), _sum_optional_ints(input_tokens, output_tokens)),
+        cached_tokens=_coalesce_int(
+            _first_clean_int(prompt_details, "cached_tokens"),
+            _first_clean_int(input_details, "cached_tokens"),
+            _first_clean_int(usage, "cache_read_input_tokens"),
+        ),
+        prompt_cache_write_tokens=_coalesce_int(
+            _first_clean_int(prompt_details, "cache_creation_tokens"),
+            _first_clean_int(input_details, "cache_creation_tokens"),
+            _first_clean_int(usage, "cache_creation_input_tokens"),
+        ),
+        prompt_audio_tokens=_coalesce_int(
+            _first_clean_int(prompt_details, "audio_tokens"),
+            _first_clean_int(input_details, "audio_tokens"),
+        ),
+        completion_reasoning_tokens=_coalesce_int(
+            _first_clean_int(completion_details, "reasoning_tokens"),
+            _first_clean_int(output_details, "reasoning_tokens"),
+            _first_clean_int(usage, "reasoning_tokens"),
+        ),
+        completion_audio_tokens=_coalesce_int(
+            _first_clean_int(completion_details, "audio_tokens"),
+            _first_clean_int(output_details, "audio_tokens"),
+        ),
+        cost_total_usd=_decimal_or_none(_cost_total_usd(body)),
+        cost_input_usd=_decimal_or_none(_cost_input_usd(body)),
+        cost_output_usd=_decimal_or_none(_cost_output_usd(body)),
     )
     attribute_bags = semantic.to_bags()
+    for key, value in body.cost_details.items():
+        if key not in {"total", "total_cost", "input", "input_cost", "prompt", "output", "output_cost", "completion"}:
+            attribute_bags.put_unhandled_source_attribute(f"llm.cost.{key}", value)
     if evaluation_context is not None:
         attribute_bags.put_json("evaluation.metadata", evaluation_context.metadata)
     return attribute_bags
@@ -214,3 +275,69 @@ def _clean_int(value: Any) -> int | None:
     if not isinstance(value, int) or isinstance(value, bool):
         return None
     return value if value >= 0 else None
+
+
+def _first_clean_int(values: dict[str, Any], *keys: str) -> int | None:
+    for key in keys:
+        value = _clean_int(values.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _sum_optional_ints(*values: int | None) -> int | None:
+    if any(value is None for value in values):
+        return None
+    return sum(value for value in values if value is not None)
+
+
+def _coalesce_int(*values: int | None) -> int | None:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _decimal_or_none(value: float | None) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _cost_total_usd(body: ChatCompletionsIngestRequest) -> float | None:
+    return (
+        body.cost_total_usd
+        if body.cost_total_usd is not None
+        else body.cost_usd
+        if body.cost_usd is not None
+        else body.cost_details.get("total_cost")
+        if body.cost_details.get("total_cost") is not None
+        else body.cost_details.get("total")
+    )
+
+
+def _cost_input_usd(body: ChatCompletionsIngestRequest) -> float | None:
+    return (
+        body.cost_input_usd
+        if body.cost_input_usd is not None
+        else body.cost_details.get("input_cost")
+        if body.cost_details.get("input_cost") is not None
+        else body.cost_details.get("input")
+        if body.cost_details.get("input") is not None
+        else body.cost_details.get("prompt")
+    )
+
+
+def _cost_output_usd(body: ChatCompletionsIngestRequest) -> float | None:
+    return (
+        body.cost_output_usd
+        if body.cost_output_usd is not None
+        else body.cost_details.get("output_cost")
+        if body.cost_details.get("output_cost") is not None
+        else body.cost_details.get("output")
+        if body.cost_details.get("output") is not None
+        else body.cost_details.get("completion")
+    )

--- a/services/intake/tests/integration/spans/test_chat_completions_ingest.py
+++ b/services/intake/tests/integration/spans/test_chat_completions_ingest.py
@@ -148,6 +148,18 @@ def test_chat_completions_ingest_persists_cost_fields(client: TestClient):
     assert Decimal(str(span["cost_details"]["cache_write"])) == Decimal("0.0002")
 
 
+def test_chat_completions_ingest_rejects_producer_cost_total_alias(client: TestClient):
+    body = {
+        "request": _openai_request(),
+        "response": _openai_response(id="chatcmpl-cost-total-alias"),
+        "session_id": "session-cost-total-alias",
+        "cost_total_usd": 0.0061,
+    }
+    response = client.post(INGEST_URL, json=body)
+
+    assert response.status_code == 422, response.text
+
+
 def test_chat_completions_ingest_accepts_anthropic_style_usage(client: TestClient):
     body = {
         "request": _openai_request(model="aws/anthropic/bedrock-claude-opus-4-7"),

--- a/services/intake/tests/integration/spans/test_chat_completions_ingest.py
+++ b/services/intake/tests/integration/spans/test_chat_completions_ingest.py
@@ -129,6 +129,9 @@ def test_chat_completions_ingest_persists_cost_fields(client: TestClient):
         "cost_input_usd": 0.0024,
         "cost_output_usd": 0.0037,
         "cost_details": {
+            "total": 0.99,
+            "input": 0.98,
+            "output": 0.97,
             "base_input": 0.0018,
             "cached_input": 0.0004,
             "cache_write": 0.0002,
@@ -160,11 +163,11 @@ def test_chat_completions_ingest_rejects_producer_cost_total_alias(client: TestC
     assert response.status_code == 422, response.text
 
 
-def test_chat_completions_ingest_accepts_anthropic_style_usage(client: TestClient):
+def test_chat_completions_ingest_uses_only_openai_usage_fields(client: TestClient):
     body = {
         "request": _openai_request(model="aws/anthropic/bedrock-claude-opus-4-7"),
         "response": _openai_response(
-            id="chatcmpl-claude-usage",
+            id="chatcmpl-openai-usage-only",
             model="aws/anthropic/bedrock-claude-opus-4-7",
             usage={
                 "input_tokens": 30,
@@ -174,20 +177,19 @@ def test_chat_completions_ingest_accepts_anthropic_style_usage(client: TestClien
                 "output_tokens_details": {"reasoning_tokens": 2},
             },
         ),
-        "session_id": "session-claude-usage",
+        "session_id": "session-openai-usage-only",
     }
     response = client.post(INGEST_URL, json=body)
     assert response.status_code == 201, response.text
 
-    listed = client.get(SPANS_URL, params={"filter[session_id]": "session-claude-usage"})
+    listed = client.get(SPANS_URL, params={"filter[session_id]": "session-openai-usage-only"})
     assert listed.status_code == 200, listed.text
     span = listed.json()["data"][0]
-    assert span["input_tokens"] == 30
-    assert span["output_tokens"] == 7
-    assert span["total_tokens"] == 37
-    assert span["cached_tokens"] == 5
-    assert span["usage_details"]["prompt_details.cache_write"] == 3
-    assert span["usage_details"]["completion_details.reasoning"] == 2
+    assert "input_tokens" not in span
+    assert "output_tokens" not in span
+    assert "total_tokens" not in span
+    assert "cached_tokens" not in span
+    assert span["usage_details"] == {}
 
 
 # ---------------------------------------------------------------------------

--- a/services/intake/tests/integration/spans/test_chat_completions_ingest.py
+++ b/services/intake/tests/integration/spans/test_chat_completions_ingest.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from typing import Any
 
 from fastapi.testclient import TestClient
@@ -117,6 +118,64 @@ def test_chat_completions_ingest_happy_path(client: TestClient):
     filtered_spans = filtered.json()["data"]
     assert len(filtered_spans) == 1
     assert filtered_spans[0]["span_id"] == "chatcmpl-test-abc123"
+
+
+def test_chat_completions_ingest_persists_cost_fields(client: TestClient):
+    body = {
+        "request": _openai_request(),
+        "response": _openai_response(id="chatcmpl-costs"),
+        "session_id": "session-costs",
+        "cost_usd": 0.0061,
+        "cost_input_usd": 0.0024,
+        "cost_output_usd": 0.0037,
+        "cost_details": {
+            "base_input": 0.0018,
+            "cached_input": 0.0004,
+            "cache_write": 0.0002,
+        },
+    }
+    response = client.post(INGEST_URL, json=body)
+    assert response.status_code == 201, response.text
+
+    listed = client.get(SPANS_URL, params={"filter[session_id]": "session-costs"})
+    assert listed.status_code == 200, listed.text
+    span = listed.json()["data"][0]
+    assert Decimal(str(span["cost_total_usd"])) == Decimal("0.0061")
+    assert Decimal(str(span["cost_input_usd"])) == Decimal("0.0024")
+    assert Decimal(str(span["cost_output_usd"])) == Decimal("0.0037")
+    assert Decimal(str(span["cost_details"]["base_input"])) == Decimal("0.0018")
+    assert Decimal(str(span["cost_details"]["cached_input"])) == Decimal("0.0004")
+    assert Decimal(str(span["cost_details"]["cache_write"])) == Decimal("0.0002")
+
+
+def test_chat_completions_ingest_accepts_anthropic_style_usage(client: TestClient):
+    body = {
+        "request": _openai_request(model="aws/anthropic/bedrock-claude-opus-4-7"),
+        "response": _openai_response(
+            id="chatcmpl-claude-usage",
+            model="aws/anthropic/bedrock-claude-opus-4-7",
+            usage={
+                "input_tokens": 30,
+                "output_tokens": 7,
+                "cache_read_input_tokens": 5,
+                "cache_creation_input_tokens": 3,
+                "output_tokens_details": {"reasoning_tokens": 2},
+            },
+        ),
+        "session_id": "session-claude-usage",
+    }
+    response = client.post(INGEST_URL, json=body)
+    assert response.status_code == 201, response.text
+
+    listed = client.get(SPANS_URL, params={"filter[session_id]": "session-claude-usage"})
+    assert listed.status_code == 200, listed.text
+    span = listed.json()["data"][0]
+    assert span["input_tokens"] == 30
+    assert span["output_tokens"] == 7
+    assert span["total_tokens"] == 37
+    assert span["cached_tokens"] == 5
+    assert span["usage_details"]["prompt_details.cache_write"] == 3
+    assert span["usage_details"]["completion_details.reasoning"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added estimated USD cost fields (total, input, output) and a normalized cost breakdown map; CLI options to submit them.
  * Cost fields are recorded on ingest spans for downstream tracking.

* **Bug Fixes / Validation**
  * Enforced non-negative values for all cost fields and reject deprecated producer alias fields.
  * Token counters now derive input/output totals from reported usage.

* **Tests**
  * Added integration tests for persistence, validation, and usage-shape handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->