### PR TITLE
fix(evaluator): Use latest config reference in nemo evaluator plugin README

### DIFF
--- a/plugins/nemo-evaluator/README.md
+++ b/plugins/nemo-evaluator/README.md
@@ -84,7 +84,7 @@ nemo jobs results download row-scores --job <job-name> --output-file row-scores.
 Use the mounted platform SDK accessor, `client.evaluator`:
 
 ```python
-from nemo_evaluator_sdk import EvaluationConfig, ExactMatchMetric
+from nemo_evaluator_sdk import ExactMatchMetric, RunConfig
 from nemo_platform import NeMoPlatform
 
 
@@ -103,13 +103,13 @@ dataset = [
 local_result = client.evaluator.run(
     metric=metric,
     dataset=dataset,
-    config=EvaluationConfig(parallelism=2),
+    config=RunConfig(parallelism=2),
 )
 
 job = client.evaluator.submit(
     metric=metric,
     dataset=dataset,
-    config=EvaluationConfig(parallelism=2),
+    config=RunConfig(parallelism=2),
 )
 job.wait_until_done()
 submitted_result = job.get_result()


### PR DESCRIPTION
The nemo evaluator README has incorrect references. This MR fixes those reference so that user does not run into error when trying out evaluator
```shell
>>> from nemo_evaluator_sdk import EvaluationConfig, ExactMatchMetric
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'EvaluationConfig' from 'nemo_evaluator_sdk' (/Users/arpsingh/aire/nemo-platform/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/__init__.py)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated quickstart examples in the Nemo Evaluator plugin to use the newer configuration object and demonstrate passing a parallelism value for both run and submit flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->