### PR TITLE
docs(skills): use platform health routes for probes

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-build-agent/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-build-agent/SKILL.md
@@ -31,11 +31,11 @@ NeMo Platform optimizes LangGraph agents wrapped in NVIDIA NeMo Agent Toolkit (N
 
 ## Pre-flight
 
-1. Confirm the platform is up using `lsof` (ground truth) + `curl` (functional). If either fails, route to `nemo-setup` and stop. Do not trust `nemo services status` — it reports stale "running" from held locks after the process has died.
+1. Confirm the platform is up using `lsof` (ground truth) + `curl` against `/health/ready` (functional). If either fails, route to `nemo-setup` and stop. Do not trust `nemo services status` — it reports stale "running" from held locks after the process has died.
 
    ```bash
    lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 || { echo "PLATFORM_DOWN"; exit 1; }
-   curl -fsS http://localhost:8080/v1/models -o /dev/null -w "%{http_code}\n" 2>/dev/null | grep -qE "^[24][0-9][0-9]$" || { echo "PLATFORM_WEDGED"; exit 1; }
+   curl -sS --connect-timeout 2 --max-time 5 http://localhost:8080/health/ready -o /dev/null -w "%{http_code}\n" 2>/dev/null | grep -q "^200$" || { echo "PLATFORM_WEDGED"; exit 1; }
    ```
 
 2. Confirm a spec exists at `agents/$AGENT_NAME.spec.md`. If missing, call `nemo-explore` then `nemo-spec`, then return.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-skill-selection/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-skill-selection/SKILL.md
@@ -65,8 +65,8 @@ Before handing off, run a host-wide platform scan. Three signals, in order — t
 # 1. Ground truth: is anything listening on the canonical port?
 lsof -iTCP:8080 -sTCP:LISTEN 2>/dev/null
 
-# 2. Functional check: does the API actually answer?
-curl -fsS http://localhost:8080/v1/models -o /dev/null -w "%{http_code}\n" 2>/dev/null || echo "no-response"
+# 2. Functional check: does the platform readiness endpoint answer?
+curl -sS --connect-timeout 2 --max-time 5 http://localhost:8080/health/ready -o /dev/null -w "%{http_code}\n" 2>/dev/null || echo "no-response"
 
 # 3. Conflict check: other platform processes / data dirs / configs on this host?
 ps -eo pid,user,command 2>/dev/null | grep -E "nemo services (run|start)|nemo-platform run" | grep -v grep
@@ -78,8 +78,8 @@ Interpretation:
 
 | What you observe | Hand off to | Why |
 |---|---|---|
-| (1) returns a listener AND (2) returns 2xx/4xx | the requested downstream skill | Platform is up and serving. Skip `setup`. |
-| (1) returns a listener but (2) returns `no-response` or 5xx | `nemo-status` | Something is bound to :8080 but the API is wedged. Do not start a second platform. |
+| (1) returns a listener AND (2) returns `200` | the requested downstream skill | Platform is up and ready. Skip `setup`. |
+| (1) returns a listener but (2) returns `no-response` or non-200 | `nemo-status` | Something is bound to :8080 but the platform is not ready. Do not start a second platform. |
 | (1) empty but (3) finds another `nemo services` process OR more than one data dir / config | **stop, do not hand off yet** | Another install on this host, possibly on a different port. Surface the inventory verbatim. Ask whether to tear that one down first, pick a different port + data dir, or abort. Two installs writing to the same `~/.config/nmp/config.yaml` is how users end up with one Studio frontend pointing at the wrong backend. |
 | (1), (2), and (3) all empty | `setup` | Clean machine, no platform installed. |
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-status/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-status/SKILL.md
@@ -60,15 +60,17 @@ curl -fsS --connect-timeout 2 --max-time 5 http://localhost:8080/status
 .venv/bin/nemo models list | head -10
 ```
 
+The `/status` response is JSON; parse `services.ready`, `services.not_ready`, `controllers.healthy`, and `controllers.status` before rendering the summary block.
+
 2. **Present one summary block.** Illustrative format (adapt fields to whatever the CLI returns; do not invent ones the commands above did not produce):
 
 ```
 NeMo Platform status
 
-Platform:   running
-Services:   <ready_count> ready, <not_ready_count> not ready
+Platform:    running
+Services:    <ready_count> ready, <not_ready_count> not ready
 Controllers: healthy
-Agents:     <count>
+Agents:      <count>
   <name1> active
   <name2> stopped
 Providers:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-status/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-status/SKILL.md
@@ -41,19 +41,20 @@ Confirm the CLI is installed. If `.venv/bin/nemo` is missing, route to `nemo-set
 # Ground truth: anything listening on :8080?
 lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 || { echo "PLATFORM_DOWN (nothing on :8080)"; exit 1; }
 
-# Functional check: API answers?
-HTTP=$(curl -fsS http://localhost:8080/v1/models -o /dev/null -w "%{http_code}" 2>/dev/null || echo "no-response")
+# Functional check: platform readiness endpoint answers?
+HTTP=$(curl -sS --connect-timeout 2 --max-time 5 http://localhost:8080/health/ready -o /dev/null -w "%{http_code}" 2>/dev/null || echo "no-response")
 case "$HTTP" in
-  2[0-9][0-9]|4[0-9][0-9]) echo "PLATFORM_UP (HTTP $HTTP)" ;;
-  *)                       echo "PLATFORM_WEDGED (listener present, API returned $HTTP)"; exit 1 ;;
+  200) echo "PLATFORM_UP (HTTP $HTTP)" ;;
+  *)   echo "PLATFORM_WEDGED (listener present, /health/ready returned $HTTP)"; exit 1 ;;
 esac
 ```
 
 Do NOT use `nemo services status` or `nemo services ls` for this check. Both report stale "running" state from a held instance lock after the underlying process has died. `lsof` is ground truth.
 
-Only if both probes pass, run the remaining three to capture the other dashboard rows:
+Only if both probes pass, run the remaining commands to capture the other dashboard rows:
 
 ```bash
+curl -fsS --connect-timeout 2 --max-time 5 http://localhost:8080/status
 .venv/bin/nemo agents deployments list 2>/dev/null
 .venv/bin/nemo inference providers list
 .venv/bin/nemo models list | head -10
@@ -65,6 +66,8 @@ Only if both probes pass, run the remaining three to capture the other dashboard
 NeMo Platform status
 
 Platform:   running
+Services:   <ready_count> ready, <not_ready_count> not ready
+Controllers: healthy
 Agents:     <count>
   <name1> active
   <name2> stopped
@@ -92,14 +95,14 @@ For drill-downs:
 
 ## Verification
 
-Status is itself a verification: the four commands together prove the platform is reachable, the agents plugin is loaded (or not), the provider is registered, and at least one model has been discovered. If any of the four returns an error, surface it in the summary block rather than hiding it.
+Status is itself a verification: the commands together prove the platform is reachable, platform services/controllers are healthy, the agents plugin is loaded (or not), the provider is registered, and at least one model has been discovered. If any command returns an error, surface it in the summary block rather than hiding it.
 
 ## If verification fails
 
 | Symptom | Cause | Recovery |
 |---|---|---|
 | `PLATFORM_DOWN` from probe | Nothing bound to :8080 | Route to `nemo-setup`; do not run the other three commands |
-| `PLATFORM_WEDGED` from probe | Listener exists, API not answering — likely a crashed or partially-started platform | Tail `.venv/bin/nemo services logs -n 100` and surface the error. Common cause is a stale instance lock; the user can clear it with `nemo services stop --force` then re-run `nemo services run`. |
+| `PLATFORM_WEDGED` from probe | Listener exists, but `/health/ready` is not returning 200 — likely a crashed, partially-started, or not-ready platform | Tail `.venv/bin/nemo services logs -n 100` and surface the error. Common cause is a stale instance lock; the user can clear it with `nemo services stop --force` then re-run `nemo services run`. |
 | `nemo services ls` shows `running` with empty PID/address column | Held instance lock, no live process | Advisory only — trust the `lsof` probe above. Tell the user the lock is stale; offer `nemo services stop --force` to clear it. |
 | `agents deployments list` returns "no such command" | Agents plugin not installed | Note in the summary: "Agents: plugin not installed"; do not fail the dashboard |
 | `inference providers list` empty | Provider not registered | Route to `nemo-setup` Step 4 (configure) |

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-try-agent/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-try-agent/SKILL.md
@@ -31,8 +31,8 @@ Confirm the platform is up and check what deployed agents exist before doing any
 ```bash
 # Ground truth: anything bound to :8080?
 lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 || { echo "PLATFORM_DOWN"; exit 1; }
-# Functional check: API answers?
-curl -fsS http://localhost:8080/v1/models -o /dev/null -w "%{http_code}\n" 2>/dev/null | grep -qE "^[24][0-9][0-9]$" || { echo "PLATFORM_WEDGED"; exit 1; }
+# Functional check: platform readiness endpoint answers?
+curl -sS --connect-timeout 2 --max-time 5 http://localhost:8080/health/ready -o /dev/null -w "%{http_code}\n" 2>/dev/null | grep -q "^200$" || { echo "PLATFORM_WEDGED"; exit 1; }
 .venv/bin/nemo agents deployments list 2>/dev/null
 ```
 
@@ -98,5 +98,5 @@ If `INVOKE_FAILED` or `EMPTY_RESPONSE`: surface that to the user and stop. Do no
 
 - **Routing must be explicit.** Silently picking a target and sending a query is the failure mode this skill exists to prevent. Announce first.
 - **`nemo chat` and `nemo agents invoke` take different model id formats.** Chat uses entity-name (hyphens). Agents use whatever the YAML specifies. Pass through what the user says; do not auto-translate.
-- **No `curl` against platform HTTP endpoints.** The CLI is the documented interface. Hand-rolled HTTP is not a substitute.
+- **Use `curl` only for the pre-flight health probe.** The CLI is the documented interface for agent and model operations. Hand-rolled HTTP is not a substitute.
 - **Loop in this skill, not in another.** Do not invoke `nemo-skill-selection` between turns. Stay here until the user asks to do something else.

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-build-agent/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-build-agent/SKILL.md
@@ -31,11 +31,11 @@ NeMo Platform optimizes LangGraph agents wrapped in NVIDIA NeMo Agent Toolkit (N
 
 ## Pre-flight
 
-1. Confirm the platform is up using `lsof` (ground truth) + `curl` (functional). If either fails, route to `nemo-setup` and stop. Do not trust `nemo services status` — it reports stale "running" from held locks after the process has died.
+1. Confirm the platform is up using `lsof` (ground truth) + `curl` against `/health/ready` (functional). If either fails, route to `nemo-setup` and stop. Do not trust `nemo services status` — it reports stale "running" from held locks after the process has died.
 
    ```bash
    lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 || { echo "PLATFORM_DOWN"; exit 1; }
-   curl -fsS http://localhost:8080/v1/models -o /dev/null -w "%{http_code}\n" 2>/dev/null | grep -qE "^[24][0-9][0-9]$" || { echo "PLATFORM_WEDGED"; exit 1; }
+   curl -sS --connect-timeout 2 --max-time 5 http://localhost:8080/health/ready -o /dev/null -w "%{http_code}\n" 2>/dev/null | grep -q "^200$" || { echo "PLATFORM_WEDGED"; exit 1; }
    ```
 
 2. Confirm a spec exists at `agents/$AGENT_NAME.spec.md`. If missing, call `nemo-explore` then `nemo-spec`, then return.

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-skill-selection/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-skill-selection/SKILL.md
@@ -65,8 +65,8 @@ Before handing off, run a host-wide platform scan. Three signals, in order — t
 # 1. Ground truth: is anything listening on the canonical port?
 lsof -iTCP:8080 -sTCP:LISTEN 2>/dev/null
 
-# 2. Functional check: does the API actually answer?
-curl -fsS http://localhost:8080/v1/models -o /dev/null -w "%{http_code}\n" 2>/dev/null || echo "no-response"
+# 2. Functional check: does the platform readiness endpoint answer?
+curl -sS --connect-timeout 2 --max-time 5 http://localhost:8080/health/ready -o /dev/null -w "%{http_code}\n" 2>/dev/null || echo "no-response"
 
 # 3. Conflict check: other platform processes / data dirs / configs on this host?
 ps -eo pid,user,command 2>/dev/null | grep -E "nemo services (run|start)|nemo-platform run" | grep -v grep
@@ -78,8 +78,8 @@ Interpretation:
 
 | What you observe | Hand off to | Why |
 |---|---|---|
-| (1) returns a listener AND (2) returns 2xx/4xx | the requested downstream skill | Platform is up and serving. Skip `setup`. |
-| (1) returns a listener but (2) returns `no-response` or 5xx | `nemo-status` | Something is bound to :8080 but the API is wedged. Do not start a second platform. |
+| (1) returns a listener AND (2) returns `200` | the requested downstream skill | Platform is up and ready. Skip `setup`. |
+| (1) returns a listener but (2) returns `no-response` or non-200 | `nemo-status` | Something is bound to :8080 but the platform is not ready. Do not start a second platform. |
 | (1) empty but (3) finds another `nemo services` process OR more than one data dir / config | **stop, do not hand off yet** | Another install on this host, possibly on a different port. Surface the inventory verbatim. Ask whether to tear that one down first, pick a different port + data dir, or abort. Two installs writing to the same `~/.config/nmp/config.yaml` is how users end up with one Studio frontend pointing at the wrong backend. |
 | (1), (2), and (3) all empty | `setup` | Clean machine, no platform installed. |
 

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-status/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-status/SKILL.md
@@ -60,15 +60,17 @@ curl -fsS --connect-timeout 2 --max-time 5 http://localhost:8080/status
 .venv/bin/nemo models list | head -10
 ```
 
+The `/status` response is JSON; parse `services.ready`, `services.not_ready`, `controllers.healthy`, and `controllers.status` before rendering the summary block.
+
 2. **Present one summary block.** Illustrative format (adapt fields to whatever the CLI returns; do not invent ones the commands above did not produce):
 
 ```
 NeMo Platform status
 
-Platform:   running
-Services:   <ready_count> ready, <not_ready_count> not ready
+Platform:    running
+Services:    <ready_count> ready, <not_ready_count> not ready
 Controllers: healthy
-Agents:     <count>
+Agents:      <count>
   <name1> active
   <name2> stopped
 Providers:

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-status/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-status/SKILL.md
@@ -41,19 +41,20 @@ Confirm the CLI is installed. If `.venv/bin/nemo` is missing, route to `nemo-set
 # Ground truth: anything listening on :8080?
 lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 || { echo "PLATFORM_DOWN (nothing on :8080)"; exit 1; }
 
-# Functional check: API answers?
-HTTP=$(curl -fsS http://localhost:8080/v1/models -o /dev/null -w "%{http_code}" 2>/dev/null || echo "no-response")
+# Functional check: platform readiness endpoint answers?
+HTTP=$(curl -sS --connect-timeout 2 --max-time 5 http://localhost:8080/health/ready -o /dev/null -w "%{http_code}" 2>/dev/null || echo "no-response")
 case "$HTTP" in
-  2[0-9][0-9]|4[0-9][0-9]) echo "PLATFORM_UP (HTTP $HTTP)" ;;
-  *)                       echo "PLATFORM_WEDGED (listener present, API returned $HTTP)"; exit 1 ;;
+  200) echo "PLATFORM_UP (HTTP $HTTP)" ;;
+  *)   echo "PLATFORM_WEDGED (listener present, /health/ready returned $HTTP)"; exit 1 ;;
 esac
 ```
 
 Do NOT use `nemo services status` or `nemo services ls` for this check. Both report stale "running" state from a held instance lock after the underlying process has died. `lsof` is ground truth.
 
-Only if both probes pass, run the remaining three to capture the other dashboard rows:
+Only if both probes pass, run the remaining commands to capture the other dashboard rows:
 
 ```bash
