### PR TITLE
fix: show more descriptive 404 page for studio build fail

### DIFF
--- a/services/studio/src/nmp/studio/service.py
+++ b/services/studio/src/nmp/studio/service.py
@@ -269,7 +269,16 @@ class StudioService(Service[StudioConfig]):
       <p>The platform is running, but Studio cannot be served because the built web assets were not found.</p>
       <p>Requested path: <code>{escape(route)}</code></p>
       <p>Expected assets at: <code>{escape(str(static_path))}</code></p>
-      <p>Install Node.js matching <code>web/package.json</code> with pnpm, rebuild Studio, and restart services:</p>
+      <h2>Build tips</h2>
+      <p>Run these commands from the repository root.</p>
+      <p>Studio uses the Node.js and pnpm engines in <code>web/package.json</code>.</p>
+      <p>If you use nvm:</p>
+      <pre>source ~/.nvm/nvm.sh
+nvm install 22
+nvm use 22
+make bootstrap-studio
+nemo services restart</pre>
+      <p>If you use pnpm-managed Node.js:</p>
       <pre>pnpm env use --global 22.18.0
 make bootstrap-studio
 nemo services restart</pre>

--- a/services/studio/tests/unit/test_service.py
+++ b/services/studio/tests/unit/test_service.py
@@ -314,9 +314,31 @@ class TestStaticFilesPath:
 
         assert response.status_code == 503
         assert "make bootstrap-studio" in response.text
+        assert "source ~/.nvm/nvm.sh" in response.text
+        assert "nvm install 22" in response.text
         assert "pnpm env use --global 22.18.0" in response.text
+        assert "Node.js and pnpm engines" in response.text
         assert "web/package.json" in response.text
+        assert "nemo services restart" in response.text
         assert str(missing_static) in response.text
+
+    def test_missing_static_files_route_handles_main_studio_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Test that the main Studio path returns build tips when assets are missing."""
+        missing_static = tmp_path / "missing-static"
+        service = StudioService()
+        monkeypatch.setattr(service, "_get_static_files_path", lambda: missing_static)
+        app = FastAPI()
+
+        service.configure_app(app)
+
+        client = TestClient(app)
+        response = client.get("/studio")
+
+        assert response.status_code == 503
+        assert "Requested path: <code>/studio</code>" in response.text
+        assert "Build tips" in response.text
+        assert "make bootstrap-studio" in response.text
+        assert "nemo services restart" in response.text
 
     def test_static_dir_without_index_route_explains_recovery(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Test that an incomplete Studio build also returns recovery instructions."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced the fallback error page displayed when static assets are missing with detailed recovery instructions for Node.js version management and build processes.

* **Tests**
  * Updated and expanded test coverage for missing asset scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->