### PR TITLE
feat: Platform-aware Data Designer validate command

### DIFF
--- a/packages/data_designer_nemo/src/data_designer_nemo/context.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/context.py
@@ -21,6 +21,7 @@ from data_designer.engine.secret_resolver import (
     PlaintextResolver,
     SecretResolver,
 )
+from data_designer_nemo.errors import NDDError
 from data_designer_nemo.fileset_file_seed_reader import FilesetFileSeedReader
 from data_designer_nemo.model_provider import (
     make_local_first_model_provider_registry,
@@ -40,7 +41,15 @@ from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 
 
 class DataDesignerContext(Protocol):
-    async def validate(self, config: dd.DataDesignerConfig) -> None: ...
+    async def validate(self, config: dd.DataDesignerConfig) -> list[NDDError]:
+        """Run validators and return all collected errors (empty if config is valid).
+
+        Implementations should run every sub-check, accumulating ``NDDError`` (config
+        and internal) results into the returned list rather than raising on the
+        first failure. Truly unexpected errors (programmer error, transport-layer
+        failures outside the validators themselves) still propagate as exceptions.
+        """
+        ...
 
     def get_secret_resolver(self) -> SecretResolver: ...
 
@@ -65,8 +74,13 @@ class LocalDataDesignerContext:
             ]
         )
 
