### PR TITLE
feat: add buildx bake target for nmp-cpu-tasks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,13 @@
 docker-bake.hcl
+.git
 .venv
+.mypy_cache
+.pytest_cache
 .ruff_cache
+.cache
+htmlcov
+dist
+build
 Dockerfile.bake
 **/Dockerfile*
 .dockerignore

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -548,6 +548,94 @@ jobs:
             report.xml
             ${{ runner.temp }}/e2e-services-logs/
 
+  # Docker quickstart E2E tests: build local images, start quickstart, and
+  # run the jobs-focused E2E suite against the live containerized stack.
+  python-e2e-docker-test:
+    name: Python docker e2e tests
+    needs: [policy-wasm]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Download policy WASM
+        uses: actions/download-artifact@v8
+        with:
+          name: policy-wasm
+          path: services/core/auth/src/nmp/core/auth/assets
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+          enable-cache: true
+      - name: Build local quickstart images
+        run: |
+          make load/nmp-api
+          make load/nmp-cpu-tasks
+      - name: Start quickstart
+        env:
+          _TYPER_FORCE_DISABLE_TERMINAL: "1"
+        run: |
+          uv run --frozen nemo quickstart up --image my-registry/nmp-api:local --no-pull --force
+      - name: Run Docker jobs e2e tests
+        env:
+          _TYPER_FORCE_DISABLE_TERMINAL: "1"
+          NMP_BASE_URL: http://localhost:8080
+        run: |
+          uv run --frozen pytest e2e/test_jobs.py -k 'not pause_resume' -v --run-e2e --junitxml=report-docker.xml
+      - name: Dump quickstart status and logs
+        if: always()
+        env:
+          _TYPER_FORCE_DISABLE_TERMINAL: "1"
+        run: |
+          echo "::group::Quickstart status"
+          uv run --frozen nemo quickstart status || true
+          echo "::endgroup::"
+          echo "::group::Quickstart logs"
+          uv run --frozen nemo quickstart logs || true
+          echo "::endgroup::"
+      - name: Stop quickstart
+        if: always()
+        env:
+          _TYPER_FORCE_DISABLE_TERMINAL: "1"
+        run: |
+          uv run --frozen nemo quickstart down || true
+      - name: Upload Docker e2e test artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: python-e2e-docker-test-results
+          retention-days: 30
+          path: |
+            report-docker.xml
+
+  # Required-check pin: branch protection should reference this aggregator
+  # rather than the per-row matrix jobs, so the matrix can grow or shrink
+  # without admin intervention. Skipped counts as pass.
+  wheel-test-aggregate:
+    name: Wheel build + test
+    needs: [wheel-test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix result
+        shell: bash
+        env:
+          MATRIX_RESULT: ${{ needs.wheel-test.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          case "${MATRIX_RESULT}" in
+            success|skipped)
+              echo "wheel-test matrix: ${MATRIX_RESULT}"
+              ;;
+            *)
+              echo "::error::wheel-test matrix concluded ${MATRIX_RESULT}"
+              echo "::error::see per-row results: ${RUN_URL}"
+              exit 1
+              ;;
+          esac
+
   web-typecheck:
     name: Web typecheck
     needs: [changes]

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ endif
 PYTEST_EXTRA ?=
 PYTHON_VERSION ?= 3.11
 BOOTSTRAP_CREATE_VENV ?= 1
+NMP_IMAGE_REGISTRY ?= my-registry
+NMP_IMAGE_TAG ?= local
+BUILD_CONTEXT ?= .
+DOCKERFILE_ROOT ?= .
 
 # Display platform info
 $(info local system architecture: $(PLATFORM)/$(ARCH))
@@ -140,6 +144,21 @@ update-cli: generate-cli-commands vendor-nemo-platform-ext generate-cli-referenc
 .PHONY: clean-python
 clean-python: ## remove python virtual environment
 	rm -rf .venv/
+
+.PHONY: load/%
+load/%: ## Build and load a local single-arch image from bake target %-docker
+	BUILD_ARCH=$(BUILD_ARCH) \
+	BUILD_CONTEXT=$(BUILD_CONTEXT) \
+	NMP_IMAGE_REGISTRY=$(NMP_IMAGE_REGISTRY) \
+	NMP_IMAGE_TAG=$(NMP_IMAGE_TAG) \
+	docker buildx bake --load $*-docker
+
+.PHONY: push/%
+push/%: ## Build and push a multi-arch image manifest from bake target %-docker
+	BUILD_CONTEXT=$(BUILD_CONTEXT) \
+	NMP_IMAGE_REGISTRY=$(NMP_IMAGE_REGISTRY) \
+	NMP_IMAGE_TAG=$(NMP_IMAGE_TAG) \
+	docker buildx bake --push $*-docker
 
 .PHONY: verify-python-version
 verify-python-version: ## Verify Python version and install if necessary

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -33,11 +33,13 @@ from typing import IO, Any
 import httpx
 import pytest
 from nemo_platform import NeMoPlatform
+from nmp.common.jobs.image import image_builder
 from nmp.testing import NemoRun, get_repo_root
+from nmp.testing.e2e import DEFAULT_REGISTRY, DEFAULT_TAG
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Enable mock inference provider for e2e tests.
+    """Enable mock inference provider for e2e tests and register markers.
 
     Sets the env var and clears the Configuration cache so that
     InferenceGatewayConfig picks up the new value. The cache must be
@@ -50,6 +52,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
     Configuration.clear_cache()
 
+    config.addinivalue_line("markers", "feature(*names): test requires named platform feature(s), e.g. auth")
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +61,7 @@ _HEALTH_POLL_INTERVAL = 1.0
 _AUTH_READY_TIMEOUT = 60
 _E2E_ADMIN_EMAIL = "admin@example.com"
 _SERVICES_LOG = Path(os.environ.get("E2E_SERVICES_LOG", os.path.join(tempfile.gettempdir(), "services.log")))
+_AUTH_ENABLED = os.environ.get("NMP_E2E_AUTH_ENABLED", "").lower() in {"1", "true", "yes"}
 
 # Number of log lines to dump from the services log on test failure.
 _TAIL_LINES_ON_FAILURE = 100
@@ -261,6 +265,22 @@ def background_process(
             proc.wait(timeout=5)
 
 
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip feature-gated E2E tests unless the local harness enables them."""
+    for item in items:
+        feature_marker = item.get_closest_marker("feature")
+        if not feature_marker:
+            continue
+
+        required_features = set(feature_marker.args)
+        if "auth" in required_features and not _AUTH_ENABLED:
+            item.add_marker(
+                pytest.mark.skip(
+                    reason="Auth-gated E2E test. Re-run with NMP_E2E_AUTH_ENABLED=1 against auth-enabled services."
+                )
+            )
+
+
 # ---- Services log tail on failure ------------------------------------------
 
 
@@ -364,6 +384,14 @@ def sdk(_services: str) -> NeMoPlatform:
         max_retries=2,
         default_headers=headers,
     )
+
+
+@pytest.fixture(scope="session")
+def image() -> Any:
+    """Resolve fully qualified NeMo image names for E2E jobs."""
+    registry = os.environ.get("NMP_E2E_REGISTRY", DEFAULT_REGISTRY)
+    tag = os.environ.get("NMP_E2E_TAG", DEFAULT_TAG)
+    return image_builder(registry=registry, tag=tag)
 
 
 @pytest.fixture(scope="function")

--- a/e2e/test_jobs.py
+++ b/e2e/test_jobs.py
@@ -1,18 +1,22 @@
-"""E2E tests for platform jobs.
+"""E2E tests for real platform jobs.
 