+curl -fsS --connect-timeout 2 --max-time 5 http://localhost:8080/status
 .venv/bin/nemo agents deployments list 2>/dev/null
 .venv/bin/nemo inference providers list
 .venv/bin/nemo models list | head -10
@@ -65,6 +66,8 @@ Only if both probes pass, run the remaining three to capture the other dashboard
 NeMo Platform status
 
 Platform:   running
+Services:   <ready_count> ready, <not_ready_count> not ready
+Controllers: healthy
 Agents:     <count>
   <name1> active
   <name2> stopped
@@ -92,14 +95,14 @@ For drill-downs:
 
 ## Verification
 
-Status is itself a verification: the four commands together prove the platform is reachable, the agents plugin is loaded (or not), the provider is registered, and at least one model has been discovered. If any of the four returns an error, surface it in the summary block rather than hiding it.
+Status is itself a verification: the commands together prove the platform is reachable, platform services/controllers are healthy, the agents plugin is loaded (or not), the provider is registered, and at least one model has been discovered. If any command returns an error, surface it in the summary block rather than hiding it.
 
 ## If verification fails
 
 | Symptom | Cause | Recovery |
 |---|---|---|
 | `PLATFORM_DOWN` from probe | Nothing bound to :8080 | Route to `nemo-setup`; do not run the other three commands |
