### PR TITLE
fix(security): rebuild proxy URL from trusted endpoint (py/full-ssrf)

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -28,7 +28,7 @@ import json
 import logging
 import os
 from typing import AsyncIterator
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlunparse
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -158,10 +158,16 @@ async def _proxy(
     transfer encoding makes the original value invalid.
     """
     endpoint_parsed = urlparse(endpoint)
-    target_url = urljoin(endpoint.rstrip("/") + "/", trailing_uri)
-    target_parsed = urlparse(target_url)
-    if target_parsed.scheme != endpoint_parsed.scheme or target_parsed.netloc != endpoint_parsed.netloc:
+    if not endpoint_parsed.scheme or not endpoint_parsed.netloc:
+        raise HTTPException(status_code=500, detail="Deployment endpoint is misconfigured.")
+    joined = urlparse(urljoin(endpoint.rstrip("/") + "/", trailing_uri))
+    if joined.scheme != endpoint_parsed.scheme or joined.netloc != endpoint_parsed.netloc:
         raise HTTPException(status_code=400, detail="Invalid proxy target URI.")
+    # Rebuild from the trusted endpoint's scheme+netloc so the final URL never
+    # depends directly on user-supplied path text for the host portion.
+    target_url = urlunparse(
+        (endpoint_parsed.scheme, endpoint_parsed.netloc, joined.path, joined.params, joined.query, "")
+    )
     if request.url.query:
         target_url = f"{target_url}?{request.url.query}"
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -163,8 +163,6 @@ async def _proxy(
     joined = urlparse(urljoin(endpoint.rstrip("/") + "/", trailing_uri))
     if joined.scheme != endpoint_parsed.scheme or joined.netloc != endpoint_parsed.netloc:
         raise HTTPException(status_code=400, detail="Invalid proxy target URI.")
-    # Rebuild from the trusted endpoint's scheme+netloc so the final URL never
-    # depends directly on user-supplied path text for the host portion.
     target_url = urlunparse(
         (endpoint_parsed.scheme, endpoint_parsed.netloc, joined.path, joined.params, joined.query, "")
     )


### PR DESCRIPTION
## Summary

Batch 3 of the CodeQL cleanup. Addresses the **1 critical `py/full-ssrf`** alert that surfaced after [#91](https://github.com/NVIDIA-NeMo/nemo-platform/pull/91) cleared the related `py/partial-ssrf`.

## Alert addressed

| Severity | Rule | # | Problem | How we addressed it |
| --- | --- | --- | --- | --- |
| Critical | `py/full-ssrf` | 1 | `plugins/nemo-agents/.../api/v2/gateway.py` — `client.stream(url=target_url, ...)` where `target_url` was the result of `urljoin(endpoint, user_path)`. The previous `py/partial-ssrf` fix validated the joined URL's scheme/netloc against the trusted deployment endpoint, but CodeQL upgraded the finding because the *full* URL still flowed directly from a user-supplied path component into the request. | Rebuild `target_url` via `urlunparse((endpoint.scheme, endpoint.netloc, joined.path, joined.params, joined.query, ""))` after the existing scheme/netloc match check. The host portion now definitely comes from the DB-loaded deployment endpoint instead of from the user-supplied path text, breaking the full-URL taint flow. Added an upfront 500 if the deployment's stored endpoint has no scheme/netloc so a malformed record can't sneak past the guard. |

## Test plan

- [x] `uv run pytest plugins/nemo-agents/tests/unit/test_gateway.py` — 20 pass (including the existing parametrized SSRF guard test from #91)
- [x] `ruff check` on touched file — clean
- [ ] Re-run CodeQL after merge and confirm `py/full-ssrf` closes

## Stacking

This branch is off `main`. PRs [#91](https://github.com/NVIDIA-NeMo/nemo-platform/pull/91) is merged; [#98](https://github.com/NVIDIA-NeMo/nemo-platform/pull/98) is still open. No conflicts expected with either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway URL validation to more robustly handle upstream target URL construction. The proxy now validates endpoint configuration and rejects requests with invalid scheme or host changes, enhancing reliability and security of request routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->