### PR TITLE
fix(studio): toast popover fix for new KUI modals

### DIFF
--- a/web/packages/common/src/providers/toast/ToastProvider.tsx
+++ b/web/packages/common/src/providers/toast/ToastProvider.tsx
@@ -21,6 +21,38 @@ import { ToastContext } from './useToast';
 export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
   const [toasts, setToasts] = useState<ToastDescriptor[]>([]);
   const timeoutRefs = useRef<Record<string, NodeJS.Timeout>>({});
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // KUI v1 modals use the native <dialog> element via showModal(), which puts
+  // them in the browser's top layer. The top layer ignores z-index from the
+  // normal stacking context, so toasts rendered as ordinary fixed-position
+  // children disappear behind any open modal's backdrop.
+  //
+  // Fix: render the toast container as a manual Popover. Popovers also enter
+  // the top layer, and "last opened wins" — re-issuing showPopover() promotes
+  // the container above any dialog that opened after it.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    if (toasts.length > 0) {
+      try {
+        el.hidePopover();
+      } catch {
+        // not currently shown — ignore
+      }
+      try {
+        el.showPopover();
+      } catch {
+        // Popover API not supported on this browser; fall back to z-index only.
+      }
+    } else {
+      try {
+        el.hidePopover();
+      } catch {
+        // already hidden — ignore
+      }
+    }
+  }, [toasts.length]);
 
   // Cleanup all timeouts when component unmounts to prevent state updates after unmount
   useEffect(() => {
@@ -130,7 +162,15 @@ export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
   return (
     <ToastContext.Provider value={contextValue}>
       {children}
-      <div className="fixed top-[calc(var(--nv-app-bar-height)+1rem)] right-4 flex flex-col items-end gap-4 z-1100 max-w-md">
+      <div
+        ref={containerRef}
+        popover="manual"
+        // Popover elements default to `display: none`; the arbitrary variant
+        // restores our flex layout when the popover is open. `position: fixed`
+        // is preserved so the container anchors to the viewport corner — the
+        // top-layer escape only governs stacking, not positioning.
+        className="fixed top-[calc(var(--nv-app-bar-height)+1rem)] right-4 m-0 hidden flex-col items-end gap-4 bg-transparent p-0 z-1100 max-w-md [&:popover-open]:flex"
+      >
         {toasts.map((toast) => (
           <Toast
             key={toast.id}

--- a/web/packages/common/src/providers/toast/ToastProvider.tsx
+++ b/web/packages/common/src/providers/toast/ToastProvider.tsx
@@ -18,11 +18,6 @@ import { getTransformStyles } from './GetTransformStyles';
 import { AddToastFn, ToastContextValue, ToastDescriptor } from './types';
 import { ToastContext } from './useToast';
 
-// Browser support is decided at load time and does not change. Computing it
-// once keeps the render path branch-free and the className stable.
-const SUPPORTS_POPOVER =
-  typeof HTMLElement !== 'undefined' && 'showPopover' in HTMLElement.prototype;
-
 export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
   const [toasts, setToasts] = useState<ToastDescriptor[]>([]);
   const timeoutRefs = useRef<Record<string, NodeJS.Timeout>>({});
@@ -40,9 +35,7 @@ export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
   // popover stays open but renders nothing visible (no children inside).
   const promoteToTopLayer = useCallback(() => {
     const el = containerRef.current;
-    // Feature-detect. Older browsers fall back to z-index-only behaviour
-    // (broken under top-layer dialogs, same as before this fix).
-    if (!el || typeof el.showPopover !== 'function') return;
+    if (!el) return;
     if (el.matches(':popover-open')) el.hidePopover();
     el.showPopover();
   }, []);
@@ -158,19 +151,12 @@ export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
       {children}
       <div
         ref={containerRef}
-        popover={SUPPORTS_POPOVER ? 'manual' : undefined}
-        // Popover elements default to `display: none`; the arbitrary variant
-        // restores our flex layout when the popover is open. The UA stylesheet
-        // also sets `[popover] { inset: 0; margin: auto; }` (centers the
-        // element); `left-auto bottom-auto m-0` releases those so `top-...` +
-        // `right-4` anchor cleanly to the upper-right corner.
-        //
-        // Fallback: without Popover API support, render `flex` unconditionally
-        // — promoteToTopLayer is a no-op there, and toasts must remain visible
-        // (top-layer ordering vs modals just won't work).
-        className={`fixed top-[calc(var(--nv-app-bar-height)+1rem)] right-4 left-auto bottom-auto m-0 flex-col items-end gap-4 bg-transparent p-0 z-1100 max-w-md ${
-          SUPPORTS_POPOVER ? 'hidden [&:popover-open]:flex' : 'flex'
-        }`}
+        popover="manual"
+        // UA stylesheet on `[popover]` sets `display: none` until open and
+        // `inset: 0; margin: auto` (centers the element). `left-auto
+        // bottom-auto m-0` releases those so `top-...` + `right-4` anchor to
+        // the upper-right corner; `[&:popover-open]:flex` restores our layout.
+        className="fixed top-[calc(var(--nv-app-bar-height)+1rem)] right-4 left-auto bottom-auto m-0 hidden flex-col items-end gap-4 bg-transparent p-0 z-1100 max-w-md [&:popover-open]:flex"
       >
         {toasts.map((toast) => (
           <Toast

--- a/web/packages/common/src/providers/toast/ToastProvider.tsx
+++ b/web/packages/common/src/providers/toast/ToastProvider.tsx
@@ -18,6 +18,11 @@ import { getTransformStyles } from './GetTransformStyles';
 import { AddToastFn, ToastContextValue, ToastDescriptor } from './types';
 import { ToastContext } from './useToast';
 
+// Browser support is decided at load time and does not change. Computing it
+// once keeps the render path branch-free and the className stable.
+const SUPPORTS_POPOVER =
+  typeof HTMLElement !== 'undefined' && 'showPopover' in HTMLElement.prototype;
+
 export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
   const [toasts, setToasts] = useState<ToastDescriptor[]>([]);
   const timeoutRefs = useRef<Record<string, NodeJS.Timeout>>({});
@@ -153,13 +158,19 @@ export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
       {children}
       <div
         ref={containerRef}
-        popover="manual"
+        popover={SUPPORTS_POPOVER ? 'manual' : undefined}
         // Popover elements default to `display: none`; the arbitrary variant
         // restores our flex layout when the popover is open. The UA stylesheet
         // also sets `[popover] { inset: 0; margin: auto; }` (centers the
         // element); `left-auto bottom-auto m-0` releases those so `top-...` +
         // `right-4` anchor cleanly to the upper-right corner.
-        className="fixed top-[calc(var(--nv-app-bar-height)+1rem)] right-4 left-auto bottom-auto m-0 hidden flex-col items-end gap-4 bg-transparent p-0 z-1100 max-w-md [&:popover-open]:flex"
+        //
+        // Fallback: without Popover API support, render `flex` unconditionally
+        // — promoteToTopLayer is a no-op there, and toasts must remain visible
+        // (top-layer ordering vs modals just won't work).
+        className={`fixed top-[calc(var(--nv-app-bar-height)+1rem)] right-4 left-auto bottom-auto m-0 flex-col items-end gap-4 bg-transparent p-0 z-1100 max-w-md ${
+          SUPPORTS_POPOVER ? 'hidden [&:popover-open]:flex' : 'flex'
+        }`}
       >
         {toasts.map((toast) => (
           <Toast

--- a/web/packages/common/src/providers/toast/ToastProvider.tsx
+++ b/web/packages/common/src/providers/toast/ToastProvider.tsx
@@ -33,24 +33,18 @@ export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
   // the container above any dialog that opened after it.
   useEffect(() => {
     const el = containerRef.current;
-    if (!el) return;
+    // Feature-detect once. Older browsers fall back to z-index-only behaviour
+    // (broken under top-layer dialogs, same as before this fix).
+    if (!el || typeof el.showPopover !== 'function') return;
+
+    const isOpen = el.matches(':popover-open');
     if (toasts.length > 0) {
-      try {
-        el.hidePopover();
-      } catch {
-        // not currently shown — ignore
-      }
-      try {
-        el.showPopover();
-      } catch {
-        // Popover API not supported on this browser; fall back to z-index only.
-      }
-    } else {
-      try {
-        el.hidePopover();
-      } catch {
-        // already hidden — ignore
-      }
+      // Toggle to re-promote above any dialog that opened after the previous
+      // showPopover() — top-layer order is "last opened wins".
+      if (isOpen) el.hidePopover();
+      el.showPopover();
+    } else if (isOpen) {
+      el.hidePopover();
     }
   }, [toasts.length]);
 

--- a/web/packages/common/src/providers/toast/ToastProvider.tsx
+++ b/web/packages/common/src/providers/toast/ToastProvider.tsx
@@ -166,10 +166,11 @@ export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
         ref={containerRef}
         popover="manual"
         // Popover elements default to `display: none`; the arbitrary variant
-        // restores our flex layout when the popover is open. `position: fixed`
-        // is preserved so the container anchors to the viewport corner — the
-        // top-layer escape only governs stacking, not positioning.
-        className="fixed top-[calc(var(--nv-app-bar-height)+1rem)] right-4 m-0 hidden flex-col items-end gap-4 bg-transparent p-0 z-1100 max-w-md [&:popover-open]:flex"
+        // restores our flex layout when the popover is open. The UA stylesheet
+        // also sets `[popover] { inset: 0; margin: auto; }` (centers the
+        // element); `left-auto bottom-auto m-0` releases those so `top-...` +
+        // `right-4` anchor cleanly to the upper-right corner.
+        className="fixed top-[calc(var(--nv-app-bar-height)+1rem)] right-4 left-auto bottom-auto m-0 hidden flex-col items-end gap-4 bg-transparent p-0 z-1100 max-w-md [&:popover-open]:flex"
       >
         {toasts.map((toast) => (
           <Toast

--- a/web/packages/common/src/providers/toast/ToastProvider.tsx
+++ b/web/packages/common/src/providers/toast/ToastProvider.tsx
@@ -28,25 +28,19 @@ export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
   // normal stacking context, so toasts rendered as ordinary fixed-position
   // children disappear behind any open modal's backdrop.
   //
-  // Fix: render the toast container as a manual Popover. Popovers also enter
-  // the top layer, and "last opened wins" — re-issuing showPopover() promotes
-  // the container above any dialog that opened after it.
-  useEffect(() => {
+  // Fix: render the toast container as a manual Popover and call .showPopover()
+  // imperatively at addToast time. Popovers also enter the top layer, and
+  // "last opened wins" — re-issuing showPopover() promotes the container above
+  // any dialog that opened after the previous call. With no toasts, the
+  // popover stays open but renders nothing visible (no children inside).
+  const promoteToTopLayer = useCallback(() => {
     const el = containerRef.current;
-    // Feature-detect once. Older browsers fall back to z-index-only behaviour
+    // Feature-detect. Older browsers fall back to z-index-only behaviour
     // (broken under top-layer dialogs, same as before this fix).
     if (!el || typeof el.showPopover !== 'function') return;
-
-    const isOpen = el.matches(':popover-open');
-    if (toasts.length > 0) {
-      // Toggle to re-promote above any dialog that opened after the previous
-      // showPopover() — top-layer order is "last opened wins".
-      if (isOpen) el.hidePopover();
-      el.showPopover();
-    } else if (isOpen) {
-      el.hidePopover();
-    }
-  }, [toasts.length]);
+    if (el.matches(':popover-open')) el.hidePopover();
+    el.showPopover();
+  }, []);
 
   // Cleanup all timeouts when component unmounts to prevent state updates after unmount
   useEffect(() => {
@@ -92,6 +86,7 @@ export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
       const durationMs = rawDurationMs === false ? undefined : rawDurationMs;
       const newToastId = `toast-${crypto.randomUUID()}`;
 
+      promoteToTopLayer();
       setToasts((prevToasts) => [
         ...prevToasts,
         {
@@ -119,7 +114,7 @@ export const ToastProvider: FC<PropsWithChildren> = ({ children }) => {
 
       return newToastId;
     },
-    [removeToast]
+    [promoteToTopLayer, removeToast]
   );
 
   const contextValue: ToastContextValue = useMemo(


### PR DESCRIPTION
New KUI modals use `<dialog>` whcih changes z-index relationship with toasts.

This fixes toasts so that they are not hidden under the modal overlay.

# Before

<img width="856" height="743" alt="Screenshot 2026-06-02 at 10 09 14 AM" src="https://github.com/user-attachments/assets/bd2819f8-a0fb-4406-a884-c8ebd1204eee" />

# After

<img width="844" height="897" alt="Screenshot 2026-06-02 at 11 41 02 AM" src="https://github.com/user-attachments/assets/bf30d363-9802-4133-aa00-cd3d645ff334" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Toasts no longer appear behind dialog backdrops; the notification container is promoted to the browser top layer so toasts remain visible.
  * New toasts now reliably bring the notification container to the front when enqueued, with a graceful fallback for browsers that don’t support the promotion mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->