-| `PLATFORM_WEDGED` from probe | Listener exists, API not answering — likely a crashed or partially-started platform | Tail `.venv/bin/nemo services logs -n 100` and surface the error. Common cause is a stale instance lock; the user can clear it with `nemo services stop --force` then re-run `nemo services run`. |
+| `PLATFORM_WEDGED` from probe | Listener exists, but `/health/ready` is not returning 200 — likely a crashed, partially-started, or not-ready platform | Tail `.venv/bin/nemo services logs -n 100` and surface the error. Common cause is a stale instance lock; the user can clear it with `nemo services stop --force` then re-run `nemo services run`. |
 | `nemo services ls` shows `running` with empty PID/address column | Held instance lock, no live process | Advisory only — trust the `lsof` probe above. Tell the user the lock is stale; offer `nemo services stop --force` to clear it. |
 | `agents deployments list` returns "no such command" | Agents plugin not installed | Note in the summary: "Agents: plugin not installed"; do not fail the dashboard |
 | `inference providers list` empty | Provider not registered | Route to `nemo-setup` Step 4 (configure) |

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-try-agent/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-try-agent/SKILL.md
@@ -31,8 +31,8 @@ Confirm the platform is up and check what deployed agents exist before doing any
 ```bash
 # Ground truth: anything bound to :8080?
 lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 || { echo "PLATFORM_DOWN"; exit 1; }
-# Functional check: API answers?
-curl -fsS http://localhost:8080/v1/models -o /dev/null -w "%{http_code}\n" 2>/dev/null | grep -qE "^[24][0-9][0-9]$" || { echo "PLATFORM_WEDGED"; exit 1; }
+# Functional check: platform readiness endpoint answers?
+curl -sS --connect-timeout 2 --max-time 5 http://localhost:8080/health/ready -o /dev/null -w "%{http_code}\n" 2>/dev/null | grep -q "^200$" || { echo "PLATFORM_WEDGED"; exit 1; }
 .venv/bin/nemo agents deployments list 2>/dev/null
 ```
 
