### PR TITLE
chore: Update DD library docs links to new host

### DIFF
--- a/docs/data-designer/index.md
+++ b/docs/data-designer/index.md
@@ -7,7 +7,7 @@ Data Designer on {{platform_name}} enables high-quality synthetic data generatio
 
 Data Designer is a framework for orchestrating complex synthetic data generation workflows. It coordinates LLM calls, manages dependencies between data fields, handles batching and parallelization, and validates generated data against specifications.
 
-The plugin is built on the open-source [NVIDIA NeMo Data Designer library](https://nvidia-nemo.github.io/DataDesigner/0.6.0/) ([GitHub](https://github.com/NVIDIA-NeMo/DataDesigner)). The library provides the configuration and generation engine; the plugin provides CLI, SDK, Data Designer API, Jobs, Files API, Secrets API, and Inference Gateway API integration.
+The plugin is built on the open-source [NVIDIA NeMo Data Designer library](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/getting-started/welcome) ([GitHub](https://github.com/NVIDIA-NeMo/DataDesigner)). The library provides the configuration and generation engine; the plugin provides CLI, SDK, Data Designer API, Jobs, Files API, Secrets API, and Inference Gateway API integration.
 
 ## How It Works
 
@@ -41,7 +41,7 @@ config_builder.add_column(dd.LLMTextColumnConfig(...))
 
 Configuration code describes the dataset schema, columns, dependencies, constraints, seed data, processors, profilers, and inference settings.
 
-**Learn more**: See the [library documentation](https://nvidia-nemo.github.io/DataDesigner/0.6.0/) for comprehensive guides on column types, samplers, constraints, and advanced features.
+**Learn more**: See the [library documentation](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/getting-started/welcome) for comprehensive guides on column types, samplers, constraints, and advanced features.
 
 ### 2. Choose Where to Execute
 
@@ -98,7 +98,7 @@ These integrations are required for `submit` and SDK execution. They are optiona
 
     Move configurations between local CLI and NeMo Services execution.
 
--   **[Library Documentation](https://nvidia-nemo.github.io/DataDesigner/0.6.0/)**
+-   **[Library Documentation](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/getting-started/welcome)**
 
     ---
 

--- a/docs/data-designer/migration.md
+++ b/docs/data-designer/migration.md
@@ -80,4 +80,4 @@ Before switching execution modes, verify:
 - **Execution Modes:** See [Execution Modes](execution-modes.md) for the conceptual model.
 - **CLI:** See [Data Designer CLI](cli.md) for `run`, `submit`, and persona commands.
 - **Tutorials:** Follow the [tutorials](tutorials/index.md) for hands-on examples.
-- **Library Docs:** Refer to the [open-source library documentation](https://nvidia-nemo.github.io/DataDesigner/0.6.0/) for configuration details.
+- **Library Docs:** Refer to the [open-source library documentation](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/getting-started/welcome) for configuration details.

--- a/docs/data-designer/tutorials/basics.md
+++ b/docs/data-designer/tutorials/basics.md
@@ -5,7 +5,7 @@
 
 This tutorial demonstrates the fundamentals of Data Designer by generating a product review dataset.
 
-For more detail about column behavior, see the [open-source library's version](https://nvidia-nemo.github.io/DataDesigner/0.6.0/notebooks/1-the-basics/) of this tutorial.
+For more detail about column behavior, see the [open-source library's version](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/tutorials/the-basics) of this tutorial.
 
 ## Prerequisites
 
@@ -44,7 +44,7 @@ config_builder = dd.DataDesignerConfigBuilder(model_configs)
 
 ### Add Columns
 
-Define the columns for your dataset. The [library documentation](https://nvidia-nemo.github.io/DataDesigner/0.6.0/notebooks/1-the-basics/) explains these column types in detail.
+Define the columns for your dataset. The [library documentation](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/tutorials/the-basics) explains these column types in detail.
 
 {% raw %}
 ```python
@@ -304,5 +304,5 @@ When you use CLI `submit` or the SDK today:
 
 - **Seed data:** Learn how to use external datasets in the [seeding tutorial](seeding.md)
 - **Execution modes:** Learn more about local and NeMo Services execution in [Execution Modes](../execution-modes.md)
-- **Column types:** Explore all available column types in the [library documentation](https://nvidia-nemo.github.io/DataDesigner/0.6.0/concepts/columns/)
-- **Advanced features:** Learn about [processors](https://nvidia-nemo.github.io/DataDesigner/0.6.0/concepts/processors/) and [validation](https://nvidia-nemo.github.io/DataDesigner/0.6.0/concepts/validators/)
+- **Column types:** Explore all available column types in the [library documentation](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/concepts/columns)
+- **Advanced features:** Learn about [processors](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/concepts/processors) and [validation](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/concepts/validators)

--- a/docs/data-designer/tutorials/index.md
+++ b/docs/data-designer/tutorials/index.md
@@ -13,7 +13,7 @@ Data Designer separates **configuration** (building dataset schemas) from **exec
 
 **Part 1: Build Configs (Library)**
 
-Use `data_designer.config` to define your dataset. See the [library documentation](https://nvidia-nemo.github.io/DataDesigner/0.6.0/) for comprehensive guides on column types, constraints, and processors.
+Use `data_designer.config` to define your dataset. See the [library documentation](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/getting-started/welcome) for comprehensive guides on column types, constraints, and processors.
 
 ```python
 import data_designer.config as dd

--- a/docs/data-designer/tutorials/seeding.md
+++ b/docs/data-designer/tutorials/seeding.md
@@ -5,7 +5,7 @@
 
 This tutorial demonstrates how to use external datasets as seed data for synthetic data generation in Data Designer.
 
-For more detail about seed dataset behavior, see the [open-source library's version](https://nvidia-nemo.github.io/DataDesigner/0.6.0/notebooks/3-seeding-with-a-dataset/) of this tutorial.
+For more detail about seed dataset behavior, see the [open-source library's version](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/tutorials/seeding-with-an-external-dataset) of this tutorial.
 
 ## Seed Sources by Execution Mode
 
@@ -343,5 +343,5 @@ When you configure a seed dataset:
 ## Next Steps
 
 - **Execution modes:** Learn more about local and NeMo Services execution in [Execution Modes](../execution-modes.md)
-- **Column types:** Explore all available column types in the [library documentation](https://nvidia-nemo.github.io/DataDesigner/0.6.0/concepts/columns/)
-- **Processors:** Transform your data with processors in the [library documentation](https://nvidia-nemo.github.io/DataDesigner/0.6.0/concepts/processors/)
+- **Column types:** Explore all available column types in the [library documentation](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/concepts/columns)
+- **Processors:** Transform your data with processors in the [library documentation](https://docs.nvidia.com/nemo/datadesigner/v0.6.0/concepts/processors)


### PR DESCRIPTION
Move from the old github pages docs site to the `docs.nvidia.com`-hosted docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated NVIDIA NeMo Data Designer documentation references throughout guides, migration documentation, and tutorials to direct users to the new docs.nvidia.com/nemo/datadesigner v0.6.0 location. Changes affect the main index, migration guide, basics tutorial, seeding tutorial, and tutorial index, replacing previous GitHub-hosted URLs with the unified documentation site for improved discoverability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->