-    async def validate(self, config: dd.DataDesignerConfig) -> None:
-        validate_seed_config_for_execution_context(config, is_local=True)
+    async def validate(self, config: dd.DataDesignerConfig) -> list[NDDError]:
+        errors: list[NDDError] = []
+        try:
+            validate_seed_config_for_execution_context(config, is_local=True)
+        except NDDError as e:
+            errors.append(e)
+        return errors
 
     def get_seed_readers(self) -> list[SeedReader]:
         return [
@@ -103,12 +117,28 @@ class RemoteDataDesignerContext:
     def get_secret_resolver(self) -> SecretResolver:
         return NMPSecretResolver(self._sdk, self._workspace)
 
-    async def validate(self, config: dd.DataDesignerConfig) -> None:
+    async def validate(self, config: dd.DataDesignerConfig) -> list[NDDError]:
         sdk = self._async_sdk()
-        validate_no_tool_configs(config)
-        validate_seed_config_for_execution_context(config, is_local=False)
-        await validate_seed(config, self._workspace, sdk)
-        await ensure_nemotron_personas_filesets(config, sdk)
+        errors: list[NDDError] = []
+
+        try:
+            validate_no_tool_configs(config)
+        except NDDError as e:
+            errors.append(e)
+        try:
+            validate_seed_config_for_execution_context(config, is_local=False)
+        except NDDError as e:
+            errors.append(e)
+        try:
+            await validate_seed(config, self._workspace, sdk)
+        except NDDError as e:
+            errors.append(e)
+        try:
+            await ensure_nemotron_personas_filesets(config, sdk)
+        except NDDError as e:
+            errors.append(e)
+
+        return errors
 
     def get_seed_readers(self) -> list[SeedReader]:
         return [

--- a/packages/data_designer_nemo/src/data_designer_nemo/errors.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/errors.py
@@ -3,10 +3,33 @@
 
 
 class NDDError(Exception):
-    "Shared base for all data_designer_nemo errors."
+    """Shared base for all data_designer_nemo errors."""
 
 
 class NDDInternalError(NDDError): ...
 
 
 class NDDInvalidConfigError(NDDError): ...
+
+
+def raise_if_errors(errors: list[NDDError]) -> None:
+    """Raise an aggregated ``NDDError`` if ``errors`` is non-empty.
+
+    This is the canonical projection from a ``list[NDDError]`` back to a single
+    exception. Any config-level error wins (HTTP 422-class) and surfaces as
+    :class:`NDDInvalidConfigError` carrying every error's message; only when
+    *every* error is internal do we raise :class:`NDDInternalError` (HTTP
+    500-class).
+
+    The "any 422 wins" rule reflects HTTP semantics: an authoritative answer
+    about the user's input shouldn't be masked by an unrelated internal
+    failure. Every error message — config and internal — is included in the
+    aggregated message either way; the exception class reflects whose fault
+    it primarily is.
+    """
+    if not errors:
+        return
+    aggregated_message = "\n".join(str(e) for e in errors)
+    if any(isinstance(e, NDDInvalidConfigError) for e in errors):
+        raise NDDInvalidConfigError(aggregated_message)
+    raise NDDInternalError(aggregated_message)

--- a/packages/data_designer_nemo/src/data_designer_nemo/errors.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/errors.py
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-class NDDInternalError(Exception): ...
+class NDDError(Exception):
+    "Shared base for all data_designer_nemo errors."
 
 
-class NDDInvalidConfigError(Exception): ...
+class NDDInternalError(NDDError): ...
+
+
+class NDDInvalidConfigError(NDDError): ...

--- a/packages/data_designer_nemo/src/data_designer_nemo/runnable.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/runnable.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared producer pass for runnable Data Designer configs.
+
+Three call sites in the plugin run the same first three checks against a
+``DataDesignerConfig`` before doing their own thing:
+
+- ``PreviewFunction.run`` (runtime — generates the preview).
+- ``CreateJob.to_spec`` (runtime — compiles the job step config).
+- ``validate_config`` (reporter — emits a ``ValidationReport``).
+
+The runtime call sites need ``(model_configs, model_providers)`` to drive
+their next step; the reporter only wants the error list. This module owns
+the shared pass and returns the error buffer plus the resolved values, so
+runtime callers can ``raise_if_errors`` and use the values, while the
+reporter can project the errors into a structured result and additionally
+run engine-level checks of its own.
+"""
+
+from __future__ import annotations
+
+import data_designer.config as dd
+from data_designer_nemo.context import DataDesignerContext
+from data_designer_nemo.errors import NDDError, NDDInternalError, NDDInvalidConfigError
+from data_designer_nemo.model_configs import get_model_configs
+
+
+async def resolve_runnable_config(
+    dd_ctx: DataDesignerContext,
+    config: dd.DataDesignerConfig,
+) -> tuple[list[NDDError], list[dd.ModelConfig], list[dd.ModelProvider]]:
+    """Run the producer pass against ``config`` and return ``(errors, model_configs, model_providers)``.
+
+    Steps, in order:
+
+    1. ``dd_ctx.validate(config)`` — runs every sub-check the context owns
+       (seed type, tool configs, IGW personas filesets, etc.) and accumulates
+       the errors.
+    2. ``get_model_configs(config)`` — extracts every ``ModelConfig``
+       referenced by columns / profilers. ``NDDInvalidConfigError`` (e.g.
+       unrecognized aliases) is appended; we then **skip** step 3 because
+       provider resolution requires resolved aliases.
+    3. ``dd_ctx.get_model_providers(model_configs)`` — resolves provider
+       references against locally-defined providers and the Inference
+       Gateway. Appends ``NDDInvalidConfigError`` /
+       ``NDDInternalError`` on failure.
+
+    Never raises ``NDDError`` — every problem ends up in the returned buffer
+    instead. Truly unexpected errors (programmer bugs, transport-layer
+    failures outside the validators themselves) propagate as exceptions.
+
+    Callers decide what to do with the result:
+
+    - Runtime callers (``CreateJob.to_spec`` / ``PreviewFunction.run``) call
+      :func:`raise_if_errors` on the buffer and then use ``model_configs``
+      / ``model_providers`` to drive their next step.
+    - The reporter (``validate_config`` in the plugin) maps the buffer into
+      its public ``ValidationError`` shape and additionally runs an
+      engine-level compile check when the buffer is empty.
+    """
+    errors: list[NDDError] = list(await dd_ctx.validate(config))
+
+    model_configs: list[dd.ModelConfig] = []
+    model_providers: list[dd.ModelProvider] = []
+
+    try:
+        model_configs = get_model_configs(config)
+    except NDDInvalidConfigError as e:
+        errors.append(e)
+    else:
+        try:
+            model_providers = await dd_ctx.get_model_providers(model_configs)
+        except (NDDInvalidConfigError, NDDInternalError) as e:
+            errors.append(e)
+
+    return errors, model_configs, model_providers

--- a/packages/data_designer_nemo/src/data_designer_nemo/unsupported_features.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/unsupported_features.py
@@ -51,12 +51,24 @@ def validate_seed_source_for_execution_context(data: Any, *, is_local: bool) -> 
     not bypass that. So, we can safely ignore all Exceptions (most commonly KeyError, on requests
     that don't include a seed_config at all) and index our way straight to the deeply nested field
     we care about for this particular validation.
+
+    Per the Pydantic v2 contract, "before"-mode validators may raise ``ValueError``,
+    ``AssertionError``, or ``PydanticCustomError`` — anything else (including our
+    ``NDDInvalidConfigError``) propagates raw out of ``model_validate`` and is not wrapped in
+    ``pydantic.ValidationError``. That breaks ``except ValidationError`` clauses in CLI / framework
+    code that turn validation problems into clean user-facing messages. To keep those code paths
+    working *and* keep ``NDDInvalidConfigError`` as the canonical error class for non-Pydantic
+    callers, we translate at this boundary: catch the plugin's error class and re-raise as a
+    ``ValueError`` carrying the same message.
     """
     seed_type = _get_raw_seed_type(data)
     if seed_type is None:
         return
 
-    _validate_seed_type_for_execution_context(seed_type, is_local=is_local)
+    try:
+        _validate_seed_type_for_execution_context(seed_type, is_local=is_local)
+    except NDDInvalidConfigError as exc:
+        raise ValueError(str(exc)) from exc
 
 
 def _validate_seed_type_for_execution_context(seed_type: str, *, is_local: bool) -> None:

--- a/packages/data_designer_nemo/tests/unit/test_errors.py
+++ b/packages/data_designer_nemo/tests/unit/test_errors.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from data_designer_nemo.errors import (
+    NDDError,
+    NDDInternalError,
+    NDDInvalidConfigError,
+    raise_if_errors,
+)
+
+
+class TestErrorHierarchy:
+    def test_invalid_config_error_is_an_ndd_error(self) -> None:
+        assert issubclass(NDDInvalidConfigError, NDDError)
+
+    def test_internal_error_is_an_ndd_error(self) -> None:
+        assert issubclass(NDDInternalError, NDDError)
+
+    def test_invalid_config_and_internal_are_distinct(self) -> None:
+        assert not issubclass(NDDInvalidConfigError, NDDInternalError)
+        assert not issubclass(NDDInternalError, NDDInvalidConfigError)
+
+
+class TestRaiseIfErrors:
+    def test_empty_list_is_a_no_op(self) -> None:
+        # Must not raise.
+        raise_if_errors([])
+
+    def test_single_config_error_raises_invalid_config(self) -> None:
+        with pytest.raises(NDDInvalidConfigError) as exc_info:
+            raise_if_errors([NDDInvalidConfigError("bad config")])
+        assert "bad config" in str(exc_info.value)
+
+    def test_single_internal_error_raises_internal(self) -> None:
+        with pytest.raises(NDDInternalError) as exc_info:
+            raise_if_errors([NDDInternalError("oops")])
+        assert "oops" in str(exc_info.value)
+
+    def test_any_config_error_wins_over_internal(self) -> None:
+        """The 422 path takes precedence over the 500 path when both are present."""
+        with pytest.raises(NDDInvalidConfigError) as exc_info:
+            raise_if_errors(
+                [
+                    NDDInternalError("internal"),
+                    NDDInvalidConfigError("config"),
+                ]
+            )
+        # Both messages must surface in the aggregated body — the exception
+        # class only reflects whose fault it primarily is.
+        message = str(exc_info.value)
+        assert "internal" in message
+        assert "config" in message
+
+    def test_only_internal_errors_raise_internal(self) -> None:
+        with pytest.raises(NDDInternalError) as exc_info:
+            raise_if_errors(
+                [
+                    NDDInternalError("first"),
+                    NDDInternalError("second"),
+                ]
+            )
+        message = str(exc_info.value)
+        assert "first" in message
+        assert "second" in message
+
+    def test_multiple_config_errors_aggregate(self) -> None:
+        with pytest.raises(NDDInvalidConfigError) as exc_info:
+            raise_if_errors(
+                [
+                    NDDInvalidConfigError("first"),
+                    NDDInvalidConfigError("second"),
+                ]
+            )
+        message = str(exc_info.value)
+        assert "first" in message
+        assert "second" in message

--- a/packages/data_designer_nemo/tests/unit/test_runnable.py
+++ b/packages/data_designer_nemo/tests/unit/test_runnable.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import data_designer.config as dd
+import pytest
+from data_designer_nemo.errors import NDDError, NDDInternalError, NDDInvalidConfigError
+from data_designer_nemo.runnable import resolve_runnable_config
+
+
+def _config_with_aliased_llm_column() -> dd.DataDesignerConfig:
+    """A minimal config that references one ModelConfig via an LLM column."""
+    return dd.DataDesignerConfig(
+        columns=[
+            dd.SamplerColumnConfig(
+                name="topic",
+                sampler_type=dd.SamplerType.CATEGORY,
+                params=dd.CategorySamplerParams(values=["a", "b"]),
+            ),
+            dd.LLMTextColumnConfig(
+                name="story",
+                prompt="Write about {{ topic }}",
+                model_alias="text",
+            ),
+        ],
+        model_configs=[
+            dd.ModelConfig(alias="text", model="some-model", provider="some-provider"),
+        ],
+    )
+
+
+def _config_without_model_configs() -> dd.DataDesignerConfig:
+    return dd.DataDesignerConfig(
+        columns=[dd.ExpressionColumnConfig(name="value", expr="'ok'")],
+        model_configs=[],
+    )
+
+
+def _make_dd_ctx(
+    *,
+    validate_errors: list[NDDError] | None = None,
+    providers: list[dd.ModelProvider] | None = None,
+    providers_exc: BaseException | None = None,
+) -> AsyncMock:
+    """Stub ``DataDesignerContext`` whose validate / get_model_providers we control.
+
+    Returns the bare :class:`AsyncMock` (not ``spec=DataDesignerContext``) so
+    the test bodies can access the mock-only ``assert_not_called`` /
+    ``assert_called_once`` introspection methods directly.
+    """
+    ctx = AsyncMock()
+    ctx.validate.return_value = list(validate_errors or [])
+    if providers_exc is not None:
+        ctx.get_model_providers.side_effect = providers_exc
+    else:
+        ctx.get_model_providers.return_value = list(providers or [])
+    return ctx
+
+
+class TestResolveRunnableConfig:
+    async def test_clean_config_returns_resolved_values_and_no_errors(self) -> None:
+        config = _config_with_aliased_llm_column()
+        provider = dd.ModelProvider(name="some-provider", endpoint="http://example.com")
+        dd_ctx = _make_dd_ctx(providers=[provider])
+
+        errors, model_configs, model_providers = await resolve_runnable_config(dd_ctx, config)
+
+        assert errors == []
+        assert [m.alias for m in model_configs] == ["text"]
+        assert model_providers == [provider]
+
+    async def test_context_validate_errors_pass_through(self) -> None:
+        config = _config_without_model_configs()
+        validate_err = NDDInvalidConfigError("seed thing")
+        dd_ctx = _make_dd_ctx(validate_errors=[validate_err])
+
+        errors, model_configs, model_providers = await resolve_runnable_config(dd_ctx, config)
+
+        # Validate errors land in the buffer; model_configs / providers
+        # resolution still runs (config has no models, so both are empty).
+        assert errors == [validate_err]
+        assert model_configs == []
+        assert model_providers == []
+
+    async def test_unrecognized_alias_skips_provider_resolution(self) -> None:
+        """An unrecognized alias short-circuits provider resolution.
+
+        Without the resolved aliases there's nothing meaningful to resolve
+        providers for, so we don't make the SDK call at all.
+        """
+        config = dd.DataDesignerConfig(
+            columns=[
+                dd.SamplerColumnConfig(
+                    name="topic",
+                    sampler_type=dd.SamplerType.CATEGORY,
+                    params=dd.CategorySamplerParams(values=["a", "b"]),
+                ),
+                dd.LLMTextColumnConfig(
+                    name="story",
+                    prompt="Write about {{ topic }}",
+                    model_alias="not-a-real-alias",
+                ),
+            ],
+            # No matching ModelConfig — triggers an NDDInvalidConfigError
+            # from get_model_configs.
+            model_configs=[],
+        )
+        dd_ctx = _make_dd_ctx(providers=[])
+
+        errors, model_configs, model_providers = await resolve_runnable_config(dd_ctx, config)
+
+        assert len(errors) == 1
+        assert isinstance(errors[0], NDDInvalidConfigError)
+        assert "not-a-real-alias" in str(errors[0])
+        assert model_configs == []
+        assert model_providers == []
+        # Provider resolution must be skipped when alias resolution failed.
+        dd_ctx.get_model_providers.assert_not_called()
+
+    async def test_provider_resolution_invalid_config_error_is_appended(self) -> None:
+        config = _config_with_aliased_llm_column()
+        provider_err = NDDInvalidConfigError("Cannot access provider 'some-provider'.")
+        dd_ctx = _make_dd_ctx(providers_exc=provider_err)
+
+        errors, model_configs, model_providers = await resolve_runnable_config(dd_ctx, config)
+
+        assert errors == [provider_err]
+        # Model configs were resolved (the SDK call below them failed).
+        assert [m.alias for m in model_configs] == ["text"]
+        # Providers list is empty because resolution failed.
+        assert model_providers == []
+
+    async def test_provider_resolution_internal_error_is_appended(self) -> None:
+        config = _config_with_aliased_llm_column()
+        provider_err = NDDInternalError("transient backend failure")
+        dd_ctx = _make_dd_ctx(providers_exc=provider_err)
+
+        errors, model_configs, model_providers = await resolve_runnable_config(dd_ctx, config)
+
+        assert errors == [provider_err]
+        assert [m.alias for m in model_configs] == ["text"]
+        assert model_providers == []
+
+    async def test_aggregates_context_validate_and_provider_errors(self) -> None:
+        """A single pass surfaces every problem that can be detected, not just the first."""
+        config = _config_with_aliased_llm_column()
+        validate_err = NDDInvalidConfigError("Tool configs are not supported")
+        provider_err = NDDInvalidConfigError("Cannot access provider 'some-provider'.")
+        dd_ctx = _make_dd_ctx(validate_errors=[validate_err], providers_exc=provider_err)
+
+        errors, _model_configs, _model_providers = await resolve_runnable_config(dd_ctx, config)
+
+        assert errors == [validate_err, provider_err]
+
+    async def test_unexpected_exception_propagates(self) -> None:
+        """Truly unexpected errors aren't swallowed — only NDDError-class ones are."""
+        config = _config_with_aliased_llm_column()
+        dd_ctx = _make_dd_ctx(providers_exc=RuntimeError("oh no"))
+
+        with pytest.raises(RuntimeError, match="oh no"):
+            await resolve_runnable_config(dd_ctx, config)

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/cli_state.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/cli_state.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for plugin CLI commands that need access to the CLI's state object.
+
+The top-level ``nemo`` CLI populates ``typer.Context.obj`` with a state object
+that exposes per-invocation handles to the platform SDK clients (sync and
+async). The auto-generated ``run`` / ``submit`` verbs in
+:mod:`nemo_platform_plugin.commands` consume that state through these helpers,
+and **plugin-authored** Typer commands (i.e. anything a plugin registers via
+:meth:`~nemo_platform_plugin.cli.NemoCLI.get_cli` rather than the
+auto-generated verbs) should use the same surface so they participate in the
+same protocol.
+
+Example::
+
+    import typer
+    from nemo_platform_plugin.cli_state import resolve_local_cli_sdks
+
+    def my_command(typer_ctx: typer.Context) -> None:
+        sdk, async_sdk = resolve_local_cli_sdks(typer_ctx)
+        if sdk is None and async_sdk is None:
+            typer.echo("No NeMo Platform SDK is available.", err=True)
+            raise typer.Exit(code=1)
+        ...
+"""
+
+import typer
+
+
+def resolve_local_cli_sdks(
+    typer_ctx: typer.Context,
+) -> tuple[object | None, object | None]:
+    """Pull ``(sdk, async_sdk)`` out of the CLI state object on ``typer_ctx.obj``.
+
+    Returns ``(None, None)`` when no state object is set (e.g. plugin tests
+    that exercise a Typer app directly without populating ``ctx.obj``). When
+    a state object is set but does not implement one of the getter methods,
+    that side returns ``None`` while the other still resolves — letting
+    callers decide which handle they actually need.
+    """
+    state = typer_ctx.obj
+    if not state:
+        return None, None
+    sdk = state.get_client() if hasattr(state, "get_client") else None
+    async_sdk = state.get_async_client() if hasattr(state, "get_async_client") else None
+    return sdk, async_sdk

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py
@@ -106,6 +106,7 @@ from nemo_platform_plugin._spec_flags import (
 from nemo_platform_plugin.cli import NemoCLI
 from nemo_platform_plugin.cli_errors import print_http_request_error, print_http_status_error
 from nemo_platform_plugin.cli_renderer import CLIRenderer, RendererContext
+from nemo_platform_plugin.cli_state import resolve_local_cli_sdks
 from nemo_platform_plugin.function import NemoFunction, returns_async_iterator
 from nemo_platform_plugin.function_context import FunctionContext
 from nemo_platform_plugin.functions.routes import DEFAULT_FUNCTION_PATH, NDJSON_MEDIA_TYPE
@@ -408,7 +409,7 @@ def _add_run_command(
         overlay = build_overlay(leaves, kwargs, unset_sentinel=UNSET)
         data = deep_merge(base, overlay)
         logger.debug("Running job %r locally with spec %r", job_cls.name, data)
-        sdk, async_sdk = _resolve_local_cli_sdks(typer_ctx)
+        sdk, async_sdk = resolve_local_cli_sdks(typer_ctx)
 
         renderer_cls: type[CLIRenderer] | None = None
         if cli is not None and not _output_format_is_json(typer_ctx):
@@ -925,7 +926,7 @@ def _add_function_run_command(
             typer.echo(f"Error: invalid spec for {fn_cls.name}: {exc}", err=True)
             raise typer.Exit(code=1) from exc
 
-        sdk, async_sdk = _resolve_local_cli_sdks(typer_ctx)
+        sdk, async_sdk = resolve_local_cli_sdks(typer_ctx)
         ctx = FunctionContext(workspace=workspace)
         renderer_cls: type[CLIRenderer] | None = None
         if cli is not None and not _output_format_is_json(typer_ctx):
@@ -1074,18 +1075,6 @@ async def _invoke_function_locally(
         return
     awaited = await result
     typer.echo(_format_value_for_stdout(awaited))
-
-
-def _resolve_local_cli_sdks(
-    typer_ctx: typer.Context,
-) -> tuple[object | None, object | None]:
-    """Build sync + async SDKs from a CLI-like context, if present."""
-    state = typer_ctx.obj
-    if not state:
-        return None, None
-    sdk = state.get_client() if hasattr(state, "get_client") else None
-    async_sdk = state.get_async_client() if hasattr(state, "get_async_client") else None
-    return sdk, async_sdk
 
 
 # ---- submit ------------------------------------------------------ #

--- a/packages/nemo_platform_plugin/tests/test_cli_state.py
+++ b/packages/nemo_platform_plugin/tests/test_cli_state.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import typer
+from nemo_platform_plugin.cli_state import resolve_local_cli_sdks
+
+
+def _typer_context_with_obj(obj: object | None) -> typer.Context:
+    return cast(typer.Context, SimpleNamespace(obj=obj))
+
+
+class TestResolveLocalCliSdks:
+    def test_returns_none_without_context_obj(self) -> None:
+        assert resolve_local_cli_sdks(_typer_context_with_obj(None)) == (None, None)
+
+    def test_uses_cli_context_client_getters(self) -> None:
+        sdk = object()
+        async_sdk = object()
+
+        # Stand in for either nemo_platform_ext.cli.core.context.CLIContext
+        # or its vendored nemo_platform.cli.core.context.CLIContext copy.
+        class _State:
+            def get_client(self) -> object:
+                return sdk
+
+            def get_async_client(self) -> object:
+                return async_sdk
+
+        assert resolve_local_cli_sdks(_typer_context_with_obj(_State())) == (sdk, async_sdk)
+
+    def test_falls_back_to_none_when_only_one_getter_is_defined(self) -> None:
+        """A state object that exposes only one getter still resolves the side it provides."""
+        sdk = object()
+
+        class _SyncOnlyState:
+            def get_client(self) -> object:
+                return sdk
+
+        resolved_sdk, resolved_async_sdk = resolve_local_cli_sdks(_typer_context_with_obj(_SyncOnlyState()))
+        assert resolved_sdk is sdk
+        assert resolved_async_sdk is None

--- a/packages/nemo_platform_plugin/tests/test_commands.py
+++ b/packages/nemo_platform_plugin/tests/test_commands.py
@@ -27,7 +27,7 @@ from typing import Any, AsyncIterator, ClassVar, cast
 import httpx
 import pytest
 import typer
-from nemo_platform_plugin.commands import _resolve_local_cli_sdks, add_function_commands, add_job_commands
+from nemo_platform_plugin.commands import add_function_commands, add_job_commands
 from nemo_platform_plugin.discovery import discover, discover_manifests
 from nemo_platform_plugin.function import NemoFunction
 from nemo_platform_plugin.function_context import FunctionContext
@@ -381,26 +381,6 @@ class TestSpecFlagRename:
         result = runner.invoke(app, ["greet", "run", "--config", '{"name": "Legacy"}'])
         assert result.exit_code == 0
         assert json.loads(result.output)["message"] == "Hello, Legacy!"
-
-
-class TestResolveLocalCliSdks:
-    def test_returns_none_without_context_obj(self) -> None:
-        assert _resolve_local_cli_sdks(_typer_context_with_obj(None)) == (None, None)
-
-    def test_uses_cli_context_client_getters(self) -> None:
-        sdk = object()
-        async_sdk = object()
-
-        # Stand in for either nemo_platform_ext.cli.core.context.CLIContext
-        # or its vendored nemo_platform.cli.core.context.CLIContext copy.
-        class _State:
-            def get_client(self) -> object:
-                return sdk
-
-            def get_async_client(self) -> object:
-                return async_sdk
-
-        assert _resolve_local_cli_sdks(_typer_context_with_obj(_State())) == (sdk, async_sdk)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-data-designer/README.md
+++ b/plugins/nemo-data-designer/README.md
@@ -2,6 +2,35 @@
 
 A NeMo Platform plugin that brings Data Designer into the platform.
 
+## Validate a Config
+
+`nemo data-designer validate` checks whether a Data Designer config is fit to run locally and/or to submit to the platform. By default it runs every applicable execution context and reports each independently:
+
+```bash
+nemo data-designer validate config.yaml
+```
+
+Limit the check to one context with `--execution-context`:
+
+```bash
+# Only the local-execution checks
+nemo data-designer validate config.yaml --execution-context local
+
+# Only the platform/remote checks
+nemo data-designer validate config.yaml --execution-context remote
+```
+
+The exit code is `0` only when every requested context validates cleanly. JSON output (`--output json`) emits a structured `ValidationReport` for CI / automation use.
+
+### Local vs. remote
+
+- **Local** mirrors what `nemo data-designer <preview|create> run` checks: the engine compiles the config and resolves model providers. Providers can be defined locally **or** referenced by name from the Inference Gateway — both are first-class.
+- **Remote** mirrors what `nemo data-designer <preview|create> submit` accepts: unsupported seed types and `tool_configs` are rejected, IGW providers are resolved against the platform, Files-service seeds are looked up, and Nemotron Personas filesets are checked. The remote pass is a client-side simulation of those checks; it does not contact the data-designer service.
+
+### Programmatic use
+
+The same logic is exposed on the SDK via `DataDesignerResource.validate(config_builder, *, execution_context=None, workspace=None)` and its async sibling. Both return a `ValidationReport` from `nemo_data_designer_plugin.sdk.validation`.
+
 ## Nemotron Personas Filesets
 
 When executing remotely, Data Designer workloads that include `PersonSampler` columns require Nemotron Personas filesets to exist in the `system` workspace for each requested locale. These filesets can be created using the CLI.

--- a/plugins/nemo-data-designer/README.md
+++ b/plugins/nemo-data-designer/README.md
@@ -24,7 +24,7 @@ The exit code is `0` only when every requested context validates cleanly. JSON o
 
 ### Local vs. remote
 
-- **Local** mirrors what `nemo data-designer <preview|create> run` checks: the engine compiles the config and resolves model providers. Providers can be defined locally **or** referenced by name from the Inference Gateway — both are first-class.
+- **Local** mirrors what `nemo data-designer <preview|create> run` accepts: the engine compiles the config and resolves model providers. Providers can be defined locally **or** referenced by name from the Inference Gateway — both are first-class.
 - **Remote** mirrors what `nemo data-designer <preview|create> submit` accepts: unsupported seed types and `tool_configs` are rejected, IGW providers are resolved against the platform, Files-service seeds are looked up, and Nemotron Personas filesets are checked. The remote pass is a client-side simulation of those checks; it does not contact the data-designer service.
 
 ### Programmatic use

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/main.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/main.py
@@ -24,9 +24,9 @@ class DataDesignerCLI(NemoCLI):
     description: ClassVar[str] = "Data Designer: generate synthetic datasets"
 
     def get_cli(self) -> typer.Typer:
-        from data_designer.cli.commands.validate import validate_command
         from data_designer.cli.main import agent_app, config_app
         from data_designer.cli.runtime import ensure_cli_default_model_settings
+        from nemo_data_designer_plugin.cli.validate import validate_command
 
         ensure_cli_default_model_settings()
 

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/validate.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/validate.py
@@ -143,7 +143,7 @@ def _render_context_block(result: ValidationContextResult) -> None:
         typer.echo("  ✔ Configuration is valid")
         return
     for err in result.errors:
-        typer.echo(f"  ✘ [{err.severity}] {err.message}")
+        typer.echo(f"  ✘ {err.message}")
 
 
 def _format_summary(report: ValidationReport) -> str:

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/validate.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/validate.py
@@ -24,7 +24,7 @@ from nemo_data_designer_plugin.sdk.validation import (
     validate_config_sync,
 )
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-from nemo_platform_plugin.commands import _resolve_local_cli_sdks
+from nemo_platform_plugin.cli_state import resolve_local_cli_sdks
 
 OutputFormat = Literal["text", "json"]
 
@@ -84,7 +84,7 @@ def validate_command(
         print_error(f"Could not load config: {e}")
         raise typer.Exit(code=1) from e
 
-    sdk, async_sdk = _resolve_local_cli_sdks(typer_ctx)
+    sdk, async_sdk = resolve_local_cli_sdks(typer_ctx)
     sdk = cast("NeMoPlatform | None", sdk)
     async_sdk = cast("AsyncNeMoPlatform | None", async_sdk)
 

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/validate.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/validate.py
@@ -1,14 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Plugin-owned ``nemo data-designer validate`` command.
-
-Replaces the upstream ``data_designer.cli.commands.validate.validate_command``,
-which is local-only and rejects IGW-provider references. This implementation
-delegates to the shared validation core in
-:mod:`nemo_data_designer_plugin.sdk.validation`, so SDK and CLI share the same
-behavior.
-"""
+"""Execution context-aware CLI validation of config sources"""
 
 from __future__ import annotations
 

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/validate.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/validate.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plugin-owned ``nemo data-designer validate`` command.
+
+Replaces the upstream ``data_designer.cli.commands.validate.validate_command``,
+which is local-only and rejects IGW-provider references. This implementation
+delegates to the shared validation core in
+:mod:`nemo_data_designer_plugin.sdk.validation`, so SDK and CLI share the same
+behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, cast
+
+import typer
+from data_designer.cli.ui import print_error, print_header, print_success
+from data_designer.cli.utils.config_loader import ConfigLoadError, load_config_builder
+from nemo_data_designer_plugin.sdk.validation import (
+    ExecutionContext,
+    ValidationContextResult,
+    ValidationReport,
+    validate_config_sync,
+)
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.commands import _resolve_local_cli_sdks
+
+OutputFormat = Literal["text", "json"]
+
+_CONTEXT_HEADINGS: dict[ExecutionContext, str] = {
+    "local": "Local execution",
+    "remote": "Remote execution",
+}
+
+
+def validate_command(
+    typer_ctx: typer.Context,
+    config_source: Annotated[
+        str,
+        typer.Argument(
+            help=(
+                "Path or URL to a config file (.yaml/.yml/.json), or a local Python module (.py)"
+                " that defines a load_config_builder() function."
+            ),
+        ),
+    ],
+    execution_context: Annotated[
+        ExecutionContext | None,
+        typer.Option(
+            "--execution-context",
+            help=("Execution context to validate against. Omit to validate every applicable context (local + remote)."),
+            case_sensitive=False,
+        ),
+    ] = None,
+    workspace: Annotated[
+        str | None,
+        typer.Option(
+            "--workspace",
+            help=(
+                "Workspace used to resolve provider references and seed sources (remote pass). "
+                "Defaults to the SDK's configured workspace, or 'default'."
+            ),
+        ),
+    ] = None,
+    output: Annotated[
+        OutputFormat,
+        typer.Option(
+            "--output",
+            help="Output format. 'json' suppresses the human-formatted blocks.",
+        ),
+    ] = "text",
+) -> None:
+    """Validate a Data Designer configuration.
+
+    By default validates the config against every applicable execution context
+    (local and remote). Pass ``--execution-context`` to limit to one. The remote
+    pass is a client-side simulation of what ``nemo data-designer create submit``
+    accepts; it does not contact the service.
+    """
+    try:
+        config_builder = load_config_builder(config_source)
+    except ConfigLoadError as e:
+        print_error(f"Could not load config: {e}")
+        raise typer.Exit(code=1) from e
+
+    sdk, async_sdk = _resolve_local_cli_sdks(typer_ctx)
+    sdk = cast("NeMoPlatform | None", sdk)
+    async_sdk = cast("AsyncNeMoPlatform | None", async_sdk)
+
+    if sdk is None and async_sdk is None:
+        print_error(
+            "No NeMo Platform SDK is available. Run `nemo` from a configured environment "
+            "or supply credentials via the top-level CLI."
+        )
+        raise typer.Exit(code=1)
+
+    resolved_workspace = (
+        workspace
+        or (getattr(sdk, "workspace", None) if sdk is not None else None)
+        or (getattr(async_sdk, "workspace", None) if async_sdk is not None else None)
+        or "default"
+    )
+
+    report = validate_config_sync(
+        config_builder,
+        sdk=sdk,
+        async_sdk=async_sdk,
+        workspace=resolved_workspace,
+        execution_context=execution_context,
+        config_source=config_source,
+    )
+
+    if output == "json":
+        typer.echo(report.model_dump_json())
+    else:
+        _render_text_report(report, config_source=config_source)
+
+    if not report.ok:
+        raise typer.Exit(code=1)
+
+
+def _render_text_report(report: ValidationReport, *, config_source: str) -> None:
+    print_header("Data Designer Validate")
+    typer.echo(f"  Config: {config_source}")
+    typer.echo("")
+
+    for result in report.results:
+        _render_context_block(result)
+        typer.echo("")
+
+    summary = _format_summary(report)
+    if report.ok:
+        print_success(summary)
+    else:
+        print_error(summary)
+
+
+def _render_context_block(result: ValidationContextResult) -> None:
+    heading = _CONTEXT_HEADINGS.get(result.context, result.context)
+    typer.echo(heading)
+    if result.ok:
+        typer.echo("  ✔ Configuration is valid")
+        return
+    for err in result.errors:
+        typer.echo(f"  ✘ [{err.severity}] {err.message}")
+
+
+def _format_summary(report: ValidationReport) -> str:
+    if not report.results:
+        return "No validation context was run"
+
+    pieces: list[str] = []
+    for result in report.results:
+        verdict = "valid" if result.ok else "invalid"
+        pieces.append(f"{verdict} for {result.context} execution")
+    return "Result: " + "; ".join(pieces)

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/preview.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/preview.py
@@ -12,11 +12,12 @@ import anyio.to_thread
 import data_designer.config as dd
 from anyio.lowlevel import current_token
 from data_designer.config.utils.constants import DEFAULT_NUM_RECORDS
-from data_designer_nemo.context import create_data_designer_context
+from data_designer_nemo.context import DataDesignerContext, create_data_designer_context
+from data_designer_nemo.errors import NDDError, NDDInternalError, NDDInvalidConfigError
 from data_designer_nemo.fileset_file_seed_reader import workspace_cvar
 from data_designer_nemo.model_configs import get_model_configs
-from fastapi import HTTPException, status
 from nemo_data_designer_plugin.config import get_config
+from nemo_data_designer_plugin.functions._preview_worker import make_preview_dataset
 from nemo_data_designer_plugin.functions._types import (
     LogFrame,
     PreviewSpec,
@@ -25,7 +26,7 @@ from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.function import NemoFunction
 from nemo_platform_plugin.function_context import FunctionContext
 from nemo_platform_plugin.functions.frames import Done, Error
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class PreviewMessageDeliveryError(Exception): ...
@@ -36,6 +37,8 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
     description: ClassVar[str] = "Generate a small preview dataset by streaming NDJSON frames."
     spec_schema: ClassVar[type[PreviewSpec]] = PreviewSpec
 
+    errors: list[NDDError] = Field(default_factory=list)
+
     async def run(
         self,
         spec: PreviewSpec,
@@ -44,13 +47,14 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
         async_sdk: AsyncNeMoPlatform,
         is_local: bool = False,
     ) -> AsyncIterator[BaseModel]:
-        model_configs = get_model_configs(spec.config)
-        num_records = _validate_and_get_num_records(spec.num_records, is_local)
-
         dd_ctx = create_data_designer_context(is_local, async_sdk, ctx.workspace)
-        await dd_ctx.validate(spec.config)
 
-        model_providers = await dd_ctx.get_model_providers(model_configs)
+        # Extract/set all necessary values, validating along the way. Raise if any errors were collected.
+        self.errors = []
+        num_records = self._validate_and_get_num_records(spec.num_records, is_local)
+        model_configs, model_providers = await self._get_model_configs_and_providers(dd_ctx, spec.config)
+        await self._validate_config(dd_ctx, spec.config)
+        self._raise_if_errors()
 
         workspace_cvar.set(ctx.workspace)
 
@@ -64,8 +68,6 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
                 raise PreviewMessageDeliveryError(
                     "Caught an anyio resource error. Most likely the request was canceled."
                 ) from None
-
-        from nemo_data_designer_plugin.functions._preview_worker import make_preview_dataset
 
         config_builder = dd.DataDesignerConfigBuilder.from_config(spec.config.to_dict())
 
@@ -101,23 +103,46 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
             if not completed_with_error:
                 yield Done()
 
+    def _validate_and_get_num_records(self, requested_num_records: int | None, is_local: bool) -> int:
+        if is_local:
+            return requested_num_records or DEFAULT_NUM_RECORDS
 
-def _validate_and_get_num_records(requested_num_records: int | None, is_local: bool) -> int:
-    if is_local:
-        return requested_num_records or DEFAULT_NUM_RECORDS
+        config = get_config()
+        num_records = config.preview_num_records.default
+        if requested_num_records:
+            if requested_num_records > config.preview_num_records.max:
+                self.errors.append(
+                    NDDInvalidConfigError(f"Max num records for preview requests is {config.preview_num_records.max}")
+                )
+            num_records = requested_num_records
 
-    config = get_config()
-    num_records = config.preview_num_records.default
-    if requested_num_records:
-        if requested_num_records > config.preview_num_records.max:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=_max_num_records_error_message(config.preview_num_records.max),
-            )
-        num_records = requested_num_records
+        return num_records
 
-    return num_records
+    async def _get_model_configs_and_providers(
+        self, dd_ctx: DataDesignerContext, config: dd.DataDesignerConfig
+    ) -> tuple[list[dd.ModelConfig], list[dd.ModelProvider]]:
+        model_configs = []
+        model_providers = []
 
+        try:
+            model_configs = get_model_configs(config)
+        except NDDInvalidConfigError as e:
+            self.errors.append(e)
+        else:
+            try:
+                model_providers = await dd_ctx.get_model_providers(model_configs)
+            except (NDDInvalidConfigError, NDDInternalError) as e:
+                self.errors.append(e)
 
-def _max_num_records_error_message(max_num_records: int) -> str:
-    return f"Max num records for preview requests is {max_num_records}"
+        return model_configs, model_providers
+
+    async def _validate_config(self, dd_ctx: DataDesignerContext, config: dd.DataDesignerConfig) -> None:
+        validation_errors = await dd_ctx.validate(config)
+        self.errors.extend(validation_errors)
+
+    def _raise_if_errors(self) -> None:
+        if self.errors:
+            aggregated_message = "\n".join(str(e) for e in self.errors)
+            if any(isinstance(e, NDDInvalidConfigError) for e in self.errors):
+                raise NDDInvalidConfigError(aggregated_message)
+            raise NDDInternalError(aggregated_message)

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/preview.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/preview.py
@@ -12,10 +12,10 @@ import anyio.to_thread
 import data_designer.config as dd
 from anyio.lowlevel import current_token
 from data_designer.config.utils.constants import DEFAULT_NUM_RECORDS
-from data_designer_nemo.context import DataDesignerContext, create_data_designer_context
-from data_designer_nemo.errors import NDDError, NDDInternalError, NDDInvalidConfigError, raise_if_errors
+from data_designer_nemo.context import create_data_designer_context
+from data_designer_nemo.errors import NDDInvalidConfigError, raise_if_errors
 from data_designer_nemo.fileset_file_seed_reader import workspace_cvar
-from data_designer_nemo.model_configs import get_model_configs
+from data_designer_nemo.runnable import resolve_runnable_config
 from nemo_data_designer_plugin.config import get_config
 from nemo_data_designer_plugin.functions._preview_worker import make_preview_dataset
 from nemo_data_designer_plugin.functions._types import (
@@ -45,13 +45,11 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
         async_sdk: AsyncNeMoPlatform,
         is_local: bool = False,
     ) -> AsyncIterator[BaseModel]:
-        dd_ctx = create_data_designer_context(is_local, async_sdk, ctx.workspace)
+        # Fail fast on request shape (``num_records``) before doing any config-validation work.
+        num_records = _validate_and_get_num_records(spec.num_records, is_local)
 
-        # Extract/set all necessary values, validating along the way. Raise if any errors were collected.
-        errors: list[NDDError] = []
-        num_records = _validate_and_get_num_records(spec.num_records, is_local, errors)
-        model_configs, model_providers = await _get_model_configs_and_providers(dd_ctx, spec.config, errors)
-        errors.extend(await dd_ctx.validate(spec.config))
+        dd_ctx = create_data_designer_context(is_local, async_sdk, ctx.workspace)
+        errors, model_configs, model_providers = await resolve_runnable_config(dd_ctx, spec.config)
         raise_if_errors(errors)
 
         workspace_cvar.set(ctx.workspace)
@@ -102,12 +100,12 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
                 yield Done()
 
 
-def _validate_and_get_num_records(
-    requested_num_records: int | None,
-    is_local: bool,
-    errors: list[NDDError],
-) -> int:
-    """Resolve the effective ``num_records``, appending to ``errors`` on overflow."""
+def _validate_and_get_num_records(requested_num_records: int | None, is_local: bool) -> int:
+    """Resolve the effective ``num_records``, raising if the user asked for too many.
+
+    Local execution is unconstrained. Remote execution caps at the
+    ``preview_num_records.max`` configured by the operator.
+    """
     if is_local:
         return requested_num_records or DEFAULT_NUM_RECORDS
 
@@ -115,31 +113,7 @@ def _validate_and_get_num_records(
     num_records = config.preview_num_records.default
     if requested_num_records:
         if requested_num_records > config.preview_num_records.max:
-            errors.append(
-                NDDInvalidConfigError(f"Max num records for preview requests is {config.preview_num_records.max}")
-            )
+            raise NDDInvalidConfigError(f"Max num records for preview requests is {config.preview_num_records.max}")
         num_records = requested_num_records
 
     return num_records
-
-
-async def _get_model_configs_and_providers(
-    dd_ctx: DataDesignerContext,
-    config: dd.DataDesignerConfig,
-    errors: list[NDDError],
-) -> tuple[list[dd.ModelConfig], list[dd.ModelProvider]]:
-    """Resolve referenced model configs / providers, appending failures to ``errors``."""
-    model_configs: list[dd.ModelConfig] = []
-    model_providers: list[dd.ModelProvider] = []
-
-    try:
-        model_configs = get_model_configs(config)
-    except NDDInvalidConfigError as e:
-        errors.append(e)
-    else:
-        try:
-            model_providers = await dd_ctx.get_model_providers(model_configs)
-        except (NDDInvalidConfigError, NDDInternalError) as e:
-            errors.append(e)
-
-    return model_configs, model_providers

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/preview.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/preview.py
@@ -13,7 +13,7 @@ import data_designer.config as dd
 from anyio.lowlevel import current_token
 from data_designer.config.utils.constants import DEFAULT_NUM_RECORDS
 from data_designer_nemo.context import DataDesignerContext, create_data_designer_context
-from data_designer_nemo.errors import NDDError, NDDInternalError, NDDInvalidConfigError
+from data_designer_nemo.errors import NDDError, NDDInternalError, NDDInvalidConfigError, raise_if_errors
 from data_designer_nemo.fileset_file_seed_reader import workspace_cvar
 from data_designer_nemo.model_configs import get_model_configs
 from nemo_data_designer_plugin.config import get_config
@@ -52,7 +52,7 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
         num_records = _validate_and_get_num_records(spec.num_records, is_local, errors)
         model_configs, model_providers = await _get_model_configs_and_providers(dd_ctx, spec.config, errors)
         errors.extend(await dd_ctx.validate(spec.config))
-        _raise_if_errors(errors)
+        raise_if_errors(errors)
 
         workspace_cvar.set(ctx.workspace)
 
@@ -143,17 +143,3 @@ async def _get_model_configs_and_providers(
             errors.append(e)
 
     return model_configs, model_providers
-
-
-def _raise_if_errors(errors: list[NDDError]) -> None:
-    """Raise an aggregated NDD error if ``errors`` is non-empty.
-
-    Any config-level error wins (422 path); only when *every* error is internal
-    do we raise ``NDDInternalError`` (500 path).
-    """
-    if not errors:
-        return
-    aggregated_message = "\n".join(str(e) for e in errors)
-    if any(isinstance(e, NDDInvalidConfigError) for e in errors):
-        raise NDDInvalidConfigError(aggregated_message)
-    raise NDDInternalError(aggregated_message)

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/preview.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/preview.py
@@ -26,7 +26,7 @@ from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.function import NemoFunction
 from nemo_platform_plugin.function_context import FunctionContext
 from nemo_platform_plugin.functions.frames import Done, Error
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class PreviewMessageDeliveryError(Exception): ...
@@ -36,8 +36,6 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
     name: ClassVar[str] = "preview"
     description: ClassVar[str] = "Generate a small preview dataset by streaming NDJSON frames."
     spec_schema: ClassVar[type[PreviewSpec]] = PreviewSpec
-
-    errors: list[NDDError] = Field(default_factory=list)
 
     async def run(
         self,
@@ -50,11 +48,11 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
         dd_ctx = create_data_designer_context(is_local, async_sdk, ctx.workspace)
 
         # Extract/set all necessary values, validating along the way. Raise if any errors were collected.
-        self.errors = []
-        num_records = self._validate_and_get_num_records(spec.num_records, is_local)
-        model_configs, model_providers = await self._get_model_configs_and_providers(dd_ctx, spec.config)
-        await self._validate_config(dd_ctx, spec.config)
-        self._raise_if_errors()
+        errors: list[NDDError] = []
+        num_records = _validate_and_get_num_records(spec.num_records, is_local, errors)
+        model_configs, model_providers = await _get_model_configs_and_providers(dd_ctx, spec.config, errors)
+        errors.extend(await dd_ctx.validate(spec.config))
+        _raise_if_errors(errors)
 
         workspace_cvar.set(ctx.workspace)
 
@@ -103,46 +101,59 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
             if not completed_with_error:
                 yield Done()
 
-    def _validate_and_get_num_records(self, requested_num_records: int | None, is_local: bool) -> int:
-        if is_local:
-            return requested_num_records or DEFAULT_NUM_RECORDS
 
-        config = get_config()
-        num_records = config.preview_num_records.default
-        if requested_num_records:
-            if requested_num_records > config.preview_num_records.max:
-                self.errors.append(
-                    NDDInvalidConfigError(f"Max num records for preview requests is {config.preview_num_records.max}")
-                )
-            num_records = requested_num_records
+def _validate_and_get_num_records(
+    requested_num_records: int | None,
+    is_local: bool,
+    errors: list[NDDError],
+) -> int:
+    """Resolve the effective ``num_records``, appending to ``errors`` on overflow."""
+    if is_local:
+        return requested_num_records or DEFAULT_NUM_RECORDS
 
-        return num_records
+    config = get_config()
+    num_records = config.preview_num_records.default
+    if requested_num_records:
+        if requested_num_records > config.preview_num_records.max:
+            errors.append(
+                NDDInvalidConfigError(f"Max num records for preview requests is {config.preview_num_records.max}")
+            )
+        num_records = requested_num_records
 
-    async def _get_model_configs_and_providers(
-        self, dd_ctx: DataDesignerContext, config: dd.DataDesignerConfig
-    ) -> tuple[list[dd.ModelConfig], list[dd.ModelProvider]]:
-        model_configs = []
-        model_providers = []
+    return num_records
 
+
+async def _get_model_configs_and_providers(
+    dd_ctx: DataDesignerContext,
+    config: dd.DataDesignerConfig,
+    errors: list[NDDError],
+) -> tuple[list[dd.ModelConfig], list[dd.ModelProvider]]:
+    """Resolve referenced model configs / providers, appending failures to ``errors``."""
+    model_configs: list[dd.ModelConfig] = []
+    model_providers: list[dd.ModelProvider] = []
+
+    try:
+        model_configs = get_model_configs(config)
+    except NDDInvalidConfigError as e:
+        errors.append(e)
+    else:
         try:
-            model_configs = get_model_configs(config)
-        except NDDInvalidConfigError as e:
-            self.errors.append(e)
-        else:
-            try:
-                model_providers = await dd_ctx.get_model_providers(model_configs)
-            except (NDDInvalidConfigError, NDDInternalError) as e:
-                self.errors.append(e)
+            model_providers = await dd_ctx.get_model_providers(model_configs)
+        except (NDDInvalidConfigError, NDDInternalError) as e:
+            errors.append(e)
 
-        return model_configs, model_providers
+    return model_configs, model_providers
 
-    async def _validate_config(self, dd_ctx: DataDesignerContext, config: dd.DataDesignerConfig) -> None:
-        validation_errors = await dd_ctx.validate(config)
-        self.errors.extend(validation_errors)
 
-    def _raise_if_errors(self) -> None:
-        if self.errors:
-            aggregated_message = "\n".join(str(e) for e in self.errors)
-            if any(isinstance(e, NDDInvalidConfigError) for e in self.errors):
-                raise NDDInvalidConfigError(aggregated_message)
-            raise NDDInternalError(aggregated_message)
+def _raise_if_errors(errors: list[NDDError]) -> None:
+    """Raise an aggregated NDD error if ``errors`` is non-empty.
+
+    Any config-level error wins (422 path); only when *every* error is internal
+    do we raise ``NDDInternalError`` (500 path).
+    """
+    if not errors:
+        return
+    aggregated_message = "\n".join(str(e) for e in errors)
+    if any(isinstance(e, NDDInvalidConfigError) for e in errors):
+        raise NDDInvalidConfigError(aggregated_message)
+    raise NDDInternalError(aggregated_message)

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 from typing import ClassVar, cast
 
-from data_designer_nemo.context import create_data_designer_context
-from data_designer_nemo.errors import NDDInternalError, NDDInvalidConfigError
+import data_designer.config as dd
+from data_designer_nemo.context import DataDesignerContext, create_data_designer_context
+from data_designer_nemo.errors import NDDError, NDDInternalError, NDDInvalidConfigError
 from data_designer_nemo.model_configs import get_model_configs
 from nemo_data_designer_plugin.jobs.run import run_step_config_result
 from nemo_data_designer_plugin.jobs.spec import DataDesignerJobConfig, DataDesignerStepConfig
@@ -49,28 +50,14 @@ class CreateJob(NemoJob):
         input_spec = cast(DataDesignerJobConfig, input_spec)
         dd_ctx = create_data_designer_context(is_local, async_sdk, workspace)
 
-        # Aggregate errors across context validation and model config/provider resolution.
-        # Raise if any errors were collected.
-        errors = await dd_ctx.validate(input_spec.config)
-
-        model_configs: list = []
-        model_providers: list = []
-        try:
-            model_configs = get_model_configs(input_spec.config)
-        except NDDInvalidConfigError as e:
-            errors.append(e)
-        else:
-            try:
-                model_providers = await dd_ctx.get_model_providers(model_configs)
-            except (NDDInvalidConfigError, NDDInternalError) as e:
-                errors.append(e)
-
-        if errors:
-            aggregated_message = "\n".join(str(e) for e in errors)
-            # TODO: raise a more generic error (not "job compilation")
-            if any(isinstance(e, NDDInvalidConfigError) for e in errors):
-                raise PlatformJobCompilationError(aggregated_message)
-            raise NDDInternalError(aggregated_message)
+        # Aggregate errors across context validation and model config/provider
+        # resolution. ``errors`` is the per-call buffer; once we've run every
+        # check we either raise (with all errors aggregated) or proceed with
+        # the resolved values.
+        errors: list[NDDError] = []
+        model_configs, model_providers = await _get_model_configs_and_providers(dd_ctx, input_spec.config, errors)
+        errors.extend(await dd_ctx.validate(input_spec.config))
+        _raise_if_errors(errors)
 
         return DataDesignerStepConfig(
             job_config=input_spec,
@@ -112,3 +99,42 @@ class CreateJob(NemoJob):
     def run(self, config: dict, *, ctx: JobContext, sdk: NeMoPlatform, is_local: bool = False) -> dict:
         step_config = DataDesignerStepConfig.model_validate(config)
         return run_step_config_result(step_config, ctx, sdk, is_local)
+
+
+async def _get_model_configs_and_providers(
+    dd_ctx: DataDesignerContext,
+    config: dd.DataDesignerConfig,
+    errors: list[NDDError],
+) -> tuple[list[dd.ModelConfig], list[dd.ModelProvider]]:
+    """Resolve referenced model configs / providers, appending failures to ``errors``."""
+    model_configs: list[dd.ModelConfig] = []
+    model_providers: list[dd.ModelProvider] = []
+
+    try:
+        model_configs = get_model_configs(config)
+    except NDDInvalidConfigError as e:
+        errors.append(e)
+    else:
+        try:
+            model_providers = await dd_ctx.get_model_providers(model_configs)
+        except (NDDInvalidConfigError, NDDInternalError) as e:
+            errors.append(e)
+
+    return model_configs, model_providers
+
+
+def _raise_if_errors(errors: list[NDDError]) -> None:
+    """Raise an aggregated error if ``errors`` is non-empty.
+
+    Any config-level error wins (422 path) and surfaces as
+    :class:`PlatformJobCompilationError`, which the job-route handler maps to
+    HTTP 422. Only when *every* error is internal do we raise
+    :class:`NDDInternalError` (500 path).
+    """
+    if not errors:
+        return
+    aggregated_message = "\n".join(str(e) for e in errors)
+    # TODO: raise a more generic error (not "job compilation")
+    if any(isinstance(e, NDDInvalidConfigError) for e in errors):
+        raise PlatformJobCompilationError(aggregated_message)
+    raise NDDInternalError(aggregated_message)

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 
 from typing import ClassVar, cast
 
-import data_designer.config as dd
-from data_designer_nemo.context import DataDesignerContext, create_data_designer_context
-from data_designer_nemo.errors import NDDError, NDDInternalError, NDDInvalidConfigError, raise_if_errors
-from data_designer_nemo.model_configs import get_model_configs
+from data_designer_nemo.context import create_data_designer_context
+from data_designer_nemo.errors import raise_if_errors
+from data_designer_nemo.runnable import resolve_runnable_config
 from nemo_data_designer_plugin.jobs.run import run_step_config_result
 from nemo_data_designer_plugin.jobs.spec import DataDesignerJobConfig, DataDesignerStepConfig
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
@@ -47,15 +46,9 @@ class CreateJob(NemoJob):
     ) -> BaseModel:  # DataDesignerStepConfig
         async_sdk = cast(AsyncNeMoPlatform, async_sdk)
         input_spec = cast(DataDesignerJobConfig, input_spec)
-        dd_ctx = create_data_designer_context(is_local, async_sdk, workspace)
 
-        # Aggregate errors across context validation and model config/provider
-        # resolution. ``errors`` is the per-call buffer; once we've run every
-        # check we either raise (with all errors aggregated) or proceed with
-        # the resolved values.
-        errors: list[NDDError] = []
-        errors.extend(await dd_ctx.validate(input_spec.config))
-        model_configs, model_providers = await _get_model_configs_and_providers(dd_ctx, input_spec.config, errors)
+        dd_ctx = create_data_designer_context(is_local, async_sdk, workspace)
+        errors, model_configs, model_providers = await resolve_runnable_config(dd_ctx, input_spec.config)
         raise_if_errors(errors)
 
         return DataDesignerStepConfig(
@@ -98,25 +91,3 @@ class CreateJob(NemoJob):
     def run(self, config: dict, *, ctx: JobContext, sdk: NeMoPlatform, is_local: bool = False) -> dict:
         step_config = DataDesignerStepConfig.model_validate(config)
         return run_step_config_result(step_config, ctx, sdk, is_local)
-
-
-async def _get_model_configs_and_providers(
-    dd_ctx: DataDesignerContext,
-    config: dd.DataDesignerConfig,
-    errors: list[NDDError],
-) -> tuple[list[dd.ModelConfig], list[dd.ModelProvider]]:
-    """Resolve referenced model configs / providers, appending failures to ``errors``."""
-    model_configs: list[dd.ModelConfig] = []
-    model_providers: list[dd.ModelProvider] = []
-
-    try:
-        model_configs = get_model_configs(config)
-    except NDDInvalidConfigError as e:
-        errors.append(e)
-    else:
-        try:
-            model_providers = await dd_ctx.get_model_providers(model_configs)
-        except (NDDInvalidConfigError, NDDInternalError) as e:
-            errors.append(e)
-
-    return model_configs, model_providers

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
@@ -9,7 +9,7 @@ from typing import ClassVar, cast
 
 import data_designer.config as dd
 from data_designer_nemo.context import DataDesignerContext, create_data_designer_context
-from data_designer_nemo.errors import NDDError, NDDInternalError, NDDInvalidConfigError
+from data_designer_nemo.errors import NDDError, NDDInternalError, NDDInvalidConfigError, raise_if_errors
 from data_designer_nemo.model_configs import get_model_configs
 from nemo_data_designer_plugin.jobs.run import run_step_config_result
 from nemo_data_designer_plugin.jobs.spec import DataDesignerJobConfig, DataDesignerStepConfig
@@ -22,7 +22,6 @@ from nemo_platform_plugin.jobs.api_factory import (
     PlatformJobSpec,
     PlatformJobStep,
 )
-from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from nmp.common.jobs.image import get_qualified_image
 from pydantic import BaseModel
 
@@ -55,9 +54,9 @@ class CreateJob(NemoJob):
         # check we either raise (with all errors aggregated) or proceed with
         # the resolved values.
         errors: list[NDDError] = []
-        model_configs, model_providers = await _get_model_configs_and_providers(dd_ctx, input_spec.config, errors)
         errors.extend(await dd_ctx.validate(input_spec.config))
-        _raise_if_errors(errors)
+        model_configs, model_providers = await _get_model_configs_and_providers(dd_ctx, input_spec.config, errors)
+        raise_if_errors(errors)
 
         return DataDesignerStepConfig(
             job_config=input_spec,
@@ -121,20 +120,3 @@ async def _get_model_configs_and_providers(
             errors.append(e)
 
     return model_configs, model_providers
-
-
-def _raise_if_errors(errors: list[NDDError]) -> None:
-    """Raise an aggregated error if ``errors`` is non-empty.
-
-    Any config-level error wins (422 path) and surfaces as
-    :class:`PlatformJobCompilationError`, which the job-route handler maps to
-    HTTP 422. Only when *every* error is internal do we raise
-    :class:`NDDInternalError` (500 path).
-    """
-    if not errors:
-        return
-    aggregated_message = "\n".join(str(e) for e in errors)
-    # TODO: raise a more generic error (not "job compilation")
-    if any(isinstance(e, NDDInvalidConfigError) for e in errors):
-        raise PlatformJobCompilationError(aggregated_message)
-    raise NDDInternalError(aggregated_message)

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/create.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import ClassVar, cast
 
 from data_designer_nemo.context import create_data_designer_context
-from data_designer_nemo.errors import NDDInvalidConfigError
+from data_designer_nemo.errors import NDDInternalError, NDDInvalidConfigError
 from data_designer_nemo.model_configs import get_model_configs
 from nemo_data_designer_plugin.jobs.run import run_step_config_result
 from nemo_data_designer_plugin.jobs.spec import DataDesignerJobConfig, DataDesignerStepConfig
@@ -49,15 +49,28 @@ class CreateJob(NemoJob):
         input_spec = cast(DataDesignerJobConfig, input_spec)
         dd_ctx = create_data_designer_context(is_local, async_sdk, workspace)
 
+        # Aggregate errors across context validation and model config/provider resolution.
+        # Raise if any errors were collected.
+        errors = await dd_ctx.validate(input_spec.config)
+
+        model_configs: list = []
+        model_providers: list = []
         try:
-            await dd_ctx.validate(input_spec.config)
             model_configs = get_model_configs(input_spec.config)
-            model_providers = await dd_ctx.get_model_providers(model_configs)
-        # Only catch-and-transform NDDInvalidConfigError here; other errors
-        # (e.g. NDDInternalError) should bubble out as 500s.
-        # TODO: raise a more generic error (not "job compilation")
         except NDDInvalidConfigError as e:
-            raise PlatformJobCompilationError(str(e)) from e
+            errors.append(e)
+        else:
+            try:
+                model_providers = await dd_ctx.get_model_providers(model_configs)
+            except (NDDInvalidConfigError, NDDInternalError) as e:
+                errors.append(e)
+
+        if errors:
+            aggregated_message = "\n".join(str(e) for e in errors)
+            # TODO: raise a more generic error (not "job compilation")
+            if any(isinstance(e, NDDInvalidConfigError) for e in errors):
+                raise PlatformJobCompilationError(aggregated_message)
+            raise NDDInternalError(aggregated_message)
 
         return DataDesignerStepConfig(
             job_config=input_spec,

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/resources.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/resources.py
@@ -37,6 +37,12 @@ from nemo_data_designer_plugin.sdk.errors import (
 )
 from nemo_data_designer_plugin.sdk.job_resources import AsyncDataDesignerJobResource, DataDesignerJobResource
 from nemo_data_designer_plugin.sdk.logging import with_logging
+from nemo_data_designer_plugin.sdk.validation import (
+    ExecutionContext,
+    ValidationReport,
+    validate_config,
+    validate_config_sync,
+)
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform.models.resources import AsyncModelsResource, ModelsResource
 from nemo_platform.types.inference import ModelProvider as NMPModelProvider
@@ -352,6 +358,46 @@ class DataDesignerResource(_BaseDataDesignerResource[NeMoPlatform]):
     def get_info(self) -> InterfaceInfo:
         return InterfaceInfo(model_providers=self.get_default_model_providers())
 
+    def validate(
+        self,
+        config_builder: dd.DataDesignerConfigBuilder,
+        *,
+        execution_context: ExecutionContext | None = None,
+        workspace: str | None = None,
+    ) -> ValidationReport:
+        """Validate a Data Designer config against one or every execution context.
+
+        This runs the same client-side checks ``preview`` / ``create`` perform
+        internally, but never short-circuits — every detectable problem is
+        reported. The remote pass is a client-side simulation and does not
+        contact the data-designer service.
+
+        Args:
+            config_builder: Data Designer configuration builder.
+            execution_context: ``"local"``, ``"remote"``, or ``None``.
+                ``None`` (the default) runs every applicable context.
+            workspace: Workspace used to resolve provider references and seed
+                sources for the remote pass. Falls back to the platform
+                client's default workspace, then to ``"default"``.
+
+        Returns:
+            A :class:`ValidationReport` whose ``ok`` property is true iff
+            every requested context validated cleanly.
+        """
+        # Reject unsupported local-only seed types eagerly, the same way
+        # ``preview`` / ``create`` do, so SDK consumers get a consistent error.
+        config = _get_config_for_api_call(config_builder)
+        # Rebuild a config_builder from the (possibly normalized) config so the
+        # downstream engine validate sees exactly what would be submitted.
+        validated_builder = dd.DataDesignerConfigBuilder.from_config(config.to_dict())
+        resolved_workspace = workspace or self._platform.workspace or "default"
+        return validate_config_sync(
+            validated_builder,
+            sdk=self._platform,
+            workspace=resolved_workspace,
+            execution_context=execution_context,
+        )
+
 
 @with_logging
 class AsyncDataDesignerResource(_BaseDataDesignerResource[AsyncNeMoPlatform]):
@@ -491,6 +537,24 @@ class AsyncDataDesignerResource(_BaseDataDesignerResource[AsyncNeMoPlatform]):
 
     async def get_info(self) -> InterfaceInfo:
         return InterfaceInfo(model_providers=await self.get_default_model_providers())
+
+    async def validate(
+        self,
+        config_builder: dd.DataDesignerConfigBuilder,
+        *,
+        execution_context: ExecutionContext | None = None,
+        workspace: str | None = None,
+    ) -> ValidationReport:
+        """Async equivalent of :meth:`DataDesignerResource.validate`."""
+        config = _get_config_for_api_call(config_builder)
+        validated_builder = dd.DataDesignerConfigBuilder.from_config(config.to_dict())
+        resolved_workspace = workspace or self._platform.workspace or "default"
+        return await validate_config(
+            validated_builder,
+            async_sdk=self._platform,
+            workspace=resolved_workspace,
+            execution_context=execution_context,
+        )
 
 
 def _get_config_for_api_call(config_builder: dd.DataDesignerConfigBuilder) -> dd.DataDesignerConfig:

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/resources.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/resources.py
@@ -384,15 +384,16 @@ class DataDesignerResource(_BaseDataDesignerResource[NeMoPlatform]):
             A :class:`ValidationReport` whose ``ok`` property is true iff
             every requested context validated cleanly.
         """
-        # Reject unsupported local-only seed types eagerly, the same way
-        # ``preview`` / ``create`` do, so SDK consumers get a consistent error.
-        config = _get_config_for_api_call(config_builder)
-        # Rebuild a config_builder from the (possibly normalized) config so the
-        # downstream engine validate sees exactly what would be submitted.
-        validated_builder = dd.DataDesignerConfigBuilder.from_config(config.to_dict())
+        # Don't apply the eager ``_get_config_for_api_call`` rejection that
+        # ``preview`` / ``create`` use — the validate pass is *meant* to
+        # surface unsupported-seed errors as part of its report, alongside
+        # any other problems. Short-circuiting on the first eager check would
+        # break aggregation and would also reject ``df``-seed configs that
+        # are surfaced cleanly with a helpful message by the validate pass
+        # itself (see ``_validate_seed_type_for_execution_context``).
         resolved_workspace = workspace or self._platform.workspace or "default"
         return validate_config_sync(
-            validated_builder,
+            config_builder,
             sdk=self._platform,
             workspace=resolved_workspace,
             execution_context=execution_context,
@@ -546,11 +547,11 @@ class AsyncDataDesignerResource(_BaseDataDesignerResource[AsyncNeMoPlatform]):
         workspace: str | None = None,
     ) -> ValidationReport:
         """Async equivalent of :meth:`DataDesignerResource.validate`."""
-        config = _get_config_for_api_call(config_builder)
-        validated_builder = dd.DataDesignerConfigBuilder.from_config(config.to_dict())
+        # See the sync ``DataDesignerResource.validate`` docstring for why we
+        # bypass ``_get_config_for_api_call`` here.
         resolved_workspace = workspace or self._platform.workspace or "default"
         return await validate_config(
-            validated_builder,
+            config_builder,
             async_sdk=self._platform,
             workspace=resolved_workspace,
             execution_context=execution_context,

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
@@ -46,8 +46,12 @@ class ValidationContextResult(BaseModel):
     """Aggregate result for a single execution context (local or remote)."""
 
     context: ExecutionContext
-    ok: bool
     errors: list[ValidationError] = Field(default_factory=list)
+
+    @computed_field
+    @property
+    def ok(self) -> bool:
+        return not self.errors
 
 
 class ValidationReport(BaseModel):
@@ -141,7 +145,6 @@ async def _validate_one_context(
 
     return ValidationContextResult(
         context=context,
-        ok=not errors,
         errors=errors,
     )
 

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
@@ -66,7 +66,7 @@ class ValidationReport(BaseModel):
         return all(r.ok for r in self.results) and len(self.results) > 0
 
 
-def _to_validation_error(exc: BaseException) -> ValidationError:
+def _to_validation_error(exc: Exception) -> ValidationError:
     return ValidationError(message=str(exc))
 
 

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
@@ -32,7 +32,6 @@ from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from pydantic import BaseModel, Field, computed_field
 
 ExecutionContext = Literal["local", "remote"]
-Severity = Literal["config", "internal"]
 
 _ALL_CONTEXTS: tuple[ExecutionContext, ...] = ("local", "remote")
 
@@ -41,7 +40,6 @@ class ValidationError(BaseModel):
     """A single problem surfaced by a validation pass."""
 
     message: str
-    severity: Severity = "config"
 
 
 class ValidationContextResult(BaseModel):
@@ -64,16 +62,8 @@ class ValidationReport(BaseModel):
         return all(r.ok for r in self.results) and len(self.results) > 0
 
 
-def _classify_severity(exc: BaseException) -> Severity:
-    if isinstance(exc, NDDInternalError):
-        return "internal"
-    # NDDInvalidConfigError, upstream InvalidConfigError, and anything else we
-    # opted to surface as a config-level problem.
-    return "config"
-
-
 def _to_validation_error(exc: BaseException) -> ValidationError:
-    return ValidationError(message=str(exc), severity=_classify_severity(exc))
+    return ValidationError(message=str(exc))
 
 
 async def _validate_one_context(
@@ -146,11 +136,7 @@ async def _validate_one_context(
                 # Engine validate is sync; run it on a worker thread so the
                 # event loop stays unblocked.
                 await asyncio.to_thread(data_designer.validate, config_builder)
-        except InvalidConfigError as e:
-            errors.append(ValidationError(message=str(e), severity="config"))
-        except NDDInvalidConfigError as e:  # defensive: in case engine surfaces our own
-            errors.append(_to_validation_error(e))
-        except NDDInternalError as e:
+        except (InvalidConfigError, NDDInvalidConfigError, NDDInternalError) as e:
             errors.append(_to_validation_error(e))
 
     return ValidationContextResult(

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
@@ -25,7 +25,7 @@ import data_designer.config as dd
 from data_designer.config.errors import InvalidConfigError
 from data_designer_nemo.context import create_data_designer_context
 from data_designer_nemo.errors import NDDInternalError, NDDInvalidConfigError
-from data_designer_nemo.model_configs import get_model_configs
+from data_designer_nemo.runnable import resolve_runnable_config
 from data_designer_nemo.sdk_translation import sync_to_async_sdk
 from nemo_data_designer_plugin._data_designer import create_data_designer
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
@@ -81,55 +81,30 @@ async def _validate_one_context(
     """Run a full validation pass for one execution context, accumulating all errors.
 
     Mirrors the work ``CreateJob.to_spec`` and ``PreviewFunction.run`` do at
-    submit/preview time, but never short-circuits: every sub-check that *can*
-    be run is run, so a single pass surfaces every problem.
+    submit/preview time — via the shared :func:`resolve_runnable_config` —
+    and additionally runs an engine-level compile check that the runtime
+    callers defer to library-execution time. Never short-circuits: every
+    sub-check that *can* be run is run, so a single pass surfaces every
+    problem.
     """
     is_local = context == "local"
     dd_ctx = create_data_designer_context(is_local, async_sdk, workspace)
 
-    errors: list[ValidationError] = []
+    # First run the same resolution that the job and function execute.
+    runnable_errors, _model_configs, model_providers = await resolve_runnable_config(dd_ctx, config)
+    errors: list[ValidationError] = [_to_validation_error(e) for e in runnable_errors]
 
-    # 1. Sub-checks that live inside the data-designer-nemo context (seed type,
-    #    tool configs, IGW personas filesets, etc.).
-    for ctx_err in await dd_ctx.validate(config):
-        errors.append(_to_validation_error(ctx_err))
-
-    # 2. Resolve referenced ModelConfigs. If aliases are unrecognized, we can't
-    #    meaningfully resolve providers, so we skip steps 3 and 4 in that case.
-    model_configs: list[dd.ModelConfig] = []
-    skip_engine_check = False
-    try:
-        model_configs = get_model_configs(config)
-    except NDDInvalidConfigError as e:
-        errors.append(_to_validation_error(e))
-        skip_engine_check = True
-
-    # 3. Resolve providers. Local context falls through to IGW (this is the
-    #    fix for the IGW-reference gap); remote uses IGW exclusively.
-    model_providers: list[dd.ModelProvider] = []
-    if not skip_engine_check:
-        try:
-            model_providers = await dd_ctx.get_model_providers(model_configs)
-        except (NDDInvalidConfigError, NDDInternalError) as e:
-            errors.append(_to_validation_error(e))
-            # NDDInternalError on the registry means we can't run the engine
-            # check below; an NDDInvalidConfigError still leaves us a usable
-            # registry so we *could* proceed, but to keep the diagnostic surface
-            # focused (and match remote behavior), we stop once provider
-            # resolution fails.
-            skip_engine_check = True
-
-    # 4. Engine-level compile check via upstream DataDesigner.validate. This is
-    #    the source of truth on column→alias→provider consistency. We supply
-    #    a registry that knows about IGW for the local case.
+    # Next additionally run engine-level compile via upstream ``DataDesigner.validate``,
+    # the source of truth on column→alias→provider consistency.
     #
-    # If we've already collected config-level errors (e.g. unsupported seed
-    # type, unrecognized aliases), the engine pass is unlikely to succeed in a
-    # diagnostically useful way — the engine surfaces internal failures (e.g.
-    # ``No reader found for seed_type 'df'``) when the config is already known
-    # to be malformed. Skip the engine check in that case so the user-facing
-    # diagnostics stay focused on the actionable problems we've already found.
-    if not skip_engine_check and not errors:
+    # If we've already collected errors above (e.g. unsupported seed type,
+    # unrecognized aliases, unresolved providers), the engine pass is
+    # unlikely to succeed in a diagnostically useful way — the engine
+    # surfaces internal failures (e.g. ``No reader found for seed_type
+    # 'df'``) when the config is already known to be malformed. Skip the
+    # engine check in that case so the user-facing diagnostics stay focused
+    # on the actionable problems we've already found.
+    if not errors:
         try:
             with tempfile.TemporaryDirectory() as artifact_path:
                 data_designer = create_data_designer(

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/validation.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Client-side validation core for Data Designer configs.
+
+This module owns the "is this config fit to run locally / submit remotely?"
+question. It is consumed by both the SDK (``DataDesignerResource.validate``)
+and the CLI (``nemo data-designer validate``); the surface layer just decides
+how to render the report and which exit code to use.
+
+The validation passes here mirror what ``CreateJob.to_spec`` and
+``PreviewFunction.run`` execute at submit/preview time, so a green
+``ValidationReport`` is a strong (but not absolute) indicator that downstream
+calls will succeed. The remote pass is a client-side simulation — it does not
+hit the data-designer service.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from typing import Literal
+
+import data_designer.config as dd
+from data_designer.config.errors import InvalidConfigError
+from data_designer_nemo.context import create_data_designer_context
+from data_designer_nemo.errors import NDDInternalError, NDDInvalidConfigError
+from data_designer_nemo.model_configs import get_model_configs
+from data_designer_nemo.sdk_translation import sync_to_async_sdk
+from nemo_data_designer_plugin._data_designer import create_data_designer
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from pydantic import BaseModel, Field, computed_field
+
+ExecutionContext = Literal["local", "remote"]
+Severity = Literal["config", "internal"]
+
+_ALL_CONTEXTS: tuple[ExecutionContext, ...] = ("local", "remote")
+
+
+class ValidationError(BaseModel):
+    """A single problem surfaced by a validation pass."""
+
+    message: str
+    severity: Severity = "config"
+
+
+class ValidationContextResult(BaseModel):
+    """Aggregate result for a single execution context (local or remote)."""
+
+    context: ExecutionContext
+    ok: bool
+    errors: list[ValidationError] = Field(default_factory=list)
+
+
+class ValidationReport(BaseModel):
+    """Top-level validation result. ``ok`` is true iff every context's ``ok`` is true."""
+
+    config_source: str | None = None
+    results: list[ValidationContextResult] = Field(default_factory=list)
+
+    @computed_field
+    @property
+    def ok(self) -> bool:
+        return all(r.ok for r in self.results) and len(self.results) > 0
+
+
+def _classify_severity(exc: BaseException) -> Severity:
+    if isinstance(exc, NDDInternalError):
+        return "internal"
+    # NDDInvalidConfigError, upstream InvalidConfigError, and anything else we
+    # opted to surface as a config-level problem.
+    return "config"
+
+
+def _to_validation_error(exc: BaseException) -> ValidationError:
+    return ValidationError(message=str(exc), severity=_classify_severity(exc))
+
+
+async def _validate_one_context(
+    *,
+    context: ExecutionContext,
+    config_builder: dd.DataDesignerConfigBuilder,
+    config: dd.DataDesignerConfig,
+    async_sdk: AsyncNeMoPlatform,
+    workspace: str,
+) -> ValidationContextResult:
+    """Run a full validation pass for one execution context, accumulating all errors.
+
+    Mirrors the work ``CreateJob.to_spec`` and ``PreviewFunction.run`` do at
+    submit/preview time, but never short-circuits: every sub-check that *can*
+    be run is run, so a single pass surfaces every problem.
+    """
+    is_local = context == "local"
+    dd_ctx = create_data_designer_context(is_local, async_sdk, workspace)
+
+    errors: list[ValidationError] = []
+
+    # 1. Sub-checks that live inside the data-designer-nemo context (seed type,
+    #    tool configs, IGW personas filesets, etc.).
+    for ctx_err in await dd_ctx.validate(config):
+        errors.append(_to_validation_error(ctx_err))
+
+    # 2. Resolve referenced ModelConfigs. If aliases are unrecognized, we can't
+    #    meaningfully resolve providers, so we skip steps 3 and 4 in that case.
+    model_configs: list[dd.ModelConfig] = []
+    skip_engine_check = False
+    try:
+        model_configs = get_model_configs(config)
+    except NDDInvalidConfigError as e:
+        errors.append(_to_validation_error(e))
+        skip_engine_check = True
+
+    # 3. Resolve providers. Local context falls through to IGW (this is the
+    #    fix for the IGW-reference gap); remote uses IGW exclusively.
+    model_providers: list[dd.ModelProvider] = []
+    if not skip_engine_check:
+        try:
+            model_providers = await dd_ctx.get_model_providers(model_configs)
+        except (NDDInvalidConfigError, NDDInternalError) as e:
+            errors.append(_to_validation_error(e))
+            # NDDInternalError on the registry means we can't run the engine
+            # check below; an NDDInvalidConfigError still leaves us a usable
+            # registry so we *could* proceed, but to keep the diagnostic surface
+            # focused (and match remote behavior), we stop once provider
+            # resolution fails.
+            skip_engine_check = True
+
+    # 4. Engine-level compile check via upstream DataDesigner.validate. This is
+    #    the source of truth on column→alias→provider consistency. We supply
+    #    a registry that knows about IGW for the local case.
+    #
+    # If we've already collected config-level errors (e.g. unsupported seed
+    # type, unrecognized aliases), the engine pass is unlikely to succeed in a
+    # diagnostically useful way — the engine surfaces internal failures (e.g.
+    # ``No reader found for seed_type 'df'``) when the config is already known
+    # to be malformed. Skip the engine check in that case so the user-facing
+    # diagnostics stay focused on the actionable problems we've already found.
+    if not skip_engine_check and not errors:
+        try:
+            with tempfile.TemporaryDirectory() as artifact_path:
+                data_designer = create_data_designer(
+                    artifact_path=artifact_path,
+                    model_providers=model_providers,
+                    dd_ctx=dd_ctx,
+                )
+                # Engine validate is sync; run it on a worker thread so the
+                # event loop stays unblocked.
+                await asyncio.to_thread(data_designer.validate, config_builder)
+        except InvalidConfigError as e:
+            errors.append(ValidationError(message=str(e), severity="config"))
+        except NDDInvalidConfigError as e:  # defensive: in case engine surfaces our own
+            errors.append(_to_validation_error(e))
+        except NDDInternalError as e:
+            errors.append(_to_validation_error(e))
+
+    return ValidationContextResult(
+        context=context,
+        ok=not errors,
+        errors=errors,
+    )
+
+
+async def validate_config(
+    config_builder: dd.DataDesignerConfigBuilder,
+    *,
+    sdk: NeMoPlatform | None = None,
+    async_sdk: AsyncNeMoPlatform | None = None,
+    workspace: str,
+    execution_context: ExecutionContext | None = None,
+    config_source: str | None = None,
+) -> ValidationReport:
+    """Validate ``config_builder`` against one or every execution context.
+
+    Args:
+        config_builder: The Data Designer config to validate.
+        sdk: Sync NeMoPlatform SDK. Used as a fallback to derive ``async_sdk``
+            when one is not supplied.
+        async_sdk: Async NeMoPlatform SDK. If omitted but ``sdk`` is supplied,
+            an async wrapper is built via ``sync_to_async_sdk``.
+        workspace: Workspace used to resolve provider references and seed
+            sources for the remote context. Pass ``"default"`` if you have
+            no better value.
+        execution_context: ``"local"``, ``"remote"``, or ``None``.
+            ``None`` (the default) runs every applicable context.
+        config_source: Informational identifier for the config source — echoed
+            back through the report. Not used for any logic.
+
+    Returns:
+        A ``ValidationReport`` aggregating the results of every requested
+        context. The report's ``ok`` property is true iff every requested
+        context validated cleanly.
+
+    Raises:
+        ValueError: If neither ``sdk`` nor ``async_sdk`` is provided.
+    """
+    if async_sdk is None:
+        if sdk is None:
+            raise ValueError("validate_config requires either sdk= or async_sdk=")
+        async_sdk = sync_to_async_sdk(sdk)
+
+    config = config_builder.build()
+
+    contexts: tuple[ExecutionContext, ...]
+    if execution_context is None:
+        contexts = _ALL_CONTEXTS
+    else:
+        contexts = (execution_context,)
+
+    results: list[ValidationContextResult] = []
+    for ctx in contexts:
+        results.append(
+            await _validate_one_context(
+                context=ctx,
+                config_builder=config_builder,
+                config=config,
+                async_sdk=async_sdk,
+                workspace=workspace,
+            )
+        )
+
+    return ValidationReport(config_source=config_source, results=results)
+
+
+def validate_config_sync(
+    config_builder: dd.DataDesignerConfigBuilder,
+    *,
+    sdk: NeMoPlatform | None = None,
+    async_sdk: AsyncNeMoPlatform | None = None,
+    workspace: str,
+    execution_context: ExecutionContext | None = None,
+    config_source: str | None = None,
+) -> ValidationReport:
+    """Sync wrapper for :func:`validate_config` for SDK callers without an event loop."""
+    return asyncio.run(
+        validate_config(
+            config_builder,
+            sdk=sdk,
+            async_sdk=async_sdk,
+            workspace=workspace,
+            execution_context=execution_context,
+            config_source=config_source,
+        )
+    )

--- a/plugins/nemo-data-designer/tests/integration/test_preview_local_cli.py
+++ b/plugins/nemo-data-designer/tests/integration/test_preview_local_cli.py
@@ -103,13 +103,58 @@ def load_config_builder() -> dd.DataDesignerConfigBuilder:
             client_context,
         )
 
-    message = result.output
-    if result.exception is not None:
-        message = f"{message}\n{result.exception}"
+    # The helpful diagnostic must reach the user via stdout/stderr, not just via
+    # the raw exception object. Earlier versions of this plugin returned a raw
+    # ``NDDInvalidConfigError`` from a Pydantic before-validator; Pydantic v2 only
+    # wraps ``ValueError`` / ``AssertionError`` / ``PydanticCustomError`` from
+    # before-validators, so the original exception escaped ``model_validate`` raw,
+    # past the framework's ``except ValidationError`` clause, leaving the user
+    # with empty output and exit code 1. The validator now translates plugin
+    # errors into ``ValueError`` so Pydantic wraps them properly; this test
+    # asserts the resulting user-visible message.
     assert result.exit_code != 0
-    assert "Dataframe seed sources (seed_type=df) are not supported on the NeMo Platform" in message
-    assert "Field required" not in message
-    assert "No such file" not in message
+    assert "Dataframe seed sources (seed_type=df) are not supported on the NeMo Platform" in result.output
+    assert "Field required" not in result.output
+    assert "No such file" not in result.output
+
+
+def test_create_run_rejects_dataframe_seed_with_clear_error(tmp_path: Path) -> None:
+    """``create run`` of a ``df``-seed config produces a clear, user-visible error.
+
+    Same root cause as the ``preview run`` case above: the ``df`` seed is rejected
+    by a Pydantic before-validator on ``DataDesignerJobConfig``. The user-visible
+    message comes through ``CreateRenderer.on_error``, which catches the exception
+    and formats it for the terminal.
+    """
+    config_path = u.write_config_file(
+        tmp_path,
+        """
+import data_designer.config as dd
+import pandas as pd
+
+
+def load_config_builder() -> dd.DataDesignerConfigBuilder:
+    builder = dd.DataDesignerConfigBuilder()
+    builder.with_seed_dataset(dd.DataFrameSeedSource(df=pd.DataFrame(data={"a": [1, 2, 3]})))
+    builder.add_column(dd.ExpressionColumnConfig(name="value", expr="{{ a }}"))
+    return builder
+""",
+        name="dataframe_seed_create_config.py",
+    )
+
+    with u.make_mock_client_context(workspace="default") as client_context:
+        result = u.invoke_cli(
+            ["create", "run", str(config_path), "--num-records", "3"],
+            client_context,
+        )
+
+    assert result.exit_code != 0
+    # ``CreateRenderer.on_error`` runs the message through Rich, which line-wraps
+    # to the terminal width, so we assert on fragments rather than the full
+    # ``"Dataframe seed sources (seed_type=df) are not supported..."`` substring.
+    assert "Dataframe seed sources" in result.output
+    assert "seed_type=df" in result.output
+    assert "Field required" not in result.output
 
 
 def test_create_run_reports_artifacts_and_dataset_path(tmp_path: Path) -> None:

--- a/plugins/nemo-data-designer/tests/integration/test_preview_remote_sdk.py
+++ b/plugins/nemo-data-designer/tests/integration/test_preview_remote_sdk.py
@@ -176,12 +176,12 @@ def test_preview_surfaces_worker_error_through_sdk(monkeypatch: pytest.MonkeyPat
     ``Error`` frame instead of ``Done``; the SDK's ``_PreviewFrameCollector`` translates
     that ``Error`` into a typed ``DataDesignerPreviewError`` with the original message.
     """
-    from nemo_data_designer_plugin.functions import _preview_worker as worker_module
+    from nemo_data_designer_plugin.functions import preview as preview_module
 
     def boom(*args: object, **kwargs: object) -> None:
         raise RuntimeError("forced worker failure")
 
-    monkeypatch.setattr(worker_module, "make_preview_dataset", boom)
+    monkeypatch.setattr(preview_module, "make_preview_dataset", boom)
 
     builder = dd.DataDesignerConfigBuilder(model_configs=[u.make_model_config()])
     builder.add_column(

--- a/plugins/nemo-data-designer/tests/integration/test_validate_cli.py
+++ b/plugins/nemo-data-designer/tests/integration/test_validate_cli.py
@@ -228,14 +228,12 @@ def test_validate_json_output_round_trips(tmp_path: Path) -> None:
     assert isinstance(payload["results"], list)
     assert payload["results"][0]["context"] == "local"
     assert payload["results"][0]["ok"] is True
-    # Severity should be present on each error (none here, but the field exists
-    # in the schema). Roundtrip validates that.
     assert payload["results"][0]["errors"] == []
     # Confirm the surface is a JSON object, not the rich text rendering.
     assert "Local execution" not in result.output
 
 
-def test_validate_json_output_carries_severity_for_failures(tmp_path: Path) -> None:
+def test_validate_json_output_reports_failures(tmp_path: Path) -> None:
     config_path = _write_unsupported_seed_with_tool_configs(tmp_path)
 
     with (
@@ -255,4 +253,6 @@ def test_validate_json_output_carries_severity_for_failures(tmp_path: Path) -> N
     assert remote_result["ok"] is False
     assert len(remote_result["errors"]) >= 2
     for err in remote_result["errors"]:
-        assert err["severity"] in {"config", "internal"}
+        # Each error is a structured object carrying at least a message string.
+        assert isinstance(err["message"], str)
+        assert err["message"]

--- a/plugins/nemo-data-designer/tests/integration/test_validate_cli.py
+++ b/plugins/nemo-data-designer/tests/integration/test_validate_cli.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for ``nemo data-designer validate``.
+
+The CLI command is a thin shell over
+:func:`nemo_data_designer_plugin.sdk.validation.validate_config`; these tests
+assert the public CLI behavior (stdout / exit code / JSON shape) against an
+in-process mock platform.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import nemo_data_designer_plugin.testing.utils as u
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _write_local_first_config(tmp_path: Path) -> Path:
+    """Config that uses an IGW-only provider — must validate clean for local + remote."""
+    return u.write_config_file(
+        tmp_path,
+        f"""
+import data_designer.config as dd
+
+
+def load_config_builder() -> dd.DataDesignerConfigBuilder:
+    builder = dd.DataDesignerConfigBuilder(
+        model_configs=[
+            dd.ModelConfig(
+                alias="text", model={u.ENABLED_MODEL_NAME!r},
+                provider={u.OPEN_PROVIDER_NAME!r},
+            )
+        ]
+    )
+    builder.add_column(
+        dd.SamplerColumnConfig(
+            name="foo",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["a", "b"]),
+        )
+    )
+    builder.add_column(
+        dd.LLMTextColumnConfig(name="story", prompt="About {{{{ foo }}}}", model_alias="text")
+    )
+    return builder
+""",
+        name="igw_provider_config.py",
+    )
+
+
+def _write_unknown_alias_config(tmp_path: Path) -> Path:
+    return u.write_config_file(
+        tmp_path,
+        f"""
+import data_designer.config as dd
+
+
+def load_config_builder() -> dd.DataDesignerConfigBuilder:
+    builder = dd.DataDesignerConfigBuilder(
+        model_configs=[
+            dd.ModelConfig(
+                alias="text", model={u.ENABLED_MODEL_NAME!r},
+                provider={u.OPEN_PROVIDER_NAME!r},
+            )
+        ]
+    )
+    builder.add_column(
+        dd.SamplerColumnConfig(
+            name="foo",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["a", "b"]),
+        )
+    )
+    builder.add_column(
+        dd.LLMTextColumnConfig(name="x", prompt="hi", model_alias="not-a-real-alias")
+    )
+    return builder
+""",
+        name="unknown_alias_config.py",
+    )
+
+
+def _write_unsupported_seed_with_tool_configs(tmp_path: Path) -> Path:
+    """Config that violates two remote rules at once: tool configs + df seed."""
+    return u.write_config_file(
+        tmp_path,
+        f"""
+import data_designer.config as dd
+import pandas as pd
+
+
+def load_config_builder() -> dd.DataDesignerConfigBuilder:
+    builder = dd.DataDesignerConfigBuilder(
+        model_configs=[
+            dd.ModelConfig(
+                alias="text", model={u.ENABLED_MODEL_NAME!r},
+                provider={u.OPEN_PROVIDER_NAME!r},
+            )
+        ],
+        tool_configs=[dd.ToolConfig(tool_alias="hello", providers=[{u.OPEN_PROVIDER_NAME!r}])],
+    )
+    builder.with_seed_dataset(dd.DataFrameSeedSource(df=pd.DataFrame({{"a": [1, 2, 3]}})))
+    builder.add_column(
+        dd.SamplerColumnConfig(
+            name="foo",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["a", "b"]),
+        )
+    )
+    return builder
+""",
+        name="multi_error_config.py",
+    )
+
+
+def test_validate_local_only_succeeds_with_igw_provider(tmp_path: Path) -> None:
+    config_path = _write_local_first_config(tmp_path)
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        result = u.invoke_cli(
+            ["validate", str(config_path), "--execution-context", "local"],
+            client_context,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Local execution" in result.output
+    assert "Configuration is valid" in result.output
+
+
+def test_validate_local_only_fails_for_unknown_alias(tmp_path: Path) -> None:
+    config_path = _write_unknown_alias_config(tmp_path)
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        result = u.invoke_cli(
+            ["validate", str(config_path), "--execution-context", "local"],
+            client_context,
+        )
+
+    assert result.exit_code == 1, result.output
+    assert "not-a-real-alias" in result.output
+
+
+def test_validate_remote_only_aggregates_multiple_errors(tmp_path: Path) -> None:
+    """A single ``validate`` invocation surfaces both the unsupported seed type
+    and the tool-config rejection without short-circuiting.
+    """
+    config_path = _write_unsupported_seed_with_tool_configs(tmp_path)
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        result = u.invoke_cli(
+            ["validate", str(config_path), "--execution-context", "remote"],
+            client_context,
+        )
+
+    assert result.exit_code == 1, result.output
+    output = result.output
+    assert "Remote execution" in output
+    assert "Tool configs" in output
+    # Either the seed-type or DataFrame rejection message must surface alongside.
+    assert ("seed" in output.lower()) or ("DataFrame" in output) or ("df" in output)
+
+
+def test_validate_default_runs_every_context(tmp_path: Path) -> None:
+    config_path = _write_local_first_config(tmp_path)
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        result = u.invoke_cli(
+            ["validate", str(config_path)],
+            client_context,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Local execution" in result.output
+    assert "Remote execution" in result.output
+
+
+def test_validate_default_exits_nonzero_when_any_context_fails(tmp_path: Path) -> None:
+    """An IGW-unknown provider validates fine for local (after IGW lookup fails),
+    but explicit local-only success isn't the point here — we just want to see
+    that omitting the flag exits nonzero when *any* context fails.
+    """
+    config_path = _write_unsupported_seed_with_tool_configs(tmp_path)
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        result = u.invoke_cli(
+            ["validate", str(config_path)],
+            client_context,
+        )
+
+    assert result.exit_code == 1, result.output
+
+
+def test_validate_json_output_round_trips(tmp_path: Path) -> None:
+    config_path = _write_local_first_config(tmp_path)
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        result = u.invoke_cli(
+            ["validate", str(config_path), "--execution-context", "local", "--output", "json"],
+            client_context,
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = u.parse_cli_json_object(result.output)
+    assert payload["ok"] is True
+    assert isinstance(payload["results"], list)
+    assert payload["results"][0]["context"] == "local"
+    assert payload["results"][0]["ok"] is True
+    # Severity should be present on each error (none here, but the field exists
+    # in the schema). Roundtrip validates that.
+    assert payload["results"][0]["errors"] == []
+    # Confirm the surface is a JSON object, not the rich text rendering.
+    assert "Local execution" not in result.output
+
+
+def test_validate_json_output_carries_severity_for_failures(tmp_path: Path) -> None:
+    config_path = _write_unsupported_seed_with_tool_configs(tmp_path)
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        result = u.invoke_cli(
+            ["validate", str(config_path), "--execution-context", "remote", "--output", "json"],
+            client_context,
+        )
+
+    # Pull JSON from the output, ignoring any leading non-JSON cruft.
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    [remote_result] = payload["results"]
+    assert remote_result["context"] == "remote"
+    assert remote_result["ok"] is False
+    assert len(remote_result["errors"]) >= 2
+    for err in remote_result["errors"]:
+        assert err["severity"] in {"config", "internal"}

--- a/plugins/nemo-data-designer/tests/integration/test_validate_cli.py
+++ b/plugins/nemo-data-designer/tests/integration/test_validate_cli.py
@@ -246,6 +246,7 @@ def test_validate_json_output_reports_failures(tmp_path: Path) -> None:
         )
 
     # Pull JSON from the output, ignoring any leading non-JSON cruft.
+    assert result.exit_code == 1
     payload = json.loads(result.output.strip().splitlines()[-1])
     assert payload["ok"] is False
     [remote_result] = payload["results"]

--- a/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
+++ b/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
@@ -187,9 +187,8 @@ def test_validate_report_round_trips_through_pydantic() -> None:
     payload = report.model_dump_json()
     rehydrated = ValidationReport.model_validate_json(payload)
     assert rehydrated.results[0].context == "local"
-    # Severity is populated on every error (none for the success case here, but
-    # the field exists on the model).
-    assert all(err.severity in {"config", "internal"} for err in rehydrated.results[0].errors)
+    # Successful pass has no errors; the model itself is round-trippable either way.
+    assert rehydrated.results[0].errors == []
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
+++ b/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
@@ -7,37 +7,25 @@ The validate SDK is a thin shell over
 :func:`nemo_data_designer_plugin.sdk.validation.validate_config`; these tests
 assert the public behavior of the SDK entry points against an in-process
 mock platform.
+
+We exercise the **async** SDK (``AsyncDataDesignerResource``) because the
+in-process test transport lives on ``client_context.async_sdk``. The sync
+SDK's ``validate`` method rebuilds an async sibling via ``sync_to_async_sdk``,
+which (correctly, in production) makes real HTTP calls — but those don't
+reach the in-process services in tests. ``test_sync_resource_exposes_validate_method``
+covers the sync surface as a smoke check.
 """
 
 from __future__ import annotations
-
-import asyncio
 
 import data_designer.config as dd
 import nemo_data_designer_plugin.testing.utils as u
 import pandas as pd
 import pytest
 from nemo_data_designer_plugin.sdk.resources import AsyncDataDesignerResource, DataDesignerResource
-from nemo_data_designer_plugin.sdk.validation import ExecutionContext, ValidationReport
+from nemo_data_designer_plugin.sdk.validation import ValidationReport, validate_config
 
 pytestmark = pytest.mark.integration
-
-
-def _validate_via_async_sdk(
-    client_context,
-    builder: dd.DataDesignerConfigBuilder,
-    *,
-    execution_context: ExecutionContext | None = None,
-) -> ValidationReport:
-    """Run validate via the async SDK against the in-process test transport.
-
-    The sync SDK's ``validate`` rebuilds an async sibling via ``sync_to_async_sdk``,
-    which (correctly, in production) makes real HTTP calls. In integration tests we
-    can't reach the in-process services that way, so we exercise the async SDK
-    directly — which is wired through the test ASGI transport.
-    """
-    dd_client = AsyncDataDesignerResource(client_context.async_sdk)
-    return asyncio.run(dd_client.validate(builder, execution_context=execution_context))
 
 
 def _llm_builder(model_config: dd.ModelConfig) -> dd.DataDesignerConfigBuilder:
@@ -57,7 +45,7 @@ def _llm_builder(model_config: dd.ModelConfig) -> dd.DataDesignerConfigBuilder:
     return builder
 
 
-def test_validate_local_only_succeeds_with_igw_provider() -> None:
+async def test_validate_local_only_succeeds_with_igw_provider() -> None:
     """The regression we are explicitly fixing: an IGW-only provider reference
     must validate cleanly under the local execution context.
     """
@@ -67,7 +55,8 @@ def test_validate_local_only_succeeds_with_igw_provider() -> None:
         u.make_mock_client_context() as client_context,
         u.setup_mock_providers(client_context),
     ):
-        report = _validate_via_async_sdk(client_context, builder, execution_context="local")
+        dd_client = AsyncDataDesignerResource(client_context.async_sdk)
+        report = await dd_client.validate(builder, execution_context="local")
 
     assert isinstance(report, ValidationReport)
     assert report.ok
@@ -76,7 +65,7 @@ def test_validate_local_only_succeeds_with_igw_provider() -> None:
     assert report.results[0].errors == []
 
 
-def test_validate_local_only_rejects_unrecognized_alias() -> None:
+async def test_validate_local_only_rejects_unrecognized_alias() -> None:
     builder = dd.DataDesignerConfigBuilder(model_configs=[u.make_model_config(provider=u.OPEN_PROVIDER_NAME)])
     builder.add_column(
         column_config=dd.SamplerColumnConfig(
@@ -97,7 +86,8 @@ def test_validate_local_only_rejects_unrecognized_alias() -> None:
         u.make_mock_client_context() as client_context,
         u.setup_mock_providers(client_context),
     ):
-        report = _validate_via_async_sdk(client_context, builder, execution_context="local")
+        dd_client = AsyncDataDesignerResource(client_context.async_sdk)
+        report = await dd_client.validate(builder, execution_context="local")
 
     assert not report.ok
     [result] = report.results
@@ -105,7 +95,7 @@ def test_validate_local_only_rejects_unrecognized_alias() -> None:
     assert any("unknown-alias" in err.message for err in result.errors)
 
 
-def test_validate_remote_only_aggregates_seed_and_tool_errors() -> None:
+async def test_validate_remote_only_aggregates_seed_and_tool_errors() -> None:
     """Remote-only validation surfaces unsupported seed type *and* tool configs
     in a single pass — exercising the §5.0 aggregation end-to-end.
     """
@@ -130,15 +120,11 @@ def test_validate_remote_only_aggregates_seed_and_tool_errors() -> None:
         # up-front. To exercise the aggregated-remote-diagnostic path we go through
         # the validation core directly with a config builder that still contains
         # the unsupported seed.
-        from nemo_data_designer_plugin.sdk.validation import validate_config
-
-        report = asyncio.run(
-            validate_config(
-                builder,
-                async_sdk=client_context.async_sdk,
-                workspace=u.WORKSPACE_NAME,
-                execution_context="remote",
-            )
+        report = await validate_config(
+            builder,
+            async_sdk=client_context.async_sdk,
+            workspace=u.WORKSPACE_NAME,
+            execution_context="remote",
         )
 
     assert not report.ok
@@ -149,18 +135,19 @@ def test_validate_remote_only_aggregates_seed_and_tool_errors() -> None:
     assert any(("seed" in m.lower()) or ("df" in m) for m in messages)
 
 
-def test_validate_remote_only_rejects_unknown_provider() -> None:
+async def test_validate_remote_only_rejects_unknown_provider() -> None:
     builder = _llm_builder(u.make_model_config(provider="some-unknown-provider"))
 
     with u.make_mock_client_context() as client_context:
-        report = _validate_via_async_sdk(client_context, builder, execution_context="remote")
+        dd_client = AsyncDataDesignerResource(client_context.async_sdk)
+        report = await dd_client.validate(builder, execution_context="remote")
 
     assert not report.ok
     [result] = report.results
     assert any("Cannot access provider" in err.message for err in result.errors)
 
 
-def test_validate_default_runs_every_context() -> None:
+async def test_validate_default_runs_every_context() -> None:
     """Omitting ``execution_context`` runs both local and remote, reports each independently."""
     builder = _llm_builder(u.make_model_config(provider=u.OPEN_PROVIDER_NAME))
 
@@ -168,31 +155,15 @@ def test_validate_default_runs_every_context() -> None:
         u.make_mock_client_context() as client_context,
         u.setup_mock_providers(client_context),
     ):
-        report = _validate_via_async_sdk(client_context, builder)
+        dd_client = AsyncDataDesignerResource(client_context.async_sdk)
+        report = await dd_client.validate(builder)
 
     assert report.ok
     contexts = [r.context for r in report.results]
     assert contexts == ["local", "remote"]
 
 
-def test_validate_report_round_trips_through_pydantic() -> None:
-    builder = _llm_builder(u.make_model_config(provider=u.OPEN_PROVIDER_NAME))
-
-    with (
-        u.make_mock_client_context() as client_context,
-        u.setup_mock_providers(client_context),
-    ):
-        report = _validate_via_async_sdk(client_context, builder, execution_context="local")
-
-    payload = report.model_dump_json()
-    rehydrated = ValidationReport.model_validate_json(payload)
-    assert rehydrated.results[0].context == "local"
-    # Successful pass has no errors; the model itself is round-trippable either way.
-    assert rehydrated.results[0].errors == []
-
-
-@pytest.mark.asyncio
-async def test_async_validate_matches_sync_for_local() -> None:
+async def test_validate_report_round_trips_through_pydantic() -> None:
     builder = _llm_builder(u.make_model_config(provider=u.OPEN_PROVIDER_NAME))
 
     with (
@@ -202,12 +173,19 @@ async def test_async_validate_matches_sync_for_local() -> None:
         dd_client = AsyncDataDesignerResource(client_context.async_sdk)
         report = await dd_client.validate(builder, execution_context="local")
 
-    assert isinstance(report, ValidationReport)
-    assert report.ok
-    assert report.results[0].context == "local"
+    payload = report.model_dump_json()
+    rehydrated = ValidationReport.model_validate_json(payload)
+    assert rehydrated.results[0].context == "local"
+    # Successful pass has no errors; the model itself is round-trippable either way.
+    assert rehydrated.results[0].errors == []
 
 
 def test_sync_resource_exposes_validate_method() -> None:
-    """Sanity check that ``DataDesignerResource.validate`` exists and has the right signature."""
-    sdk_resource = DataDesignerResource.__dict__["validate"]
-    assert callable(sdk_resource)
+    """Sanity check that ``DataDesignerResource.validate`` exists on the public API.
+
+    The sync resource's ``validate`` rebuilds an async sibling via
+    ``sync_to_async_sdk`` to do the actual work; we don't exercise the full
+    flow here because the in-process test transport doesn't survive that
+    rebuild. The async resource (above) covers behavior end-to-end.
+    """
+    assert callable(DataDesignerResource.__dict__["validate"])

--- a/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
+++ b/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for ``DataDesignerResource.validate`` and its async sibling.
+
+The validate SDK is a thin shell over
+:func:`nemo_data_designer_plugin.sdk.validation.validate_config`; these tests
+assert the public behavior of the SDK entry points against an in-process
+mock platform.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import data_designer.config as dd
+import nemo_data_designer_plugin.testing.utils as u
+import pandas as pd
+import pytest
+from nemo_data_designer_plugin.sdk.resources import AsyncDataDesignerResource, DataDesignerResource
+from nemo_data_designer_plugin.sdk.validation import ExecutionContext, ValidationReport
+
+pytestmark = pytest.mark.integration
+
+
+def _validate_via_async_sdk(
+    client_context,
+    builder: dd.DataDesignerConfigBuilder,
+    *,
+    execution_context: ExecutionContext | None = None,
+) -> ValidationReport:
+    """Run validate via the async SDK against the in-process test transport.
+
+    The sync SDK's ``validate`` rebuilds an async sibling via ``sync_to_async_sdk``,
+    which (correctly, in production) makes real HTTP calls. In integration tests we
+    can't reach the in-process services that way, so we exercise the async SDK
+    directly — which is wired through the test ASGI transport.
+    """
+    dd_client = AsyncDataDesignerResource(client_context.async_sdk)
+    return asyncio.run(dd_client.validate(builder, execution_context=execution_context))
+
+
+def _llm_builder(model_config: dd.ModelConfig) -> dd.DataDesignerConfigBuilder:
+    builder = dd.DataDesignerConfigBuilder(model_configs=[model_config])
+    builder.add_column(
+        column_config=dd.SamplerColumnConfig(
+            name="foo",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["a", "b"]),
+        )
+    )
+    builder.add_column(
+        column_config=dd.LLMTextColumnConfig(
+            name="story", prompt="Write a story about {{ foo }}", model_alias=model_config.alias
+        )
+    )
+    return builder
+
+
+def test_validate_local_only_succeeds_with_igw_provider() -> None:
+    """The regression we are explicitly fixing: an IGW-only provider reference
+    must validate cleanly under the local execution context.
+    """
+    builder = _llm_builder(u.make_model_config(provider=u.OPEN_PROVIDER_NAME))
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        report = _validate_via_async_sdk(client_context, builder, execution_context="local")
+
+    assert isinstance(report, ValidationReport)
+    assert report.ok
+    assert len(report.results) == 1
+    assert report.results[0].context == "local"
+    assert report.results[0].errors == []
+
+
+def test_validate_local_only_rejects_unrecognized_alias() -> None:
+    builder = dd.DataDesignerConfigBuilder(model_configs=[u.make_model_config(provider=u.OPEN_PROVIDER_NAME)])
+    builder.add_column(
+        column_config=dd.SamplerColumnConfig(
+            name="topic",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["a", "b"]),
+        )
+    )
+    builder.add_column(
+        column_config=dd.LLMTextColumnConfig(
+            name="description",
+            model_alias="unknown-alias",
+            prompt="Describe {{ topic }}",
+        )
+    )
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        report = _validate_via_async_sdk(client_context, builder, execution_context="local")
+
+    assert not report.ok
+    [result] = report.results
+    assert result.context == "local"
+    assert any("unknown-alias" in err.message for err in result.errors)
+
+
+def test_validate_remote_only_aggregates_seed_and_tool_errors() -> None:
+    """Remote-only validation surfaces unsupported seed type *and* tool configs
+    in a single pass — exercising the §5.0 aggregation end-to-end.
+    """
+    builder = dd.DataDesignerConfigBuilder(
+        model_configs=[u.make_model_config(provider=u.OPEN_PROVIDER_NAME)],
+        tool_configs=[dd.ToolConfig(tool_alias="hello", providers=[u.OPEN_PROVIDER_NAME])],
+    )
+    builder.with_seed_dataset(dd.DataFrameSeedSource(df=pd.DataFrame(data={"a": [1, 2, 3]})))
+    builder.add_column(
+        column_config=dd.SamplerColumnConfig(
+            name="foo",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["a", "b"]),
+        )
+    )
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        # The SDK's _get_config_for_api_call rejects unsupported remote seed types
+        # up-front. To exercise the aggregated-remote-diagnostic path we go through
+        # the validation core directly with a config builder that still contains
+        # the unsupported seed.
+        from nemo_data_designer_plugin.sdk.validation import validate_config
+
+        report = asyncio.run(
+            validate_config(
+                builder,
+                async_sdk=client_context.async_sdk,
+                workspace=u.WORKSPACE_NAME,
+                execution_context="remote",
+            )
+        )
+
+    assert not report.ok
+    [result] = report.results
+    assert result.context == "remote"
+    messages = [err.message for err in result.errors]
+    assert any("Tool configs" in m for m in messages)
+    assert any(("seed" in m.lower()) or ("df" in m) for m in messages)
+
+
+def test_validate_remote_only_rejects_unknown_provider() -> None:
+    builder = _llm_builder(u.make_model_config(provider="some-unknown-provider"))
+
+    with u.make_mock_client_context() as client_context:
+        report = _validate_via_async_sdk(client_context, builder, execution_context="remote")
+
+    assert not report.ok
+    [result] = report.results
+    assert any("Cannot access provider" in err.message for err in result.errors)
+
+
+def test_validate_default_runs_every_context() -> None:
+    """Omitting ``execution_context`` runs both local and remote, reports each independently."""
+    builder = _llm_builder(u.make_model_config(provider=u.OPEN_PROVIDER_NAME))
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        report = _validate_via_async_sdk(client_context, builder)
+
+    assert report.ok
+    contexts = [r.context for r in report.results]
+    assert contexts == ["local", "remote"]
+
+
+def test_validate_report_round_trips_through_pydantic() -> None:
+    builder = _llm_builder(u.make_model_config(provider=u.OPEN_PROVIDER_NAME))
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        report = _validate_via_async_sdk(client_context, builder, execution_context="local")
+
+    payload = report.model_dump_json()
+    rehydrated = ValidationReport.model_validate_json(payload)
+    assert rehydrated.results[0].context == "local"
+    # Severity is populated on every error (none for the success case here, but
+    # the field exists on the model).
+    assert all(err.severity in {"config", "internal"} for err in rehydrated.results[0].errors)
+
+
+@pytest.mark.asyncio
+async def test_async_validate_matches_sync_for_local() -> None:
+    builder = _llm_builder(u.make_model_config(provider=u.OPEN_PROVIDER_NAME))
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        dd_client = AsyncDataDesignerResource(client_context.async_sdk)
+        report = await dd_client.validate(builder, execution_context="local")
+
+    assert isinstance(report, ValidationReport)
+    assert report.ok
+    assert report.results[0].context == "local"
+
+
+def test_sync_resource_exposes_validate_method() -> None:
+    """Sanity check that ``DataDesignerResource.validate`` exists and has the right signature."""
+    sdk_resource = DataDesignerResource.__dict__["validate"]
+    assert callable(sdk_resource)

--- a/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
+++ b/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
@@ -115,10 +115,9 @@ async def test_validate_remote_only_aggregates_seed_and_tool_errors() -> None:
         u.make_mock_client_context() as client_context,
         u.setup_mock_providers(client_context),
     ):
-        # The SDK's _get_config_for_api_call rejects unsupported remote seed types
-        # up-front. To exercise the aggregated-remote-diagnostic path we go through
-        # the validation core directly with a config builder that still contains
-        # the unsupported seed.
+        # Exercise the validation core directly so the contract is documented
+        # without going through the SDK shell. The SDK-shell path is covered
+        # by ``test_sdk_validate_method_aggregates_df_seed_with_other_remote_errors``.
         report = await validate_config(
             builder,
             async_sdk=client_context.async_sdk,
@@ -132,6 +131,79 @@ async def test_validate_remote_only_aggregates_seed_and_tool_errors() -> None:
     messages = [err.message for err in result.errors]
     assert any("Tool configs" in m for m in messages)
     assert any(("seed" in m.lower()) or ("df" in m) for m in messages)
+
+
+async def test_sdk_validate_method_aggregates_df_seed_with_other_remote_errors() -> None:
+    """Regression: ``DataDesignerResource.validate`` itself (not just the
+    underlying ``validate_config`` core) must accept a ``df``-seed config and
+    aggregate the unsupported-seed error with every other detected problem.
+
+    Earlier versions of the SDK applied an eager
+    ``_get_config_for_api_call`` rejection (the same one ``preview`` /
+    ``create`` use) and short-circuited with a single error before the
+    validate pass could run.
+    """
+    builder = dd.DataDesignerConfigBuilder(
+        model_configs=[u.make_model_config(provider=u.OPEN_PROVIDER_NAME)],
+        tool_configs=[dd.ToolConfig(tool_alias="hello", providers=[u.OPEN_PROVIDER_NAME])],
+    )
+    builder.with_seed_dataset(dd.DataFrameSeedSource(df=pd.DataFrame(data={"a": [1, 2, 3]})))
+    builder.add_column(
+        column_config=dd.SamplerColumnConfig(
+            name="foo",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["a", "b"]),
+        )
+    )
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        dd_client = AsyncDataDesignerResource(client_context.async_sdk)
+        report = await dd_client.validate(builder, execution_context="remote")
+
+    assert not report.ok
+    [result] = report.results
+    assert result.context == "remote"
+    messages = [err.message for err in result.errors]
+    # Both messages must surface in a single pass.
+    assert any("Tool configs" in m for m in messages)
+    # Remote rejects everything outside the {hf, nmp} whitelist; the message
+    # mentions both supported types rather than calling out "df" specifically.
+    assert any("seed_type=hf" in m and "seed_type=nmp" in m for m in messages)
+
+
+async def test_sdk_validate_method_rejects_df_seed_for_local() -> None:
+    """A ``df``-seed config is invalid for local execution too — preview
+    serializes the config across the worker-thread boundary, which a
+    pandas DataFrame can't survive — but the diagnostic must come from
+    the validate pass (with a helpful message), not from an eager
+    pre-flight rejection.
+    """
+    builder = dd.DataDesignerConfigBuilder(
+        model_configs=[u.make_model_config(provider=u.OPEN_PROVIDER_NAME)],
+    )
+    builder.with_seed_dataset(dd.DataFrameSeedSource(df=pd.DataFrame(data={"a": [1, 2, 3]})))
+    builder.add_column(
+        column_config=dd.SamplerColumnConfig(
+            name="foo",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["a", "b"]),
+        )
+    )
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        dd_client = AsyncDataDesignerResource(client_context.async_sdk)
+        report = await dd_client.validate(builder, execution_context="local")
+
+    assert not report.ok
+    [result] = report.results
+    assert result.context == "local"
+    assert any("Dataframe seed sources" in err.message for err in result.errors)
 
 
 async def test_validate_remote_only_rejects_unknown_provider() -> None:

--- a/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
+++ b/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
@@ -12,8 +12,7 @@ We exercise the **async** SDK (``AsyncDataDesignerResource``) because the
 in-process test transport lives on ``client_context.async_sdk``. The sync
 SDK's ``validate`` method rebuilds an async sibling via ``sync_to_async_sdk``,
 which (correctly, in production) makes real HTTP calls — but those don't
-reach the in-process services in tests. ``test_sync_resource_exposes_validate_method``
-covers the sync surface as a smoke check.
+reach the in-process services in tests.
 """
 
 from __future__ import annotations
@@ -22,7 +21,7 @@ import data_designer.config as dd
 import nemo_data_designer_plugin.testing.utils as u
 import pandas as pd
 import pytest
-from nemo_data_designer_plugin.sdk.resources import AsyncDataDesignerResource, DataDesignerResource
+from nemo_data_designer_plugin.sdk.resources import AsyncDataDesignerResource
 from nemo_data_designer_plugin.sdk.validation import ValidationReport, validate_config
 
 pytestmark = pytest.mark.integration
@@ -178,14 +177,3 @@ async def test_validate_report_round_trips_through_pydantic() -> None:
     assert rehydrated.results[0].context == "local"
     # Successful pass has no errors; the model itself is round-trippable either way.
     assert rehydrated.results[0].errors == []
-
-
-def test_sync_resource_exposes_validate_method() -> None:
-    """Sanity check that ``DataDesignerResource.validate`` exists on the public API.
-
-    The sync resource's ``validate`` rebuilds an async sibling via
-    ``sync_to_async_sdk`` to do the actual work; we don't exercise the full
-    flow here because the in-process test transport doesn't survive that
-    rebuild. The async resource (above) covers behavior end-to-end.
-    """
-    assert callable(DataDesignerResource.__dict__["validate"])

--- a/plugins/nemo-data-designer/tests/unit/test_context.py
+++ b/plugins/nemo-data-designer/tests/unit/test_context.py
@@ -58,17 +58,19 @@ async def test_local_validate_does_not_apply_remote_only_tool_validation() -> No
     config = _simple_config(tool_configs=[tool_config])
     dd_ctx = LocalDataDesignerContext(Mock(), u.WORKSPACE_NAME)
 
-    await dd_ctx.validate(config)
+    errors = await dd_ctx.validate(config)
+    assert errors == []
 
 
 async def test_local_validate_rejects_dataframe_seed_config() -> None:
     config = _simple_config(seed_source=dd.DataFrameSeedSource(df=pd.DataFrame(data={"a": [1, 2, 3]})))
     dd_ctx = LocalDataDesignerContext(Mock(), u.WORKSPACE_NAME)
 
-    with pytest.raises(NDDInvalidConfigError) as exc_info:
-        await dd_ctx.validate(config)
+    errors = await dd_ctx.validate(config)
 
-    assert "Dataframe seed sources" in str(exc_info.value)
+    assert len(errors) == 1
+    assert isinstance(errors[0], NDDInvalidConfigError)
+    assert "Dataframe seed sources" in str(errors[0])
 
 
 async def test_remote_validate_runs_remote_validators(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -103,8 +105,9 @@ async def test_remote_validate_runs_remote_validators(monkeypatch: pytest.Monkey
     monkeypatch.setattr("data_designer_nemo.context.validate_seed", validate_seed)
     monkeypatch.setattr("data_designer_nemo.context.ensure_nemotron_personas_filesets", validate_personas)
 
-    await RemoteDataDesignerContext(sdk, u.WORKSPACE_NAME).validate(config)
+    errors = await RemoteDataDesignerContext(sdk, u.WORKSPACE_NAME).validate(config)
 
+    assert errors == []
     assert calls == ["tools", "seed-type", "seed", "personas"]
 
 
@@ -112,10 +115,31 @@ async def test_remote_validate_rejects_unsupported_seed_config() -> None:
     config = _simple_config(seed_source=dd.DataFrameSeedSource(df=pd.DataFrame(data={"a": [1, 2, 3]})))
     dd_ctx = RemoteDataDesignerContext(AsyncMock(spec=AsyncNeMoPlatform), u.WORKSPACE_NAME)
 
-    with pytest.raises(NDDInvalidConfigError) as exc_info:
-        await dd_ctx.validate(config)
+    errors = await dd_ctx.validate(config)
 
-    assert "seed data" in str(exc_info.value)
+    assert len(errors) == 1
+    assert isinstance(errors[0], NDDInvalidConfigError)
+    assert "seed data" in str(errors[0])
+
+
+async def test_remote_validate_aggregates_multiple_failures() -> None:
+    """Tool configs *and* an unsupported seed type both surface from a single pass."""
+    config = _simple_config(
+        tool_configs=[dd.ToolConfig(tool_alias="hello", providers=["provider"])],
+        seed_source=dd.DataFrameSeedSource(df=pd.DataFrame(data={"a": [1, 2, 3]})),
+    )
+    sdk = AsyncMock(spec=AsyncNeMoPlatform)
+    dd_ctx = RemoteDataDesignerContext(sdk, u.WORKSPACE_NAME)
+
+    errors = await dd_ctx.validate(config)
+
+    messages = [str(e) for e in errors]
+    assert all(isinstance(e, NDDInvalidConfigError) for e in errors)
+    # We expect at least the tool-config and seed-type messages; both must surface
+    # in a single pass (no short-circuiting on the first failure).
+    assert any("Tool configs" in m for m in messages)
+    assert any("seed data" in m or "df" in m for m in messages)
+    assert len(errors) >= 2
 
 
 async def test_local_model_providers_all_local(local_providers: dict[str, dd.ModelProvider]):

--- a/plugins/nemo-data-designer/tests/unit/test_create_job.py
+++ b/plugins/nemo-data-designer/tests/unit/test_create_job.py
@@ -310,7 +310,7 @@ async def test_to_spec_aggregates_multiple_config_errors() -> None:
     msg = str(exc_info.value)
     # Both messages must surface together (no short-circuit on the first failure).
     assert "Tool configs" in msg
-    assert ("seed data" in msg) or ("DataFrameSeedSource" in msg) or ("df" in msg)
+    assert "seed data" in msg
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-data-designer/tests/unit/test_create_job.py
+++ b/plugins/nemo-data-designer/tests/unit/test_create_job.py
@@ -5,7 +5,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import data_designer.config as dd
 import nemo_data_designer_plugin.testing.utils as u
+import pandas as pd
 import pytest
+from data_designer_nemo.errors import NDDInternalError
 from data_designer_nemo.fileset_file_seed_source import FilesetFileSeedSource
 from nemo_data_designer_plugin.jobs.create import CreateJob
 from nemo_data_designer_plugin.jobs.spec import DataDesignerJobConfig, DataDesignerStepConfig
@@ -279,3 +281,64 @@ async def test_successful_compilation() -> None:
     assert len(dd_step_config.model_providers) == 1
     model_provider = dd_step_config.model_providers[0]
     assert model_provider.name == u.RESTRICTED_PROVIDER_NAME
+
+
+@pytest.mark.asyncio
+async def test_to_spec_aggregates_multiple_config_errors() -> None:
+    """A single ``to_spec`` call surfaces every config problem at once."""
+    # Tool configs are remote-only invalid AND the seed type is unsupported on the platform.
+    builder = dd.DataDesignerConfigBuilder(
+        model_configs=[u.make_model_config()],
+        tool_configs=[dd.ToolConfig(tool_alias="hello", providers=["provider"])],
+    )
+    builder.with_seed_dataset(dd.DataFrameSeedSource(df=pd.DataFrame(data={"a": [1, 2, 3]})))
+    builder.add_column(
+        column_config=dd.SamplerColumnConfig(
+            name="foo",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["a", "b"]),
+        )
+    )
+    dd_job_config = DataDesignerJobConfig(num_records=42, config=builder.build())
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+        pytest.raises(PlatformJobCompilationError) as exc_info,
+    ):
+        await u.compile_create_job(dd_job_config, sdk=client_context.async_sdk)
+
+    msg = str(exc_info.value)
+    # Both messages must surface together (no short-circuit on the first failure).
+    assert "Tool configs" in msg
+    assert ("seed data" in msg) or ("DataFrameSeedSource" in msg) or ("df" in msg)
+
+
+@pytest.mark.asyncio
+async def test_to_spec_pure_internal_errors_raise_internal_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When validate produces only internal errors, ``to_spec`` raises NDDInternalError (500 path)."""
+    builder = dd.DataDesignerConfigBuilder(model_configs=[u.make_model_config()])
+    builder.add_column(
+        column_config=dd.SamplerColumnConfig(
+            name="foo",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["a", "b"]),
+        )
+    )
+    dd_job_config = DataDesignerJobConfig(num_records=42, config=builder.build())
+
+    async def _internal_only(self, _config):
+        return [NDDInternalError("simulated internal failure")]
+
+    monkeypatch.setattr(
+        "data_designer_nemo.context.RemoteDataDesignerContext.validate",
+        _internal_only,
+    )
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+        pytest.raises(NDDInternalError) as exc_info,
+    ):
+        await u.compile_create_job(dd_job_config, sdk=client_context.async_sdk)
+    assert "simulated internal failure" in str(exc_info.value)