@@ -98,5 +98,5 @@ If `INVOKE_FAILED` or `EMPTY_RESPONSE`: surface that to the user and stop. Do no
 
 - **Routing must be explicit.** Silently picking a target and sending a query is the failure mode this skill exists to prevent. Announce first.
 - **`nemo chat` and `nemo agents invoke` take different model id formats.** Chat uses entity-name (hyphens). Agents use whatever the YAML specifies. Pass through what the user says; do not auto-translate.
-- **No `curl` against platform HTTP endpoints.** The CLI is the documented interface. Hand-rolled HTTP is not a substitute.
+- **Use `curl` only for the pre-flight health probe.** The CLI is the documented interface for agent and model operations. Hand-rolled HTTP is not a substitute.
 - **Loop in this skill, not in another.** Do not invoke `nemo-skill-selection` between turns. Stay here until the user asks to do something else.


### PR DESCRIPTION
## Motivation
- Hit this issue when trying to document AIQ agent with NeMo Platform. My agent pulled from these skills, continually trying to get platform status from /v1/models at the root, instead of using the ready endpoint

## Change Summary
- Replace stale root `/v1/models` skill probes with the platform `/health/ready` readiness endpoint.
- Add `/status` to the `nemo-status` dashboard flow so services and controllers are surfaced from the platform health router.
- Keep source skill files and SDK-vendored skill copies in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized platform readiness checks to probe /health/ready and require HTTP 200 for “ready”.
  * Tightened interpretation so only HTTP 200 (when a listener exists) proceeds; other results route to status handling.
  * Clarified pre-flight guidance to allow using curl specifically for the health probe.
  * Enhanced status output to show Services (ready/not-ready counts) and Controllers health.
  * Updated verification and wedge-detection wording with clearer recovery instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->