### PR TITLE
ci(codeql): exclude generated SDK from analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,7 @@
+name: NeMo Platform CodeQL config
+
+queries:
+  - uses: security-and-quality
+
+paths-ignore:
+  - sdk/python

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
             languages: ${{matrix.language}}
-            queries: +security-and-quality
+            config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary
- Add `.github/codeql/codeql-config.yml` with `paths-ignore: [sdk/python]` so the Stainless-generated SDK is skipped during CodeQL analysis.
- Switch the CodeQL init step in `security.yaml` to reference the config file (preserving the `security-and-quality` query suite, additive to defaults).

## Why
CodeQL was scanning generated SDK code under `sdk/python/`, producing alerts on code the team does not maintain.

## Test plan
- [ ] Security workflow runs on this PR
- [ ] CodeQL job succeeds for both `python` and `javascript-typescript`
- [ ] No new alerts originating from `sdk/python/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CodeQL configuration file to define code analysis query rules and exclusion parameters.
  * Updated security workflow to reference the new CodeQL configuration for centralized analysis settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->