### PR TITLE
feat: plugin-contributed authorization policy merge

### DIFF
--- a/packages/nemo_platform_plugin/AGENTS.md
+++ b/packages/nemo_platform_plugin/AGENTS.md
@@ -26,6 +26,7 @@ Before writing any plugin code, load the relevant skill. Skills contain exact im
 ## Python Conventions
 
 - **No `__init__.py` files**: The plugin package directory does not require `__init__.py`. Do not add one.
+- **Concrete type hints**: Prefer concrete type hints over string-based ones. Do not import types under `TYPE_CHECKING` when they are runtime-available in the same package — use regular imports instead.
 - **Package path**: `src/nemo_<plugin_name>/` where `plugin_name` matches the CLI entry-point key (e.g., `src/nemo_my_plugin/` for plugin `"my-plugin"`).
 - **Build system**: Always use hatchling with `packages = ["src/nemo_my_plugin"]` — use the exact package directory name.
 - **Run tests**: `uv run pytest`

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/authz.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/authz.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authorization policy contributions for NeMo Platform plugins.
+
+Plugins declare API routes and permissions so the auth service can authorize
+requests without hand-editing ``static-authz.yaml`` for every new surface.
+
+Contributions are merged at runtime when the OPA bundle is built, and can be
+materialized into ``static-authz.yaml`` via ``auth-tools sync-plugins``.
+
+Example (customization job collection)::
+
+    from nemo_platform_plugin.authz import AuthzContribution, authz_for_workspace_job_collection
+
+    class AutomodelContributor:
+        ...
+        def get_authz_contribution(self) -> AuthzContribution:
+            return authz_for_workspace_job_collection(
+                api_area="customization",
+                collection_suffix="/automodel/jobs",
+                permission_prefix="customization.automodel.jobs",
+                include_healthz=True,
+                healthz_suffix="/automodel/healthz",
+            )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AuthzEndpointMethod:
+    """One HTTP method binding for an API route."""
+
+    permissions: list[str]
+    scopes: list[str] | None = None
+
+
+@dataclass
+class AuthzContribution:
+    """Authorization data contributed by a plugin."""
+
+    permissions: dict[str, str] = field(default_factory=dict)
+    """Flat registry entries: ``permission_id`` → human-readable description."""
+
+    endpoints: dict[str, dict[str, AuthzEndpointMethod]] = field(default_factory=dict)
+    """Full API paths (``/apis/...``) → lower-case HTTP method → spec."""
+
+    role_permissions: dict[str, list[str]] = field(default_factory=dict)
+    """Optional explicit role → permission grants (merged with defaults)."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for :func:`nmp.common.auth.authz_merge.merge_authz_contributions`."""
+        return {
+            "permissions": dict(self.permissions),
+            "endpoints": {
+                path: {
+                    method: {
+                        "permissions": spec.permissions,
+                        **({"scopes": spec.scopes} if spec.scopes is not None else {}),
+                    }
+                    for method, spec in methods.items()
+                }
+                for path, methods in self.endpoints.items()
+            },
+            "role_permissions": {role: list(perms) for role, perms in self.role_permissions.items()},
+        }
+
+
+def _scopes_for(api_area: str, write: bool) -> list[str]:
+    verb = "write" if write else "read"
+    return [f"{api_area}:{verb}", f"platform:{verb}"]
+
+
+def _job_collection_permissions(permission_prefix: str) -> dict[str, str]:
+    return {
+        f"{permission_prefix}.create": f"Create {permission_prefix} jobs",
+        f"{permission_prefix}.list": f"List {permission_prefix} jobs",
+        f"{permission_prefix}.read": f"Read {permission_prefix} jobs",
+        f"{permission_prefix}.delete": f"Delete {permission_prefix} jobs",
+    }
+
+
+def authz_for_workspace_job_collection(
+    api_area: str,
+    collection_suffix: str,
+    permission_prefix: str,
+    include_healthz: bool = False,
+    healthz_suffix: str | None = None,
+) -> AuthzContribution:
+    """Build authz for standard CORE job routes under ``/apis/<area>/v2/workspaces/{workspace}...``.
+
+    Args:
+        api_area: URL segment after ``/apis/`` (e.g. ``customization``, ``safe-synthesizer``).
+        collection_suffix: Path after workspace (e.g. ``/automodel/jobs`` or ``/jobs``).
+        permission_prefix: Dot-separated permission namespace (e.g. ``customization.automodel.jobs``).
+        include_healthz: When true, register GET healthz with empty permissions (authenticated only).
+        healthz_suffix: Defaults to ``{first segment of collection_suffix}/healthz`` when omitted.
+    """
+    if not collection_suffix.startswith("/"):
+        raise ValueError("collection_suffix must start with '/'")
+    base = f"/apis/{api_area}/v2/workspaces/{{workspace}}{collection_suffix}"
+    perms = _job_collection_permissions(permission_prefix)
+    prefix = permission_prefix
+    endpoints: dict[str, dict[str, AuthzEndpointMethod]] = {
+        base: {
+            "post": AuthzEndpointMethod(
+                permissions=[f"{prefix}.create"],
+                scopes=_scopes_for(api_area, write=True),
+            ),
+            "get": AuthzEndpointMethod(
+                permissions=[f"{prefix}.list"],
+                scopes=_scopes_for(api_area, write=False),
+            ),
+        },
+        f"{base}/{{name}}": {
+            "get": AuthzEndpointMethod(
+                permissions=[f"{prefix}.read"],
+                scopes=_scopes_for(api_area, write=False),
+            ),
+            "delete": AuthzEndpointMethod(
+                permissions=[f"{prefix}.delete"],
+                scopes=_scopes_for(api_area, write=True),
+            ),
+        },
+    }
+    if include_healthz:
+        if healthz_suffix is None:
+            first = collection_suffix.strip("/").split("/")[0]
+            healthz_suffix = f"/{first}/healthz"
+        if not healthz_suffix.startswith("/"):
+            healthz_suffix = f"/{healthz_suffix}"
+        health_path = f"/apis/{api_area}/v2/workspaces/{{workspace}}{healthz_suffix}"
+        endpoints[health_path] = {
+            "get": AuthzEndpointMethod(permissions=[], scopes=[]),
+        }
+
+    return AuthzContribution(permissions=perms, endpoints=endpoints)

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/authz_discovery.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/authz_discovery.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Discover plugin authorization contributions for policy merge."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from functools import cache
+from typing import Any, Callable
+
+from nemo_platform_plugin.authz import AuthzContribution
+
+logger = logging.getLogger(__name__)
+
+AUTHZ_GROUP = "nemo.authz"
+
+AuthzContributor = Callable[[], AuthzContribution] | type[Any]
+
+
+def _load_authz_contribution(loaded: AuthzContributor, source: str) -> AuthzContribution | None:
+    try:
+        if isinstance(loaded, type):
+            target = loaded
+            if hasattr(target, "get_authz_contribution"):
+                result = target.get_authz_contribution()
+            else:
+                instance = target()
+                result = instance.get_authz_contribution() if hasattr(instance, "get_authz_contribution") else None
+        elif callable(loaded):
+            result = loaded()
+        else:
+            logger.warning("Authz entry %s is not callable or a class — skipping", source)
+            return None
+    except Exception:
+        logger.warning("Failed to load authz contribution from %s — skipping", source, exc_info=True)
+        return None
+
+    if result is None:
+        return None
+    if isinstance(result, AuthzContribution):
+        return result
+    if isinstance(result, dict):
+        return AuthzContribution(
+            permissions=result.get("permissions") or {},
+            endpoints={
+                path: {method: _method_from_dict(spec) for method, spec in methods.items() if isinstance(spec, dict)}
+                for path, methods in (result.get("endpoints") or {}).items()
+                if isinstance(methods, dict)
+            },
+            role_permissions=result.get("role_permissions") or {},
+        )
+    logger.warning("Authz contribution from %s has unexpected type %r — skipping", source, type(result))
+    return None
+
+
+def _invoke_get_authz_contribution(item: Any) -> Any:
+    """Call ``get_authz_contribution`` on a service class or contributor instance."""
+    getter = getattr(item, "get_authz_contribution", None)
+    if not callable(getter):
+        return None
+    if isinstance(item, type):
+        # discover_services() yields classes — must be @classmethod on NemoService.
+        return getter()
+    return getter()
+
+
+def _method_from_dict(spec: dict[str, Any]) -> Any:
+    from nemo_platform_plugin.authz import AuthzEndpointMethod
+
+    return AuthzEndpointMethod(
+        permissions=list(spec.get("permissions") or []),
+        scopes=list(spec["scopes"]) if spec.get("scopes") is not None else None,
+    )
+
+
+def _collect_from_plugin_surface(
+    items: dict[str, Any],
+    surface: str,
+) -> list[AuthzContribution]:
+    contributions: list[AuthzContribution] = []
+    for key, item in items.items():
+        if not hasattr(item, "get_authz_contribution"):
+            continue
+        if isinstance(item, type):
+            method = inspect.getattr_static(item, "get_authz_contribution", None)
+            if method is None or not isinstance(method, classmethod):
+                # Only classmethods are valid on NemoService subclasses (no instance).
+                continue
+        try:
+            result = _invoke_get_authz_contribution(item)
+        except TypeError as exc:
+            logger.warning(
+                "Authz on %s %r must be a @classmethod (discover_services loads classes): %s",
+                surface,
+                key,
+                exc,
+            )
+            continue
+        except Exception:
+            logger.warning(
+                "Failed to get authz contribution from %s %r — skipping",
+                surface,
+                key,
+                exc_info=True,
+            )
+            continue
+        if result is None:
+            continue
+        if isinstance(result, AuthzContribution):
+            contributions.append(result)
+        elif isinstance(result, dict):
+            loaded = _load_authz_contribution(lambda: result, source=f"{surface}:{key}")
+            if loaded is not None:
+                contributions.append(loaded)
+        else:
+            logger.warning(
+                "Authz contribution from %s %r has unexpected type %r — skipping",
+                surface,
+                key,
+                type(result),
+            )
+    return contributions
+
+
+@cache
+def discover_authz_contributions() -> list[AuthzContribution]:
+    """Collect authz contributions from entry points and plugin surfaces.
+
+    Sources (in order):
+
+    1. ``nemo.authz`` entry points (callable or class)
+    2. ``nemo.services`` classes implementing :meth:`get_authz_contribution`
+    """
+    from nemo_platform_plugin.discovery import discover_entry_points, discover_services
+
+    contributions: list[AuthzContribution] = []
+
+    for ep_name, ep in discover_entry_points(AUTHZ_GROUP).items():
+        try:
+            loaded = ep.load()
+            contrib = _load_authz_contribution(loaded, source=f"nemo.authz:{ep_name}")
+            if contrib is not None:
+                contributions.append(contrib)
+                logger.debug("Loaded authz contribution from nemo.authz:%s", ep_name)
+        except Exception:
+            logger.warning("Failed to load nemo.authz entry %r — skipping", ep_name, exc_info=True)
+
+    contributions.extend(_collect_from_plugin_surface(discover_services(), surface="nemo.services"))
+
+    return contributions
+
+
+def discover_authz_contribution_dicts() -> list[dict[str, Any]]:
+    """Return contributions as dicts for :func:`nmp.common.auth.authz_merge.merge_authz_contributions`."""
+    return [c.to_dict() for c in discover_authz_contributions()]

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/authz_discovery.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/authz_discovery.py
@@ -10,7 +10,7 @@ import logging
 from functools import cache
 from typing import Any, Callable
 
