### PR TITLE
fix(cli): surface missing services extra in setup output

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
@@ -56,7 +56,7 @@ def services_callback(ctx: typer.Context) -> None:
 
 
 def _require_services_extra() -> None:
-    """Ensure the ``[services]`` extra (e.g. ``pyleak``) is installed."""
+    """Ensure the ``[all]`` extra (e.g. ``pyleak``) is installed."""
     if importlib.util.find_spec("pyleak") is not None:
         return
     typer.echo(

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -730,6 +730,12 @@ def _maybe_start_services(
     else:
         data_dir = _prompt_data_dir()
 
+    if importlib.util.find_spec("pyleak") is None:
+        console.print(f"{CROSS} Local services require extra dependencies that aren't installed.")
+        console.print("  Install them with:")
+        console.print("    [cyan]pip install 'nemo-platform\\[all]'[/cyan]")
+        raise typer.Exit(1)
+
     if already_running:
         console.print("  Restarting platform services...")
         _kill_existing_services(base_url)

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -499,6 +499,21 @@ class TestMaybeStartServices:
         mock_start.assert_called_once_with("http://localhost:8080", data_dir="/tmp/test-data")
         mock_db_prompt.assert_called_once()
 
+    def test_exits_early_when_services_extra_missing(self, capsys):
+        """Preflight aborts with install hint before spawning a subprocess."""
+        with (
+            patch(f"{SETUP_MOD}._check_platform_reachable", return_value=False),
+            patch(f"{SETUP_MOD}.importlib.util.find_spec", return_value=None),
+            patch(f"{SETUP_MOD}._start_services_background") as mock_start,
+            patch(f"{SETUP_MOD}.prompt_choice", return_value="yes"),
+            patch(f"{SETUP_MOD}._prompt_data_dir", return_value="/tmp/data"),
+            pytest.raises(ClickExit),
+        ):
+            _maybe_start_services("http://localhost:8080", auto=False, start_services=True)
+        mock_start.assert_not_called()
+        captured = capsys.readouterr()
+        assert "nemo-platform[all]" in captured.err
+
 
 class TestLocalDataDirHelpers:
     """Tests for the XDG-default data-dir helpers used by `nemo setup`."""

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
@@ -56,7 +56,7 @@ def services_callback(ctx: typer.Context) -> None:
 
 
 def _require_services_extra() -> None:
-    """Ensure the ``[services]`` extra (e.g. ``pyleak``) is installed."""
+    """Ensure the ``[all]`` extra (e.g. ``pyleak``) is installed."""
     if importlib.util.find_spec("pyleak") is not None:
         return
     typer.echo(

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
@@ -730,6 +730,12 @@ def _maybe_start_services(
     else:
         data_dir = _prompt_data_dir()
 
+    if importlib.util.find_spec("pyleak") is None:
+        console.print(f"{CROSS} Local services require extra dependencies that aren't installed.")
+        console.print("  Install them with:")
+        console.print("    [cyan]pip install 'nemo-platform\\[all]'[/cyan]")
+        raise typer.Exit(1)
+
     if already_running:
         console.print("  Restarting platform services...")
         _kill_existing_services(base_url)

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
@@ -499,6 +499,21 @@ class TestMaybeStartServices:
         mock_start.assert_called_once_with("http://localhost:8080", data_dir="/tmp/test-data")
         mock_db_prompt.assert_called_once()
 
+    def test_exits_early_when_services_extra_missing(self, capsys):
+        """Preflight aborts with install hint before spawning a subprocess."""
+        with (
+            patch(f"{SETUP_MOD}._check_platform_reachable", return_value=False),
+            patch(f"{SETUP_MOD}.importlib.util.find_spec", return_value=None),
+            patch(f"{SETUP_MOD}._start_services_background") as mock_start,
+            patch(f"{SETUP_MOD}.prompt_choice", return_value="yes"),
+            patch(f"{SETUP_MOD}._prompt_data_dir", return_value="/tmp/data"),
+            pytest.raises(ClickExit),
+        ):
+            _maybe_start_services("http://localhost:8080", auto=False, start_services=True)
+        mock_start.assert_not_called()
+        captured = capsys.readouterr()
+        assert "nemo-platform[all]" in captured.err
+
 
 class TestLocalDataDirHelpers:
     """Tests for the XDG-default data-dir helpers used by `nemo setup`."""


### PR DESCRIPTION
## Summary

- Add a preflight check in `nemo setup` that detects the missing `[all]` extra before spawning the background service process, printing the install command directly to the console instead of burying it in `services.log`.
- Update `_require_services_extra()` in `nemo services run/start/restart` to reference `[all]` (the new canonical extra name per AIRCORE-654).

Resolves: https://nvbugspro.nvidia.com/bug/6216073

## Test plan

- [x] Existing `test_run_shows_services_extra_hint_when_pyleak_missing` updated and passing
- [x] Existing `test_start_shows_extra_hint_when_pyleak_missing` updated and passing
- [x] Existing `test_restart_checks_extras_before_stopping` updated and passing
- [x] New `test_exits_early_when_services_extra_missing` verifies setup preflight aborts before subprocess spawn
- [ ] Manual: `pip install nemo-platform && nemo setup` in a fresh venv shows install hint on console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup process to validate required optional dependencies and display clearer installation instructions for users.

* **Tests**
  * Added test coverage for handling missing optional dependencies during setup configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->