--- a/plugins/nemo-data-designer/tests/unit/test_create_job.py
+++ b/plugins/nemo-data-designer/tests/unit/test_create_job.py
@@ -7,12 +7,11 @@ import data_designer.config as dd
 import nemo_data_designer_plugin.testing.utils as u
 import pandas as pd
 import pytest
-from data_designer_nemo.errors import NDDInternalError
+from data_designer_nemo.errors import NDDInternalError, NDDInvalidConfigError
 from data_designer_nemo.fileset_file_seed_source import FilesetFileSeedSource
 from nemo_data_designer_plugin.jobs.create import CreateJob
 from nemo_data_designer_plugin.jobs.spec import DataDesignerJobConfig, DataDesignerStepConfig
 from nemo_platform import AsyncNeMoPlatform
-from nmp.common.jobs.exceptions import PlatformJobCompilationError
 
 
 def test_create_job_runs_step_config() -> None:
@@ -94,7 +93,7 @@ async def test_validate_user_models_belong_to_accessible_providers() -> None:
 
     with (
         u.make_mock_client_context() as client_context,
-        pytest.raises(PlatformJobCompilationError) as exc_info,
+        pytest.raises(NDDInvalidConfigError) as exc_info,
     ):
         await u.compile_create_job(dd_job_config, sdk=client_context.async_sdk)
     assert unknown_provider in str(exc_info.value)
