### PR TITLE
feat(studio): when model fileset created, land on detail page

### DIFF
--- a/web/packages/studio/src/components/FilesetCreateModal/index.spec.tsx
+++ b/web/packages/studio/src/components/FilesetCreateModal/index.spec.tsx
@@ -260,7 +260,7 @@ describe('FilesetCreateModal', () => {
       });
     });
 
-    it('Model purpose navigates to the side-panel fileset route', async () => {
+    it('Model + Local navigates to model detail Files tab', async () => {
       const navigate = vi.fn();
       mockUseNavigate(navigate);
       mockMutate.mockResolvedValue({
@@ -283,9 +283,8 @@ describe('FilesetCreateModal', () => {
       await user.type(screen.getByRole('textbox', { name: /^name$/i }), 'mymodel');
       await user.click(screen.getByRole('button', { name: 'Create Model Fileset' }));
       await waitFor(() => {
-        // Side panel route encodes "<workspace>/<name>" as the filesetId param.
         expect(navigate).toHaveBeenCalledWith(
-          expect.stringContaining('/workspaces/default/filesets/default%2Fmymodel')
+          expect.stringContaining('/workspaces/default/models/mymodel?tab=files')
         );
       });
     });

--- a/web/packages/studio/src/components/FilesetCreateModal/index.tsx
+++ b/web/packages/studio/src/components/FilesetCreateModal/index.tsx
@@ -5,7 +5,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { ControlledTextArea } from '@nemo/common/src/components/form/ControlledTextArea';
 import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
 import { FormModal } from '@nemo/common/src/components/FormModal';
-import { getEntityReference } from '@nemo/common/src/namedEntity';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { toValidFilesetName } from '@nemo/common/src/utils/filesetName';
 import {
@@ -24,9 +23,10 @@ import {
 } from '@studio/components/FilesetCreateModal/constants';
 import { useRemoteRepoMetadata } from '@studio/hooks/useRemoteRepoMetadata';
 import { DatasetDetailTab } from '@studio/routes/DatasetDetailRoute/constants';
+import { ModelDetailTab } from '@studio/routes/ModelDetailRoute/constants';
 import { CreateSecretModal } from '@studio/routes/SecretsListRoute/CreateSecretModal';
 import { SecretSearchableSelect } from '@studio/routes/SecretsListRoute/SecretSearchableSelect';
-import { getDatasetDetailRoute, getFilesetDetailsRoute } from '@studio/routes/utils';
+import { getDatasetDetailRoute, getModelDetailRoute } from '@studio/routes/utils';
 import { handleFormErrorsGeneric } from '@studio/util/forms/error';
 import {
   isHuggingFaceUrl,
@@ -184,10 +184,8 @@ export const FilesetCreateModal: FC<FilesetCreateModalProps> = ({
       }
 
       // Post-create navigation, per ASTD-167:
-      //   Dataset purpose: External -> Card tab (README rendered there);
-      //                    Local    -> Files tab (user uploads next).
-      //   Model purpose: no Card/Files tabs yet (model detail route owned by
-      //                  parallel team, not landed). Side-panel for now.
+      //   External -> Card tab (where the README renders)
+      //   Local    -> Files tab (where the user uploads next)
       handleClose();
       if (purpose === FilesetPurpose.dataset) {
         navigate(
@@ -197,15 +195,10 @@ export const FilesetCreateModal: FC<FilesetCreateModalProps> = ({
         );
         return;
       }
-      // The filesets route param is an encoded "workspace/name" entity
-      // reference (parsed by `getPartsFromReference`), not a bare name.
       navigate(
-        getFilesetDetailsRoute(
-          fileset.workspace,
-          getEntityReference(fileset, { encode: true }),
-          undefined,
-          true
-        )
+        getModelDetailRoute(fileset.workspace, fileset.name, {
+          tab: isExternal ? ModelDetailTab.Card : ModelDetailTab.Files,
+        })
       );
     },
     [storageMode, createFileset, workspace, purpose, toast, navigate, handleClose]

--- a/web/packages/studio/src/routes/ModelDetailRoute/ModelCardTab/index.tsx
+++ b/web/packages/studio/src/routes/ModelDetailRoute/ModelCardTab/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { FilesetFileOutput, FilesetOutput } from '@nemo/sdk/generated/platform/schema';
-import { Grid, GridItem } from '@nvidia/foundations-react-core';
+import { Grid, GridItem, Stack, Text } from '@nvidia/foundations-react-core';
 import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
 import { ReadmeBody } from '@studio/routes/ModelDetailRoute/ModelCardTab/ReadmeBody';
 import { ModelMetadataPanel } from '@studio/routes/ModelDetailRoute/ModelMetadataPanel';
@@ -53,13 +53,20 @@ export const ModelCardTab: FC<ModelCardTabProps> = ({
         cols={{ lg: 8 }}
         className="min-w-0 overflow-hidden rounded-lg border border-base bg-surface-raised p-density-xl"
       >
-        <ReadmeBody
-          isFilesError={isFilesError}
-          readmePath={readmePath}
-          isContentLoading={isContentLoading}
-          isContentError={isContentError}
-          content={parsed?.content}
-        />
+        <Stack gap="density-md">
+          {fileset.description && (
+            <Text kind="body/regular/md" data-testid="model-card-fileset-description">
+              {fileset.description}
+            </Text>
+          )}
+          <ReadmeBody
+            isFilesError={isFilesError}
+            readmePath={readmePath}
+            isContentLoading={isContentLoading}
+            isContentError={isContentError}
+            content={parsed?.content}
+          />
+        </Stack>
       </GridItem>
       <GridItem cols={{ lg: 4 }} className="min-w-0">
         <ModelMetadataPanel fileset={fileset} readmeMetadata={parsed?.metadata} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Post-creation navigation now sends users to the correct model details page and tab based on storage mode (local vs external) instead of the previous fileset route.

* **New Features**
  * Files tab now displays a fileset description above the README when a description is present.

* **Tests**
  * Updated navigation test to assert the new model-details tab behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->