### PR TITLE
fix(services): sweep orphaned child processes on `nemo services stop`

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/_process.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/_process.py
@@ -28,7 +28,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
@@ -322,6 +322,53 @@ def log_path_for(scope: str, *, base_dir: Path | None = None) -> Path:
 @dataclass
 class StopResult:
     stopped_pids: list[int]
+    swept_children: list[int] = field(default_factory=list)
+
+
+def _snapshot_children(pid: int) -> list[psutil.Process]:
+    """Return all descendant processes of *pid*.
+
+    Must be called while the parent is still alive; once it exits,
+    children are reparented to init and won't appear in the tree.
+    """
+    try:
+        return psutil.Process(pid).children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return []
+
+
+def _sweep_orphans(children: list[psutil.Process], timeout: float = 5.0) -> list[int]:
+    """Terminate any still-alive processes from a prior snapshot.
+
+    Sends SIGTERM, waits up to *timeout*, then SIGKILL survivors.
+    Returns PIDs that were signaled.  Handles ``NoSuchProcess`` gracefully
+    since children may have already exited during graceful shutdown.
+    """
+    alive_children = [c for c in children if c.is_running()]
+    if not alive_children:
+        return []
+
+    killed: list[int] = []
+    for child in alive_children:
+        try:
+            child.terminate()
+            killed.append(child.pid)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+    _, still_alive = psutil.wait_procs(alive_children, timeout=timeout)
+    for child in still_alive:
+        try:
+            child.kill()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+    if killed:
+        logger.info(
+            "Swept %d orphaned child %s: %s", len(killed), "process" if len(killed) == 1 else "processes", killed
+        )
+
+    return killed
 
 
 def stop_instance(
@@ -342,6 +389,8 @@ def stop_instance(
     stopped via Ctrl-C in their own terminal.  Pass *force=True* to override.
 
     Sends SIGTERM, waits up to *timeout* seconds, then escalates to SIGKILL.
+    After the parent exits, any surviving child processes (e.g. agent
+    deployments) are swept up via SIGTERM/SIGKILL.
     """
     desc = read_descriptor(scope, base_dir=base_dir)
     alive = is_instance_alive(scope, base_dir=base_dir)
@@ -361,6 +410,10 @@ def stop_instance(
         remove_descriptor(scope, base_dir=base_dir)
         return StopResult(stopped_pids=[])
 
+    # Snapshot child tree while parent is alive — children are reparented to
+    # init once the parent exits, making them invisible to psutil afterwards.
+    children = _snapshot_children(pid)
+
     try:
         os.kill(pid, signal.SIGTERM)
         logger.debug("Sent SIGTERM to pid %d", pid)
@@ -379,12 +432,16 @@ def stop_instance(
                 logger.debug("Sent SIGKILL to pid %d", pid)
             except PermissionError:
                 logger.warning("No permission to SIGKILL pid %d; process may still be running", pid)
-                return StopResult(stopped_pids=[])
+                swept = _sweep_orphans(children) if children else []
+                remove_descriptor(scope, base_dir=base_dir)
+                return StopResult(stopped_pids=[], swept_children=swept)
             except OSError:
                 logger.debug("Failed to send SIGKILL to pid %d", pid, exc_info=True)
 
+    swept = _sweep_orphans(children) if children else []
+
     remove_descriptor(scope, base_dir=base_dir)
-    return StopResult(stopped_pids=[pid])
+    return StopResult(stopped_pids=[pid], swept_children=swept)
 
 
 def _pid_alive(pid: int) -> bool:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/_process.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/_process.py
@@ -354,14 +354,14 @@ def _sweep_orphans(children: list[psutil.Process], timeout: float = 5.0) -> list
             child.terminate()
             killed.append(child.pid)
         except (psutil.NoSuchProcess, psutil.AccessDenied):
-            pass
+            pass  # Already exited or not owned by us — skip.
 
     _, still_alive = psutil.wait_procs(alive_children, timeout=timeout)
     for child in still_alive:
         try:
             child.kill()
         except (psutil.NoSuchProcess, psutil.AccessDenied):
-            pass
+            pass  # Raced with exit or not owned — nothing to do.
 
     if killed:
         logger.info(
@@ -433,7 +433,7 @@ def stop_instance(
             except PermissionError:
                 logger.warning("No permission to SIGKILL pid %d; process may still be running", pid)
                 swept = _sweep_orphans(children) if children else []
-                remove_descriptor(scope, base_dir=base_dir)
+                # Keep the descriptor so subsequent stop/restart can retry.
                 return StopResult(stopped_pids=[], swept_children=swept)
             except OSError:
                 logger.debug("Failed to send SIGKILL to pid %d", pid, exc_info=True)

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
@@ -409,7 +409,11 @@ def stop_services_cmd(
         typer.echo("Platform services are not running.")
         return
     pids_str = ", ".join(str(p) for p in result.stopped_pids)
-    typer.echo(f"Stopped platform services (pid {pids_str})")
+    msg = f"Stopped platform services (pid {pids_str})"
+    if result.swept_children:
+        n = len(result.swept_children)
+        msg += f" and {n} child {'process' if n == 1 else 'processes'}"
+    typer.echo(msg)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
@@ -412,7 +412,8 @@ def stop_services_cmd(
     msg = f"Stopped platform services (pid {pids_str})"
     if result.swept_children:
         n = len(result.swept_children)
-        msg += f" and {n} child {'process' if n == 1 else 'processes'}"
+        noun = "process" if n == 1 else "processes"
+        msg += f" and {n} child {noun}"
     typer.echo(msg)
 
 

--- a/packages/nemo_platform_ext/tests/cli/commands/test_services_process.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_services_process.py
@@ -565,16 +565,17 @@ def _wait_for_children(pid: int, timeout: float = 5.0) -> list[psutil.Process]:
     return []
 
 
+_SPAWN_CHILD_SCRIPT = (
+    "import subprocess, sys, time; "
+    "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
+    "time.sleep(60)"
+)
+
+
 class TestSnapshotChildren:
     def test_captures_child_processes(self) -> None:
         parent = subprocess.Popen(
-            [
-                sys.executable,
-                "-c",
-                "import subprocess, sys, time; "
-                "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
-                "time.sleep(60)",
-            ],
+            [sys.executable, "-c", _SPAWN_CHILD_SCRIPT],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -674,13 +675,7 @@ class TestStopInstanceChildSweep:
     def test_sweeps_surviving_children(self, base_dir: Path) -> None:
         """Parent + child spawned; stop should kill both and report the child."""
         parent = subprocess.Popen(
-            [
-                sys.executable,
-                "-c",
-                "import subprocess, sys, time; "
-                "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
-                "time.sleep(60)",
-            ],
+            [sys.executable, "-c", _SPAWN_CHILD_SCRIPT],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -711,7 +706,7 @@ class TestStopInstanceChildSweep:
                 for c in psutil.Process(parent.pid).children(recursive=True):
                     c.kill()
             except psutil.NoSuchProcess:
-                pass
+                pass  # Parent already exited — children cleaned up.
             if parent.poll() is None:
                 parent.kill()
                 parent.wait(timeout=5)
@@ -749,13 +744,7 @@ class TestStopInstanceChildSweep:
     def test_restart_path_sweeps_children(self, base_dir: Path) -> None:
         """The restart flow calls stop_instance(force=True); verify it sweeps children too."""
         parent = subprocess.Popen(
-            [
-                sys.executable,
-                "-c",
-                "import subprocess, sys, time; "
-                "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
-                "time.sleep(60)",
-            ],
+            [sys.executable, "-c", _SPAWN_CHILD_SCRIPT],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -788,7 +777,7 @@ class TestStopInstanceChildSweep:
                 for c in psutil.Process(parent.pid).children(recursive=True):
                     c.kill()
             except psutil.NoSuchProcess:
-                pass
+                pass  # Parent already exited — children cleaned up.
             if parent.poll() is None:
                 parent.kill()
                 parent.wait(timeout=5)

--- a/packages/nemo_platform_ext/tests/cli/commands/test_services_process.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_services_process.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -17,6 +18,9 @@ from nemo_platform_ext.cli.commands.services._process import (
     ForegroundInstanceError,
     InstanceAlreadyRunningError,
     InstanceDescriptor,
+    _pid_alive,
+    _snapshot_children,
+    _sweep_orphans,
     acquire_lock,
     compute_scope,
     instance_dir,
@@ -540,3 +544,251 @@ class TestStartBackground:
             start_background(scope="mode-test", base_dir=base_dir)
 
         assert captured_env.get("_NMP_LAUNCH_MODE") == "background"
+
+
+# ---------------------------------------------------------------------------
+# _snapshot_children / _sweep_orphans
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_children(pid: int, timeout: float = 5.0) -> list[psutil.Process]:
+    """Poll until *pid* has at least one child process, or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            children = psutil.Process(pid).children(recursive=True)
+            if children:
+                return children
+        except psutil.NoSuchProcess:
+            break
+        time.sleep(0.1)
+    return []
+
+
+class TestSnapshotChildren:
+    def test_captures_child_processes(self) -> None:
+        parent = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import subprocess, sys, time; "
+                "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
+                "time.sleep(60)",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            _wait_for_children(parent.pid)
+            children = _snapshot_children(parent.pid)
+            assert len(children) >= 1
+            child_pids = [c.pid for c in children]
+            assert all(isinstance(p, int) for p in child_pids)
+        finally:
+            for c in psutil.Process(parent.pid).children(recursive=True):
+                c.kill()
+            parent.kill()
+            parent.wait(timeout=5)
+
+    def test_returns_empty_for_dead_pid(self) -> None:
+        assert _snapshot_children(999999999) == []
+
+    def test_returns_empty_for_process_with_no_children(self) -> None:
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            children = _snapshot_children(proc.pid)
+            assert children == []
+        finally:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+class TestSweepOrphans:
+    def test_terminates_surviving_children(self) -> None:
+        procs = []
+        for _ in range(3):
+            p = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(60)"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            procs.append(p)
+        try:
+            ps_children = [psutil.Process(p.pid) for p in procs]
+            killed = _sweep_orphans(ps_children, timeout=3.0)
+            assert len(killed) == 3
+            for p in procs:
+                p.wait(timeout=5)
+                assert p.poll() is not None
+        finally:
+            for p in procs:
+                if p.poll() is None:
+                    p.kill()
+                    p.wait(timeout=5)
+
+    def test_noop_when_all_already_exited(self) -> None:
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        ps_child = psutil.Process(proc.pid)
+        proc.kill()
+        proc.wait(timeout=5)
+        killed = _sweep_orphans([ps_child], timeout=1.0)
+        assert killed == []
+
+    def test_escalates_to_sigkill(self) -> None:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            time.sleep(0.3)
+            ps_child = psutil.Process(proc.pid)
+            killed = _sweep_orphans([ps_child], timeout=2.0)
+            assert proc.pid in killed
+            proc.wait(timeout=5)
+            assert proc.poll() is not None
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# stop_instance — child sweep integration
+# ---------------------------------------------------------------------------
+
+
+class TestStopInstanceChildSweep:
+    def test_sweeps_surviving_children(self, base_dir: Path) -> None:
+        """Parent + child spawned; stop should kill both and report the child."""
+        parent = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import subprocess, sys, time; "
+                "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
+                "time.sleep(60)",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            _wait_for_children(parent.pid)
+
+            scope = "sweep-test"
+            fd = acquire_lock(scope, base_dir=base_dir)
+            desc = InstanceDescriptor(
+                pid=parent.pid,
+                scope=scope,
+                host="127.0.0.1",
+                port=8080,
+                mode="background",
+                create_time=psutil.Process(parent.pid).create_time(),
+            )
+            write_descriptor(desc, base_dir=base_dir)
+            os.close(fd)
+
+            result = stop_instance(scope, base_dir=base_dir, timeout=5.0)
+            assert parent.pid in result.stopped_pids
+            assert len(result.swept_children) >= 1
+            for child_pid in result.swept_children:
+                assert not _pid_alive(child_pid)
+            parent.wait(timeout=5)
+        finally:
+            try:
+                for c in psutil.Process(parent.pid).children(recursive=True):
+                    c.kill()
+            except psutil.NoSuchProcess:
+                pass
+            if parent.poll() is None:
+                parent.kill()
+                parent.wait(timeout=5)
+
+    def test_swept_children_empty_when_no_children(self, base_dir: Path) -> None:
+        """Process with no children -- swept_children should be empty."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            scope = "clean-stop"
+            fd = acquire_lock(scope, base_dir=base_dir)
+            desc = InstanceDescriptor(
+                pid=proc.pid,
+                scope=scope,
+                host="127.0.0.1",
+                port=8080,
+                mode="background",
+                create_time=psutil.Process(proc.pid).create_time(),
+            )
+            write_descriptor(desc, base_dir=base_dir)
+            os.close(fd)
+
+            result = stop_instance(scope, base_dir=base_dir, timeout=5.0)
+            assert proc.pid in result.stopped_pids
+            assert result.swept_children == []
+            proc.wait(timeout=5)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_restart_path_sweeps_children(self, base_dir: Path) -> None:
+        """The restart flow calls stop_instance(force=True); verify it sweeps children too."""
+        parent = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import subprocess, sys, time; "
+                "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
+                "time.sleep(60)",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            _wait_for_children(parent.pid)
+            child_pids_before = [c.pid for c in psutil.Process(parent.pid).children(recursive=True)]
+            assert len(child_pids_before) >= 1
+
+            scope = "restart-sweep"
+            fd = acquire_lock(scope, base_dir=base_dir)
+            desc = InstanceDescriptor(
+                pid=parent.pid,
+                scope=scope,
+                host="127.0.0.1",
+                port=8080,
+                mode="foreground",
+                create_time=psutil.Process(parent.pid).create_time(),
+            )
+            write_descriptor(desc, base_dir=base_dir)
+            os.close(fd)
+
+            result = stop_instance(scope, base_dir=base_dir, force=True, timeout=5.0)
+            assert parent.pid in result.stopped_pids
+            assert len(result.swept_children) >= 1
+            for child_pid in result.swept_children:
+                assert not _pid_alive(child_pid)
+            parent.wait(timeout=5)
+        finally:
+            try:
+                for c in psutil.Process(parent.pid).children(recursive=True):
+                    c.kill()
+            except psutil.NoSuchProcess:
+                pass
+            if parent.poll() is None:
+                parent.kill()
+                parent.wait(timeout=5)

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/_process.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/_process.py
@@ -28,7 +28,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
@@ -322,6 +322,53 @@ def log_path_for(scope: str, *, base_dir: Path | None = None) -> Path:
 @dataclass
 class StopResult:
     stopped_pids: list[int]
+    swept_children: list[int] = field(default_factory=list)
+
+
+def _snapshot_children(pid: int) -> list[psutil.Process]:
+    """Return all descendant processes of *pid*.
+
+    Must be called while the parent is still alive; once it exits,
+    children are reparented to init and won't appear in the tree.
+    """
+    try:
+        return psutil.Process(pid).children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return []
+
+
+def _sweep_orphans(children: list[psutil.Process], timeout: float = 5.0) -> list[int]:
+    """Terminate any still-alive processes from a prior snapshot.
+
+    Sends SIGTERM, waits up to *timeout*, then SIGKILL survivors.
+    Returns PIDs that were signaled.  Handles ``NoSuchProcess`` gracefully
+    since children may have already exited during graceful shutdown.
+    """
+    alive_children = [c for c in children if c.is_running()]
+    if not alive_children:
+        return []
+
+    killed: list[int] = []
+    for child in alive_children:
+        try:
+            child.terminate()
+            killed.append(child.pid)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+    _, still_alive = psutil.wait_procs(alive_children, timeout=timeout)
+    for child in still_alive:
+        try:
+            child.kill()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+    if killed:
+        logger.info(
+            "Swept %d orphaned child %s: %s", len(killed), "process" if len(killed) == 1 else "processes", killed
+        )
+
+    return killed
 
 
 def stop_instance(
@@ -342,6 +389,8 @@ def stop_instance(
     stopped via Ctrl-C in their own terminal.  Pass *force=True* to override.
 
     Sends SIGTERM, waits up to *timeout* seconds, then escalates to SIGKILL.
+    After the parent exits, any surviving child processes (e.g. agent
+    deployments) are swept up via SIGTERM/SIGKILL.
     """
     desc = read_descriptor(scope, base_dir=base_dir)
     alive = is_instance_alive(scope, base_dir=base_dir)
@@ -361,6 +410,10 @@ def stop_instance(
         remove_descriptor(scope, base_dir=base_dir)
         return StopResult(stopped_pids=[])
 
+    # Snapshot child tree while parent is alive — children are reparented to
+    # init once the parent exits, making them invisible to psutil afterwards.
+    children = _snapshot_children(pid)
+
     try:
         os.kill(pid, signal.SIGTERM)
         logger.debug("Sent SIGTERM to pid %d", pid)
@@ -379,12 +432,16 @@ def stop_instance(
                 logger.debug("Sent SIGKILL to pid %d", pid)
             except PermissionError:
                 logger.warning("No permission to SIGKILL pid %d; process may still be running", pid)
-                return StopResult(stopped_pids=[])
+                swept = _sweep_orphans(children) if children else []
+                remove_descriptor(scope, base_dir=base_dir)
+                return StopResult(stopped_pids=[], swept_children=swept)
             except OSError:
                 logger.debug("Failed to send SIGKILL to pid %d", pid, exc_info=True)
 
+    swept = _sweep_orphans(children) if children else []
+
     remove_descriptor(scope, base_dir=base_dir)
-    return StopResult(stopped_pids=[pid])
+    return StopResult(stopped_pids=[pid], swept_children=swept)
 
 
 def _pid_alive(pid: int) -> bool:

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/_process.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/_process.py
@@ -354,14 +354,14 @@ def _sweep_orphans(children: list[psutil.Process], timeout: float = 5.0) -> list
             child.terminate()
             killed.append(child.pid)
         except (psutil.NoSuchProcess, psutil.AccessDenied):
-            pass
+            pass  # Already exited or not owned by us — skip.
 
     _, still_alive = psutil.wait_procs(alive_children, timeout=timeout)
     for child in still_alive:
         try:
             child.kill()
         except (psutil.NoSuchProcess, psutil.AccessDenied):
-            pass
+            pass  # Raced with exit or not owned — nothing to do.
 
     if killed:
         logger.info(
@@ -433,7 +433,7 @@ def stop_instance(
             except PermissionError:
                 logger.warning("No permission to SIGKILL pid %d; process may still be running", pid)
                 swept = _sweep_orphans(children) if children else []
-                remove_descriptor(scope, base_dir=base_dir)
+                # Keep the descriptor so subsequent stop/restart can retry.
                 return StopResult(stopped_pids=[], swept_children=swept)
             except OSError:
                 logger.debug("Failed to send SIGKILL to pid %d", pid, exc_info=True)

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
@@ -409,7 +409,11 @@ def stop_services_cmd(
         typer.echo("Platform services are not running.")
         return
     pids_str = ", ".join(str(p) for p in result.stopped_pids)
-    typer.echo(f"Stopped platform services (pid {pids_str})")
+    msg = f"Stopped platform services (pid {pids_str})"
+    if result.swept_children:
+        n = len(result.swept_children)
+        msg += f" and {n} child {'process' if n == 1 else 'processes'}"
+    typer.echo(msg)
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
@@ -412,7 +412,8 @@ def stop_services_cmd(
     msg = f"Stopped platform services (pid {pids_str})"
     if result.swept_children:
         n = len(result.swept_children)
-        msg += f" and {n} child {'process' if n == 1 else 'processes'}"
+        noun = "process" if n == 1 else "processes"
+        msg += f" and {n} child {noun}"
     typer.echo(msg)
 
 

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_process.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_process.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -17,6 +18,9 @@ from nemo_platform.cli.commands.services._process import (
     ForegroundInstanceError,
     InstanceAlreadyRunningError,
     InstanceDescriptor,
+    _pid_alive,
+    _snapshot_children,
+    _sweep_orphans,
     acquire_lock,
     compute_scope,
     instance_dir,
@@ -540,3 +544,240 @@ class TestStartBackground:
             start_background(scope="mode-test", base_dir=base_dir)
 
         assert captured_env.get("_NMP_LAUNCH_MODE") == "background"
+
+
+# ---------------------------------------------------------------------------
+# _snapshot_children / _sweep_orphans
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_children(pid: int, timeout: float = 5.0) -> list[psutil.Process]:
+    """Poll until *pid* has at least one child process, or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            children = psutil.Process(pid).children(recursive=True)
+            if children:
+                return children
+        except psutil.NoSuchProcess:
+            break
+        time.sleep(0.1)
+    return []
+
+
+_SPAWN_CHILD_SCRIPT = (
+    "import subprocess, sys, time; "
+    "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
+    "time.sleep(60)"
+)
+
+
+class TestSnapshotChildren:
+    def test_captures_child_processes(self) -> None:
+        parent = subprocess.Popen(
+            [sys.executable, "-c", _SPAWN_CHILD_SCRIPT],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            _wait_for_children(parent.pid)
+            children = _snapshot_children(parent.pid)
+            assert len(children) >= 1
+            child_pids = [c.pid for c in children]
+            assert all(isinstance(p, int) for p in child_pids)
+        finally:
+            for c in psutil.Process(parent.pid).children(recursive=True):
+                c.kill()
+            parent.kill()
+            parent.wait(timeout=5)
+
+    def test_returns_empty_for_dead_pid(self) -> None:
+        assert _snapshot_children(999999999) == []
+
+    def test_returns_empty_for_process_with_no_children(self) -> None:
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            children = _snapshot_children(proc.pid)
+            assert children == []
+        finally:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+class TestSweepOrphans:
+    def test_terminates_surviving_children(self) -> None:
+        procs = []
+        for _ in range(3):
+            p = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(60)"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            procs.append(p)
+        try:
+            ps_children = [psutil.Process(p.pid) for p in procs]
+            killed = _sweep_orphans(ps_children, timeout=3.0)
+            assert len(killed) == 3
+            for p in procs:
+                p.wait(timeout=5)
+                assert p.poll() is not None
+        finally:
+            for p in procs:
+                if p.poll() is None:
+                    p.kill()
+                    p.wait(timeout=5)
+
+    def test_noop_when_all_already_exited(self) -> None:
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        ps_child = psutil.Process(proc.pid)
+        proc.kill()
+        proc.wait(timeout=5)
+        killed = _sweep_orphans([ps_child], timeout=1.0)
+        assert killed == []
+
+    def test_escalates_to_sigkill(self) -> None:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            time.sleep(0.3)
+            ps_child = psutil.Process(proc.pid)
+            killed = _sweep_orphans([ps_child], timeout=2.0)
+            assert proc.pid in killed
+            proc.wait(timeout=5)
+            assert proc.poll() is not None
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# stop_instance — child sweep integration
+# ---------------------------------------------------------------------------
+
+
+class TestStopInstanceChildSweep:
+    def test_sweeps_surviving_children(self, base_dir: Path) -> None:
+        """Parent + child spawned; stop should kill both and report the child."""
+        parent = subprocess.Popen(
+            [sys.executable, "-c", _SPAWN_CHILD_SCRIPT],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            _wait_for_children(parent.pid)
+
+            scope = "sweep-test"
+            fd = acquire_lock(scope, base_dir=base_dir)
+            desc = InstanceDescriptor(
+                pid=parent.pid,
+                scope=scope,
+                host="127.0.0.1",
+                port=8080,
+                mode="background",
+                create_time=psutil.Process(parent.pid).create_time(),
+            )
+            write_descriptor(desc, base_dir=base_dir)
+            os.close(fd)
+
+            result = stop_instance(scope, base_dir=base_dir, timeout=5.0)
+            assert parent.pid in result.stopped_pids
+            assert len(result.swept_children) >= 1
+            for child_pid in result.swept_children:
+                assert not _pid_alive(child_pid)
+            parent.wait(timeout=5)
+        finally:
+            try:
+                for c in psutil.Process(parent.pid).children(recursive=True):
+                    c.kill()
+            except psutil.NoSuchProcess:
+                pass  # Parent already exited — children cleaned up.
+            if parent.poll() is None:
+                parent.kill()
+                parent.wait(timeout=5)
+
+    def test_swept_children_empty_when_no_children(self, base_dir: Path) -> None:
+        """Process with no children -- swept_children should be empty."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            scope = "clean-stop"
+            fd = acquire_lock(scope, base_dir=base_dir)
+            desc = InstanceDescriptor(
+                pid=proc.pid,
+                scope=scope,
+                host="127.0.0.1",
+                port=8080,
+                mode="background",
+                create_time=psutil.Process(proc.pid).create_time(),
+            )
+            write_descriptor(desc, base_dir=base_dir)
+            os.close(fd)
+
+            result = stop_instance(scope, base_dir=base_dir, timeout=5.0)
+            assert proc.pid in result.stopped_pids
+            assert result.swept_children == []
+            proc.wait(timeout=5)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_restart_path_sweeps_children(self, base_dir: Path) -> None:
+        """The restart flow calls stop_instance(force=True); verify it sweeps children too."""
+        parent = subprocess.Popen(
+            [sys.executable, "-c", _SPAWN_CHILD_SCRIPT],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            _wait_for_children(parent.pid)
+            child_pids_before = [c.pid for c in psutil.Process(parent.pid).children(recursive=True)]
+            assert len(child_pids_before) >= 1
+
+            scope = "restart-sweep"
+            fd = acquire_lock(scope, base_dir=base_dir)
+            desc = InstanceDescriptor(
+                pid=parent.pid,
+                scope=scope,
+                host="127.0.0.1",
+                port=8080,
+                mode="foreground",
+                create_time=psutil.Process(parent.pid).create_time(),
+            )
+            write_descriptor(desc, base_dir=base_dir)
+            os.close(fd)
+
+            result = stop_instance(scope, base_dir=base_dir, force=True, timeout=5.0)
+            assert parent.pid in result.stopped_pids
+            assert len(result.swept_children) >= 1
+            for child_pid in result.swept_children:
+                assert not _pid_alive(child_pid)
+            parent.wait(timeout=5)
+        finally:
+            try:
+                for c in psutil.Process(parent.pid).children(recursive=True):
+                    c.kill()
+            except psutil.NoSuchProcess:
+                pass  # Parent already exited — children cleaned up.
+            if parent.poll() is None:
+                parent.kill()
+                parent.wait(timeout=5)


### PR DESCRIPTION
## Summary

- `nemo services stop` only killed the platform PID, leaving agent deployment subprocesses (`nat start fastapi`) alive across stop/start cycles — potentially causing OOM
- Added `_snapshot_children()` / `_sweep_orphans()` helpers that capture the child process tree before SIGTERM and sweep survivors after the parent exits
- Graceful shutdown still gets first shot; the psutil-based sweep is a belt-and-suspenders safety net
- Updated CLI output to report swept child count separately

## Test plan

- [x] Unit tests for `_snapshot_children()` (live children, dead PID, childless process)
- [x] Unit tests for `_sweep_orphans()` (surviving children, already-exited children, SIGKILL escalation)
- [x] Integration tests for `stop_instance()` (swept children populated vs empty on clean shutdown)
- [x] All 46 tests pass
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass
- [x] Vendored SDK copy in sync

Closes AIRCORE-675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stop operations now report how many orphaned child processes were swept and include those PIDs in results.

* **Bug Fixes**
  * Improved cleanup of orphaned child processes during stop flows; sweeping runs reliably after stop attempts.

* **Tests**
  * Added tests covering snapshotting, sweeping of child processes, and stop behavior including swept-child reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->