### PR TITLE
feat(studio): Model Fileset detail view

### DIFF
--- a/web/packages/studio/src/api/datasets/useDatasetFilesUpload.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFilesUpload.ts
@@ -41,7 +41,7 @@ export const useDatasetFilesUpload = (options?: UseDatasetFilesUploadOptions) =>
     ...options,
     mutationFn: uploadFilesToDataset,
     onSuccess: (data, variables, onMutateResult, context) => {
-      invalidateDatasetCaches(variables.workspace, variables.datasetName, ['files']);
+      invalidateDatasetCaches(variables.workspace, variables.datasetName, ['files', 'content']);
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });

--- a/web/packages/studio/src/components/DatasetsTable/index.tsx
+++ b/web/packages/studio/src/components/DatasetsTable/index.tsx
@@ -36,6 +36,7 @@ import { NewDatasetButton } from '@studio/components/NewDatasetButton';
 import { LINK_DOCS_DATASETS } from '@studio/constants/links';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { DatasetBulkDeleteModal } from '@studio/routes/FilesetListRoute/DatasetBulkDeleteModal';
+import { formatStorageBackendLabel, type StorageBackend } from '@studio/util/storageBackend';
 import { keepPreviousData } from '@tanstack/react-query';
 import { Cloud, X, Database, Trash } from 'lucide-react';
 import {
@@ -58,29 +59,15 @@ type StorageConfig =
   | HuggingfaceStorageConfig
   | S3StorageConfig;
 
-function getStorageBackend(storage: StorageConfig | undefined): string | null {
-  if (!storage) return null;
-  const type = (storage as { type?: string }).type;
-  return type ?? null;
+function getStorageBackend(storage: StorageConfig | undefined): StorageBackend | null {
+  return storage?.type ?? null;
 }
-
-const STORAGE_BACKEND_LABELS: Record<string, string> = {
-  local: 'Local',
-  ngc: 'NGC',
-  huggingface: 'Hugging Face',
-  s3: 'S3',
-};
 
 const PURPOSE_LABELS: Record<FilesetPurpose, string> = {
   [FilesetPurpose.generic]: 'Generic',
   [FilesetPurpose.dataset]: 'Dataset',
   [FilesetPurpose.model]: 'Model',
 };
-
-function formatStorageBackendLabel(type: string | null): string | null {
-  if (!type) return null;
-  return STORAGE_BACKEND_LABELS[type] ?? type.charAt(0).toUpperCase() + type.slice(1);
-}
 
 function getStoragePath(storage: StorageConfig | undefined): string | null {
   if (!storage) return null;

--- a/web/packages/studio/src/components/filesets/FilesetFileExplorer/index.tsx
+++ b/web/packages/studio/src/components/filesets/FilesetFileExplorer/index.tsx
@@ -82,8 +82,11 @@ export interface FilesetFileExplorerProps {
   isLoading: boolean;
   /** Whether files are currently being fetched */
   isFilesFetching: boolean;
-  /** Callback when a file is selected for viewing */
-  onFileSelect: (filePath: string) => void;
+  /** Callback when a file is selected for viewing. When omitted, file rows are
+   *  non-interactive (no row-click navigation, no "View File" quick action).
+   *  Hosts that don't yet have a preview surface should leave this undefined
+   *  rather than passing a no-op, so the view affordance isn't exposed. */
+  onFileSelect?: (filePath: string) => void;
   /** Gates the fileset metadata fetch. Defaults to true.
    *  Hosts that mount the explorer behind a panel animation can pass the panel's
    *  open state to suppress fetches while closed. */
@@ -363,14 +366,17 @@ export const FilesetFileExplorer: FC<FilesetFileExplorerProps> = ({
             ),
             onCellSelect: () => {
               if (node.type === 'file') {
-                onFileSelect(node.path);
+                onFileSelect?.(node.path);
               } else if (node.type === 'directory') {
                 handleUserFolderToggle(node.path);
               }
             },
             attributes: {
               TableDataCell: {
-                className: 'cursor-pointer',
+                // Directories always toggle on click; files only do so when a
+                // view handler is wired up. Skip the pointer cursor for files
+                // without a handler so the row doesn't look interactive.
+                className: node.type === 'directory' || onFileSelect ? 'cursor-pointer' : undefined,
               },
             },
           },

--- a/web/packages/studio/src/constants/routes.ts
+++ b/web/packages/studio/src/constants/routes.ts
@@ -77,6 +77,8 @@ export const ROUTES = {
     filesetFile: `/workspaces/:${P.workspace}/filesets/:${P.filesetId}/file/:${P.filePathEncoded}`,
     /** Dataset-only detail page (gated by VITE_FF_FILESET_DETAILS_ENABLED) */
     datasetDetail: `/workspaces/:${P.workspace}/datasets/:${P.datasetName}`,
+    /** Model-only detail page (gated by VITE_FF_FILESET_DETAILS_ENABLED) */
+    modelDetail: `/workspaces/:${P.workspace}/models/:${P.modelName}`,
     inferenceProviders: `/workspaces/:${P.workspace}/inference-providers`,
     deploymentConfigs: `/workspaces/:${P.workspace}/deployment-configs`,
     deployments: `/workspaces/:${P.workspace}/deployments`,

--- a/web/packages/studio/src/routes/FilesetListRoute/index.tsx
+++ b/web/packages/studio/src/routes/FilesetListRoute/index.tsx
@@ -14,6 +14,7 @@ import { PanelManagement } from '@studio/routes/FilesetListRoute/PanelManagement
 import {
   getDatasetDetailRoute,
   getFilesetDetailsRoute,
+  getModelDetailRoute,
   getNewFilesetRoute,
   getWorkspaceFilesetsRoute,
 } from '@studio/routes/utils';
@@ -30,13 +31,11 @@ export const FilesetListRoute: FC = () => {
 
   const getDatasetRoute = useCallback(
     (dataset: FilesetOutput) => {
-      // Bifurcate by purpose when the feature flag is on:
-      //   dataset -> new dedicated detail page
-      //   model   -> model detail page (owned by parallel team; helper not yet available -
-      //              falls through to the side-panel URL until the model team's bead lands)
-      //   other   -> existing side panel
       if (FILESET_DETAILS_ENABLED && dataset.purpose === 'dataset') {
         return getDatasetDetailRoute(workspace, dataset.name);
+      }
+      if (FILESET_DETAILS_ENABLED && dataset.purpose === 'model') {
+        return getModelDetailRoute(workspace, dataset.name);
       }
       return getFilesetDetailsRoute(workspace, getEntityReference(dataset, { encode: true }));
     },

--- a/web/packages/studio/src/routes/FilesetNewRoute/index.tsx
+++ b/web/packages/studio/src/routes/FilesetNewRoute/index.tsx
@@ -45,11 +45,17 @@ import {
 } from '@nvidia/foundations-react-core';
 import { getErrorMessage as getApiErrorMessage } from '@studio/api/common/utils';
 import { useSampleDatasetFiles } from '@studio/api/datasets/useSampleDatasetFiles';
+import { FILESET_DETAILS_ENABLED } from '@studio/constants/environment';
 import { SAMPLE_DATASETS, SampleDataset } from '@studio/constants/sampleDatasets';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { CreateSecretModal } from '@studio/routes/SecretsListRoute/CreateSecretModal';
 import { SecretSearchableSelect } from '@studio/routes/SecretsListRoute/SecretSearchableSelect';
-import { getFilesetDetailsRoute, getWorkspaceFilesetsRoute } from '@studio/routes/utils';
+import {
+  getDatasetDetailRoute,
+  getFilesetDetailsRoute,
+  getModelDetailRoute,
+  getWorkspaceFilesetsRoute,
+} from '@studio/routes/utils';
 import { handleFormErrorsGeneric } from '@studio/util/forms/error';
 import {
   isHuggingFaceUrl,
@@ -405,6 +411,14 @@ export const FilesetNewRoute: FC = () => {
       }
 
       setIsSubmitPending(false);
+      if (FILESET_DETAILS_ENABLED && fileset.purpose === FilesetPurpose.dataset) {
+        navigate(getDatasetDetailRoute(workspace, fileset.name));
+        return;
+      }
+      if (FILESET_DETAILS_ENABLED && fileset.purpose === FilesetPurpose.model) {
+        navigate(getModelDetailRoute(workspace, fileset.name));
+        return;
+      }
       navigate(
         getFilesetDetailsRoute(
           workspace,

--- a/web/packages/studio/src/routes/ModelDetailRoute/FilesTab/index.tsx
+++ b/web/packages/studio/src/routes/ModelDetailRoute/FilesTab/index.tsx
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useQueryParams } from '@nemo/common/src/hooks/useQueryParams';
+import type { FilesetFileOutput } from '@nemo/sdk/generated/platform/schema';
+import { Flex, Text } from '@nvidia/foundations-react-core';
+import { FilesetFilePreviewContent } from '@studio/components/FilesetFilePreviewPanel/FilesetFilePreviewContent';
+import { FilesetFileExplorer } from '@studio/components/filesets/FilesetFileExplorer';
+import { QUERY_PARAMETERS } from '@studio/routes/constants';
+import { useCallback, type FC } from 'react';
+
+export interface FilesTabProps {
+  workspace: string;
+  modelName: string;
+  modelId: string;
+  files: FilesetFileOutput[] | undefined;
+  isFilesError: boolean;
+  isFilesFetching: boolean;
+}
+
+export const FilesTab: FC<FilesTabProps> = ({
+  workspace,
+  modelName,
+  modelId,
+  files,
+  isFilesError,
+  isFilesFetching,
+}) => {
+  const { getQueryParam, setQueryParam, setQueryParams } = useQueryParams();
+  const currentFolder = getQueryParam(QUERY_PARAMETERS.filesetFolder) ?? undefined;
+  const selectedFilePath = getQueryParam(QUERY_PARAMETERS.file) || undefined;
+
+  const handleFileSelect = useCallback(
+    (filePath: string) => {
+      setQueryParam(QUERY_PARAMETERS.file, filePath);
+    },
+    [setQueryParam]
+  );
+
+  const handleClosePreview = useCallback(() => {
+    setQueryParams({
+      [QUERY_PARAMETERS.file]: undefined,
+      [QUERY_PARAMETERS.filesetFolder]: undefined,
+    });
+  }, [setQueryParams]);
+
+  const handleFolderChange = useCallback(
+    (folderPath: string) => {
+      setQueryParams({
+        [QUERY_PARAMETERS.file]: undefined,
+        [QUERY_PARAMETERS.filesetFolder]: folderPath || undefined,
+      });
+    },
+    [setQueryParams]
+  );
+
+  const handleFolderToggle = useCallback(
+    (folderPath: string, isExpanded: boolean) => {
+      if (isExpanded || !currentFolder) return;
+      const isCurrentOrAncestor =
+        currentFolder === folderPath || currentFolder.startsWith(`${folderPath}/`);
+      if (isCurrentOrAncestor) {
+        setQueryParams({ [QUERY_PARAMETERS.filesetFolder]: undefined });
+      }
+    },
+    [currentFolder, setQueryParams]
+  );
+
+  if (isFilesError) {
+    return (
+      <Flex
+        className="w-full min-h-80"
+        align="center"
+        justify="center"
+        data-testid="model-files-tab"
+      >
+        <Text className="text-feedback-danger">Failed to load model files.</Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex
+      direction="row"
+      gap="density-md"
+      className="w-full h-full min-h-0"
+      data-testid="model-files-tab"
+    >
+      <Flex direction="col" className="flex-1 min-w-0 min-h-0">
+        {selectedFilePath ? (
+          <div className="w-full h-full min-h-0" data-testid="model-files-tab-preview">
+            <FilesetFilePreviewContent
+              workspace={workspace}
+              filesetName={modelName}
+              filePath={selectedFilePath}
+              onFilesetClick={handleClosePreview}
+              onFolderClick={handleFolderChange}
+              onDeleteSuccess={handleClosePreview}
+              onRenameSuccess={(newPath) => setQueryParam(QUERY_PARAMETERS.file, newPath)}
+            />
+          </div>
+        ) : (
+          <div className="flex-1 min-h-0 overflow-auto">
+            <FilesetFileExplorer
+              workspace={workspace}
+              datasetName={modelName}
+              datasetId={modelId}
+              currentFolder={currentFolder}
+              filesList={files}
+              isLoading={false}
+              isFilesFetching={isFilesFetching}
+              onFileSelect={handleFileSelect}
+              onFolderToggle={handleFolderToggle}
+            />
+          </div>
+        )}
+      </Flex>
+    </Flex>
+  );
+};

--- a/web/packages/studio/src/routes/ModelDetailRoute/ModelCardTab/ReadmeBody.tsx
+++ b/web/packages/studio/src/routes/ModelDetailRoute/ModelCardTab/ReadmeBody.tsx
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { MarkdownContent } from '@nemo/common/src/components/MarkdownContent';
+import { Flex, Spinner, Text } from '@nvidia/foundations-react-core';
+import { type FC } from 'react';
+
+export interface ReadmeBodyProps {
+  isFilesError: boolean;
+  readmePath: string | undefined;
+  isContentLoading: boolean;
+  isContentError: boolean;
+  content: string | undefined;
+}
+
+export const ReadmeBody: FC<ReadmeBodyProps> = ({
+  isFilesError,
+  readmePath,
+  isContentLoading,
+  isContentError,
+  content,
+}) => {
+  if (isFilesError) {
+    return (
+      <Flex className="min-h-80" align="center" justify="center">
+        <Text className="text-feedback-danger">Failed to load model files.</Text>
+      </Flex>
+    );
+  }
+
+  if (!readmePath) {
+    return (
+      <Flex className="min-h-80" align="center" justify="center">
+        <Text color="secondary">No README.md found at the root of this model fileset.</Text>
+      </Flex>
+    );
+  }
+
+  if (isContentLoading) {
+    return (
+      <Flex className="min-h-80" align="center" justify="center">
+        <Spinner description="Loading README..." />
+      </Flex>
+    );
+  }
+
+  if (isContentError || content === undefined) {
+    return (
+      <Flex className="min-h-80" align="center" justify="center">
+        <Text className="text-feedback-danger">Failed to load README.</Text>
+      </Flex>
+    );
+  }
+
+  return <MarkdownContent content={content} />;
+};

--- a/web/packages/studio/src/routes/ModelDetailRoute/ModelCardTab/index.tsx
+++ b/web/packages/studio/src/routes/ModelDetailRoute/ModelCardTab/index.tsx
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FilesetFileOutput, FilesetOutput } from '@nemo/sdk/generated/platform/schema';
+import { Grid, GridItem } from '@nvidia/foundations-react-core';
+import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
+import { ReadmeBody } from '@studio/routes/ModelDetailRoute/ModelCardTab/ReadmeBody';
+import { ModelMetadataPanel } from '@studio/routes/ModelDetailRoute/ModelMetadataPanel';
+import { isRootReadme, parseReadme } from '@studio/routes/ModelDetailRoute/utils';
+import { useMemo, type FC } from 'react';
+
+export interface ModelCardTabProps {
+  workspace: string;
+  modelName: string;
+  fileset: FilesetOutput;
+  files: FilesetFileOutput[] | undefined;
+  isFilesError: boolean;
+}
+
+export const ModelCardTab: FC<ModelCardTabProps> = ({
+  workspace,
+  modelName,
+  fileset,
+  files,
+  isFilesError,
+}) => {
+  const readmePath = useMemo(() => files?.find(isRootReadme)?.path, [files]);
+
+  const {
+    data: rawContent,
+    isLoading: isContentLoading,
+    isError: isContentError,
+  } = useDatasetFileContent({
+    workspace,
+    name: modelName,
+    path: readmePath ?? '',
+    enabled: Boolean(readmePath),
+  });
+
+  const parsed = useMemo(
+    () => (rawContent !== undefined ? parseReadme(rawContent) : undefined),
+    [rawContent]
+  );
+
+  return (
+    <Grid
+      cols={{ base: 1, xl: 12 }}
+      gap="density-xl"
+      className="w-full items-start"
+      data-testid="model-card-tab"
+    >
+      <GridItem
+        cols={{ lg: 8 }}
+        className="min-w-0 overflow-hidden rounded-lg border border-base bg-surface-raised p-density-xl"
+      >
+        <ReadmeBody
+          isFilesError={isFilesError}
+          readmePath={readmePath}
+          isContentLoading={isContentLoading}
+          isContentError={isContentError}
+          content={parsed?.content}
+        />
+      </GridItem>
+      <GridItem cols={{ lg: 4 }} className="min-w-0">
+        <ModelMetadataPanel fileset={fileset} readmeMetadata={parsed?.metadata} />
+      </GridItem>
+    </Grid>
+  );
+};

--- a/web/packages/studio/src/routes/ModelDetailRoute/ModelMetadataPanel/TagList.tsx
+++ b/web/packages/studio/src/routes/ModelDetailRoute/ModelMetadataPanel/TagList.tsx
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Tag } from '@nvidia/foundations-react-core';
+import { type FC } from 'react';
+
+export interface TagListProps {
+  items: string[];
+}
+
+export const TagList: FC<TagListProps> = ({ items }) => (
+  <span className="inline-flex flex-wrap gap-density-xs">
+    {items.map((item) => (
+      <Tag key={item} kind="outline" color="gray" density="compact" readOnly>
+        {item}
+      </Tag>
+    ))}
+  </span>
+);

--- a/web/packages/studio/src/routes/ModelDetailRoute/ModelMetadataPanel/index.tsx
+++ b/web/packages/studio/src/routes/ModelDetailRoute/ModelMetadataPanel/index.tsx
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { KVPair } from '@nemo/common/src/components/KVPair';
+import type { FilesetOutput } from '@nemo/sdk/generated/platform/schema';
+import { Divider, Panel, Stack, Text } from '@nvidia/foundations-react-core';
+import { getMetadataSections } from '@studio/routes/ModelDetailRoute/ModelMetadataPanel/utils';
+import { type FC } from 'react';
+
+export interface ModelMetadataPanelProps {
+  fileset: FilesetOutput;
+  readmeMetadata?: Record<string, unknown>;
+}
+
+export const ModelMetadataPanel: FC<ModelMetadataPanelProps> = ({ fileset, readmeMetadata }) => {
+  const sections = getMetadataSections(fileset, readmeMetadata);
+
+  return (
+    <Panel elevation="high" density="compact" className="w-full" data-testid="model-metadata-panel">
+      <Stack gap="density-xl">
+        {sections.map((section, index) => (
+          <Stack key={section.value} gap="density-lg">
+            {index > 0 ? <Divider /> : null}
+            <Text kind="label/bold/sm">{section.title}</Text>
+            <Stack gap="density-md">
+              {section.rows.map((row) => (
+                <KVPair
+                  key={`${section.value}-${row.label}`}
+                  label={row.label}
+                  value={row.value}
+                  orientation="horizontal"
+                  size="narrow"
+                  attributes={{
+                    value: { className: 'min-w-0 break-words text-wrap' },
+                  }}
+                />
+              ))}
+            </Stack>
+          </Stack>
+        ))}
+      </Stack>
+    </Panel>
+  );
+};

--- a/web/packages/studio/src/routes/ModelDetailRoute/ModelMetadataPanel/utils.spec.tsx
+++ b/web/packages/studio/src/routes/ModelDetailRoute/ModelMetadataPanel/utils.spec.tsx
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  FilesetPurpose,
+  type FilesetOutput,
+  type HuggingfaceStorageConfig,
+} from '@nemo/sdk/generated/platform/schema';
+import { getMetadataSections } from '@studio/routes/ModelDetailRoute/ModelMetadataPanel/utils';
+import { isValidElement } from 'react';
+
+const huggingfaceFileset: FilesetOutput = {
+  id: 'model-1',
+  name: 'my-model',
+  workspace: 'ws',
+  description: '',
+  purpose: FilesetPurpose.model,
+  storage: {
+    type: 'huggingface',
+    repo_id: 'meta-llama/Llama-2-7b',
+  } as HuggingfaceStorageConfig,
+  metadata: {},
+  custom_fields: {},
+  project: '',
+  created_at: '',
+  updated_at: '',
+};
+
+const findRow = (
+  sections: ReturnType<typeof getMetadataSections>,
+  sectionValue: string,
+  rowLabel: string
+) =>
+  sections
+    .find((section) => section.value === sectionValue)
+    ?.rows.find((row) => row.label === rowLabel);
+
+describe('getMetadataSections', () => {
+  // README frontmatter is user-supplied. `license_link` must be gated against
+  // `javascript:` / `data:` so a malicious model card can't inject an
+  // executable URL into the rendered <Anchor>.
+  describe('license_link safety', () => {
+    it('renders license as plain text when license_link uses an unsafe scheme', () => {
+      const sections = getMetadataSections(huggingfaceFileset, {
+        license: 'MIT',
+        license_link: 'javascript:alert(1)',
+      });
+      const license = findRow(sections, 'details', 'License');
+      expect(license?.value).toBe('MIT');
+    });
+
+    it('renders license as an anchor when license_link is https', () => {
+      const sections = getMetadataSections(huggingfaceFileset, {
+        license: 'MIT',
+        license_link: 'https://opensource.org/license/mit',
+      });
+      const license = findRow(sections, 'details', 'License');
+      expect(isValidElement(license?.value)).toBe(true);
+    });
+  });
+
+  it('always includes a Source section with a Storage row', () => {
+    const sections = getMetadataSections(huggingfaceFileset, undefined);
+    expect(findRow(sections, 'source', 'Storage')?.value).toBe('Hugging Face');
+  });
+
+  it('omits the Details section when readme metadata is empty', () => {
+    const sections = getMetadataSections(huggingfaceFileset, {});
+    expect(sections.find((section) => section.value === 'details')).toBeUndefined();
+  });
+});

--- a/web/packages/studio/src/routes/ModelDetailRoute/ModelMetadataPanel/utils.tsx
+++ b/web/packages/studio/src/routes/ModelDetailRoute/ModelMetadataPanel/utils.tsx
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FilesetOutput } from '@nemo/sdk/generated/platform/schema';
+import { Anchor } from '@nvidia/foundations-react-core';
+import { TagList } from '@studio/routes/ModelDetailRoute/ModelMetadataPanel/TagList';
+import { getModelSource } from '@studio/routes/ModelDetailRoute/utils';
+import { formatStorageBackendLabel } from '@studio/util/storageBackend';
+import { type ReactNode } from 'react';
+
+interface MetadataRow {
+  label: string;
+  value: ReactNode;
+}
+
+interface MetadataSection {
+  value: string;
+  title: string;
+  rows: MetadataRow[];
+}
+
+export const getMetadataSections = (
+  fileset: FilesetOutput,
+  readmeMetadata: Record<string, unknown> | undefined
+): MetadataSection[] => {
+  const sections: MetadataSection[] = [
+    { value: 'source', title: 'Source', rows: getSourceRows(fileset) },
+  ];
+
+  const detailsRows = getModelCardRows(readmeMetadata);
+  if (detailsRows.length > 0) {
+    sections.push({ value: 'details', title: 'Details', rows: detailsRows });
+  }
+
+  return sections;
+};
+
+const getSourceRows = (fileset: FilesetOutput): MetadataRow[] => {
+  const { storage } = fileset;
+  const source = getModelSource(fileset);
+
+  const rows: MetadataRow[] = [
+    { label: 'Storage', value: formatStorageBackendLabel(storage.type) ?? 'Unknown' },
+  ];
+
+  if (source) {
+    rows.push({
+      label: 'Source',
+      value:
+        storage.type === 'huggingface' ? (
+          <Anchor
+            href={`https://huggingface.co/${source.path}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {source.path}
+          </Anchor>
+        ) : (
+          source.path
+        ),
+    });
+  }
+
+  if (storage.type === 'huggingface' && storage.revision) {
+    rows.push({ label: 'Revision', value: storage.revision });
+  } else if (storage.type === 'ngc' && 'target' in storage) {
+    if (storage.team) rows.push({ label: 'Team', value: storage.team });
+    if (storage.version) rows.push({ label: 'Version', value: storage.version });
+  } else if (storage.type === 's3' && 'bucket' in storage) {
+    if (storage.region) rows.push({ label: 'Region', value: storage.region });
+    if (storage.prefix) rows.push({ label: 'Prefix', value: storage.prefix });
+  }
+
+  return rows;
+};
+
+const getModelCardRows = (metadata: Record<string, unknown> | undefined): MetadataRow[] => {
+  if (!metadata) return [];
+
+  const rows: MetadataRow[] = [];
+
+  const license = readString(metadata.license);
+  const licenseLink = readString(metadata.license_link);
+  if (license) {
+    // `license_link` comes from user-supplied README frontmatter; gate it
+    // through `isSafeHttpUrl` to block `javascript:` / `data:` URLs.
+    const safeLicenseLink = licenseLink && isSafeHttpUrl(licenseLink) ? licenseLink : undefined;
+    rows.push({
+      label: 'License',
+      value: safeLicenseLink ? (
+        <Anchor href={safeLicenseLink} target="_blank" rel="noopener noreferrer">
+          {license}
+        </Anchor>
+      ) : (
+        license
+      ),
+    });
+  }
+
+  const library = readString(metadata.library_name);
+  if (library) rows.push({ label: 'Library', value: library });
+
+  const pipeline = readString(metadata.pipeline_tag);
+  if (pipeline) rows.push({ label: 'Task', value: pipeline });
+
+  const baseModel = readString(metadata.base_model);
+  if (baseModel) {
+    rows.push({
+      label: 'Based on',
+      value: looksLikeHuggingFaceRepo(baseModel) ? (
+        <Anchor
+          href={`https://huggingface.co/${baseModel}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {baseModel}
+        </Anchor>
+      ) : (
+        baseModel
+      ),
+    });
+  }
+
+  const languages = readStringList(metadata.language ?? metadata.languages);
+  if (languages.length > 0) {
+    rows.push({
+      label: languages.length === 1 ? 'Language' : 'Languages',
+      value: <TagList items={languages} />,
+    });
+  }
+
+  const tags = readStringList(metadata.tags);
+  if (tags.length > 0) {
+    rows.push({ label: 'Tags', value: <TagList items={tags} /> });
+  }
+
+  return rows;
+};
+
+const readString = (value: unknown): string | undefined => {
+  if (typeof value === 'string' && value.trim().length > 0) return value.trim();
+  return undefined;
+};
+
+const readStringList = (value: unknown): string[] => {
+  if (typeof value === 'string') {
+    const single = readString(value);
+    return single ? [single] : [];
+  }
+  if (Array.isArray(value)) {
+    return value.filter(
+      (item): item is string => typeof item === 'string' && item.trim().length > 0
+    );
+  }
+  return [];
+};
+
+const looksLikeHuggingFaceRepo = (value: string): boolean =>
+  /^[\w.-]+\/[\w.-]+$/.test(value) && !value.startsWith('http');
+
+const isSafeHttpUrl = (value: string): boolean => {
+  try {
+    const { protocol } = new URL(value);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+};

--- a/web/packages/studio/src/routes/ModelDetailRoute/constants.ts
+++ b/web/packages/studio/src/routes/ModelDetailRoute/constants.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export enum ModelDetailTab {
+  Card = 'card',
+  Files = 'files',
+}
+
+export const isModelDetailTab = (value: string | undefined): value is ModelDetailTab =>
+  Object.values(ModelDetailTab).includes(value as ModelDetailTab);

--- a/web/packages/studio/src/routes/ModelDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ModelDetailRoute/index.tsx
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { creatorToIcon } from '@nemo/common/src/constants/modelMetadata';
+import { useQueryParams } from '@nemo/common/src/hooks/useQueryParams';
+import { getEntityReference } from '@nemo/common/src/namedEntity';
+import {
+  useFilesListFilesetFiles,
+  useFilesRetrieveFileset,
+} from '@nemo/sdk/generated/platform/api';
+import {
+  Flex,
+  PageHeader,
+  Stack,
+  TabsContent,
+  TabsList,
+  TabsRoot,
+  TabsTrigger,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { Loading } from '@studio/components/Layouts/Loading';
+import { ROUTE_PARAMS } from '@studio/constants/routes';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { QUERY_PARAMETERS } from '@studio/routes/constants';
+import { isModelDetailTab, ModelDetailTab } from '@studio/routes/ModelDetailRoute/constants';
+import { FilesTab } from '@studio/routes/ModelDetailRoute/FilesTab';
+import { ModelCardTab } from '@studio/routes/ModelDetailRoute/ModelCardTab';
+import { getModelSource, isRootReadme } from '@studio/routes/ModelDetailRoute/utils';
+import { getWorkspaceFilesetsRoute } from '@studio/routes/utils';
+import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
+import type { FC } from 'react';
+
+export const ModelDetailRoute: FC = () => {
+  const workspace = useWorkspaceFromPath();
+  const { modelName } = useRequiredPathParams([ROUTE_PARAMS.modelName]);
+  const modelId = getEntityReference({ namespace: workspace, name: modelName });
+
+  const { getQueryParam, setQueryParam } = useQueryParams();
+  const tabFromUrl = getQueryParam(QUERY_PARAMETERS.tab) || undefined;
+
+  useBreadcrumbs({
+    items: [
+      { href: getWorkspaceFilesetsRoute(workspace), slotLabel: 'Filesets' },
+      { slotLabel: modelName },
+    ],
+  });
+
+  const queryEnabled = Boolean(workspace && modelName);
+  const {
+    data: filesResponse,
+    isPending: isFilesPending,
+    isFetching: isFilesFetching,
+    isError: isFilesError,
+  } = useFilesListFilesetFiles(workspace, modelName, undefined, {
+    query: { enabled: queryEnabled },
+  });
+  const files = filesResponse?.data;
+
+  const {
+    data: fileset,
+    isPending: isFilesetPending,
+    isError: isFilesetError,
+  } = useFilesRetrieveFileset(workspace, modelName, {
+    query: { enabled: queryEnabled },
+  });
+
+  const hasReadme = files?.some(isRootReadme) ?? false;
+  const defaultTab = hasReadme ? ModelDetailTab.Card : ModelDetailTab.Files;
+  const currentTab: ModelDetailTab = isModelDetailTab(tabFromUrl) ? tabFromUrl : defaultTab;
+
+  const source = fileset ? getModelSource(fileset) : undefined;
+  const description = source ? (
+    <Flex gap="density-sm" align="center">
+      {creatorToIcon(source.creatorSlug, { className: 'w-4 h-4 flex-shrink-0' })}
+      <span>{source.path}</span>
+    </Flex>
+  ) : undefined;
+
+  const handleTabChange = (value: string) => {
+    if (isModelDetailTab(value)) {
+      setQueryParam(QUERY_PARAMETERS.tab, value);
+    }
+  };
+
+  if (isFilesPending || isFilesetPending) {
+    return <Loading description="Loading model..." />;
+  }
+
+  if (isFilesetError || !fileset) {
+    return (
+      <AccessibleTitle title={`Model ${modelName}`}>
+        <Stack className="w-full h-full min-h-0 p-density-2xl" gap="density-xl">
+          <PageHeader slotHeading={modelName} />
+          <Text className="text-feedback-danger">Failed to load model.</Text>
+        </Stack>
+      </AccessibleTitle>
+    );
+  }
+
+  return (
+    <AccessibleTitle title={`Model ${modelName}`}>
+      <Stack className="w-full h-full min-h-0 p-density-2xl" gap="density-xl">
+        <PageHeader slotHeading={modelName} slotDescription={description} />
+        <TabsRoot
+          className="flex-1 min-h-0 flex flex-col"
+          value={currentTab}
+          onValueChange={handleTabChange}
+        >
+          <TabsList>
+            <TabsTrigger value={ModelDetailTab.Card}>Model Card</TabsTrigger>
+            <TabsTrigger value={ModelDetailTab.Files}>Files</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value={ModelDetailTab.Card} className="p-0 flex-1 min-h-0 overflow-auto">
+            <ModelCardTab
+              workspace={workspace}
+              modelName={modelName}
+              fileset={fileset}
+              files={files}
+              isFilesError={isFilesError}
+            />
+          </TabsContent>
+
+          <TabsContent value={ModelDetailTab.Files} className="p-0 flex-1 min-h-0">
+            <FilesTab
+              workspace={workspace}
+              modelName={modelName}
+              modelId={modelId}
+              files={files}
+              isFilesError={isFilesError}
+              isFilesFetching={isFilesFetching}
+            />
+          </TabsContent>
+        </TabsRoot>
+      </Stack>
+    </AccessibleTitle>
+  );
+};

--- a/web/packages/studio/src/routes/ModelDetailRoute/utils.spec.ts
+++ b/web/packages/studio/src/routes/ModelDetailRoute/utils.spec.ts
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  FilesetPurpose,
+  type FilesetOutput,
+  type HuggingfaceStorageConfig,
+  type LocalStorageConfig,
+  type NGCStorageConfig,
+} from '@nemo/sdk/generated/platform/schema';
+import { getModelSource, isRootReadme, parseReadme } from '@studio/routes/ModelDetailRoute/utils';
+
+const makeFileset = (storage: FilesetOutput['storage']): FilesetOutput => ({
+  id: 'fs',
+  name: 'my-model',
+  workspace: 'ws',
+  description: '',
+  purpose: FilesetPurpose.model,
+  storage,
+  metadata: {},
+  custom_fields: {},
+  project: '',
+  created_at: '',
+  updated_at: '',
+});
+
+describe('isRootReadme', () => {
+  it('matches case-insensitive readme.md / readme.markdown at the root', () => {
+    expect(isRootReadme({ path: 'README.md' } as never)).toBe(true);
+    expect(isRootReadme({ path: 'readme.markdown' } as never)).toBe(true);
+  });
+
+  it('rejects nested README files', () => {
+    expect(isRootReadme({ path: 'docs/README.md' } as never)).toBe(false);
+  });
+});
+
+describe('parseReadme', () => {
+  it('returns content unchanged when there is no YAML frontmatter', () => {
+    expect(parseReadme('# Hello world\nbody')).toEqual({ content: '# Hello world\nbody' });
+  });
+
+  it('parses YAML frontmatter and strips it from the markdown body', () => {
+    const input = '---\nlicense: MIT\n---\n# Body';
+    expect(parseReadme(input)).toEqual({
+      content: '# Body',
+      metadata: { license: 'MIT' },
+    });
+  });
+
+  it('falls back to raw content when frontmatter never closes', () => {
+    const input = '---\nlicense: MIT\nno-close';
+    expect(parseReadme(input)).toEqual({ content: input });
+  });
+});
+
+describe('getModelSource', () => {
+  it('derives source from a Hugging Face repo_id', () => {
+    const source = getModelSource(
+      makeFileset({
+        type: 'huggingface',
+        repo_id: 'meta-llama/Llama-2-7b',
+      } as HuggingfaceStorageConfig)
+    );
+    expect(source).toEqual({ path: 'meta-llama/Llama-2-7b', creatorSlug: 'meta' });
+  });
+
+  it('derives source from an NGC org/team/target', () => {
+    const source = getModelSource(
+      makeFileset({
+        type: 'ngc',
+        org: 'nvidia',
+        team: 'nemo',
+        target: 'llama-3.1-nemotron-nano-8b',
+      } as NGCStorageConfig)
+    );
+    expect(source).toEqual({
+      path: 'nvidia/nemo/llama-3.1-nemotron-nano-8b',
+      creatorSlug: 'nvidia',
+    });
+  });
+
+  it('falls back to workspace/name for local storage', () => {
+    const source = getModelSource(
+      makeFileset({
+        type: 'local',
+        path: '/some/path',
+      } as LocalStorageConfig)
+    );
+    expect(source).toEqual({ path: 'ws/my-model', creatorSlug: 'ws' });
+  });
+});

--- a/web/packages/studio/src/routes/ModelDetailRoute/utils.ts
+++ b/web/packages/studio/src/routes/ModelDetailRoute/utils.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FilesetFileOutput, FilesetOutput } from '@nemo/sdk/generated/platform/schema';
+import YAML from 'yaml';
+
+export interface ParsedReadme {
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+export const isRootReadme = (file: FilesetFileOutput): boolean => {
+  if (file.path.includes('/')) return false;
+  const lower = file.path.toLowerCase();
+  return lower === 'readme.md' || lower === 'readme.markdown';
+};
+
+export const parseReadme = (content: string): ParsedReadme => {
+  const normalized = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
+
+  if (!normalized.startsWith('---')) {
+    return { content: normalized };
+  }
+
+  const frontMatterEndIndex = normalized.indexOf('\n---', 3);
+  if (frontMatterEndIndex === -1) {
+    return { content: normalized };
+  }
+
+  const frontMatter = normalized.slice(3, frontMatterEndIndex).trim();
+  const sliceStart = frontMatterEndIndex + 4;
+  const bodyStartIndex = normalized.indexOf('\n', sliceStart);
+  const start = bodyStartIndex === -1 ? sliceStart : bodyStartIndex + 1;
+  const body = normalized.slice(start).trimStart();
+
+  try {
+    const parsed = YAML.parse(frontMatter);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return { content: body, metadata: parsed as Record<string, unknown> };
+    }
+  } catch {
+    return { content: normalized };
+  }
+
+  return { content: body };
+};
+
+export interface ModelSource {
+  path: string;
+  creatorSlug: string;
+}
+
+export const getModelSource = (fileset: FilesetOutput): ModelSource | undefined => {
+  const { storage } = fileset;
+
+  if (storage.type === 'huggingface' && 'repo_id' in storage && storage.repo_id) {
+    const [creator] = storage.repo_id.split('/');
+    if (!creator) return undefined;
+    return { path: storage.repo_id, creatorSlug: normalizeCreatorSlug(creator) };
+  }
+
+  if (
+    storage.type === 'ngc' &&
+    'org' in storage &&
+    storage.org &&
+    'target' in storage &&
+    storage.target
+  ) {
+    const path = storage.team
+      ? `${storage.org}/${storage.team}/${storage.target}`
+      : `${storage.org}/${storage.target}`;
+    return {
+      path,
+      creatorSlug: normalizeCreatorSlug(storage.org),
+    };
+  }
+
+  if (fileset.workspace && fileset.name) {
+    return {
+      path: `${fileset.workspace}/${fileset.name}`,
+      creatorSlug: normalizeCreatorSlug(fileset.workspace),
+    };
+  }
+
+  return undefined;
+};
+
+const normalizeCreatorSlug = (raw: string): string => {
+  const lower = raw.toLowerCase();
+  return lower.split('-')[0] ?? lower;
+};

--- a/web/packages/studio/src/routes/index.tsx
+++ b/web/packages/studio/src/routes/index.tsx
@@ -102,6 +102,11 @@ const DatasetDetailRoute = lazy(() =>
     default: module.DatasetDetailRoute,
   }))
 );
+const ModelDetailRoute = lazy(() =>
+  import('@studio/routes/ModelDetailRoute').then((module) => ({
+    default: module.ModelDetailRoute,
+  }))
+);
 const SecretsListRoute = lazy(() =>
   import('@studio/routes/SecretsListRoute').then((module) => ({ default: module.SecretsListRoute }))
 );
@@ -437,6 +442,15 @@ export const routes: RouteObject[] = [
                       </Suspense>
                     ),
                     errorElement: <ErrorPanel title="Dataset" />,
+                  },
+                  {
+                    path: ROUTES.workspace.modelDetail,
+                    element: (
+                      <Suspense fallback={<Loading description="Loading Model..." />}>
+                        <ModelDetailRoute />
+                      </Suspense>
+                    ),
+                    errorElement: <ErrorPanel title="Model" />,
                   },
                 ]),
               ]),

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -26,6 +26,7 @@ import {
 import { ROUTES } from '@studio/constants/routes';
 import { QUERY_PARAMETERS } from '@studio/routes/constants';
 import { DatasetDetailTab } from '@studio/routes/DatasetDetailRoute/constants';
+import { ModelDetailTab } from '@studio/routes/ModelDetailRoute/constants';
 import { generatePath, RouteObject } from 'react-router';
 
 const gateRoutes = (enabled: boolean, routes: RouteObject | RouteObject[]) => {
@@ -367,6 +368,15 @@ export const getDatasetDetailRoute = (
   options?: { tab?: DatasetDetailTab }
 ) => {
   const base = generatePath(ROUTES.workspace.datasetDetail, { workspace, datasetName });
+  return options?.tab ? `${base}?${QUERY_PARAMETERS.tab}=${options.tab}` : base;
+};
+
+export const getModelDetailRoute = (
+  workspace: string,
+  modelName: string,
+  options?: { tab?: ModelDetailTab }
+) => {
+  const base = generatePath(ROUTES.workspace.modelDetail, { workspace, modelName });
   return options?.tab ? `${base}?${QUERY_PARAMETERS.tab}=${options.tab}` : base;
 };
 

--- a/web/packages/studio/src/util/storageBackend.ts
+++ b/web/packages/studio/src/util/storageBackend.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FilesetOutput } from '@nemo/sdk/generated/platform/schema';
+
+export type StorageBackend = NonNullable<FilesetOutput['storage']['type']>;
+
+const STORAGE_BACKEND_LABELS: Record<StorageBackend, string> = {
+  huggingface: 'Hugging Face',
+  ngc: 'NGC',
+  s3: 'S3',
+  local: 'Local',
+};
+
+export const formatStorageBackendLabel = (
+  type: StorageBackend | null | undefined
+): string | null => (type ? STORAGE_BACKEND_LABELS[type] : null);


### PR DESCRIPTION
The goal on this PR is to do an initial pass of the Model Card view, so we can show the user more interesting information on a model fileset than just weight files. This might help guide the user on deployment parameters and where to find more resources. In the future I would want to show deployment information here too so the user can follow the weights -> model -> deployment -> inference -> eval logical path more easily
 
- <img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/93e4afb8-54c2-49f4-a71b-2cf94276772f" />
- <img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/1e4c1842-1d15-437a-a388-503cd10737bc" />
- <img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/5a4c03b0-33ed-450a-9ef3-82c6160949a1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dedicated model detail pages with tabbed interface for enhanced model exploration.
  * Model Card tab displays model README documentation with parsed metadata including license, supported languages, tags, and base model information.
  * Files tab enables browsing and previewing individual model files directly from the detail page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->