### PR TITLE
feat(studio): add unified Fileset create modal

### DIFF
--- a/web/packages/common/src/utils/filesetName.test.ts
+++ b/web/packages/common/src/utils/filesetName.test.ts
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  FILESET_NAME_MAX_LENGTH,
+  FILESET_NAME_REGEXP,
+  toValidFilesetName,
+} from '@nemo/common/src/utils/filesetName';
+
+describe('toValidFilesetName', () => {
+  describe('produces output that satisfies FILESET_NAME_REGEXP', () => {
+    const inputs = [
+      'Qwen3.6-35B-A3B-MTP-GGUF', // HF slug with uppercase
+      'mistralai/Mistral-7B-Instruct-v0.3',
+      'hello world',
+      '   leading-trailing   ',
+      '123-starts-with-digit',
+      '@starts-with-at',
+      'has--double--dashes',
+      'ends-with-dash-',
+      'name.with.dots',
+      'with_underscore',
+      'has+plus@symbol',
+      'a'.repeat(120), // long input
+    ];
+    it.each(inputs)('%s -> matches regex', (input) => {
+      const out = toValidFilesetName(input);
+      expect(out).toMatch(FILESET_NAME_REGEXP);
+    });
+  });
+
+  it('lowercases letters', () => {
+    expect(toValidFilesetName('ABC')).toBe('abc');
+  });
+
+  it('preserves a valid name unchanged (apart from trimming/lowercasing)', () => {
+    expect(toValidFilesetName('qwen3.6-35b-a3b-mtp-gguf')).toBe('qwen3.6-35b-a3b-mtp-gguf');
+  });
+
+  it('replaces invalid chars with a single hyphen', () => {
+    expect(toValidFilesetName('a b c')).toBe('a-b-c');
+    expect(toValidFilesetName('a!!!b')).toBe('a-b');
+  });
+
+  it('collapses consecutive hyphens to one', () => {
+    expect(toValidFilesetName('a--b---c')).toBe('a-b-c');
+  });
+
+  it('strips leading non-letter characters', () => {
+    expect(toValidFilesetName('123abc')).toBe('abc');
+    expect(toValidFilesetName('@home')).toBe('home');
+    expect(toValidFilesetName('--leading-dash')).toBe('leading-dash');
+  });
+
+  it('strips trailing hyphens', () => {
+    expect(toValidFilesetName('abc---')).toBe('abc');
+  });
+
+  it('truncates to FILESET_NAME_MAX_LENGTH and removes a newly-exposed trailing dash', () => {
+    const padded = `a${'-b'.repeat(50)}`; // alternating ending up with - at boundary
+    const out = toValidFilesetName(padded);
+    expect(out.length).toBeLessThanOrEqual(FILESET_NAME_MAX_LENGTH);
+    expect(out.endsWith('-')).toBe(false);
+  });
+
+  it('falls back to "fileset" when the sanitized result is too short', () => {
+    expect(toValidFilesetName('')).toBe('fileset');
+    expect(toValidFilesetName('---')).toBe('fileset');
+    expect(toValidFilesetName('@')).toBe('fileset');
+    expect(toValidFilesetName('a')).toBe('fileset'); // length 1 < min 2
+  });
+
+  it('handles HuggingFace-style slugs', () => {
+    expect(toValidFilesetName('Llama-3.2-3B-Instruct')).toBe('llama-3.2-3b-instruct');
+    expect(toValidFilesetName('SDXL/refiner-1.0')).toBe('sdxl-refiner-1.0');
+  });
+
+  it('handles NGC-style targets', () => {
+    expect(toValidFilesetName('ngc_cli')).toBe('ngc_cli');
+    expect(toValidFilesetName('llama2_7b_chat_hf')).toBe('llama2_7b_chat_hf');
+  });
+});

--- a/web/packages/common/src/utils/filesetName.ts
+++ b/web/packages/common/src/utils/filesetName.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Mirrors the entity store's RFC-1035-ish name pattern from
+ * `packages/nmp_common/src/nmp/common/entities/constants.py` (`NAME_PATTERN`):
+ *
+ *   ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
+ *
+ *   - 2-63 chars total
+ *   - First char must be a lowercase letter
+ *   - Body chars: lowercase letters, digits, `-`, `@`, `.`, `+`, `_`
+ *   - No consecutive `--`
+ *   - No trailing `-`
+ *
+ * The Files service's `CreateFilesetRequest` DTO advertises a looser pattern
+ * (`^[\w\-.]+$`, max 255), which is what OpenAPI/orval pulls into zod. The
+ * stricter pattern is only enforced downstream by the entity store, so the
+ * generated SDK and a naive sanitizer let invalid names through to a confusing
+ * 422 at write time.
+ */
+
+/** Source-of-truth regex for fileset names. */
+export const FILESET_NAME_REGEXP = /^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$/;
+
+/** Max length (first char + 62) per the entity store pattern. */
+export const FILESET_NAME_MAX_LENGTH = 63;
+
+/** Fallback when the input sanitizes down to nothing valid. */
+const FALLBACK = 'fileset';
+
+const INVALID_BODY = /[^a-z0-9\-@.+_]+/g;
+const COLLAPSE_DASHES = /-{2,}/g;
+const STRIP_LEADING_NON_LETTER = /^[^a-z]+/;
+const STRIP_TRAILING_DASH = /-+$/;
+
+/**
+ * Rewrite any input into a value that satisfies `FILESET_NAME_REGEXP`.
+ *
+ * Strategy: lowercase, replace disallowed body chars with `-`, collapse `--`,
+ * strip leading non-letter chars (first char must be `[a-z]`), strip trailing
+ * `-`, truncate to 63 chars, then strip any newly-exposed trailing `-`.
+ * Falls back to `"fileset"` when nothing valid remains.
+ */
+export function toValidFilesetName(input: string): string {
+  let s = input
+    .trim()
+    .toLowerCase()
+    .replace(INVALID_BODY, '-')
+    .replace(COLLAPSE_DASHES, '-')
+    .replace(STRIP_LEADING_NON_LETTER, '')
+    .replace(STRIP_TRAILING_DASH, '')
+    .slice(0, FILESET_NAME_MAX_LENGTH)
+    .replace(STRIP_TRAILING_DASH, '');
+
+  // Min length is 2 (one leading letter + at least one body char).
+  if (s.length < 2) s = FALLBACK;
+  return s;
+}