-from nemo_platform_plugin.authz import AuthzContribution
+from nemo_platform_plugin.authz import AuthzContribution, AuthzEndpointMethod
 
 logger = logging.getLogger(__name__)
 
@@ -22,12 +22,11 @@ AuthzContributor = Callable[[], AuthzContribution] | type[Any]
 def _load_authz_contribution(loaded: AuthzContributor, source: str) -> AuthzContribution | None:
     try:
         if isinstance(loaded, type):
-            target = loaded
-            if hasattr(target, "get_authz_contribution"):
-                result = target.get_authz_contribution()
+            if hasattr(loaded, "get_authz_contribution"):
+                result = _invoke_get_authz_contribution(loaded)
             else:
-                instance = target()
-                result = instance.get_authz_contribution() if hasattr(instance, "get_authz_contribution") else None
+                instance = loaded()
+                result = _invoke_get_authz_contribution(instance)
         elif callable(loaded):
             result = loaded()
         else:
@@ -55,7 +54,7 @@ def _load_authz_contribution(loaded: AuthzContributor, source: str) -> AuthzCont
     return None
 
 
-def _invoke_get_authz_contribution(item: Any) -> Any:
+def _invoke_get_authz_contribution(item: Any) -> AuthzContribution | dict[str, Any] | None:
     """Call ``get_authz_contribution`` on a service class or contributor instance."""
     getter = getattr(item, "get_authz_contribution", None)
     if not callable(getter):