@@ -126,7 +125,7 @@ async def test_validate_user_models_are_allowed_by_providers() -> None:
     with (
         u.make_mock_client_context() as client_context,
         u.setup_mock_providers(client_context),
-        pytest.raises(PlatformJobCompilationError) as exc_info,
+        pytest.raises(NDDInvalidConfigError) as exc_info,
     ):
         await u.compile_create_job(dd_job_config, sdk=client_context.async_sdk)
     assert forbidden_model in str(exc_info.value)
@@ -154,7 +153,7 @@ async def test_validate_model_alias_values_in_column_configs() -> None:
     )
     dd_job_config = DataDesignerJobConfig(num_records=42, config=builder.build())
 
-    with u.make_mock_client_context(), pytest.raises(PlatformJobCompilationError) as exc_info:
+    with u.make_mock_client_context(), pytest.raises(NDDInvalidConfigError) as exc_info:
         await u.compile_create_job(dd_job_config)
     assert model_alias in str(exc_info.value)
     assert "Unrecognized model alias" in str(exc_info.value)
@@ -175,7 +174,7 @@ async def test_validate_profilers() -> None:
     builder.add_profiler(dd.JudgeScoreProfilerConfig(model_alias=model_alias))
     dd_job_config = DataDesignerJobConfig(num_records=42, config=builder.build())
 
