### PR TITLE
fix(plugin): use absolute GitHub URLs in PyPI README

### DIFF
--- a/packages/nemo_platform_plugin/pyproject.toml
+++ b/packages/nemo_platform_plugin/pyproject.toml
@@ -33,6 +33,11 @@ dependencies = [
 ]
 license = "Apache-2.0"
 
+[project.urls]
+Homepage = "https://github.com/NVIDIA-NeMo/nemo-platform"
+Source = "https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin"
+Documentation = "https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs"
+
 [project.optional-dependencies]
 # Generated from [tool.bundle-package]; do not edit by hand.
 nemo-platform-sdk = [

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/README.md
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/README.md
@@ -25,7 +25,7 @@ uv add nemo-platform-plugin nemo-platform
 
 ## How plugins are discovered
 
-Declare surfaces in `pyproject.toml` entry-point groups. Install the package and the platform picks them up at startup — no registration code needed. See [QUICKSTART.md](docs/QUICKSTART.md) for the full template.
+Declare surfaces in `pyproject.toml` entry-point groups. Install the package and the platform picks them up at startup — no registration code needed. See [QUICKSTART.md](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/QUICKSTART.md) for the full template.
 
 ## The `name` rule
 
@@ -33,11 +33,13 @@ Every surface class requires a non-empty `name: ClassVar[str]`. Checked at class
 
 ## Next steps
 
-- [QUICKSTART.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/QUICKSTART.md) — build your first plugin end-to-end
-- [SERVICE.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/SERVICE.md) — HTTP routes, CRUD patterns, testing
-- [JOB.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/JOB.md) — jobs, CLI commands, auto-generated job commands
-- [CONTROLLER.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/CONTROLLER.md) — reconcile loops, state machines, service principal
-- [CONFIG.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/CONFIG.md) — typed configuration, env vars, YAML, test overrides
-- [ENTITY.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/ENTITY.md) — entity store, CRUD client, pagination, optimistic locking
-- [INFERENCE_MIDDLEWARE.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/INFERENCE_MIDDLEWARE.md) — inference request/response middleware, typed bodies, and response annotations
-- [ARCHITECTURE.md](https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/ARCHITECTURE.md) — discovery, startup, all surfaces, SDK surface
+- [QUICKSTART.md](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/QUICKSTART.md) — build your first plugin end-to-end
+- [SERVICE.md](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/SERVICE.md) — HTTP routes, CRUD patterns, testing
+- [JOB.md](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/JOB.md) — jobs, CLI commands, auto-generated job commands
+- [CONTROLLER.md](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/CONTROLLER.md) — reconcile loops, state machines, service principal
+- [CONFIG.md](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/CONFIG.md) — typed configuration, env vars, YAML, test overrides
+- [ENTITY.md](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/ENTITY.md) — entity store, CRUD client, pagination, optimistic locking
+- [INFERENCE_MIDDLEWARE.md](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/INFERENCE_MIDDLEWARE.md) — inference request/response middleware, typed bodies, and response annotations
+- [ARCHITECTURE.md](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/ARCHITECTURE.md) — discovery, startup, all surfaces, SDK surface
+
+> **Tip:** These guides also ship inside the installed package at `nemo_platform_plugin/docs/`.


### PR DESCRIPTION
## Summary

- Replace all relative markdown links in the `nemo-platform-plugin` README with absolute GitHub blob URLs so they resolve correctly on PyPI
- Correct existing "Next steps" links from `/tree/main/` to the canonical `/blob/main/` form for individual files
- Add `[project.urls]` to `pyproject.toml` so PyPI renders Homepage, Source, and Documentation sidebar links
- Add a tip noting that guides also ship inside the installed package at `nemo_platform_plugin/docs/`

Fixes NVBugs 6216282

## Test plan

- [ ] Open the [PyPI project page](https://pypi.org/project/nemo-platform-plugin/) after next publish and verify all "Next steps" links navigate to the correct GitHub docs
- [ ] Verify the PyPI sidebar shows Homepage, Source, and Documentation links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added official project URLs to the package metadata, including links to homepage, source code repository, and documentation resources.
  * Updated README documentation links from relative paths to absolute GitHub URLs for more direct and reliable access.
  * Added clarification that comprehensive documentation guides are also included within the installed package for offline reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->