### PR TITLE
fix(codeql): batch-5 cyclic-import, multiple-definition, unreachable

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/tool_calling.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/tool_calling.py
@@ -118,7 +118,6 @@ class ToolCallingMetric(ToolCalling):
 
         fn_names_match = set(gt_fn_names) == set(pred_fn_name)
         fn_name_accuracy_score = 1.0 if fn_names_match else 0.0
-        fn_name_and_args_accuracy_score = 0.0
 
         try:
             pred_fn_args_by_name: dict[str, dict] = {}

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/pagination.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/pagination.py
@@ -124,7 +124,6 @@ def _fetch_all_pages_page_number(
     This is used for endpoints with `default_pagination` in the stainless config.
     """
     all_items: list[Any] = []
-    page_num = 1
     total_pages_count = 0
     total_results = 0
     original_page_size = None

--- a/packages/nmp_common/tests/secrets/test_secret_key.py
+++ b/packages/nmp_common/tests/secrets/test_secret_key.py
@@ -124,12 +124,12 @@ def test_secret_key_encryptor_config_validation():
     # Invalid key (too short)
     short_key = base64.b64encode(SHORT_TEST_KEY).decode()
     with pytest.raises(ValueError):
-        config = SecretKeyEncryptorConfig(value=short_key)
+        SecretKeyEncryptorConfig(value=short_key)
 
     # Invalid base64
     invalid_base64_key = "not-a-valid-base64-string"
     with pytest.raises(ValueError):
-        config = SecretKeyEncryptorConfig(value=invalid_base64_key)
+        SecretKeyEncryptorConfig(value=invalid_base64_key)
 
 
 def test_secret_key_encryptor_config_from_env(monkeypatch):

--- a/packages/nmp_testing/src/nmp/testing/e2e/evaluator.py
+++ b/packages/nmp_testing/src/nmp/testing/e2e/evaluator.py
@@ -163,7 +163,7 @@ def verify_job_completed_successfully(
         f"Expect 100% progress completed for successful jobs: {outputs.job_status}"
     )
     if require_samples_processed:
-        samples_processed = cast("int", outputs.job_status.status_details.get("samples_processed", 0))
+        samples_processed = cast(int, outputs.job_status.status_details.get("samples_processed", 0))
         assert samples_processed > 0, (
             f"Expect samples_processed for custom jobs and industry metrics with limit_samples: {outputs.job_status}"
         )
@@ -176,7 +176,7 @@ def verify_job_completed_successfully(
         len_row_scores = len(outputs.row_scores)
         assert len_row_scores > 0, "Row scores should not be empty"
         if require_samples_processed:
-            samples_processed = cast("int", outputs.job_status.status_details.get("samples_processed", 0))
+            samples_processed = cast(int, outputs.job_status.status_details.get("samples_processed", 0))
             assert samples_processed >= len_row_scores, (
                 f"Expect samples_processed to match number of rows: {outputs.job_status}"
             )

--- a/packages/nmp_testing/src/nmp/testing/e2e/evaluator.py
+++ b/packages/nmp_testing/src/nmp/testing/e2e/evaluator.py
@@ -101,9 +101,7 @@ def get_job_outputs(
     job = sdk.evaluation.metric_jobs.retrieve(job_name, workspace=workspace)
     job_status = sdk.evaluation.metric_jobs.get_status(job_name, workspace=workspace)
 
-    # Verify file download is functional: exercise the generic results.download
-    # endpoint for each known result name (content is validated below via the
-    # typed accessors).
+    # Verify file download is functional
     results = sdk.evaluation.metric_jobs.results.list(job_name, workspace=workspace)
     for result in results.data:
         if result.name in (AGGREGATE_SCORES_RESULT, ROW_SCORES_RESULT):

--- a/packages/nmp_testing/src/nmp/testing/e2e/evaluator.py
+++ b/packages/nmp_testing/src/nmp/testing/e2e/evaluator.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
+from typing import cast
 
 from nemo_platform import NeMoPlatform
 from nemo_platform.types.evaluation import AggregatedMetricResult, MetricEvaluationJob, RowScore
@@ -100,23 +101,18 @@ def get_job_outputs(
     job = sdk.evaluation.metric_jobs.retrieve(job_name, workspace=workspace)
     job_status = sdk.evaluation.metric_jobs.get_status(job_name, workspace=workspace)
 
-    # Verify file download is functional
+    # Verify file download is functional: exercise the generic results.download
+    # endpoint for each known result name (content is validated below via the
+    # typed accessors).
     results = sdk.evaluation.metric_jobs.results.list(job_name, workspace=workspace)
     for result in results.data:
-        if result.name == AGGREGATE_SCORES_RESULT:
+        if result.name in (AGGREGATE_SCORES_RESULT, ROW_SCORES_RESULT):
             response = sdk.evaluation.metric_jobs.results.download(
                 result.name,
                 job=job_name,
                 workspace=workspace,
             )
-            aggregate_scores = json.loads(response.read())
-        elif result.name == ROW_SCORES_RESULT:
-            response = sdk.evaluation.metric_jobs.results.download(
-                result.name,
-                job=job_name,
-                workspace=workspace,
-            )
-            row_scores = [json.loads(line) for line in response.read().decode().strip().split("\n") if line.strip()]
+            response.read()
 
     # Verify result entity is registered
     job_result = sdk.evaluation.metric_job_results.retrieve(job_name, workspace=workspace)
@@ -168,7 +164,8 @@ def verify_job_completed_successfully(
         f"Expect 100% progress completed for successful jobs: {outputs.job_status}"
     )
     if require_samples_processed:
-        assert outputs.job_status.status_details.get("samples_processed", 0) > 0, (
+        samples_processed = cast("int", outputs.job_status.status_details.get("samples_processed", 0))
+        assert samples_processed > 0, (
             f"Expect samples_processed for custom jobs and industry metrics with limit_samples: {outputs.job_status}"
         )
 
@@ -180,7 +177,8 @@ def verify_job_completed_successfully(
         len_row_scores = len(outputs.row_scores)
         assert len_row_scores > 0, "Row scores should not be empty"
         if require_samples_processed:
-            assert outputs.job_status.status_details.get("samples_processed", 0) >= len_row_scores, (
+            samples_processed = cast("int", outputs.job_status.status_details.get("samples_processed", 0))
+            assert samples_processed >= len_row_scores, (
                 f"Expect samples_processed to match number of rows: {outputs.job_status}"
             )
 
@@ -241,14 +239,14 @@ def create_dataset_fileset(
     filename: str = "dataset.json",
 ) -> str:
     """Create a fileset with optional dataset schema metadata and upload rows."""
-    create_kwargs = {
-        "workspace": workspace,
-        "name": fileset_name,
-    }
     if schema is not None:
-        create_kwargs["metadata"] = {"dataset": {"schema": schema}}
-
-    sdk.files.filesets.create(**create_kwargs)
+        sdk.files.filesets.create(
+            workspace=workspace,
+            name=fileset_name,
+            metadata={"dataset": {"schema": schema}},
+        )
+    else:
+        sdk.files.filesets.create(workspace=workspace, name=fileset_name)
     return upload_dataset_to_fileset(sdk, workspace, fileset_name, rows, filename=filename)
 
 

--- a/packages/nmp_testing/src/nmp/testing/e2e/evaluator.py
+++ b/packages/nmp_testing/src/nmp/testing/e2e/evaluator.py
@@ -101,7 +101,8 @@ def get_job_outputs(
     job = sdk.evaluation.metric_jobs.retrieve(job_name, workspace=workspace)
     job_status = sdk.evaluation.metric_jobs.get_status(job_name, workspace=workspace)
 
-    # Verify file download is functional
+    # Smoke-test the generic results.download endpoint (status + body readable).
+    # Content is validated below via the typed aggregate_scores/row_scores accessors.
     results = sdk.evaluation.metric_jobs.results.list(job_name, workspace=workspace)
     for result in results.data:
         if result.name in (AGGREGATE_SCORES_RESULT, ROW_SCORES_RESULT):

--- a/plugins/nemo-auditor/src/nemo_auditor/sdk_resources/_parent.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/sdk_resources/_parent.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parent protocols for auditor SDK sub-resources.
+
+Sub-resources (``configs``, ``targets``) only need their parent's HTTP client
+and URL builder. Typing against these protocols instead of importing the
+concrete ``AuditorPluginResource`` classes keeps the import graph acyclic.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import httpx
+
+
+class AuditorResourceParent(Protocol):
+    """Sync parent surface used by sub-resources."""
+
+    _http_client: httpx.Client
+
+    def _url(self, path: str) -> str: ...
+
+
+class AsyncAuditorResourceParent(Protocol):
+    """Async parent surface used by sub-resources."""
+
+    _http_client: httpx.AsyncClient
+
+    def _url(self, path: str) -> str: ...

--- a/plugins/nemo-auditor/src/nemo_auditor/sdk_resources/_parent.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/sdk_resources/_parent.py
@@ -20,7 +20,9 @@ class AuditorResourceParent(Protocol):
 
     _http_client: httpx.Client
 
-    def _url(self, path: str) -> str: ...
+    def _url(self, path: str) -> str:
+        """Build the absolute request URL for ``path``."""
+        raise NotImplementedError
 
 
 class AsyncAuditorResourceParent(Protocol):
@@ -28,4 +30,6 @@ class AsyncAuditorResourceParent(Protocol):
 
     _http_client: httpx.AsyncClient
 
-    def _url(self, path: str) -> str: ...
+    def _url(self, path: str) -> str:
+        """Build the absolute request URL for ``path``."""
+        raise NotImplementedError

--- a/plugins/nemo-auditor/src/nemo_auditor/sdk_resources/configs.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/sdk_resources/configs.py
@@ -10,8 +10,6 @@ the FastAPI routes in :mod:`nemo_auditor.api.v2.configs`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from nemo_auditor.api.v2.schemas import CreateAuditConfigRequest, UpdateAuditConfigRequest
 from nemo_auditor.entities import (
     AuditConfig,
@@ -20,9 +18,7 @@ from nemo_auditor.entities import (
     AuditRunData,
     AuditSystemData,
 )
-
-if TYPE_CHECKING:
-    from nemo_auditor.sdk import AsyncAuditorPluginResource, AuditorPluginResource
+from nemo_auditor.sdk_resources._parent import AsyncAuditorResourceParent, AuditorResourceParent
 
 
 def _build_create_body(
@@ -66,7 +62,7 @@ def _build_update_body(
 class _ConfigResource:
     """Sync ``configs`` sub-resource — five CRUD verbs."""
 
-    def __init__(self, parent: AuditorPluginResource) -> None:
+    def __init__(self, parent: AuditorResourceParent) -> None:
         self._parent = parent
 
     def create(
@@ -152,7 +148,7 @@ class _ConfigResource:
 class _AsyncConfigResource:
     """Async ``configs`` sub-resource — mirrors :class:`_ConfigResource`."""
 
-    def __init__(self, parent: AsyncAuditorPluginResource) -> None:
+    def __init__(self, parent: AsyncAuditorResourceParent) -> None:
         self._parent = parent
 
     async def create(

--- a/plugins/nemo-auditor/src/nemo_auditor/sdk_resources/targets.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/sdk_resources/targets.py
@@ -10,13 +10,11 @@ the FastAPI routes in :mod:`nemo_auditor.api.v2.targets`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from nemo_auditor.api.v2.schemas import CreateAuditTargetRequest, UpdateAuditTargetRequest
 from nemo_auditor.entities import AuditTarget
-
-if TYPE_CHECKING:
-    from nemo_auditor.sdk import AsyncAuditorPluginResource, AuditorPluginResource
+from nemo_auditor.sdk_resources._parent import AsyncAuditorResourceParent, AuditorResourceParent
 
 
 def _build_create_body(
@@ -56,7 +54,7 @@ def _build_update_body(
 class _TargetResource:
     """Sync ``targets`` sub-resource — five CRUD verbs."""
 
-    def __init__(self, parent: AuditorPluginResource) -> None:
+    def __init__(self, parent: AuditorResourceParent) -> None:
         self._parent = parent
 
     def create(
@@ -138,7 +136,7 @@ class _TargetResource:
 class _AsyncTargetResource:
     """Async ``targets`` sub-resource — mirrors :class:`_TargetResource`."""
 
-    def __init__(self, parent: AsyncAuditorPluginResource) -> None:
+    def __init__(self, parent: AsyncAuditorResourceParent) -> None:
         self._parent = parent
 
     async def create(

--- a/script/openapi_helper/openapi_tools.py
+++ b/script/openapi_helper/openapi_tools.py
@@ -887,8 +887,7 @@ def fix_schema(
 
     except Exception as e:
         print_verbose(f"Error: {str(e)}", style="bold red")
-        raise e
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
 def rename_schema_references(spec: dict, old_name: str, new_name: str) -> None:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/tool_calling.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/tool_calling.py
@@ -118,7 +118,6 @@ class ToolCallingMetric(ToolCalling):
 
         fn_names_match = set(gt_fn_names) == set(pred_fn_name)
         fn_name_accuracy_score = 1.0 if fn_names_match else 0.0
-        fn_name_and_args_accuracy_score = 0.0
 
         try:
             pred_fn_args_by_name: dict[str, dict] = {}

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/pagination.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/pagination.py
@@ -124,7 +124,6 @@ def _fetch_all_pages_page_number(
     This is used for endpoints with `default_pagination` in the stainless config.
     """
     all_items: list[Any] = []
-    page_num = 1
     total_pages_count = 0
     total_results = 0
     original_page_size = None

--- a/services/core/jobs/tests/test_jobs_api.py
+++ b/services/core/jobs/tests/test_jobs_api.py
@@ -287,7 +287,7 @@ async def test_hello_world_jobs_list(test_client: AsyncClient):
     assert response.status_code == 201, f"POST failed: {response.status_code} {response.text}"
 
     response = await test_client.get("/apis/jobs/v2/workspaces/default/hello-world/jobs")
-    data = response.json()
+    assert response.status_code == 200, f"GET failed: {response.status_code} {response.text}"
 
     response = await test_client.get("/apis/jobs/v2/workspaces/default/jobs")
     data = response.json()
@@ -317,6 +317,7 @@ async def test_hello_world_jobs_list(test_client: AsyncClient):
             "ownership": {"user": "fake-user", "service": "fake-ms"},
         },
     )
