### PR TITLE
feat(studio): Landing page for coding agents in studio

### DIFF
--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -3,3 +3,7 @@ helm/
 
 # Lock file
 pnpm-lock.yaml
+
+# Build output
+dist/
+packages/*/dist/

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ROUTES } from '@studio/constants/routes';
+import { DashboardLandingRoute } from '@studio/routes/DashboardLandingRoute';
+import { TestProviders } from '@studio/tests/util/TestProviders';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createMemoryRouter, generatePath, RouterProvider } from 'react-router';
+
+const workspace = 'default';
+
+const renderRoute = () => {
+  const route = generatePath(ROUTES.workspace.dashboard, { workspace });
+  const router = createMemoryRouter(
+    [{ path: ROUTES.workspace.dashboard, element: <DashboardLandingRoute /> }],
+    {
+      initialEntries: [route],
+    }
+  );
+
+  return render(
+    <TestProviders>
+      <RouterProvider router={router} />
+    </TestProviders>
+  );
+};
+
+describe('DashboardLandingRoute', () => {
+  it('renders the dashboard landing page', async () => {
+    renderRoute();
+
+    expect(await screen.findByText('What should we build in nemo-platform?')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Message Claude' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Explore repo/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Draft a change/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Review recent work/ })).toBeInTheDocument();
+  });
+
+  it('lets prompt suggestions populate the landing composer', async () => {
+    const user = userEvent.setup();
+    renderRoute();
+
+    await user.click(await screen.findByRole('button', { name: /Explore repo/ }));
+
+    expect(screen.getByRole('textbox', { name: 'Message Claude' })).toHaveValue(
+      'Give me a concise map of this repo and the main places I should know about.'
+    );
+  });
+
+  it('only enables the send affordance once the composer has text', async () => {
+    const user = userEvent.setup();
+    renderRoute();
+
+    const composer = await screen.findByRole('textbox', { name: 'Message Claude' });
+    const sendButton = screen.getByRole('button', { name: 'Send message' });
+
+    expect(sendButton).toBeDisabled();
+
+    await user.type(composer, 'Sketch a dashboard');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Send message' })).toBeEnabled();
+    });
+  });
+});

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
@@ -30,7 +30,7 @@ describe('DashboardLandingRoute', () => {
   it('renders the dashboard landing page', async () => {
     renderRoute();
 
-    expect(await screen.findByText('What should we build in nemo-platform?')).toBeInTheDocument();
+    expect(await screen.findByText('What would you like to do?')).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: 'Message Claude' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Explore repo/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Draft a change/ })).toBeInTheDocument();

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
@@ -1,14 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Button, Text, TextArea, Tooltip } from '@nvidia/foundations-react-core';
+import { Button, Card, Flex, Text, TextArea, Tooltip } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
-import { Boxes, GitBranch, Hammer, Search, Send, Terminal } from 'lucide-react';
+import { GitBranch, Hammer, Search, Send, Terminal } from 'lucide-react';
 import {
   type ChangeEvent,
   type FC,
-  type FormEvent,
   type ReactNode,
   useCallback,
   useState,
@@ -20,7 +19,7 @@ interface PromptSuggestion {
   icon: ReactNode;
 }
 
-const promptSuggestions: PromptSuggestion[] = [
+const PROMPT_SUGGESTIONS: PromptSuggestion[] = [
   {
     title: 'Explore repo',
     prompt: 'Give me a concise map of this repo and the main places I should know about.',
@@ -45,21 +44,19 @@ const PromptCard = ({
   suggestion: PromptSuggestion;
   onSelect: () => void;
 }) => (
-  <button
-    type="button"
-    onClick={onSelect}
-    className="flex min-h-28 flex-col items-start gap-3 rounded-lg border border-base bg-surface-base p-4 text-left transition hover:border-accent hover:bg-surface-raised focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-  >
-    <span className="flex size-8 items-center justify-center rounded bg-surface-raised text-accent">
-      {suggestion.icon}
-    </span>
-    <span className="min-w-0">
-      <Text kind="label/bold/md">{suggestion.title}</Text>
-      <Text kind="body/regular/sm" color="secondary" className="mt-1 line-clamp-2">
-        {suggestion.prompt}
-      </Text>
-    </span>
-  </button>
+  <Card asChild interactive className="min-h-28 w-full cursor-pointer shadow-none!">
+    <button type="button" onClick={onSelect}>
+      <span className="flex size-8 items-center justify-center rounded bg-surface-raised text-accent">
+        {suggestion.icon}
+      </span>
+      <span className="min-w-0">
+        <Text kind="label/bold/md">{suggestion.title}</Text>
+        <Text kind="body/regular/sm" color="secondary" className="mt-1 line-clamp-2">
+          {suggestion.prompt}
+        </Text>
+      </span>
+    </button>
+  </Card>
 );
 
 const LandingComposer = ({
@@ -69,7 +66,7 @@ const LandingComposer = ({
   input: string;
   onChange: (value: string) => void;
 }) => {
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: React.SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
   };
 
@@ -87,11 +84,11 @@ const LandingComposer = ({
         resizeable="auto"
         className="max-h-56 w-full border-0 bg-transparent"
       />
-      <div className="flex items-center justify-between gap-3 px-1 pt-2">
-        <div className="flex items-center gap-2 text-secondary">
+      <Flex className="flex items-center justify-between gap-3 px-1 pt-2">
+        <Flex className="flex items-center gap-2 text-secondary">
           <Terminal size={16} />
           <Text kind="body/regular/sm">Claude Code</Text>
-        </div>
+        </Flex>
         <Tooltip slotContent="Send">
           <Button
             color="brand"
@@ -103,7 +100,7 @@ const LandingComposer = ({
             <Send size={16} />
           </Button>
         </Tooltip>
-      </div>
+      </Flex>
     </form>
   );
 };
@@ -122,28 +119,25 @@ export const DashboardLandingRoute: FC = () => {
   return (
     <AccessibleTitle title="Dashboard">
       <main className="flex h-full min-h-[calc(100vh-var(--nv-app-bar-height))] items-center justify-center bg-surface-sunken px-4 py-10 text-primary">
-        <div className="mx-auto flex w-full max-w-4xl flex-col items-center gap-8">
-          <div className="flex flex-col items-center gap-3 text-center">
-            <div className="flex size-12 items-center justify-center rounded-lg border border-base bg-surface-base text-accent">
-              <Boxes size={24} />
-            </div>
+        <Flex className="mx-auto flex w-full max-w-4xl flex-col items-center gap-8">
+          <Flex className="flex flex-col items-center gap-3 text-center">
             <Text kind="body/bold/2xl" className="text-center">
               What would you like to do?
             </Text>
-          </div>
+          </Flex>
 
           <LandingComposer input={input} onChange={setInput} />
 
-          <div className="grid w-full grid-cols-1 gap-3 md:grid-cols-3">
-            {promptSuggestions.map((suggestion) => (
+          <Flex className="grid w-full grid-cols-1 gap-3 md:grid-cols-3">
+            {PROMPT_SUGGESTIONS.map((suggestion) => (
               <PromptCard
                 key={suggestion.title}
                 suggestion={suggestion}
                 onSelect={() => handlePromptSelect(suggestion.prompt)}
               />
             ))}
-          </div>
-        </div>
+          </Flex>
+        </Flex>
       </main>
     </AccessibleTitle>
   );

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Button, Text, TextArea, Tooltip } from '@nvidia/foundations-react-core';
+import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { Boxes, GitBranch, Hammer, Search, Send, Terminal } from 'lucide-react';
+import {
+  type ChangeEvent,
+  type FC,
+  type FormEvent,
+  type ReactNode,
+  useCallback,
+  useState,
+} from 'react';
+
+interface PromptSuggestion {
+  title: string;
+  prompt: string;
+  icon: ReactNode;
+}
+
+const promptSuggestions: PromptSuggestion[] = [
+  {
+    title: 'Explore repo',
+    prompt: 'Give me a concise map of this repo and the main places I should know about.',
+    icon: <Search size={18} />,
+  },
+  {
+    title: 'Draft a change',
+    prompt: 'Help me plan and implement the next small product improvement in nemo-platform.',
+    icon: <Hammer size={18} />,
+  },
+  {
+    title: 'Review recent work',
+    prompt: 'Review the current working tree and call out anything risky or unfinished.',
+    icon: <GitBranch size={18} />,
+  },
+];
+
+const PromptCard = ({
+  suggestion,
+  onSelect,
+}: {
+  suggestion: PromptSuggestion;
+  onSelect: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onSelect}
+    className="flex min-h-28 flex-col items-start gap-3 rounded-lg border border-base bg-surface-base p-4 text-left transition hover:border-accent hover:bg-surface-raised focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+  >
+    <span className="flex size-8 items-center justify-center rounded bg-surface-raised text-accent">
+      {suggestion.icon}
+    </span>
+    <span className="min-w-0">
+      <Text kind="label/bold/md">{suggestion.title}</Text>
+      <Text kind="body/regular/sm" color="secondary" className="mt-1 line-clamp-2">
+        {suggestion.prompt}
+      </Text>
+    </span>
+  </button>
+);
+
+const LandingComposer = ({
+  input,
+  onChange,
+}: {
+  input: string;
+  onChange: (value: string) => void;
+}) => {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="w-full rounded-2xl border border-base bg-surface-base p-2 shadow-xl"
+    >
+      <TextArea
+        aria-label="Message Claude"
+        value={input}
+        onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange(event.target.value)}
+        placeholder="Message Claude"
+        rows={3}
+        resizeable="auto"
+        className="max-h-56 w-full border-0 bg-transparent"
+      />
+      <div className="flex items-center justify-between gap-3 px-1 pt-2">
+        <div className="flex items-center gap-2 text-secondary">
+          <Terminal size={16} />
+          <Text kind="body/regular/sm">Claude Code</Text>
+        </div>
+        <Tooltip slotContent="Send">
+          <Button
+            color="brand"
+            size="small"
+            aria-label="Send message"
+            type="submit"
+            disabled={!input.trim()}
+          >
+            <Send size={16} />
+          </Button>
+        </Tooltip>
+      </div>
+    </form>
+  );
+};
+
+export const DashboardLandingRoute: FC = () => {
+  const [input, setInput] = useState('');
+
+  useBreadcrumbs({
+    items: [{ slotLabel: 'Dashboard' }],
+  });
+
+  const handlePromptSelect = useCallback((prompt: string) => {
+    setInput(prompt);
+  }, []);
+
+  return (
+    <AccessibleTitle title="Dashboard">
+      <main className="flex h-full min-h-[calc(100vh-var(--nv-app-bar-height))] items-center justify-center bg-surface-sunken px-4 py-10 text-primary">
+        <div className="mx-auto flex w-full max-w-4xl flex-col items-center gap-8">
+          <div className="flex flex-col items-center gap-3 text-center">
+            <div className="flex size-12 items-center justify-center rounded-lg border border-base bg-surface-base text-accent">
+              <Boxes size={24} />
+            </div>
+            <Text kind="body/bold/2xl" className="text-center">
+              What should we build in nemo-platform?
+            </Text>
+          </div>
+
+          <LandingComposer input={input} onChange={setInput} />
+
+          <div className="grid w-full grid-cols-1 gap-3 md:grid-cols-3">
+            {promptSuggestions.map((suggestion) => (
+              <PromptCard
+                key={suggestion.title}
+                suggestion={suggestion}
+                onSelect={() => handlePromptSelect(suggestion.prompt)}
+              />
+            ))}
+          </div>
+        </div>
+      </main>
+    </AccessibleTitle>
+  );
+};

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
@@ -128,7 +128,7 @@ export const DashboardLandingRoute: FC = () => {
               <Boxes size={24} />
             </div>
             <Text kind="body/bold/2xl" className="text-center">
-              What should we build in nemo-platform?
+              What would you like to do?
             </Text>
           </div>
 

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
@@ -8,6 +8,7 @@ import { GitBranch, Hammer, Search, Send, Terminal } from 'lucide-react';
 import {
   type ChangeEvent,
   type FC,
+  type FormEvent,
   type ReactNode,
   useCallback,
   useState,
@@ -66,7 +67,7 @@ const LandingComposer = ({
   input: string;
   onChange: (value: string) => void;
 }) => {
-  const handleSubmit = (event: React.SubmitEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
   };
 

--- a/web/packages/studio/src/routes/RootRedirect/index.spec.tsx
+++ b/web/packages/studio/src/routes/RootRedirect/index.spec.tsx
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ROUTES } from '@studio/constants/routes';
+import { LOCATION_DISPLAY_TEST_ID } from '@studio/tests/util/constants';
+import { LocationDisplay } from '@studio/tests/util/LocationDisplay';
+import { TestProviders } from '@studio/tests/util/TestProviders';
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+
+const renderRootRedirect = async (initialPath = '/') => {
+  const { RootRedirect } = await import('@studio/routes/RootRedirect');
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: <RootRedirect />,
+      },
+      {
+        path: '/workspaces',
+        element: <RootRedirect />,
+      },
+      {
+        path: ROUTES.workspace.dashboard,
+        element: <LocationDisplay />,
+      },
+      {
+        path: ROUTES.workspace.agentsList,
+        element: <LocationDisplay />,
+      },
+      {
+        path: ROUTES.workspace.index,
+        element: <LocationDisplay />,
+      },
+    ],
+    { initialEntries: [initialPath] }
+  );
+
+  return render(
+    <TestProviders>
+      <RouterProvider router={router} />
+    </TestProviders>
+  );
+};
+
+describe('RootRedirect', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses coding agent studio as the root landing page when enabled', async () => {
+    vi.resetModules();
+    vi.stubEnv('VITE_FF_CODING_AGENT_STUDIO_ENABLED', 'true');
+
+    await renderRootRedirect();
+
+    const location = await screen.findByTestId(LOCATION_DISPLAY_TEST_ID);
+    expect(location).toHaveTextContent('/workspaces/');
+    expect(location).toHaveTextContent('/dashboard');
+  });
+
+  it('uses the dashboard route as the /workspaces landing page when coding agent studio is enabled', async () => {
+    vi.resetModules();
+    vi.stubEnv('VITE_FF_CODING_AGENT_STUDIO_ENABLED', 'true');
+    await renderRootRedirect('/workspaces');
+
+    const location = await screen.findByTestId(LOCATION_DISPLAY_TEST_ID);
+    expect(location).toHaveTextContent('/workspaces/');
+    expect(location).toHaveTextContent('/dashboard');
+  });
+});

--- a/web/packages/studio/src/routes/WorkspaceLayout/WorkspaceSideNav.tsx
+++ b/web/packages/studio/src/routes/WorkspaceLayout/WorkspaceSideNav.tsx
@@ -6,6 +6,7 @@ import { NavigationDrawer } from '@studio/components/Layouts/NavigationDrawer';
 import {
   AGENTS_ENABLED,
   BASE_MODELS_ENABLED,
+  CODING_AGENT_STUDIO_ENABLED,
   CUSTOMIZER_ENABLED,
   DASHBOARD_ENABLED,
   DATA_DESIGNER_ENABLED,
@@ -68,16 +69,17 @@ export const WorkspaceSideNav = ({ collapsed }: { collapsed?: boolean }) => {
   const workspace = useWorkspaceFromPath();
 
   const items = useMemo(() => {
-    const dashboardNav = DASHBOARD_ENABLED
-      ? [
-          {
-            id: 'dashboard',
-            slotIcon: <Home className={iconColorClass} />,
-            slotLabel: 'Dashboard',
-            href: getWorkspaceDashboardRoute(workspace),
-          },
-        ]
-      : [];
+    const dashboardNav =
+      DASHBOARD_ENABLED || CODING_AGENT_STUDIO_ENABLED
+        ? [
+            {
+              id: 'dashboard',
+              slotIcon: <Home className={iconColorClass} />,
+              slotLabel: 'Dashboard',
+              href: getWorkspaceDashboardRoute(workspace),
+            },
+          ]
+        : [];
     const jobsNav = JOBS_ENABLED
       ? [
           {

--- a/web/packages/studio/src/routes/index.spec.tsx
+++ b/web/packages/studio/src/routes/index.spec.tsx
@@ -165,6 +165,13 @@ describe('Routes', () => {
       ).toBe(true);
     });
 
+    it('should include the dashboard route if coding agent studio is enabled', async () => {
+      vi.stubEnv('VITE_FF_CODING_AGENT_STUDIO_ENABLED', 'true');
+      vi.stubEnv('VITE_FF_DASHBOARD_ENABLED', 'false');
+      const { routes } = await import('./index');
+      expect(findIfRouteExists(routes, ROUTES.workspace.dashboard)).toBe(true);
+    });
+
     it('should exclude safe synthesizer routes if safe synthesizer is disabled', async () => {
       vi.stubEnv('VITE_FF_SAFE_SYNTHESIZER_ENABLED', 'false');
       const { routes } = await import('./index');

--- a/web/packages/studio/src/routes/index.tsx
+++ b/web/packages/studio/src/routes/index.tsx
@@ -7,6 +7,7 @@ import { ErrorPanel } from '@studio/components/ErrorPanel';
 import { Loading } from '@studio/components/Layouts/Loading';
 import {
   AGENTS_ENABLED,
+  CODING_AGENT_STUDIO_ENABLED,
   DATA_DESIGNER_ENABLED,
   DEPLOYMENTS_ENABLED,
   GUARDRAILS_ENABLED,
@@ -168,6 +169,11 @@ const NoMatchRoute = lazy(() =>
 const PromptTuningFormRoute = lazy(() =>
   import('@studio/routes/PromptTuningFormRoute/index').then((module) => ({
     default: module.PromptTuningFormRoute,
+  }))
+);
+const DashboardLandingRoute = lazy(() =>
+  import('@studio/routes/DashboardLandingRoute').then((module) => ({
+    default: module.DashboardLandingRoute,
   }))
 );
 const ModelCompareRoute =
@@ -391,7 +397,13 @@ export const routes: RouteObject[] = [
               ...gateDashboardRoutes([
                 {
                   path: ROUTES.workspace.dashboard,
-                  element: <WorkspaceDashboardRoute />,
+                  element: CODING_AGENT_STUDIO_ENABLED ? (
+                    <Suspense fallback={<Loading description="Loading Dashboard..." />}>
+                      <DashboardLandingRoute />
+                    </Suspense>
+                  ) : (
+                    <WorkspaceDashboardRoute />
+                  ),
                   errorElement: <ErrorPanel title="Workspace" />,
                 },
               ]),

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -5,6 +5,7 @@ import { getPartsFromNamedEntityRef, NamedEntityRef } from '@nemo/common/src/nam
 import {
   AGENTS_ENABLED,
   BASE_MODELS_ENABLED,
+  CODING_AGENT_STUDIO_ENABLED,
   CUSTOMIZER_ENABLED,
   DASHBOARD_ENABLED,
   DATA_DESIGNER_ENABLED,
@@ -41,7 +42,7 @@ export const gateCustomizationRoutes = (routes: RouteObject | RouteObject[]) =>
   gateRoutes(CUSTOMIZER_ENABLED, routes);
 
 export const gateDashboardRoutes = (routes: RouteObject | RouteObject[]) =>
-  gateRoutes(DASHBOARD_ENABLED, routes);
+  gateRoutes(DASHBOARD_ENABLED || CODING_AGENT_STUDIO_ENABLED, routes);
 
 export const gateDatasetsRoutes = (routes: RouteObject | RouteObject[]) =>
   gateRoutes(DATASETS_ENABLED, routes);
@@ -126,7 +127,8 @@ export const getWorkspaceIndexRoute = (workspace: string) => {
 };
 
 export const getWorkspaceDetailsDefaultRoute = (workspace: string) => {
-  if (DASHBOARD_ENABLED) return getWorkspaceDashboardRoute(workspace);
+  if (DASHBOARD_ENABLED || CODING_AGENT_STUDIO_ENABLED)
+    return getWorkspaceDashboardRoute(workspace);
   if (AGENTS_ENABLED) return getAgentsListRoute(workspace);
   if (BASE_MODELS_ENABLED) return getWorkspaceBaseModelsRoute(workspace);
   if (JOBS_ENABLED) return getWorkspaceJobsRoute(workspace);


### PR DESCRIPTION
<img width="1563" height="1001" alt="Screenshot 2026-06-02 at 2 26 20 PM" src="https://github.com/user-attachments/assets/d8f7a68d-feb8-4892-a555-f04a7aa41cd8" />

Just setting up the landing page for new chats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dashboard landing page with a prompt composer and suggestion cards.
  * Dashboard navigation now appears when the coding agent studio feature is enabled.

* **Tests**
  * Added landing page UI tests (prompt/composer, suggestion selection enabling the send button).
  * Added route gating/redirect tests for dashboard feature flags.

* **Chores**
  * Routing and defaults updated to respect the expanded dashboard feature flag.
* **Chores**
  * Prettier ignore updated to exclude build output directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->