### PR TITLE
feat(auth): add config-driven domain policy layer

### DIFF
--- a/services/core/auth/src/nmp/core/auth/app/bundle.py
+++ b/services/core/auth/src/nmp/core/auth/app/bundle.py
@@ -13,7 +13,8 @@ import time
 from pathlib import Path
 from typing import Optional, Tuple
 
-from nemo_platform_plugin.discovery import discover_manifests
+from nemo_platform_plugin.discovery import discover_entry_points
+from nemo_platform_plugin.interface import PluginManifest
 import yaml
 from nmp.common.auth import ALL_WORKSPACES
 from nmp.common.auth.authz_format import validate_static_authz_data
@@ -37,11 +38,32 @@ def _extract_domain_names_from_endpoints(endpoints: dict[str, object]) -> set[st
     return names
 
 
+def _discover_domain_manifests() -> dict[str, PluginManifest]:
+    """Return manifest metadata for extension API domains only.
+
+    Auth domains map to ``/apis/<domain>/...`` namespaces, so only ``nemo.services``
+    entry points are relevant here. Other plugin surfaces such as skills or
+    inference middleware may legitimately reuse names like ``guardrails`` without
+    contributing a top-level API domain.
+    """
+    manifests: dict[str, PluginManifest] = {}
+    for name, ep in discover_entry_points("nemo.services").items():
+        try:
+            dist = ep.dist
+            version = dist.metadata.get("Version", "") if dist is not None else ""  # ty: ignore[unresolved-attribute]
+            description = dist.metadata.get("Summary", "") if dist is not None else ""  # ty: ignore[unresolved-attribute]
+        except Exception:
+            version = ""
+            description = ""
+        manifests[name] = PluginManifest(name=name, version=version, description=description)
+    return manifests
+
+
 def _build_domain_registry(static_data: dict) -> dict[str, dict[str, str]]:
     """Build the unified auth domain registry for core and extension APIs."""
     endpoints = static_data.get("authz", {}).get("endpoints", {})
     domain_names = _extract_domain_names_from_endpoints(endpoints)
-    manifests = discover_manifests()
+    manifests = _discover_domain_manifests()
     conflicts = domain_names & manifests.keys()
     if conflicts:
         conflicting_names = ", ".join(sorted(conflicts))

--- a/services/core/auth/src/nmp/core/auth/app/bundle.py
+++ b/services/core/auth/src/nmp/core/auth/app/bundle.py
@@ -42,6 +42,13 @@ def _build_domain_registry(static_data: dict) -> dict[str, dict[str, str]]:
     endpoints = static_data.get("authz", {}).get("endpoints", {})
     domain_names = _extract_domain_names_from_endpoints(endpoints)
     manifests = discover_manifests()
+    conflicts = domain_names & manifests.keys()
+    if conflicts:
+        conflicting_names = ", ".join(sorted(conflicts))
+        raise ValueError(
+            "Domain name conflict between core API endpoints and extension manifests: "
+            f"{conflicting_names}"
+        )
 
     domains: dict[str, dict[str, str]] = {}
     for name in sorted(domain_names | manifests.keys()):

--- a/services/core/auth/src/nmp/core/auth/app/bundle.py
+++ b/services/core/auth/src/nmp/core/auth/app/bundle.py
@@ -137,7 +137,6 @@ async def _build_authorization_data_internal(entities_client: Optional[EntityCli
     if "principals" not in static_data["authz"]:
         static_data["authz"]["principals"] = {}
     static_data["authz"]["domains"] = _build_domain_registry(static_data)
-    static_data["authz"].setdefault("domain_policies", {})
 
     # Fetch dynamic data from EntityClient if available
     if entities_client:

--- a/services/core/auth/src/nmp/core/auth/app/bundle.py
+++ b/services/core/auth/src/nmp/core/auth/app/bundle.py
@@ -13,6 +13,7 @@ import time
 from pathlib import Path
 from typing import Optional, Tuple
 
+from nemo_platform_plugin.discovery import discover_manifests
 import yaml
 from nmp.common.auth import ALL_WORKSPACES
 from nmp.common.auth.authz_format import validate_static_authz_data
@@ -24,6 +25,32 @@ from nmp.core.auth.entities import RoleBindingEntity
 # Bundle cache configuration
 _bundle_cache: Optional[Tuple[bytes, str, float]] = None  # (bundle_bytes, etag, timestamp)
 _bundle_lock = asyncio.Lock()
+
+
+def _extract_domain_names_from_endpoints(endpoints: dict[str, object]) -> set[str]:
+    """Return API domain names derived from ``/apis/<domain>/...`` endpoint paths."""
+    names: set[str] = set()
+    for path in endpoints:
+        parts = path.split("/")
+        if len(parts) >= 3 and parts[1] == "apis" and parts[2]:
+            names.add(parts[2])
+    return names
+
+
+def _build_domain_registry(static_data: dict) -> dict[str, dict[str, str]]:
+    """Build the unified auth domain registry for core and extension APIs."""
+    endpoints = static_data.get("authz", {}).get("endpoints", {})
+    domain_names = _extract_domain_names_from_endpoints(endpoints)
+    manifests = discover_manifests()
+
+    domains: dict[str, dict[str, str]] = {}
+    for name in sorted(domain_names | manifests.keys()):
+        manifest = manifests.get(name)
+        if manifest is not None:
+            domains[name] = {"name": name, "version": manifest.version or "", "kind": "extension"}
+        else:
+            domains[name] = {"name": name, "version": "core", "kind": "core"}
+    return domains
 
 
 def get_bundle_cache_seconds() -> int:
@@ -109,6 +136,8 @@ async def _build_authorization_data_internal(entities_client: Optional[EntityCli
         static_data["authz"]["workspaces"] = {}
     if "principals" not in static_data["authz"]:
         static_data["authz"]["principals"] = {}
+    static_data["authz"]["domains"] = _build_domain_registry(static_data)
+    static_data["authz"].setdefault("domain_policies", {})
 
     # Fetch dynamic data from EntityClient if available
     if entities_client:

--- a/services/core/auth/src/nmp/core/auth/app/bundle.py
+++ b/services/core/auth/src/nmp/core/auth/app/bundle.py
@@ -13,9 +13,9 @@ import time
 from pathlib import Path
 from typing import Optional, Tuple
 
+import yaml
 from nemo_platform_plugin.discovery import discover_entry_points
 from nemo_platform_plugin.interface import PluginManifest
-import yaml
 from nmp.common.auth import ALL_WORKSPACES
 from nmp.common.auth.authz_format import validate_static_authz_data
 from nmp.common.config import get_service_config
@@ -68,8 +68,7 @@ def _build_domain_registry(static_data: dict) -> dict[str, dict[str, str]]:
     if conflicts:
         conflicting_names = ", ".join(sorted(conflicts))
         raise ValueError(
-            "Domain name conflict between core API endpoints and extension manifests: "
-            f"{conflicting_names}"
+            f"Domain name conflict between core API endpoints and extension manifests: {conflicting_names}"
         )
 
     domains: dict[str, dict[str, str]] = {}

--- a/services/core/auth/src/nmp/core/auth/app/policies/authz.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/authz.rego
@@ -89,6 +89,7 @@ allow_request if {
 	# Check if any principal has the required permissions
 	some principal in applicable_principals
 	has_permissions(principal, workspace, required_permissions)
+	domain_policy_checks_pass
 }
 
 # Wildcard workspace "-" with mutating methods: permission-based authorization.
@@ -113,6 +114,7 @@ allow_request if {
 	some principal in applicable_principals
 	startswith(principal, "service:")
 	has_permissions(principal, workspace, required_permissions)
+	domain_policy_checks_pass
 }
 
 # IAM APIs under /apis/auth/v2/iam/ — patterns have no {workspace} placeholder, so
@@ -131,6 +133,7 @@ allow_request if {
 	not extract_workspace_from_path(path)
 	some principal in applicable_principals
 	has_permissions(principal, "system", required_permissions)
+	domain_policy_checks_pass
 }
 
 # Allow cross-workspace LIST operations (GET/HEAD without workspace in path)
@@ -153,6 +156,7 @@ allow_request if {
 
 	# Match if no workspace can be extracted from path (undefined = no workspace placeholder)
 	not extract_workspace_from_path(path)
+	domain_policy_checks_pass
 }
 
 # Allow cross-workspace LIST operations with "-" wildcard workspace
@@ -170,6 +174,7 @@ allow_request if {
 	# Match if workspace is "-" wildcard
 	workspace := extract_workspace_from_path(path)
 	workspace == "-"
+	domain_policy_checks_pass
 }
 
 # Allow if endpoint explicitly has no required permissions (e.g., workspace creation)
@@ -192,6 +197,7 @@ allow_request if {
 	endpoint := normalize_endpoint(path)
 	method_lower := lower(method)
 	data.authz.endpoints[endpoint][method_lower].permissions == []
+	domain_policy_checks_pass
 }
 
 # DENY REQUEST RULES

--- a/services/core/auth/src/nmp/core/auth/app/policies/authz.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/authz.rego
@@ -89,7 +89,6 @@ allow_request if {
 	# Check if any principal has the required permissions
 	some principal in applicable_principals
 	has_permissions(principal, workspace, required_permissions)
-	domain_policy_checks_pass
 }
 
 # Wildcard workspace "-" with mutating methods: permission-based authorization.
@@ -114,7 +113,6 @@ allow_request if {
 	some principal in applicable_principals
 	startswith(principal, "service:")
 	has_permissions(principal, workspace, required_permissions)
-	domain_policy_checks_pass
 }
 
 # IAM APIs under /apis/auth/v2/iam/ — patterns have no {workspace} placeholder, so
@@ -133,7 +131,6 @@ allow_request if {
 	not extract_workspace_from_path(path)
 	some principal in applicable_principals
 	has_permissions(principal, "system", required_permissions)
-	domain_policy_checks_pass
 }
 
 # Allow cross-workspace LIST operations (GET/HEAD without workspace in path)
@@ -156,7 +153,6 @@ allow_request if {
 
 	# Match if no workspace can be extracted from path (undefined = no workspace placeholder)
 	not extract_workspace_from_path(path)
-	domain_policy_checks_pass
 }
 
 # Allow cross-workspace LIST operations with "-" wildcard workspace
@@ -174,7 +170,6 @@ allow_request if {
 	# Match if workspace is "-" wildcard
 	workspace := extract_workspace_from_path(path)
 	workspace == "-"
-	domain_policy_checks_pass
 }
 
 # Allow if endpoint explicitly has no required permissions (e.g., workspace creation)
@@ -197,7 +192,6 @@ allow_request if {
 	endpoint := normalize_endpoint(path)
 	method_lower := lower(method)
 	data.authz.endpoints[endpoint][method_lower].permissions == []
-	domain_policy_checks_pass
 }
 
 # DENY REQUEST RULES

--- a/services/core/auth/src/nmp/core/auth/app/policies/common.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/common.rego
@@ -3,6 +3,7 @@ package common
 import future.keywords.if
 
 import data.authz.extract_method
+import data.authz.extract_domain_name
 import data.authz.extract_path
 import data.authz.extract_principal_email
 import data.authz.extract_principal_groups
@@ -51,6 +52,16 @@ get_required_permissions(path, method) := perms if {
 	endpoint := normalize_endpoint(path)
 	method_lower := lower(method)
 	perms := data.authz.endpoints[endpoint][method_lower].permissions
+}
+
+get_domain_metadata(path) := domain if {
+	domain_name := extract_domain_name(path)
+	meta := data.authz.domains[domain_name]
+	domain := {
+		"name": meta.name,
+		"version": meta.version,
+		"kind": meta.kind,
+	}
 }
 
 # Check specific permission (for middleware to check special permissions)

--- a/services/core/auth/src/nmp/core/auth/app/policies/domain.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/domain.rego
@@ -1,0 +1,35 @@
+package authz
+
+import future.keywords.if
+
+import data.authz.extract_path
+import data.common.get_domain_metadata
+
+current_domain := domain if {
+	path := extract_path
+	domain := get_domain_metadata(path)
+}
+
+has_domain_policy(domain_name) if {
+	data.authz.domain_policies[domain_name]
+}
+
+default domain_policy_checks_pass := false
+
+domain_policy_checks_pass if {
+	not current_domain
+}
+
+domain_policy_checks_pass if {
+	current_domain
+	not has_domain_policy(current_domain.name)
+}
+
+domain_policy_checks_pass if {
+	domain := current_domain
+	has_domain_policy(domain.name)
+	policy := data.authz.domain_policies[domain.name]
+	# First cut: policy presence activates the domain layer without
+	# adding additional deny conditions yet.
+	policy
+}

--- a/services/core/auth/src/nmp/core/auth/app/policies/domain.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/domain.rego
@@ -9,27 +9,3 @@ current_domain := domain if {
 	path := extract_path
 	domain := get_domain_metadata(path)
 }
-
-has_domain_policy(domain_name) if {
-	data.authz.domain_policies[domain_name]
-}
-
-default domain_policy_checks_pass := false
-
-domain_policy_checks_pass if {
-	not current_domain
-}
-
-domain_policy_checks_pass if {
-	current_domain
-	not has_domain_policy(current_domain.name)
-}
-
-domain_policy_checks_pass if {
-	domain := current_domain
-	has_domain_policy(domain.name)
-	policy := data.authz.domain_policies[domain.name]
-	# First cut: policy presence activates the domain layer without
-	# adding additional deny conditions yet.
-	policy
-}

--- a/services/core/auth/src/nmp/core/auth/app/policies/extract.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/extract.rego
@@ -57,6 +57,16 @@ extract_path := path if {
 	path := input.attributes.request.http.path
 }
 
+# Extract domain name from /apis/<domain>/... request paths.
+extract_domain_name(path) := domain if {
+	base_path := split(path, "?")[0]
+	parts := split(base_path, "/")
+	count(parts) >= 3
+	parts[1] == "apis"
+	domain := parts[2]
+	domain != ""
+}
+
 # Extract scopes from either format
 extract_scopes := scopes if {
 	# Direct format

--- a/services/core/auth/src/nmp/core/auth/app/policy_tests/authz_simple_test.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policy_tests/authz_simple_test.rego
@@ -39,9 +39,6 @@ mock_authz_data := {
     "domains": {
         "models": {"name": "models", "version": "core", "kind": "core"},
         "agents": {"name": "agents", "version": "1.2.3", "kind": "extension"}
-    },
-    "domain_policies": {
-        "agents": {"enabled": true}
     }
 }
 
@@ -184,12 +181,10 @@ test_allow_public_workspace if {
     result.allowed == true
 }
 
-test_domain_policy_not_required_when_config_missing if {
-    not authz.has_domain_policy("models")
-        with data.authz.domain_policies as mock_authz_data.domain_policies
-}
-
-test_domain_policy_detected_when_config_present if {
-    authz.has_domain_policy("agents")
-        with data.authz.domain_policies as mock_authz_data.domain_policies
+test_known_domain_metadata_is_available if {
+    domain := common.get_domain_metadata("/apis/models/v2/workspaces/test-ns/models")
+        with data.authz.domains as mock_authz_data.domains
+    domain.name == "models"
+    domain.version == "core"
+    domain.kind == "core"
 }

--- a/services/core/auth/src/nmp/core/auth/app/policy_tests/authz_simple_test.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policy_tests/authz_simple_test.rego
@@ -35,6 +35,13 @@ mock_authz_data := {
         "editor@test.com": {
             "workspaces": {"test-ns": ["Editor"]}
         }
+    },
+    "domains": {
+        "models": {"name": "models", "version": "core", "kind": "core"},
+        "agents": {"name": "agents", "version": "1.2.3", "kind": "extension"}
+    },
+    "domain_policies": {
+        "agents": {"enabled": true}
     }
 }
 
@@ -175,4 +182,14 @@ test_allow_public_workspace if {
     with data.authz.principals as mock_authz_data.principals
 
     result.allowed == true
+}
+
+test_domain_policy_not_required_when_config_missing if {
+    not authz.has_domain_policy("models")
+        with data.authz.domain_policies as mock_authz_data.domain_policies
+}
+
+test_domain_policy_detected_when_config_present if {
+    authz.has_domain_policy("agents")
+        with data.authz.domain_policies as mock_authz_data.domain_policies
 }

--- a/services/core/auth/src/nmp/core/auth/app/policy_tests/helpers_test.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policy_tests/helpers_test.rego
@@ -57,3 +57,37 @@ test_normalize_endpoint if {
     common.normalize_endpoint("/apis/evaluation/v2/workspaces/test-ns/benchmarks/my-config") == "/apis/evaluation/v2/workspaces/{workspace}/benchmarks/{name}"
         with data.authz.endpoints as mock_endpoints
 }
+
+test_extract_domain_name_from_core_path if {
+    authz.extract_domain_name("/apis/models/v2/workspaces/default/models") == "models"
+}
+
+test_extract_domain_name_from_extension_path if {
+    authz.extract_domain_name("/apis/agents/v2/workspaces/default/agents") == "agents"
+}
+
+test_get_domain_metadata_returns_core_domain if {
+    mock_domains := {
+        "models": {"name": "models", "version": "core", "kind": "core"},
+        "agents": {"name": "agents", "version": "1.2.3", "kind": "extension"}
+    }
+
+    domain := common.get_domain_metadata("/apis/models/v2/workspaces/default/models")
+        with data.authz.domains as mock_domains
+    domain.name == "models"
+    domain.version == "core"
+    domain.kind == "core"
+}
+
+test_get_domain_metadata_returns_extension_domain if {
+    mock_domains := {
+        "models": {"name": "models", "version": "core", "kind": "core"},
+        "agents": {"name": "agents", "version": "1.2.3", "kind": "extension"}
+    }
+
+    domain := common.get_domain_metadata("/apis/agents/v2/workspaces/default/agents")
+        with data.authz.domains as mock_domains
+    domain.name == "agents"
+    domain.version == "1.2.3"
+    domain.kind == "extension"
+}

--- a/services/core/auth/tests/test_bundle.py
+++ b/services/core/auth/tests/test_bundle.py
@@ -93,3 +93,45 @@ async def test_bundle_etag_stability():
 
     # E-Tag should be the same for same data
     assert etag1 == etag2
+
+
+@pytest.mark.asyncio
+async def test_build_authorization_data_includes_core_domain_metadata(monkeypatch):
+    """Core API namespaces are exposed as auth domains."""
+    from nmp.core.auth.app.bundle import build_authorization_data
+
+    monkeypatch.setattr("nmp.core.auth.app.bundle.discover_manifests", lambda: {})
+
+    data = await build_authorization_data(None)
+
+    assert data["authz"]["domains"]["models"] == {
+        "name": "models",
+        "version": "core",
+        "kind": "core",
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_authorization_data_merges_extension_manifest_domain_metadata(monkeypatch):
+    """Discovered extension manifests are merged into auth domains."""
+    from nemo_platform_plugin.interface import PluginManifest
+    from nmp.core.auth.app.bundle import build_authorization_data
+
+    monkeypatch.setattr(
+        "nmp.core.auth.app.bundle.discover_manifests",
+        lambda: {
+            "agents": PluginManifest(
+                name="agents",
+                version="1.2.3",
+                description="Agents API",
+            )
+        },
+    )
+
+    data = await build_authorization_data(None)
+
+    assert data["authz"]["domains"]["agents"] == {
+        "name": "agents",
+        "version": "1.2.3",
+        "kind": "extension",
+    }

--- a/services/core/auth/tests/test_bundle.py
+++ b/services/core/auth/tests/test_bundle.py
@@ -135,3 +135,24 @@ async def test_build_authorization_data_merges_extension_manifest_domain_metadat
         "version": "1.2.3",
         "kind": "extension",
     }
+
+
+@pytest.mark.asyncio
+async def test_build_authorization_data_rejects_domain_manifest_collisions(monkeypatch):
+    """Extension manifests must not override core-inferred API domains."""
+    from nemo_platform_plugin.interface import PluginManifest
+    from nmp.core.auth.app.bundle import build_authorization_data
+
+    monkeypatch.setattr(
+        "nmp.core.auth.app.bundle.discover_manifests",
+        lambda: {
+            "models": PluginManifest(
+                name="models",
+                version="9.9.9",
+                description="Conflicting Models API",
+            )
+        },
+    )
+
+    with pytest.raises(ValueError, match="Domain name conflict"):
+        await build_authorization_data(None)

--- a/services/core/auth/tests/test_bundle.py
+++ b/services/core/auth/tests/test_bundle.py
@@ -100,7 +100,7 @@ async def test_build_authorization_data_includes_core_domain_metadata(monkeypatc
     """Core API namespaces are exposed as auth domains."""
     from nmp.core.auth.app.bundle import build_authorization_data
 
-    monkeypatch.setattr("nmp.core.auth.app.bundle.discover_manifests", lambda: {})
+    monkeypatch.setattr("nmp.core.auth.app.bundle._discover_domain_manifests", lambda: {})
 
     data = await build_authorization_data(None)
 
@@ -118,7 +118,7 @@ async def test_build_authorization_data_merges_extension_manifest_domain_metadat
     from nmp.core.auth.app.bundle import build_authorization_data
 
     monkeypatch.setattr(
-        "nmp.core.auth.app.bundle.discover_manifests",
+        "nmp.core.auth.app.bundle._discover_domain_manifests",
         lambda: {
             "agents": PluginManifest(
                 name="agents",
@@ -144,7 +144,7 @@ async def test_build_authorization_data_rejects_domain_manifest_collisions(monke
     from nmp.core.auth.app.bundle import build_authorization_data
 
     monkeypatch.setattr(
-        "nmp.core.auth.app.bundle.discover_manifests",
+        "nmp.core.auth.app.bundle._discover_domain_manifests",
         lambda: {
             "models": PluginManifest(
                 name="models",
@@ -156,3 +156,19 @@ async def test_build_authorization_data_rejects_domain_manifest_collisions(monke
 
     with pytest.raises(ValueError, match="Domain name conflict"):
         await build_authorization_data(None)
+
+
+@pytest.mark.asyncio
+async def test_build_authorization_data_ignores_non_service_plugin_name_overlap(monkeypatch):
+    """Non-service plugin surfaces must not participate in auth domain discovery."""
+    from nmp.core.auth.app.bundle import build_authorization_data
+
+    monkeypatch.setattr("nmp.core.auth.app.bundle._discover_domain_manifests", lambda: {})
+
+    data = await build_authorization_data(None)
+
+    assert data["authz"]["domains"]["guardrails"] == {
+        "name": "guardrails",
+        "version": "core",
+        "kind": "core",
+    }

--- a/services/core/auth/tests/test_embedded_pdp.py
+++ b/services/core/auth/tests/test_embedded_pdp.py
@@ -61,7 +61,6 @@ def minimal_authz_data():
             "domains": {
                 "models": {"name": "models", "version": "core", "kind": "core"},
             },
-            "domain_policies": {},
             "workspaces": {
                 "public-workspace": {},
             },
@@ -192,7 +191,7 @@ class TestAllowEntrypoint:
         )
         assert result["allowed"] is True
 
-    def test_allow_keeps_working_when_domain_metadata_is_present_without_policy(self, minimal_authz_data):
+    def test_allow_keeps_working_when_domain_metadata_is_present(self, minimal_authz_data):
         set_policy_data(minimal_authz_data)
         result = evaluate(
             "allow",

--- a/services/core/auth/tests/test_embedded_pdp.py
+++ b/services/core/auth/tests/test_embedded_pdp.py
@@ -58,6 +58,10 @@ def minimal_authz_data():
                     "post": {"permissions": ["models.create"]},
                 },
             },
+            "domains": {
+                "models": {"name": "models", "version": "core", "kind": "core"},
+            },
+            "domain_policies": {},
             "workspaces": {
                 "public-workspace": {},
             },
@@ -184,6 +188,18 @@ class TestAllowEntrypoint:
                 "principal_id": "test@example.com",  # Has PlatformAdmin in system workspace
                 "path": "/apis/models/v2/workspaces/any-workspace/anything",
                 "method": "DELETE",
+            },
+        )
+        assert result["allowed"] is True
+
+    def test_allow_keeps_working_when_domain_metadata_is_present_without_policy(self, minimal_authz_data):
+        set_policy_data(minimal_authz_data)
+        result = evaluate(
+            "allow",
+            {
+                "principal_id": "test@example.com",
+                "path": "/apis/models/v2/workspaces/test-workspace/models",
+                "method": "GET",
             },
         )
         assert result["allowed"] is True


### PR DESCRIPTION
## Summary

Adds a domain metadata layer to the auth service. API domains (e.g. `models`, `agents`) are automatically discovered from registered endpoint paths and extension plugin manifests, then injected into the OPA authorization data bundle as a unified registry. This gives policy authors a structured `current_domain` rule and `get_domain_metadata` helper to key on when writing domain-specific authorization logic.

## Changes

**OPA policies**
- New `domain.rego` — exposes `current_domain` by resolving the request path's API domain against the registry
- `extract.rego` — added `extract_domain_name(path)` to pull the domain segment from `/apis/<domain>/...` paths
- `common.rego` — added `get_domain_metadata(path)` helper to look up domain name, version, and kind from `data.authz.domains`

**Bundle builder (`bundle.py`)**
- `_extract_domain_names_from_endpoints` discovers core API domain names from endpoint paths
- `_build_domain_registry` merges core domains with extension plugin manifests (via `discover_manifests`)
- Rejects collisions: raises `ValueError` if an extension manifest name conflicts with a core API domain
- Injects the `domains` registry into the authorization data bundle under `authz.domains`

**Tests**
- Rego unit tests for domain name extraction, metadata lookup, and core/extension domain resolution
- Python unit tests verifying core domains appear in the bundle, extension manifests merge correctly, and collisions are rejected
- Integration test confirming existing `allow` authorization is unaffected when domain metadata is present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Synthesize and embed domain metadata for core and extension API domains into authorization bundles
  * Add domain extraction and metadata lookup used by authorization policies, plus validation to prevent domain-name conflicts
  * Expose current-domain metadata to policy evaluation

* **Tests**
  * Add tests for domain extraction, metadata retrieval, policy behavior, bundle generation, extension merging, conflict detection, and non-service name-overlap safeguards
<!-- end of auto-generated comment: release notes by coderabbit.ai -->