### PR TITLE
feat: allow reusing an adapter layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ Regenerate the SDK whenever you modify:
 ### Type Checking
 
 Use the `ty` tool for type checking:
-- Check all files: `uv run --frozen --extra cpu ty check`
+- Check all files: `uv run --frozen ty check`
 
 Type checking runs automatically in CI via the `lint:uv` job.
 

--- a/docs/safe-synthesizer/about/host-local-development.md
+++ b/docs/safe-synthesizer/about/host-local-development.md
@@ -1,0 +1,167 @@
+<!-- @nemo-nb: process -->
+<!-- @nemo-nb: skip-test -->
+<a id="host-local-development"></a>
+# Host-Local Development and Testing
+
+Run {{nss_short_name}} on your machine's GPU with `nemo safe-synthesizer run-local`. This page covers the plugin CLI only (`run-local` and `runtime`). It does not cover platform job submission or `nemo safe-synthesizer jobs …` commands (not exposed in the CLI today).
+
+## Prerequisites
+
+- CUDA-capable NVIDIA GPU on the host (80GB+ VRAM recommended; check with `nvidia-smi`). See [Getting Started](../getting-started.md).
+- NeMo Platform repository checkout with the Safe Synthesizer plugin installed.
+- **No running platform required** for a typical local run when you pass `--data-source` — the NSS runtime can download base models from Hugging Face directly.
+
+```bash
+# From the NeMo Platform repository root
+BOOTSTRAP_LOCAL_PLUGIN_DIRS=plugins/nemo-safe-synthesizer make bootstrap-python
+uv run nemo safe-synthesizer runtime setup
+uv run nemo safe-synthesizer runtime info
+```
+
+Confirm the CLI surface:
+
+```bash
+uv run nemo safe-synthesizer --help
+# Commands: run-local, runtime
+```
+
+## Run a job locally
+
+Use a job spec JSON (example in `plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/nss-job.json`) and a local input file:
+
+```bash
+uv run nemo safe-synthesizer run-local \
+  --workspace default \
+  --spec-file ./nss-job.json \
+  --data-source ./input.csv \
+  --output-dir ./nss-output
+```
+
+| Flag | Role |
+|------|------|
+| `--spec-file` | Job spec JSON (`data_source`, `config`, …) |
+| `--data-source` | Local CSV (or other supported file) used **instead of** downloading from `data_source` in the spec |
+| `--output-dir` | Where artifacts are written (default `./nss-output`) |
+| `--workspace` | Workspace label for spec fields that reference workspaces (default `default`) |
+
+### Output layout
+
+| Path | Description |
+|------|-------------|
+| `nss-output/synthetic-data.csv` | Generated records |
+| `nss-output/summary.json` | Timing and run summary |
+| `nss-output/evaluation-report.html` | Present when evaluation is enabled |
+| `nss-output/adapter/` | LoRA adapter directory when synthesis training ran |
+
+## Reuse a prior adapter (generation only)
+
+Adapter reuse always skips training and runs **generate + evaluate** only — the same path as the OSS library's `load_from_save_path().generate()`.
+
+### Run-local
+
+Point `config.training.pretrained_model` at a prior run's adapter directory or work tree:
+
+**Run 1** — train and write an adapter:
+
+```bash
+uv run nemo safe-synthesizer run-local \
+  --spec-file ./job1-spec.json \
+  --data-source ./input.csv \
+  --output-dir ./nss-output-1
+```
+
+**Run 2** — generate more records from that adapter:
+
+```json
+{
+  "data_source": "default/placeholder#input.csv",
+  "config": {
+    "enable_synthesis": true,
+    "enable_replace_pii": false,
+    "training": {
+      "pretrained_model": "./nss-output-1/adapter"
+    },
+    "generation": {
+      "num_records": 100
+    }
+  }
+}
+```
+
+The plugin resolves `./nss-output-1/adapter` to the prior run under `./nss-output-1/work`. The `work/` tree must still exist from run 1.
+
+You can also point at `./nss-output-1/work` or a specific run directory under it.
+
+### Platform jobs (`pretrained_model_job`)
+
+For platform jobs, set `pretrained_model_job` to a completed job that has an **`adapter`** result stored in Files:
+
+```json
+{
+  "pretrained_model_job": "my-first-synth-job",
+  "config": {
+    "generation": {
+      "num_records": 100
+    }
+  }
+}
+```
+
+Do not set `config.training.pretrained_model` when using `pretrained_model_job`.
+
+Training runs embed `safe-synthesizer-config.json` in the adapter artifact uploaded to Files so subsequent generation-only jobs can reload the prior run configuration.
+
+Use an absolute path for local `pretrained_model` if you run from a different working directory.
+
+## Runtime commands
+
+```bash
+# One-time: create the NSS engine/CUDA venv
+uv run nemo safe-synthesizer runtime setup
+
+# Inspect configured runtime paths and Python
+uv run nemo safe-synthesizer runtime info
+
+# Recreate the venv after driver or package changes
+uv run nemo safe-synthesizer runtime setup --force
+```
+
+## Automated tests
+
+### Unit tests (no GPU)
+
+From `plugins/nemo-safe-synthesizer`:
+
+```bash
+uv run pytest plugins/nemo-safe-synthesizer/tests/unit/test_local_run.py -v
+```
+
+### Opt-in host-local E2E (GPU)
+
+```bash
+cd /path/to/nemo-platform
+RUN_NSS_LOCAL_E2E=1 uv run pytest \
+  plugins/nemo-safe-synthesizer/tests/e2e/test_local_synthesis.py \
+  -v -m e2e
+```
+
+Optional: `NSS_LOCAL_E2E_TIMEOUT_SECONDS` (default `3600`).
+
+Requires `RUN_NSS_LOCAL_E2E=1`, CUDA, and `nemo safe-synthesizer runtime setup`.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|--------|
+| `run-local` not in `nemo safe-synthesizer --help` | `BOOTSTRAP_LOCAL_PLUGIN_DIRS=plugins/nemo-safe-synthesizer make bootstrap-python`; no duplicate top-level generated `safe-synthesizer` CLI |
+| `runtime setup` / CUDA errors | `uv run nemo safe-synthesizer runtime info` and `nvidia-smi` |
+| Model download failures | Hugging Face access from the NSS runtime venv; network and disk space |
+| Reuse run fails to load adapter | Prior run's `work/` tree still exists (run-local), or adapter artifact in Files includes `metadata_v2.json` and embedded `safe-synthesizer-config.json` (platform) |
+| `Use either 'pretrained_model_job' or 'config.training.pretrained_model'` | For run-local-only workflows, use only `config.training.pretrained_model` |
+
+## Related topics
+
+- [Parameters Reference](reference.md) — spec and `config` fields
+- [Getting Started](../getting-started.md) — GPU and platform context
+- [Jobs](jobs.md) — platform job lifecycle (separate from this run-local guide)
+- Plugin README: `plugins/nemo-safe-synthesizer/README.md`

--- a/docs/safe-synthesizer/about/index.md
+++ b/docs/safe-synthesizer/about/index.md
@@ -106,6 +106,12 @@ Get hands-on experience with Safe Synthesizer through step-by-step tutorials.
 
     Understand the job lifecycle, configuration, and execution for Safe Synthesizer pipelines.
 
+-   **[Host-Local Development](host-local-development.md)**
+
+    ---
+
+    Run on a host GPU with `nemo safe-synthesizer run-local` and `runtime` commands; reuse local adapters and run plugin tests.
+
 -   **[Parameters Reference](reference.md)**
 
     ---