-    with u.make_mock_client_context(), pytest.raises(PlatformJobCompilationError) as exc_info:
+    with u.make_mock_client_context(), pytest.raises(NDDInvalidConfigError) as exc_info:
         await u.compile_create_job(dd_job_config)
     assert model_alias in str(exc_info.value)
     assert "Unrecognized model alias" in str(exc_info.value)
@@ -199,7 +198,7 @@ async def test_validate_hf_token_secret() -> None:
     with (
         u.make_mock_client_context() as client_context,
         u.setup_mock_secret(client_context),
-        pytest.raises(PlatformJobCompilationError),
+        pytest.raises(NDDInvalidConfigError),
     ):
         await u.compile_create_job(dd_job_config, sdk=client_context.async_sdk)
 
@@ -230,7 +229,7 @@ async def test_validate_fileset_seed_source_is_accessible() -> None:
     with (
         u.make_mock_client_context(workspace="workspace") as client_context,
         u.setup_mock_file(client_context),
-        pytest.raises(PlatformJobCompilationError),
+        pytest.raises(NDDInvalidConfigError),
     ):
         await u.compile_create_job(dd_job_config, workspace="workspace", sdk=client_context.async_sdk)
 
@@ -304,7 +303,7 @@ async def test_to_spec_aggregates_multiple_config_errors() -> None:
     with (
         u.make_mock_client_context() as client_context,
         u.setup_mock_providers(client_context),
-        pytest.raises(PlatformJobCompilationError) as exc_info,
+        pytest.raises(NDDInvalidConfigError) as exc_info,
     ):
         await u.compile_create_job(dd_job_config, sdk=client_context.async_sdk)
 