+    assert response.status_code == 201, f"POST failed: {response.status_code} {response.text}"
     response = await test_client.get("/apis/jobs/v2/workspaces/default/jobs")
     data = response.json()
     assert len(data["data"]) == 2
@@ -341,6 +342,7 @@ async def test_hello_world_jobs_list(test_client: AsyncClient):
             "ownership": {"user": "fake-user", "service": "fake-ms"},
         },
     )
+    assert response.status_code == 201, f"POST failed: {response.status_code} {response.text}"
     response = await test_client.get("/apis/jobs/v2/workspaces/default/jobs")
     data = response.json()
     assert len(data["data"]) == 3

--- a/services/core/models/src/nmp/core/models/parallelism/models.py
+++ b/services/core/models/src/nmp/core/models/parallelism/models.py
@@ -472,11 +472,8 @@ def detect_mamba_config_from_cfg(
     if has_ssm_config and "_h" in family:
         return detect_hybrid_mamba_via_introspection(cfg, n_layers, is_trusted)
 
-    # Priority 4: Pure Mamba model
-    if has_ssm_config:
-        return detect_pure_mamba_from_cfg(cfg, n_layers)
-
-    return None
+    # Priority 4: Pure Mamba model (has_ssm_config is guaranteed True here)
+    return detect_pure_mamba_from_cfg(cfg, n_layers)
 
 
 def _has_config_json(pretrained_or_path: str) -> bool:

--- a/services/core/models/src/nmp/core/models/parallelism/models.py
+++ b/services/core/models/src/nmp/core/models/parallelism/models.py
@@ -472,7 +472,7 @@ def detect_mamba_config_from_cfg(
     if has_ssm_config and "_h" in family:
         return detect_hybrid_mamba_via_introspection(cfg, n_layers, is_trusted)
 
-    # Priority 4: Pure Mamba model (has_ssm_config is guaranteed True here)
+    # Priority 4: Pure Mamba model
     return detect_pure_mamba_from_cfg(cfg, n_layers)
 
 

--- a/services/core/models/tests/unit/parallelism/test_parallelism_models.py
+++ b/services/core/models/tests/unit/parallelism/test_parallelism_models.py
@@ -383,8 +383,8 @@ def test_precision_in_model_config_serialization():
 def test_precision_required():
     """Test that precision field is required and must be provided."""
     # Test that precision is required
-    try:
-        config = ModelSpec(
+    with pytest.raises(Exception):  # noqa: B017 - any validation error is acceptable here
+        ModelSpec(
             checkpoint_model_name="test-model",
             family="test",
             num_layers=32,
@@ -398,10 +398,6 @@ def test_precision_required():
             base_num_parameters=7_000_000_000,
             # precision not provided - should fail
         )
-        assert False, "Expected validation error for missing precision field"
-    except Exception:
-        # Expected - precision is required
-        pass
 
     # Test that precision can be provided
     config = ModelSpec(

--- a/services/core/models/tests/unit/parallelism/test_parallelism_models.py
+++ b/services/core/models/tests/unit/parallelism/test_parallelism_models.py
@@ -383,7 +383,7 @@ def test_precision_in_model_config_serialization():
 def test_precision_required():
     """Test that precision field is required and must be provided."""
     # Test that precision is required
-    with pytest.raises(Exception):  # noqa: B017 - any validation error is acceptable here
+    with pytest.raises(Exception):  # noqa: B017
         ModelSpec(
             checkpoint_model_name="test-model",
             family="test",

--- a/services/core/models/tests/unit/parallelism/test_parallelism_models.py
+++ b/services/core/models/tests/unit/parallelism/test_parallelism_models.py
@@ -20,6 +20,7 @@ from nmp.core.models.schemas import (
     ModelSpec,
     MoEConfig,
 )
+from pydantic import ValidationError
 
 # =================================================================================================
 # PYDANTIC MODEL TESTS
@@ -383,7 +384,7 @@ def test_precision_in_model_config_serialization():
 def test_precision_required():
     """Test that precision field is required and must be provided."""
     # Test that precision is required
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(ValidationError):
         ModelSpec(
             checkpoint_model_name="test-model",
             family="test",

--- a/services/customizer/src/nmp/customizer/tasks/training/backends/nemo_rl/ray_bootstrap.py
+++ b/services/customizer/src/nmp/customizer/tasks/training/backends/nemo_rl/ray_bootstrap.py
@@ -301,7 +301,6 @@ class RayClusterBootstrap:
         Returns:
             Exit code from driver execution
         """
-        exit_code = 1
         try:
             if not self._start_head_background():
                 raise RuntimeError("Failed to start Ray head node")

--- a/services/evaluator/src/nmp/evaluator/app/datasets/nmp_datasets/utils.py
+++ b/services/evaluator/src/nmp/evaluator/app/datasets/nmp_datasets/utils.py
@@ -52,7 +52,6 @@ async def to_dataset(dataset: str | URN | Dataset | None) -> Dataset:
                 return Dataset.model_validate(await response.json())
     else:
         raise ValueError(f"Unsupported dataset type: {type(dataset)}")
-    return dataset
 
 
 def extract_path(dataset_files_url: str) -> str:


### PR DESCRIPTION
## Summary

Batch 5 of the CodeQL cleanup. Targets the error/warning-severity rules deferred from prior batches: `py/unsafe-cyclic-import`, `py/multiple-definition`, `py/unreachable-statement`. **22 alerts fixed in-tree, 14 dismissed** (vendored, false-positives, defensive guards).

Branches off `main` after #91/#98/#100 merged; no overlap with the still-open #102 (batch-4) — files in flight there were intentionally excluded.

## Alerts addressed

| Severity | Rule | Fixed | Dismissed | How |
| --- | --- | --- | --- | --- |
| Error | `py/unsafe-cyclic-import` | 8 | 4 | **nemo-auditor**: broke the `sdk ⇄ sdk_resources` import cycle by introducing `AuditorResourceParent` / `AsyncAuditorResourceParent` Protocols in `sdk_resources/_parent.py` and typing the sub-resource `parent` against them, instead of importing the concrete `AuditorPluginResource` under `TYPE_CHECKING`. The 4 vendored switchyard cycles were dismissed (snapshot, overwritten on re-vendor). |
| Warning | `py/multiple-definition` | 11 | — | Dropped dead pre-assignments later reassigned before use (`tool_calling` score init, `pagination` page_num, `ray_bootstrap` exit_code, `e2e/evaluator` loop bindings). In tests, dropped pointless bindings inside `pytest.raises` blocks and—where the dead `response` rebind in `test_jobs_api` masked a **latent missing assertion**—added the absent `status_code == 201/200` checks. |
| Warning | `py/unreachable-statement` | 3 | 10 | Fixed: `openapi_tools` double-`raise` → `raise … from e`; `parallelism/models` always-true Priority-4 guard + dead `return None`; `evaluator/datasets/utils` dead trailing `return`. Dismissed: post-`pytest.raises`-block assertions CodeQL marks unreachable because it doesn't model `__exit__` suppression (6), a defensive `del` in a `finally` (1), a type-checker-load-bearing terminal `raise` (1), a WIP stub (1), illustrative test scaffolding (1). |

## Notable

- **Latent test gaps found**: `test_jobs_api` created jobs 2 and 3 but never asserted the POST succeeded (the `response` was clobbered by the next GET). Added the missing `assert response.status_code == 201`.
- **No `# noqa` left behind**: the missing-precision test now asserts `pydantic.ValidationError` rather than a broad `Exception` (no `B017` suppression).

## Test plan

- [x] `uv run pytest plugins/nemo-auditor/tests/test_sdk_resources.py` — 15 pass
- [x] `uv run pytest packages/nmp_common/tests/secrets packages/nemo_evaluator_sdk/tests services/core/jobs/tests/test_jobs_api.py services/intake/tests/test_entries.py` — green (894 in the broad run)
- [x] `ruff check` + `ty check` clean on all touched, non-excluded files
- [x] auditor sdk import-cycle removed (verified `import nemo_auditor.sdk` + both sub-resource modules load)
- [ ] Re-run CodeQL after merge; confirm the 22 fixed alerts close

## Dismissals

14 alerts dismissed via the Security tab with rationale (vendored switchyard, `pytest.raises`-suppression false positives, defensive `finally`/terminal-`raise` guards, one WIP stub). See per-alert comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal flows and variable initialization across metrics, pagination, and parallelism handling.
  * Introduced generic parent interfaces for SDK resources to standardize resource architecture.
  * Streamlined bootstrap and exception-exit behavior.

* **Behavior**
  * Dataset resolution now enforces remote entity lookup and validates availability.

* **Tests**
  * Strengthened tests with explicit HTTP status assertions and improved validation error checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->