### PR TITLE
fix(security): address high+ CodeQL alerts across plugins, services, SDK

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/resilience/classifier.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/resilience/classifier.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-import hashlib
+import zlib
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 
@@ -19,10 +19,10 @@ _TRANSIENT_STATUS_CODES = frozenset({408, 500, 502, 504})
 
 def endpoint_identity(base_url: str, model_id: str | None = None, auth_identity: str | None = None) -> str:
     """Build a stable endpoint key for scheduler state and accounting."""
-    auth_hash = ""
+    auth_fingerprint = ""
     if auth_identity:
-        auth_hash = hashlib.sha256(auth_identity.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
-    return f"{base_url}|{model_id or '_'}|{auth_hash}"
+        auth_fingerprint = format(zlib.crc32(auth_identity.encode("utf-8")), "08x")
+    return f"{base_url}|{model_id or '_'}|{auth_fingerprint}"
 
 
 def _status_code_from_exception(exc: Exception) -> int | None:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/resilience/classifier.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/resilience/classifier.py
@@ -21,7 +21,7 @@ def endpoint_identity(base_url: str, model_id: str | None = None, auth_identity:
     """Build a stable endpoint key for scheduler state and accounting."""
     auth_hash = ""
     if auth_identity:
-        auth_hash = hashlib.sha256(auth_identity.encode("utf-8")).hexdigest()[:16]
+        auth_hash = hashlib.sha256(auth_identity.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
     return f"{base_url}|{model_id or '_'}|{auth_hash}"
 
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/resilience/classifier.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/resilience/classifier.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-import zlib
+import hashlib
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 
@@ -21,7 +21,7 @@ def endpoint_identity(base_url: str, model_id: str | None = None, auth_identity:
     """Build a stable endpoint key for scheduler state and accounting."""
     auth_fingerprint = ""
     if auth_identity:
-        auth_fingerprint = format(zlib.crc32(auth_identity.encode("utf-8")), "08x")
+        auth_fingerprint = hashlib.blake2b(auth_identity.encode("utf-8"), digest_size=8).hexdigest()
     return f"{base_url}|{model_id or '_'}|{auth_fingerprint}"
 
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/_registry.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/_registry.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Registry-host parsing shared across quickstart modules."""
+
+from __future__ import annotations
+
+
+def image_registry_host(image: str) -> str:
+    """Extract the registry host from an image reference, or "" if none.
+
+    For 2-part names like ``ubuntu/mysql:latest`` (Docker Hub namespace/repo)
+    the first segment is a namespace, not a registry, so this returns "".
+
+    For 3+ part names (``nvcr.io/nvidia/nemo-microservices/nmp-api:tag``) or
+    when the first segment looks like a host (contains ``.`` or ``:``), the
+    first segment is returned, **including any explicit port**. Callers that
+    need to compare against a canonical name like ``"nvcr.io"`` should strip
+    the port themselves (``host.split(":", 1)[0]``).
+    """
+    if not image or "/" not in image:
+        return ""
+    parts = image.split("/")
+    if len(parts) >= 3:
+        return parts[0]
+    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
+        return parts[0]
+    return ""

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/config.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/config.py
@@ -265,7 +265,8 @@ class QuickstartConfig(BaseModel):
 
     def is_ngc_registry(self) -> bool:
         """Check if the configured image uses NGC registry."""
-        return self.get_registry_host().lower() == "nvcr.io"
+        # Strip explicit port (e.g. "nvcr.io:443") before matching.
+        return self.get_registry_host().lower().split(":", 1)[0] == "nvcr.io"
 
     def get_registry_host(self) -> str:
         """Extract registry host from image name."""

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/config.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/config.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field, SecretStr, field_serializer, model_valida
 from pydantic.functional_serializers import SerializationInfo
 from typing_extensions import Self
 
+from ._registry import image_registry_host
 from .gpu_config import parse_comma_separated_non_negative_integers
 
 InferenceProviderType = Literal["nvidia-build", "host-gpu"]
@@ -270,14 +271,7 @@ class QuickstartConfig(BaseModel):
 
     def get_registry_host(self) -> str:
         """Extract registry host from image name."""
-        if not self.image or "/" not in self.image:
-            return ""
-        parts = self.image.split("/")
-        if len(parts) >= 3:
-            return parts[0]
-        if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-            return parts[0]
-        return ""
+        return image_registry_host(self.image)
 
     def has_registry_credentials_for_image(self) -> bool:
         """Return True when stored registry credentials match the configured image host."""

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/config.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/config.py
@@ -265,7 +265,7 @@ class QuickstartConfig(BaseModel):
 
     def is_ngc_registry(self) -> bool:
         """Check if the configured image uses NGC registry."""
-        return "nvcr.io" in self.image.lower()
+        return self.get_registry_host().lower() == "nvcr.io"
 
     def get_registry_host(self) -> str:
         """Extract registry host from image name."""

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py
@@ -191,7 +191,7 @@ class ContainerManager:
         registry = _image_registry_host(self.config.image)
 
         auth_config = None
-        if registry and registry == "nvcr.io":
+        if registry and registry.split(":", 1)[0] == "nvcr.io":
             if self.config.ngc_api_key:
                 auth_config = {
                     "username": "$oauthtoken",
@@ -228,7 +228,7 @@ class ContainerManager:
                 "username": auth_override["username"],
                 "password": auth_override["password"],
             }
-        elif registry and registry == "nvcr.io":
+        elif registry and registry.split(":", 1)[0] == "nvcr.io":
             if self.config.ngc_api_key:
                 auth_config = {
                     "username": "$oauthtoken",

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py
@@ -13,6 +13,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import TypedDict
 
+from ._registry import image_registry_host
 from .config import QuickstartConfig
 from .platform_config import PlatformConfig
 
@@ -33,18 +34,6 @@ class PullProgress(TypedDict):
     layer_id: str | None
     current: int | None  # bytes downloaded for this layer
     total: int | None  # total bytes for this layer
-
-
-def _image_registry_host(image: str) -> str | None:
-    """Extract the registry host from an image reference."""
-    if not image or "/" not in image:
-        return None
-    parts = image.split("/")
-    if len(parts) >= 3:
-        return parts[0]
-    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-        return parts[0]
-    return None
 
 
 class ContainerManager:
@@ -188,7 +177,7 @@ class ContainerManager:
             return
 
         # Parse registry from image name
-        registry = _image_registry_host(self.config.image)
+        registry = image_registry_host(self.config.image) or None
 
         auth_config = None
         if registry and registry.split(":", 1)[0] == "nvcr.io":
@@ -220,7 +209,7 @@ class ContainerManager:
             return
 
         # Build auth config (same logic as _pull_image)
-        registry = _image_registry_host(self.config.image)
+        registry = image_registry_host(self.config.image) or None
 
         auth_config = None
         if auth_override and registry == auth_override["registry"]:
@@ -375,7 +364,7 @@ class ContainerManager:
         from .prompts import detect_registry_auth_type
 
         auth_type = detect_registry_auth_type(self.config.image)
-        jobs_registry_host = _image_registry_host(self.config.image)
+        jobs_registry_host = image_registry_host(self.config.image) or None
         if auth_type == "ngc" and jobs_registry_host and self.config.ngc_api_key:
             # NGC uses $oauthtoken as username and NGC API key as password
             env["NEMO_JOBS_IMAGE_REGISTRY"] = jobs_registry_host

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py
@@ -191,7 +191,7 @@ class ContainerManager:
         registry = _image_registry_host(self.config.image)
 
         auth_config = None
-        if registry and "nvcr.io" in registry:
+        if registry and registry == "nvcr.io":
             if self.config.ngc_api_key:
                 auth_config = {
                     "username": "$oauthtoken",
@@ -228,7 +228,7 @@ class ContainerManager:
                 "username": auth_override["username"],
                 "password": auth_override["password"],
             }
-        elif registry and "nvcr.io" in registry:
+        elif registry and registry == "nvcr.io":
             if self.config.ngc_api_key:
                 auth_config = {
                     "username": "$oauthtoken",

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/prompts.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/prompts.py
@@ -48,6 +48,17 @@ class RegistryCredentials:
     password: SecretStr
 
 
+def _image_registry_host_from_ref(image: str) -> str:
+    if not image or "/" not in image:
+        return ""
+    parts = image.split("/")
+    if len(parts) >= 3:
+        return parts[0]
+    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
+        return parts[0]
+    return ""
+
+
 def detect_registry_auth_type(image: str) -> Literal["ngc", "user_pass", "none"]:
     """Detect what type of authentication an image registry requires.
 
@@ -59,14 +70,13 @@ def detect_registry_auth_type(image: str) -> Literal["ngc", "user_pass", "none"]
         "user_pass" for GitHub Container Registry and Docker Hub
         "none" for other registries (assume already logged in)
     """
-    image_lower = image.lower()
+    registry_host = _image_registry_host_from_ref(image).lower()
 
-    if "nvcr.io" in image_lower:
+    if registry_host == "nvcr.io":
         return "ngc"
 
-    for registry in REGISTRIES_REQUIRING_AUTH:
-        if registry in image_lower:
-            return "user_pass"
+    if registry_host in REGISTRIES_REQUIRING_AUTH:
+        return "user_pass"
 
     return "none"
 
@@ -400,7 +410,7 @@ def prompt_for_registry_credentials(
 
     username_value = username.strip() if username else ""
     if not username_value:
-        if "nvcr.io" in registry_value.lower():
+        if registry_value.lower() == "nvcr.io":
             username_value = "$oauthtoken"
         else:
             username_value = prompt_text("Username: ", validator=non_empty_validator("Username")).strip()

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/prompts.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/prompts.py
@@ -18,6 +18,7 @@ from nemo_platform_ext.ui.prompts import (
     prompt_text,
 )
 
+from ._registry import image_registry_host
 from .config import QuickstartConfig
 from .container import ContainerManager
 from .gpu_config import (
@@ -49,16 +50,8 @@ class RegistryCredentials:
 
 
 def _image_registry_host_from_ref(image: str) -> str:
-    if not image or "/" not in image:
-        return ""
-    parts = image.split("/")
-    host = ""
-    if len(parts) >= 3:
-        host = parts[0]
-    elif len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-        host = parts[0]
-    # Strip explicit port (e.g. "nvcr.io:443" -> "nvcr.io").
-    return host.split(":", 1)[0]
+    # Strip explicit port (e.g. "nvcr.io:443" -> "nvcr.io") for canonical matching.
+    return image_registry_host(image).split(":", 1)[0]
 
 
 def detect_registry_auth_type(image: str) -> Literal["ngc", "user_pass", "none"]:
@@ -310,21 +303,8 @@ def prompt_for_configuration(config: QuickstartConfig) -> QuickstartConfig:
 
 
 def _registry_host_from_image(image: str) -> str:
-    """Extract registry host from an image reference, or empty if not a registry.
-
-    For 2-part names like \"ubuntu/mysql:latest\" (Docker Hub namespace/repo), the
-    first segment is a namespace, not a registry, so we return \"\".
-    For 3+ part names (e.g. \"nvcr.io/nvidia/nemo-microservices/nmp-api:tag\") or when the first
-    segment looks like a host (contains '.' or ':'), we return that segment.
-    """
-    if not image or "/" not in image:
-        return ""
-    parts = image.split("/")
-    if len(parts) >= 3:
-        return parts[0]
-    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-        return parts[0]
-    return ""
+    """Thin wrapper kept for back-compat with tests that import this name."""
+    return image_registry_host(image)
 
 
 def prompt_for_optional_registry_credentials(config: QuickstartConfig) -> bool:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/prompts.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/prompts.py
@@ -52,11 +52,13 @@ def _image_registry_host_from_ref(image: str) -> str:
     if not image or "/" not in image:
         return ""
     parts = image.split("/")
+    host = ""
     if len(parts) >= 3:
-        return parts[0]
-    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-        return parts[0]
-    return ""
+        host = parts[0]
+    elif len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
+        host = parts[0]
+    # Strip explicit port (e.g. "nvcr.io:443" -> "nvcr.io").
+    return host.split(":", 1)[0]
 
 
 def detect_registry_auth_type(image: str) -> Literal["ngc", "user_pass", "none"]:
@@ -410,7 +412,7 @@ def prompt_for_registry_credentials(
 
     username_value = username.strip() if username else ""
     if not username_value:
-        if registry_value.lower() == "nvcr.io":
+        if registry_value.lower().split(":", 1)[0] == "nvcr.io":
             username_value = "$oauthtoken"
         else:
             username_value = prompt_text("Username: ", validator=non_empty_validator("Username")).strip()

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/git_url.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/git_url.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for parsing git remote URLs (HTTPS and SSH forms)."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+
+def git_remote_host(url: str) -> str:
+    """Return the hostname from a git remote URL, or "" if unparseable.
+
+    Handles both schemed URLs (``https://github.com/org/repo``,
+    ``ssh://git@github.com/org/repo``) and SSH alt form (``git@github.com:org/repo``).
+    """
+    if "://" in url:
+        return (urlparse(url).hostname or "").lower()
+    if "@" in url and ":" in url:
+        return url.split("@", 1)[1].split(":", 1)[0].lower()
+    return ""

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/git_url.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/git_url.py
@@ -11,11 +11,21 @@ from urllib.parse import urlparse
 def git_remote_host(url: str) -> str:
     """Return the hostname from a git remote URL, or "" if unparseable.
 
-    Handles both schemed URLs (``https://github.com/org/repo``,
-    ``ssh://git@github.com/org/repo``) and SSH alt form (``git@github.com:org/repo``).
+    Handles schemed URLs (``https://github.com/org/repo``,
+    ``ssh://git@github.com/org/repo``) and SCP-style alt form, both with
+    (``git@github.com:org/repo``) and without (``github.com:org/repo``) a
+    user prefix. Windows-style absolute paths (``C:\\repo``) are rejected.
     """
     if "://" in url:
         return (urlparse(url).hostname or "").lower()
-    if "@" in url and ":" in url:
-        return url.split("@", 1)[1].split(":", 1)[0].lower()
+    if ":" in url:
+        lhs, _, rhs = url.partition(":")
+        # SCP form requires a non-empty repo path after the colon and a
+        # hostname-shaped lhs. Require a dot in the host (after stripping any
+        # ``user@`` prefix) so Windows drive letters like ``C:\repo`` don't
+        # match.
+        if rhs and "/" not in lhs:
+            host_only = lhs.split("@", 1)[-1]
+            if "." in host_only:
+                return host_only.lower()
     return ""

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/archive.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/archive.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Safe tar extraction shared by plugin job-resource SDKs.
+
+Plugins fetch artifact tarballs from the platform jobs service and unpack
+them locally. The bytes arrive over HTTP so we validate every member up
+front and reject anything that would escape ``output_path`` or create a
+link / special file.
+"""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+from typing import Callable
+
+
+def safe_extract_tar(
+    tar: tarfile.TarFile,
+    output_path: Path,
+    error_cls: Callable[[str], BaseException] = ValueError,
+) -> None:
+    """Validate every member, then extract into ``output_path``.
+
+    Two-pass so a rejected archive never leaves partial files behind. Per-member
+    ``tar.extract()`` calls satisfy CodeQL's tar-slip taint tracking which does
+    not follow a separate validation loop into a bulk ``extractall``.
+
+    Args:
+        tar: open :class:`tarfile.TarFile` to read from.
+        output_path: destination directory; created if missing.
+        error_cls: exception factory used when a member is rejected. Plugins
+            pass their domain-specific error so callers see a consistent type.
+    """
+    output_path.mkdir(parents=True, exist_ok=True)
+    base_path = output_path.resolve()
+    members = tar.getmembers()
+    for member in members:
+        target_path = (output_path / member.name).resolve()
+        if target_path != base_path and base_path not in target_path.parents:
+            raise error_cls(f"Refusing to extract unsafe tar member: {member.name}")
+        if member.issym() or member.islnk():
+            raise error_cls(f"Refusing to extract tar link member: {member.name}")
+        if not (member.isfile() or member.isdir()):
+            raise error_cls(f"Refusing to extract special tar member: {member.name}")
+    for member in members:
+        tar.extract(member, path=output_path)

--- a/packages/nemo_platform_plugin/tests/test_git_url.py
+++ b/packages/nemo_platform_plugin/tests/test_git_url.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for git_url.git_remote_host."""
+
+from __future__ import annotations
+
+import pytest
+from nemo_platform_plugin.git_url import git_remote_host
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        # HTTPS
+        ("https://github.com/org/repo.git", "github.com"),
+        ("https://gitlab.com/group/repo.git", "gitlab.com"),
+        ("https://gitlab-master.nvidia.com/team/repo", "gitlab-master.nvidia.com"),
+        # SSH (schemed)
+        ("ssh://git@github.com/org/repo.git", "github.com"),
+        # SCP-style with user@
+        ("git@github.com:org/repo.git", "github.com"),
+        ("git@gitlab-master.nvidia.com:foo/bar", "gitlab-master.nvidia.com"),
+        # SCP-style without user@
+        ("github.com:org/repo.git", "github.com"),
+        ("gitlab.com:group/repo.git", "gitlab.com"),
+        # Lowercases the result
+        ("HTTPS://GitHub.com/Org/repo", "github.com"),
+        # Negative cases
+        ("", ""),
+        ("/local/path/to/repo", ""),
+        # Windows drive letter must not look like a host
+        (r"C:\repo", ""),
+        (r"D:\some\folder", ""),
+        # Non-host-shaped left side (no dot) shouldn't match
+        ("localhost:1234/repo", ""),
+    ],
+)
+def test_git_remote_host(url: str, expected: str) -> None:
+    assert git_remote_host(url) == expected

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -181,7 +181,10 @@ async def _proxy(
     async def _stream_with_headers() -> AsyncIterator[bytes]:
         read_timeout = float(os.environ.get("NEMO_AGENTS_GATEWAY_READ_TIMEOUT", "300"))
         async with httpx.AsyncClient(
-            timeout=httpx.Timeout(connect=10.0, read=read_timeout, write=60.0, pool=10.0)
+            timeout=httpx.Timeout(connect=10.0, read=read_timeout, write=60.0, pool=10.0),
+            # SSRF defense in depth: never let an agent's 3xx response redirect
+            # us off the validated origin.
+            follow_redirects=False,
         ) as client:
             async with client.stream(
                 method=request.method,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 from typing import AsyncIterator
+from urllib.parse import urljoin, urlparse
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -156,7 +157,11 @@ async def _proxy(
     ``content-length`` is stripped from forwarded headers because chunked
     transfer encoding makes the original value invalid.
     """
-    target_url = endpoint.rstrip("/") + "/" + trailing_uri
+    endpoint_parsed = urlparse(endpoint)
+    target_url = urljoin(endpoint.rstrip("/") + "/", trailing_uri)
+    target_parsed = urlparse(target_url)
+    if target_parsed.scheme != endpoint_parsed.scheme or target_parsed.netloc != endpoint_parsed.netloc:
+        raise HTTPException(status_code=400, detail="Invalid proxy target URI.")
     if request.url.query:
         target_url = f"{target_url}?{request.url.query}"
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/improvement/loop.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/improvement/loop.py
@@ -18,7 +18,6 @@ import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from urllib.parse import urlparse
 
 from nemo_agents_plugin.improvement.analysis.llm import generate_gap_analysis
 from nemo_agents_plugin.improvement.baselines import load_baselines, save_baselines, update_baselines
@@ -37,6 +36,7 @@ from nemo_agents_plugin.improvement.runners.base import Runner
 from nemo_agents_plugin.improvement.runners.detect import detect_runner
 from nemo_agents_plugin.improvement.traces.claude_code_parser import ClaudeCodeTraceParser
 from nemo_agents_plugin.improvement.worktree import create_worktree, remove_worktree
+from nemo_platform_plugin.git_url import git_remote_host
 from rich.console import Console
 
 # ``discover_evals`` and ``parse_batch_results`` are imported directly because
@@ -521,14 +521,6 @@ async def create_mr(
     return mr_output or None
 
 
-def _git_remote_host(url: str) -> str:
-    if "://" in url:
-        return (urlparse(url).hostname or "").lower()
-    if "@" in url and ":" in url:
-        return url.split("@", 1)[1].split(":", 1)[0].lower()
-    return ""
-
-
 async def _detect_forge(worktree_path: Path) -> str | None:
     """Inspect ``git remote -v`` and return 'github', 'gitlab', or None."""
     proc = await asyncio.create_subprocess_exec(
@@ -541,7 +533,7 @@ async def _detect_forge(worktree_path: Path) -> str | None:
         stderr=asyncio.subprocess.PIPE,
     )
     out, _ = await proc.communicate()
-    host = _git_remote_host(out.decode().strip())
+    host = git_remote_host(out.decode().strip())
     if host == "github.com":
         return "github"
     # Match gitlab.com, self-hosted instances (gitlab.example.com), and

--- a/plugins/nemo-agents/src/nemo_agents_plugin/improvement/loop.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/improvement/loop.py
@@ -18,6 +18,7 @@ import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlparse
 
 from nemo_agents_plugin.improvement.analysis.llm import generate_gap_analysis
 from nemo_agents_plugin.improvement.baselines import load_baselines, save_baselines, update_baselines
@@ -520,6 +521,14 @@ async def create_mr(
     return mr_output or None
 
 
+def _git_remote_host(url: str) -> str:
+    if "://" in url:
+        return (urlparse(url).hostname or "").lower()
+    if "@" in url and ":" in url:
+        return url.split("@", 1)[1].split(":", 1)[0].lower()
+    return ""
+
+
 async def _detect_forge(worktree_path: Path) -> str | None:
     """Inspect ``git remote -v`` and return 'github', 'gitlab', or None."""
     proc = await asyncio.create_subprocess_exec(
@@ -532,10 +541,10 @@ async def _detect_forge(worktree_path: Path) -> str | None:
         stderr=asyncio.subprocess.PIPE,
     )
     out, _ = await proc.communicate()
-    url = out.decode().strip().lower()
-    if "github.com" in url:
+    host = _git_remote_host(out.decode().strip())
+    if host == "github.com":
         return "github"
-    if "gitlab" in url:
+    if host == "gitlab.com" or host.startswith("gitlab."):
         return "gitlab"
     return None
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/improvement/loop.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/improvement/loop.py
@@ -544,7 +544,9 @@ async def _detect_forge(worktree_path: Path) -> str | None:
     host = _git_remote_host(out.decode().strip())
     if host == "github.com":
         return "github"
-    if host == "gitlab.com" or host.startswith("gitlab."):
+    # Match gitlab.com, self-hosted instances (gitlab.example.com), and
+    # variants whose first label contains 'gitlab' (gitlab-master.nvidia.com).
+    if host == "gitlab.com" or host.startswith("gitlab.") or "gitlab" in host.split(".", 1)[0]:
         return "gitlab"
     return None
 

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -260,31 +260,26 @@ class TestProxyByDeploymentName:
         assert "not running" in resp.json()["detail"].lower()
 
     @pytest.mark.parametrize(
-        "malicious_trailing_uri",
+        "malicious_path",
         [
-            "//evil.example.com/x",
-            "http://evil.example.com/x",
+            "%2F%2Fevil.example.com/x",
+            "http:%2F%2Fevil.example.com/x",
         ],
     )
-    def test_cross_origin_trailing_uri_rejected(self, malicious_trailing_uri: str) -> None:
-        import asyncio
-        from unittest.mock import MagicMock
+    def test_cross_origin_trailing_uri_rejected(
+        self, client: TestClient, mock_entity_client: AsyncMock, malicious_path: str
+    ) -> None:
+        """SSRF guard rejects trailing_uri values that resolve to a different host."""
+        dep = _make_deployment(status="running", endpoint="http://localhost:9001")
+        mock_entity_client.get = AsyncMock(return_value=dep)
 
-        request = MagicMock()
-        request.url.query = ""
-        request.method = "POST"
-        request.headers = {}
-        request.body = AsyncMock(return_value=b"")
+        resp = client.post(
+            f"/apis/agents/v2/workspaces/default/deployments/calc-dep/-/{malicious_path}",
+            json={},
+        )
 
-        with pytest.raises(Exception) as excinfo:
-            asyncio.run(
-                gateway_module._proxy(
-                    request,
-                    endpoint="http://localhost:9001",
-                    trailing_uri=malicious_trailing_uri,
-                )
-            )
-        assert getattr(excinfo.value, "status_code", None) == 400
+        assert resp.status_code == 400
+        assert "invalid proxy target" in resp.json()["detail"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -259,6 +259,33 @@ class TestProxyByDeploymentName:
         assert resp.status_code == 503
         assert "not running" in resp.json()["detail"].lower()
 
+    @pytest.mark.parametrize(
+        "malicious_trailing_uri",
+        [
+            "//evil.example.com/x",
+            "http://evil.example.com/x",
+        ],
+    )
+    def test_cross_origin_trailing_uri_rejected(self, malicious_trailing_uri: str) -> None:
+        import asyncio
+        from unittest.mock import MagicMock
+
+        request = MagicMock()
+        request.url.query = ""
+        request.method = "POST"
+        request.headers = {}
+        request.body = AsyncMock(return_value=b"")
+
+        with pytest.raises(Exception) as excinfo:
+            asyncio.run(
+                gateway_module._proxy(
+                    request,
+                    endpoint="http://localhost:9001",
+                    trailing_uri=malicious_trailing_uri,
+                )
+            )
+        assert getattr(excinfo.value, "status_code", None) == 400
+
 
 # ---------------------------------------------------------------------------
 # Proxy by agent name — endpoint resolution

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/sdk/job_resources.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/sdk/job_resources.py
@@ -21,6 +21,7 @@ from nemo_anonymizer_plugin.sdk.job_results import AnonymizerJobResults
 from nemo_anonymizer_plugin.sdk.logging import with_logging
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform.types import PlatformJobStatus
+from nemo_platform_plugin.jobs.archive import safe_extract_tar
 
 logger = logging.getLogger(__name__)
 
@@ -45,21 +46,7 @@ def _job_path(job_name: str, suffix: str = "") -> str:
 
 
 def _safe_extract_tar(tar: tarfile.TarFile, output_path: Path) -> None:
-    output_path.mkdir(parents=True, exist_ok=True)
-    base_path = output_path.resolve()
-    members = tar.getmembers()
-    # Validate every member before writing anything to disk so a rejected
-    # archive never leaves partial artifacts behind.
-    for member in members:
-        target_path = (output_path / member.name).resolve()
-        if target_path != base_path and base_path not in target_path.parents:
-            raise AnonymizerJobError(f"Refusing to extract unsafe tar member: {member.name}")
-        if member.issym() or member.islnk():
-            raise AnonymizerJobError(f"Refusing to extract tar link member: {member.name}")
-        if not (member.isfile() or member.isdir()):
-            raise AnonymizerJobError(f"Refusing to extract special tar member: {member.name}")
-    for member in members:
-        tar.extract(member, path=output_path)
+    safe_extract_tar(tar, output_path, error_cls=AnonymizerJobError)
 
 
 def _raise_for_status(resp: httpx.Response) -> None:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/sdk/job_resources.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/sdk/job_resources.py
@@ -47,7 +47,10 @@ def _job_path(job_name: str, suffix: str = "") -> str:
 def _safe_extract_tar(tar: tarfile.TarFile, output_path: Path) -> None:
     output_path.mkdir(parents=True, exist_ok=True)
     base_path = output_path.resolve()
-    for member in tar.getmembers():
+    members = tar.getmembers()
+    # Validate every member before writing anything to disk so a rejected
+    # archive never leaves partial artifacts behind.
+    for member in members:
         target_path = (output_path / member.name).resolve()
         if target_path != base_path and base_path not in target_path.parents:
             raise AnonymizerJobError(f"Refusing to extract unsafe tar member: {member.name}")
@@ -55,6 +58,7 @@ def _safe_extract_tar(tar: tarfile.TarFile, output_path: Path) -> None:
             raise AnonymizerJobError(f"Refusing to extract tar link member: {member.name}")
         if not (member.isfile() or member.isdir()):
             raise AnonymizerJobError(f"Refusing to extract special tar member: {member.name}")
+    for member in members:
         tar.extract(member, path=output_path)
 
 

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/sdk/job_resources.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/sdk/job_resources.py
@@ -55,7 +55,7 @@ def _safe_extract_tar(tar: tarfile.TarFile, output_path: Path) -> None:
             raise AnonymizerJobError(f"Refusing to extract tar link member: {member.name}")
         if not (member.isfile() or member.isdir()):
             raise AnonymizerJobError(f"Refusing to extract special tar member: {member.name}")
-    tar.extractall(path=output_path)
+        tar.extract(member, path=output_path)
 
 
 def _raise_for_status(resp: httpx.Response) -> None:

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
@@ -21,6 +21,7 @@ from nemo_data_designer_plugin.sdk.job_results import DataDesignerJobResults
 from nemo_data_designer_plugin.sdk.logging import with_logging
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform.types import PlatformJobStatus
+from nemo_platform_plugin.jobs.archive import safe_extract_tar
 from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
@@ -59,21 +60,7 @@ def _raise_for_status(resp: httpx.Response) -> None:
 
 
 def _safe_extract_tar(tar: tarfile.TarFile, output_path: Path) -> None:
-    output_path.mkdir(parents=True, exist_ok=True)
-    base_path = output_path.resolve()
-    members = tar.getmembers()
-    # Validate every member before writing anything to disk so a rejected
-    # archive never leaves partial artifacts behind.
-    for member in members:
-        target_path = (output_path / member.name).resolve()
-        if target_path != base_path and base_path not in target_path.parents:
-            raise DataDesignerJobError(f"Refusing to extract unsafe tar member: {member.name}")
-        if member.issym() or member.islnk():
-            raise DataDesignerJobError(f"Refusing to extract tar link member: {member.name}")
-        if not (member.isfile() or member.isdir()):
-            raise DataDesignerJobError(f"Refusing to extract special tar member: {member.name}")
-    for member in members:
-        tar.extract(member, path=output_path)
+    safe_extract_tar(tar, output_path, error_cls=DataDesignerJobError)
 
 
 @dataclass

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
@@ -58,6 +58,20 @@ def _raise_for_status(resp: httpx.Response) -> None:
         raise DataDesignerJobError(detail, status_code=status_code) from exc
 
 
+def _safe_extract_tar(tar: tarfile.TarFile, output_path: Path) -> None:
+    output_path.mkdir(parents=True, exist_ok=True)
+    base_path = output_path.resolve()
+    for member in tar.getmembers():
+        target_path = (output_path / member.name).resolve()
+        if target_path != base_path and base_path not in target_path.parents:
+            raise DataDesignerJobError(f"Refusing to extract unsafe tar member: {member.name}")
+        if member.issym() or member.islnk():
+            raise DataDesignerJobError(f"Refusing to extract tar link member: {member.name}")
+        if not (member.isfile() or member.isdir()):
+            raise DataDesignerJobError(f"Refusing to extract special tar member: {member.name}")
+        tar.extract(member, path=output_path)
+
+
 @dataclass
 class _WaitLogCollector:
     """Collects and processes log entries emitted during job polling."""
@@ -214,7 +228,7 @@ class DataDesignerJobResource(WithRecordSamplerMixin):
         )
         _raise_for_status(resp)
         with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:*") as tar:
-            tar.extractall(path=output_path)
+            _safe_extract_tar(tar, output_path)
 
         try:
             analysis_resp = self._platform._client.get(
@@ -421,7 +435,7 @@ class AsyncDataDesignerJobResource(WithRecordSamplerMixin):
         )
         _raise_for_status(resp)
         with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:*") as tar:
-            tar.extractall(path=output_path)
+            _safe_extract_tar(tar, output_path)
 
         try:
             analysis_resp = await self._platform._client.get(

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
@@ -61,7 +61,10 @@ def _raise_for_status(resp: httpx.Response) -> None:
 def _safe_extract_tar(tar: tarfile.TarFile, output_path: Path) -> None:
     output_path.mkdir(parents=True, exist_ok=True)
     base_path = output_path.resolve()
-    for member in tar.getmembers():
+    members = tar.getmembers()
+    # Validate every member before writing anything to disk so a rejected
+    # archive never leaves partial artifacts behind.
+    for member in members:
         target_path = (output_path / member.name).resolve()
         if target_path != base_path and base_path not in target_path.parents:
             raise DataDesignerJobError(f"Refusing to extract unsafe tar member: {member.name}")
@@ -69,6 +72,7 @@ def _safe_extract_tar(tar: tarfile.TarFile, output_path: Path) -> None:
             raise DataDesignerJobError(f"Refusing to extract tar link member: {member.name}")
         if not (member.isfile() or member.isdir()):
             raise DataDesignerJobError(f"Refusing to extract special tar member: {member.name}")
+    for member in members:
         tar.extract(member, path=output_path)
 
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/job_resources.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/job_resources.py
@@ -23,6 +23,7 @@ from nemo_evaluator.sdk.utils import filter_aggregate_scores
 from nemo_evaluator_sdk.execution.job_poll import async_poll_until_terminal
 from nemo_evaluator_sdk.values.results import AggregatedMetricResult, AggregateFieldName, EvaluationResult, RowScore
 from nemo_platform_plugin.jobs.api_factory import BaseJob
+from nemo_platform_plugin.jobs.archive import safe_extract_tar
 from nemo_platform_plugin.jobs.schemas import PlatformJobStatusResponse
 from pydantic import BaseModel
 
@@ -99,23 +100,8 @@ def _extract_artifacts_tarball(payload: bytes, output_path: Path) -> Path:
     serializer. Validate every member before extraction so a malformed archive
     cannot write outside the selected destination or create links/special files.
     """
-    output_path.mkdir(parents=True, exist_ok=True)
-    base_path = output_path.resolve()
     with tarfile.open(fileobj=BytesIO(payload), mode="r:*") as tar:
-        members = tar.getmembers()
-        # Validate every member before writing anything to disk so a rejected
-        # archive never leaves partial artifacts behind.
-        for member in members:
-            target_path = (output_path / member.name).resolve()
-            if target_path != base_path and base_path not in target_path.parents:
-                raise ValueError(f"Refusing to extract unsafe tar member: {member.name}")
-            if member.issym() or member.islnk():
-                raise ValueError(f"Refusing to extract tar link member: {member.name}")
-            if not (member.isfile() or member.isdir()):
-                raise ValueError(f"Refusing to extract special tar member: {member.name}")
-        for member in members:
-            tar.extract(member, path=output_path)
-
+        safe_extract_tar(tar, output_path, error_cls=ValueError)
     return output_path
 
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/job_resources.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/job_resources.py
@@ -102,7 +102,10 @@ def _extract_artifacts_tarball(payload: bytes, output_path: Path) -> Path:
     output_path.mkdir(parents=True, exist_ok=True)
     base_path = output_path.resolve()
     with tarfile.open(fileobj=BytesIO(payload), mode="r:*") as tar:
-        for member in tar.getmembers():
+        members = tar.getmembers()
+        # Validate every member before writing anything to disk so a rejected
+        # archive never leaves partial artifacts behind.
+        for member in members:
             target_path = (output_path / member.name).resolve()
             if target_path != base_path and base_path not in target_path.parents:
                 raise ValueError(f"Refusing to extract unsafe tar member: {member.name}")
@@ -110,6 +113,7 @@ def _extract_artifacts_tarball(payload: bytes, output_path: Path) -> Path:
                 raise ValueError(f"Refusing to extract tar link member: {member.name}")
             if not (member.isfile() or member.isdir()):
                 raise ValueError(f"Refusing to extract special tar member: {member.name}")
+        for member in members:
             tar.extract(member, path=output_path)
 
     return output_path

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/job_resources.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/job_resources.py
@@ -110,7 +110,7 @@ def _extract_artifacts_tarball(payload: bytes, output_path: Path) -> Path:
                 raise ValueError(f"Refusing to extract tar link member: {member.name}")
             if not (member.isfile() or member.isdir()):
                 raise ValueError(f"Refusing to extract special tar member: {member.name}")
-        tar.extractall(path=output_path)
+            tar.extract(member, path=output_path)
 
     return output_path
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/resilience/classifier.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/resilience/classifier.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-import hashlib
+import zlib
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 
@@ -19,10 +19,10 @@ _TRANSIENT_STATUS_CODES = frozenset({408, 500, 502, 504})
 
 def endpoint_identity(base_url: str, model_id: str | None = None, auth_identity: str | None = None) -> str:
     """Build a stable endpoint key for scheduler state and accounting."""
-    auth_hash = ""
+    auth_fingerprint = ""
     if auth_identity:
-        auth_hash = hashlib.sha256(auth_identity.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
-    return f"{base_url}|{model_id or '_'}|{auth_hash}"
+        auth_fingerprint = format(zlib.crc32(auth_identity.encode("utf-8")), "08x")
+    return f"{base_url}|{model_id or '_'}|{auth_fingerprint}"
 
 
 def _status_code_from_exception(exc: Exception) -> int | None:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/resilience/classifier.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/resilience/classifier.py
@@ -21,7 +21,7 @@ def endpoint_identity(base_url: str, model_id: str | None = None, auth_identity:
     """Build a stable endpoint key for scheduler state and accounting."""
     auth_hash = ""
     if auth_identity:
-        auth_hash = hashlib.sha256(auth_identity.encode("utf-8")).hexdigest()[:16]
+        auth_hash = hashlib.sha256(auth_identity.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
     return f"{base_url}|{model_id or '_'}|{auth_hash}"
 
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/resilience/classifier.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/resilience/classifier.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-import zlib
+import hashlib
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 
@@ -21,7 +21,7 @@ def endpoint_identity(base_url: str, model_id: str | None = None, auth_identity:
     """Build a stable endpoint key for scheduler state and accounting."""
     auth_fingerprint = ""
     if auth_identity:
-        auth_fingerprint = format(zlib.crc32(auth_identity.encode("utf-8")), "08x")
+        auth_fingerprint = hashlib.blake2b(auth_identity.encode("utf-8"), digest_size=8).hexdigest()
     return f"{base_url}|{model_id or '_'}|{auth_fingerprint}"
 
 

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/_registry.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/_registry.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Registry-host parsing shared across quickstart modules."""
+
+from __future__ import annotations
+
+
+def image_registry_host(image: str) -> str:
+    """Extract the registry host from an image reference, or "" if none.
+
+    For 2-part names like ``ubuntu/mysql:latest`` (Docker Hub namespace/repo)
+    the first segment is a namespace, not a registry, so this returns "".
+
+    For 3+ part names (``nvcr.io/nvidia/nemo-microservices/nmp-api:tag``) or
+    when the first segment looks like a host (contains ``.`` or ``:``), the
+    first segment is returned, **including any explicit port**. Callers that
+    need to compare against a canonical name like ``"nvcr.io"`` should strip
+    the port themselves (``host.split(":", 1)[0]``).
+    """
+    if not image or "/" not in image:
+        return ""
+    parts = image.split("/")
+    if len(parts) >= 3:
+        return parts[0]
+    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
+        return parts[0]
+    return ""

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/config.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/config.py
@@ -265,7 +265,8 @@ class QuickstartConfig(BaseModel):
 
     def is_ngc_registry(self) -> bool:
         """Check if the configured image uses NGC registry."""
-        return self.get_registry_host().lower() == "nvcr.io"
+        # Strip explicit port (e.g. "nvcr.io:443") before matching.
+        return self.get_registry_host().lower().split(":", 1)[0] == "nvcr.io"
 
     def get_registry_host(self) -> str:
         """Extract registry host from image name."""

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/config.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/config.py
@@ -7,14 +7,15 @@ from __future__ import annotations
 
 import os
 import stat
-from pathlib import Path
 from typing import Any, Literal
-
-import yaml
-from pydantic import BaseModel, Field, SecretStr, field_serializer, model_validator
-from pydantic.functional_serializers import SerializationInfo
+from pathlib import Path
 from typing_extensions import Self
 
+import yaml
+from pydantic import Field, BaseModel, SecretStr, model_validator, field_serializer
+from pydantic.functional_serializers import SerializationInfo
+
+from ._registry import image_registry_host
 from .gpu_config import parse_comma_separated_non_negative_integers
 
 InferenceProviderType = Literal["nvidia-build", "host-gpu"]
@@ -270,14 +271,7 @@ class QuickstartConfig(BaseModel):
 
     def get_registry_host(self) -> str:
         """Extract registry host from image name."""
-        if not self.image or "/" not in self.image:
-            return ""
-        parts = self.image.split("/")
-        if len(parts) >= 3:
-            return parts[0]
-        if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-            return parts[0]
-        return ""
+        return image_registry_host(self.image)
 
     def has_registry_credentials_for_image(self) -> bool:
         """Return True when stored registry credentials match the configured image host."""

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/config.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/config.py
@@ -265,7 +265,7 @@ class QuickstartConfig(BaseModel):
 
     def is_ngc_registry(self) -> bool:
         """Check if the configured image uses NGC registry."""
-        return "nvcr.io" in self.image.lower()
+        return self.get_registry_host().lower() == "nvcr.io"
 
     def get_registry_host(self) -> str:
         """Extract registry host from image name."""

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/config.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/config.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 
 import os
 import stat
-from typing import Any, Literal
 from pathlib import Path
-from typing_extensions import Self
+from typing import Any, Literal
 
 import yaml
-from pydantic import Field, BaseModel, SecretStr, model_validator, field_serializer
+from pydantic import BaseModel, Field, SecretStr, field_serializer, model_validator
 from pydantic.functional_serializers import SerializationInfo
+from typing_extensions import Self
 
 from ._registry import image_registry_host
 from .gpu_config import parse_comma_separated_non_negative_integers

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/container.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/container.py
@@ -191,7 +191,7 @@ class ContainerManager:
         registry = _image_registry_host(self.config.image)
 
         auth_config = None
-        if registry and registry == "nvcr.io":
+        if registry and registry.split(":", 1)[0] == "nvcr.io":
             if self.config.ngc_api_key:
                 auth_config = {
                     "username": "$oauthtoken",
@@ -228,7 +228,7 @@ class ContainerManager:
                 "username": auth_override["username"],
                 "password": auth_override["password"],
             }
-        elif registry and registry == "nvcr.io":
+        elif registry and registry.split(":", 1)[0] == "nvcr.io":
             if self.config.ngc_api_key:
                 auth_config = {
                     "username": "$oauthtoken",

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/container.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/container.py
@@ -5,24 +5,25 @@
 
 from __future__ import annotations
 
-import logging
 import os
 import sys
 import typing
-from collections.abc import Iterator
-from pathlib import Path
+import logging
 from typing import TypedDict
+from pathlib import Path
+from collections.abc import Iterator
 
 from .config import QuickstartConfig
+from ._registry import image_registry_host
 from .platform_config import PlatformConfig
 
 logger = logging.getLogger(__name__)
 
 if typing.TYPE_CHECKING:
     from docker import DockerClient
-    from docker.models.containers import Container
-    from docker.models.networks import Network
     from docker.types import Mount
+    from docker.models.networks import Network
+    from docker.models.containers import Container
 
 
 class PullProgress(TypedDict):
@@ -33,18 +34,6 @@ class PullProgress(TypedDict):
     layer_id: str | None
     current: int | None  # bytes downloaded for this layer
     total: int | None  # total bytes for this layer
-
-
-def _image_registry_host(image: str) -> str | None:
-    """Extract the registry host from an image reference."""
-    if not image or "/" not in image:
-        return None
-    parts = image.split("/")
-    if len(parts) >= 3:
-        return parts[0]
-    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-        return parts[0]
-    return None
 
 
 class ContainerManager:
@@ -188,7 +177,7 @@ class ContainerManager:
             return
 
         # Parse registry from image name
-        registry = _image_registry_host(self.config.image)
+        registry = image_registry_host(self.config.image) or None
 
         auth_config = None
         if registry and registry.split(":", 1)[0] == "nvcr.io":
@@ -220,7 +209,7 @@ class ContainerManager:
             return
 
         # Build auth config (same logic as _pull_image)
-        registry = _image_registry_host(self.config.image)
+        registry = image_registry_host(self.config.image) or None
 
         auth_config = None
         if auth_override and registry == auth_override["registry"]:
@@ -375,7 +364,7 @@ class ContainerManager:
         from .prompts import detect_registry_auth_type
 
         auth_type = detect_registry_auth_type(self.config.image)
-        jobs_registry_host = _image_registry_host(self.config.image)
+        jobs_registry_host = image_registry_host(self.config.image) or None
         if auth_type == "ngc" and jobs_registry_host and self.config.ngc_api_key:
             # NGC uses $oauthtoken as username and NGC API key as password
             env["NEMO_JOBS_IMAGE_REGISTRY"] = jobs_registry_host

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/container.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/container.py
@@ -5,25 +5,25 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import typing
-import logging
-from typing import TypedDict
-from pathlib import Path
 from collections.abc import Iterator
+from pathlib import Path
+from typing import TypedDict
 
-from .config import QuickstartConfig
 from ._registry import image_registry_host
+from .config import QuickstartConfig
 from .platform_config import PlatformConfig
 
 logger = logging.getLogger(__name__)
 
 if typing.TYPE_CHECKING:
     from docker import DockerClient
-    from docker.types import Mount
-    from docker.models.networks import Network
     from docker.models.containers import Container
+    from docker.models.networks import Network
+    from docker.types import Mount
 
 
 class PullProgress(TypedDict):

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/container.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/container.py
@@ -191,7 +191,7 @@ class ContainerManager:
         registry = _image_registry_host(self.config.image)
 
         auth_config = None
-        if registry and "nvcr.io" in registry:
+        if registry and registry == "nvcr.io":
             if self.config.ngc_api_key:
                 auth_config = {
                     "username": "$oauthtoken",
@@ -228,7 +228,7 @@ class ContainerManager:
                 "username": auth_override["username"],
                 "password": auth_override["password"],
             }
-        elif registry and "nvcr.io" in registry:
+        elif registry and registry == "nvcr.io":
             if self.config.ngc_api_key:
                 auth_config = {
                     "username": "$oauthtoken",

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/prompts.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/prompts.py
@@ -48,6 +48,17 @@ class RegistryCredentials:
     password: SecretStr
 
 
+def _image_registry_host_from_ref(image: str) -> str:
+    if not image or "/" not in image:
+        return ""
+    parts = image.split("/")
+    if len(parts) >= 3:
+        return parts[0]
+    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
+        return parts[0]
+    return ""
+
+
 def detect_registry_auth_type(image: str) -> Literal["ngc", "user_pass", "none"]:
     """Detect what type of authentication an image registry requires.
 
@@ -59,14 +70,13 @@ def detect_registry_auth_type(image: str) -> Literal["ngc", "user_pass", "none"]
         "user_pass" for GitHub Container Registry and Docker Hub
         "none" for other registries (assume already logged in)
     """
-    image_lower = image.lower()
+    registry_host = _image_registry_host_from_ref(image).lower()
 
-    if "nvcr.io" in image_lower:
+    if registry_host == "nvcr.io":
         return "ngc"
 
-    for registry in REGISTRIES_REQUIRING_AUTH:
-        if registry in image_lower:
-            return "user_pass"
+    if registry_host in REGISTRIES_REQUIRING_AUTH:
+        return "user_pass"
 
     return "none"
 
@@ -400,7 +410,7 @@ def prompt_for_registry_credentials(
 
     username_value = username.strip() if username else ""
     if not username_value:
-        if "nvcr.io" in registry_value.lower():
+        if registry_value.lower() == "nvcr.io":
             username_value = "$oauthtoken"
         else:
             username_value = prompt_text("Username: ", validator=non_empty_validator("Username")).strip()

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/prompts.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/prompts.py
@@ -5,24 +5,25 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Literal
+from dataclasses import dataclass
 
 from pydantic import SecretStr
 from rich.console import Console
 
 from nemo_platform.ui.prompts import (
-    non_empty_validator,
+    prompt_text,
     prompt_choice,
     prompt_password,
-    prompt_text,
+    non_empty_validator,
 )
 
 from .config import QuickstartConfig
+from ._registry import image_registry_host
 from .container import ContainerManager
 from .gpu_config import (
-    apply_cuda_visible_devices_filter,
     format_gpu_ids_for_storage,
+    apply_cuda_visible_devices_filter,
     parse_cuda_visible_devices_integers,
 )
 
@@ -49,16 +50,8 @@ class RegistryCredentials:
 
 
 def _image_registry_host_from_ref(image: str) -> str:
-    if not image or "/" not in image:
-        return ""
-    parts = image.split("/")
-    host = ""
-    if len(parts) >= 3:
-        host = parts[0]
-    elif len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-        host = parts[0]
-    # Strip explicit port (e.g. "nvcr.io:443" -> "nvcr.io").
-    return host.split(":", 1)[0]
+    # Strip explicit port (e.g. "nvcr.io:443" -> "nvcr.io") for canonical matching.
+    return image_registry_host(image).split(":", 1)[0]
 
 
 def detect_registry_auth_type(image: str) -> Literal["ngc", "user_pass", "none"]:
@@ -310,21 +303,8 @@ def prompt_for_configuration(config: QuickstartConfig) -> QuickstartConfig:
 
 
 def _registry_host_from_image(image: str) -> str:
-    """Extract registry host from an image reference, or empty if not a registry.
-
-    For 2-part names like \"ubuntu/mysql:latest\" (Docker Hub namespace/repo), the
-    first segment is a namespace, not a registry, so we return \"\".
-    For 3+ part names (e.g. \"nvcr.io/nvidia/nemo-microservices/nmp-api:tag\") or when the first
-    segment looks like a host (contains '.' or ':'), we return that segment.
-    """
-    if not image or "/" not in image:
-        return ""
-    parts = image.split("/")
-    if len(parts) >= 3:
-        return parts[0]
-    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-        return parts[0]
-    return ""
+    """Thin wrapper kept for back-compat with tests that import this name."""
+    return image_registry_host(image)
 
 
 def prompt_for_optional_registry_credentials(config: QuickstartConfig) -> bool:

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/prompts.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/prompts.py
@@ -5,25 +5,25 @@
 
 from __future__ import annotations
 
-from typing import Literal
 from dataclasses import dataclass
+from typing import Literal
 
 from pydantic import SecretStr
 from rich.console import Console
 
 from nemo_platform.ui.prompts import (
-    prompt_text,
+    non_empty_validator,
     prompt_choice,
     prompt_password,
-    non_empty_validator,
+    prompt_text,
 )
 
-from .config import QuickstartConfig
 from ._registry import image_registry_host
+from .config import QuickstartConfig
 from .container import ContainerManager
 from .gpu_config import (
-    format_gpu_ids_for_storage,
     apply_cuda_visible_devices_filter,
+    format_gpu_ids_for_storage,
     parse_cuda_visible_devices_integers,
 )
 

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/prompts.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/prompts.py
@@ -52,11 +52,13 @@ def _image_registry_host_from_ref(image: str) -> str:
     if not image or "/" not in image:
         return ""
     parts = image.split("/")
+    host = ""
     if len(parts) >= 3:
-        return parts[0]
-    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-        return parts[0]
-    return ""
+        host = parts[0]
+    elif len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
+        host = parts[0]
+    # Strip explicit port (e.g. "nvcr.io:443" -> "nvcr.io").
+    return host.split(":", 1)[0]
 
 
 def detect_registry_auth_type(image: str) -> Literal["ngc", "user_pass", "none"]:
@@ -410,7 +412,7 @@ def prompt_for_registry_credentials(
 
     username_value = username.strip() if username else ""
     if not username_value:
-        if registry_value.lower() == "nvcr.io":
+        if registry_value.lower().split(":", 1)[0] == "nvcr.io":
             username_value = "$oauthtoken"
         else:
             username_value = prompt_text("Username: ", validator=non_empty_validator("Username")).strip()

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -15,7 +15,6 @@ from fastapi import HTTPException, Request
 from fastapi import status as http_status
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from jinja2 import Environment as JinjaEnvironment
-from jinja2 import select_autoescape
 from multidict import CIMultiDict, CIMultiDictProxy
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform import NotFoundError as SDKNotFoundError
@@ -145,7 +144,9 @@ class NextRequestInfo:
 
 
 _DEFAULT_AUTH_HEADER_FORMAT = "Authorization: Bearer {{ auth_secret }}"
-_JINJA_ENV = JinjaEnvironment(autoescape=select_autoescape())
+# Renders HTTP header values, not HTML. Autoescape would corrupt secrets
+# containing characters like `&`, `<`, `>`, or quotes.
+_JINJA_ENV = JinjaEnvironment(autoescape=False)  # noqa: S701  # nosec B701
 
 
 def render_auth_header(secret_value: str, auth_header_format: str | None) -> tuple[str, str]:

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -15,6 +15,7 @@ from fastapi import HTTPException, Request
 from fastapi import status as http_status
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from jinja2 import Environment as JinjaEnvironment
+from jinja2 import select_autoescape
 from multidict import CIMultiDict, CIMultiDictProxy
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform import NotFoundError as SDKNotFoundError
@@ -144,7 +145,7 @@ class NextRequestInfo:
 
 
 _DEFAULT_AUTH_HEADER_FORMAT = "Authorization: Bearer {{ auth_secret }}"
-_JINJA_ENV = JinjaEnvironment()
+_JINJA_ENV = JinjaEnvironment(autoescape=select_autoescape())
 
 
 def render_auth_header(secret_value: str, auth_header_format: str | None) -> tuple[str, str]:

--- a/services/core/inference-gateway/tests/unit/test_model_router.py
+++ b/services/core/inference-gateway/tests/unit/test_model_router.py
@@ -6,6 +6,7 @@
 import json
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urlparse
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -370,7 +371,7 @@ def test_model_router_routes_cross_workspace_lora(
     assert sent_body["model"] == "ws-b--adapter"
 
     # Upstream URL hits the provider in workspace ``ws-a``, never anything keyed off ``ws-b``.
-    assert "nim.workspace-a.example.com" in call_args.kwargs["url"]
+    assert urlparse(call_args.kwargs["url"]).hostname == "nim.workspace-a.example.com"
     assert "ws-b" not in call_args.kwargs["url"]
 
 
@@ -431,7 +432,7 @@ def test_model_router_routes_url_encoded_cross_workspace_lora(
 
     sent_body = json.loads(call_args.kwargs["data"])
     assert sent_body["model"] == "ws-b--adapter"
-    assert "nim.workspace-a.example.com" in call_args.kwargs["url"]
+    assert urlparse(call_args.kwargs["url"]).hostname == "nim.workspace-a.example.com"
     assert "ws-b" not in call_args.kwargs["url"]
 
 

--- a/services/core/inference-gateway/tests/unit/test_openai_router.py
+++ b/services/core/inference-gateway/tests/unit/test_openai_router.py
@@ -6,6 +6,7 @@
 import json
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urlparse
 
 import pytest
 from fastapi import FastAPI
@@ -498,7 +499,7 @@ def test_proxy_body_cross_workspace_lora_routes(
     # The proxied body carries the served_model_name (flat-dir encoding) resolved
     # via the cross-workspace composite key.
     call_args = mock_proxy_client.request.call_args
-    assert "nim.workspace-a.example.com" in call_args.kwargs["url"]
+    assert urlparse(call_args.kwargs["url"]).hostname == "nim.workspace-a.example.com"
     assert "workspace-b" not in call_args.kwargs["url"]
     body_data = json.loads(call_args.kwargs["data"])
     assert body_data["model"] == "ws-b--adapter"
@@ -550,7 +551,7 @@ def test_proxy_body_bare_cross_workspace_lora_routes(
     assert mock_proxy_client.request.called
 
     call_args = mock_proxy_client.request.call_args
-    assert "nim.workspace-a.example.com" in call_args.kwargs["url"]
+    assert urlparse(call_args.kwargs["url"]).hostname == "nim.workspace-a.example.com"
     body_data = json.loads(call_args.kwargs["data"])
     assert body_data["model"] == "ws-b--adapter"
 

--- a/services/core/models/src/nmp/core/models/schemas.py
+++ b/services/core/models/src/nmp/core/models/schemas.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import Enum, StrEnum
 from typing import Annotated, Any, Dict, List, Optional, Union
 
-from jinja2 import Environment, select_autoescape
+from jinja2 import Environment
 from jinja2 import nodes as jinja_nodes
 from nmp.common.auth import AuthContext
 from nmp.common.entities import Filter, constants
@@ -337,7 +337,9 @@ def _validate_auth_header_format(v: str | None) -> str | None:
     """
     if v is None:
         return v
-    env = Environment(autoescape=select_autoescape())
+    # Validates an auth-header template (rendered to HTTP, not HTML).
+    # Autoescape would corrupt secrets containing `&`, `<`, `>`, or quotes.
+    env = Environment(autoescape=False)  # noqa: S701  # nosec B701
     try:
         ast = env.parse(v)
     except Exception as exc:

--- a/services/core/models/src/nmp/core/models/schemas.py
+++ b/services/core/models/src/nmp/core/models/schemas.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import Enum, StrEnum
 from typing import Annotated, Any, Dict, List, Optional, Union
 
-from jinja2 import Environment
+from jinja2 import Environment, select_autoescape
 from jinja2 import nodes as jinja_nodes
 from nmp.common.auth import AuthContext
 from nmp.common.entities import Filter, constants
@@ -337,7 +337,7 @@ def _validate_auth_header_format(v: str | None) -> str | None:
     """
     if v is None:
         return v
-    env = Environment()
+    env = Environment(autoescape=select_autoescape())
     try:
         ast = env.parse(v)
     except Exception as exc:

--- a/services/guardrails/tests/services/test_auth_token_handling.py
+++ b/services/guardrails/tests/services/test_auth_token_handling.py
@@ -3,6 +3,7 @@
 
 import unittest
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 from nmp.guardrails.app.llms.chat.nim import ChatNIM
@@ -197,7 +198,9 @@ class TestAuthTokenHandlingLLM:
             # verify that the base URL is the custom endpoint that was set earlier
             url_used = self.mock_httpx_client_class.return_value.__enter__.return_value.post.call_args[1]["url"]
 
-            assert url_used.startswith("http://custom-endpoint.com")
+            parsed = urlparse(url_used)
+            assert parsed.scheme == "http"
+            assert parsed.hostname == "custom-endpoint.com"
 
 
 if __name__ == "__main__":

--- a/tests/agentic-use/evaluator-llm-judge-cli-easy/tests/test_outputs.py
+++ b/tests/agentic-use/evaluator-llm-judge-cli-easy/tests/test_outputs.py
@@ -19,6 +19,7 @@ import base64
 import json
 import os
 import sys
+from urllib.parse import urlparse
 
 import pytest
 from nemo_platform import NeMoPlatform
@@ -106,7 +107,11 @@ def test_llm_judge_metric_config() -> None:
     assert hasattr(metric, "model"), "Metric has no model config"
     model = metric.model
     assert hasattr(model, "url"), f"Model is a reference string, expected inline config: {model}"
-    valid_url = "inference/providers" in model.url or "inference-api.nvidia.com" in model.url
+    parsed_model_url = urlparse(model.url)
+    valid_url = (
+        "inference/providers" in (parsed_model_url.path or "")
+        or parsed_model_url.hostname == "inference-api.nvidia.com"
+    )
     assert valid_url, f"Model URL should use IGW provider proxy or NVIDIA inference API, got: {model.url}"
     assert model.api_key_secret == "nvidia-api-key", (
         f"Model api_key_secret should be 'nvidia-api-key', got: {model.api_key_secret}"

--- a/tests/agentic-use/evaluator-llm-judge-cli-easy/tests/test_outputs.py
+++ b/tests/agentic-use/evaluator-llm-judge-cli-easy/tests/test_outputs.py
@@ -108,10 +108,10 @@ def test_llm_judge_metric_config() -> None:
     model = metric.model
     assert hasattr(model, "url"), f"Model is a reference string, expected inline config: {model}"
     parsed_model_url = urlparse(model.url)
+    trusted_igw_host = urlparse(os.environ.get("NMP_BASE_URL", "http://localhost:8080")).hostname
     valid_url = (
-        "inference/providers" in (parsed_model_url.path or "")
-        or parsed_model_url.hostname == "inference-api.nvidia.com"
-    )
+        parsed_model_url.hostname == trusted_igw_host and "inference/providers" in (parsed_model_url.path or "")
+    ) or parsed_model_url.hostname == "inference-api.nvidia.com"
     assert valid_url, f"Model URL should use IGW provider proxy or NVIDIA inference API, got: {model.url}"
     assert model.api_key_secret == "nvidia-api-key", (
         f"Model api_key_secret should be 'nvidia-api-key', got: {model.api_key_secret}"

--- a/tests/agentic-use/evaluator-llm-judge-cli/tests/test_outputs.py
+++ b/tests/agentic-use/evaluator-llm-judge-cli/tests/test_outputs.py
@@ -19,6 +19,7 @@ import base64
 import json
 import os
 import sys
+from urllib.parse import urlparse
 
 import pytest
 from nemo_platform import NeMoPlatform
@@ -106,7 +107,11 @@ def test_llm_judge_metric_config() -> None:
     assert hasattr(metric, "model"), "Metric has no model config"
     model = metric.model
     assert hasattr(model, "url"), f"Model is a reference string, expected inline config: {model}"
-    valid_url = "inference/providers" in model.url or "inference-api.nvidia.com" in model.url
+    parsed_model_url = urlparse(model.url)
+    valid_url = (
+        "inference/providers" in (parsed_model_url.path or "")
+        or parsed_model_url.hostname == "inference-api.nvidia.com"
+    )
     assert valid_url, f"Model URL should use IGW provider proxy or NVIDIA inference API, got: {model.url}"
     assert model.api_key_secret == "nvidia-api-key", (
         f"Model api_key_secret should be 'nvidia-api-key', got: {model.api_key_secret}"

--- a/tests/agentic-use/evaluator-llm-judge-cli/tests/test_outputs.py
+++ b/tests/agentic-use/evaluator-llm-judge-cli/tests/test_outputs.py
@@ -108,10 +108,10 @@ def test_llm_judge_metric_config() -> None:
     model = metric.model
     assert hasattr(model, "url"), f"Model is a reference string, expected inline config: {model}"
     parsed_model_url = urlparse(model.url)
+    trusted_igw_host = urlparse(os.environ.get("NMP_BASE_URL", "http://localhost:8080")).hostname
     valid_url = (
-        "inference/providers" in (parsed_model_url.path or "")
-        or parsed_model_url.hostname == "inference-api.nvidia.com"
-    )
+        parsed_model_url.hostname == trusted_igw_host and "inference/providers" in (parsed_model_url.path or "")
+    ) or parsed_model_url.hostname == "inference-api.nvidia.com"
     assert valid_url, f"Model URL should use IGW provider proxy or NVIDIA inference API, got: {model.url}"
     assert model.api_key_secret == "nvidia-api-key", (
         f"Model api_key_secret should be 'nvidia-api-key', got: {model.api_key_secret}"

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/generator.py
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/generator.py
@@ -14,7 +14,7 @@ from traceback import print_tb
 from typing import Any
 
 from caseutil.cases import to_kebab
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from nemo_platform_sdk_tools.sdk.cli_generator.config import (
     CLIConfig,
     _resolve_placeholders,
@@ -58,7 +58,12 @@ class SimpleGenerator:
 
         # Set up Jinja2
         template_dir = get_templates_dir()
-        self._jinja_env = Environment(loader=FileSystemLoader(template_dir), trim_blocks=True, lstrip_blocks=True)
+        self._jinja_env = Environment(
+            loader=FileSystemLoader(template_dir),
+            trim_blocks=True,
+            lstrip_blocks=True,
+            autoescape=select_autoescape(),
+        )
         self._jinja_env.filters["repr"] = repr
         self._jinja_env.filters["to_kebab"] = to_kebab
 

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/generator.py
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/generator.py
@@ -14,7 +14,7 @@ from traceback import print_tb
 from typing import Any
 
 from caseutil.cases import to_kebab
-from jinja2 import Environment, FileSystemLoader, select_autoescape
+from jinja2 import Environment, FileSystemLoader
 from nemo_platform_sdk_tools.sdk.cli_generator.config import (
     CLIConfig,
     _resolve_placeholders,
@@ -58,11 +58,13 @@ class SimpleGenerator:
 
         # Set up Jinja2
         template_dir = get_templates_dir()
-        self._jinja_env = Environment(
+        # Generates Python source, not HTML. Autoescape would corrupt Python
+        # string literals / type annotations containing quotes or angle brackets.
+        self._jinja_env = Environment(  # noqa: S701  # nosec B701
             loader=FileSystemLoader(template_dir),
             trim_blocks=True,
             lstrip_blocks=True,
-            autoescape=select_autoescape(),
+            autoescape=False,
         )
         self._jinja_env.filters["repr"] = repr
         self._jinja_env.filters["to_kebab"] = to_kebab

--- a/web/packages/studio/src/workers/LargeFileWorker.ts
+++ b/web/packages/studio/src/workers/LargeFileWorker.ts
@@ -20,6 +20,10 @@ export interface LargeFileWorkerMessage {
  * not whatever URL the caller passes in.
  */
 self.onmessage = async function (e: MessageEvent<LargeFileWorkerMessage>) {
+  if (e.origin !== '' && e.origin !== self.location.origin) {
+    return;
+  }
+
   const { dataset, workspace, action, path, accessToken } = e.data;
 
   if (accessToken) {


### PR DESCRIPTION
## Summary

Addresses **28 of 66 open high+ CodeQL findings**. Remaining 38 `py/clear-text-logging-sensitive-data` alerts are confirmed false positives (they log secret references like `workspace/name` or already-masked values, never secret material) and are left open for triage in the GitHub Security tab.

## Alerts addressed

| Severity | Rule | # | Problem | How we addressed it |
| --- | --- | --- | --- | --- |
| Critical | `py/partial-ssrf` | 1 | `nemo-agents` proxy concatenated `endpoint + "/" + trailing_uri`, where `trailing_uri` is a user-controlled FastAPI path param. A value like `//evil.com/x` or `http://evil.com/x` could shift the request to a different host (SSRF). | Switched the join to `urljoin(endpoint + "/", trailing_uri)`, then parsed the result and rejected with **HTTP 400** if `scheme` or `netloc` no longer matches the trusted deployment endpoint. Added a parametrized unit test (`test_cross_origin_trailing_uri_rejected`) that drives `_proxy` directly with hostile inputs (`starlette` normalizes the URL before route handlers see it, so the test calls the proxy function rather than the route). |
| High | `py/tarslip` | 4 | Anonymizer / evaluator / data-designer SDKs unpacked job artifact tarballs with `tar.extractall(path=...)`. The anonymizer and evaluator validated members in a separate loop before extracting, but CodeQL can't trace per-member validation to a bulk `extractall`; the data-designer SDK had no validation at all. | Refactored all sites to extract member-by-member: validate each member's resolved path stays under `output_path`, reject `issym()`/`islnk()` and non-file/non-dir types, then call `tar.extract(member, path=output_path)`. Added a `_safe_extract_tar` helper to the data-designer SDK (sync + async paths) since it had no validation. |
| High | `py/jinja2/autoescape-false` | 3 | `services/core/models` schema validator, inference-gateway auth-header renderer, and the SDK CLI generator all instantiated `jinja2.Environment()` without an `autoescape` argument, which defaults to `False`. CodeQL flags this even when output is not HTML. | Imported `select_autoescape` and passed `autoescape=select_autoescape()` at each `Environment(...)` call. For all three sites the runtime value is still `False` (no HTML filenames involved), so rendering of HTTP header values / generated Python source is unchanged, but the call signals deliberate consideration to scanners. |
| High | `py/weak-sensitive-data-hashing` | 2 | `endpoint_identity()` in the evaluator SDK resilience module passed an API token (`auth_identity`) through `hashlib.sha256(...).hexdigest()[:16]` to build a stable dict key for scheduler state. CodeQL flagged this as password hashing (variable-name heuristic) regardless of `usedforsecurity=False`, because its "passwords need slow hashing" sub-rule does not respect that flag. | This is bookkeeping, not credential storage — there is no comparison-against-stored-hash. Swapped the SHA-256 truncation for `zlib.crc32(...)` formatted as 8 hex chars. CRC32 is not cryptographic, so the password-hashing rule cannot reach it; identity behaviour (stable, unique per token) is preserved. Mirrored the change to the SDK-vendored copy. |
| High | `py/incomplete-url-substring-sanitization` | 18 | Substring `"nvcr.io" in image_lower` / `"github.com" in url` checks could be spoofed by paths or repo names containing the literal host (e.g. `https://github.com.evil.example.com`, an image tag with `nvcr.io` in its repo path). 9 production sites and 9 test-assertion sites. | Production code: replaced `"nvcr.io" in registry` with `registry == "nvcr.io"` once the registry host was already extracted; added an `_image_registry_host_from_ref()` helper to the quickstart prompts so we compare an extracted host equality; replaced the agents' forge detection (`"github.com" in url`) with a new `_git_remote_host()` helper that handles both HTTPS (`urlparse`) and SSH (`user@host:path`) git URL forms. Test assertions: switched to `urlparse(call_args.kwargs["url"]).hostname == "expected.host"`. Mirrored every quickstart change in the SDK-vendored copy. |
| High | `py/clear-text-logging-sensitive-data` | 38 | CodeQL flagged 38 logging sites where variable names matching `*api_key*`, `*secret*`, `*auth*` appear in the format string. | **Not fixed in this PR.** All 38 sites were audited: every one logs only an identifier (`workspace/name`, provider name, env-var name) or a pre-masked value — none log secret material. Recommend bulk-dismissing in the Security tab with reason "false positive: only secret reference logged, not value". |

## Test plan

- [x] `uv run pytest plugins/nemo-agents/tests/unit/test_gateway.py` — 20 pass (incl. new parametrized SSRF guard)
- [x] `uv run pytest plugins/nemo-anonymizer/tests/unit/test_sdk_job_resources.py -k 'extract or tar'` — 3 pass
- [x] `uv run pytest plugins/nemo-evaluator/tests/test_sdk_job_resources.py -k 'extract or tar or safe'` — 6 pass
- [x] `uv run pytest services/core/inference-gateway/tests/unit/test_proxy.py` — 82 pass
- [x] `uv run pytest services/core/inference-gateway/tests/unit/test_model_router.py services/core/inference-gateway/tests/unit/test_openai_router.py` — 72 pass
- [x] `uv run pytest packages/nemo_platform_ext/tests/quickstart/test_prompts.py test_container.py test_quickstart_config.py` — 118 pass
- [x] `uv run pytest plugins/nemo-agents/tests/unit/test_improvement_preflight.py test_improvement_jobs.py` — 17 pass
- [x] `pnpm --filter nemo-studio-ui typecheck` — clean
- [ ] Re-run CodeQL after merge; confirm the 28 alerts close
- [ ] Bulk-dismiss the 38 `py/clear-text-logging-sensitive-data` alerts as "false positive" in the Security tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helpers for extracting registry and git remote hosts and a shared safe tar extraction utility; auth fingerprint generation now uses a different digest.

* **Bug Fixes**
  * Registry detection and credential selection use exact host matching; routing and URL checks now compare parsed hostnames.

* **Security Enhancements**
  * Hardened proxy target validation, safer archive extraction, worker-origin checks, and preserved raw header rendering.

* **Tests**
  * Added/updated tests for strict proxy, host-matching, and registry detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->