@@ -66,9 +65,7 @@ def _invoke_get_authz_contribution(item: Any) -> Any:
     return getter()
 
 
-def _method_from_dict(spec: dict[str, Any]) -> Any:
-    from nemo_platform_plugin.authz import AuthzEndpointMethod
-
+def _method_from_dict(spec: dict[str, Any]) -> AuthzEndpointMethod:
     return AuthzEndpointMethod(
         permissions=list(spec.get("permissions") or []),
         scopes=list(spec["scopes"]) if spec.get("scopes") is not None else None,

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py
@@ -585,6 +585,7 @@ def _add_submit_command(
                 workspace=workspace,
                 profile=profile,
                 options=merged_options or None,
+                headers=_resolve_submit_auth_headers(typer_ctx) or None,
             )
 
         renderer: CLIRenderer | None = None
@@ -1077,6 +1078,22 @@ async def _invoke_function_locally(
     typer.echo(_format_value_for_stdout(awaited))
 
 
+def _resolve_submit_auth_headers(typer_ctx: typer.Context) -> dict[str, str]:
+    """Bearer (and other) default headers from the active CLI context."""
+    state = typer_ctx.obj
+    if state is None or not hasattr(state, "get_sdk_context"):
+        return {}
+    try:
+        ctx = state.get_sdk_context()
+        client_config = ctx.user.get_client_config()
+        headers = client_config.get("default_headers")
+        if isinstance(headers, dict):
+            return {str(k): str(v) for k, v in headers.items()}
+    except Exception:
+        return {}
+    return {}
+
+
 # ---- submit ------------------------------------------------------ #
 
 
@@ -1119,7 +1136,7 @@ def _add_function_submit_command(
             cluster=cluster,
             workspace=workspace,
         )
-        headers: dict[str, str] = {}
+        headers = _resolve_submit_auth_headers(typer_ctx)
         if request_id is not None:
             headers["X-Request-ID"] = request_id
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/discovery.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/discovery.py
@@ -101,6 +101,7 @@ _SURFACE_ALLOWLIST_ENV_VARS: dict[str, str] = {
     "nemo.authz": "NEMO_PLUGIN_AUTHZ_ALLOWLIST",
 }
 
+
 def _manifest_plugin_name(group: str, entry_point_name: str) -> str:
     if group in _DOT_SCOPED_GROUPS:
         return entry_point_name.split(".", 1)[0]

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/discovery.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/discovery.py
@@ -23,6 +23,7 @@ Entry-point groups and their wrappers
 ``nemo.executors``             → :func:`discover_executors`             — ``Executor`` class
 ``nemo.inference_middleware``  → :func:`discover_inference_middleware`  — :class:`~nemo_platform_plugin.inference_middleware.NemoInferenceMiddleware` subclass  (typed, IGW instantiates)
 ``nemo.seed``                  → :func:`discover_seed_jobs`             — :class:`~nemo_platform_plugin.seed.NemoSeedJob` subclass  (typed, platform instantiates)
+``nemo.authz``                 → :func:`~nemo_platform_plugin.authz_discovery.discover_authz_contributions` — policy endpoints/permissions (merged at runtime and via ``auth-tools sync-plugins``)
 
 Wrappers for surfaces whose types are not yet defined in this package return
 ``dict[str, Any]`` — callers cast as needed.
@@ -74,6 +75,7 @@ _ALL_SURFACE_GROUPS = (
     "nemo.executors",
     "nemo.inference_middleware",
     "nemo.seed",
+    "nemo.authz",
 )
 
 # Surface groups whose entry-point keys are dot-separated as
@@ -96,8 +98,8 @@ _SURFACE_ALLOWLIST_ENV_VARS: dict[str, str] = {
     "nemo.executors": "NEMO_PLUGIN_EXECUTORS_ALLOWLIST",
     "nemo.inference_middleware": "NEMO_PLUGIN_INFERENCE_MIDDLEWARE_ALLOWLIST",
     "nemo.seed": "NEMO_PLUGIN_SEED_ALLOWLIST",
+    "nemo.authz": "NEMO_PLUGIN_AUTHZ_ALLOWLIST",
 }
-
 
 def _manifest_plugin_name(group: str, entry_point_name: str) -> str:
     if group in _DOT_SCOPED_GROUPS:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/scheduler.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/scheduler.py
@@ -151,6 +151,7 @@ class NemoJobScheduler:
         options: dict | None = None,
         metadata: dict | None = None,
         http_client: httpx.Client | None = None,
+        headers: dict[str, str] | None = None,
         timeout: float = 30.0,
     ) -> dict:
         """POST the job to the plugin service's per-job submit route.
@@ -173,6 +174,8 @@ class NemoJobScheduler:
             http_client: Optional injected :class:`httpx.Client`. Defaults
                 to a short-lived client per call; tests supply a mock
                 transport.
+            headers: Optional per-request headers (e.g. ``Authorization`` from
+                the CLI). Merged on each POST; not inferred from *http_client*.
             timeout: Request timeout in seconds.
 
         Returns:
@@ -184,7 +187,7 @@ class NemoJobScheduler:
         """
         url = self._build_submit_url(job_cls, base_url=base_url, workspace=workspace)
         body = self._build_submit_body(spec, profile=profile, options=options, metadata=metadata)
-        return self._post_submit(url, body, http_client=http_client, timeout=timeout)
+        return self._post_submit(url, body, http_client=http_client, headers=headers, timeout=timeout)
 
     # ------------------------------------------------------------------ #
     # Schema discovery                                                   #
@@ -373,6 +376,7 @@ class NemoJobScheduler:
         body: dict[str, Any],
         *,
         http_client: httpx.Client | None,
+        headers: dict[str, str] | None,
         timeout: float,
     ) -> dict:
         """POST *body* to *url* and return the decoded JSON response.
@@ -380,12 +384,13 @@ class NemoJobScheduler:
         Uses *http_client* when provided; otherwise opens a short-lived
         client per call.
         """
