### PR TITLE
feat(build): Add CI test that builds+tests the wheels

### DIFF
--- a/.github/actions/build-nemo-platform-wheel/action.yaml
+++ b/.github/actions/build-nemo-platform-wheel/action.yaml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: nemo-platform
   out-dir:
-    description: Absolute path where the wheel is written. Must be absolute.
+    description: Absolute path where the wheel is written.
     required: true
   cadence:
     description: >
@@ -72,6 +72,43 @@ runs:
         version-file: ${{ inputs.source-root }}/pyproject.toml
         cache-dependency-glob: ${{ inputs.source-root }}/uv.lock
 
+    # Stamp early, before pnpm/node setup, so bad cadence/label/timestamp
+    # inputs fail fast instead of after spending ~20s on tool setup. The
+    # version is written into packages/nmp_common/.../version.py and the
+    # generated _version.py before `uv build` runs (hatchling reads
+    # version.py via its regex source but does not write it). The
+    # --print-version flag emits just the resolved version on stdout;
+    # the human banner goes to stderr.
+    - name: Stamp SDK version
+      id: stamp
+      shell: bash
+      env:
+        SOURCE_ROOT: ${{ inputs.source-root }}
+        PACKAGE: ${{ inputs.package }}
+        CADENCE: ${{ inputs.cadence }}
+        RELEASE_LABEL: ${{ inputs.release-label }}
+        NIGHTLY_TIMESTAMP: ${{ inputs.nightly-timestamp }}
+        # Run the stamp script from the action's own checkout (the workflow
+        # ref), not from inputs.source-root. For ci.yaml these are the same;
+        # for release-bundle.yaml the source checkout can be at an older
+        # source_sha (RC/stable rerun of an old tag) and we want today's
+        # stamping logic to apply.
+        STAMP_SCRIPT_PATH: ${{ github.action_path }}/../../scripts/stamp_sdk_version.py
+      run: |
+        set -euo pipefail
+        args=(
+          --source-root "${SOURCE_ROOT}"
+          --sdk-id "${PACKAGE}"
+          --cadence "${CADENCE}"
+          --nightly-timestamp "${NIGHTLY_TIMESTAMP}"
+          --print-version
+        )
+        if [[ -n "${RELEASE_LABEL}" ]]; then
+          args+=(--release-label "${RELEASE_LABEL}")
+        fi
+        wheel_version="$(uv run --no-project python "${STAMP_SCRIPT_PATH}" "${args[@]}")"
+        echo "wheel-version=${wheel_version}" >>"${GITHUB_OUTPUT}"
+
     # Studio assets are only force-included by the nemo-platform wrapper.
     # The hatch hook in packages/nemo-platform/hatch_build.py compiles them
     # via pnpm during `uv build`; we set up pnpm/node here so the hook can
@@ -90,52 +127,13 @@ runs:
         cache: pnpm
         cache-dependency-path: ${{ inputs.source-root }}/web/pnpm-lock.yaml
 
-    # Stamp the version into packages/nmp_common/.../version.py and the
-    # generated _version.py before `uv build` runs (hatchling reads
-    # version.py via its regex source but does not write it). The
-    # --print-version flag emits just the resolved version on stdout;
-    # the human banner goes to stderr.
-    - name: Stamp SDK version
-      id: stamp
-      shell: bash
-      env:
-        SOURCE_ROOT: ${{ inputs.source-root }}
-        SDK_ID: ${{ inputs.package }}
-        CADENCE: ${{ inputs.cadence }}
-        RELEASE_LABEL: ${{ inputs.release-label }}
-        NIGHTLY_TIMESTAMP: ${{ inputs.nightly-timestamp }}
-        # Run the stamp script from the action's own checkout (the workflow
-        # ref), not from inputs.source-root. For ci.yaml these are the same;
-        # for release-bundle.yaml the source checkout can be at an older
-        # source_sha (RC/stable rerun of an old tag) and we want today's
-        # stamping logic to apply.
-        STAMP_SCRIPT: ${{ github.action_path }}/../../scripts/stamp_sdk_version.py
-      run: |
-        set -euo pipefail
-        args=(
-          --source-root "${SOURCE_ROOT}"
-          --sdk-id "${SDK_ID}"
-          --cadence "${CADENCE}"
-          --nightly-timestamp "${NIGHTLY_TIMESTAMP}"
-          --print-version
-        )
-        if [[ -n "${RELEASE_LABEL}" ]]; then
-          args+=(--release-label "${RELEASE_LABEL}")
-        fi
-        wheel_version="$(uv run --no-project python "${STAMP_SCRIPT}" "${args[@]}")"
-        if [[ -z "${wheel_version}" ]]; then
-          echo "::error::stamp_sdk_version.py produced empty output" >&2
-          exit 1
-        fi
-        echo "wheel-version=${wheel_version}" >>"${GITHUB_OUTPUT}"
-
     - name: Build wheel
       id: build
       shell: bash
       env:
         SOURCE_ROOT: ${{ inputs.source-root }}
         OUT_DIR: ${{ inputs.out-dir }}