-These tests submit jobs with CPUExecutionProviderSpec (container + command).
-The container image is omitted so that:
-- On subprocess mode, the cpu→subprocess translation discards it anyway.
-- On Kubernetes/Docker, the execution profile's default_task_image is used.
-
-Ported from Platform-Deploy e2e/test_jobs.py, adapted for the SDK's TypedDict
-param types and filtered to tests that work without Docker.
+These focus on the live jobs API and container execution path, including logs,
+config injection, inter-step storage, secrets, and lifecycle controls.
 """
 
-import uuid
+from collections.abc import Callable
+from uuid import uuid4
 
 import pytest
 from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.jobs.api_factory import (
+    ContainerSpec,
+    CPUExecutionProviderSpec,
+    EnvironmentVariable,
+    EnvironmentVariableFromSecret,
+    PlatformJobSpec,
+    PlatformJobStep,
+)
 from nmp.testing.e2e import wait_for_job_logs, wait_for_platform_job
 
 JOB_SOURCE = "e2e-test-jobs"
@@ -20,72 +24,94 @@ JOB_SOURCE = "e2e-test-jobs"
 pytestmark = [pytest.mark.timeout(600)]
 
 
-def _job_diagnostic_message(sdk: NeMoPlatform, job, workspace: str, prefix: str) -> str:
-    """Build a diagnostic message with job error details and logs for assertion failures."""
+def _single_step_job(
+    *,
+    image: str,
+    name: str,
+    command: list[str],
+    entrypoint: list[str] | None = None,
+    config: dict[str, object] | None = None,
+    environment: list[EnvironmentVariable] | None = None,
+) -> PlatformJobSpec:
+    container = (
+        ContainerSpec(image=image, command=command, entrypoint=entrypoint)
+        if entrypoint is not None
+        else ContainerSpec(image=image, command=command)
+    )
+
+    executor = CPUExecutionProviderSpec(provider="cpu", container=container)
+    if config is not None and environment is not None:
+        step = PlatformJobStep(name=name, executor=executor, config=config, environment=environment)
+    elif config is not None:
+        step = PlatformJobStep(name=name, executor=executor, config=config)
+    elif environment is not None:
+        step = PlatformJobStep(name=name, executor=executor, environment=environment)
+    else:
+        step = PlatformJobStep(name=name, executor=executor)
+
+    return PlatformJobSpec(steps=[step])
+
+
+def _job_diagnostic_message(sdk: NeMoPlatform, job_name: str, workspace: str, prefix: str) -> str:
     parts = [prefix]
-    if job.status_details:
-        parts.append(f"Status details: {job.status_details}")
-    if job.error_details:
-        parts.append(f"Error details: {job.error_details}")
     try:
-        logs = sdk.jobs.get_logs(workspace=workspace, name=job.name)
+        job = sdk.jobs.retrieve(job_name, workspace=workspace)
+        parts.append(f"Job status: {job.status}")
+        parts.append(f"Job status details: {job.status_details}")
+        parts.append(f"Job error details: {job.error_details}")
+    except Exception as exc:
+        parts.append(f"Could not retrieve job: {exc}")
+
+    try:
+        steps = list(sdk.jobs.steps.list(job_name, workspace=workspace))
+        if steps:
+            parts.append("Steps:")
+            for step in steps:
+                parts.append(
+                    f"  - {step.name}: status={step.status} status_details={step.status_details} error_details={step.error_details}"
+                )
+                tasks_response = sdk.jobs.tasks.list(step.name, job=job_name, workspace=workspace)
+                for task in tasks_response.data:
+                    parts.append(
+                        f"    task {task.name}: status={task.status} status_details={task.status_details} error_details={task.error_details} error_stack={task.error_stack}"
+                    )
+    except Exception as exc:
+        parts.append(f"Could not list steps/tasks: {exc}")
+
+    try:
+        logs = sdk.jobs.get_logs(workspace=workspace, name=job_name)
         if logs.data:
-            parts.append(f"Job logs ({len(logs.data)} entries):")
+            parts.append("Logs:")
             for entry in logs.data:
                 parts.append(f"  - {entry.message}")
-    except Exception as log_err:
-        parts.append(f"Could not fetch job logs: {log_err}")
+    except Exception as exc:
+        parts.append(f"Could not fetch logs: {exc}")
+
     return "\n".join(parts)
 
 
-def test_basic_platform_job_lifecycle(sdk: NeMoPlatform, workspace: str):
-    """Test a basic platform job lifecycle: create, run, complete.
-
-    Verifies the platform jobs system works end-to-end:
-    1. Create a job with a simple command
-    2. Wait for the job to complete
-    3. Verify job reaches completed status
-    4. Retrieve and check step logs
-    """
+def test_basic_platform_job_lifecycle(sdk: NeMoPlatform, workspace: str, image: Callable[[str], str]):
     job = sdk.jobs.create(
         workspace=workspace,
         source=JOB_SOURCE,
-        spec={"test": "value"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "echo-step",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": ["echo", "Hello from e2e test!"],
-                        },
-                    },
-                },
-            ],
-        },
+        spec={"test": "basic"},
+        platform_spec=_single_step_job(
+            image=image("nmp-cpu-tasks"),
+            name="echo-step",
+            command=["echo", "Hello from e2e test!"],
+        ),
     )
 
     completed_job = wait_for_platform_job(sdk, job.name, workspace)
-    assert completed_job.status == "completed", _job_diagnostic_message(
-        sdk, completed_job, workspace, f"Job failed with status: {completed_job.status}"
-    )
+    assert completed_job.status == "completed"
 
-    step_logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=1, timeout=240)
-    all_messages = " ".join(log.message for log in step_logs.data)
-    assert "Hello from e2e test!" in all_messages, "Step logs do not contain expected output"
+    logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=1, timeout=240)
+    assert "Hello from e2e test!" in " ".join(log.message for log in logs.data)
 
 
-def test_job_logs_across_multiple_batches(sdk: NeMoPlatform, workspace: str):
-    """Test that logs spanning multiple OTLP batches are correctly stored and retrieved.
-
-    The OTLP BatchProcessor batches logs before sending, so logs output with
-    delays between them will end up in different batches (and potentially
-    different parquet files).
-    """
+def test_job_logs_across_multiple_batches(sdk: NeMoPlatform, workspace: str, image: Callable[[str], str]):
     num_logs = 5
     delay_seconds = 2
-
     log_command = "; ".join(
         [f'echo "Log message {i} of {num_logs}"; sleep {delay_seconds}' for i in range(1, num_logs + 1)]
     )
@@ -94,418 +120,233 @@ def test_job_logs_across_multiple_batches(sdk: NeMoPlatform, workspace: str):
         workspace=workspace,
         source=JOB_SOURCE,
         spec={"test": "multi-batch-logs"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "multi-log-step",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": ["sh", "-c", log_command],
-                        },
-                    },
-                },
-            ],
-        },
+        platform_spec=_single_step_job(
+            image=image("nmp-cpu-tasks"),
+            name="multi-log-step",
+            command=["sh", "-c", log_command],
+        ),
     )
 
     completed_job = wait_for_platform_job(sdk, job.name, workspace, timeout=120)
-    assert completed_job.status == "completed", _job_diagnostic_message(
-        sdk, completed_job, workspace, f"Job failed with status: {completed_job.status}"
-    )
+    assert completed_job.status == "completed"
 
-    step_logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=num_logs, timeout=120)
-
-    assert len(step_logs.data) >= num_logs, f"Expected at least {num_logs} logs, got {len(step_logs.data)}"
-
-    # Verify all log messages are present and in order
+    logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=num_logs, timeout=120)
+    assert len(logs.data) == num_logs
     for i in range(1, num_logs + 1):
-        expected_message = f"Log message {i} of {num_logs}"
-        assert expected_message in step_logs.data[i - 1].message, (
-            f"Log {i} not found at expected position. "
-            f"Expected '{expected_message}', got '{step_logs.data[i - 1].message}'"
-        )
+        assert f"Log message {i} of {num_logs}" in logs.data[i - 1].message
 
 
-def test_job_config_is_readable(sdk: NeMoPlatform, workspace: str):
-    """Test that a job can read its configuration via $NEMO_JOB_STEP_CONFIG_FILE_PATH."""
+def test_job_config_is_readable(sdk: NeMoPlatform, workspace: str, image: Callable[[str], str]):
     job = sdk.jobs.create(
         workspace=workspace,
         source=JOB_SOURCE,
-        spec={"test": "value"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "config-step",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": ["sh", "-c", "echo 'Step config:'; cat $NEMO_JOB_STEP_CONFIG_FILE_PATH;"],
-                        },
-                    },
-                    "config": {
-                        "message": "Hello from job config!",
-                    },
-                },
-            ],
-        },
+        spec={"test": "config"},
+        platform_spec=_single_step_job(
+            image=image("nmp-cpu-tasks"),
+            name="config-step",
+            command=["sh", "-c", "echo 'Step config:'; cat \"$NEMO_JOB_STEP_CONFIG_FILE_PATH\";"],
+            config={"message": "Hello from job config!"},
+        ),
     )
 
     completed_job = wait_for_platform_job(sdk, job.name, workspace)
-    assert completed_job.status == "completed", _job_diagnostic_message(
-        sdk, completed_job, workspace, f"Job failed with status: {completed_job.status}"
-    )
+    assert completed_job.status == "completed"
 
-    step_logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=2, timeout=60)
-    all_messages = " ".join(log.message for log in step_logs.data)
-    assert "Hello from job config!" in all_messages, "Step logs do not show config was read"
+    logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=2, timeout=60)
+    assert "Hello from job config!" in " ".join(log.message for log in logs.data)
 
 
-def test_job_passing_data_between_steps(sdk: NeMoPlatform, workspace: str):
-    """Test that data can be passed between job steps via persistent storage."""
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_job_passing_data_between_steps(sdk: NeMoPlatform, workspace: str, image: Callable[[str], str]):
     job = sdk.jobs.create(
         workspace=workspace,
         source=JOB_SOURCE,
-        spec={"test": "value"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "generate-data-step",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": [
+        spec={"test": "step-data"},
+        platform_spec=PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="generate-data-step",
+                    executor=CPUExecutionProviderSpec(
+                        provider="cpu",
+                        container=ContainerSpec(
+                            image=image("nmp-cpu-tasks"),
+                            command=[
                                 "sh",
                                 "-c",
-                                "echo 'Data from first step' > $NEMO_JOB_PERSISTENT_JOB_STORAGE_PATH/data.txt",
+                                "echo 'Data from first step' > \"$NEMO_JOB_PERSISTENT_JOB_STORAGE_PATH/data.txt\"",
                             ],
-                        },
-                    },
-                },
-                {
-                    "name": "consume-data-step",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": [
-                                "sh",
-                                "-c",
-                                "echo 'Consuming data:'; cat $NEMO_JOB_PERSISTENT_JOB_STORAGE_PATH/data.txt",
-                            ],
-                        },
-                    },
-                },
-            ],
-        },
-    )
-
-    completed_job = wait_for_platform_job(sdk, job.name, workspace)
-    assert completed_job.status == "completed", _job_diagnostic_message(
-        sdk, completed_job, workspace, f"Job failed with status: {completed_job.status}"
-    )
-
-    step_logs = sdk.jobs.get_logs(workspace=workspace, name=job.name)
-    all_messages = " ".join(log.message for log in step_logs.data)
-    assert "Data from first step" in all_messages, "Second step did not receive data from first step"
-
-
-def test_job_using_secret_environment_variable(sdk: NeMoPlatform, workspace: str):
-    """Test that a job can use secret environment variables."""
-    secret_name = f"e2e-secret-{uuid.uuid4().hex[:8]}"
-    secret_value = "s3cret-val"
-
-    secret = sdk.secrets.create(workspace=workspace, name=secret_name, value=secret_value)
-    assert secret.name is not None, "Failed to create platform secret"
-
-    job = sdk.jobs.create(
-        workspace=workspace,
-        source=JOB_SOURCE,
-        spec={"test": "value"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "secret-envvar-step",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": ["sh", "-c", 'echo "Secret value is: $SECRET_ENV_VAR"'],
-                        },
-                    },
-                    "environment": [
-                        {
-                            "name": "SECRET_ENV_VAR",
-                            "from_secret": {"name": secret.name},
-                        },
+                        ),
+                    ),
+                    environment=[
+                        EnvironmentVariable(
+                            name="NEMO_JOB_PERSISTENT_JOB_STORAGE_PATH",
+                            value="/mnt/persistent_storage",
+                        )
                     ],
-                },
-            ],
-        },
+                ),
+                PlatformJobStep(
+                    name="consume-data-step",
+                    executor=CPUExecutionProviderSpec(
+                        provider="cpu",
+                        container=ContainerSpec(
+                            image=image("nmp-cpu-tasks"),
+                            command=[
+                                "sh",
+                                "-c",
+                                "echo 'Consuming data:'; cat \"$NEMO_JOB_PERSISTENT_JOB_STORAGE_PATH/data.txt\"",
+                            ],
+                        ),
+                    ),
+                    environment=[
+                        EnvironmentVariable(
+                            name="NEMO_JOB_PERSISTENT_JOB_STORAGE_PATH",
+                            value="/mnt/persistent_storage",
+                        )
+                    ],
+                ),
+            ]
+        ),
     )
 
     completed_job = wait_for_platform_job(sdk, job.name, workspace)
     assert completed_job.status == "completed", _job_diagnostic_message(
-        sdk, completed_job, workspace, f"Job failed with status: {completed_job.status}"
+        sdk,
+        job.name,
+        workspace,
+        "Expected shared persistent storage to work across steps.",
     )
 
-    step_logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=1, timeout=120)
-    all_messages = " ".join(log.message for log in step_logs.data)
-    assert secret_value in all_messages, "Step logs do not show secret environment variable was used"
+    logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=2, timeout=60)
+    assert "Data from first step" in logs.data[-1].message
 
 
-def test_job_with_expected_failure(sdk: NeMoPlatform, workspace: str):
-    """Test that a job correctly reports failure when a step exits non-zero."""
+def test_job_using_secret_environment_variable(sdk: NeMoPlatform, workspace: str, image: Callable[[str], str]):
+    secret_name = f"e2e-secret-{uuid4().hex[:8]}"
+    secret = sdk.secrets.create(
+        workspace=workspace,
+        name=secret_name,
+        value="3",
+    )
+
     job = sdk.jobs.create(
         workspace=workspace,
         source=JOB_SOURCE,
-        spec={"test": "value"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "failing-step",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": ["sh", "-c", "echo 'This step will fail'; exit 1;"],
-                        },
-                    },
-                },
+        spec={"test": "secret-env"},
+        platform_spec=_single_step_job(
+            image=image("nmp-cpu-tasks"),
+            name="secret-envvar-step",
+            command=["sh", "-c", 'test "$SECRET_ENV_VAR" = "3" && echo "Secret env var was injected"'],
+            environment=[
+                EnvironmentVariable(
+                    name="SECRET_ENV_VAR",
+                    from_secret=EnvironmentVariableFromSecret(name=secret.name),
+                )
             ],
-        },
+        ),
     )
 
     completed_job = wait_for_platform_job(sdk, job.name, workspace)
-    assert completed_job.status == "error", f"Job should have failed but has status: {completed_job.status}"
+    assert completed_job.status == "completed"
 
-    step_logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=1, timeout=30)
-    assert len(step_logs.data) == 1, "Expected one step log"
-    assert "This step will fail" in step_logs.data[0].message, "Step logs do not contain expected output"
+    logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=1, timeout=120)
+    log_text = " ".join(log.message for log in logs.data)
+    assert "Secret env var was injected" in log_text
+    assert "3" not in log_text
 
 
-def test_job_cancel_immediately(sdk: NeMoPlatform, workspace: str):
-    """Test that a job can be created and then cancelled immediately."""
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_job_with_expected_failure(sdk: NeMoPlatform, workspace: str, image: Callable[[str], str]):
     job = sdk.jobs.create(
         workspace=workspace,
         source=JOB_SOURCE,
-        spec={"test": "value"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "long-running-step",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": ["sh", "-c", "sleep 60"],
-                        },
-                    },
-                },
-            ],
-        },
+        spec={"test": "expected-failure"},
+        platform_spec=_single_step_job(
+            image=image("nmp-cpu-tasks"),
+            name="failing-step",
+            command=["sh", "-c", "echo 'This step will fail'; exit 1;"],
+        ),
+    )
+
+    completed_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert completed_job.status == "error"
+
+    logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=1, timeout=30)
+    assert "This step will fail" in logs.data[0].message
+
+
+def test_job_cancel_immediately(sdk: NeMoPlatform, workspace: str, image: Callable[[str], str]):
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "cancel-immediate"},
+        platform_spec=_single_step_job(
+            image=image("nmp-cpu-tasks"),
+            name="cancel-immediate-step",
+            command=["sh", "-c", "sleep 60"],
+        ),
     )
 
     sdk.jobs.cancel(workspace=workspace, name=job.name)
 
     cancelled_job = wait_for_platform_job(sdk, job.name, workspace)
-    assert cancelled_job.status == "cancelled", _job_diagnostic_message(
-        sdk, cancelled_job, workspace, f"Job should have been cancelled but has status: {cancelled_job.status}"
-    )
+    assert cancelled_job.status == "cancelled"
 
 
-def test_job_cancel_once_active(sdk: NeMoPlatform, workspace: str):
-    """Test that an active job can be cancelled."""
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_job_cancel_once_active(sdk: NeMoPlatform, workspace: str, image: Callable[[str], str]):
     job = sdk.jobs.create(
         workspace=workspace,
         source=JOB_SOURCE,
-        spec={"test": "value"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "long-running-step",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": ["sh", "-c", "sleep 300"],
-                        },
-                    },
-                },
-            ],
-        },
+        spec={"test": "cancel-active"},
+        platform_spec=_single_step_job(
+            image=image("nmp-cpu-tasks"),
+            name="cancel-active-step",
+            entrypoint=["nemo-platform"],
+            command=["run", "task", "--task", "nmp.hello_world.tasks.hello_world"],
+        ),
     )
 
     active_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="active")
-    assert active_job.status == "active", _job_diagnostic_message(
-        sdk, active_job, workspace, f"Job did not become active, status: {active_job.status}"
-    )
+    assert active_job.status == "active"
 
     sdk.jobs.cancel(workspace=workspace, name=job.name)
 
     cancelled_job = wait_for_platform_job(sdk, job.name, workspace)
-    assert cancelled_job.status == "cancelled", _job_diagnostic_message(
-        sdk, cancelled_job, workspace, f"Job should have been cancelled but has status: {cancelled_job.status}"
-    )
+    assert cancelled_job.status == "cancelled"
 
 
-# ---------------------------------------------------------------------------
-# Tests that require Docker backend
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.skip(reason="Subprocess backend does not support pause/resume (no SIGSTOP/SIGCONT handling)")
-def test_job_pause_resume(sdk: NeMoPlatform, workspace: str):
-    """Test that a job can be paused and then resumed after being paused."""
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
+def test_job_pause_resume(sdk: NeMoPlatform, workspace: str, image: Callable[[str], str]):
     job = sdk.jobs.create(
         workspace=workspace,
         source=JOB_SOURCE,
-        spec={"test": "value"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "long-running-step-pause-resume",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": ["sh", "-c", "sleep 300"],
-                        },
-                    },
-                },
-            ],
-        },
+        spec={"test": "pause-resume"},
+        platform_spec=_single_step_job(
+            image=image("nmp-cpu-tasks"),
+            name="pause-resume-step",
+            entrypoint=["nemo-platform"],
+            command=["run", "task", "--task", "nmp.hello_world.tasks.hello_world"],
+            environment=[EnvironmentVariable(name="BUSY_LOOP_DURATION_SECONDS", value="120")],
+        ),
     )
 
     active_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="active")
-    assert active_job.status == "active", f"Job did not become active, status: {active_job.status}"
+    assert active_job.status == "active"
 
     sdk.jobs.pause(workspace=workspace, name=job.name)
 
     paused_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="paused")
-    assert paused_job.status == "paused", f"Job should have been paused but has status: {paused_job.status}"
+    assert paused_job.status == "paused", _job_diagnostic_message(
+        sdk,
+        job.name,
+        workspace,
+        "Expected the job to reach paused after pause().",
+    )
 
     sdk.jobs.resume(workspace=workspace, name=job.name)
 
     resumed_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="active")
-    assert resumed_job.status in ("active", "completed"), (
-        f"Job should have been resumed but has status: {resumed_job.status}"
-    )
+    assert resumed_job.status in ("active", "completed")
 
     completed_job = wait_for_platform_job(sdk, job.name, workspace)
-    assert completed_job.status == "completed", f"Job failed with status: {completed_job.status}"
-
-
-@pytest.mark.skip(reason="Subprocess backend does not support pause/resume (no SIGSTOP/SIGCONT handling)")
-def test_job_pause_and_cancel(sdk: NeMoPlatform, workspace: str):
-    """Test that a job can be paused and then cancelled after being paused."""
-    job = sdk.jobs.create(
-        workspace=workspace,
-        source=JOB_SOURCE,
-        spec={"test": "value"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "long-running-step-pause-cancel",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": ["sh", "-c", "sleep 300"],
-                        },
-                    },
-                },
-            ],
-        },
-    )
-
-    active_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="active")
-    assert active_job.status == "active", f"Job did not become active, status: {active_job.status}"
-
-    sdk.jobs.pause(workspace=workspace, name=job.name)
-
-    paused_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="paused")
-    assert paused_job.status == "paused", f"Job should have been paused but has status: {paused_job.status}"
-
-    sdk.jobs.cancel(workspace=workspace, name=job.name)
-
-    cancelled_job = wait_for_platform_job(sdk, job.name, workspace)
-    assert cancelled_job.status == "cancelled", f"Job should have been cancelled but has status: {cancelled_job.status}"
-
-
-@pytest.mark.skip(reason="Docker-only: additional volumes require container volume mounts")
-def test_job_using_additional_volume(sdk: NeMoPlatform, workspace: str):
-    """Test that a job can use an additional volume to store data between steps."""
-    job = sdk.jobs.create(
-        workspace=workspace,
-        source=JOB_SOURCE,
-        spec={"test": "data-between-steps"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "write-data",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": [
-                                "sh",
-                                "-c",
-                                "echo 'Hello, World!' > /mnt/additional_storage/shared_data.txt; "
-                                "echo 'Successfully wrote data to persistent storage';",
-                            ],
-                        },
-                    },
-                },
-                {
-                    "name": "read-data",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "command": [
-                                "sh",
-                                "-c",
-                                "cat /mnt/additional_storage/shared_data.txt; "
-                                "echo 'Successfully read data from persistent storage';",
-                            ],
-                        },
-                    },
-                },
-            ],
-        },
-    )
-
-    completed_job = wait_for_platform_job(sdk, job.name, workspace)
-    assert completed_job.status == "completed", f"Job failed with status: {completed_job.status}"
-
-    step_logs = sdk.jobs.get_logs(workspace=workspace, name=job.name)
-    assert len(step_logs.data) == 3, "Expected three step logs"
-    assert "Successfully wrote data to persistent storage" in step_logs.data[0].message
-    assert "Hello, World!" in step_logs.data[1].message
-    assert "Successfully read data from persistent storage" in step_logs.data[2].message
-
-
-@pytest.mark.skip(
-    reason="Docker-only: image validation is bypassed in subprocess mode "
-    "(cpu→subprocess translation discards the container image)"
-)
-@pytest.mark.parametrize("bad_image", ["__invalid_ubuntu:image", "ubuntu:does-not-exist-1234"])
-def test_job_invalid_image_format(sdk: NeMoPlatform, workspace: str, bad_image: str):
-    """Test that a job with a bad image fails appropriately."""
-    job = sdk.jobs.create(
-        workspace=workspace,
-        source=JOB_SOURCE,
-        spec={"test": "value"},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "bad-image-step",
-                    "executor": {
-                        "provider": "cpu",
-                        "container": {
-                            "image": bad_image,
-                            "command": ["echo", "This should not run"],
-                        },
-                    },
-                },
-            ],
-        },
-    )
-
-    completed_job = wait_for_platform_job(sdk, job.name, workspace)
-    assert completed_job.status == "error", f"Job should have failed but has status: {completed_job.status}"
-
-    job_status = sdk.jobs.get_status(workspace=workspace, name=job.name)
-    assert job_status.steps[0].status == "error", "Step should have failed"
+    assert completed_job.status == "completed"

--- a/e2e/test_jobs_auth.py
+++ b/e2e/test_jobs_auth.py
@@ -1,0 +1,173 @@
+"""E2E tests for jobs with auth enabled."""
+
+from collections.abc import Callable
+
+import pytest
+from nemo_platform import NeMoPlatform
+from nemo_platform_ext.auth.helpers import generate_unsigned_jwt
+from nemo_platform_plugin.jobs.api_factory import (
+    ContainerSpec,
+    CPUExecutionProviderSpec,
+    EnvironmentVariable,
+    PlatformJobSpec,
+    PlatformJobStep,
+)
+from nmp.common.entities import ALL_WORKSPACES
+from nmp.testing import TEST_ADMIN_EMAIL, grant_workspace_role, short_unique_name, unique_email
+from nmp.testing.e2e import wait_for_platform_job
+
+JOB_SOURCE = "e2e-auth-test"
+
+pytestmark = [pytest.mark.feature("auth")]
+
+
+def _as_bearer_user(
+    sdk: NeMoPlatform,
+    email: str,
+    *,
+    groups: list[str] | None = None,
+) -> NeMoPlatform:
+    token = generate_unsigned_jwt(
+        principal_id=email,
+        email=email,
+        groups=groups,
+    )
+    return sdk.with_options(set_default_headers={"Authorization": f"Bearer {token}"})
+
+
+def test_job_principal_propagation(sdk: NeMoPlatform, image: Callable[[str], str]):
+    admin_sdk = _as_bearer_user(sdk, TEST_ADMIN_EMAIL, groups=["admin"])
+    user_email = unique_email("job-creator")
+    workspace_name = short_unique_name("job-auth-test")
+
+    admin_sdk.workspaces.create(name=workspace_name)
+    grant_workspace_role(admin_sdk, workspace=workspace_name, principal=user_email, roles=["Editor"])
+
+    user_sdk = _as_bearer_user(sdk, user_email)
+    job = user_sdk.jobs.create(
+        workspace=workspace_name,
+        source=JOB_SOURCE,
+        spec={"test": "auth-propagation"},
+        platform_spec=PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="auth-test-step",
+                    executor=CPUExecutionProviderSpec(
+                        provider="cpu",
+                        container=ContainerSpec(
+                            image=image("nmp-cpu-tasks"),
+                            entrypoint=["nemo-platform"],
+                            command=["run", "task", "--task", "nmp.hello_world.tasks.hello_world"],
+                        ),
+                    ),
+                    environment=[EnvironmentVariable(name="BUSY_LOOP_DURATION_SECONDS", value="0")],
+                    config={"message": "auth propagation test"},
+                )
+            ]
+        ),
+    )
+
+    completed_job = wait_for_platform_job(user_sdk, job.name, workspace_name)
+    assert completed_job.status == "completed"
+
+    fileset_name = f"hello-world-{job.name}"
+    fileset = user_sdk.files.filesets.retrieve(workspace=workspace_name, name=fileset_name)
+    assert fileset is not None
+
+    file_content = user_sdk.files.download_content(
+        remote_path="message.txt",
+        fileset=fileset_name,
+        workspace=workspace_name,
+    )
+    assert file_content == b"auth propagation test"
+
+
+def test_job_cannot_access_unauthorized_workspace(sdk: NeMoPlatform, image: Callable[[str], str]):
+    admin_sdk = _as_bearer_user(sdk, TEST_ADMIN_EMAIL, groups=["admin"])
+    owner_email = unique_email("owner")
+    other_email = unique_email("other")
+
+    restricted_workspace = short_unique_name("restricted")
+    runner_workspace = short_unique_name("runner")
+
+    admin_sdk.workspaces.create(name=restricted_workspace)
+    admin_sdk.workspaces.create(name=runner_workspace)
+    grant_workspace_role(admin_sdk, workspace=restricted_workspace, principal=owner_email, roles=["Editor"])
+    grant_workspace_role(admin_sdk, workspace=runner_workspace, principal=other_email, roles=["Editor"])
+
+    owner_sdk = _as_bearer_user(sdk, owner_email)
+    other_sdk = _as_bearer_user(sdk, other_email)
+
+    fileset_name = "private-data"
+    owner_sdk.files.filesets.create(workspace=restricted_workspace, name=fileset_name)
+
+    job = other_sdk.jobs.create(
+        workspace=runner_workspace,
+        source=JOB_SOURCE,
+        spec={"test": "auth-denial"},
+        platform_spec=PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="access-test-step",
+                    executor=CPUExecutionProviderSpec(
+                        provider="cpu",
+                        container=ContainerSpec(
+                            image=image("nmp-cpu-tasks"),
+                            entrypoint=["nemo-platform"],
+                            command=["run", "task", "--task", "nmp.hello_world.tasks.access_fileset"],
+                        ),
+                    ),
+                    config={
+                        "workspace": restricted_workspace,
+                        "fileset": fileset_name,
+                    },
+                )
+            ]
+        ),
+    )
+
+    completed_job = wait_for_platform_job(other_sdk, job.name, runner_workspace)
+    assert completed_job.status == "error"
+
+    tasks_response = other_sdk.jobs.tasks.list("access-test-step", job=job.name, workspace=runner_workspace)
+    assert tasks_response.data
+    task = tasks_response.data[0]
+    assert task.error_stack
+    assert "403" in task.error_stack and "Forbidden" in task.error_stack
+
+
+def test_job_admin_can_list_jobs_in_all_workspaces(sdk: NeMoPlatform, image: Callable[[str], str]):
+    admin_sdk = _as_bearer_user(sdk, TEST_ADMIN_EMAIL, groups=["admin"])
+    user_email = unique_email("member")
+    workspace_name = short_unique_name("admin-list-jobs")
+
+    admin_sdk.workspaces.create(name=workspace_name)
+    grant_workspace_role(admin_sdk, workspace=workspace_name, principal=user_email, roles=["Editor"])
+
+    user_sdk = _as_bearer_user(sdk, user_email)
+    job = user_sdk.jobs.create(
+        workspace=workspace_name,
+        source=JOB_SOURCE,
+        spec={"test": "admin-list"},
+        platform_spec=PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="admin-list-step",
+                    executor=CPUExecutionProviderSpec(
+                        provider="cpu",
+                        container=ContainerSpec(
+                            image=image("nmp-cpu-tasks"),
+                            command=["echo", "admin list jobs"],
+                        ),
+                    ),
+                )
+            ]
+        ),
+    )
+
+    completed_job = wait_for_platform_job(user_sdk, job.name, workspace_name)
+    assert completed_job.status == "completed"
+
+    jobs = admin_sdk.jobs.list(workspace=ALL_WORKSPACES)
+    assert jobs.pagination is not None
+    assert any(item.name == job.name for item in jobs.data)

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/cluster.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/cluster.py
@@ -107,6 +107,13 @@ class QuickstartCluster:
         # Initialize storage directories
         self._storage_manager.initialize()
 
+        # Quickstart always generates a canonical global config for the container
+        # unless the user explicitly supplied one.
+        if self.config.platform_config_path is None:
+            generated_config_path = self.config.storage_path / "platform-config.yaml"
+            self.platform_config.save(generated_config_path)
+            self.config.platform_config_path = generated_config_path.resolve()
+
         self._container_manager.start(
             platform_config=self.platform_config,
             pull=pull,

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py
@@ -8,10 +8,15 @@ from __future__ import annotations
 import logging
 import os
 import sys
-import typing
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TypedDict
+
+from docker.models.containers import Container
+from docker.models.networks import Network
+from docker.types import Mount
+
+from docker import DockerClient
 
 from ._registry import image_registry_host
 from .config import QuickstartConfig
@@ -25,7 +30,6 @@ if typing.TYPE_CHECKING:
     from docker.types import Mount
 
     from docker import DockerClient
-
 
 class PullProgress(TypedDict):
     """Progress update from image pull operation."""
@@ -306,6 +310,7 @@ class ContainerManager:
         env["XDG_CONFIG_HOME"] = "/data/.config"
         env["XDG_DATA_HOME"] = "/data/.local/share"
         env["XDG_CACHE_HOME"] = "/data/.cache"
+        env["XDG_STATE_HOME"] = "/data/.local/state"
 
         # Database in mounted /data so it persists across container restarts
         env["DATABASE_URL"] = "sqlite:////data/nmp-platform.db"

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/platform_config.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/platform_config.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 from pydantic import BaseModel, Field
@@ -53,7 +54,30 @@ class PlatformConfig(BaseModel):
             except yaml.YAMLError as e:
                 raise ValueError(f"Error parsing platform config at {path}: {e}") from e
 
+        if "platform" in config_data or "files" in config_data:
+            values: dict[str, Any] = {}
+            platform_config = config_data.get("platform")
+            if isinstance(platform_config, dict):
+                nvidia_api_key = platform_config.get("nvidia_api_key")
+                if isinstance(nvidia_api_key, str):
+                    values["nvidia_api_key"] = nvidia_api_key
+            return cls.model_validate(values)
+
         return cls.model_validate(config_data)
+
+    def to_config_dict(self) -> dict[str, Any]:
+        """Convert quickstart settings to the global config shape mounted in the container."""
+        config_data: dict[str, Any] = {
+            "files": {
+                "default_storage_config": {
+                    "type": "local",
+                    "path": "/data/files_storage",
+                }
+            }
+        }
+        if self.nvidia_api_key:
+            config_data["platform"] = {"nvidia_api_key": self.nvidia_api_key}
+        return config_data
 
     def save(self, path: Path) -> None:
         """Save platform config to YAML file.