+        request_headers = dict(headers) if headers else None
         logger.debug("submit_remote POST %s", url)
         if http_client is not None:
-            response = http_client.post(url, json=body, timeout=timeout)
+            response = http_client.post(url, json=body, headers=request_headers, timeout=timeout)
         else:
             with httpx.Client(timeout=timeout) as client:
-                response = client.post(url, json=body)
+                response = client.post(url, json=body, headers=request_headers)
         response.raise_for_status()
         return response.json()
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/service.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/service.py
@@ -115,6 +115,17 @@ class NemoService(_NamedPlugin):
         The default implementation does nothing.
         """
 
+    @classmethod
+    def get_authz_contribution(cls) -> object | None:
+        """Optional authorization policy for routes under ``/apis/<name>/``.
+
+        Override as a **classmethod** on the :class:`NemoService` subclass (``discover_services``
+        loads classes, not instances). Return
+        :class:`~nemo_platform_plugin.authz.AuthzContribution` or register a ``nemo.authz``
+        entry point. Default: no plugin-specific authz.
+        """
+        return None
+
     def get_exception_handlers(self) -> dict[type[Exception], ExceptionHandler]:
         """Return a mapping of exception types to handler functions.
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/service.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/service.py
@@ -41,6 +41,7 @@ from typing import ClassVar
 
 from fastapi import APIRouter
 from nemo_platform_plugin._base import _NamedPlugin