--- a/plugins/nemo-data-designer/tests/unit/test_preview_function.py
+++ b/plugins/nemo-data-designer/tests/unit/test_preview_function.py
@@ -36,7 +36,13 @@ def _config() -> dd.DataDesignerConfig:
 
 
 def _patch_preview_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(preview_module, "get_model_configs", lambda config: [])
+    # Bypass real model-config extraction so the test config's incomplete
+    # ``ModelConfig`` (no provider) doesn't fail provider resolution. The
+    # call site lives inside ``data_designer_nemo.runnable.resolve_runnable_config``
+    # since the cross-call-site refactor.
+    from data_designer_nemo import runnable as runnable_module
+
+    monkeypatch.setattr(runnable_module, "get_model_configs", lambda config: [])
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-data-designer/tests/unit/test_preview_function.py
+++ b/plugins/nemo-data-designer/tests/unit/test_preview_function.py
@@ -13,7 +13,6 @@ import pytest
 from data_designer_nemo.context import DataDesignerContext, LocalDataDesignerContext
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from nemo_data_designer_plugin.functions import _preview_worker as worker_module
 from nemo_data_designer_plugin.functions import preview as preview_module
 from nemo_data_designer_plugin.functions._types import LogFrame, PreviewSpec
 from nemo_data_designer_plugin.functions.preview import PreviewFunction