-        SDK_ID: ${{ inputs.package }}
+        PACKAGE: ${{ inputs.package }}
       run: |
         set -euo pipefail
         if [[ "${OUT_DIR}" != /* ]]; then
@@ -145,13 +143,13 @@ runs:
 
         uv build --wheel \
           --directory "${SOURCE_ROOT}" \
-          --package "${SDK_ID}" \
+          --package "${PACKAGE}" \
           --out-dir "${OUT_DIR}"
 
         shopt -s nullglob
         wheels=("${OUT_DIR}"/*.whl)
         if [[ "${#wheels[@]}" -ne 1 ]]; then
-          echo "::error::expected exactly one wheel for ${SDK_ID}, found ${#wheels[@]}" >&2
+          echo "::error::expected exactly one wheel for ${PACKAGE}, found ${#wheels[@]}" >&2
           printf '  %s\n' "${wheels[@]}" >&2
           exit 1
         fi

--- a/.github/actions/build-nemo-platform-wheel/action.yaml
+++ b/.github/actions/build-nemo-platform-wheel/action.yaml
@@ -1,0 +1,158 @@
+name: Build nemo-platform wheel
+description: >
+  Set up the build toolchain (uv, plus pnpm/node when building nemo-platform
+  so the hatch hook can compile Studio assets), stamp the SDK version, and
+  run `uv build --wheel --package <pkg>`. The build itself — including
+  Studio asset compilation and wheel content force-includes — lives in the
+  package's hatch_build.py; this action only handles environment setup,
+  the pre-build version stamp, and capturing the produced wheel.
+
+  Both ci.yaml's wheel-test job and release-bundle.yaml's build-sdks matrix
+  call this action so the test wheel and the published wheel come out of
+  one code path.
+
+  Assumes the repository has already been checked out to `inputs.source-root`
+  and that any required runtime assets (e.g. policy.wasm via the
+  build-policy-wasm action) already exist on disk.
+
+inputs:
+  package:
+    description: >
+      Distribution name passed to `uv build --package`. Must match a workspace
+      package such as `nemo-platform` or `nemo-platform-plugin`.
+    required: false
+    default: nemo-platform
+  out-dir:
+    description: Absolute path where the wheel is written. Must be absolute.
+    required: true
+  cadence:
+    description: >
+      Forwarded to stamp_sdk_version.py. One of `nightly`, `rc`, `release`.
+    required: false
+    default: nightly
+  release-label:
+    description: >
+      Forwarded to stamp_sdk_version.py. Required for `cadence: rc` (e.g.
+      `1.0.0-rc0`) or `cadence: release` (e.g. `1.0.0`); ignored for `nightly`.
+    required: false
+    default: ""
+  nightly-timestamp:
+    description: >
+      Forwarded to stamp_sdk_version.py. Required for `cadence: nightly`. Must
+      be exactly 14 digits in `YYYYMMDDHHMMSS` form.
+    required: false
+    default: "19700101000000"
+  python-version:
+    description: Python version for setup-uv.
+    required: false
+    default: "3.11"
+  source-root:
+    description: >
+      Path to the checked-out repository. release-bundle.yaml uses `source`;
+      the ci.yaml test job uses `.`.
+    required: false
+    default: "."
+
+outputs:
+  wheel-path:
+    description: Absolute path to the single wheel produced by `uv build`.
+    value: ${{ steps.build.outputs.wheel-path }}
+  wheel-version:
+    description: Resolved version string written into the wheel metadata.
+    value: ${{ steps.stamp.outputs.wheel-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: ${{ inputs.python-version }}
+        enable-cache: true
+        version-file: ${{ inputs.source-root }}/pyproject.toml
+        cache-dependency-glob: ${{ inputs.source-root }}/uv.lock
+
+    # Studio assets are only force-included by the nemo-platform wrapper.
+    # The hatch hook in packages/nemo-platform/hatch_build.py compiles them
+    # via pnpm during `uv build`; we set up pnpm/node here so the hook can
+    # find them. Other packages (nemo-platform-plugin, ...) skip these.
+    - name: Set up pnpm
+      if: inputs.package == 'nemo-platform'
+      uses: pnpm/action-setup@v4
+      with:
+        package_json_file: ${{ inputs.source-root }}/web/package.json
+
+    - name: Set up Node.js
+      if: inputs.package == 'nemo-platform'
+      uses: actions/setup-node@v4
+      with:
+        node-version: "22"
+        cache: pnpm
+        cache-dependency-path: ${{ inputs.source-root }}/web/pnpm-lock.yaml
+
+    # Stamp the version into packages/nmp_common/.../version.py and the
+    # generated _version.py before `uv build` runs (hatchling reads
+    # version.py via its regex source but does not write it). The
+    # --print-version flag emits just the resolved version on stdout;
+    # the human banner goes to stderr.
+    - name: Stamp SDK version
+      id: stamp
+      shell: bash
+      env:
+        SOURCE_ROOT: ${{ inputs.source-root }}
+        SDK_ID: ${{ inputs.package }}
+        CADENCE: ${{ inputs.cadence }}
+        RELEASE_LABEL: ${{ inputs.release-label }}
+        NIGHTLY_TIMESTAMP: ${{ inputs.nightly-timestamp }}
+        # Run the stamp script from the action's own checkout (the workflow
+        # ref), not from inputs.source-root. For ci.yaml these are the same;
+        # for release-bundle.yaml the source checkout can be at an older
+        # source_sha (RC/stable rerun of an old tag) and we want today's
+        # stamping logic to apply.
+        STAMP_SCRIPT: ${{ github.action_path }}/../../scripts/stamp_sdk_version.py
+      run: |
+        set -euo pipefail
+        args=(
+          --source-root "${SOURCE_ROOT}"
+          --sdk-id "${SDK_ID}"
+          --cadence "${CADENCE}"
+          --nightly-timestamp "${NIGHTLY_TIMESTAMP}"
+          --print-version
+        )
+        if [[ -n "${RELEASE_LABEL}" ]]; then
+          args+=(--release-label "${RELEASE_LABEL}")
+        fi
+        wheel_version="$(uv run --no-project python "${STAMP_SCRIPT}" "${args[@]}")"
+        if [[ -z "${wheel_version}" ]]; then
+          echo "::error::stamp_sdk_version.py produced empty output" >&2
+          exit 1
+        fi
+        echo "wheel-version=${wheel_version}" >>"${GITHUB_OUTPUT}"
+
+    - name: Build wheel
+      id: build
+      shell: bash
+      env:
+        SOURCE_ROOT: ${{ inputs.source-root }}
+        OUT_DIR: ${{ inputs.out-dir }}
+        SDK_ID: ${{ inputs.package }}
+      run: |
+        set -euo pipefail
+        if [[ "${OUT_DIR}" != /* ]]; then
+          echo "::error::out-dir must be absolute, got: '${OUT_DIR}'" >&2
+          exit 1
+        fi
+
+        uv build --wheel \
+          --directory "${SOURCE_ROOT}" \
+          --package "${SDK_ID}" \
+          --out-dir "${OUT_DIR}"
+
+        shopt -s nullglob
+        wheels=("${OUT_DIR}"/*.whl)
+        if [[ "${#wheels[@]}" -ne 1 ]]; then
+          echo "::error::expected exactly one wheel for ${SDK_ID}, found ${#wheels[@]}" >&2
+          printf '  %s\n' "${wheels[@]}" >&2
+          exit 1
+        fi
+        echo "wheel-path=${wheels[0]}" >>"${GITHUB_OUTPUT}"

--- a/.github/scripts/stamp_sdk_version.py
+++ b/.github/scripts/stamp_sdk_version.py
@@ -110,8 +110,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--source-root", required=True, type=Path)
     parser.add_argument("--sdk-id", required=True)
     parser.add_argument("--cadence", required=True, choices=["nightly", "rc", "release"])
-    parser.add_argument("--release-label", required=True)
+    # --release-label is unused for cadence=nightly; cadence-specific validation
+    # in resolve_sdk_version() rejects empty/missing labels for rc and release.
+    parser.add_argument("--release-label", default="")
     parser.add_argument("--nightly-timestamp", default="")
+    parser.add_argument(
+        "--print-version",
+        action="store_true",
+        help="Print only the resolved version to stdout (and the human banner to stderr) "
+        "for machine-readable consumption.",
+    )
     return parser.parse_args(argv)
 
 
@@ -129,7 +137,12 @@ def main(argv: list[str]) -> int:
         print(error, file=sys.stderr)
         return 1
 
-    print(f"Stamped sdk:{args.sdk_id} version {sdk_version}.")
+    if args.print_version:
+        # Machine-readable mode: human banner to stderr, just the version on stdout.
+        print(f"Stamped sdk:{args.sdk_id} version {sdk_version}.", file=sys.stderr)
+        print(sdk_version)
+    else:
+        print(f"Stamped sdk:{args.sdk_id} version {sdk_version}.")
     return 0
 
 

--- a/.github/scripts/stamp_sdk_version.py
+++ b/.github/scripts/stamp_sdk_version.py
@@ -117,8 +117,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--print-version",
         action="store_true",
-        help="Print only the resolved version to stdout (and the human banner to stderr) "
-        "for machine-readable consumption.",
+        help="Print only the resolved version on stdout; send the human banner to stderr.",
     )
     return parser.parse_args(argv)
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,6 +202,118 @@ jobs:
             coverage.xml
             coverage.json
 
+  # nemo-platform's wheel force-includes auth's policy.wasm at build time;
+  # nemo-platform-plugin doesn't, but plugin rows still wait on policy-wasm
+  # because needs: is per-job. ~5s of harmless wait per plugin row.
+  wheel-test:
+    name: ${{ matrix.package }} wheel build + test (py${{ matrix.python-version }})
+    needs: [policy-wasm]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [nemo-platform, nemo-platform-plugin]
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Download policy WASM
+        if: matrix.package == 'nemo-platform'
+        uses: actions/download-artifact@v8
+        with:
+          name: policy-wasm
+          path: services/core/auth/src/nmp/core/auth/assets
+      - name: Build ${{ matrix.package }} wheel
+        id: build
+        uses: ./.github/actions/build-nemo-platform-wheel
+        with:
+          package: ${{ matrix.package }}
+          out-dir: ${{ github.workspace }}/dist
+          cadence: nightly
+          # Sentinel epoch — the wheel version is meaningless for a CI test
+          # build, but stamp_sdk_version.py requires \d{14}.
+          nightly-timestamp: "19700101000000"
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install + test nemo-platform CLI
+        if: matrix.package == 'nemo-platform'
+        shell: bash
+        env:
+          WHEEL: ${{ steps.build.outputs.wheel-path }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+          NMP_DATA_DIR: ${{ runner.temp }}/nemo-data
+        run: |
+          set -euo pipefail
+          # Copy the wheel out of $GITHUB_WORKSPACE so the test cd's away
+          # from the source tree and Python can't reach back into it.
+          mkdir -p "${RUNNER_TEMP}/wheelcheck"
+          cp "${WHEEL}" "${RUNNER_TEMP}/wheelcheck/"
+          uv tool install --force --python "${PYTHON_VERSION}" \
+            "${RUNNER_TEMP}/wheelcheck/$(basename "${WHEEL}")[services]"
+          cd "${RUNNER_TEMP}/wheelcheck"
+          unset PYTHONPATH VIRTUAL_ENV
+          bash "${GITHUB_WORKSPACE}/script/test-nemo-cli.sh"
+
+      - name: Install + test nemo-platform-plugin
+        if: matrix.package == 'nemo-platform-plugin'
+        shell: bash
+        env:
+          WHEEL: ${{ steps.build.outputs.wheel-path }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/wheelcheck"
+          cp "${WHEEL}" "${RUNNER_TEMP}/wheelcheck/"
+          cd "${RUNNER_TEMP}/wheelcheck"
+          uv venv .venv --python "${PYTHON_VERSION}"
+          uv pip install --python .venv/bin/python "$(basename "${WHEEL}")"
+          unset PYTHONPATH VIRTUAL_ENV
+          .venv/bin/python -c "
+          import nemo_platform_plugin
+          import nemo_platform_plugin.cli
+          import nemo_platform_plugin.commands
+          print('nemo_platform_plugin', getattr(nemo_platform_plugin, '__version__', '<no __version__>'))
+          "
+
+      - name: Upload wheel
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.package }}-wheel-py${{ matrix.python-version }}
+          path: dist/*.whl
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # Required-check pin: branch protection should reference this aggregator
+  # rather than the per-row matrix jobs, so the matrix can grow or shrink
+  # without admin intervention. Skipped counts as pass.
+  wheel-test-aggregate:
+    name: Wheel build + test
+    needs: [wheel-test]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check matrix result
+        shell: bash
+        env:
+          MATRIX_RESULT: ${{ needs.wheel-test.result }}
+        run: |
+          set -euo pipefail
+          case "${MATRIX_RESULT}" in
+            success|skipped)
+              echo "wheel-test matrix: ${MATRIX_RESULT}"
+              ;;
+            *)
+              echo "::error::wheel-test matrix concluded ${MATRIX_RESULT}"
+              exit 1
+              ;;
+          esac
+
   coverage-comment:
     name: Post coverage comment
     needs: [python-unit-test, python-integration-test]
@@ -271,7 +383,7 @@ jobs:
 
   notify-ci-consumer:
     name: Notify CI consumer
-    needs: [lint, python-unit-test, opa-policy-test]
+    needs: [lint, python-unit-test, opa-policy-test, wheel-test-aggregate]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,6 +202,9 @@ jobs:
             coverage.xml
             coverage.json
 
+  # One job, one (package x python) matrix — kept as a single job rather
+  # than split per-package because the build path is identical and the
+  # matrix definition is the natural place to change what's covered.
   # nemo-platform's wheel force-includes auth's policy.wasm at build time;
   # nemo-platform-plugin doesn't, but plugin rows still wait on policy-wasm
   # because needs: is per-job. ~5s of harmless wait per plugin row.
@@ -238,6 +241,9 @@ jobs:
           nightly-timestamp: "19700101000000"
           python-version: ${{ matrix.python-version }}
 
+      # The two install+test steps below intentionally share a small preamble
+      # (mkdir + cp). Hoisting it into a separate step would cost more in
+      # workflow indirection than the 3 duplicated lines save.
       - name: Install + test nemo-platform CLI
         if: matrix.package == 'nemo-platform'
         shell: bash
@@ -271,6 +277,12 @@ jobs:
           uv venv .venv --python "${PYTHON_VERSION}"
           uv pip install --python .venv/bin/python "$(basename "${WHEEL}")"
           unset PYTHONPATH VIRTUAL_ENV
+          # Import the package + a couple of representative submodules
+          # (cli, commands). These are the surfaces a plugin author would
+          # touch first; if any of them fail to import, the wheel is
+          # broken in a way that surfaces immediately on day one. If
+          # the plugin's public API surface changes substantially, this
+          # list should be revisited.
           .venv/bin/python -c "
           import nemo_platform_plugin
           import nemo_platform_plugin.cli
@@ -283,9 +295,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.package }}-wheel-py${{ matrix.python-version }}
-          path: dist/*.whl
+          path: ${{ steps.build.outputs.wheel-path }}
           retention-days: 7
-          if-no-files-found: ignore
+          if-no-files-found: error
 
   # Required-check pin: branch protection should reference this aggregator
   # rather than the per-row matrix jobs, so the matrix can grow or shrink
@@ -302,6 +314,11 @@ jobs:
         shell: bash
         env:
           MATRIX_RESULT: ${{ needs.wheel-test.result }}
+          # Per-row results, useful for debugging which (package, python)
+          # combination failed. GitHub doesn't expose individual matrix
+          # results by name; the workflow run UI is the canonical place
+          # to look. We surface a pointer in the failure message.
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           case "${MATRIX_RESULT}" in
@@ -310,6 +327,7 @@ jobs:
               ;;
             *)
               echo "::error::wheel-test matrix concluded ${MATRIX_RESULT}"
+              echo "::error::see per-row results: ${RUN_URL}"
               exit 1
               ;;
           esac

--- a/.github/workflows/release-bundle.yaml
+++ b/.github/workflows/release-bundle.yaml
@@ -366,78 +366,27 @@ jobs:
           ref: ${{ needs.plan-release.outputs.source_sha }}
           path: source
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.11"
-          enable-cache: true
-          version-file: source/pyproject.toml
-          cache-dependency-glob: source/uv.lock
-
-      - name: Set up pnpm
-        if: matrix.id == 'nemo-platform'
-        uses: pnpm/action-setup@v4
-        with:
-          package_json_file: source/web/package.json
-
-      - name: Set up Node.js
-        if: matrix.id == 'nemo-platform'
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
-          cache-dependency-path: source/web/pnpm-lock.yaml
-
-      # Stamp the checked-out source so the wheel metadata matches the planned release label.
-      - name: Stamp SDK version
-        shell: bash
-        env:
-          CADENCE: ${{ inputs.cadence }}
-          RELEASE_LABEL: ${{ needs.plan-release.outputs.release_label }}
-          NIGHTLY_TIMESTAMP: ${{ needs.plan-release.outputs.nightly_timestamp }}
-          SDK_ID: ${{ matrix.id }}
-        run: |
-          set -euo pipefail
-
-          uv run python workflow/.github/scripts/stamp_sdk_version.py \
-            --source-root source \
-            --sdk-id "${SDK_ID}" \
-            --cadence "${CADENCE}" \
-            --release-label "${RELEASE_LABEL}" \
-            --nightly-timestamp "${NIGHTLY_TIMESTAMP}"
-
+      # Toolchain setup + version stamp + `uv build` are factored into the
+      # composite action, which ci.yaml's wheel-test job also calls so the
+      # test wheel and the published wheel come out of one code path.
+      # The action lives in the workflow repo checkout (path: workflow),
+      # not the release-target source checkout.
       - name: Build SDK wheel
         id: build-sdk-wheel
-        shell: bash
-        env:
-          SDK_ID: ${{ matrix.id }}
-        run: |
-          set -euo pipefail
-
-          wheel_dir="${GITHUB_WORKSPACE}/release-sdk-wheel"
-          rm -rf "${wheel_dir}"
-          mkdir -p "${wheel_dir}"
-
-          uv build --wheel \
-            --directory source \
-            --package "${SDK_ID}" \
-            --out-dir "${wheel_dir}"
-
-          shopt -s nullglob
-          wheels=("${wheel_dir}"/*.whl)
-          if [[ "${#wheels[@]}" -ne 1 ]]; then
-            echo "::error::expected exactly one wheel for sdk:${SDK_ID}, found ${#wheels[@]}"
-            exit 1
-          fi
-
-          printf 'wheel_path=%s\n' "${wheels[0]}" >>"${GITHUB_OUTPUT}"
-          echo "Built sdk:${SDK_ID} -> ${wheels[0]}."
+        uses: ./workflow/.github/actions/build-nemo-platform-wheel
+        with:
+          package: ${{ matrix.id }}
+          source-root: source
+          out-dir: ${{ github.workspace }}/release-sdk-wheel
+          cadence: ${{ inputs.cadence }}
+          release-label: ${{ needs.plan-release.outputs.release_label }}
+          nightly-timestamp: ${{ needs.plan-release.outputs.nightly_timestamp }}
 
       - name: Upload SDK wheel
         uses: actions/upload-artifact@v6
         with:
           name: release-sdk-${{ matrix.id }}
-          path: ${{ steps.build-sdk-wheel.outputs.wheel_path }}
+          path: ${{ steps.build-sdk-wheel.outputs.wheel-path }}
           if-no-files-found: error
           overwrite: true
           retention-days: 1

--- a/.github/workflows/release-bundle.yaml
+++ b/.github/workflows/release-bundle.yaml
@@ -368,9 +368,9 @@ jobs:
 
       # Toolchain setup + version stamp + `uv build` are factored into the
       # composite action, which ci.yaml's wheel-test job also calls so the
-      # test wheel and the published wheel come out of one code path.
-      # The action lives in the workflow repo checkout (path: workflow),
-      # not the release-target source checkout.
+      # test wheel and the published wheel come out of one code path. The
+      # action runs out of the workflow checkout above, not the
+      # release-target source checkout.
       - name: Build SDK wheel
         id: build-sdk-wheel
         uses: ./workflow/.github/actions/build-nemo-platform-wheel

--- a/script/test-nemo-cli.sh
+++ b/script/test-nemo-cli.sh
@@ -7,9 +7,11 @@
 # it boots.
 #
 # Used by .github/workflows/ci.yaml's wheel-test job; runs locally too.
+#
+# Env vars:
+#   WHEEL_TEST_TIMEOUT   seconds to wait for platform health (default: 60)
 set -euo pipefail
-
-# bash job control: backgrounded jobs get their own process group, so
+# Job control: backgrounded jobs get their own process group, so
 # `kill -- -$!` later takes down the whole tree (parent + worker
 # subprocesses spawned by `nemo services run`) without depending on
 # `setsid` (which isn't standard on macOS).
@@ -20,11 +22,11 @@ set -m
 export _TYPER_FORCE_DISABLE_TERMINAL="${_TYPER_FORCE_DISABLE_TERMINAL:-1}"
 
 LOG="${RUNNER_TEMP:-/tmp}/nemo-services.log"
-SERVICES_PID=""
+TIMEOUT_SECS="${WHEEL_TEST_TIMEOUT:-60}"
 
 cleanup() {
   set +e
-  if [[ -n "${SERVICES_PID}" ]]; then
+  if [[ -n "${SERVICES_PID:-}" ]]; then
     kill -TERM -- "-${SERVICES_PID}" 2>/dev/null
     for _ in 1 2 3 4 5; do
       kill -0 "${SERVICES_PID}" 2>/dev/null || break
@@ -39,10 +41,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if ! command -v nemo >/dev/null 2>&1; then
-  echo "::error::nemo is not on PATH; install the CLI before running this script" >&2
-  exit 1
-fi
+# Required runtime tools. jq is preinstalled on standard GH runners; surface
+# a clear error for local users running this script with an incomplete env.
+for cmd in nemo jq; do
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "::error::${cmd} is not on PATH; install it before running this script" >&2
+    exit 1
+  fi
+done
 
 echo "----- nemo on PATH -----"
 command -v nemo
@@ -70,14 +76,14 @@ SERVICES_PID=$!
 # services/core/entities/.../initialize.py — requiring both catches the
 # case where seeding partially succeeded then crashed. JSON output is
 # used so the assertion survives Rich table rendering changes.
-deadline=$(($(date +%s) + 60))
+deadline=$(($(date +%s) + TIMEOUT_SECS))
 until output="$(nemo workspaces list -f json 2>/dev/null)" \
   && jq -e '
        any(.data[]?; .name == "default")
        and any(.data[]?; .name == "system")
      ' >/dev/null <<<"${output}"; do
   if (($(date +%s) > deadline)); then
-    echo "::error::platform did not become healthy with default+system workspaces in 60s"
+    echo "::error::platform did not become healthy with default+system workspaces in ${TIMEOUT_SECS}s"
     echo "----- last \`nemo workspaces list -f json\` output (stdout+stderr) -----"
     nemo workspaces list -f json 2>&1 || true
     # Full services log is dumped by the EXIT trap.

--- a/script/test-nemo-cli.sh
+++ b/script/test-nemo-cli.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Test that the `nemo` CLI on PATH actually works.
+#
+# Install-method agnostic: whatever put `nemo` on PATH (`uv tool install` from
+# a wheel, `uv sync` in the dev workspace, `pipx`, a distro package, ...) is
+# the caller's concern. This script only exercises the CLI and the platform
+# it boots.
+#
+# Used by .github/workflows/ci.yaml's wheel-test job; runs locally too.
+set -euo pipefail
+
+# bash job control: backgrounded jobs get their own process group, so
+# `kill -- -$!` later takes down the whole tree (parent + worker
+# subprocesses spawned by `nemo services run`) without depending on
+# `setsid` (which isn't standard on macOS).
+set -m
+
+# Default to non-TTY rendering so Typer / Rich don't try to draw progress bars
+# or wrap based on a fake terminal width. Caller can override.
+export _TYPER_FORCE_DISABLE_TERMINAL="${_TYPER_FORCE_DISABLE_TERMINAL:-1}"
+
+LOG="${RUNNER_TEMP:-/tmp}/nemo-services.log"
+SERVICES_PID=""
+
+cleanup() {
+  set +e
+  if [[ -n "${SERVICES_PID}" ]]; then
+    kill -TERM -- "-${SERVICES_PID}" 2>/dev/null
+    for _ in 1 2 3 4 5; do
+      kill -0 "${SERVICES_PID}" 2>/dev/null || break
+      sleep 1
+    done
+    kill -KILL -- "-${SERVICES_PID}" 2>/dev/null
+  fi
+  if [[ -f "${LOG}" ]]; then
+    echo "----- nemo services log -----"
+    cat "${LOG}"
+  fi
+}
+trap cleanup EXIT
+
+if ! command -v nemo >/dev/null 2>&1; then
+  echo "::error::nemo is not on PATH; install the CLI before running this script" >&2
+  exit 1
+fi
+
+echo "----- nemo on PATH -----"
+command -v nemo
+nemo --version
+
+# Import-time checks for commands that ship in the bundled wrapper. We don't
+# call `nemo services --help` here because `nemo services run` below is a
+# stronger functional check of that group.
+echo "----- import-time CLI checks -----"
+nemo --help >/dev/null
+nemo agents --help >/dev/null
+nemo skills list >/dev/null
+
+echo "----- boot platform and wait for default+system workspaces -----"
+# No --services / --controllers: the CLI's default is "every service the
+# install knows about." For a wheel-test job that's exactly what we want —
+# any bundled service module that fails to import, run alembic, or answer
+# health probes is a real wheel-installability bug. The caller must have
+# installed `nemo-platform[services]` (the umbrella extra) for this to
+# resolve a meaningful set; with the base install you'd get just the SDK.
+nemo services run >"${LOG}" 2>&1 &
+SERVICES_PID=$!
+
+# The entities service seeds `default` and `system` back-to-back in
+# services/core/entities/.../initialize.py — requiring both catches the
+# case where seeding partially succeeded then crashed. JSON output is
+# used so the assertion survives Rich table rendering changes.
+deadline=$(($(date +%s) + 60))
+until output="$(nemo workspaces list -f json 2>/dev/null)" \
+  && jq -e '
+       any(.data[]?; .name == "default")
+       and any(.data[]?; .name == "system")
+     ' >/dev/null <<<"${output}"; do
+  if (($(date +%s) > deadline)); then
+    echo "::error::platform did not become healthy with default+system workspaces in 60s"
+    echo "----- last \`nemo workspaces list -f json\` output (stdout+stderr) -----"
+    nemo workspaces list -f json 2>&1 || true
+    # Full services log is dumped by the EXIT trap.
+    exit 1
+  fi
+  if ! kill -0 "${SERVICES_PID}" 2>/dev/null; then
+    # Reap so the error message carries the actual exit code.
+    wait "${SERVICES_PID}" 2>/dev/null
+    services_exit=$?
+    echo "::error::nemo services run exited (code ${services_exit}) before becoming healthy"
+    SERVICES_PID=""  # cleanup shouldn't re-kill
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "platform healthy; default+system workspaces present"


### PR DESCRIPTION
## What

Adds a CI job that builds and tests every shipping wheel — `nemo-platform` and `nemo-platform-plugin` — across every supported Python (3.11, 3.12, 3.13). Each row builds the wheel with the exact same code path the release workflow uses, installs it into an isolated env, and exercises it end-to-end. Today CI only runs against the editable workspace install, so wheel-install breakages (missing `policy.wasm`, vendor-metadata drift, entry-point typos, namespace-package gotchas, broken `Requires-Dist`, generated-extra mismatches) only surface on manual post-release smoke checks.

The build itself is factored into a new composite action, `.github/actions/build-nemo-platform-wheel`, which is also called by `release-bundle.yaml`'s `build-sdks` matrix. CI test wheels and published wheels now come out of one code path.

## Shape

```
policy-wasm  ──▶  wheel-test  ──▶  wheel-test-aggregate
                  matrix(package × python)        (required-check pin)
                  6 rows
```

- **`wheel-test`** matrix is `package: [nemo-platform, nemo-platform-plugin] × python-version: [3.11, 3.12, 3.13]` = 6 rows. `fail-fast: false` so a single-row failure doesn't hide the others' logs.
- **`wheel-test-aggregate`** is a single-job umbrella that succeeds iff every matrix row succeeded. Branch protection should pin *this* check name (`Wheel build + test`); the matrix can grow without anyone touching protection settings.
- **Composite action** owns the build path (uv setup, conditional Studio asset compile, version stamping via `stamp_sdk_version.py`, `uv build --wheel`, single-wheel guard, `rm -rf` safety check on caller-provided `out-dir`). Stamping always runs regardless of caller, with `cadence: nightly` + sentinel epoch `19700101000000` for CI tests so the test wheel version is well-formed PEP 440 dev but obviously synthetic.

## Per-package test surface

- **`nemo-platform`**: `uv tool install ./*.whl[services]`, then `script/test-nemo-cli.sh` boots the platform via `nemo services run` (no `--services` filter — every bundled service module loads, ~17 services + 4 controllers) and polls `nemo workspaces list -f json` until both `default` and `system` (the platform-seeded workspaces) appear, with SIGTERM-then-SIGKILL teardown of the whole process group via bash job control (`set -m`).
- **`nemo-platform-plugin`**: library-only (no `[project.scripts]`), so `uv venv` + `uv pip install` + `python -c "import nemo_platform_plugin; import nemo_platform_plugin.cli; import nemo_platform_plugin.commands"`. That still catches the bug classes a wheel-test is supposed to catch (broken pyproject.toml, broken `Requires-Dist`, `hatch_build.py` regressions, namespace-package gotchas).

`script/test-nemo-cli.sh` is install-method agnostic — anywhere `nemo` is on PATH (`uv tool install` from a wheel, `uv sync` in dev, `pipx`, distro package), the script can run and prove the CLI works.

## What this does NOT do (yet)

- **Not yet a required check.** The aggregator name `Wheel build + test` is set up to be the single pin point; flipping branch-protection-required is a one-line admin change once this has been green for a few working days.
- **Doesn't gate `release-stable.yaml`.** That's the second admin step: extend the stable-release dispatch to fail if `Wheel build + test` didn't pass on the source SHA.
- **Platform-Deploy migration is separate.** `Platform-Deploy/.github/workflows/release-sdk.yaml` still has its own inline build path that drifts from this action; migrating it to consume `build-nemo-platform-wheel@<sha>` is a Platform-Deploy PR.
- **No vendor-drift handling.** The test deliberately runs against committed metadata; vendor-drift detection belongs in `lint`.

## Coderabbit feedback addressed

- `rm -rf "${abs_out_dir}"` in the action now rejects empty/`/` paths and requires the resolved path to live inside source-root or `$GITHUB_WORKSPACE`.
- Readiness probe now requires both `default` and `system` workspaces (the entities service seeds them back-to-back, so missing one is a real signal that init partially failed).
- `github.run_started_at` reference removed in favor of the sentinel epoch (the context property doesn't exist).
- SHA-pinning of `actions/checkout@v6` etc. and `persist-credentials: false` deferred — every other job in `ci.yaml` uses major-version tags, so policy-pinning the wheel-test job alone would be inconsistent. Belongs in a separate repo-wide PR.

## Verification

- All YAML files parse with `yaml.safe_load`.
- `script/test-nemo-cli.sh` is `shellcheck` and `bash -n` clean.
- Pre-commit clean on all changed files.
- Most recent CI run on this branch: 7 jobs green (6 matrix rows + aggregator).

## Tracking

- Linear: [AIRCORE-682](https://linear.app/nvidia/issue/AIRCORE-682/ci-build-wheel-install-in-fresh-env-smoke-test-nemo-platform-end-to)
- Plan: `docs/plans/aircore-682-wheel-test.md`

Signed-off-by: Matthew Grossman <mgrossman@nvidia.com>