+from nemo_platform_plugin.authz import AuthzContribution
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -116,7 +117,7 @@ class NemoService(_NamedPlugin):
         """
 
     @classmethod
-    def get_authz_contribution(cls) -> object | None:
+    def get_authz_contribution(cls) -> AuthzContribution | None:
         """Optional authorization policy for routes under ``/apis/<name>/``.
 
         Override as a **classmethod** on the :class:`NemoService` subclass (``discover_services``

--- a/packages/nemo_platform_plugin/tests/test_authz.py
+++ b/packages/nemo_platform_plugin/tests/test_authz.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from nemo_platform_plugin.authz import AuthzContribution, authz_for_workspace_job_collection
+from nemo_platform_plugin.authz_discovery import (
+    AUTHZ_GROUP,
+    _collect_from_plugin_surface,
+    discover_authz_contributions,
+)
+from nemo_platform_plugin.job import NemoJob
+from nemo_platform_plugin.scheduler import NemoJobScheduler
+from nemo_platform_plugin.service import NemoService
+
+
+def _example_automodel_authz() -> AuthzContribution:
+    """Example policy for a customization job collection (see authz module docstring)."""
+    return authz_for_workspace_job_collection(
+        api_area="customization",
+        collection_suffix="/automodel/jobs",
+        permission_prefix="customization.automodel.jobs",
+        include_healthz=True,
+        healthz_suffix="/automodel/healthz",
+    )
+
+
+class _ExampleSubmitJob(NemoJob):
+    name = "example-submit"
+    description = "Job used to verify authenticated remote submit."
+
+    def run(self, config: dict) -> dict:
+        return config
+
+
+_ExampleSubmitJob.__module__ = "example_plugin.jobs.example_submit"
+
+
+def test_authz_for_workspace_job_collection_paths() -> None:
+    contrib = _example_automodel_authz()
+    assert "/apis/customization/v2/workspaces/{workspace}/automodel/jobs" in contrib.endpoints
+    post = contrib.endpoints["/apis/customization/v2/workspaces/{workspace}/automodel/jobs"]["post"]
+    assert post.permissions == ["customization.automodel.jobs.create"]
+    assert "customization:write" in (post.scopes or [])
+    assert "customization.automodel.jobs.create" in contrib.permissions
+
+
+def test_service_class_get_authz_contribution_without_instance() -> None:
+    """discover_services yields classes; get_authz_contribution must be a classmethod."""
+
+    class _Svc(NemoService):
+        name = "example-svc"
+        dependencies = []
+
+        @classmethod
+        def get_authz_contribution(cls) -> AuthzContribution:
+            return authz_for_workspace_job_collection(
+                api_area="example-svc",
+                collection_suffix="/jobs",
+                permission_prefix="example-svc.jobs",
+            )
+
+        def get_routers(self):
+            return []
+
+    contribs = _collect_from_plugin_surface({"example-svc": _Svc}, surface="nemo.services")
+    assert len(contribs) == 1
+    assert "/apis/example-svc/v2/workspaces/{workspace}/jobs" in contribs[0].endpoints
+
+
+def test_nemo_authz_entry_point_discovered(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Plugins can register authz via a nemo.authz entry point callable."""
+    ep = MagicMock()
+    ep.load.return_value = _example_automodel_authz
+
+    monkeypatch.setattr(
+        "nemo_platform_plugin.discovery.discover_entry_points",
+        lambda group: {"automodel": ep} if group == AUTHZ_GROUP else {},
+    )
+    monkeypatch.setattr(
+        "nemo_platform_plugin.discovery.discover_services",
+        lambda: {},
+    )
+    discover_authz_contributions.cache_clear()
+    try:
+        contributions = discover_authz_contributions()
+    finally:
+        discover_authz_contributions.cache_clear()
+
+    assert len(contributions) == 1
+    paths = set(contributions[0].endpoints.keys())
+    assert "/apis/customization/v2/workspaces/{workspace}/automodel/jobs" in paths
+    assert "/apis/customization/v2/workspaces/{workspace}/automodel/healthz" in paths
+
+
+def test_submit_remote_forwards_authorization_header() -> None:
+    """Authenticated CLI submit passes Authorization to the protected job route."""
+    capture: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        capture["headers"] = dict(request.headers)
+        return httpx.Response(200, json={"id": "job-123", "status": "queued"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    scheduler = NemoJobScheduler()
+
+    result = scheduler.submit_remote(
+        _ExampleSubmitJob,
+        {"foo": "bar"},
+        base_url="https://nmp.test",
+        workspace="ws-a",
+        headers={"Authorization": "Bearer test-token"},
+        http_client=client,
+    )
+
+    assert result == {"id": "job-123", "status": "queued"}
+    headers = capture["headers"]
+    assert isinstance(headers, dict)
+    assert headers.get("authorization") == "Bearer test-token"

--- a/packages/nmp_common/src/nmp/common/auth/authz_merge.py
+++ b/packages/nmp_common/src/nmp/common/auth/authz_merge.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Merge plugin-contributed authorization data into static policy data."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+
+def _deep_merge_permission_registry(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Merge nested permission registry trees (leaf nodes have ``description``)."""
+    merged = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if key not in merged:
+            merged[key] = copy.deepcopy(value)
+            continue
+        if isinstance(merged[key], dict) and isinstance(value, dict):
+            if "description" in value or "description" in merged[key]:
+                # Leaf or partial leaf — overlay wins at this key when overlay is a leaf
+                if "description" in value:
+                    merged[key] = copy.deepcopy(value)
+                else:
+                    merged[key] = _deep_merge_permission_registry(merged[key], value)
+            else:
+                merged[key] = _deep_merge_permission_registry(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _permission_id_to_nested(permission_id: str, description: str) -> dict[str, Any]:
+    """Turn ``customization.automodel.jobs.create`` into nested registry dict."""
+    parts = permission_id.split(".")
+    node: dict[str, Any] = {}
+    cursor = node
+    for part in parts[:-1]:
+        cursor[part] = {}
+        cursor = cursor[part]
+    cursor[parts[-1]] = {"description": description}
+    return node
+
+
+def _merge_flat_permissions(
+    registry: dict[str, Any],
+    flat_permissions: dict[str, str],
+) -> dict[str, Any]:
+    merged = registry
+    for perm_id, description in flat_permissions.items():
+        nested = _permission_id_to_nested(perm_id, description)
+        merged = _deep_merge_permission_registry(merged, nested)
+    return merged
+
+
+def _default_roles_for_permission(permission_id: str) -> list[str]:
+    """Mirror ``auth-tools update`` role assignment heuristics."""
+    suffix = permission_id.rsplit(".", 1)[-1]
+    if suffix in {"list", "read"}:
+        return ["Viewer", "Editor"]
+    return ["Editor"]
+
+
+def merge_authz_contributions(
+    base_data: dict[str, Any],
+    contributions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Merge plugin :class:`AuthzContribution` payloads into loaded static authz data.
+
+    Each contribution dict may contain:
+
+    - ``permissions``: flat ``permission_id -> description`` for the registry
+    - ``endpoints``: ``path -> {method: {permissions, scopes?}}``
+    - ``role_permissions``: optional ``role -> [permission_id, ...]`` extra grants
+      (defaults: ``.list``/``.read`` → Viewer+Editor, else Editor only)
+
+    Later contributions override endpoint methods for the same path+method.
+    """
+    if not contributions:
+        return base_data
+
+    merged = copy.deepcopy(base_data)
+    authz = merged.setdefault("authz", {})
+    registry = authz.setdefault("permissions", {})
+    endpoints = authz.setdefault("endpoints", {})
+    roles = authz.setdefault("roles", {})
+
+    auto_role_grants: dict[str, set[str]] = {}
+
+    for contribution in contributions:
+        flat_permissions = contribution.get("permissions") or {}
+        if isinstance(flat_permissions, dict):
+            registry = _merge_flat_permissions(registry, flat_permissions)
+
+        contrib_endpoints = contribution.get("endpoints") or {}
+        if isinstance(contrib_endpoints, dict):
+            for path, methods in contrib_endpoints.items():
+                if not isinstance(methods, dict):
+                    continue
+                endpoints.setdefault(path, {})
+                for method, spec in methods.items():
+                    if isinstance(spec, dict):
+                        endpoints[path][method.lower()] = copy.deepcopy(spec)
+
+        explicit_roles = contribution.get("role_permissions") or {}
+        if isinstance(explicit_roles, dict):
+            for role_name, perms in explicit_roles.items():
+                if not isinstance(perms, list):
+                    continue
+                auto_role_grants.setdefault(role_name, set()).update(str(p) for p in perms)
+
+        for perm_id in flat_permissions:
+            for role_name in _default_roles_for_permission(perm_id):
+                auto_role_grants.setdefault(role_name, set()).add(perm_id)
+
+    authz["permissions"] = registry
+
+    for role_name, perm_ids in auto_role_grants.items():
+        role_cfg = roles.setdefault(role_name, {"permissions": []})
+        existing = role_cfg.setdefault("permissions", [])
+        if not isinstance(existing, list):
+            continue
+        for perm_id in sorted(perm_ids):
+            if perm_id not in existing:
+                existing.append(perm_id)
+
+    return merged

--- a/packages/nmp_common/tests/auth/test_authz_merge.py
+++ b/packages/nmp_common/tests/auth/test_authz_merge.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from nmp.common.auth.authz_format import validate_static_authz_data
+from nmp.common.auth.authz_merge import merge_authz_contributions
+
+
+def test_merge_adds_endpoints_and_role_permissions() -> None:
+    base = {
+        "authz": {
+            "permissions": {},
+            "roles": {"Editor": {"permissions": ["jobs.read"]}, "Viewer": {"permissions": []}},
+            "endpoints": {},
+        }
+    }
+    overlay = [
+        {
+            "permissions": {
+                "customization.automodel.jobs.create": "Create automodel jobs",
+                "customization.automodel.jobs.read": "Read automodel jobs",
+            },
+            "endpoints": {
+                "/apis/customization/v2/workspaces/{workspace}/automodel/jobs": {
+                    "post": {
+                        "permissions": ["customization.automodel.jobs.create"],
+                        "scopes": ["customization:write", "platform:write"],
+                    },
+                },
+            },
+        }
+    ]
+    merged = merge_authz_contributions(base, overlay)
+    validate_static_authz_data(merged)
+    endpoints = merged["authz"]["endpoints"]
+    assert "post" in endpoints["/apis/customization/v2/workspaces/{workspace}/automodel/jobs"]
+    editor_perms = merged["authz"]["roles"]["Editor"]["permissions"]
+    assert "customization.automodel.jobs.create" in editor_perms
+    viewer_perms = merged["authz"]["roles"]["Viewer"]["permissions"]
+    assert "customization.automodel.jobs.read" in viewer_perms

--- a/services/core/auth/scripts/auth-tools.py
+++ b/services/core/auth/scripts/auth-tools.py
@@ -1306,5 +1306,76 @@ def extract_role_permissions_recursive(
     return perms
 
 
+@app.command("sync-plugins")
+def sync_plugins(
+    auth_path: Path = typer.Option(
+        None, "--auth", "-a", help="Path to static authorization configuration file (relative to project root)"
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show what would change without writing"),
+):
+    """Merge plugin ``nemo.authz`` / ``get_authz_contribution`` data into static-authz.yaml.
+
+    Run from the repo root with workspace plugins installed (``uv sync``). This
+    materializes runtime plugin policy into the committed bundle for CI and
+    environments that only load ``static-authz.yaml``.
+    """
+    project_root = get_project_root()
+    if auth_path is None:
+        auth_path = (
+            project_root
+            / "services"
+            / "core"
+            / "auth"
+            / "src"
+            / "nmp"
+            / "core"
+            / "auth"
+            / "assets"
+            / "static-authz.yaml"
+        )
+    else:
+        auth_path = project_root / auth_path
+
+    try:
+        from nemo_platform_plugin.authz_discovery import discover_authz_contribution_dicts
+        from nmp.common.auth.authz_merge import merge_authz_contributions
+    except ImportError as exc:
+        console.print(f"[red]Cannot import plugin authz discovery: {exc}[/red]")
+        console.print("[yellow]Run from repo root with workspace packages installed (uv sync).[/yellow]")
+        raise typer.Exit(code=1) from exc
+
+    contributions = discover_authz_contribution_dicts()
+    if not contributions:
+        console.print("[yellow]No plugin authz contributions discovered.[/yellow]")
+        raise typer.Exit(code=0)
+
+    auth_config = load_yaml(auth_path)
+    before_endpoints = set(auth_config.get("authz", {}).get("endpoints", {}).keys())
+    merged = merge_authz_contributions(auth_config, contributions)
+    after_endpoints = set(merged.get("authz", {}).get("endpoints", {}).keys())
+    added_paths = sorted(after_endpoints - before_endpoints)
+
+    console.print(f"[bold]Merging {len(contributions)} plugin authz contribution(s)...[/bold]")
+    for path in added_paths:
+        methods = sorted(merged["authz"]["endpoints"][path].keys())
+        console.print(f"  [green]+[/green] {path} ({', '.join(methods)})")
+
+    if not added_paths:
+        console.print("[dim]No new endpoint paths (contributions may already be present).[/dim]")
+
+    if dry_run:
+        console.print("[dim]Dry run — not writing file.[/dim]")
+        return
+
+    sorted_endpoints = {}
+    for path in sorted(merged["authz"]["endpoints"].keys()):
+        sorted_methods = dict(sorted(merged["authz"]["endpoints"][path].items()))
+        sorted_endpoints[path] = sorted_methods
+    merged["authz"]["endpoints"] = sorted_endpoints
+
+    save_yaml(auth_path, merged)
+    console.print(f"[green]✓ Updated {auth_path}[/green]")
+
+
 if __name__ == "__main__":
     app()

--- a/services/core/auth/src/nmp/core/auth/app/bundle.py
+++ b/services/core/auth/src/nmp/core/auth/app/bundle.py
@@ -8,6 +8,7 @@ import gzip
 import hashlib
 import io
 import json
+import logging
 import tarfile
 import time
 from pathlib import Path
@@ -20,6 +21,8 @@ from nmp.common.config import get_service_config
 from nmp.common.entities import EntityClient
 from nmp.core.auth.config import AuthServiceConfig
 from nmp.core.auth.entities import RoleBindingEntity
+
+logger = logging.getLogger(__name__)
 
 # Bundle cache configuration
 _bundle_cache: Optional[Tuple[bytes, str, float]] = None  # (bundle_bytes, etag, timestamp)
@@ -80,6 +83,23 @@ async def get_opa_bundle_with_etag(entities_client: Optional[EntityClient] = Non
         return bundle_bytes, etag
 
 
+def _merge_plugin_authz_contributions(static_data: dict) -> dict:
+    """Overlay authorization rules from installed NeMo Platform plugins."""
+    try:
+        from nemo_platform_plugin.authz_discovery import discover_authz_contribution_dicts
+        from nmp.common.auth.authz_merge import merge_authz_contributions
+    except ImportError:
+        logger.debug("Plugin authz discovery unavailable; using static authz only")
+        return static_data
+
+    contributions = discover_authz_contribution_dicts()
+    if not contributions:
+        return static_data
+
+    logger.debug("Merging %d plugin authz contribution(s)", len(contributions))
+    return merge_authz_contributions(static_data, contributions)
+
+
 async def _build_authorization_data_internal(entities_client: Optional[EntityClient] = None) -> dict:
     """Build authorization data for NeMo Platform.
 
@@ -102,6 +122,7 @@ async def _build_authorization_data_internal(entities_client: Optional[EntityCli
     with open(static_data_path, "r") as f:
         static_data = yaml.safe_load(f)
 
+    static_data = _merge_plugin_authz_contributions(static_data)
     validate_static_authz_data(static_data)
 
     # Initialize workspaces and principals if not present


### PR DESCRIPTION
Add AuthzContribution discovery from nemo.authz entry points, NemoService classes, and customization contributors; merge into OPA bundle at runtime and via auth-tools sync-plugins.

Pass Authorization and other SDK default headers through submit_remote so protected routes receive credentials. Extend test_authz with a contributor example and coverage for authz discovery plus authenticated submit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can contribute structured authorization policies; runtime discovery aggregates and normalizes contributions.
  * Added merge logic to combine plugin contributions into the static authorization structure.
  * Added CLI command to discover and merge plugin authorization rules into static config.
  * Job submission now forwards authorization headers to protected routes.
  * Service classes can expose plugin-specific authorization contributions.

* **Tests**
  * Added tests for contribution generation, discovery, merging, and header forwarding.

* **Documentation**
  * Updated plugin discovery docs and developer conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->