@@ -53,7 +52,11 @@ async def test_preview_function_streams_worker_frames_and_done(monkeypatch: pyte
         assert isinstance(dd_ctx, LocalDataDesignerContext)
         send_frame(LogFrame(level="info", message="generated"))
 
-    monkeypatch.setattr(worker_module, "make_preview_dataset", fake_worker)
+    # Patch the symbol on ``preview_module`` (not ``_preview_worker``) because
+    # ``preview.py`` imports ``make_preview_dataset`` at module load time, so
+    # the local reference inside ``PreviewFunction.run`` does not pick up
+    # patches applied to ``_preview_worker.make_preview_dataset``.
+    monkeypatch.setattr(preview_module, "make_preview_dataset", fake_worker)
 
     frames = [
         frame
@@ -81,7 +84,7 @@ def test_preview_route_streams_ndjson_and_heartbeats(monkeypatch: pytest.MonkeyP
         time.sleep(0.05)
         send_frame(LogFrame(level="info", message=f"generated in {workspace}"))
 
-    monkeypatch.setattr(worker_module, "make_preview_dataset", slow_worker)
+    monkeypatch.setattr(preview_module, "make_preview_dataset", slow_worker)
 
     app = FastAPI()
     app.dependency_overrides[get_sdk_client] = lambda: AsyncMock(spec=AsyncNeMoPlatform)

--- a/plugins/nemo-data-designer/tests/unit/test_spec.py
+++ b/plugins/nemo-data-designer/tests/unit/test_spec.py
@@ -6,9 +6,9 @@ import tempfile
 import data_designer.config as dd
 import pandas as pd
 import pytest
-from data_designer_nemo.errors import NDDInvalidConfigError
 from nemo_data_designer_plugin.functions._types import PreviewSpec
 from nemo_data_designer_plugin.jobs.spec import DataDesignerJobConfig
+from pydantic import ValidationError
 
 
 def test_dataframe_seeds_are_rejected() -> None:
@@ -28,7 +28,12 @@ def test_dataframe_seeds_are_rejected() -> None:
         ),
     )
 
-    with pytest.raises(NDDInvalidConfigError) as exc_info:
+    # The before-validator translates plugin errors into ``ValueError`` so that
+    # Pydantic wraps them in ``ValidationError`` (the v2 contract). Earlier
+    # versions raised the plugin's ``NDDInvalidConfigError`` straight out of
+    # ``model_validate``, which Pydantic does not wrap and which therefore
+    # escaped framework-level ``except ValidationError`` handlers.
+    with pytest.raises(ValidationError) as exc_info:
         DataDesignerJobConfig.model_validate(config.model_dump())
 
     assert "seed data" in str(exc_info.value)
@@ -52,7 +57,7 @@ def test_local_file_seeds_are_rejected() -> None:
             ),
         )
 