--- a/docs/safe-synthesizer/about/jobs.md
+++ b/docs/safe-synthesizer/about/jobs.md
@@ -102,7 +102,14 @@ When the job completes, access:
 - **Synthetic data**: Generated CSV files
 - **Evaluation report**: HTML report with scores and visualizations
 - **Metadata**: Job summary and configuration
+- **Adapter**: LoRA adapter from the training step (when synthesis ran)
 - **Logs**: Complete execution history
+
+### Reusing a Trained Adapter
+
+For **platform jobs**, set `pretrained_model_job` in the job spec to a completed job that has an **`adapter`** result in Files. Reuse is generation-only (no retraining). Use either `pretrained_model_job` or `config.training.pretrained_model`, not both.
+
+For **host-local** development (`nemo safe-synthesizer run-local`), set `config.training.pretrained_model` to a local adapter or work directory from an earlier run. See [Host-Local Development and Testing](host-local-development.md).
 
 ## Job Builder API
 
@@ -302,6 +309,7 @@ kubectl get events -n <namespace> --sort-by='.lastTimestamp'
 
 ## Related Topics
 
+- [Host-Local Development and Testing](host-local-development.md): `run-local`, adapter reuse, and plugin tests
 - [safe-synthesizer-101](../tutorials/safe-synthesizer-101.md): Get started with {{nss_short_name}} jobs
 - [index](../tutorials/index.md): More hands-on tutorials
 - [reference](reference.md): Full parameter reference