--- a/web/packages/studio/src/components/DatasetsTable/index.tsx
+++ b/web/packages/studio/src/components/DatasetsTable/index.tsx
@@ -33,6 +33,8 @@ import { DeleteConfirmationModal } from '@studio/components/DeleteConfirmationMo
 import { DocumentationButton } from '@studio/components/DocumentationButton';
 import { Loading } from '@studio/components/Layouts/Loading';
 import { NewDatasetButton } from '@studio/components/NewDatasetButton';
+import { NewModelFilesetButton } from '@studio/components/NewModelFilesetButton';
+import { FILESET_DETAILS_ENABLED } from '@studio/constants/environment';
 import { LINK_DOCS_DATASETS } from '@studio/constants/links';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { DatasetBulkDeleteModal } from '@studio/routes/FilesetListRoute/DatasetBulkDeleteModal';
@@ -548,6 +550,7 @@ export const DatasetsTable: FC<DatasetsTableProps> = ({
                     <>
                       <DocumentationButton href={LINK_DOCS_DATASETS} />
                       <NewDatasetButton />
+                      {FILESET_DETAILS_ENABLED && <NewModelFilesetButton />}
                     </>
                   }
                 />

--- a/web/packages/studio/src/components/FilesetCreateModal/constants.ts
+++ b/web/packages/studio/src/components/FilesetCreateModal/constants.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 const NAME_REQUIRED_MESSAGE = 'Name is required.';
 
 const NAME_PATTERN_MESSAGE =
-  'Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).';
+  'Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, dots, underscores, plus, and @ (no consecutive hyphens, cannot end with a hyphen).';
 
 export enum StorageMode {
   Local = 'local',

--- a/web/packages/studio/src/components/FilesetCreateModal/constants.ts
+++ b/web/packages/studio/src/components/FilesetCreateModal/constants.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { FILESET_NAME_MAX_LENGTH, FILESET_NAME_REGEXP } from '@nemo/common/src/utils/filesetName';
+import { FilesetPurpose } from '@nemo/sdk/generated/platform/schema';
+import { FilesCreateFilesetBody } from '@nemo/sdk/generated/platform/zod/files';
+import { z } from 'zod';
+
+const NAME_REQUIRED_MESSAGE = 'Name is required.';
+
+const NAME_PATTERN_MESSAGE =
+  'Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).';
+
+export enum StorageMode {
+  Local = 'local',
+  External = 'external',
+}
+
+export type SupportedPurpose = typeof FilesetPurpose.dataset | typeof FilesetPurpose.model;
+
+// Override the SDK-generated `name` validation. The generated zod uses the
+// Files service DTO's loose pattern (`^[\w\-.]+$`, max 255); the entity store
+// downstream enforces a stricter RFC-1035-ish pattern. We validate against the
+// strict one here so the user sees a useful error instead of a 422 toast.
+export const filesetCreateFormSchema = FilesCreateFilesetBody.pick({
+  name: true,
+  description: true,
+}).extend({
+  name: z
+    .string()
+    .trim()
+    .min(1, NAME_REQUIRED_MESSAGE)
+    .max(FILESET_NAME_MAX_LENGTH)
+    .regex(FILESET_NAME_REGEXP, NAME_PATTERN_MESSAGE),
+  url: z.string().optional(),
+  secretKey: z.string().optional(),
+});
+
+export type FilesetCreateFormData = z.infer<typeof filesetCreateFormSchema>;
+
+export const PURPOSE_COPY: Record<SupportedPurpose, { title: string; submit: string }> = {
+  [FilesetPurpose.dataset]: {
+    title: 'Create Dataset',
+    submit: 'Create Dataset',
+  },
+  [FilesetPurpose.model]: {
+    title: 'Create Model Fileset',
+    submit: 'Create Model Fileset',
+  },
+};

--- a/web/packages/studio/src/components/FilesetCreateModal/index.spec.tsx
+++ b/web/packages/studio/src/components/FilesetCreateModal/index.spec.tsx
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { MockToastProvider } from '@nemo/common/src/tests/MockToastProvider';
+import type { FilesetOutput } from '@nemo/sdk/generated/platform/schema';
+import { FilesetPurpose } from '@nemo/sdk/generated/platform/schema';
+import { FilesetCreateModal } from '@studio/components/FilesetCreateModal';
+import { ROUTE_PARAMS } from '@studio/constants/routes';
+import { mockUseNavigate, mockUseParams } from '@studio/tests/util/mockUseParams';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+
+// Hoisted mocks for hooks the modal calls.
+const { mockMutate, mockUseRemoteRepoMetadata } = vi.hoisted(() => ({
+  mockMutate: vi.fn<(args: unknown) => Promise<FilesetOutput>>(),
+  mockUseRemoteRepoMetadata: vi.fn<
+    (url: string | undefined, enabled: boolean) => {
+      data: { slug: string; description: string | null } | null | undefined;
+      isFetching: boolean;
+    }
+  >(),
+}));
+
+vi.mock('@nemo/sdk/generated/platform/api', async () => {
+  const actual = await vi.importActual<typeof import('@nemo/sdk/generated/platform/api')>(
+    '@nemo/sdk/generated/platform/api'
+  );
+  return {
+    ...actual,
+    useFilesCreateFileset: () => ({ mutateAsync: mockMutate, isPending: false }),
+  };
+});
+
+vi.mock('@studio/hooks/useRemoteRepoMetadata', () => ({
+  useRemoteRepoMetadata: (url: string | undefined, enabled: boolean) =>
+    mockUseRemoteRepoMetadata(url, enabled),
+}));
+
+// SecretSearchableSelect pulls in a heavier dep tree; replace with a stub
+// since we only assert that the External fields appear, not their internals.
+vi.mock('@studio/routes/SecretsListRoute/SecretSearchableSelect', () => ({
+  SecretSearchableSelect: () => <div data-testid="secret-select-stub" />,
+}));
+
+vi.mock('@studio/routes/SecretsListRoute/CreateSecretModal', () => ({
+  CreateSecretModal: () => null,
+}));
+
+const FILESET_RESPONSE: FilesetOutput = {
+  id: 'fs-id',
+  name: 'mod3',
+  workspace: 'default',
+  description: '',
+  purpose: 'model',
+  storage: { type: 'local', path: '/data' },
+  metadata: {},
+  custom_fields: {},
+  project: 'default',
+  created_at: '2026-05-29T00:00:00Z',
+  updated_at: '2026-05-29T00:00:00Z',
+};
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <MockToastProvider>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>{children}</BrowserRouter>
+      </QueryClientProvider>
+    </MockToastProvider>
+  );
+}
+
+describe('FilesetCreateModal', () => {
+  beforeEach(() => {
+    mockUseParams({ [ROUTE_PARAMS.workspace]: 'default' });
+    mockUseNavigate();
+    mockMutate.mockReset();
+    mockMutate.mockResolvedValue(FILESET_RESPONSE);
+    mockUseRemoteRepoMetadata.mockReset();
+    mockUseRemoteRepoMetadata.mockReturnValue({ data: undefined, isFetching: false });
+  });
+
+  describe('heading + submit copy by purpose', () => {
+    it.each([
+      [FilesetPurpose.dataset, 'Create Dataset'],
+      [FilesetPurpose.model, 'Create Model Fileset'],
+    ])('purpose=%s renders %s', (purpose, expected) => {
+      const Wrapper = makeWrapper();
+      render(
+        <Wrapper>
+          <FilesetCreateModal
+            open
+            onClose={vi.fn()}
+            workspace="default"
+            purpose={purpose as typeof FilesetPurpose.dataset | typeof FilesetPurpose.model}
+          />
+        </Wrapper>
+      );
+      // Heading + primary button both use the same copy.
+      const matches = screen.getAllByText(expected);
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('storage mode toggle', () => {
+    it('shows only Name + Description in Local mode', () => {
+      const Wrapper = makeWrapper();
+      render(
+        <Wrapper>
+          <FilesetCreateModal
+            open
+            onClose={vi.fn()}
+            workspace="default"
+            purpose={FilesetPurpose.dataset}
+          />
+        </Wrapper>
+      );
+      expect(screen.getByRole('textbox', { name: /^name$/i })).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /description/i })).toBeInTheDocument();
+      expect(screen.queryByRole('textbox', { name: /^url$/i })).not.toBeInTheDocument();
+      expect(screen.queryByTestId('secret-select-stub')).not.toBeInTheDocument();
+    });
+
+    it('shows URL + Secret above Name in External mode', async () => {
+      const user = userEvent.setup();
+      const Wrapper = makeWrapper();
+      render(
+        <Wrapper>
+          <FilesetCreateModal
+            open
+            onClose={vi.fn()}
+            workspace="default"
+            purpose={FilesetPurpose.dataset}
+          />
+        </Wrapper>
+      );
+      await user.click(screen.getByRole('radio', { name: 'External' }));
+      expect(screen.getByRole('textbox', { name: /^url$/i })).toBeInTheDocument();
+      expect(screen.getByTestId('secret-select-stub')).toBeInTheDocument();
+    });
+  });
+
+  describe('remote metadata auto-fill (External mode)', () => {
+    it('fills the name from the slug when the field has not been edited', async () => {
+      const user = userEvent.setup();
+      mockUseRemoteRepoMetadata.mockReturnValue({
+        data: { slug: 'Qwen3.6-35B-A3B-MTP-GGUF', description: null },
+        isFetching: false,
+      });
+      const Wrapper = makeWrapper();
+      render(
+        <Wrapper>
+          <FilesetCreateModal
+            open
+            onClose={vi.fn()}
+            workspace="default"
+            purpose={FilesetPurpose.dataset}
+          />
+        </Wrapper>
+      );
+      await user.click(screen.getByRole('radio', { name: 'External' }));
+      const nameInput = screen.getByRole('textbox', { name: /^name$/i }) as HTMLInputElement;
+      await waitFor(() => {
+        // Sanitized: lowercase, valid chars
+        expect(nameInput.value).toBe('qwen3.6-35b-a3b-mtp-gguf');
+      });
+    });
+
+    it('does not overwrite a user-typed name', async () => {
+      const user = userEvent.setup();
+      // Start with no metadata; user types into Name; later metadata arrives.
+      mockUseRemoteRepoMetadata.mockReturnValue({ data: undefined, isFetching: false });
+      const Wrapper = makeWrapper();
+      const { rerender } = render(
+        <Wrapper>
+          <FilesetCreateModal
+            open
+            onClose={vi.fn()}
+            workspace="default"
+            purpose={FilesetPurpose.dataset}
+          />
+        </Wrapper>
+      );
+      await user.click(screen.getByRole('radio', { name: 'External' }));
+      const nameInput = screen.getByRole('textbox', { name: /^name$/i }) as HTMLInputElement;
+      await user.type(nameInput, 'my-own-name');
+
+      // Now simulate metadata arriving on a subsequent render.
+      mockUseRemoteRepoMetadata.mockReturnValue({
+        data: { slug: 'OtherSlug', description: null },
+        isFetching: false,
+      });
+      rerender(
+        <Wrapper>
+          <FilesetCreateModal
+            open
+            onClose={vi.fn()}
+            workspace="default"
+            purpose={FilesetPurpose.dataset}
+          />
+        </Wrapper>
+      );
+      // User input survives.
+      expect(nameInput.value).toBe('my-own-name');
+    });
+
+    it('disables Name + Description while fetch is in flight', async () => {
+      const user = userEvent.setup();
+      mockUseRemoteRepoMetadata.mockReturnValue({ data: undefined, isFetching: true });
+      const Wrapper = makeWrapper();
+      render(
+        <Wrapper>
+          <FilesetCreateModal
+            open
+            onClose={vi.fn()}
+            workspace="default"
+            purpose={FilesetPurpose.dataset}
+          />
+        </Wrapper>
+      );
+      await user.click(screen.getByRole('radio', { name: 'External' }));
+      expect(screen.getByRole('textbox', { name: /^name$/i })).toBeDisabled();
+      expect(screen.getByRole('textbox', { name: /description/i })).toBeDisabled();
+    });
+  });
+
+  describe('navigation after create', () => {
+    it('Dataset + Local navigates to dataset detail Files tab', async () => {
+      const navigate = vi.fn();
+      mockUseNavigate(navigate);
+      mockMutate.mockResolvedValue({
+        ...FILESET_RESPONSE,
+        name: 'mydataset',
+        purpose: 'dataset',
+        storage: { type: 'local', path: '/x' },
+      });
+      const user = userEvent.setup();
+      const Wrapper = makeWrapper();
+      render(
+        <Wrapper>
+          <FilesetCreateModal
+            open
+            onClose={vi.fn()}
+            workspace="default"
+            purpose={FilesetPurpose.dataset}
+          />
+        </Wrapper>
+      );
+      await user.type(screen.getByRole('textbox', { name: /^name$/i }), 'mydataset');
+      await user.click(screen.getByRole('button', { name: 'Create Dataset' }));
+      await waitFor(() => {
+        expect(navigate).toHaveBeenCalledWith(
+          expect.stringContaining('/workspaces/default/datasets/mydataset?tab=files')
+        );
+      });
+    });
+
+    it('Model purpose navigates to the side-panel fileset route', async () => {
+      const navigate = vi.fn();
+      mockUseNavigate(navigate);
+      mockMutate.mockResolvedValue({
+        ...FILESET_RESPONSE,
+        name: 'mymodel',
+        purpose: 'model',
+      });
+      const user = userEvent.setup();
+      const Wrapper = makeWrapper();
+      render(
+        <Wrapper>
+          <FilesetCreateModal
+            open
+            onClose={vi.fn()}
+            workspace="default"
+            purpose={FilesetPurpose.model}
+          />
+        </Wrapper>
+      );
+      await user.type(screen.getByRole('textbox', { name: /^name$/i }), 'mymodel');
+      await user.click(screen.getByRole('button', { name: 'Create Model Fileset' }));
+      await waitFor(() => {
+        // Side panel route encodes "<workspace>/<name>" as the filesetId param.
+        expect(navigate).toHaveBeenCalledWith(
+          expect.stringContaining('/workspaces/default/filesets/default%2Fmymodel')
+        );
+      });
+    });
+  });
+});

--- a/web/packages/studio/src/components/FilesetCreateModal/index.spec.tsx
+++ b/web/packages/studio/src/components/FilesetCreateModal/index.spec.tsx
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { MockToastProvider } from '@nemo/common/src/tests/MockToastProvider';
-import type { FilesetOutput } from '@nemo/sdk/generated/platform/schema';
-import { FilesetPurpose } from '@nemo/sdk/generated/platform/schema';
+import { FilesetPurpose, type FilesetOutput } from '@nemo/sdk/generated/platform/schema';
 import { FilesetCreateModal } from '@studio/components/FilesetCreateModal';
 import { ROUTE_PARAMS } from '@studio/constants/routes';
 import { mockUseNavigate, mockUseParams } from '@studio/tests/util/mockUseParams';
@@ -16,7 +15,10 @@ import { BrowserRouter } from 'react-router-dom';
 const { mockMutate, mockUseRemoteRepoMetadata } = vi.hoisted(() => ({
   mockMutate: vi.fn<(args: unknown) => Promise<FilesetOutput>>(),
   mockUseRemoteRepoMetadata: vi.fn<
-    (url: string | undefined, enabled: boolean) => {
+    (
+      url: string | undefined,
+      enabled: boolean
+    ) => {
       data: { slug: string; description: string | null } | null | undefined;
       isFetching: boolean;
     }

--- a/web/packages/studio/src/components/FilesetCreateModal/index.tsx
+++ b/web/packages/studio/src/components/FilesetCreateModal/index.tsx
@@ -23,9 +23,9 @@ import {
   type SupportedPurpose,
 } from '@studio/components/FilesetCreateModal/constants';
 import { useRemoteRepoMetadata } from '@studio/hooks/useRemoteRepoMetadata';
+import { DatasetDetailTab } from '@studio/routes/DatasetDetailRoute/constants';
 import { CreateSecretModal } from '@studio/routes/SecretsListRoute/CreateSecretModal';
 import { SecretSearchableSelect } from '@studio/routes/SecretsListRoute/SecretSearchableSelect';
-import { DatasetDetailTab } from '@studio/routes/DatasetDetailRoute/constants';
 import { getDatasetDetailRoute, getFilesetDetailsRoute } from '@studio/routes/utils';
 import { handleFormErrorsGeneric } from '@studio/util/forms/error';
 import {

--- a/web/packages/studio/src/components/FilesetCreateModal/index.tsx
+++ b/web/packages/studio/src/components/FilesetCreateModal/index.tsx
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ControlledTextArea } from '@nemo/common/src/components/form/ControlledTextArea';
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { FormModal } from '@nemo/common/src/components/FormModal';
+import { getEntityReference } from '@nemo/common/src/namedEntity';
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import { toValidFilesetName } from '@nemo/common/src/utils/filesetName';
+import {
+  getFilesListFilesetsQueryKey,
+  useFilesCreateFileset,
+} from '@nemo/sdk/generated/platform/api';
+import { FilesetOutput, FilesetPurpose } from '@nemo/sdk/generated/platform/schema';
+import { SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
+import { getErrorMessage as getApiErrorMessage } from '@studio/api/common/utils';
+import {
+  filesetCreateFormSchema,
+  type FilesetCreateFormData,
+  PURPOSE_COPY,
+  StorageMode,
+  type SupportedPurpose,
+} from '@studio/components/FilesetCreateModal/constants';
+import { useRemoteRepoMetadata } from '@studio/hooks/useRemoteRepoMetadata';
+import { CreateSecretModal } from '@studio/routes/SecretsListRoute/CreateSecretModal';
+import { SecretSearchableSelect } from '@studio/routes/SecretsListRoute/SecretSearchableSelect';
+import { DatasetDetailTab } from '@studio/routes/DatasetDetailRoute/constants';
+import { getDatasetDetailRoute, getFilesetDetailsRoute } from '@studio/routes/utils';
+import { handleFormErrorsGeneric } from '@studio/util/forms/error';
+import {
+  isHuggingFaceUrl,
+  isNgcUrl,
+  storageConfigFromUrl,
+} from '@studio/util/storageConfigFromUrl';
+import { useQueryClient } from '@tanstack/react-query';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+export interface FilesetCreateModalProps {
+  open: boolean;
+  onClose: () => void;
+  workspace: string;
+  purpose: SupportedPurpose;
+}
+
+/** "Lean" create modal for filesets. Heading and post-create navigation differ
+ *  by purpose (dataset vs model). Generic purpose is not supported here -
+ *  flag-off paths and the API itself still allow it.
+ *
+ *  Local mode: name + description only. User adds files later via the detail
+ *  page. (No file upload here, by design.)
+ *  External mode: name + description + URL + workspace secret. */
+export const FilesetCreateModal: FC<FilesetCreateModalProps> = ({
+  open,
+  onClose,
+  workspace,
+  purpose,
+}) => {
+  const toast = useToast();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [storageMode, setStorageMode] = useState<StorageMode>(StorageMode.Local);
+  const [createSecretModalOpen, setCreateSecretModalOpen] = useState(false);
+
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors, isValid, dirtyFields },
+  } = useForm<FilesetCreateFormData>({
+    resolver: zodResolver(filesetCreateFormSchema),
+    defaultValues: { name: '', description: '', url: '', secretKey: '' },
+    mode: 'onChange',
+  });
+
+  const url = watch('url');
+  const selectedSecretName = watch('secretKey');
+
+  const secretKeyLabel = useMemo(() => {
+    if (!url?.trim()) return 'Secret Key';
+    try {
+      const parsed = new URL(url);
+      if (isHuggingFaceUrl(parsed)) return 'HuggingFace Token (optional)';
+      if (isNgcUrl(parsed)) return 'NGC API Key';
+    } catch {
+      // invalid URL — fall through
+    }
+    return 'Secret Key';
+  }, [url]);
+
+  // External mode auto-fill: when the URL resolves to a recognised remote
+  // repo, derive a name slug (HF + NGC) and a description (HF public only).
+  // Only fills fields the user has not edited. Backend preview endpoint
+  // (nmp-1tk) will eventually replace the client-side fetch.
+  const isExternalMode = storageMode === StorageMode.External;
+  const { data: remoteMetadata, isFetching: isRemoteFetching } = useRemoteRepoMetadata(
+    url,
+    isExternalMode
+  );
+
+  useEffect(() => {
+    if (!isExternalMode || !remoteMetadata) return;
+    if (!dirtyFields.name && remoteMetadata.slug) {
+      setValue('name', toValidFilesetName(remoteMetadata.slug), {
+        shouldValidate: true,
+        shouldDirty: false,
+      });
+    }
+    if (!dirtyFields.description && remoteMetadata.description) {
+      setValue('description', remoteMetadata.description.slice(0, 255), {
+        shouldValidate: false,
+        shouldDirty: false,
+      });
+    }
+  }, [isExternalMode, remoteMetadata, dirtyFields.name, dirtyFields.description, setValue]);
+
+  const { mutateAsync: createFileset, isPending } = useFilesCreateFileset({
+    mutation: {
+      onSuccess: (fileset: FilesetOutput) => {
+        // Invalidate the workspace-wide fileset list so the table picks up the
+        // new row. Per-fileset caches are seeded directly in onSubmit so the
+        // destination page renders without a loading spinner — see below.
+        queryClient.invalidateQueries({
+          queryKey: getFilesListFilesetsQueryKey(fileset.workspace),
+        });
+      },
+    },
+  });
+
+  const handleClose = useCallback(() => {
+    reset();
+    setStorageMode(StorageMode.Local);
+    onClose();
+  }, [reset, onClose]);
+
+  const handleSecretCreated = useCallback(
+    (secretName: string) => {
+      setValue('secretKey', secretName, { shouldValidate: true });
+    },
+    [setValue]
+  );
+
+  const onSubmit = useCallback(
+    async (data: FilesetCreateFormData) => {
+      const trimmedUrl = data.url?.trim();
+      const isExternal = storageMode === StorageMode.External && !!trimmedUrl;
+
+      let storage: ReturnType<typeof storageConfigFromUrl> | undefined;
+      if (isExternal) {
+        try {
+          storage = storageConfigFromUrl({
+            url: trimmedUrl,
+            secretKey: data.secretKey?.trim() || undefined,
+          });
+        } catch (e) {
+          toast.error(
+            e instanceof Error
+              ? e.message
+              : 'Invalid external storage URL or credential. For NGC, select a secret with your API key.'
+          );
+          return;
+        }
+      }
+
+      let fileset: FilesetOutput;
+      try {
+        fileset = await createFileset({
+          workspace,
+          data: {
+            name: data.name,
+            description: data.description ?? '',
+            purpose,
+            storage,
+          },
+        });
+      } catch (err) {
+        toast.error(getApiErrorMessage(err as Error, 'Failed to create fileset'));
+        return;
+      }
+
+      // Post-create navigation, per ASTD-167:
+      //   Dataset purpose: External -> Card tab (README rendered there);
+      //                    Local    -> Files tab (user uploads next).
+      //   Model purpose: no Card/Files tabs yet (model detail route owned by
+      //                  parallel team, not landed). Side-panel for now.
+      handleClose();
+      if (purpose === FilesetPurpose.dataset) {
+        navigate(
+          getDatasetDetailRoute(fileset.workspace, fileset.name, {
+            tab: isExternal ? DatasetDetailTab.Card : DatasetDetailTab.Files,
+          })
+        );
+        return;
+      }
+      // The filesets route param is an encoded "workspace/name" entity
+      // reference (parsed by `getPartsFromReference`), not a bare name.
+      navigate(
+        getFilesetDetailsRoute(
+          fileset.workspace,
+          getEntityReference(fileset, { encode: true }),
+          undefined,
+          true
+        )
+      );
+    },
+    [storageMode, createFileset, workspace, purpose, toast, navigate, handleClose]
+  );
+
+  return (
+    <>
+      <FormModal
+        open={open}
+        onClose={handleClose}
+        title={PURPOSE_COPY[purpose].title}
+        submitButtonText={isPending ? 'Creating…' : PURPOSE_COPY[purpose].submit}
+        loading={isPending}
+        submitDisabled={!isValid}
+        onSubmit={handleSubmit(
+          onSubmit,
+          handleFormErrorsGeneric({ title: 'Fileset Create Form Errors' })
+        )}
+      >
+        <Stack gap="density-lg">
+          <SegmentedControl
+            size="tiny"
+            className="w-full"
+            value={storageMode}
+            onValueChange={(value) => setStorageMode(value as StorageMode)}
+            items={[
+              { value: StorageMode.Local, children: 'Local' },
+              { value: StorageMode.External, children: 'External' },
+            ]}
+          />
+
+          {isExternalMode && (
+            <>
+              <ControlledTextInput
+                label="URL"
+                disabled={isPending}
+                autoFocus
+                useControllerProps={{ name: 'url', control }}
+              />
+              <SecretSearchableSelect
+                workspace={workspace}
+                queryEnabled={Boolean(workspace)}
+                ensureOptionValue={selectedSecretName || undefined}
+                useControllerProps={{ control, name: 'secretKey' }}
+                onRequestNewSecret={() => setCreateSecretModalOpen(true)}
+                triggerPlaceholder=""
+                formFieldProps={{
+                  slotLabel: secretKeyLabel,
+                  slotInfo:
+                    'Select a secret that stores the credential for this URL, or choose New Secret to create one.',
+                  slotError: errors.secretKey?.message,
+                }}
+              />
+            </>
+          )}
+
+          <ControlledTextInput
+            label="Name"
+            disabled={isPending || (isExternalMode && isRemoteFetching)}
+            autoFocus={!isExternalMode}
+            useControllerProps={{ name: 'name', control }}
+          />
+          <ControlledTextArea
+            label="Description (optional)"
+            disabled={isPending || (isExternalMode && isRemoteFetching)}
+            useControllerProps={{ name: 'description', control }}
+          />
+
+          {!isExternalMode && (
+            <Text kind="body/regular/sm">You can upload files after creating the fileset.</Text>
+          )}
+        </Stack>
+      </FormModal>
+      <CreateSecretModal
+        workspace={workspace}
+        open={createSecretModalOpen}
+        onClose={() => setCreateSecretModalOpen(false)}
+        onSecretCreated={handleSecretCreated}
+      />
+    </>
+  );
+};

--- a/web/packages/studio/src/components/NewDatasetButton/index.tsx
+++ b/web/packages/studio/src/components/NewDatasetButton/index.tsx
@@ -10,9 +10,13 @@
  * its affiliates is strictly prohibited.
  */
 
+import { FilesetPurpose } from '@nemo/sdk/generated/platform/schema';
 import { ButtonProps } from '@nvidia/foundations-react-core';
 import { CreateButton } from '@studio/components/common/CreateButton';
 import { DatasetCreateModal } from '@studio/components/DatasetCreateModal';
+import { FilesetCreateModal } from '@studio/components/FilesetCreateModal';
+import { FILESET_DETAILS_ENABLED } from '@studio/constants/environment';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBoolean } from '@studio/util/hooks/useBoolean';
 import { FC } from 'react';
 
@@ -23,15 +27,24 @@ interface Props extends Omit<ButtonProps, 'onClick'> {
 
 export const NewDatasetButton: FC<Props> = ({ ...buttonProps }) => {
   const [isOpen, setOpen, setClosed] = useBoolean(false);
+  const workspace = useWorkspaceFromPath();
 
   return (
     <>
       <CreateButton onClick={() => setOpen()} {...buttonProps}>
         Create Dataset
       </CreateButton>
-      {isOpen && (
-        <DatasetCreateModal open={isOpen} onClose={setClosed} onDatasetCreated={setClosed} />
-      )}
+      {isOpen &&
+        (FILESET_DETAILS_ENABLED ? (
+          <FilesetCreateModal
+            open={isOpen}
+            onClose={setClosed}
+            workspace={workspace}
+            purpose={FilesetPurpose.dataset}
+          />
+        ) : (
+          <DatasetCreateModal open={isOpen} onClose={setClosed} onDatasetCreated={setClosed} />
+        ))}
     </>
   );
 };

--- a/web/packages/studio/src/components/NewModelFilesetButton/index.tsx
+++ b/web/packages/studio/src/components/NewModelFilesetButton/index.tsx
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { FilesetPurpose } from '@nemo/sdk/generated/platform/schema';
+import { ButtonProps } from '@nvidia/foundations-react-core';
+import { CreateButton } from '@studio/components/common/CreateButton';
+import { FilesetCreateModal } from '@studio/components/FilesetCreateModal';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { useBoolean } from '@studio/util/hooks/useBoolean';
+import { FC } from 'react';
+
+interface Props extends Omit<ButtonProps, 'onClick'> {
+  expanded?: boolean;
+  withIcon?: boolean;
+}
+
+export const NewModelFilesetButton: FC<Props> = ({ ...buttonProps }) => {
+  const [isOpen, setOpen, setClosed] = useBoolean(false);
+  const workspace = useWorkspaceFromPath();
+
+  return (
+    <>
+      <CreateButton onClick={() => setOpen()} {...buttonProps}>
+        Create Model Fileset
+      </CreateButton>
+      {isOpen && (
+        <FilesetCreateModal
+          open={isOpen}
+          onClose={setClosed}
+          workspace={workspace}
+          purpose={FilesetPurpose.model}
+        />
+      )}
+    </>
+  );
+};

--- a/web/packages/studio/src/hooks/useRemoteRepoMetadata/index.ts
+++ b/web/packages/studio/src/hooks/useRemoteRepoMetadata/index.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  isHuggingFaceUrl,
+  isNgcUrl,
+  parseHuggingFaceUrl,
+  parseNgcUrl,
+} from '@studio/util/storageConfigFromUrl';
+import { useQuery } from '@tanstack/react-query';
+
+export interface RemoteRepoMetadata {
+  /** Last segment of the canonical remote identifier; suitable for use as a
+   *  fileset name after running through `toValidFilesetName`. */
+  slug: string;
+  /** Remote description. Only populated for HuggingFace public repos in phase 1
+   *  — NGC + private HF require the backend preview endpoint (see nmp-1tk). */
+  description: string | null;
+}
+
+interface HfApiResponse {
+  cardData?: { description?: string } | null;
+}
+
+async function fetchHuggingFaceMetadata(
+  repoId: string,
+  repoType: 'dataset' | 'model' | 'space',
+  signal: AbortSignal
+): Promise<RemoteRepoMetadata | null> {
+  // Spaces don't have an obvious dataset/model description endpoint; skip.
+  if (repoType === 'space') {
+    return { slug: repoId.split('/').pop() ?? repoId, description: null };
+  }
+  const resource = repoType === 'dataset' ? 'datasets' : 'models';
+  const response = await fetch(`https://huggingface.co/api/${resource}/${repoId}`, {
+    signal,
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    // 404 / 401 — repo may be private or non-existent. Fall back to slug-only.
+    return { slug: repoId.split('/').pop() ?? repoId, description: null };
+  }
+  const body = (await response.json()) as HfApiResponse;
+  // Only the YAML frontmatter description is short enough to fit the backend's
+  // 255-char cap. Falling back to the README body would force an ugly
+  // mid-sentence truncation on auto-fill, so leave the field empty instead and
+  // let the user type/paste their own summary.
+  const description = body.cardData?.description?.trim() || null;
+  return {
+    slug: repoId.split('/').pop() ?? repoId,
+    description,
+  };
+}
+
+function deriveNgcMetadata(target: string): RemoteRepoMetadata {
+  // NGC description fetch requires API-key headers; the secret is not
+  // available client-side. Slug-only here. Backend preview (nmp-1tk) closes
+  // the gap.
+  return { slug: target, description: null };
+}
+
+/** Resolve a remote repo URL into a name slug (+ description when feasible
+ *  client-side). Returns `undefined` until the URL is valid + recognised.
+ *
+ *  Returns `null` data if the URL is recognised but the fetch failed —
+ *  callers should treat that as "no auto-fill available" rather than an
+ *  error to surface to the user. */
+export function useRemoteRepoMetadata(url: string | undefined, enabled: boolean) {
+  const trimmed = url?.trim() ?? '';
+  return useQuery({
+    queryKey: ['remoteRepoMetadata', trimmed],
+    queryFn: async ({ signal }): Promise<RemoteRepoMetadata | null> => {
+      let parsed: URL;
+      try {
+        parsed = new URL(trimmed);
+      } catch {
+        return null;
+      }
+      if (isHuggingFaceUrl(parsed)) {
+        try {
+          const { repoId, repoType } = parseHuggingFaceUrl(parsed);
+          return await fetchHuggingFaceMetadata(repoId, repoType, signal);
+        } catch {
+          return null;
+        }
+      }
+      if (isNgcUrl(parsed)) {
+        try {
+          const { target } = parseNgcUrl(parsed);
+          return deriveNgcMetadata(target);
+        } catch {
+          return null;
+        }
+      }
+      return null;
+    },
+    enabled: enabled && trimmed.length > 0,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+}

--- a/web/packages/studio/src/routes/FilesetListRoute/index.tsx
+++ b/web/packages/studio/src/routes/FilesetListRoute/index.tsx
@@ -6,6 +6,8 @@ import { FilesetOutput } from '@nemo/sdk/generated/platform/schema';
 import { Button, PageHeader, Stack } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { DatasetsTable } from '@studio/components/DatasetsTable';
+import { NewDatasetButton } from '@studio/components/NewDatasetButton';
+import { NewModelFilesetButton } from '@studio/components/NewModelFilesetButton';
 import { FILESET_DETAILS_ENABLED } from '@studio/constants/environment';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
@@ -58,9 +60,16 @@ export const FilesetListRoute: FC = () => {
           slotHeading="Filesets"
           slotDescription="Filesets organize files by purpose — Generic, Dataset, or Model. Purpose determines which metadata fields are available and can't be changed after creation. Use Dataset for training and evaluation data, Model for model weights and checkpoints, and Generic for everything else."
           slotActions={
-            <Button asChild color="brand">
-              <Link to={getNewFilesetRoute(workspace)}>Create Fileset</Link>
-            </Button>
+            FILESET_DETAILS_ENABLED ? (
+              <>
+                <NewDatasetButton color="brand" />
+                <NewModelFilesetButton color="brand" />
+              </>
+            ) : (
+              <Button asChild color="brand">
+                <Link to={getNewFilesetRoute(workspace)}>Create Fileset</Link>
+              </Button>
+            )
           }
         />
         <DatasetsTable

--- a/web/packages/studio/src/util/storageConfigFromUrl.ts
+++ b/web/packages/studio/src/util/storageConfigFromUrl.ts
@@ -51,7 +51,7 @@ export function isHuggingFaceUrl(url: URL): boolean {
   );
 }
 
-function parseNgcUrl(url: URL): { org: string; team: string; target: string } {
+export function parseNgcUrl(url: URL): { org: string; team: string; target: string } {
   const path = url.pathname;
   const match = path.match(NGC_ORG_TEAM_RESOURCE);
   if (!match) {
@@ -66,7 +66,7 @@ function parseNgcUrl(url: URL): { org: string; team: string; target: string } {
   return { org, team, target };
 }
 
-function parseHuggingFaceUrl(url: URL): {
+export function parseHuggingFaceUrl(url: URL): {
   repoId: string;
   repoType: 'dataset' | 'model' | 'space';
 } {


### PR DESCRIPTION
## Summary

  Implements [ASTD-167](https://linear.app/nvidia/issue/ASTD-167) (Filesets: add new Dataset & Fileset modals) and the bundled [ASTD-168](https://linear.app/nvidia/issue/ASTD-168) (Separate Create CTA into 2  buttons). Behind `VITE_FF_FILESET_DETAILS_ENABLED`.

  - **CTA split**: replaces single `Create Fileset` link with two primary CTAs — `Create Dataset` and `Create Model Fileset` — on `FilesetListRoute` upper-right and `DatasetsTable` empty state.
  - **New `FilesetCreateModal`**: purpose is set by the CTA (no in-form selector). `Local` / `External` segmented toggle inside.
    - **Local** mode: name + description only ("lean" — user uploads files later via the detail page).
    - **External** mode: URL + Secret moved to the top so users fill them first; Name + Description below, disabled while the remote metadata fetch is in flight.
  - **Eager remote metadata** (External): on URL paste, derives a sanitized name from the HF / NGC slug and pulls the description from HuggingFace `cardData.description` (public repos). Non-destructive — only fills fields the user has not edited.
  - **Strict name sanitizer**: mirrors the entity store `NAME_PATTERN` (lowercase, 2-63 chars, no `--`, no trailing `-`). Overrides the looser regex pulled into generated zod from the Files DTO. See follow-up backend ticket for aligning the DTO.
  - **Post-create navigation**

    | CTA | Local | External |
    | --- | ----- | -------- |
    | Create Dataset | `DatasetDetailRoute` Files tab | `DatasetDetailRoute` Card tab |
    | Create Model Fileset | Existing fileset side panel | Existing fileset side panel |

    Model detail page is owned by a parallel team and not in this repo yet; the existing side panel is the temporary destination. Swap when their helper exports.
  - **Flag-off behavior preserved**: `FilesetNewRoute` (sidebar) and the existing `DatasetCreateModal` callers (`NewDatasetButton`, `FilesetListRoute/ActionMenu`, `DatasetsTable` Edit mode) are untouched.

  ## Files

  **Added**
  - `web/packages/studio/src/components/FilesetCreateModal/{index.tsx,constants.ts,index.spec.tsx}`
  - `web/packages/studio/src/components/NewModelFilesetButton/index.tsx`
  - `web/packages/studio/src/hooks/useRemoteRepoMetadata/index.ts`
  - `web/packages/common/src/utils/filesetName.ts` + `.test.ts`

  **Modified**
  - `web/packages/studio/src/components/NewDatasetButton/index.tsx` — flag-gated swap to
  `FilesetCreateModal`
  - `web/packages/studio/src/routes/FilesetListRoute/index.tsx` — 2-CTA upper-right when flag on
  - `web/packages/studio/src/components/DatasetsTable/index.tsx` — empty state adds Model CTA when flag on
  - `web/packages/studio/src/util/storageConfigFromUrl.ts` — exported `parseHuggingFaceUrl` + `parseNgcUrl` for reuse

  ## Tests

  - `web/packages/common/src/utils/filesetName.test.ts` — 22 tests covering sanitizer edge cases.
  - `web/packages/studio/src/components/FilesetCreateModal/index.spec.tsx` — 9 tests covering heading
  copy, storage mode toggle, auto-fill (set + skip-when-dirty), disabled state during fetch, and
  post-create navigation for Dataset+Local and Model paths.
  

<img width="465" height="558" alt="Screenshot 2026-06-01 at 11 15 24 AM" src="https://github.com/user-attachments/assets/1c74c596-5e29-4257-b77c-059d99885dd0" />


<img width="494" height="456" alt="Screenshot 2026-06-01 at 11 15 18 AM" src="https://github.com/user-attachments/assets/2ea195d9-8f4b-4128-8fe8-16100e0b83f5" />


<img width="1473" height="648" alt="Screenshot 2026-06-01 at 11 15 13 AM" src="https://github.com/user-attachments/assets/385e2ef1-12ec-472a-9d64-38159f21bda6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced fileset creation modal with Local and External storage mode support
* Auto-fill fileset name and description from remote HuggingFace and NGC repositories
* Added model fileset creation capability
* Implemented fileset name validation using RFC-1035-style naming rules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/nemo-platform/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->