@@ -63,7 +87,7 @@ class PlatformConfig(BaseModel):
         """
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        config_data = self.model_dump(mode="json", exclude_none=True)
+        config_data = self.to_config_dict()
 
         with open(path, "w") as f:
             yaml.safe_dump(config_data, f, default_flow_style=False, sort_keys=False)

--- a/packages/nemo_platform_ext/tests/quickstart/test_cluster.py
+++ b/packages/nemo_platform_ext/tests/quickstart/test_cluster.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from nemo_platform_ext.quickstart.cluster import QuickstartCluster
+from nemo_platform_ext.quickstart.config import QuickstartConfig
+from nemo_platform_ext.quickstart.platform_config import PlatformConfig
+
+
+def test_start_generates_canonical_platform_config_when_missing(tmp_path: Path) -> None:
+    config = QuickstartConfig(storage_path=tmp_path, platform_config_path=None)
+    cluster = QuickstartCluster(config=config, platform_config=PlatformConfig(nvidia_api_key="nvapi-test"))
+    cluster._preflight_checker.results = []
+    cluster._preflight_checker.has_failures = MagicMock(return_value=False)
+    cluster._preflight_checker.run_all = MagicMock(return_value=[])
+    cluster._storage_manager.initialize = MagicMock()
+    cluster._container_manager.start = MagicMock()
+
+    cluster.start()
+
+    assert config.platform_config_path == (tmp_path / "platform-config.yaml").resolve()
+    assert config.platform_config_path.exists()
+    cluster._container_manager.start.assert_called_once_with(platform_config=cluster.platform_config, pull=True)

--- a/packages/nemo_platform_ext/tests/quickstart/test_container.py
+++ b/packages/nemo_platform_ext/tests/quickstart/test_container.py
@@ -204,6 +204,27 @@ class TestCreateEnvironmentGPU:
 
         assert env["NMP_DOCKER_RESERVED_GPU_DEVICE_IDS"] == "0"
 
+    def test_platform_config_mount_uses_platform_config_path(self, tmp_path: Path):
+        config = QuickstartConfig(platform_config_path=tmp_path / "platform-config.yaml")
+        config.platform_config_path.write_text("files: {}\n")
+        manager = ContainerManager.__new__(ContainerManager)
+        manager.config = config
+
+        mounts = manager._create_mounts()
+
+        assert any(mount["Target"] == "/etc/nmp/platform-config.yaml" for mount in mounts)
+
+    def test_sets_config_file_path_for_platform_config(self, tmp_path: Path):
+        manager = self._make_manager()
+        manager.config.platform_config_path = tmp_path / "platform-config.yaml"
+        manager.config.platform_config_path.write_text("files: {}\n")
+        mock_platform_config = MagicMock()
+        mock_platform_config.to_env_vars.return_value = {}
+
+        env = manager._create_environment(mock_platform_config)
+
+        assert env["NMP_CONFIG_FILE_PATH"] == "/etc/nmp/platform-config.yaml"
+
 
 class TestCreateEnvironmentRegistryCredentials:
     """Tests for registry credential env var passthrough."""
@@ -544,9 +565,7 @@ class TestStartCleansUpBeforeCreatingNetwork:
             patch.object(manager, "_create_mounts", return_value=[]),
             patch.object(manager, "_create_environment", return_value={}),
             patch.object(manager, "_remove_existing_container", side_effect=lambda: call_order.append("container")),
-            patch.object(
-                manager, "_remove_model_deployments", side_effect=lambda **kw: call_order.append("deployments")
-            ),
+            patch.object(manager, "_remove_model_deployments", side_effect=lambda: call_order.append("deployments")),
             patch.object(manager, "_remove_existing_network", side_effect=lambda: call_order.append("network")),
         ):
             manager.start(platform_config=MagicMock(), pull=False)

--- a/packages/nemo_platform_ext/tests/quickstart/test_quickstart_config.py
+++ b/packages/nemo_platform_ext/tests/quickstart/test_quickstart_config.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 from nemo_platform_ext.quickstart.config import QuickstartConfig, _is_internal_tag
+from nemo_platform_ext.quickstart.platform_config import PlatformConfig
 from nemo_platform_ext.quickstart.validators import validate_config
 
 
@@ -224,6 +225,43 @@ class TestQuickstartConfigBackwardCompatibility:
         assert not hasattr(config, "registry_user")
         assert config.registry_password is None
         assert not config.has_registry_credentials_for_image()
+
+
+class TestPlatformConfig:
+    """Tests for quickstart platform config serialization."""
+
+    def test_save_writes_canonical_global_config(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "platform-config.yaml"
+        config = PlatformConfig(nvidia_api_key="nvapi-test")
+
+        config.save(config_path)
+
+        saved = yaml.safe_load(config_path.read_text())
+        assert saved["platform"]["nvidia_api_key"] == "nvapi-test"
+        assert saved["files"]["default_storage_config"] == {
+            "type": "local",
+            "path": "/data/files_storage",
+        }
+
+    def test_load_reads_canonical_global_config(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "platform-config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "platform": {"nvidia_api_key": "nvapi-test"},
+                    "files": {
+                        "default_storage_config": {
+                            "type": "local",
+                            "path": "/custom/files",
+                        }
+                    },
+                }
+            )
+        )
+
+        config = PlatformConfig.load(config_path)
+
+        assert config.nvidia_api_key == "nvapi-test"
 
 
 class TestIsInternalTag:

--- a/packages/nmp_platform/config/local.yaml
+++ b/packages/nmp_platform/config/local.yaml
@@ -76,11 +76,13 @@ jobs:
     #   profile: gpu
     #   backend: docker
     #   config:
+    #     # Path to the jobs-launcher binary on the local filesystem
     #     launcher_tool_path: ./services/core/jobs/jobs-launcher/jobs-launcher
     # - provider: gpu
     #   profile: gpu
     #   backend: docker
     #   config:
+    #     # Path to the jobs-launcher binary on the local filesystem
     #     launcher_tool_path: ./services/core/jobs/jobs-launcher/jobs-launcher
 
   # Local path to the jobs-launcher binary used by the Docker job backend

--- a/packages/nmp_platform_runner/tests/test_config.py
+++ b/packages/nmp_platform_runner/tests/test_config.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from importlib.resources import files
+
 import pytest
+import yaml
 from nmp.platform_runner import registry
 from nmp.platform_runner.config import (
     ResolvedRunConfiguration,
@@ -46,6 +49,13 @@ def test_default_config_path_points_to_bundled_local_config():
     path = default_config_path()
 
     assert path.endswith(("nmp/platform_runner/config/local.yaml", "nemo_platform/services/runner/config/local.yaml"))
+
+
+def test_bundled_local_config_uses_host_safe_files_storage_path():
+    config_path = files("nmp.platform_runner").joinpath("config/local.yaml")
+    config = yaml.safe_load(config_path.read_text())
+
+    assert config["files"]["default_storage_config"]["path"] == "~/.local/share/nemo/files"
 
 
 def test_no_arguments_defaults_to_all_services_and_default_controllers():

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/cluster.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/cluster.py
@@ -107,6 +107,13 @@ class QuickstartCluster:
         # Initialize storage directories
         self._storage_manager.initialize()
 
+        # Quickstart always generates a canonical global config for the container
+        # unless the user explicitly supplied one.
+        if self.config.platform_config_path is None:
+            generated_config_path = self.config.storage_path / "platform-config.yaml"
+            self.platform_config.save(generated_config_path)
+            self.config.platform_config_path = generated_config_path.resolve()
+
         self._container_manager.start(
             platform_config=self.platform_config,
             pull=pull,

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/container.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/container.py
@@ -8,10 +8,15 @@ from __future__ import annotations
 import logging
 import os
 import sys
-import typing
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TypedDict
+
+from docker.models.containers import Container
+from docker.models.networks import Network
+from docker.types import Mount
+
+from docker import DockerClient
 
 from ._registry import image_registry_host
 from .config import QuickstartConfig
@@ -25,7 +30,6 @@ if typing.TYPE_CHECKING:
     from docker.types import Mount
 
     from docker import DockerClient
-
 
 class PullProgress(TypedDict):
     """Progress update from image pull operation."""
@@ -306,6 +310,7 @@ class ContainerManager:
         env["XDG_CONFIG_HOME"] = "/data/.config"
         env["XDG_DATA_HOME"] = "/data/.local/share"
         env["XDG_CACHE_HOME"] = "/data/.cache"
+        env["XDG_STATE_HOME"] = "/data/.local/state"
 
         # Database in mounted /data so it persists across container restarts
         env["DATABASE_URL"] = "sqlite:////data/nmp-platform.db"

--- a/sdk/python/nemo-platform/src/nemo_platform/quickstart/platform_config.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/quickstart/platform_config.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 from pydantic import BaseModel, Field
@@ -53,7 +54,30 @@ class PlatformConfig(BaseModel):
             except yaml.YAMLError as e:
                 raise ValueError(f"Error parsing platform config at {path}: {e}") from e
 
+        if "platform" in config_data or "files" in config_data:
+            values: dict[str, Any] = {}
+            platform_config = config_data.get("platform")
+            if isinstance(platform_config, dict):
+                nvidia_api_key = platform_config.get("nvidia_api_key")
+                if isinstance(nvidia_api_key, str):
+                    values["nvidia_api_key"] = nvidia_api_key
+            return cls.model_validate(values)
+
         return cls.model_validate(config_data)
+
+    def to_config_dict(self) -> dict[str, Any]:
+        """Convert quickstart settings to the global config shape mounted in the container."""
+        config_data: dict[str, Any] = {
+            "files": {
+                "default_storage_config": {
+                    "type": "local",
+                    "path": "/data/files_storage",
+                }
+            }
+        }
+        if self.nvidia_api_key:
+            config_data["platform"] = {"nvidia_api_key": self.nvidia_api_key}
+        return config_data
 
     def save(self, path: Path) -> None:
         """Save platform config to YAML file.