--- a/docs/safe-synthesizer/about/reference.md
+++ b/docs/safe-synthesizer/about/reference.md
@@ -7,6 +7,18 @@ This page summarizes the main configuration groups available when creating
 {{nss_short_name}} jobs. For generated REST API schema details, see the
 [Safe Synthesizer API Reference](../../api/index.md#tag-safe-synthesizer).
 
+## Job Spec (Plugin / REST)
+
+Top-level fields on the Safe Synthesizer job spec (alongside `config`):
+
+| Field | Description |
+|-------|-------------|
+| `data_source` | Input data as a platform fileset URL (`workspace/fileset#path`). With `run-local`, override via `--data-source` and use any placeholder in the spec. |
+| `pretrained_model_job` | Prior completed job whose **`adapter`** result in Files is reused for **generation-only** synthesis. Format: `<job>` or `<workspace>/<job>`. Mutually exclusive with `config.training.pretrained_model`. |
+| `hf_token_secret` | Platform secret name for Hugging Face token during model initialization |
+
+For host-local runs, see [Host-Local Development and Testing](host-local-development.md). Reuse a local adapter with `config.training.pretrained_model`, not `pretrained_model_job`.
+
 ## Top-Level Configuration
 
 The `SafeSynthesizerParameters` schema defines the main configuration structure for Safe Synthesizer jobs.

--- a/docs/safe-synthesizer/getting-started.md
+++ b/docs/safe-synthesizer/getting-started.md
@@ -18,20 +18,20 @@ For general platform troubleshooting (port conflicts, health checks, and so on),
 
 ---
 
-## Using the CLI
+## Host-local CLI
 
-Interact with {{nss_short_name}} using the `nemo` CLI:
+For GPU development on your machine, install the Safe Synthesizer plugin from this repository and use `nemo safe-synthesizer run-local` (see [Host-Local Development and Testing](about/host-local-development.md)):
 
 ```shell
-# List jobs
-nemo safe-synthesizer jobs list
-
-# Create a job from a config file
-nemo safe-synthesizer jobs create --input-file config.json
-
-# Create a job with inline JSON
-nemo safe-synthesizer jobs create --input-data '{"spec": {...}}'
+BOOTSTRAP_LOCAL_PLUGIN_DIRS=plugins/nemo-safe-synthesizer make bootstrap-python
+uv run nemo safe-synthesizer runtime setup
+uv run nemo safe-synthesizer run-local \
+  --spec-file ./nss-job.json \
+  --data-source ./input.csv \
+  --output-dir ./nss-output
 ```
+
+Platform job submission (Jobs API, Studio, tutorials) is documented separately in [Jobs](about/jobs.md) and the [tutorials](tutorials/index.md). The `nemo safe-synthesizer` CLI today exposes **run-local** and **runtime** only.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -325,6 +325,7 @@ nav:
       - Data Synthesis: safe-synthesizer/about/data-synthesis.md
       - Evaluation: safe-synthesizer/about/evaluation.md
       - Jobs: safe-synthesizer/about/jobs.md
+      - Host-Local Development: safe-synthesizer/about/host-local-development.md
       - PII Replacement: safe-synthesizer/about/pii-replacement.md
       - Parameters Reference: safe-synthesizer/about/reference.md
     - Getting Started: safe-synthesizer/getting-started.md

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/app.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/app.py
@@ -50,9 +50,13 @@ app = typer.Typer(
 
 
 def _build_top_level_lazy_entries() -> tuple[TopLevelEntry, ...]:
+    plugin_entry_points = _installed_plugin_command_entry_points()
+    # Plugin `nemo.cli` entry points own their command name (e.g. safe-synthesizer).
+    # Drop generated API top-level groups with the same name so run-local/runtime stay available.
+    api_entries = tuple(entry for entry in API_TOP_LEVEL_ENTRIES if entry.name not in plugin_entry_points)
     return build_top_level_entries(
-        (*TOP_LEVEL_ENTRIES, *API_TOP_LEVEL_ENTRIES),
-        _installed_plugin_command_entry_points(),
+        (*TOP_LEVEL_ENTRIES, *api_entries),
+        plugin_entry_points,
         include_hidden=True,
     )
 

--- a/packages/nemo_platform_ext/tests/cli/test_app.py
+++ b/packages/nemo_platform_ext/tests/cli/test_app.py
@@ -266,6 +266,45 @@ def test_lazy_group_help_uses_loaded_group_help():
     assert "--list" in result.stdout
 
 
+def test_build_top_level_lazy_entries_prefers_plugin_over_api_name_collision():
+    from nemo_platform_ext.cli.app import _build_top_level_lazy_entries
+
+    plugin_entry_points = {
+        "safe-synthesizer": SimpleNamespace(value="nemo_safe_synthesizer_plugin.cli:SafeSynthesizerCLI"),
+    }
+    api_entries = (
+        TopLevelEntry(
+            import_path="nemo_platform_ext.cli.commands.api.safe_synthesizer:app",
+            name="safe-synthesizer",
+            help="Safe Synthesizer operations.",
+            panel="Functional plugins",
+            kind="group",
+        ),
+        TopLevelEntry(
+            import_path="nemo_platform_ext.cli.commands.api.files:app",
+            name="files",
+            help="Manage files.",
+            panel="Core plugins",
+            kind="group",
+        ),
+    )
+
+    with (
+        patch("nemo_platform_ext.cli.app.TOP_LEVEL_ENTRIES", ()),
+        patch("nemo_platform_ext.cli.app.API_TOP_LEVEL_ENTRIES", api_entries),
+        patch(
+            "nemo_platform_ext.cli.app._installed_plugin_command_entry_points",
+            return_value=plugin_entry_points,
+        ),
+    ):
+        entries = _build_top_level_lazy_entries()
+
+    by_name = {entry.name: entry for entry in entries}
+    assert set(by_name) == {"files", "safe-synthesizer"}
+    assert by_name["files"].source == "module"
+    assert by_name["safe-synthesizer"].source == "plugin"
+
+
 def test_plugin_entry_point_name_collision_is_skipped(caplog):
     entries = (
         TopLevelEntry(

--- a/plugins/nemo-safe-synthesizer/README.md
+++ b/plugins/nemo-safe-synthesizer/README.md
@@ -8,7 +8,7 @@ Use the Safe Synthesizer plugin to run a job on a host GPU while preserving the 
 - The Safe Synthesizer plugin installed as a local editable plugin.
 - The separate Safe Synthesizer runtime venv created with the engine/CUDA dependencies.
 - A Safe Synthesizer job spec, such as `nss-job.json`.
-- A running Files API if the job references platform filesets.
+- A running platform only if you use platform filesets, Jobs APIs, or `pretrained_model_job`. Pure `run-local` with `--data-source` does not require it.
 
 ## Steps
 
@@ -26,7 +26,7 @@ Use the Safe Synthesizer plugin to run a job on a host GPU while preserving the 
        uv run nemo safe-synthesizer runtime setup
        ```
 
-    3. Create the model filesets used for offline model cache initialization:
+    3. (Optional, platform jobs only) After `curl -s http://localhost:8080/health/ready`, register model filesets:
 
        ```bash
        uv run python plugins/nemo-safe-synthesizer/scripts/setup_model_filesets.py --files-api-url http://localhost:8080
@@ -45,6 +45,7 @@ Use the Safe Synthesizer plugin to run a job on a host GPU while preserving the 
        ```bash
        BOOTSTRAP_LOCAL_PLUGIN_DIRS=plugins/nemo-safe-synthesizer make bootstrap-python
        uv run nemo safe-synthesizer runtime setup
+       # Optional after platform is up — see step 3 in the CLI section
        uv run python plugins/nemo-safe-synthesizer/scripts/setup_model_filesets.py --files-api-url http://localhost:8080
        ```
 
@@ -64,6 +65,7 @@ The command writes generated data, summaries, and any adapter output under `./ns
 
 ## Related Links
 
+- `docs/safe-synthesizer/about/host-local-development.md` — host-local runs, adapter reuse, and tests
 - `docs/safe-synthesizer/about/reference.md`
 - `plugins/nemo-safe-synthesizer/scripts/setup_model_filesets.py`
 

--- a/plugins/nemo-safe-synthesizer/openapi/openapi.yaml
+++ b/plugins/nemo-safe-synthesizer/openapi/openapi.yaml
@@ -1459,6 +1459,13 @@ components:
           description: Name of platform secret containing the HuggingFace token. Must
             exist in the same workspace as the job.
           type: string
+        pretrained_model_job:
+          title: Pretrained Model Job
+          description: Optional previous NSS job whose stored adapter artifact is
+            reused for generation-only synthesis. Accepts either '<job>' in the current
+            workspace or '<workspace>/<job>'. The plugin resolves the prior job's
+            'adapter' result from Files.
+          type: string
       type: object
       required:
       - data_source

--- a/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/api/v2/jobs/endpoints.py
+++ b/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/api/v2/jobs/endpoints.py
@@ -68,6 +68,13 @@ class SafeSynthesizerJobConfig(SafeSynthesizerJobConfigInternal):
     config: SafeSynthesizerParameters = Field(
         description="The Safe Synthesizer parameters configuration.",
     )
+    pretrained_model_job: str | None = Field(
+        default=None,
+        description="Optional previous NSS job whose stored adapter artifact is reused for generation-only "
+        "synthesis. Accepts either '<job>' in the current workspace or '<workspace>/<job>'. "
+        "The plugin resolves the prior job's 'adapter' result from Files.",
+    )
+
     enable_synthesis: SkipJsonSchema[bool] = Field(
         default=True,
         description="Whether to run LLM training and generation phases. "
@@ -113,6 +120,38 @@ class SafeSynthesizerJobConfig(SafeSynthesizerJobConfigInternal):
         deep_update(default, replace_pii)
         config_data["replace_pii"] = default
         return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_pretrained_model_source(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        if not data.get("pretrained_model_job"):
+            return data
+        config_data = data.get("config")
+        training_data = config_data.get("training") if isinstance(config_data, dict) else None
+        if isinstance(training_data, dict) and "pretrained_model" in training_data:
+            raise ValueError("Use either 'pretrained_model_job' or 'config.training.pretrained_model', not both.")
+        return data
+
+
+def parse_pretrained_model_job_ref(job_ref: str, workspace_fallback: str) -> tuple[str, str]:
+    """Parse a previous NSS job reference.
+
+    Accepts either "<job>" in the current workspace or "<workspace>/<job>".
+    """
+    parts = job_ref.split("/", 1)
+    if len(parts) == 1:
+        workspace = workspace_fallback
+        job_name = parts[0]
+    else:
+        workspace, job_name = parts
+
+    if not workspace or not job_name:
+        raise PlatformJobCompilationError(
+            f"Invalid pretrained_model_job format: {job_ref!r}. Expected '<job>' or '<workspace>/<job>'."
+        )
+    return workspace, job_name
 
 
 def _create_job_step(job_config: SafeSynthesizerJobConfig, environment: list[EnvironmentVariable]) -> PlatformJobStep:
@@ -223,6 +262,22 @@ async def job_config_compiler(
                 name="HF_TOKEN", from_secret=EnvironmentVariableFromSecret(name=transformed_spec.hf_token_secret)
             )
         )
+
+    if transformed_spec.pretrained_model_job:
+        model_workspace, model_job = parse_pretrained_model_job_ref(
+            transformed_spec.pretrained_model_job, workspace_fallback=workspace
+        )
+        try:
+            await sdk.jobs.results.retrieve(name="adapter", job=model_job, workspace=model_workspace)
+        except NotFoundError as e:
+            raise PlatformJobCompilationError(
+                f"Could not find adapter result for NSS job {model_workspace}/{model_job!r}"
+            ) from e
+        except PermissionDeniedError as e:
+            raise PlatformJobCompilationError(
+                f"Failed to retrieve adapter result for NSS job {model_workspace}/{model_job!r}: "
+                f"access denied to workspace {model_workspace!r}"
+            ) from e
 
     if transformed_spec.config:
         steps.append(_create_job_step(job_config=transformed_spec, environment=environment))

--- a/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/SKILL.md
+++ b/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/SKILL.md
@@ -29,7 +29,7 @@ Task router for agents helping a person use the NeMo Safe Synthesizer NMP plugin
 - Prefer the plugin CLI surface over upstream-only commands.
 - Use `nemo safe-synthesizer run-local` for host-local CUDA/GPU development.
 - Use `nemo safe-synthesizer runtime setup` to install engine/CUDA dependencies into the separate runtime venv.
-- Use `nemo safe-synthesizer jobs create` for platform jobs.
+- Use the Jobs API or SDK for platform jobs. The `nemo safe-synthesizer` CLI exposes `run-local` and `runtime` only.
 - Treat `data_source` as a fileset URL for platform jobs, usually `<workspace>/<fileset>#<path>`.
 - For local runs, prefer `--data-source <local-file-or-dir>` when the input is already on disk.
 - If the job uses PII classification, `config.replace_pii.globals.classify.classify_model_provider` must be `<workspace>/<provider_name>`.

--- a/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/workflows/config.md
+++ b/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/workflows/config.md
@@ -50,3 +50,9 @@ See `workflows/pii-architecture.md` for "PII classification architecture".
 ## Secrets
 
 Use `hf_token_secret` at the top level of the job spec when model initialization needs a Hugging Face token from the platform secrets service.
+
+## Reusing a Previously Trained NSS Model
+
+For **`nemo safe-synthesizer run-local`**, set `config.training.pretrained_model` to the adapter directory from a prior run (for example `./nss-output/adapter`). The plugin reuses that adapter for **generation only** (no retraining). See `docs/safe-synthesizer/about/host-local-development.md`.
+
+For **platform jobs**, set `pretrained_model_job` at the top level of the job spec; the plugin resolves that job's `adapter` result from Files for generation-only reuse. Use either `pretrained_model_job` or `config.training.pretrained_model`, not both.

--- a/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/workflows/run.md
+++ b/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/workflows/run.md
@@ -8,11 +8,14 @@
 - A job spec JSON file with `data_source` and `config`.
 - A local input file or directory when using `--data-source`.
 
-If model downloads are needed through platform filesets, run:
+If you submit **platform jobs** (not bare `run-local` with `--data-source`), start services first (`nemo setup --start-services` or `nemo services run`), then optionally register model filesets:
 
 ```bash
+curl -s http://localhost:8080/health/ready
 uv run python plugins/nemo-safe-synthesizer/scripts/setup_model_filesets.py --files-api-url http://localhost:8080
 ```
+
+See `docs/safe-synthesizer/about/host-local-development.md` for when the platform is required.
 
 ## Platform Job Prerequisites
 
@@ -90,6 +93,7 @@ For platform submission, pass this object as the `spec` field when using `--inpu
 ## Next Steps
 
 - Tune job parameters with `workflows/config.md` and `workflows/config-runs.md`.
+- Reuse a prior adapter or run plugin tests: `docs/safe-synthesizer/about/host-local-development.md`.
 - Retrieve job result files with `workflows/results.md`.
 - Interpret output files with `workflows/artifacts.md`.
 - Debug failed runs with `workflows/diagnose.md`.

--- a/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/tasks/safe_synthesizer/__main__.py
+++ b/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/tasks/safe_synthesizer/__main__.py
@@ -30,7 +30,15 @@ from nemo_platform.filesets import parse_fileset_ref
 from nemo_safe_synthesizer.config.internal_results import SafeSynthesizerResults
 from nemo_safe_synthesizer.observability import initialize_observability
 from nemo_safe_synthesizer.sdk.library_builder import SafeSynthesizer
-from nemo_safe_synthesizer_plugin.api.v2.jobs.endpoints import SafeSynthesizerJobConfig
+from nemo_safe_synthesizer_plugin.api.v2.jobs.endpoints import (
+    SafeSynthesizerJobConfig,
+    parse_pretrained_model_job_ref,
+)
+from nemo_safe_synthesizer_plugin.tasks.safe_synthesizer.adapter_resolution import (
+    embed_run_config_in_adapter,
+    is_adapter_reuse_requested,
+    run_generation_from_prior_adapter,
+)
 from nemo_safe_synthesizer_plugin.tasks.safe_synthesizer.jsonl_loader import load_jsonl_file
 from nemo_safe_synthesizer_plugin.tasks.safe_synthesizer.logging_setup import configure_logging
 from nemo_safe_synthesizer_plugin.tasks.safe_synthesizer.model_init import init_models_sync
@@ -173,6 +181,7 @@ def upload_results(result: SafeSynthesizerResults, adapter_path: Path | None = N
             _create_job_result(sdk, workspace, job_id, "evaluation-report", artifact_url)
 
     if adapter_path is not None and adapter_path.exists():
+        embed_run_config_in_adapter(adapter_path)
         artifact_url = file_manager.upload(adapter_path, f"results/{attempt_id}/adapter")
         _create_job_result(sdk, workspace, job_id, "adapter", artifact_url)
 
@@ -188,6 +197,7 @@ def write_results_local(result: SafeSynthesizerResults, output_dir: Path, adapte
     if result.evaluation_report_html:
         (output_dir / "evaluation-report.html").write_text(result.evaluation_report_html, encoding="utf-8")
     if adapter_path is not None and adapter_path.exists():
+        embed_run_config_in_adapter(adapter_path)
         adapter_target = output_dir / "adapter"
         if adapter_path.is_dir():
             import shutil
@@ -209,6 +219,50 @@ def _create_job_result(sdk: NeMoPlatform, workspace: str, job_name: str, result_
     logger.info("Created job result: %s", result_name)
 
 
+def _resolve_pretrained_model(
+    job_config: SafeSynthesizerJobConfig,
+    *,
+    workspace: str,
+    sdk: NeMoPlatform | None = None,
+) -> tuple[object | None, Path | None]:
+    """Download a prior job's adapter artifact from Files when ``pretrained_model_job`` is set."""
+    if not job_config.pretrained_model_job:
+        return None, None
+
+    if sdk is None:
+        sdk = get_platform_sdk()
+
+    model_workspace, model_job = parse_pretrained_model_job_ref(
+        job_config.pretrained_model_job,
+        workspace_fallback=workspace,
+    )
+    try:
+        adapter_result = sdk.jobs.results.retrieve(name="adapter", job=model_job, workspace=model_workspace)
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to resolve adapter result for pretrained_model_job={job_config.pretrained_model_job!r}"
+        ) from e
+
+    fileset_workspace, fileset_name, _ = parse_fileset_ref(
+        adapter_result.artifact_url,
+        workspace_fallback=model_workspace,
+    )
+    file_manager = FilesetFileManager(
+        workspace=fileset_workspace,
+        fileset_name=fileset_name,
+        sdk=sdk,
+        ensure_fileset_exists=False,
+    )
+    tmp_dir_path = file_manager.download_from_url(adapter_result.artifact_url)
+    adapter_path = tmp_dir_path.path
+    logger.info(
+        "Resolved pretrained_model_job %s to adapter artifact at %s",
+        job_config.pretrained_model_job,
+        adapter_path,
+    )
+    return tmp_dir_path, adapter_path
+
+
 def _setup_classify_endpoint():
     """Set up the NIM_ENDPOINT_URL for column classification from platform env vars."""
     endpoint_path = os.environ.get("CLASSIFY_LLM_ENDPOINT_PATH")
@@ -226,7 +280,11 @@ def _setup_classify_endpoint():
 
 
 def run_config(
-    job_config: SafeSynthesizerJobConfig, data_source: pd.DataFrame, save_path: Path
+    job_config: SafeSynthesizerJobConfig,
+    data_source: pd.DataFrame,
+    save_path: Path,
+    *,
+    adapter_location: str | Path | None = None,
 ) -> tuple[SafeSynthesizerResults, Path | None]:
     """Run NSS against a validated config and already-loaded data source."""
     enable_synthesis: bool = job_config.enable_synthesis
@@ -247,6 +305,15 @@ def run_config(
             job_config.config.data.holdout = 0
             job_config.config.data.max_holdout = 0
 
+        if enable_synthesis and is_adapter_reuse_requested(job_config):
+            location = adapter_location or job_config.config.training.pretrained_model
+            return run_generation_from_prior_adapter(
+                job_config,
+                data_source,
+                save_path,
+                adapter_location=str(location) if location is not None else None,
+            )
+
         ss: SafeSynthesizer = SafeSynthesizer(config=job_config.config, save_path=save_path).with_data_source(
             data_source
         )
@@ -266,12 +333,16 @@ def run_config(
             http_backoff.__kwdefaults__["max_retries"] = original_max_retries
 
     adapter_path = ss._workdir.adapter_path if ss._workdir and enable_synthesis else None
+    if adapter_path is not None:
+        embed_run_config_in_adapter(adapter_path)
     return ss.results, adapter_path
 
 
 def run_from_env() -> None:
     """Run in the platform task-container environment."""
     initialize_observability()
+    workspace = os.environ.get(NEMO_JOB_WORKSPACE_ENVVAR, "default")
+    sdk = get_platform_sdk()
     files_url = get_platform_config().get_service_url("files")
     if files_url:
         logger.info("Initializing model weights from Files API...")
@@ -299,8 +370,18 @@ def run_from_env() -> None:
 
     job_config = SafeSynthesizerJobConfig.model_validate(raw_job_config)
     save_path = Path(os.environ.get(EPHEMERAL_TASK_STORAGE_PATH_ENVVAR, DEFAULT_TASK_STORAGE_PATH))
-    result, adapter_path = run_config(job_config, data_source, save_path)
-    upload_results(result=result, adapter_path=adapter_path)
+    pretrained_model_tmp, adapter_path = _resolve_pretrained_model(job_config, workspace=workspace, sdk=sdk)
+    try:
+        result, adapter_path = run_config(
+            job_config,
+            data_source,
+            save_path,
+            adapter_location=adapter_path,
+        )
+        upload_results(result=result, adapter_path=adapter_path)
+    finally:
+        if pretrained_model_tmp is not None:
+            pretrained_model_tmp.cleanup_tmp_dir()
 
 
 def run_local(spec_file: Path, workspace: str, output_dir: Path, data_source: Path | None = None) -> None:
@@ -313,8 +394,18 @@ def run_local(spec_file: Path, workspace: str, output_dir: Path, data_source: Pa
         loaded_data = download_from_fileset(job_config.data_source)
     else:
         loaded_data = _load_file_as_dataframe(data_source)
-    result, adapter_path = run_config(job_config, loaded_data, output_dir / "work")
-    write_results_local(result, output_dir, adapter_path)
+    pretrained_model_tmp, adapter_path = _resolve_pretrained_model(job_config, workspace=workspace)
+    try:
+        result, new_adapter_path = run_config(
+            job_config,
+            loaded_data,
+            output_dir / "work",
+            adapter_location=adapter_path,
+        )
+        write_results_local(result, output_dir, new_adapter_path)
+    finally:
+        if pretrained_model_tmp is not None:
+            pretrained_model_tmp.cleanup_tmp_dir()
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/tasks/safe_synthesizer/adapter_resolution.py
+++ b/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/tasks/safe_synthesizer/adapter_resolution.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generation-only reuse of prior NSS adapter artifacts."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from nemo_safe_synthesizer.cli.artifact_structure import RunName, Workdir
+from nemo_safe_synthesizer.config.internal_results import SafeSynthesizerResults
+
+if TYPE_CHECKING:
+    from nemo_safe_synthesizer.sdk.library_builder import SafeSynthesizer
+    from nemo_safe_synthesizer_plugin.api.v2.jobs.endpoints import SafeSynthesizerJobConfig
+
+logger = logging.getLogger("safe_synthesizer")
+
+DEFAULT_PRETRAINED_MODEL = "HuggingFaceTB/SmolLM3-3B"
+EMBEDDED_RUN_CONFIG_NAME = "safe-synthesizer-config.json"
+
+
+def is_peft_adapter_directory(path: Path) -> bool:
+    """Return whether ``path`` looks like a PEFT LoRA adapter directory."""
+    return path.is_dir() and (path / "adapter_config.json").is_file()
+
+
+def embed_run_config_in_adapter(adapter_dir: Path) -> None:
+    """Copy the training run config into an adapter directory for Files reuse."""
+    if not is_peft_adapter_directory(adapter_dir):
+        return
+    sibling_config = adapter_dir.parent / EMBEDDED_RUN_CONFIG_NAME
+    embedded_config = adapter_dir / EMBEDDED_RUN_CONFIG_NAME
+    if sibling_config.is_file() and not embedded_config.exists():
+        shutil.copy2(sibling_config, embedded_config)
+
+
+def resolve_pretrained_model_path(pretrained_model: str) -> Path:
+    """Resolve a configured path relative to the current working directory."""
+    path = Path(pretrained_model).expanduser()
+    if not path.is_absolute():
+        path = (Path.cwd() / path).resolve()
+    return path.resolve()
+
+
+def is_adapter_reuse_requested(job_config: SafeSynthesizerJobConfig) -> bool:
+    """Return whether the job spec requests generation-only reuse of a prior adapter."""
+    if job_config.pretrained_model_job:
+        return True
+
+    pretrained_model = job_config.config.training.pretrained_model
+    if not pretrained_model or pretrained_model == DEFAULT_PRETRAINED_MODEL:
+        return False
+
+    path = resolve_pretrained_model_path(pretrained_model)
+    if not path.exists():
+        return False
+    if is_peft_adapter_directory(path):
+        return True
+
+    try:
+        Workdir.from_path(path)
+    except ValueError:
+        return False
+    return True
+
+
+def resolve_prior_training_workdir(adapter_location: str | Path) -> Workdir:
+    """Locate or materialize the prior NSS training ``Workdir`` for an adapter."""
+    path = resolve_pretrained_model_path(str(adapter_location))
+
+    if is_peft_adapter_directory(path):
+        train_dir = path.parent
+        if train_dir.name == "train" and (train_dir.parent / "dataset").is_dir():
+            return Workdir.from_path(train_dir.parent)
+        work_base = path.parent / "work"
+        if work_base.is_dir():
+            return Workdir.from_path(work_base)
+        return _materialize_workdir_from_adapter(path)
+
+    return Workdir.from_path(path)
+
+
+def _materialize_workdir_from_adapter(adapter_dir: Path) -> Workdir:
+    """Build an NSS run layout from a standalone adapter directory (for example from Files)."""
+    if not is_peft_adapter_directory(adapter_dir):
+        raise ValueError(f"Not a PEFT adapter directory: {adapter_dir}")
+
+    metadata_path = adapter_dir / "metadata_v2.json"
+    if not metadata_path.is_file():
+        raise ValueError(
+            f"Adapter at {adapter_dir} is missing metadata_v2.json, which is required for generation-only reuse."
+        )
+
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    workdir_info = metadata.get("workdir") if isinstance(metadata.get("workdir"), dict) else {}
+    config_name = workdir_info.get("config_name", "default")
+    dataset_name = workdir_info.get("dataset_name", "data")
+    run_name = workdir_info.get("run_name", "adapter-reuse")
+
+    if adapter_dir.name == "adapter" and (adapter_dir.parent / "train").is_dir():
+        return Workdir.from_path(adapter_dir.parent.parent)
+
+    run_root = adapter_dir.parent / f"{config_name}---{dataset_name}" / run_name
+    train_adapter = run_root / "train" / "adapter"
+    if train_adapter.resolve() != adapter_dir.resolve():
+        if train_adapter.exists():
+            shutil.rmtree(train_adapter)
+        train_adapter.parent.mkdir(parents=True, exist_ok=True)
+        if adapter_dir.resolve().is_relative_to(run_root.resolve()):
+            shutil.copytree(adapter_dir, train_adapter)
+        else:
+            shutil.copytree(adapter_dir, train_adapter)
+
+    embedded_config = train_adapter / EMBEDDED_RUN_CONFIG_NAME
+    train_config = run_root / "train" / EMBEDDED_RUN_CONFIG_NAME
+    if embedded_config.is_file() and not train_config.is_file():
+        shutil.copy2(embedded_config, train_config)
+
+    if not train_config.is_file():
+        raise ValueError(
+            f"Adapter at {adapter_dir} is missing {EMBEDDED_RUN_CONFIG_NAME}. "
+            "Re-run training with a current NSS plugin build so the config is embedded in the adapter artifact."
+        )
+
+    return Workdir.from_path(run_root)
+
+
+def create_generation_workdir(parent_workdir: Workdir, save_path: Path) -> Workdir:
+    """Create a child generation workdir that reads adapter/config/data from ``parent_workdir``."""
+    return Workdir(
+        base_path=save_path,
+        config_name=parent_workdir.config_name,
+        dataset_name=parent_workdir.dataset_name,
+        run_name=RunName().to_string(),
+        _current_phase="generate",
+        _parent_workdir=parent_workdir,
+    )
+
+
+def _apply_generation_overrides(ss: SafeSynthesizer, job_config: SafeSynthesizerJobConfig) -> None:
+    """Apply generation and evaluation overrides from the job spec onto a resumed run."""
+    if ss._nss_config is None:
+        raise RuntimeError("SafeSynthesizer config was not loaded from the prior run")
+    ss._nss_config.generation = job_config.config.generation
+    ss._nss_config.evaluation = job_config.config.evaluation
+
+
+def _write_cached_training_split(parent_workdir: Workdir, data_source: pd.DataFrame) -> None:
+    """Persist a training split when the reused adapter bundle does not include one."""
+    training_path = parent_workdir.dataset.training
+    if training_path.exists():
+        return
+    parent_workdir.dataset.path.mkdir(parents=True, exist_ok=True)
+    data_source.to_csv(training_path, index=False)
+
+
+def run_generation_from_prior_adapter(
+    job_config: SafeSynthesizerJobConfig,
+    data_source: pd.DataFrame | None,
+    save_path: Path,
+    *,
+    adapter_location: str | None = None,
+) -> tuple[SafeSynthesizerResults, Path | None]:
+    """Generate synthetic data from a prior adapter without retraining."""
+    from nemo_safe_synthesizer.sdk.library_builder import SafeSynthesizer
+
+    if adapter_location is None:
+        if not job_config.config.training.pretrained_model:
+            raise ValueError("Adapter reuse requires pretrained_model_job or config.training.pretrained_model.")
+        adapter_location = job_config.config.training.pretrained_model
+
+    parent_workdir = resolve_prior_training_workdir(adapter_location)
+    if data_source is not None:
+        _write_cached_training_split(parent_workdir, data_source)
+
+    gen_workdir = create_generation_workdir(parent_workdir, save_path)
+    gen_workdir.ensure_directories()
+
+    logger.info(
+        "Generation-only adapter reuse: loading adapter from %s into run %s",
+        parent_workdir.adapter_path,
+        gen_workdir.run_dir,
+    )
+
+    ss = SafeSynthesizer(config=job_config.config, workdir=gen_workdir)
+    if data_source is not None:
+        ss = ss.with_data_source(data_source)
+    ss.load_from_save_path()
+    _apply_generation_overrides(ss, job_config)
+    ss.generate().evaluate()
+    ss.save_results()
+    return ss.results, parent_workdir.adapter_path

--- a/plugins/nemo-safe-synthesizer/tests/unit/test_adapter_resolution.py
+++ b/plugins/nemo-safe-synthesizer/tests/unit/test_adapter_resolution.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+
+import pytest
+from nemo_safe_synthesizer_plugin.tasks.safe_synthesizer.adapter_resolution import (
+    EMBEDDED_RUN_CONFIG_NAME,
+    embed_run_config_in_adapter,
+    is_adapter_reuse_requested,
+    is_peft_adapter_directory,
+    resolve_prior_training_workdir,
+)
+
+
+def _write_adapter_dir(tmp_path: Path, *, include_metadata: bool = True) -> Path:
+    adapter_dir = tmp_path / "adapter"
+    adapter_dir.mkdir(parents=True)
+    (adapter_dir / "adapter_config.json").write_text("{}", encoding="utf-8")
+    (adapter_dir / "adapter_model.safetensors").write_bytes(b"stub")
+    if include_metadata:
+        (adapter_dir / "metadata_v2.json").write_text(
+            json.dumps(
+                {
+                    "workdir": {
+                        "config_name": "default",
+                        "dataset_name": "data",
+                        "run_name": "2026-01-01T00:00:00",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+    return adapter_dir
+
+
+def test_is_peft_adapter_directory(tmp_path):
+    adapter_dir = _write_adapter_dir(tmp_path)
+    assert is_peft_adapter_directory(adapter_dir)
+    assert not is_peft_adapter_directory(tmp_path / "missing")
+
+
+def test_embed_run_config_in_adapter(tmp_path):
+    run_root = tmp_path / "run"
+    train_dir = run_root / "train"
+    adapter_dir = train_dir / "adapter"
+    adapter_dir.mkdir(parents=True)
+    (adapter_dir / "adapter_config.json").write_text("{}", encoding="utf-8")
+    (train_dir / EMBEDDED_RUN_CONFIG_NAME).write_text('{"generation": {"num_records": 1}}', encoding="utf-8")
+
+    embed_run_config_in_adapter(adapter_dir)
+
+    assert (adapter_dir / EMBEDDED_RUN_CONFIG_NAME).is_file()
+
+
+def test_resolve_prior_training_workdir_from_output_adapter_copy(tmp_path, monkeypatch):
+    output_dir = tmp_path / "nss-output"
+    work_dir = output_dir / "work" / "default---data" / "2026-01-01T00:00:00"
+    adapter_dir = work_dir / "train" / "adapter"
+    adapter_dir.mkdir(parents=True)
+    (adapter_dir / "adapter_config.json").write_text("{}", encoding="utf-8")
+    (adapter_dir / "adapter_model.safetensors").write_bytes(b"stub")
+    (work_dir / "dataset").mkdir()
+    (work_dir / "dataset" / "training.csv").write_text("value\n1\n", encoding="utf-8")
+    (work_dir / "train" / EMBEDDED_RUN_CONFIG_NAME).write_text("{}", encoding="utf-8")
+    (adapter_dir / "metadata_v2.json").write_text("{}", encoding="utf-8")
+
+    copied_adapter = _write_adapter_dir(output_dir, include_metadata=True)
+
+    monkeypatch.chdir(tmp_path)
+    workdir = resolve_prior_training_workdir("./nss-output/adapter")
+    assert workdir.adapter_path == adapter_dir
+    assert copied_adapter.is_dir()
+
+
+def test_materialize_workdir_from_downloaded_adapter(tmp_path):
+    adapter_dir = _write_adapter_dir(tmp_path)
+    (adapter_dir / EMBEDDED_RUN_CONFIG_NAME).write_text("{}", encoding="utf-8")
+
+    workdir = resolve_prior_training_workdir(adapter_dir)
+    assert workdir.adapter_path.is_dir()
+    assert (workdir.train.config).is_file()
+
+
+def test_is_adapter_reuse_requested_for_local_adapter(tmp_path, monkeypatch):
+    pytest.importorskip("nemo_safe_synthesizer.config.job")
+    from nemo_safe_synthesizer_plugin.api.v2.jobs.endpoints import SafeSynthesizerJobConfig
+
+    output_dir = tmp_path / "nss-output"
+    _write_adapter_dir(output_dir)
+    work_dir = output_dir / "work" / "default---data" / "2026-01-01T00:00:00" / "train" / "adapter"
+    work_dir.mkdir(parents=True)
+    (work_dir / "adapter_model.safetensors").write_bytes(b"stub")
+
+    monkeypatch.chdir(tmp_path)
+    job_config = SafeSynthesizerJobConfig.model_validate(
+        {
+            "data_source": "default/data#input.csv",
+            "config": {"training": {"pretrained_model": "./nss-output/adapter"}},
+        }
+    )
+    assert is_adapter_reuse_requested(job_config) is True
+
+
+def test_is_adapter_reuse_requested_for_pretrained_model_job(tmp_path):
+    pytest.importorskip("nemo_safe_synthesizer.config.job")
+    from nemo_safe_synthesizer_plugin.api.v2.jobs.endpoints import SafeSynthesizerJobConfig
+
+    job_config = SafeSynthesizerJobConfig.model_validate(
+        {
+            "data_source": "default/data#input.csv",
+            "pretrained_model_job": "prior-safe-synth-job",
+            "config": {},
+        }
+    )
+    assert is_adapter_reuse_requested(job_config) is True

--- a/plugins/nemo-safe-synthesizer/tests/unit/test_jobs.py
+++ b/plugins/nemo-safe-synthesizer/tests/unit/test_jobs.py
@@ -1,25 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import importlib
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from nemo_platform import NotFoundError, PermissionDeniedError
+from nemo_safe_synthesizer.config.replace_pii import ClassifyConfig, Globals, PiiReplacerConfig, StepDefinition
+from nemo_safe_synthesizer_plugin.api.v2.jobs import endpoints
+from nemo_safe_synthesizer_plugin.api.v2.jobs.endpoints import SafeSynthesizerJobConfig as PluginJobConfig
+from nemo_safe_synthesizer_plugin.api.v2.jobs.endpoints import SafeSynthesizerParameters, job_config_compiler
 from nemo_safe_synthesizer_plugin.runtime import TASK_MODULE
 from nmp.common.jobs.exceptions import PlatformJobCompilationError
-
-nss_job = pytest.importorskip("nemo_safe_synthesizer.config.job")
-nss_pii = pytest.importorskip("nemo_safe_synthesizer.config.replace_pii")
-endpoints = importlib.import_module("nemo_safe_synthesizer_plugin.api.v2.jobs.endpoints")
-SafeSynthesizerJobConfig = nss_job.SafeSynthesizerJobConfig
-SafeSynthesizerParameters = nss_job.SafeSynthesizerParameters
-ClassifyConfig = nss_pii.ClassifyConfig
-Globals = nss_pii.Globals
-PiiReplacerConfig = nss_pii.PiiReplacerConfig
-StepDefinition = nss_pii.StepDefinition
-PluginJobConfig = endpoints.SafeSynthesizerJobConfig
-job_config_compiler = endpoints.job_config_compiler
 
 DEFAULT_WORKSPACE = "default"
 DEFAULT_DATA_SOURCE = "default/test-data#file.csv"
@@ -48,7 +39,7 @@ def _make_spec(data_source: str = DEFAULT_DATA_SOURCE, model_provider: str | Non
             globals=Globals(classify=ClassifyConfig(classify_model_provider=model_provider)),
             steps=[StepDefinition()],
         )
-    return SafeSynthesizerJobConfig(
+    return PluginJobConfig(
         data_source=data_source,
         config=SafeSynthesizerParameters(replace_pii=replace_pii),
     )
@@ -104,6 +95,56 @@ async def test_job_config_compiler_with_classify_provider(mock_sdk):
     assert step["executor"]["command"] == ["/runtime/bin/python", "-m", TASK_MODULE]
     env = {e["name"]: e.get("value") for e in step.get("environment", [])}
     assert env["CLASSIFY_LLM_ENDPOINT_PATH"] == "/apis/inference-gateway/v2/workspaces/default/provider/my-nim/-/v1"
+
+
+@pytest.mark.asyncio
+async def test_job_config_compiler_validates_pretrained_model_job(mock_sdk):
+    mock_sdk.jobs.results.retrieve = AsyncMock(
+        return_value=MagicMock(artifact_url="default/job-results-prior#results/attempt-1/adapter")
+    )
+    spec = PluginJobConfig.model_validate(
+        {
+            "data_source": DEFAULT_DATA_SOURCE,
+            "pretrained_model_job": "prior-safe-synth-job",
+            "config": {},
+        }
+    )
+
+    await _compile(spec, mock_sdk)
+
+    mock_sdk.jobs.results.retrieve.assert_awaited_once_with(
+        name="adapter",
+        job="prior-safe-synth-job",
+        workspace=DEFAULT_WORKSPACE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_job_config_compiler_pretrained_model_job_not_found(mock_sdk):
+    mock_sdk.jobs.results.retrieve = AsyncMock(
+        side_effect=NotFoundError(message="not found", response=MagicMock(status_code=404), body=None)
+    )
+    spec = PluginJobConfig.model_validate(
+        {
+            "data_source": DEFAULT_DATA_SOURCE,
+            "pretrained_model_job": "other-ws/prior-safe-synth-job",
+            "config": {},
+        }
+    )
+
+    with pytest.raises(PlatformJobCompilationError, match="Could not find adapter result"):
+        await _compile(spec, mock_sdk)
+
+
+def test_plugin_job_config_rejects_conflicting_pretrained_model_sources():
+    with pytest.raises(ValueError, match="Use either 'pretrained_model_job' or 'config.training.pretrained_model'"):
+        PluginJobConfig.model_validate(
+            {
+                "data_source": DEFAULT_DATA_SOURCE,
+                "pretrained_model_job": "prior-safe-synth-job",
+                "config": {"training": {"pretrained_model": "HuggingFaceTB/SmolLM3-3B"}},
+            }
+        )
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-safe-synthesizer/tests/unit/test_local_run.py
+++ b/plugins/nemo-safe-synthesizer/tests/unit/test_local_run.py
@@ -5,6 +5,7 @@ import importlib
 import json
 import sys
 from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
@@ -41,13 +42,20 @@ def test_run_local_loads_spec_and_writes_results(tmp_path, monkeypatch):
         summary=SimpleNamespace(model_dump=lambda: {"row_count": 1}),
         evaluation_report_html=None,
     )
-    monkeypatch.setattr(task_main, "run_config", lambda job_config, data_source, save_path: (result, None))
+    monkeypatch.setattr(
+        task_main,
+        "run_config",
+        lambda job_config, data_source, save_path, *, adapter_location=None: (result, None),
+    )
+    get_platform_sdk = MagicMock(side_effect=AssertionError("offline run should not initialize the platform SDK"))
+    monkeypatch.setattr(task_main, "get_platform_sdk", get_platform_sdk)
 
     output_dir = tmp_path / "output"
     task_main.run_local(spec_file=spec_file, workspace="default", output_dir=output_dir, data_source=data_file)
 
     assert (output_dir / "synthetic-data.csv").exists()
     assert json.loads((output_dir / "summary.json").read_text(encoding="utf-8")) == {"row_count": 1}
+    get_platform_sdk.assert_not_called()
 
 
 def test_run_from_env_reports_missing_config_path(monkeypatch):
@@ -61,3 +69,118 @@ def test_run_from_env_reports_missing_config_path(monkeypatch):
 
     with pytest.raises(ValueError, match=f"{task_main.NEMO_JOB_STEP_CONFIG_FILE_PATH_ENVVAR} is not set"):
         task_main.run_from_env()
+
+
+def test_run_local_resolves_pretrained_model_job_before_run(tmp_path, monkeypatch):
+    task_main = import_task_main_without_heavy_runtime(monkeypatch)
+    spec_file = tmp_path / "spec.json"
+    spec_file.write_text(
+        json.dumps(
+            {
+                "data_source": "default/data#input.csv",
+                "pretrained_model_job": "prior-safe-synth-job",
+                "config": {
+                    "enable_synthesis": False,
+                    "enable_replace_pii": False,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    data_file = tmp_path / "input.csv"
+    data_file.write_text("value\n1\n", encoding="utf-8")
+
+    adapter_dir = tmp_path / "downloaded-adapter"
+    adapter_dir.mkdir()
+    (adapter_dir / "adapter_config.json").write_text(
+        json.dumps({"base_model_name_or_path": "HuggingFaceTB/SmolLM3-3B"}),
+        encoding="utf-8",
+    )
+
+    sdk = MagicMock()
+    sdk.jobs.results.retrieve.return_value = SimpleNamespace(
+        artifact_url="default/job-results-prior#results/attempt-1/adapter"
+    )
+    monkeypatch.setattr(task_main, "get_platform_sdk", lambda: sdk)
+
+    file_manager = MagicMock()
+    file_manager.download_from_url.return_value = SimpleNamespace(
+        path=adapter_dir,
+        cleanup_tmp_dir=MagicMock(),
+    )
+    monkeypatch.setattr(task_main, "FilesetFileManager", MagicMock(return_value=file_manager))
+
+    captured = {}
+    result = SimpleNamespace(
+        synthetic_data=pd.DataFrame({"value": [1]}),
+        summary=SimpleNamespace(model_dump=lambda: {"row_count": 1}),
+        evaluation_report_html=None,
+    )
+
+    def fake_run_config(job_config, data_source, save_path, *, adapter_location=None):
+        captured["adapter_location"] = adapter_location
+        return result, None
+
+    monkeypatch.setattr(task_main, "run_config", fake_run_config)
+
+    output_dir = tmp_path / "output"
+    task_main.run_local(spec_file=spec_file, workspace="default", output_dir=output_dir, data_source=data_file)
+
+    assert captured["adapter_location"] == adapter_dir
+    sdk.jobs.results.retrieve.assert_called_once_with(
+        name="adapter",
+        job="prior-safe-synth-job",
+        workspace="default",
+    )
+
+
+def test_run_local_cleans_pretrained_model_tmp_when_run_config_raises(tmp_path, monkeypatch):
+    task_main = import_task_main_without_heavy_runtime(monkeypatch)
+    spec_file = tmp_path / "spec.json"
+    spec_file.write_text(
+        json.dumps(
+            {
+                "data_source": "default/data#input.csv",
+                "pretrained_model_job": "prior-safe-synth-job",
+                "config": {
+                    "enable_synthesis": False,
+                    "enable_replace_pii": False,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    data_file = tmp_path / "input.csv"
+    data_file.write_text("value\n1\n", encoding="utf-8")
+
+    adapter_dir = tmp_path / "downloaded-adapter"
+    adapter_dir.mkdir()
+    (adapter_dir / "adapter_config.json").write_text(
+        json.dumps({"base_model_name_or_path": "HuggingFaceTB/SmolLM3-3B"}),
+        encoding="utf-8",
+    )
+
+    sdk = MagicMock()
+    sdk.jobs.results.retrieve.return_value = SimpleNamespace(
+        artifact_url="default/job-results-prior#results/attempt-1/adapter"
+    )
+    monkeypatch.setattr(task_main, "get_platform_sdk", lambda: sdk)
+
+    pretrained_model_tmp = SimpleNamespace(
+        path=adapter_dir,
+        cleanup_tmp_dir=MagicMock(),
+    )
+    file_manager = MagicMock()
+    file_manager.download_from_url.return_value = pretrained_model_tmp
+    monkeypatch.setattr(task_main, "FilesetFileManager", MagicMock(return_value=file_manager))
+
+    def raise_run_config(job_config, data_source, save_path, *, adapter_location=None):
+        raise RuntimeError("run_config failed")
+
+    monkeypatch.setattr(task_main, "run_config", raise_run_config)
+
+    output_dir = tmp_path / "output"
+    with pytest.raises(RuntimeError, match="run_config failed"):
+        task_main.run_local(spec_file=spec_file, workspace="default", output_dir=output_dir, data_source=data_file)
+
+    pretrained_model_tmp.cleanup_tmp_dir.assert_called_once_with()

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/app.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/app.py
@@ -50,9 +50,13 @@ app = typer.Typer(
 
 
 def _build_top_level_lazy_entries() -> tuple[TopLevelEntry, ...]:
+    plugin_entry_points = _installed_plugin_command_entry_points()
+    # Plugin `nemo.cli` entry points own their command name (e.g. safe-synthesizer).
+    # Drop generated API top-level groups with the same name so run-local/runtime stay available.
+    api_entries = tuple(entry for entry in API_TOP_LEVEL_ENTRIES if entry.name not in plugin_entry_points)
     return build_top_level_entries(
-        (*TOP_LEVEL_ENTRIES, *API_TOP_LEVEL_ENTRIES),
-        _installed_plugin_command_entry_points(),
+        (*TOP_LEVEL_ENTRIES, *api_entries),
+        plugin_entry_points,
         include_hidden=True,
     )
 

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/test_app.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/test_app.py
@@ -266,6 +266,45 @@ def test_lazy_group_help_uses_loaded_group_help():
     assert "--list" in result.stdout
 
 
+def test_build_top_level_lazy_entries_prefers_plugin_over_api_name_collision():
+    from nemo_platform.cli.app import _build_top_level_lazy_entries
+
+    plugin_entry_points = {
+        "safe-synthesizer": SimpleNamespace(value="nemo_safe_synthesizer_plugin.cli:SafeSynthesizerCLI"),
+    }
+    api_entries = (
+        TopLevelEntry(
+            import_path="nemo_platform.cli.commands.api.safe_synthesizer:app",
+            name="safe-synthesizer",
+            help="Safe Synthesizer operations.",
+            panel="Functional plugins",
+            kind="group",
+        ),
+        TopLevelEntry(
+            import_path="nemo_platform.cli.commands.api.files:app",
+            name="files",
+            help="Manage files.",
+            panel="Core plugins",
+            kind="group",
+        ),
+    )
+
+    with (
+        patch("nemo_platform.cli.app.TOP_LEVEL_ENTRIES", ()),
+        patch("nemo_platform.cli.app.API_TOP_LEVEL_ENTRIES", api_entries),
+        patch(
+            "nemo_platform.cli.app._installed_plugin_command_entry_points",
+            return_value=plugin_entry_points,
+        ),
+    ):
+        entries = _build_top_level_lazy_entries()
+
+    by_name = {entry.name: entry for entry in entries}
+    assert set(by_name) == {"files", "safe-synthesizer"}
+    assert by_name["files"].source == "module"
+    assert by_name["safe-synthesizer"].source == "plugin"
+
+
 def test_plugin_entry_point_name_collision_is_skipped(caplog):
     entries = (
         TopLevelEntry(

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/cli_config.yaml
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/cli_config.yaml
@@ -48,10 +48,6 @@ top_level:
     panel: Core plugins
     help: Manage projects.
     hidden: true
-  safe-synthesizer:
-    panel: Functional plugins
-    help: Safe Synthesizer operations.
-    hidden: true
   secrets:
     panel: Core plugins
     help: Manage secrets.
@@ -261,23 +257,9 @@ config:
       - description
       - status
       - created_at
-- resource: [safe_synthesizer, jobs]
-  methods:
-    create:
-      wait:
-        type: platform_job
-        resource_label: safe-synthesizer job
-    list:
-      columns:
-      - name
-      - description
-      - status
-      - created_at
 
-- resource: [safe_synthesizer, jobs, results, summary]
-  methods:
-    download:
-      operation_type: default
+- resource: [safe_synthesizer]
+  skip: true
 
 - resource: [guardrail]
   methods:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reuse a prior Safe Synthesizer job as the pretrained model via a new pretrained_model_job option; local adapter resolution and embedding of run config for generation-only runs.

* **Documentation**
  * Host-local development guide, CLI usage updates, and pretrained_model_job / HF token guidance added across docs and README.

* **Improvements**
  * Validation to prevent conflicting pretrained model settings; safer local-run adapter download and cleanup; CLI entry/command collision handling.

* **Tests**
  * New unit tests covering adapter resolution, pretrained_model_job handling, validation, and local-run cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->