-        with pytest.raises(NDDInvalidConfigError) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             DataDesignerJobConfig.model_validate(config.model_dump())
 
         assert "seed data" in str(exc_info.value)
@@ -70,9 +75,9 @@ def test_dataframe_seeds_are_rejected_with_clear_local_context_error() -> None:
     )
     payload = config.model_dump(mode="json")
 
-    with pytest.raises(NDDInvalidConfigError) as job_exc_info:
+    with pytest.raises(ValidationError) as job_exc_info:
         DataDesignerJobConfig.model_validate(payload, context={"is_local": True})
-    with pytest.raises(NDDInvalidConfigError) as preview_exc_info:
+    with pytest.raises(ValidationError) as preview_exc_info:
         PreviewSpec.model_validate({"config": payload["config"]}, context={"is_local": True})
 
     assert "Dataframe seed sources" in str(job_exc_info.value)

--- a/skills/nemo-data-designer-plugin/references/nemo-platform-plugin-additions.md
+++ b/skills/nemo-data-designer-plugin/references/nemo-platform-plugin-additions.md
@@ -2,6 +2,40 @@
 
 This skill ships in the NeMo Platform data-designer plugin. The CLI surface is `nemo data-designer …`. Most subcommands accept the same arguments as the upstream `data-designer` CLI; the differences are documented below.
 
+## `validate`: local + remote contexts
+
+Upstream `data-designer validate` runs a local-only engine compile check. The plugin's `validate` does that **and** verifies the config against NeMo Platform-specific constraints — Inference Gateway provider resolution, Files-service seed sources, Nemotron Personas filesets, the remote seed-type whitelist, etc.
+
+By default it reports both contexts independently:
+
+```bash
+nemo data-designer validate <path>
+```
+
+```
+Local execution
+  ✔ Configuration is valid
+
+Remote execution
+  ✘ Seed source 'df' is not supported on the NeMo Platform.
+    Use a serializable seed source such as a HuggingFace dataset
+    or the Files service.
+
+Result: valid for local execution; invalid for remote execution
+```
+
+A single invocation surfaces **every** problem it can detect (it doesn't short-circuit on the first failure). Exit code is 0 only when every reported context validates cleanly.
+
+Useful flags:
+
+- `--execution-context {local,remote}` — limit the report to one context. Omit to validate both.
+- `--workspace <name>` — workspace used to resolve Inference Gateway providers and Files-service seed sources for the remote pass. Defaults to the SDK's configured workspace.
+- `--output {text,json}` — `json` emits a structured `ValidationReport` for CI / scripting use.
+
+Treat a "valid for local; invalid for remote" mixed result as **safe to proceed with `preview run` / `create run`**. Only the remote pass needs to pass before the user runs `preview submit` / `create submit`. If the user is iterating locally and the remote diagnostic is a true blocker (e.g., they intend to submit later), report it but don't loop on re-validation until they ask to.
+
+Configs that reference Inference Gateway providers exclusively (no locally-defined providers) are first-class — they validate cleanly under both contexts as long as the provider names resolve via `nemo inference providers list`.
+
 ## `preview` and `create`: local vs cluster
 
 Upstream's `preview` and `create` are flat commands that take the config path positional directly. In the plugin, both are command groups with two execution modes:

--- a/skills/nemo-data-designer-plugin/references/nemo-platform-plugin-additions.md
+++ b/skills/nemo-data-designer-plugin/references/nemo-platform-plugin-additions.md
@@ -12,7 +12,7 @@ By default it reports both contexts independently:
 nemo data-designer validate <path>
 ```
 
-```
+```text
 Local execution
   ✔ Configuration is valid
 


### PR DESCRIPTION
The existing `nemo data-designer validate` CLI command is a direct passthrough to the upstream library's command of the same name. This is problematic in the platform context, where:
- certain additional things are supported (e.g. IGW model providers)
- certain features are not supported (e.g. DataFrame seed sources)

This PR updates validation in the plugin across the board. Logic is centralized as much as possible to be shared between `validate`, `preview`, and `create`. A UX bug is fixed (ugly error message/stack leaking out from a Pydantic before validator). The plugin's SKILL is updated to properly understand platform context validation. A `validate` method is also added to the SDK resources (sync and async).

`validate` is a standalone CLI command (not a `NemoFunction` or `NemoJob`) that requires a Nemo Platform SDK instance. I lifted a previously private helper function in `nemo_platform_plugin` to a public one so that plugin authors can access an SDK instance in that context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `nemo data-designer validate` CLI and SDK sync/async `validate()` returning structured ValidationReport; preview/create flows run consolidated pre-run validation.

* **Bug Fixes**
  * Validation now accumulates multiple independent errors (no fail-fast) and reports clearer aggregated messages; internal vs config errors are distinguished.

* **Documentation**
  * Docs updated to explain validation semantics, execution-contexts, outputs, and JSON reporting.

* **Tests**
  * Extensive new unit and integration tests covering validation, CLI, SDK, error aggregation, and preview/create behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->