@@ -63,7 +87,7 @@ class PlatformConfig(BaseModel):
         """
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        config_data = self.model_dump(mode="json", exclude_none=True)
+        config_data = self.to_config_dict()
 
         with open(path, "w") as f:
             yaml.safe_dump(config_data, f, default_flow_style=False, sort_keys=False)

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/quickstart/test_cluster.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/quickstart/test_cluster.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from nemo_platform.quickstart.cluster import QuickstartCluster
+from nemo_platform.quickstart.config import QuickstartConfig
+from nemo_platform.quickstart.platform_config import PlatformConfig
+
+
+def test_start_generates_canonical_platform_config_when_missing(tmp_path: Path) -> None:
+    config = QuickstartConfig(storage_path=tmp_path, platform_config_path=None)
+    cluster = QuickstartCluster(config=config, platform_config=PlatformConfig(nvidia_api_key="nvapi-test"))
+    cluster._preflight_checker.results = []
+    cluster._preflight_checker.has_failures = MagicMock(return_value=False)
+    cluster._preflight_checker.run_all = MagicMock(return_value=[])
+    cluster._storage_manager.initialize = MagicMock()
+    cluster._container_manager.start = MagicMock()
+
+    cluster.start()
+
+    assert config.platform_config_path == (tmp_path / "platform-config.yaml").resolve()
+    assert config.platform_config_path.exists()
+    cluster._container_manager.start.assert_called_once_with(platform_config=cluster.platform_config, pull=True)

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/quickstart/test_container.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/quickstart/test_container.py
@@ -204,6 +204,27 @@ class TestCreateEnvironmentGPU:
 
         assert env["NMP_DOCKER_RESERVED_GPU_DEVICE_IDS"] == "0"
 
+    def test_platform_config_mount_uses_platform_config_path(self, tmp_path: Path):
+        config = QuickstartConfig(platform_config_path=tmp_path / "platform-config.yaml")
+        config.platform_config_path.write_text("files: {}\n")
+        manager = ContainerManager.__new__(ContainerManager)
+        manager.config = config
+
+        mounts = manager._create_mounts()
+
+        assert any(mount["Target"] == "/etc/nmp/platform-config.yaml" for mount in mounts)
+
+    def test_sets_config_file_path_for_platform_config(self, tmp_path: Path):
+        manager = self._make_manager()
+        manager.config.platform_config_path = tmp_path / "platform-config.yaml"
+        manager.config.platform_config_path.write_text("files: {}\n")
+        mock_platform_config = MagicMock()
+        mock_platform_config.to_env_vars.return_value = {}
+
+        env = manager._create_environment(mock_platform_config)
+
+        assert env["NMP_CONFIG_FILE_PATH"] == "/etc/nmp/platform-config.yaml"
+
 
 class TestCreateEnvironmentRegistryCredentials:
     """Tests for registry credential env var passthrough."""
@@ -544,9 +565,7 @@ class TestStartCleansUpBeforeCreatingNetwork:
             patch.object(manager, "_create_mounts", return_value=[]),
             patch.object(manager, "_create_environment", return_value={}),
             patch.object(manager, "_remove_existing_container", side_effect=lambda: call_order.append("container")),
-            patch.object(
-                manager, "_remove_model_deployments", side_effect=lambda **kw: call_order.append("deployments")
-            ),
+            patch.object(manager, "_remove_model_deployments", side_effect=lambda: call_order.append("deployments")),
             patch.object(manager, "_remove_existing_network", side_effect=lambda: call_order.append("network")),
         ):
             manager.start(platform_config=MagicMock(), pull=False)

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/quickstart/test_quickstart_config.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/quickstart/test_quickstart_config.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 from nemo_platform.quickstart.config import QuickstartConfig, _is_internal_tag
+from nemo_platform.quickstart.platform_config import PlatformConfig
 from nemo_platform.quickstart.validators import validate_config
 
 
@@ -224,6 +225,43 @@ class TestQuickstartConfigBackwardCompatibility:
         assert not hasattr(config, "registry_user")
         assert config.registry_password is None
         assert not config.has_registry_credentials_for_image()
+
+
+class TestPlatformConfig:
+    """Tests for quickstart platform config serialization."""
+
+    def test_save_writes_canonical_global_config(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "platform-config.yaml"
+        config = PlatformConfig(nvidia_api_key="nvapi-test")
+
+        config.save(config_path)
+
+        saved = yaml.safe_load(config_path.read_text())
+        assert saved["platform"]["nvidia_api_key"] == "nvapi-test"
+        assert saved["files"]["default_storage_config"] == {
+            "type": "local",
+            "path": "/data/files_storage",
+        }
+
+    def test_load_reads_canonical_global_config(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "platform-config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "platform": {"nvidia_api_key": "nvapi-test"},
+                    "files": {
+                        "default_storage_config": {
+                            "type": "local",
+                            "path": "/custom/files",
+                        }
+                    },
+                }
+            )
+        )
+
+        config = PlatformConfig.load(config_path)
+
+        assert config.nvidia_api_key == "nvapi-test"
 
 
 class TestIsInternalTag:

--- a/services/core/jobs/jobs-launcher/build-manual.sh
+++ b/services/core/jobs/jobs-launcher/build-manual.sh
@@ -7,6 +7,12 @@ GOARCH=${2:-amd64}
 
 echo "Building static binary for ${APP_NAME}..."
 
+# Warning: this binary is copied by the Docker jobs controller into the target
+# job container at /jobs-launcher. The current Docker backend assumes the
+# launcher matches the target job container OS/arch. Build it for the target
+# container platform, not for the controller host platform. Cross-arch only
+# works when the runtime has emulation configured (for example binfmt/QEMU).
+
 # Use -trimpath and disable CGO for a fully static binary
 CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build \
     -a \

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
@@ -753,7 +753,20 @@ chmod -R 777 {job_vol}/{storage_subpath}
         return is_cancelling_or_pausing
 
     def get_jobs_launcher_binary(self) -> io.BytesIO | None:
-        """Get a copy of the jobs-launcher binary as a tar stream to include in the job container."""
+        """Get a copy of the jobs-launcher binary as a tar stream to include in the job container.
+
+        Warning:
+        - ``launcher_tool_path`` is resolved on the jobs-controller host filesystem, not inside
+          the job container image.
+        - The controller copies that host-side binary into the job container at ``/jobs-launcher``
+          and rewrites the entrypoint to execute it.
+        - This assumes the binary at ``launcher_tool_path`` matches the target job container OS
+          and CPU architecture.
+        - If that assumption does not hold, the binary may be injected successfully but fail at
+          runtime inside the container.
+        - Cross-architecture execution is only expected to work when the container runtime has
+          emulation configured, for example via ``binfmt_misc``/QEMU.
+        """
         jobs_launcher_stream = None
         if os.path.exists(self._execution_profile_config.launcher_tool_path):
             jobs_launcher_stream = io.BytesIO()

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
@@ -286,8 +286,10 @@ class SubprocessJobBackend(JobBackend[SubprocessExecutionProvider, SubprocessJob
                 error_details={"message": "Local subprocess metadata not found"},
             )
 
-        if step.status == PlatformJobStatus.CANCELLING and metadata.process.poll() is None:
-            self._terminate_process(metadata)
+        if step.status in (PlatformJobStatus.CANCELLING, PlatformJobStatus.PAUSING):
+            if metadata.process.poll() is None:
+                self._terminate_process(metadata)
+            return self._create_step_update(step, metadata)
 
         ttl_seconds = (
             self._execution_profile_config.ttl_seconds_active
@@ -471,6 +473,8 @@ class SubprocessJobBackend(JobBackend[SubprocessExecutionProvider, SubprocessJob
         if exit_code is None:
             if step.status == PlatformJobStatus.CANCELLING:
                 return PlatformJobStatus.CANCELLING, {"message": "Job is cancelling", **status_details}, {}, ""
+            if step.status == PlatformJobStatus.PAUSING:
+                return PlatformJobStatus.PAUSING, {"message": "Job is pausing", **status_details}, {}, ""
             return PlatformJobStatus.ACTIVE, {"message": "Job is running", **status_details}, {}, ""
 
         self._finish_logs(metadata)
@@ -479,6 +483,13 @@ class SubprocessJobBackend(JobBackend[SubprocessExecutionProvider, SubprocessJob
             return (
                 PlatformJobStatus.CANCELLED,
                 {"message": f"Job was cancelled with exit code {exit_code}", **status_details},
+                {},
+                "",
+            )
+        if step.status == PlatformJobStatus.PAUSING:
+            return (
+                PlatformJobStatus.PAUSED,
+                {"message": f"Job paused with exit code {exit_code}", **status_details},
                 {},
                 "",
             )

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess_runtime.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess_runtime.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import logging
 import threading
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -42,7 +43,9 @@ class SubprocessOtelLogger:
     def emit(self, message: str, stream_name: str) -> None:
         severity_number = SeverityNumber.INFO if stream_name == "stdout" else SeverityNumber.ERROR
         severity_text = "INFO" if stream_name == "stdout" else "ERROR"
+        timestamp = time.time_ns()
         self.logger.emit(
+            timestamp=timestamp,
             body=message,
             timestamp=time_ns(),
             severity_number=severity_number,

--- a/services/core/jobs/tests/controllers/test_subprocess_backend.py
+++ b/services/core/jobs/tests/controllers/test_subprocess_backend.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import datetime
 import os
 import sys
 import time
@@ -148,6 +149,7 @@ def test_schedule_terminates_process_when_post_popen_setup_fails(
         update = backend.schedule(step.step_spec.executor, step)
 
     assert update.status == PlatformJobStatus.ERROR
+    assert update.error_details is not None
     assert "initialize subprocess runtime" in update.error_details["message"]
     mock_terminate.assert_called_once()
     assert backend._process_registry.is_empty()
@@ -203,6 +205,46 @@ def test_sync_nonzero_exit_sets_error(mock_nmp_client, tmp_path, mock_platform_c
 
     assert update.status == PlatformJobStatus.ERROR
     assert update.error_details == {"message": "Job exited with code 7"}
+
+
+def test_sync_pausing_transitions_to_paused(mock_nmp_client, tmp_path, mock_platform_config, test_step_pausing):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(test_step_pausing, ["/bin/sh", "-c", "sleep 30"])
+
+    _schedule_without_otel_export(backend, step)
+    key = SubprocessProcessKey(step.workspace, step.job, str(step.attempt_id), step.name)
+    metadata = backend._process_registry.get(key)
+    assert metadata is not None
+
+    update = backend.sync(step)
+    assert update.status in (PlatformJobStatus.PAUSING, PlatformJobStatus.PAUSED)
+
+    metadata.process.wait(timeout=5)
+    update = backend.sync(step)
+
+    assert update.status == PlatformJobStatus.PAUSED
+    last_call = mock_nmp_client.jobs.tasks.create_or_update.call_args
+    assert last_call.kwargs["status"] == PlatformJobStatus.PAUSED.value
+
+
+def test_sync_pausing_skips_before_active_ttl(mock_nmp_client, tmp_path, mock_platform_config, test_step_pausing):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    backend._execution_profile_config.ttl_seconds_before_active = 1
+    step = _step_with_command(test_step_pausing, ["/bin/sh", "-c", "sleep 30"])
+
+    _schedule_without_otel_export(backend, step)
+    key = SubprocessProcessKey(step.workspace, step.job, str(step.attempt_id), step.name)
+    metadata = backend._process_registry.get(key)
+    assert metadata is not None
+
+    old_timestamp = step.created_at - datetime.timedelta(days=365)
+    step.created_at = old_timestamp
+    step.updated_at = old_timestamp
+
+    update = backend.sync(step)
+
+    assert update.status in (PlatformJobStatus.PAUSING, PlatformJobStatus.PAUSED)
+    assert update.error_details == {}
 
 
 def test_missing_command_fails_without_process(mock_nmp_client, tmp_path, mock_platform_config, test_step_pending):
@@ -285,6 +327,7 @@ def test_schedule_python_command_does_not_depend_on_runtime_path(
         SubprocessProcessKey(step.workspace, step.job, str(step.attempt_id), step.name)
     )
     assert metadata is not None
+    assert isinstance(metadata.process.args, list)
     assert metadata.process.args[0] == sys.executable
     assert metadata.process.wait(timeout=5) == 0
 

--- a/services/core/jobs/tests/controllers/test_subprocess_runtime.py
+++ b/services/core/jobs/tests/controllers/test_subprocess_runtime.py
@@ -122,3 +122,15 @@ def test_local_otel_logger_close_flushes_and_shuts_down():
     mock_otel_logger.emit.assert_called_once()
     mock_provider.force_flush.assert_called_once()
     mock_provider.shutdown.assert_called_once()
+
+
+def test_local_otel_logger_emits_timestamp():
+    mock_otel_logger = MagicMock()
+    mock_provider = MagicMock()
+    otel_logger = SubprocessOtelLogger(mock_otel_logger, mock_provider)
+
+    otel_logger.emit("hello", "stdout")
+
+    timestamp = mock_otel_logger.emit.call_args.kwargs["timestamp"]
+    assert isinstance(timestamp, int)
+    assert timestamp > 0


### PR DESCRIPTION
## Summary
- add a local docker buildx bake target for nmp-cpu-tasks
- add generic Makefile wrappers for load/<target> and push/<target>
- add the nmp-cpu-tasks Dockerfile used by the bake target

## Testing
- docker buildx bake --print nmp-cpu-tasks-docker
- BUILD_ARCH=linux/arm64 docker buildx bake --print nmp-cpu-tasks-docker
- BUILD_ARCH=linux/amd64 docker buildx bake --print nmp-cpu-tasks-docker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configurable image/build defaults and Makefile targets for load/push; updated .dockerignore; CI job to build/run Docker-focused E2E tests.
* **New Features**
  * New Docker bake targets and dedicated Dockerfiles for API, core, and CPU-tasks enabling single- and multi-arch image builds.
* **Documentation**
  * Docker-based quickstart for local image loading, verification, and restart.
* **Bug Fixes**
  * Improved subprocess backend handling for pausing → paused transitions.
* **Tests**
  * Expanded E2E suites covering jobs, logs, secrets, pause/resume, cancellation, and auth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->