### PR TITLE
feat(studio): Add chat to the Code Agent landing page

### DIFF
--- a/web/packages/studio/package.json
+++ b/web/packages/studio/package.json
@@ -36,6 +36,7 @@
     "feature-flags": "tsx scripts/feature-flag-matrix.ts"
   },
   "dependencies": {
+    "@assistant-ui/react": "^0.12.28",
     "@hookform/resolvers": "^4.1.3",
     "@mui/x-charts": "catalog:",
     "@mui/x-data-grid": "catalog:",

--- a/web/packages/studio/src/constants/routes.ts
+++ b/web/packages/studio/src/constants/routes.ts
@@ -102,6 +102,7 @@ export const ROUTES = {
     /** Workspace members and role-based access (Entities role bindings) */
     members: `/workspaces/:${P.workspace}/members`,
     agentsList: `/workspaces/:${P.workspace}/agents`,
+    claudeCodeChat: `/workspaces/:${P.workspace}/dashboard/code-agent`,
     agentDetail: `/workspaces/:${P.workspace}/agents/:${P.agentName}`,
     agentDeploymentsList: `/workspaces/:${P.workspace}/agent-deployments`,
     agentDeploymentDetail: `/workspaces/:${P.workspace}/agent-deployments/:${P.agentDeploymentName}`,

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
@@ -6,14 +6,29 @@ import { DashboardLandingRoute } from '@studio/routes/DashboardLandingRoute';
 import { TestProviders } from '@studio/tests/util/TestProviders';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createMemoryRouter, generatePath, RouterProvider } from 'react-router';
+import { createMemoryRouter, generatePath, RouterProvider, useLocation } from 'react-router';
 
 const workspace = 'default';
+const CHAT_ROUTE_TEST_ID = 'chat-route';
+
+const ChatRouteProbe = () => {
+  const location = useLocation();
+  const state = location.state as { initialPrompt?: string } | null;
+
+  return (
+    <div data-testid={CHAT_ROUTE_TEST_ID}>
+      {location.pathname}|{state?.initialPrompt}
+    </div>
+  );
+};
 
 const renderRoute = () => {
   const route = generatePath(ROUTES.workspace.dashboard, { workspace });
   const router = createMemoryRouter(
-    [{ path: ROUTES.workspace.dashboard, element: <DashboardLandingRoute /> }],
+    [
+      { path: ROUTES.workspace.dashboard, element: <DashboardLandingRoute /> },
+      { path: ROUTES.workspace.claudeCodeChat, element: <ChatRouteProbe /> },
+    ],
     {
       initialEntries: [route],
     }
@@ -62,5 +77,17 @@ describe('DashboardLandingRoute', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Send message' })).toBeEnabled();
     });
+  });
+
+  it('navigates to Claude Code chat with the submitted prompt', async () => {
+    const user = userEvent.setup();
+    renderRoute();
+
+    await user.type(await screen.findByRole('textbox', { name: 'Message Claude' }), 'Check repo');
+    await user.click(screen.getByRole('button', { name: 'Send message' }));
+
+    expect(await screen.findByTestId(CHAT_ROUTE_TEST_ID)).toHaveTextContent(
+      `${generatePath(ROUTES.workspace.claudeCodeChat, { workspace })}|Check repo`
+    );
   });
 });

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
@@ -3,7 +3,10 @@
 
 import { Button, Card, Flex, Text, TextArea, Tooltip } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import type { ClaudeCodeChatRouteState } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import { getClaudeCodeChatRoute } from '@studio/routes/utils';
 import { GitBranch, Hammer, Search, Send, Terminal } from 'lucide-react';
 import {
   type ChangeEvent,
@@ -13,6 +16,7 @@ import {
   useCallback,
   useState,
 } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface PromptSuggestion {
   title: string;
@@ -63,12 +67,18 @@ const PromptCard = ({
 const LandingComposer = ({
   input,
   onChange,
+  onSubmit,
 }: {
   input: string;
   onChange: (value: string) => void;
+  onSubmit: (prompt: string) => void;
 }) => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    const prompt = input.trim();
+    if (!prompt) return;
+
+    onSubmit(prompt);
   };
 
   return (
@@ -107,6 +117,8 @@ const LandingComposer = ({
 };
 
 export const DashboardLandingRoute: FC = () => {
+  const workspace = useWorkspaceFromPath();
+  const navigate = useNavigate();
   const [input, setInput] = useState('');
 
   useBreadcrumbs({
@@ -116,6 +128,14 @@ export const DashboardLandingRoute: FC = () => {
   const handlePromptSelect = useCallback((prompt: string) => {
     setInput(prompt);
   }, []);
+
+  const handleSubmit = useCallback(
+    (prompt: string) => {
+      const state: ClaudeCodeChatRouteState = { initialPrompt: prompt };
+      navigate(getClaudeCodeChatRoute(workspace), { state });
+    },
+    [navigate, workspace]
+  );
 
   return (
     <AccessibleTitle title="Dashboard">
@@ -127,7 +147,7 @@ export const DashboardLandingRoute: FC = () => {
             </Text>
           </Flex>
 
-          <LandingComposer input={input} onChange={setInput} />
+          <LandingComposer input={input} onChange={setInput} onSubmit={handleSubmit} />
 
           <Flex className="grid w-full grid-cols-1 gap-3 md:grid-cols-3">
             {PROMPT_SUGGESTIONS.map((suggestion) => (

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.ts
@@ -102,25 +102,36 @@ export const streamClaudeCodeMessage = async ({
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffered = '';
+  let shouldCancelReader = true;
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        shouldCancelReader = false;
+        break;
+      }
 
-    buffered += decoder.decode(value, { stream: true });
-    const parsed = parseSseChunk(buffered);
-    buffered = parsed.rest;
+      buffered += decoder.decode(value, { stream: true });
+      const parsed = parseSseChunk(buffered);
+      buffered = parsed.rest;
 
-    for (const event of parsed.events) {
-      if (!handleSseEvent(event, handlers)) return;
+      for (const event of parsed.events) {
+        if (!handleSseEvent(event, handlers)) return;
+      }
     }
-  }
 
-  buffered += decoder.decode();
-  if (buffered) {
-    const parsed = parseSseChunk(`${buffered}\n\n`);
-    for (const event of parsed.events) {
-      if (!handleSseEvent(event, handlers)) return;
+    buffered += decoder.decode();
+    if (buffered) {
+      const parsed = parseSseChunk(`${buffered}\n\n`);
+      for (const event of parsed.events) {
+        if (!handleSseEvent(event, handlers)) return;
+      }
     }
+  } finally {
+    if (shouldCancelReader) {
+      await reader.cancel().catch(() => undefined);
+    }
+    reader.releaseLock();
   }
 };

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.ts
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import { parseJsonObject, parseSseChunk } from '@studio/routes/agents/ClaudeCodeChatRoute/stream';
+import type { ClaudeCodeStreamHandlers } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+
+const CLAUDE_CODE_API_BASE_PATH = '/apis/studio/v2/coding-agents';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const claudeCodeApiUrl = (path: string): string =>
+  `${PLATFORM_BASE_URL}${CLAUDE_CODE_API_BASE_PATH}${path}`;
+
+const getResponseErrorMessage = async (response: Response, fallback: string): Promise<string> => {
+  const text = await response.text();
+  if (!text) return fallback;
+
+  try {
+    const body = JSON.parse(text) as unknown;
+    if (isRecord(body) && typeof body.detail === 'string') return body.detail;
+  } catch {
+    return text;
+  }
+
+  return text;
+};
+
+export const createClaudeCodeSession = async (): Promise<string> => {
+  const response = await fetch(claudeCodeApiUrl('/sessions'), {
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      await getResponseErrorMessage(response, 'Failed to create Claude Code session')
+    );
+  }
+
+  const body = (await response.json()) as unknown;
+  if (!isRecord(body) || typeof body.session_id !== 'string') {
+    throw new Error('Claude Code session response did not include a session id');
+  }
+
+  return body.session_id;
+};
+
+const getStreamErrorMessage = (payload: unknown): string => {
+  if (!isRecord(payload)) return 'Claude Code stream failed';
+  if (typeof payload.stderr === 'string' && payload.stderr) return payload.stderr;
+  if (typeof payload.detail === 'string' && payload.detail) return payload.detail;
+  if (typeof payload.message === 'string' && payload.message) return payload.message;
+  return 'Claude Code stream failed';
+};
+
+const handleSseEvent = (
+  event: { event?: string; data: string },
+  handlers: ClaudeCodeStreamHandlers
+): boolean => {
+  if (event.event === 'done') {
+    handlers.onDone();
+    return true;
+  }
+
+  if (event.event === 'error') {
+    handlers.onError(new Error(getStreamErrorMessage(parseJsonObject(event.data))));
+    return false;
+  }
+
+  handlers.onClaudeEvent(parseJsonObject(event.data));
+  return true;
+};
+
+export const streamClaudeCodeMessage = async ({
+  sessionId,
+  message,
+  signal,
+  handlers,
+}: {
+  sessionId: string;
+  message: string;
+  signal: AbortSignal;
+  handlers: ClaudeCodeStreamHandlers;
+}): Promise<void> => {
+  const response = await fetch(claudeCodeApiUrl(`/sessions/${sessionId}/messages`), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ message }),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(await getResponseErrorMessage(response, 'Failed to send Claude Code message'));
+  }
+  if (!response.body) {
+    throw new Error('Claude Code response did not include a stream');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffered = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffered += decoder.decode(value, { stream: true });
+    const parsed = parseSseChunk(buffered);
+    buffered = parsed.rest;
+
+    for (const event of parsed.events) {
+      if (!handleSseEvent(event, handlers)) return;
+    }
+  }
+
+  buffered += decoder.decode();
+  if (buffered) {
+    const parsed = parseSseChunk(`${buffered}\n\n`);
+    for (const event of parsed.events) {
+      if (!handleSseEvent(event, handlers)) return;
+    }
+  }
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.tsx
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AssistantRuntimeProvider } from '@assistant-ui/react';
+import { AssistantChatThread } from '@nemo/common/src/components/AssistantChat/AssistantChatThread';
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import { Stack } from '@nvidia/foundations-react-core';
+import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import type { ClaudeCodeChatRouteState } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import { useClaudeCodeChatRuntime } from '@studio/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime';
+import { getWorkspaceDashboardRoute } from '@studio/routes/utils';
+import { type FC, useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const getInitialPrompt = (state: unknown): string | undefined => {
+  if (typeof state !== 'object' || state === null) return undefined;
+
+  const initialPrompt = (state as ClaudeCodeChatRouteState).initialPrompt;
+  if (typeof initialPrompt !== 'string') return undefined;
+
+  const trimmedPrompt = initialPrompt.trim();
+  return trimmedPrompt || undefined;
+};
+
+export const ClaudeCodeChatRoute: FC = () => {
+  const workspace = useWorkspaceFromPath();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const toast = useToast();
+  const consumedInitialPromptRef = useRef<string | undefined>(undefined);
+  const { handleReset, runtime, submitPrompt } = useClaudeCodeChatRuntime({
+    onError: (error) => toast.error(error.message),
+  });
+  const initialPrompt = getInitialPrompt(location.state);
+
+  useBreadcrumbs({
+    items: [
+      { slotLabel: 'Dashboard', href: getWorkspaceDashboardRoute(workspace) },
+      { slotLabel: 'Code Agent' },
+    ],
+  });
+
+  useEffect(() => {
+    if (!initialPrompt || consumedInitialPromptRef.current === initialPrompt) return;
+
+    consumedInitialPromptRef.current = initialPrompt;
+    navigate(location.pathname, { replace: true, state: null });
+    void submitPrompt(initialPrompt);
+  }, [initialPrompt, location.pathname, navigate, submitPrompt]);
+
+  return (
+    <AccessibleTitle title={`Code Agent chat for ${workspace}`}>
+      <Stack className="h-full" padding="density-2xl">
+        <Stack className="mx-auto min-h-0 w-full max-w-180 flex-1">
+          <AssistantRuntimeProvider runtime={runtime}>
+            <AssistantChatThread
+              placeholder="Ask Claude Code to work in this workspace"
+              onReset={handleReset}
+              emptyState={{
+                slotHeading: 'Start a Claude Code session',
+                slotSubheading: 'Ask Claude Code to work in this workspace.',
+              }}
+            />
+          </AssistantRuntimeProvider>
+        </Stack>
+      </Stack>
+    </AccessibleTitle>
+  );
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/stream.spec.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/stream.spec.ts
@@ -3,8 +3,10 @@
 
 import {
   getAssistantTextFromClaudeEvent,
+  parseJsonObject,
   parseSseChunk,
 } from '@studio/routes/agents/ClaudeCodeChatRoute/stream';
+import { websiteLogger } from '@studio/util/logger';
 
 describe('Claude Code stream utilities', () => {
   it('parses SSE events and preserves incomplete trailing data', () => {
@@ -38,5 +40,16 @@ describe('Claude Code stream utilities', () => {
         },
       })
     ).toBe('I can check that.\n\nUsing Bash...');
+  });
+
+  it('returns undefined and logs when JSON parsing fails', () => {
+    const loggerSpy = vi.spyOn(websiteLogger, 'error').mockImplementation(() => undefined);
+
+    expect(parseJsonObject('{')).toBeUndefined();
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse Claude Code stream JSON')
+    );
+
+    loggerSpy.mockRestore();
   });
 });

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/stream.spec.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/stream.spec.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  getAssistantTextFromClaudeEvent,
+  parseSseChunk,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/stream';
+
+describe('Claude Code stream utilities', () => {
+  it('parses SSE events and preserves incomplete trailing data', () => {
+    const parsed = parseSseChunk(
+      [
+        'data: {"type":"assistant"}',
+        '',
+        'event: custom_event',
+        'data: {"request_id":"req-1"}',
+        '',
+        'event: don',
+      ].join('\n')
+    );
+
+    expect(parsed.events).toEqual([
+      { event: undefined, data: '{"type":"assistant"}' },
+      { event: 'custom_event', data: '{"request_id":"req-1"}' },
+    ]);
+    expect(parsed.rest).toBe('event: don');
+  });
+
+  it('extracts assistant text and tool summaries from Claude Code events', () => {
+    expect(
+      getAssistantTextFromClaudeEvent({
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'text', text: 'I can check that.' },
+            { type: 'tool_use', name: 'Bash' },
+          ],
+        },
+      })
+    ).toBe('I can check that.\n\nUsing Bash...');
+  });
+});

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/stream.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/stream.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { websiteLogger } from '@studio/util/logger';
+
 interface ServerSentEvent {
   event?: string;
   data: string;
@@ -83,5 +85,12 @@ export const getAssistantTextFromClaudeEvent = (event: unknown): string => {
 
 export const parseJsonObject = (value: string): unknown => {
   if (!value) return undefined;
-  return JSON.parse(value) as unknown;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch (error) {
+    websiteLogger.error(
+      `Failed to parse Claude Code stream JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return undefined;
+  }
 };

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/stream.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/stream.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+interface ServerSentEvent {
+  event?: string;
+  data: string;
+}
+
+interface ParsedSseChunk {
+  events: ServerSentEvent[];
+  rest: string;
+}
+
+interface ClaudeCodeTextPart {
+  type?: unknown;
+  text?: unknown;
+  name?: unknown;
+}
+
+interface ClaudeCodeMessage {
+  content?: unknown;
+}
+
+interface ClaudeCodeStreamEvent {
+  type?: unknown;
+  message?: ClaudeCodeMessage;
+}
+
+export const parseSseChunk = (chunk: string): ParsedSseChunk => {
+  const normalized = chunk.replace(/\r\n/g, '\n');
+  const blocks = normalized.split('\n\n');
+  const rest = blocks.pop() ?? '';
+
+  return {
+    rest,
+    events: blocks
+      .map((block) => {
+        const lines = block.split('\n');
+        let event: string | undefined;
+        const dataLines: string[] = [];
+
+        for (const line of lines) {
+          if (line.startsWith('event:')) {
+            event = line.slice('event:'.length).trim();
+          } else if (line.startsWith('data:')) {
+            dataLines.push(line.slice('data:'.length).replace(/^ /, ''));
+          }
+        }
+
+        return { event, data: dataLines.join('\n') };
+      })
+      .filter((event) => event.event || event.data),
+  };
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const getContentParts = (event: ClaudeCodeStreamEvent): ClaudeCodeTextPart[] => {
+  const content = event.message?.content;
+  if (!Array.isArray(content)) return [];
+  return content.filter(isRecord);
+};
+
+export const getAssistantTextFromClaudeEvent = (event: unknown): string => {
+  if (!isRecord(event) || event.type !== 'assistant') return '';
+
+  const parts = getContentParts(event);
+  const text = parts
+    .map((part) => {
+      if (part.type === 'text' && typeof part.text === 'string') return part.text;
+      if (part.type === 'tool_use') {
+        const toolName = typeof part.name === 'string' ? part.name : 'tool';
+        return `\n\nUsing ${toolName}...`;
+      }
+      return '';
+    })
+    .filter(Boolean)
+    .join('');
+
+  return text;
+};
+
+export const parseJsonObject = (value: string): unknown => {
+  if (!value) return undefined;
+  return JSON.parse(value) as unknown;
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/types.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/types.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface ClaudeCodeStreamHandlers {
+  onClaudeEvent: (event: unknown) => void;
+  onDone: () => void;
+  onError: (error: Error) => void;
+}
+
+export interface ClaudeCodeChatRouteState {
+  initialPrompt?: string;
+}

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  CANCELLED_STATUS,
+  COMPLETE_STATUS,
+} from '@nemo/common/src/components/AssistantChat/constants';
+import {
+  createClaudeCodeSession,
+  streamClaudeCodeMessage,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/api';
+import { getAssistantTextFromClaudeEvent } from '@studio/routes/agents/ClaudeCodeChatRoute/stream';
+import { useCustomAssistantChatRuntime } from '@studio/routes/agents/ClaudeCodeChatRoute/useCustomAssistantChatRuntime';
+import { useCallback, useRef, useState } from 'react';
+
+export const useClaudeCodeChatRuntime = (options?: { onError?: (error: Error) => void }) => {
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+
+  const ensureSessionId = useCallback(async (): Promise<string> => {
+    if (sessionIdRef.current) return sessionIdRef.current;
+
+    const nextSessionId = await createClaudeCodeSession();
+    sessionIdRef.current = nextSessionId;
+    setSessionId(nextSessionId);
+    return nextSessionId;
+  }, []);
+
+  const {
+    handleReset: resetThread,
+    isRunning,
+    runtime,
+    submitPrompt,
+  } = useCustomAssistantChatRuntime({
+    onError: options?.onError,
+    onRun: async ({ prompt, signal, appendAssistantText, isCurrentRun }) => {
+      const activeSessionId = await ensureSessionId();
+      let doneReceived = false;
+
+      await streamClaudeCodeMessage({
+        sessionId: activeSessionId,
+        message: prompt,
+        signal,
+        handlers: {
+          onClaudeEvent: (event) => {
+            if (signal.aborted || !isCurrentRun()) return;
+
+            const text = getAssistantTextFromClaudeEvent(event);
+            if (text) appendAssistantText(text);
+          },
+          onDone: () => {
+            doneReceived = true;
+          },
+          onError: (error) => {
+            throw error;
+          },
+        },
+      });
+
+      return { status: doneReceived ? COMPLETE_STATUS : CANCELLED_STATUS };
+    },
+  });
+
+  const handleReset = useCallback(() => {
+    sessionIdRef.current = null;
+    setSessionId(null);
+    resetThread();
+  }, [resetThread]);
+
+  return {
+    handleReset,
+    isRunning,
+    runtime,
+    sessionId,
+    submitPrompt,
+  };
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useCustomAssistantChatRuntime.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useCustomAssistantChatRuntime.ts
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type AppendMessage,
+  type MessageStatus,
+  type ThreadMessageLike,
+  useExternalStoreRuntime,
+} from '@assistant-ui/react';
+import {
+  CANCELLED_STATUS,
+  COMPLETE_STATUS,
+  RUNNING_STATUS,
+} from '@nemo/common/src/components/AssistantChat/constants';
+import {
+  appendMessageToThreadMessage,
+  createTextMessage,
+  getMessageText,
+} from '@nemo/common/src/components/AssistantChat/messageUtils';
+import { useCallback, useRef, useState } from 'react';
+
+export interface CustomAssistantRunContext {
+  prompt: string;
+  signal: AbortSignal;
+  appendAssistantText: (text: string) => void;
+  setAssistantText: (text: string) => void;
+  isCurrentRun: () => boolean;
+}
+
+export interface CustomAssistantRunResult {
+  status?: MessageStatus;
+  text?: string;
+}
+
+interface UseCustomAssistantChatRuntimeOptions {
+  onRun: (context: CustomAssistantRunContext) => Promise<CustomAssistantRunResult | void>;
+  onError?: (error: Error) => void;
+}
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof DOMException && error.name === 'AbortError';
+
+export const useCustomAssistantChatRuntime = ({
+  onRun,
+  onError,
+}: UseCustomAssistantChatRuntimeOptions) => {
+  const [messages, setMessages] = useState<readonly ThreadMessageLike[]>([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const messagesRef = useRef<readonly ThreadMessageLike[]>([]);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const setThreadMessages = useCallback((nextMessages: readonly ThreadMessageLike[]) => {
+    messagesRef.current = nextMessages;
+    setMessages(nextMessages);
+  }, []);
+
+  const updateAssistantMessage = useCallback(
+    (assistantMessageId: string, text: string, status: MessageStatus) => {
+      setThreadMessages(
+        messagesRef.current.map((message) =>
+          message.id === assistantMessageId
+            ? {
+                ...message,
+                content: [{ type: 'text', text }],
+                status,
+              }
+            : message
+        )
+      );
+    },
+    [setThreadMessages]
+  );
+
+  const runCompletion = useCallback(
+    async (conversationMessages: readonly ThreadMessageLike[]) => {
+      const latestMessage = conversationMessages.at(-1);
+      const prompt = latestMessage ? getMessageText(latestMessage).trim() : '';
+      if (!prompt) return;
+
+      abortControllerRef.current?.abort();
+      const runController = new AbortController();
+      abortControllerRef.current = runController;
+      const isCurrentRun = () => abortControllerRef.current === runController;
+
+      const assistantMessage = createTextMessage('assistant', '', RUNNING_STATUS);
+      setThreadMessages([...conversationMessages, assistantMessage]);
+      setIsRunning(true);
+      let responseText = '';
+
+      const setAssistantText = (text: string) => {
+        responseText = text;
+        updateAssistantMessage(assistantMessage.id!, responseText, RUNNING_STATUS);
+      };
+
+      const appendAssistantText = (text: string) => {
+        responseText += text;
+        updateAssistantMessage(assistantMessage.id!, responseText, RUNNING_STATUS);
+      };
+
+      try {
+        const result = await onRun({
+          prompt,
+          signal: runController.signal,
+          appendAssistantText,
+          setAssistantText,
+          isCurrentRun,
+        });
+
+        if (runController.signal.aborted || !isCurrentRun()) {
+          updateAssistantMessage(assistantMessage.id!, responseText, CANCELLED_STATUS);
+          return;
+        }
+
+        updateAssistantMessage(
+          assistantMessage.id!,
+          result?.text ?? responseText,
+          result?.status ?? COMPLETE_STATUS
+        );
+      } catch (error: unknown) {
+        if (runController.signal.aborted || isAbortError(error)) {
+          updateAssistantMessage(assistantMessage.id!, responseText, CANCELLED_STATUS);
+          return;
+        }
+
+        const errorMessage = error instanceof Error ? error.message : 'Unknown Error';
+        updateAssistantMessage(assistantMessage.id!, errorMessage, {
+          type: 'incomplete',
+          reason: 'error',
+          error: errorMessage,
+        });
+        onError?.(error instanceof Error ? error : new Error(errorMessage));
+      } finally {
+        if (abortControllerRef.current === runController) {
+          abortControllerRef.current = null;
+          setIsRunning(false);
+        }
+      }
+    },
+    [onError, onRun, setThreadMessages, updateAssistantMessage]
+  );
+
+  const handleNewMessage = useCallback(
+    async (message: AppendMessage): Promise<void> => {
+      const text = getMessageText(message).trim();
+      if (!text) return;
+
+      const userMessage = appendMessageToThreadMessage({
+        ...message,
+        content: [{ type: 'text', text }],
+      });
+      const nextMessages = [...messagesRef.current, userMessage];
+      setThreadMessages(nextMessages);
+      await runCompletion(nextMessages);
+    },
+    [runCompletion, setThreadMessages]
+  );
+
+  const submitPrompt = useCallback(
+    async (prompt: string): Promise<void> => {
+      const text = prompt.trim();
+      if (!text) return;
+
+      const userMessage = createTextMessage('user', text);
+      const nextMessages = [...messagesRef.current, userMessage];
+      setThreadMessages(nextMessages);
+      await runCompletion(nextMessages);
+    },
+    [runCompletion, setThreadMessages]
+  );
+
+  const handleCancel = useCallback(async () => {
+    abortControllerRef.current?.abort();
+    setIsRunning(false);
+    setThreadMessages(
+      messagesRef.current.map((message) =>
+        message.role === 'assistant' && message.status?.type === 'running'
+          ? { ...message, status: CANCELLED_STATUS }
+          : message
+      )
+    );
+  }, [setThreadMessages]);
+
+  const handleReset = useCallback(() => {
+    abortControllerRef.current?.abort();
+    setIsRunning(false);
+    setThreadMessages([]);
+  }, [setThreadMessages]);
+
+  const runtime = useExternalStoreRuntime<ThreadMessageLike>({
+    messages,
+    setMessages: setThreadMessages,
+    isRunning,
+    onNew: handleNewMessage,
+    onCancel: handleCancel,
+    convertMessage: (message) => message,
+    unstable_capabilities: {
+      copy: true,
+    },
+  });
+
+  return {
+    handleReset,
+    isRunning,
+    runtime,
+    submitPrompt,
+  };
+};

--- a/web/packages/studio/src/routes/index.tsx
+++ b/web/packages/studio/src/routes/index.tsx
@@ -22,6 +22,7 @@ import { RootRedirect } from '@studio/routes/RootRedirect';
 import {
   agentsRoutes,
   gateBaseModelsRoutes,
+  gateCodingAgentStudioRoutes,
   gateCustomizationRoutes,
   gateDatasetsRoutes,
   gateDeploymentsRoutes,
@@ -310,6 +311,11 @@ const AgentsListRoute =
       default: m.AgentsListRoute,
     }))
   );
+const ClaudeCodeChatRoute = lazy(() =>
+  import('@studio/routes/agents/ClaudeCodeChatRoute').then((m) => ({
+    default: m.ClaudeCodeChatRoute,
+  }))
+);
 const AgentOptimizationsRoute =
   AGENTS_ENABLED &&
   lazy(() =>
@@ -406,6 +412,17 @@ export const routes: RouteObject[] = [
                   ),
                   errorElement: <ErrorPanel title="Workspace" />,
                 },
+                ...gateCodingAgentStudioRoutes([
+                  {
+                    path: ROUTES.workspace.claudeCodeChat,
+                    element: (
+                      <Suspense fallback={<Loading description="Loading..." />}>
+                        <ClaudeCodeChatRoute />
+                      </Suspense>
+                    ),
+                    errorElement: <ErrorPanel title="Claude Code" />,
+                  },
+                ]),
               ]),
               ...gateBaseModelsRoutes([
                 {

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -86,6 +86,9 @@ export const gateMembersRoutes = (routes: RouteObject | RouteObject[]) =>
 export const agentsRoutes = (routes: RouteObject | RouteObject[]) =>
   gateRoutes(AGENTS_ENABLED, routes);
 
+export const gateCodingAgentStudioRoutes = (routes: RouteObject | RouteObject[]) =>
+  gateRoutes(CODING_AGENT_STUDIO_ENABLED, routes);
+
 export const gateDeploymentsRoutes = (routes: RouteObject | RouteObject[]) =>
   gateRoutes(DEPLOYMENTS_ENABLED, routes);
 
@@ -457,6 +460,10 @@ export const getModelChatRoute = (model: NamedEntityRef) => {
 
 export const getAgentsListRoute = (workspace: string) => {
   return generatePath(ROUTES.workspace.agentsList, { workspace });
+};
+
+export const getClaudeCodeChatRoute = (workspace: string) => {
+  return generatePath(ROUTES.workspace.claudeCodeChat, { workspace });
 };
 
 export const getAgentDetailRoute = (workspace: string, agentName: string) => {

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -561,6 +561,9 @@ importers:
 
   packages/studio:
     dependencies:
+      '@assistant-ui/react':
+        specifier: ^0.12.28
+        version: 0.12.28(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
       '@hookform/resolvers':
         specifier: ^4.1.3
         version: 4.1.3(react-hook-form@7.71.2(react@19.2.5))


### PR DESCRIPTION
<img width="1726" height="996" alt="image" src="https://github.com/user-attachments/assets/ec12a54b-7ee8-41d3-ae13-45957bee4273" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code chat agent with session-based conversations and real-time streamed responses.
  * Start a Claude Code chat directly from the dashboard, with support for pre-filled initial prompts that auto-submit.
  * Persistent session management and runtime controls (reset/cancel) to maintain chat continuity and handle long-running responses.
  * Improved assistant message handling and clearer Claude Code-specific UI text and empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->