### PR TITLE
chore(skills): refine nemo-setup skill eval flow

### DIFF
--- a/skills/nemo-setup/SKILL.md
+++ b/skills/nemo-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nemo-setup
-description: Set up a local NeMo Platform (`make bootstrap` + `nemo setup`) — services, providers, plugins, default model, and an optional demo agent. Use when the user asks to install, bootstrap, set up, run, or start a local NeMo Platform.
+description: Set up or start a local NeMo Platform with `make bootstrap` and `nemo setup`; use for install, bootstrap, local services, provider setup, skill install, or demo-agent deployment.
 version: "0.1"
 metadata:
   owner: nemo-platform
@@ -10,221 +10,125 @@ license: Apache-2.0
 
 # NeMo Platform Setup
 
-Get a local NeMo platform running on `localhost:8080`. Work through the prereq questions below before bootstrapping — they shape which services start and what state survives the run. When setup is finished, [What's next?](#whats-next) maps the user's stated goal to the right follow-up skill.
+Get a local NeMo Platform running on `localhost:8080`. Optimize for completing setup, not for stopping at preflight questions. Use safe defaults unless the user asks for a destructive reset or a running process blocks startup.
 
-> This document is the canonical setup guide at `skills/nemo-setup/SKILL.md`. Unlike the other skills, it is **not** installed by `nemo skills install` — it has to be available before the platform is bootstrapped, when the CLI may not yet exist.
+This is the canonical setup guide at `skills/nemo-setup/SKILL.md`. It is not installed by `nemo skills install` because agents need it before the platform is bootstrapped.
+
+## Purpose
+
+Use this skill when the user asks to install, bootstrap, set up, run, start, or repair a local NeMo Platform checkout. The expected successful outcome is:
+
+1. dependencies are bootstrapped,
+2. local services are reachable at `http://localhost:8080`,
+3. provider/skills/demo-agent setup is attempted when credentials are available, and
+4. the user receives concise next-step options.
 
 ## Prerequisites
 
 - Python 3.11-3.13, Git, GNU Make, and `uv`.
-- Node.js and `pnpm` that satisfy `web/package.json`: currently Node.js `>=22.18.0 <23` and pnpm `>=10.32.1`. `make bootstrap` can start API services without Studio assets, but `make bootstrap-studio` requires these exact engine constraints.
-- An inference provider credential if the user wants setup to register a provider. [NVIDIA Build keys](https://build.nvidia.com/settings/api-keys) are expected in `$NVIDIA_API_KEY` and normally start with `nvapi-`.
+- Node.js and `pnpm` matching `web/package.json` for Studio assets. If Studio asset bootstrap fails, the API can still run.
+- Optional provider credential for non-interactive provider setup. Supported env vars include `NVIDIA_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, and `NEMO_DEFAULT_INFERENCE_KEY`.
 
-Do not print secret values. Never run broad environment dumps such as `env`, `printenv`, or `set` without filtering out secrets. To check whether a key exists, print only presence, for example `test -n "${NVIDIA_API_KEY:-}" && echo "NVIDIA_API_KEY is set"`. Do not send API keys to ad hoc network commands; only `nemo setup`, `nemo secrets`, or the documented provider-registration flow below should receive provider credentials.
-
-## Mandatory preflight decisions
-
-Before running `make bootstrap`, `nemo setup --auto`, `nemo services run`, or any state-changing setup command, the agent MUST ask the user for whether to reset an existing local database before proceeding.
-
-## Question 1 — Is a NeMo platform already running locally?
-
-Before starting `nemo services run`, check for an existing instance:
+Do not print secret values. Do not run broad environment dumps such as `env`, `printenv`, or `set`. To check whether a key exists, print only presence:
 
 ```bash
-lsof -iTCP:8080 -sTCP:LISTEN
-ps -ef | grep "nemo services run" | grep -v grep
+test -n "${NVIDIA_API_KEY:-}" && echo "NVIDIA_API_KEY is set"
 ```
 
-Alternatively, probe the API with `nemo workspaces list` — a workspaces table back means the platform is up. **Don't `curl /v1/workspaces`** to check; that path returns 404 even when the platform is healthy.
+## Default Policy
 
-If port 8080 is in use **or** a `nemo services run` process exists, do not silently start a new one — the new instance will fail to bind, and it gets confusing which platform is answering requests (the controller piece can still partially start and connect to the old API on `:8080`, producing logs that look like a fresh boot but are reading state from the old DB). Surface the exact PIDs and command line, then ask which path the user wants:
+- Data directory: use the CLI default, usually `~/.local/share/nemo`.
+- Existing local DB: preserve it by default.
+- `NMP_BASE_URL`: set `http://localhost:8080` before local CLI verification so a remote config file cannot hijack commands.
+- Destructive actions: ask before deleting the data directory or killing a running platform process.
+- Completion: setup is not complete until local services are verified and next-step options are offered.
 
-- **(a) Kill the running platform and start fresh.** Use this when the running process is stale (long-running, crashed, or pre-dates the changes the user is now making). Procedure:
-  1. SIGTERM the exact PIDs — `kill <pid> [<pid>...]`
-  2. Wait ~10s; if still alive, **re-verify** each PID still matches a `nemo services run` command (paranoid check against PID reuse), then SIGKILL only those exact PIDs.
-  3. Only **after** the processes are gone, follow the user's reset decision from Question 3 below.
-- **(b) Keep it running and skip setup.** Use the running platform as-is — skip Switchyard install / DB wipe / startup entirely and proceed straight to your task. Caveats:
-  - Middleware plugins like `nemo-switchyard` are loaded at platform **startup**, so a VirtualModel that needs middleware the running platform did not load will fail. Confirm the loaded plugins by grepping the platform log for `Loaded inference middleware plugin` before assuming a middleware is available. The first VirtualModel create with `nemo-switchyard` either succeeds or returns `422 references unknown plugin 'nemo-switchyard'`; a 422 means restart is needed.
-  - The running services should include what the task needs: `inference-gateway`, `secrets`, `models`, `entities`, plus `guardrails` if the task uses rails. There is no public "list running services" endpoint — infer from feature attempts (`nemo guardrail configs list` returning 404 means the guardrails service isn't loaded).
-  - The user may already have the workspace / secret / provider seeded — check with `nemo workspaces list`, `nemo secrets list --workspace …`, and `nemo inference providers list --workspace …` before re-creating anything (creates may 409).
-- **(c) Abort and let the user investigate.**
+Do not ask the user to choose a data directory or DB reset for the normal fresh setup path. Ask only when the user requested a custom path/reset, or when an existing process or corrupted state requires a choice.
 
-> ⚠️ **macOS unlinked-inode gotcha:** deleting data files in the `~/.local/share/nemo` while a `nemo services run` process is still alive does **not** reset state. The files get unlinked from the directory tree but the running process keeps writing to its open inode, and a freshly-spawned platform can see a new empty file while the old process still owns the data. Always stop the platform process first, then use the reset path from Question 3 only if the user confirmed it.
+## Fast Path
 
-## Question 2 — Local data directory?
+Run from the repo root.
 
-Confirm where the user wants local platform state (entity-store DB, encryption key, files-service uploads) persisted. Use the same prompt language as `nemo setup`:
-
-> **Local data directory:** `~/.local/share/nemo`
-
-Most users accept the default. Override paths follow XDG conventions:
-
-1. **`$NMP_DATA_DIR`** (most explicit) — used as-is, no `/nemo` suffix appended.
-2. **`$XDG_DATA_HOME/nemo`** — if `XDG_DATA_HOME` is set in the shell.
-3. **`~/.local/share/nemo`** — the default.
-
-If the user picks a custom path, export it before starting services so the spawned platform inherits it:
+1. Check for an existing local platform or port conflict:
 
 ```bash
-export NMP_DATA_DIR=/custom/path/to/state
+lsof -iTCP:8080 -sTCP:LISTEN || true
+ps -ef | grep "nemo services run" | grep -v grep || true
 ```
 
-`nemo setup` persists the choice to `~/.config/nmp/config.yaml` under `local_services.data_dir` and re-uses it on subsequent runs. If you're running services manually (not via `nemo setup`), set `NMP_DATA_DIR` yourself each session.
+If a healthy NeMo Platform is already running, keep it and go straight to verification. If a stale `nemo services run` process or a non-NeMo process owns port 8080, show the PID/command and ask before killing it.
 
-## Question 3 — Wipe the local DB?
-
-Ask whether the user wants to reset the local entity-store database before platform startup. Warn clearly that this deletes local platform state, including secret metadata and the local encryption key. Providers/secrets must be re-seeded afterward. If the database and encryption key get out of sync, later runs can fail with decryption errors such as `cryptography.exceptions.InvalidTag`. **The wipe only works if no `nemo services run` process is currently holding the file open** (see the macOS gotcha under Question 1). Only if the user confirms, you can reset the data by deleting content of what was chosen in Q2 (`$NMP_DATA_DIR`, `$XDG_DATA_HOME/nemo`, or the default `~/.local/share/nemo`) before starting the service `nemo services run`. Make sure to ask user before proceeding. 
----
-
-## Bootstrap and start
-
-The README documents the streamlined path. Prefer this over the manual steps below whenever the task fits — it covers prerequisites install, service startup, provider registration, default-model selection, and demo agent deployment in one shot:
+2. Bootstrap dependencies:
 
 ```bash
-make bootstrap           # installs Python deps, Studio assets, and plugins (including demo calculator agent)
+make bootstrap
+```
+
+3. Activate the environment and force the CLI to target the local platform:
+
+```bash
 source .venv/bin/activate
-nemo setup               # interactive: prompts for provider, picks default model, optionally deploys calculator-agent
+export NMP_BASE_URL=http://localhost:8080
 ```
 
-Non-interactive equivalent (useful for CI / agent-driven invocations):
+4. Run setup.
+
+If a provider credential is present, prefer the non-interactive completion path:
 
 ```bash
-export NVIDIA_API_KEY=nvapi-...
 nemo setup --auto --start-services --install-skills --deploy-agent
 ```
 
-`make bootstrap` is the umbrella for three finer-grained targets — use these if you only need a subset:
-
-| Target | What it does |
-|---|---|
-| `make bootstrap-python` | Creates `.venv` and runs `uv sync` (Python deps + workspace packages) |
-| `make bootstrap-studio` | Installs web deps via `pnpm` and builds Studio assets for FastAPI |
-
-`make clean` removes the venv; `make clean-python` is the venv-only variant.
-
-If `nemo setup` is too high-level for the task (e.g. debugging startup, custom service set, custom plugin install after bootstrap), use the manual sections below.
-
-### Default model selection (under `--auto`)
-
-`$NEMO_DEFAULT_MODEL` **must be a hyphenated entity ID** from `nemo models list` (e.g. `nvidia-llama-3-3-nemotron-super-49b-v1-5` or `default/nvidia-llama-3-3-nemotron-super-49b-v1-5`). The slash-with-dots form (`nvidia/llama-3.3-nemotron-super-49b-v1-5`) is the upstream catalog's `served_model_name` — it's shown for human display but the gateway rejects it as a request input.
-
-`nemo setup --auto` picks the default model in this order:
-
-1. `$NEMO_DEFAULT_MODEL` (if set) — used as-is. The user may have exported this from a previous session; it takes precedence over anything discovered from the registered provider.
-2. Otherwise, the first model entity returned by provider discovery.
-
-If the user is surprised by which model got picked, check `echo $NEMO_DEFAULT_MODEL` first — that's the most common cause.
-
-The first-discovered fallback is intentionally simple — providers like NVIDIA Build expose dozens of models and "first one" rarely matches the user's intent. If the user wants a specific model as the default (or wants to compare options before committing), don't rely on the `--auto` fallback. After setup finishes, the `inference` skill's "Step 2 — Discover available models" enumerates entity IDs and shows the jq filters for picking one out by vendor or family. The user can then pin their choice via `export NEMO_DEFAULT_MODEL=<workspace>/<entity-id>` or by overriding `body["model"]` per request.
-
-If `nemo agents invoke …` fails with HTTP 422 in under a second on the first call, the cause is almost always a slash-with-dots model name reaching the gateway (e.g. via a stale `NEMO_DEFAULT_MODEL` or an agent config that hardcoded the upstream catalog form). The `inference` skill's "Common failure: HTTP 422 from chat completion" subsection has the diagnose-and-recover steps — don't conclude the platform is broken.
-
-### Starting the platform (without Switchyard)
-
-If `make bootstrap` has already run, just start the services. `nemo setup` does this for you; the manual equivalent is:
+If no provider credential is present, still start local services and install skills where possible:
 
 ```bash
-uv run nemo services run \
-  --services entities,models,inference-gateway,secrets \
-  --controllers models
+nemo setup --start-services --install-skills --no-deploy-agent
 ```
 
-### Starting the platform with Switchyard middleware
+If that command becomes interactive and blocks for provider input, stop the interactive prompt, report that services can run but provider registration needs a key, and tell the user which env vars are supported.
 
-`make bootstrap-python` and bare `uv sync` install `plugins/nemo-switchyard` through the root workspace's `enabled-plugins` group. The Switchyard library is vendored in-tree at `plugins/nemo-switchyard/vendor/switchyard/` (a snapshot pinned in `tool.uv.sources`) — no separate Switchyard checkout, `SWITCHYARD_PATH` env var, or PyPI workaround is needed. Start with debug logging to see routing decisions:
+## Verification
+
+Verify local reachability before reporting success:
 
 ```bash
-# Start with LOG_LEVEL=DEBUG to see routing decisions.
-LOG_LEVEL=DEBUG uv run nemo services run \
-  --services entities,models,inference-gateway,secrets \
-  --controllers models
+nemo workspaces list
+nemo services status
 ```
 
-`nemo-switchyard` is auto-discovered via its `nemo.inference_middleware` entry point once dependencies are installed.
+Do not use `curl /v1/workspaces`; that path can return 404 even when the platform is healthy.
 
-### Demo agent
-
-`make bootstrap` installs the NeMo agents plugin and the calculator-agent example through the root workspace, so no separate `uv pip install` is needed. After services start, `nemo setup` (or `nemo setup --auto --deploy-agent`) will deploy a demo `calculator-agent` in the default workspace. Verify with:
+If the demo agent was deployed, verify it:
 
 ```bash
 nemo agents list
 nemo agents invoke --agent calculator-agent --input "What is 12 * 8?"
 ```
 
-### Local platform environment summary
+When verification passes, state that the platform is running at `http://localhost:8080`.
 
-- **Port**: `8080` (CLI default — do NOT pass a custom `--base-url`).
-- **`export NMP_BASE_URL=http://localhost:8080` — required when targeting a local platform.** If your `~/.config/nmp/config.yaml` already points at a remote cluster, the CLI uses that base URL and ignores the local platform entirely. Setting this env var overrides the config file for the current shell session.
-- **Reset state:** only after the user explicitly confirms Question 3 for the exact chosen data directory.
+## Reset Path
 
----
+Use this only when the user explicitly asks to reset local state, accepts a fresh setup, or a concrete stale-state error requires it.
 
-## What's next?
+1. Ask for confirmation before deleting data. Warn that this removes local platform state, secret metadata, and the local encryption key.
+2. Stop any running `nemo services run` process first. Deleting files while the process is alive can leave macOS with an unlinked open DB file.
+3. Delete the selected data directory contents only after confirmation. The default target is `~/.local/share/nemo`, unless `NMP_DATA_DIR` or `XDG_DATA_HOME` changes the active path.
+4. Rerun the fast path from bootstrap/setup through verification.
 
-The platform is running. Don't leave the user with "you're good to go" — offer a menu of what they can do next based on what they originally asked for. Match the user's intent to one of the patterns from the [README's "Use NeMo Platform from your coding agent" section](/README.md#use-nemo-platform-from-your-coding-agent):
+## Troubleshooting
 
-| User says… | Goal | Follow-up skill |
-|---|---|---|
-| "Optimize my agent", "my agent is too slow / using too many tokens" | Cost / latency optimization via routing or skill tuning | `nemo-agents-optimize` |
-| "Secure my agent", "my agent is producing dangerous output" | Content safety / red-team / leak audit | `nemo-agents-secure`, `nemo-guardrails`, `nemo-auditor` |
-| "Can my agent use multiple models?", "split traffic across N backends" | Multi-backend routing via Switchyard | (inline; see `inference` skill) |
-| "Evaluate my model / agent on \<benchmark\>" | Eval against a dataset / harness | `nemo-evaluator`, `nemo-evaluator-plugin` |
-| "Generate synthetic data", "I have sensitive data and need…" | Data generation / anonymization / safe synthesis | `nemo-data-designer-plugin`, `nemo-anonymizer`, `nemo-safe-synthesizer` |
-| "Just deploy / invoke an agent" | Deploy the demo calculator agent or your own | `nemo-agents-optimize` (later, if needed) |
-| "Chat with a model", "call \<model\> via inference" | Plain inference through IGW | `inference` skill |
-| "Register an inference provider" (no further use case) | Provider registration only | `inference` skill |
+For custom data paths or coding-agent skill install details, read [Configuration](references/configuration.md). For service-only startup, read [Manual Startup](references/manual-start.md). For Switchyard routing, middleware, or VirtualModel plugin loading, read [Switchyard](references/switchyard.md). For stale DB/encryption-key failures, port conflicts, and default-model 422s, read [Troubleshooting](references/troubleshooting.md). Do not load any reference during the normal fast path unless one of those issues appears.
 
-If the user's prompt doesn't already pin one down, ask: *"The platform is up. What would you like to do next — optimize an agent, deploy one, run inference, evaluate, generate data, or something else?"*
+## What's Next
 
-If the user wants to **pick or swap the default model** (e.g. they didn't like the one `--auto` selected, or they want to compare options), don't guess — hand off to the `inference` skill. Step 2 there enumerates `served_models[].model_entity_id` and shows jq filters for picking by vendor / family. To pin the choice for subsequent runs, export `NEMO_DEFAULT_MODEL=<workspace>/<entity-id>` before the next `nemo setup --auto`. For one-off commands, pass the entity ID positionally: `nemo chat <entity-id>`.
+After setup is verified, offer a short menu based on the user's goal:
 
-### Available skills
+- optimize an agent: use `nemo-agents-optimize`
+- secure an agent: use `nemo-agents-secure`, `nemo-guardrails`, or `nemo-auditor`
+- run inference or choose a model: use `inference`
+- evaluate a model or agent: use `nemo-evaluator` or `nemo-evaluator-plugin`
+- generate synthetic data: use `nemo-data-designer-plugin`
+- deploy or invoke an agent: use the agent build/deploy skills
 
-`nemo skills list` is the canonical check for what's actually loaded — the entries depend on which plugins are installed. Expected entries after `make bootstrap`:
-
-CLI built-ins (always present):
-
-- **`inference`** — ModelProvider + VirtualModel + Switchyard reference. End-to-end inference flow, routing patterns, middleware ordering, troubleshooting.
-
-> Setup lives at `skills/nemo-setup/SKILL.md` rather than as a CLI-installable skill, since coding agents need it before the platform is bootstrapped.
-
-Plugin-provided (appear once the plugin is installed):
-
-- **`nemo-agents-optimize`** — optimize a deployed agent (routing splits, skill tuning, prompt tuning, evals against newer models). From `plugins/nemo-agents`.
-- **`nemo-agents-secure`** — audit a deployed agent for missing guardrails, PII exposure, leaked secrets/keys. From `plugins/nemo-agents`.
-- **`nemo-guardrails`** — guardrail config CRUD, content-safety rails, the `nemo-guardrails` middleware. From `plugins/nemo-guardrails`.
-- **`nemo-auditor`** — vulnerability scanning, audit configs/targets/jobs, red-team probes. From `plugins/nemo-auditor`.
-- **`nemo-evaluator`** / **`nemo-evaluator-plugin`** — metrics, sync/async evaluations, llm-judge, benchmark jobs. From `plugins/nemo-evaluator`.
-- **`nemo-data-designer-plugin`** — synthetic dataset generation pipelines. From `plugins/nemo-data-designer`.
-- **`nemo-entities`**, **`nemo-files`**, **`nemo-secrets`**, **`nemo-auth`**, **`nemo-inference-gateway`** — CLI references for the matching services.
-
-### Installing skills into the coding agent on demand
-
-`nemo skills list` lists every skill the **platform** can install — but that's not the same as what's currently loaded in the coding agent (Claude Code, Cursor, Codex, OpenCode). After `make bootstrap` finishes, the relevant subset must still be **installed into the coding agent** for it to actually use them.
-
-Default flow (already wired into `nemo setup`):
-
-```bash
-nemo skills install --agent <claude|cursor|codex|opencode>
-```
-
-With no `--skill` flag, this installs **all** skills from `nemo skills list` into the chosen agent. Run it again any time `nemo skills list` changes (new plugin installed, plugin updated).
-
-If the user's goal in the table above maps to a skill that you (the coding agent) don't currently have in this session, install only the skills you need rather than all of them:
-
-```bash
-# Single skill
-nemo skills install --agent claude --skill nemo-agents-optimize
-
-# Multiple skills
-nemo skills install --agent claude --skill nemo-agents-secure --skill nemo-guardrails
-```
-
-Then invoke the freshly-installed skill — e.g. ask the user "I just installed the `nemo-agents-optimize` skill; want me to use it to walk through optimizing your agent now?"
-
-If a goal-relevant skill is **missing from `nemo skills list` entirely**, the plugin that ships it isn't installed. Install the plugin first, then re-run `nemo skills install`:
-
-```bash
-uv pip install -e plugins/<plugin-name>
-nemo skills install --agent <agent>            # picks up the new skill(s)
-```
+If the user has not stated a next goal, ask: "The platform is up. What would you like to do next: optimize an agent, deploy one, run inference, evaluate, generate data, or something else?"

--- a/skills/nemo-setup/SKILL.md
+++ b/skills/nemo-setup/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: nemo-setup
+description: Set up a local NeMo Platform (`make bootstrap` + `nemo setup`) — services, providers, plugins, default model, and an optional demo agent. Use when the user asks to install, bootstrap, set up, run, or start a local NeMo Platform.
+version: "0.1"
+metadata:
+  owner: nemo-platform
+  maturity: active
+license: Apache-2.0
+---
+
+# NeMo Platform Setup
+
+Get a local NeMo platform running on `localhost:8080`. Work through the prereq questions below before bootstrapping — they shape which services start and what state survives the run. When setup is finished, [What's next?](#whats-next) maps the user's stated goal to the right follow-up skill.
+
+> This document is the canonical setup guide at `skills/nemo-setup/SKILL.md`. Unlike the other skills, it is **not** installed by `nemo skills install` — it has to be available before the platform is bootstrapped, when the CLI may not yet exist.
+
+## Prerequisites
+
+- Python 3.11-3.13, Git, GNU Make, and `uv`.
+- Node.js and `pnpm` that satisfy `web/package.json`: currently Node.js `>=22.18.0 <23` and pnpm `>=10.32.1`. `make bootstrap` can start API services without Studio assets, but `make bootstrap-studio` requires these exact engine constraints.
+- An inference provider credential if the user wants setup to register a provider. [NVIDIA Build keys](https://build.nvidia.com/settings/api-keys) are expected in `$NVIDIA_API_KEY` and normally start with `nvapi-`.
+
+Do not print secret values. Never run broad environment dumps such as `env`, `printenv`, or `set` without filtering out secrets. To check whether a key exists, print only presence, for example `test -n "${NVIDIA_API_KEY:-}" && echo "NVIDIA_API_KEY is set"`. Do not send API keys to ad hoc network commands; only `nemo setup`, `nemo secrets`, or the documented provider-registration flow below should receive provider credentials.
+
+## Mandatory preflight decisions
+
+Before running `make bootstrap`, `nemo setup --auto`, `nemo services run`, or any state-changing setup command, the agent MUST ask the user for whether to reset an existing local database before proceeding.
+
+## Question 1 — Is a NeMo platform already running locally?
+
+Before starting `nemo services run`, check for an existing instance:
+
+```bash
+lsof -iTCP:8080 -sTCP:LISTEN
+ps -ef | grep "nemo services run" | grep -v grep
+```
+
+Alternatively, probe the API with `nemo workspaces list` — a workspaces table back means the platform is up. **Don't `curl /v1/workspaces`** to check; that path returns 404 even when the platform is healthy.
+
+If port 8080 is in use **or** a `nemo services run` process exists, do not silently start a new one — the new instance will fail to bind, and it gets confusing which platform is answering requests (the controller piece can still partially start and connect to the old API on `:8080`, producing logs that look like a fresh boot but are reading state from the old DB). Surface the exact PIDs and command line, then ask which path the user wants:
+
+- **(a) Kill the running platform and start fresh.** Use this when the running process is stale (long-running, crashed, or pre-dates the changes the user is now making). Procedure:
+  1. SIGTERM the exact PIDs — `kill <pid> [<pid>...]`
+  2. Wait ~10s; if still alive, **re-verify** each PID still matches a `nemo services run` command (paranoid check against PID reuse), then SIGKILL only those exact PIDs.
+  3. Only **after** the processes are gone, follow the user's reset decision from Question 3 below.
+- **(b) Keep it running and skip setup.** Use the running platform as-is — skip Switchyard install / DB wipe / startup entirely and proceed straight to your task. Caveats:
+  - Middleware plugins like `nemo-switchyard` are loaded at platform **startup**, so a VirtualModel that needs middleware the running platform did not load will fail. Confirm the loaded plugins by grepping the platform log for `Loaded inference middleware plugin` before assuming a middleware is available. The first VirtualModel create with `nemo-switchyard` either succeeds or returns `422 references unknown plugin 'nemo-switchyard'`; a 422 means restart is needed.
+  - The running services should include what the task needs: `inference-gateway`, `secrets`, `models`, `entities`, plus `guardrails` if the task uses rails. There is no public "list running services" endpoint — infer from feature attempts (`nemo guardrail configs list` returning 404 means the guardrails service isn't loaded).
+  - The user may already have the workspace / secret / provider seeded — check with `nemo workspaces list`, `nemo secrets list --workspace …`, and `nemo inference providers list --workspace …` before re-creating anything (creates may 409).
+- **(c) Abort and let the user investigate.**
+
+> ⚠️ **macOS unlinked-inode gotcha:** deleting data files in the `~/.local/share/nemo` while a `nemo services run` process is still alive does **not** reset state. The files get unlinked from the directory tree but the running process keeps writing to its open inode, and a freshly-spawned platform can see a new empty file while the old process still owns the data. Always stop the platform process first, then use the reset path from Question 3 only if the user confirmed it.
+
+## Question 2 — Local data directory?
+
+Confirm where the user wants local platform state (entity-store DB, encryption key, files-service uploads) persisted. Use the same prompt language as `nemo setup`:
+
+> **Local data directory:** `~/.local/share/nemo`
+
+Most users accept the default. Override paths follow XDG conventions:
+
+1. **`$NMP_DATA_DIR`** (most explicit) — used as-is, no `/nemo` suffix appended.
+2. **`$XDG_DATA_HOME/nemo`** — if `XDG_DATA_HOME` is set in the shell.
+3. **`~/.local/share/nemo`** — the default.
+
+If the user picks a custom path, export it before starting services so the spawned platform inherits it:
+
+```bash
+export NMP_DATA_DIR=/custom/path/to/state
+```
+
+`nemo setup` persists the choice to `~/.config/nmp/config.yaml` under `local_services.data_dir` and re-uses it on subsequent runs. If you're running services manually (not via `nemo setup`), set `NMP_DATA_DIR` yourself each session.
+
+## Question 3 — Wipe the local DB?
+
+Ask whether the user wants to reset the local entity-store database before platform startup. Warn clearly that this deletes local platform state, including secret metadata and the local encryption key. Providers/secrets must be re-seeded afterward. If the database and encryption key get out of sync, later runs can fail with decryption errors such as `cryptography.exceptions.InvalidTag`. **The wipe only works if no `nemo services run` process is currently holding the file open** (see the macOS gotcha under Question 1). Only if the user confirms, you can reset the data by deleting content of what was chosen in Q2 (`$NMP_DATA_DIR`, `$XDG_DATA_HOME/nemo`, or the default `~/.local/share/nemo`) before starting the service `nemo services run`. Make sure to ask user before proceeding. 
+---
+
+## Bootstrap and start
+
+The README documents the streamlined path. Prefer this over the manual steps below whenever the task fits — it covers prerequisites install, service startup, provider registration, default-model selection, and demo agent deployment in one shot:
+
+```bash
+make bootstrap           # installs Python deps, Studio assets, and plugins (including demo calculator agent)
+source .venv/bin/activate
+nemo setup               # interactive: prompts for provider, picks default model, optionally deploys calculator-agent
+```
+
+Non-interactive equivalent (useful for CI / agent-driven invocations):
+
+```bash
+export NVIDIA_API_KEY=nvapi-...
+nemo setup --auto --start-services --install-skills --deploy-agent
+```
+
+`make bootstrap` is the umbrella for three finer-grained targets — use these if you only need a subset:
+
+| Target | What it does |
+|---|---|
+| `make bootstrap-python` | Creates `.venv` and runs `uv sync` (Python deps + workspace packages) |
+| `make bootstrap-studio` | Installs web deps via `pnpm` and builds Studio assets for FastAPI |
+
+`make clean` removes the venv; `make clean-python` is the venv-only variant.
+
+If `nemo setup` is too high-level for the task (e.g. debugging startup, custom service set, custom plugin install after bootstrap), use the manual sections below.
+
+### Default model selection (under `--auto`)
+
+`$NEMO_DEFAULT_MODEL` **must be a hyphenated entity ID** from `nemo models list` (e.g. `nvidia-llama-3-3-nemotron-super-49b-v1-5` or `default/nvidia-llama-3-3-nemotron-super-49b-v1-5`). The slash-with-dots form (`nvidia/llama-3.3-nemotron-super-49b-v1-5`) is the upstream catalog's `served_model_name` — it's shown for human display but the gateway rejects it as a request input.
+
+`nemo setup --auto` picks the default model in this order:
+
+1. `$NEMO_DEFAULT_MODEL` (if set) — used as-is. The user may have exported this from a previous session; it takes precedence over anything discovered from the registered provider.
+2. Otherwise, the first model entity returned by provider discovery.
+
+If the user is surprised by which model got picked, check `echo $NEMO_DEFAULT_MODEL` first — that's the most common cause.
+
+The first-discovered fallback is intentionally simple — providers like NVIDIA Build expose dozens of models and "first one" rarely matches the user's intent. If the user wants a specific model as the default (or wants to compare options before committing), don't rely on the `--auto` fallback. After setup finishes, the `inference` skill's "Step 2 — Discover available models" enumerates entity IDs and shows the jq filters for picking one out by vendor or family. The user can then pin their choice via `export NEMO_DEFAULT_MODEL=<workspace>/<entity-id>` or by overriding `body["model"]` per request.
+
+If `nemo agents invoke …` fails with HTTP 422 in under a second on the first call, the cause is almost always a slash-with-dots model name reaching the gateway (e.g. via a stale `NEMO_DEFAULT_MODEL` or an agent config that hardcoded the upstream catalog form). The `inference` skill's "Common failure: HTTP 422 from chat completion" subsection has the diagnose-and-recover steps — don't conclude the platform is broken.
+
+### Starting the platform (without Switchyard)
+
+If `make bootstrap` has already run, just start the services. `nemo setup` does this for you; the manual equivalent is:
+
+```bash
+uv run nemo services run \
+  --services entities,models,inference-gateway,secrets \
+  --controllers models
+```
+
+### Starting the platform with Switchyard middleware
+
+`make bootstrap-python` and bare `uv sync` install `plugins/nemo-switchyard` through the root workspace's `enabled-plugins` group. The Switchyard library is vendored in-tree at `plugins/nemo-switchyard/vendor/switchyard/` (a snapshot pinned in `tool.uv.sources`) — no separate Switchyard checkout, `SWITCHYARD_PATH` env var, or PyPI workaround is needed. Start with debug logging to see routing decisions:
+
+```bash
+# Start with LOG_LEVEL=DEBUG to see routing decisions.
+LOG_LEVEL=DEBUG uv run nemo services run \
+  --services entities,models,inference-gateway,secrets \
+  --controllers models
+```
+
+`nemo-switchyard` is auto-discovered via its `nemo.inference_middleware` entry point once dependencies are installed.
+
+### Demo agent
+
+`make bootstrap` installs the NeMo agents plugin and the calculator-agent example through the root workspace, so no separate `uv pip install` is needed. After services start, `nemo setup` (or `nemo setup --auto --deploy-agent`) will deploy a demo `calculator-agent` in the default workspace. Verify with:
+
+```bash
+nemo agents list
+nemo agents invoke --agent calculator-agent --input "What is 12 * 8?"
+```
+
+### Local platform environment summary
+
+- **Port**: `8080` (CLI default — do NOT pass a custom `--base-url`).
+- **`export NMP_BASE_URL=http://localhost:8080` — required when targeting a local platform.** If your `~/.config/nmp/config.yaml` already points at a remote cluster, the CLI uses that base URL and ignores the local platform entirely. Setting this env var overrides the config file for the current shell session.
+- **Reset state:** only after the user explicitly confirms Question 3 for the exact chosen data directory.
+
+---
+
+## What's next?
+
+The platform is running. Don't leave the user with "you're good to go" — offer a menu of what they can do next based on what they originally asked for. Match the user's intent to one of the patterns from the [README's "Use NeMo Platform from your coding agent" section](/README.md#use-nemo-platform-from-your-coding-agent):
+
+| User says… | Goal | Follow-up skill |
+|---|---|---|
+| "Optimize my agent", "my agent is too slow / using too many tokens" | Cost / latency optimization via routing or skill tuning | `nemo-agents-optimize` |
+| "Secure my agent", "my agent is producing dangerous output" | Content safety / red-team / leak audit | `nemo-agents-secure`, `nemo-guardrails`, `nemo-auditor` |
+| "Can my agent use multiple models?", "split traffic across N backends" | Multi-backend routing via Switchyard | (inline; see `inference` skill) |
+| "Evaluate my model / agent on \<benchmark\>" | Eval against a dataset / harness | `nemo-evaluator`, `nemo-evaluator-plugin` |
+| "Generate synthetic data", "I have sensitive data and need…" | Data generation / anonymization / safe synthesis | `nemo-data-designer-plugin`, `nemo-anonymizer`, `nemo-safe-synthesizer` |
+| "Just deploy / invoke an agent" | Deploy the demo calculator agent or your own | `nemo-agents-optimize` (later, if needed) |
+| "Chat with a model", "call \<model\> via inference" | Plain inference through IGW | `inference` skill |
+| "Register an inference provider" (no further use case) | Provider registration only | `inference` skill |
+
+If the user's prompt doesn't already pin one down, ask: *"The platform is up. What would you like to do next — optimize an agent, deploy one, run inference, evaluate, generate data, or something else?"*
+
+If the user wants to **pick or swap the default model** (e.g. they didn't like the one `--auto` selected, or they want to compare options), don't guess — hand off to the `inference` skill. Step 2 there enumerates `served_models[].model_entity_id` and shows jq filters for picking by vendor / family. To pin the choice for subsequent runs, export `NEMO_DEFAULT_MODEL=<workspace>/<entity-id>` before the next `nemo setup --auto`. For one-off commands, pass the entity ID positionally: `nemo chat <entity-id>`.
+
+### Available skills
+
+`nemo skills list` is the canonical check for what's actually loaded — the entries depend on which plugins are installed. Expected entries after `make bootstrap`:
+
+CLI built-ins (always present):
+
+- **`inference`** — ModelProvider + VirtualModel + Switchyard reference. End-to-end inference flow, routing patterns, middleware ordering, troubleshooting.
+
+> Setup lives at `skills/nemo-setup/SKILL.md` rather than as a CLI-installable skill, since coding agents need it before the platform is bootstrapped.
+
+Plugin-provided (appear once the plugin is installed):
+
+- **`nemo-agents-optimize`** — optimize a deployed agent (routing splits, skill tuning, prompt tuning, evals against newer models). From `plugins/nemo-agents`.
+- **`nemo-agents-secure`** — audit a deployed agent for missing guardrails, PII exposure, leaked secrets/keys. From `plugins/nemo-agents`.
+- **`nemo-guardrails`** — guardrail config CRUD, content-safety rails, the `nemo-guardrails` middleware. From `plugins/nemo-guardrails`.
+- **`nemo-auditor`** — vulnerability scanning, audit configs/targets/jobs, red-team probes. From `plugins/nemo-auditor`.
+- **`nemo-evaluator`** / **`nemo-evaluator-plugin`** — metrics, sync/async evaluations, llm-judge, benchmark jobs. From `plugins/nemo-evaluator`.
+- **`nemo-data-designer-plugin`** — synthetic dataset generation pipelines. From `plugins/nemo-data-designer`.
+- **`nemo-entities`**, **`nemo-files`**, **`nemo-secrets`**, **`nemo-auth`**, **`nemo-inference-gateway`** — CLI references for the matching services.
+
+### Installing skills into the coding agent on demand
+
+`nemo skills list` lists every skill the **platform** can install — but that's not the same as what's currently loaded in the coding agent (Claude Code, Cursor, Codex, OpenCode). After `make bootstrap` finishes, the relevant subset must still be **installed into the coding agent** for it to actually use them.
+
+Default flow (already wired into `nemo setup`):
+
+```bash
+nemo skills install --agent <claude|cursor|codex|opencode>
+```
+
+With no `--skill` flag, this installs **all** skills from `nemo skills list` into the chosen agent. Run it again any time `nemo skills list` changes (new plugin installed, plugin updated).
+
+If the user's goal in the table above maps to a skill that you (the coding agent) don't currently have in this session, install only the skills you need rather than all of them:
+
+```bash
+# Single skill
+nemo skills install --agent claude --skill nemo-agents-optimize
+
+# Multiple skills
+nemo skills install --agent claude --skill nemo-agents-secure --skill nemo-guardrails
+```
+
+Then invoke the freshly-installed skill — e.g. ask the user "I just installed the `nemo-agents-optimize` skill; want me to use it to walk through optimizing your agent now?"
+
+If a goal-relevant skill is **missing from `nemo skills list` entirely**, the plugin that ships it isn't installed. Install the plugin first, then re-run `nemo skills install`:
+
+```bash
+uv pip install -e plugins/<plugin-name>
+nemo skills install --agent <agent>            # picks up the new skill(s)
+```

--- a/skills/nemo-setup/evals/evals.json
+++ b/skills/nemo-setup/evals/evals.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "setup-fresh-local-platform",
+    "question": "Set up NeMo Platform locally so I can start developing.",
+    "expected_skill": "nemo-setup",
+    "expected_script": null,
+    "ground_truth": "Run `make bootstrap` to install Python dependencies, Studio assets, and plugins. Then activate the venv with `source .venv/bin/activate` and run `nemo setup` (interactive) or `nemo setup --auto --start-services --install-skills --deploy-agent` (non-interactive). The platform will be available at localhost:8080. Before starting, check if port 8080 is already in use and decide whether to wipe the local DB at ~/.local/share/nemo.",
+    "expected_behavior": [
+      "Check if a NeMo platform is already running on port 8080",
+      "Ask about the local data directory preference (default ~/.local/share/nemo)",
+      "Ask whether to wipe the existing local database",
+      "Run make bootstrap followed by nemo setup",
+      "Verify services are running on localhost:8080",
+      "Offer next-step options based on the user's goal"
+    ]
+  }
+]

--- a/skills/nemo-setup/evals/evals.json
+++ b/skills/nemo-setup/evals/evals.json
@@ -4,14 +4,29 @@
     "question": "Set up NeMo Platform locally so I can start developing.",
     "expected_skill": "nemo-setup",
     "expected_script": null,
-    "ground_truth": "Run `make bootstrap` to install Python dependencies, Studio assets, and plugins. Then activate the venv with `source .venv/bin/activate` and run `nemo setup` (interactive) or `nemo setup --auto --start-services --install-skills --deploy-agent` (non-interactive). The platform will be available at localhost:8080. Before starting, check if port 8080 is already in use and decide whether to wipe the local DB at ~/.local/share/nemo.",
+    "ground_truth": "Use the nemo-setup skill and complete the safe default local setup path. Check whether localhost:8080 or a `nemo services run` process is already active, run `make bootstrap`, activate the venv with `source .venv/bin/activate`, set `NMP_BASE_URL=http://localhost:8080`, then run `nemo setup --auto --start-services --install-skills --deploy-agent` when a provider credential is present. If no provider credential is present, start local services and install skills where possible, then report that provider registration needs a supported API key. Preserve the default local data directory and existing DB unless the user explicitly requested reset. Verify with `nemo workspaces list` or `nemo services status`, and offer next-step options.",
     "expected_behavior": [
-      "Check if a NeMo platform is already running on port 8080",
-      "Ask about the local data directory preference (default ~/.local/share/nemo)",
-      "Ask whether to wipe the existing local database",
-      "Run make bootstrap followed by nemo setup",
-      "Verify services are running on localhost:8080",
-      "Offer next-step options based on the user's goal"
+      "Checks for an existing local NeMo Platform or port 8080 conflict before starting services",
+      "Uses the default local data directory and preserves existing DB state without pausing for reset confirmation",
+      "Runs `make bootstrap`, activates `.venv`, and sets `NMP_BASE_URL=http://localhost:8080`",
+      "Runs `nemo setup` with start-services and skill-install options, using the non-interactive `--auto --start-services --install-skills --deploy-agent` path when provider credentials are available",
+      "Verifies services are reachable on localhost:8080 with NeMo CLI commands",
+      "Offers concise next-step options based on the user's goal"
+    ]
+  },
+  {
+    "id": "setup-reset-local-platform",
+    "question": "Reset my local NeMo Platform state and set it up again from scratch.",
+    "expected_skill": "nemo-setup",
+    "expected_script": null,
+    "ground_truth": "Use the nemo-setup reset path only because the user explicitly asked for reset. Warn that reset deletes local platform state, secret metadata, and the local encryption key. Check for any running `nemo services run` process or port 8080 owner before deleting data. Ask for explicit confirmation before deleting the active data directory, defaulting to `~/.local/share/nemo` unless `NMP_DATA_DIR` or `XDG_DATA_HOME` changes it. After confirmed reset, run the normal setup flow and verify localhost:8080.",
+    "expected_behavior": [
+      "Recognizes reset as destructive and asks for explicit confirmation before deleting local state",
+      "Checks for and stops any running `nemo services run` process before deleting data, asking before killing exact PIDs",
+      "Identifies the active local data directory using `NMP_DATA_DIR`, `XDG_DATA_HOME`, or the default `~/.local/share/nemo`",
+      "Runs the normal setup flow after reset is confirmed",
+      "Verifies services are reachable on localhost:8080",
+      "Does not print provider secret values or dump the full environment"
     ]
   }
 ]

--- a/skills/nemo-setup/references/configuration.md
+++ b/skills/nemo-setup/references/configuration.md
@@ -1,0 +1,35 @@
+# NeMo Setup Configuration
+
+Load this reference when the user asks about local data paths, coding-agent skill installation, or setup configuration details outside the fast path.
+
+## Local Data Directory
+
+Local platform state includes the entity-store DB, encryption key, and files-service uploads.
+
+Resolution order:
+
+1. `NMP_DATA_DIR` exactly as set
+2. `$XDG_DATA_HOME/nemo`
+3. `~/.local/share/nemo`
+
+If the user picks a custom path, export it before starting services:
+
+```bash
+export NMP_DATA_DIR=/custom/path/to/state
+```
+
+`nemo setup` persists the choice to `~/.config/nmp/config.yaml` under `local_services.data_dir`.
+
+## Skill Install
+
+`nemo skills list` lists platform-provided skills, but coding agents need those skills installed into their own skill directories. `nemo setup` normally handles this. To refresh manually:
+
+```bash
+nemo skills install --agent <claude|cursor|codex|opencode>
+```
+
+Install a single skill when only one follow-up workflow is needed:
+
+```bash
+nemo skills install --agent claude --skill nemo-agents-optimize
+```

--- a/skills/nemo-setup/references/manual-start.md
+++ b/skills/nemo-setup/references/manual-start.md
@@ -1,0 +1,15 @@
+# Manual Service Startup
+
+Load this reference when the user asks to run only the local services, debug service startup directly, or avoid the higher-level `nemo setup` wizard.
+
+If `nemo setup` is too high-level for debugging, start the core services manually after bootstrap:
+
+```bash
+source .venv/bin/activate
+export NMP_BASE_URL=http://localhost:8080
+uv run nemo services run \
+  --services entities,models,inference-gateway,secrets \
+  --controllers models
+```
+
+Use `nemo setup` again for provider registration, default-model selection, skill install, and demo-agent deployment.

--- a/skills/nemo-setup/references/switchyard.md
+++ b/skills/nemo-setup/references/switchyard.md
@@ -1,0 +1,15 @@
+# Switchyard Middleware
+
+Load this reference when the user asks about routing, middleware, Switchyard, VirtualModels, or `nemo-switchyard` plugin loading.
+
+`make bootstrap-python` and bare `uv sync` install `plugins/nemo-switchyard` through the workspace `enabled-plugins` group. The Switchyard library is vendored in-tree at `plugins/nemo-switchyard/vendor/switchyard/`; no separate checkout, `SWITCHYARD_PATH`, or PyPI workaround is needed.
+
+Start with debug logging when investigating routing:
+
+```bash
+LOG_LEVEL=DEBUG uv run nemo services run \
+  --services entities,models,inference-gateway,secrets \
+  --controllers models
+```
+
+Middleware plugins load at platform startup. If a `VirtualModel` create fails with `422 references unknown plugin 'nemo-switchyard'`, restart services after bootstrap.

--- a/skills/nemo-setup/references/troubleshooting.md
+++ b/skills/nemo-setup/references/troubleshooting.md
@@ -1,0 +1,40 @@
+# NeMo Setup Troubleshooting
+
+Load this reference only when the fast path in `../SKILL.md` fails or the user asks for failure recovery.
+
+## Existing Service Or Port Conflict
+
+Before starting services:
+
+```bash
+lsof -iTCP:8080 -sTCP:LISTEN || true
+ps -ef | grep "nemo services run" | grep -v grep || true
+```
+
+If a healthy NeMo Platform is already running, keep it and verify with `nemo workspaces list`. If the process is stale or the user wants a fresh run, ask before killing exact PIDs.
+
+Safe stop sequence:
+
+1. `kill <pid> [<pid>...]`
+2. wait about 10 seconds
+3. re-check that each PID still belongs to `nemo services run`
+4. use SIGKILL only for those exact still-running PIDs
+
+## Stale DB Or Encryption-Key Errors
+
+If the database and encryption key get out of sync, later runs can fail with errors such as `cryptography.exceptions.InvalidTag`.
+
+Reset only after explicit user confirmation. Warn that reset deletes local platform state, secret metadata, and the local encryption key. Stop `nemo services run` first; on macOS, deleting files while the process is alive can unlink the visible file while the running process keeps writing to the old inode.
+
+## Default Model 422
+
+`NEMO_DEFAULT_MODEL` must be a hyphenated model entity ID from `nemo models list`, for example `default/nvidia-llama-3-3-nemotron-super-49b-v1-5`. The upstream catalog form with slash and dots, such as `nvidia/llama-3.3-nemotron-super-49b-v1-5`, is display-oriented and can be rejected by the gateway.
+
+If `nemo agents invoke ...` fails with HTTP 422 in under a second, check:
+
+```bash
+echo "${NEMO_DEFAULT_MODEL:-}"
+nemo models list
+```
+
+Then choose the entity ID via the `inference` skill.


### PR DESCRIPTION
## Summary

Refines the `nemo-setup` skill so the default path completes local setup instead of stopping at preflight questions, and reorganizes setup reference material by intent.

## What changed

- Rewrote `skills/nemo-setup/SKILL.md` around a completion-oriented fast path: check local service/port state, run `make bootstrap`, activate `.venv`, set `NMP_BASE_URL=http://localhost:8080`, run `nemo setup`, verify local services, then offer next steps.
- Updated `skills/nemo-setup/evals/evals.json` so the fresh setup case rewards safe defaults and setup completion, not mandatory data-dir/reset questions.
- Added a separate reset eval case so destructive reset confirmation remains covered without blocking the normal setup flow.
- Split reference content by usage:
  - `configuration.md` for custom data paths and coding-agent skill install details.
  - `manual-start.md` for service-only/manual startup.
  - `switchyard.md` for routing/middleware/VirtualModel setup.
  - `troubleshooting.md` for true failure recovery such as port conflicts, stale DB/encryption-key issues, and default-model 422s.

## Why

The attached validation report showed high-severity `AGENT_EVAL` regressions from negative live-eval lift. The trial evidence pointed to agents, especially Codex, following the skill but stopping after data-directory/reset questions instead of running `make bootstrap` and `nemo setup`. Efficiency also dropped because the main skill loaded too much branching guidance in the hot path.

This change keeps the normal path concise and action-oriented while preserving destructive confirmation and advanced setup details behind targeted references.

## Validation

- `python3 -m json.tool skills/nemo-setup/evals/evals.json`
- `astra-skill-eval validate skills/nemo-setup`
- `rg -n "Local Data Directory|Manual Service Startup|Switchyard Middleware|Skill Install|configuration\\.md|manual-start\\.md|switchyard\\.md|troubleshooting\\.md" skills/nemo-setup`
