### PR TITLE
feat(studio): external filesets readonly

### DIFF
--- a/web/packages/studio/src/components/Breadcrumbs/index.tsx
+++ b/web/packages/studio/src/components/Breadcrumbs/index.tsx
@@ -7,6 +7,9 @@ import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { FC, useMemo } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
+// Breadcrumb links navigate "up" the hierarchy, so query/hash from the current detail context is irrelevant at the parent level and only leaks state.
+const pathnameOnly = (href: string) => href.split(/[?#]/)[0];
+
 export const Breadcrumbs: FC = () => {
   const { breadcrumbs } = useBreadcrumbs();
   const { workspace } = useParams();
@@ -18,7 +21,7 @@ export const Breadcrumbs: FC = () => {
     }
     return allItems.concat(
       breadcrumbs.map(({ href = '#', slotLabel }) => ({
-        children: <Link to={href}>{slotLabel}</Link>,
+        children: <Link to={pathnameOnly(href)}>{slotLabel}</Link>,
       }))
     );
   }, [breadcrumbs, workspace]);

--- a/web/packages/studio/src/components/FilesTable/FileQuickActions/index.spec.tsx
+++ b/web/packages/studio/src/components/FilesTable/FileQuickActions/index.spec.tsx
@@ -55,7 +55,7 @@ describe('FileQuickActions', () => {
     await openMenu();
     expect(screen.getByText('Download')).toBeInTheDocument();
     expect(screen.getByText('Copy Path')).toBeInTheDocument();
-    expect(screen.getByText('Delete')).toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
     expect(screen.queryByText('Move')).not.toBeInTheDocument();
     expect(screen.queryByText('Rename')).not.toBeInTheDocument();
   });
@@ -148,7 +148,6 @@ describe('FileQuickActions', () => {
 
     expect(screen.getByText('Download')).toBeInTheDocument();
     expect(screen.getByText('Copy Path')).toBeInTheDocument();
-    expect(screen.getByText('Delete')).toBeInTheDocument();
   });
 
   it('opens the rename file modal for read/write dataset', async () => {
@@ -160,8 +159,8 @@ describe('FileQuickActions', () => {
     expect(screen.getByText('Edit File')).toBeInTheDocument();
   });
 
-  it('opens the delete file modal', async () => {
-    renderComponent();
+  it('opens the delete file modal for read/write dataset', async () => {
+    renderComponent({ isReadWriteDataset: true });
     await openMenu();
     const deleteButton = screen.getByText('Delete');
     await user.click(deleteButton);

--- a/web/packages/studio/src/components/FilesTable/FileQuickActions/index.tsx
+++ b/web/packages/studio/src/components/FilesTable/FileQuickActions/index.tsx
@@ -125,8 +125,7 @@ export const FileQuickActions: FC<Props> = ({
     : [
         ...(onViewFile ? [{ label: 'View File', onSelect: handleViewFile }] : []),
         { label: 'Download', onSelect: downloadFile, disabled: isDownloading },
-        { label: 'Copy Path', onSelect: handleCopyPath, divider: { width: 'large' } },
-        { label: 'Delete', onSelect: openModalWithFile('delete'), danger: true },
+        { label: 'Copy Path', onSelect: handleCopyPath },
       ];
 
   return (

--- a/web/packages/studio/src/components/filesets/FilesetFileExplorer/DatasetFileDropzone/index.tsx
+++ b/web/packages/studio/src/components/filesets/FilesetFileExplorer/DatasetFileDropzone/index.tsx
@@ -9,12 +9,16 @@ type DatasetFileDropzoneProps = {
   children: (openFileDialog: () => void) => ReactNode;
   onUpload?: (files: File[]) => void;
   datasetName: string;
+  /** When true, drag-drop intake and the picker are no-ops. Use for read-only
+   *  filesets where uploads would be rejected by the backend anyway. */
+  disabled?: boolean;
 };
 
 export const DatasetFileDropzone: FC<DatasetFileDropzoneProps> = ({
   children,
   onUpload,
   datasetName,
+  disabled = false,
 }) => {
   const handleDropAccepted = useCallback(
     (acceptedFiles: File[]) => {
@@ -45,6 +49,7 @@ export const DatasetFileDropzone: FC<DatasetFileDropzoneProps> = ({
     useFsAccessApi: false, // Fixes issue with react-dropzone and playwright.
     noClick: true, // Prevent clicking on the dropzone from opening file dialog
     noKeyboard: true, // Prevent keyboard events from opening file dialog
+    disabled,
   });
 
   return (

--- a/web/packages/studio/src/components/filesets/FilesetFileExplorer/index.spec.tsx
+++ b/web/packages/studio/src/components/filesets/FilesetFileExplorer/index.spec.tsx
@@ -1,11 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { FilesetOutput } from '@nemo/sdk/generated/platform/schema';
 import { FilesetFileExplorer } from '@studio/components/filesets/FilesetFileExplorer';
 import { GITKEEP_FILENAME } from '@studio/components/FilesTable/utils';
+import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import { server } from '@studio/mocks/node';
 import { render } from '@studio/tests/util/render';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
 
 vi.mock('@studio/providers/workers/useWorkers', () => ({
   useWorkers: () => ({
@@ -107,6 +111,88 @@ describe('FilesetFileExplorer', () => {
     });
 
     expect(await screen.findByText('No Files')).toBeInTheDocument();
+  });
+
+  describe('read-only gating by storage.type', () => {
+    const stubFileset = (storageType: FilesetOutput['storage']['type']): FilesetOutput =>
+      ({
+        id: 'default/test-dataset',
+        name: 'test-dataset',
+        workspace: 'default',
+        description: '',
+        purpose: 'dataset',
+        storage: { type: storageType } as FilesetOutput['storage'],
+        metadata: {},
+        custom_fields: {},
+        project: 'default',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      }) as FilesetOutput;
+
+    const stubRetrieve = (storageType: FilesetOutput['storage']['type']) => {
+      server.use(
+        http.get(`${PLATFORM_BASE_URL}/apis/files/v2/workspaces/:workspace/filesets/:name`, () =>
+          HttpResponse.json(stubFileset(storageType))
+        )
+      );
+    };
+
+    it('shows New Directory + Upload File toolbar buttons for local fileset', async () => {
+      stubRetrieve('local');
+      renderComponent({
+        filesList: [
+          { path: 'file1.txt', size: 100, file_ref: 'oid1', file_url: filesetUrl('file1.txt') },
+        ],
+      });
+      expect(await screen.findByTestId('dataset-details-new-directory-button')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Upload File' })).toBeInTheDocument();
+    });
+
+    it.each<FilesetOutput['storage']['type']>(['huggingface', 'ngc', 's3'])(
+      'hides New Directory + Upload File toolbar buttons for %s fileset',
+      async (storageType) => {
+        stubRetrieve(storageType);
+        renderComponent({
+          filesList: [
+            { path: 'file1.txt', size: 100, file_ref: 'oid1', file_url: filesetUrl('file1.txt') },
+          ],
+        });
+        // Wait for the fileset query to resolve; assert via a stable surface
+        // (search input is always present) before checking absence.
+        await screen.findByTestId('dataset-details-search-input');
+        await waitFor(() => {
+          expect(
+            screen.queryByTestId('dataset-details-new-directory-button')
+          ).not.toBeInTheDocument();
+        });
+        expect(screen.queryByRole('button', { name: 'Upload File' })).not.toBeInTheDocument();
+      }
+    );
+
+    it('shows empty-state action buttons for local fileset', async () => {
+      stubRetrieve('local');
+      renderComponent({ filesList: [] });
+      await screen.findByText('No Files');
+      // Toolbar + empty-state both expose these buttons; wait for at least
+      // one of each since they only mount after the fileset query resolves.
+      expect(
+        (await screen.findAllByRole('button', { name: 'New Directory' })).length
+      ).toBeGreaterThan(0);
+      expect(
+        (await screen.findAllByRole('button', { name: 'Upload File' })).length
+      ).toBeGreaterThan(0);
+    });
+
+    it('hides empty-state action buttons and shows read-only copy for external fileset', async () => {
+      stubRetrieve('huggingface');
+      renderComponent({ filesList: [] });
+      await screen.findByText('No Files');
+      await waitFor(() => {
+        expect(screen.getByText('This fileset is read-only.')).toBeInTheDocument();
+      });
+      expect(screen.queryByRole('button', { name: 'New Directory' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Upload File' })).not.toBeInTheDocument();
+    });
   });
 
   it('renders extraColumns: header in the table head + cell-per-file in rows', async () => {

--- a/web/packages/studio/src/components/filesets/FilesetFileExplorer/index.tsx
+++ b/web/packages/studio/src/components/filesets/FilesetFileExplorer/index.tsx
@@ -115,11 +115,18 @@ export const FilesetFileExplorer: FC<FilesetFileExplorerProps> = ({
   extraColumns,
   onFolderToggle,
 }) => {
-  // Dataset storage type: local and s3 are read/write; ngc and huggingface are read-only
+  // Only the default `local` backend is treated as mutable here. S3 supports
+  // writes in principle, but only when the linked secret carries write creds,
+  // and the FE has no way to know — defaulting to read-only avoids surfacing
+  // affordances that would 4xx at the API. HF + NGC backends raise
+  // NotImplementedError on upload/delete server-side.
+  //
+  // Follow-up: when a backend write-capability endpoint ships (e.g. nmp-2gk),
+  // swap the source of this signal from `storage.type` to the API response.
   const { data: dataset } = useFilesRetrieveFileset(workspace, datasetName, {
     query: { enabled },
   });
-  const isReadWriteDataset = dataset?.storage?.type === 'local' || dataset?.storage?.type === 's3';
+  const isReadWriteDataset = dataset?.storage?.type === 'local';
 
   // Folder navigation
   const folderContents = useDatasetNavigator(filesList, currentFolder ?? '');
@@ -431,7 +438,11 @@ export const FilesetFileExplorer: FC<FilesetFileExplorerProps> = ({
   );
 
   return (
-    <DatasetFileDropzone onUpload={handleUploadIntent} datasetName={datasetName}>
+    <DatasetFileDropzone
+      onUpload={handleUploadIntent}
+      datasetName={datasetName}
+      disabled={!isReadWriteDataset}
+    >
       {(openFileDialog) => (
         <>
           {isLoading ? (
@@ -538,18 +549,20 @@ export const FilesetFileExplorer: FC<FilesetFileExplorerProps> = ({
                       data-testid="dataset-details-search-input"
                       className="min-w-0 flex-1"
                     />
-                    <Flex gap="density-md" className="ml-auto">
-                      <Button
-                        kind="secondary"
-                        onClick={() => setNewDirectoryOpen(true)}
-                        data-testid="dataset-details-new-directory-button"
-                      >
-                        New Directory
-                      </Button>
-                      <Button kind="secondary" onClick={handleOpenUploadModal}>
-                        Upload File
-                      </Button>
-                    </Flex>
+                    {isReadWriteDataset && (
+                      <Flex gap="density-md" className="ml-auto">
+                        <Button
+                          kind="secondary"
+                          onClick={() => setNewDirectoryOpen(true)}
+                          data-testid="dataset-details-new-directory-button"
+                        >
+                          New Directory
+                        </Button>
+                        <Button kind="secondary" onClick={handleOpenUploadModal}>
+                          Upload File
+                        </Button>
+                      </Flex>
+                    )}
                   </Flex>
                 </TableToolbar>
                 {searchQuery && (
@@ -575,7 +588,7 @@ export const FilesetFileExplorer: FC<FilesetFileExplorerProps> = ({
                       emptyMessage={
                         searchQuery ? (
                           'No files match your search.'
-                        ) : (
+                        ) : isReadWriteDataset ? (
                           <>
                             Organize with folders or upload files by drag-and-drop or browsing.{' '}
                             <br /> Visit the docs for setup instructions.{' '}
@@ -587,10 +600,12 @@ export const FilesetFileExplorer: FC<FilesetFileExplorerProps> = ({
                               Documentation
                             </Anchor>
                           </>
+                        ) : (
+                          'This fileset is read-only.'
                         )
                       }
                       actions={
-                        searchQuery ? null : (
+                        searchQuery || !isReadWriteDataset ? null : (
                           <Flex gap="density-md">
                             <Button kind="secondary" onClick={() => setNewDirectoryOpen(true)}>
                               New Directory


### PR DESCRIPTION
Closes https://linear.app/nvidia/issue/ASTD-169/filesets-external-fileset-ui-updates

When browsing external Dataset or Model, we should show a "read only" UX because backend doesn't allow changes to files in external filesets. (S3 is an exception, because in that case write access depends on your credentials, but that will be handled in a later issue).

Gate all write affordances in `FilesetFileExplorer` (the fileset Files tab + side-panel browser) so
  external read-only filesets (HuggingFace, NGC, S3) no longer expose upload, create-directory, or delete
  UI that the backend would reject.

* also fixes a bug where clicking one level up in the breadcrumb carries along the query params from page you left. This cause a bug where query params used for detail page get carried over to url for list view, polluting state. Bug fix just makes breadcrumb links strip query params.

# External Fileset can't edit files

<img width="980" height="675" alt="Screenshot 2026-06-03 at 11 59 23 AM" src="https://github.com/user-attachments/assets/3c77bac8-f0c8-4331-9fc7-ef3aacc8a0a5" />


# Local Fileset can edit files

<img width="1010" height="812" alt="Screenshot 2026-06-03 at 12 00 27 PM" src="https://github.com/user-attachments/assets/7da34672-017c-46a4-a0e5-4860c2eeb910" />


  - **Redefined `isReadWriteDataset`** from `storage.type ∈ {local, s3}` → `storage.type === 'local'`. HF
  + NGC raise `NotImplementedError` server-side; S3 only writes when the linked secret carries write creds
   and the FE has no way to know — default-to-read-only until a backend write-capability endpoint lands.
  - **Gated affordances** in `FilesetFileExplorer`:
    - `DatasetFileDropzone` accepts a new `disabled` prop wired through to `react-dropzone`, suppressing
  drag-drop and the click-to-open picker.
    - Toolbar **New Directory** / **Upload File** buttons hidden when read-only.
    - Empty-state buttons hidden when read-only; copy switches to "This fileset is read-only.".
  - **Fixed a pre-existing bug** in `FileQuickActions`: the read-only branch incorrectly included
  `Delete`. Now only the read/write branch exposes it. Three stale tests updated.
  - **Fixed breadcrumb query-leak**: clicking the "Filesets" breadcrumb from a Dataset/Model detail route
  was carrying `?tab=files` (and `datasetFolder`, etc.) into the list URL. Strip `?` and `#` from all
  breadcrumb `href`s in `Breadcrumbs/index.tsx` — applies site-wide.

  ## Files

  **Modified**
  - `web/packages/studio/src/components/filesets/FilesetFileExplorer/index.tsx`
  - `web/packages/studio/src/components/filesets/FilesetFileExplorer/DatasetFileDropzone/index.tsx`
  - `web/packages/studio/src/components/FilesTable/FileQuickActions/index.tsx`
  - `web/packages/studio/src/components/Breadcrumbs/index.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumbs no longer carry query strings or hash fragments when navigating up.
  * Action menu: Delete is hidden for read-only datasets; removed visual divider after "Copy Path".
  * Fileset browsing: non-local storage is treated as read-only—upload/new-directory controls and empty-state actions hidden; read-only message shown.

* **New Features**
  * File dropzone supports an optional disabled state to disable drag-and-drop and picker.

* **Tests**
  * Added tests for storage-type read-only gating and file-action behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->