### PR TITLE
fix(models): extend provider discovery timeout and reduce log noise

### DIFF
--- a/docs/set-up/config-reference.md
+++ b/docs/set-up/config-reference.md
@@ -538,6 +538,10 @@ models:
     drift_recovery_base_delay_seconds: 30
     # Maximum delay in seconds between drift recovery attempts (caps exponential backoff) | default: 300
     drift_recovery_max_delay_seconds: 300
+    # Per-request timeout in seconds for GET /v1/models provider autodiscovery via the inference gateway. External providers (e.g. NVIDIA Build) can return large model lists and need longer than the SDK default. | default: 180
+    provider_discovery_timeout_seconds: 180
+    # SDK retry count for provider autodiscovery requests. The controller loop already retries on each cycle; disabling SDK retries avoids multi-minute retry storms on slow upstreams. | default: 0
+    provider_discovery_max_retries: 0
   # Parallelism estimation heuristics (model size thresholds, TP/PP/DP/CP/EP costs, balance bonuses)
   parallelism:
     # Standard node configuration (e.g., DGX H100) | default: 8

--- a/services/core/models/config/default.yaml
+++ b/services/core/models/config/default.yaml
@@ -5,6 +5,8 @@ models:
     interval_seconds: 10
     model_deployment_garbage_collection_ttl_seconds: 30
     error_deployment_ttl_seconds: 10800
+    provider_discovery_timeout_seconds: 180
+    provider_discovery_max_retries: 0
     backends:
       docker:
         enabled: true

--- a/services/core/models/src/nmp/core/models/config.py
+++ b/services/core/models/src/nmp/core/models/config.py
@@ -336,6 +336,23 @@ class ControllerConfig(BaseModel):
         description="Maximum delay in seconds between drift recovery attempts (caps exponential backoff)",
     )
 
+    provider_discovery_timeout_seconds: int = Field(
+        default=180,
+        ge=1,
+        description=(
+            "Per-request timeout in seconds for GET /v1/models provider autodiscovery via the inference gateway. "
+            "External providers (e.g. NVIDIA Build) can return large model lists and need longer than the SDK default."
+        ),
+    )
+    provider_discovery_max_retries: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "SDK retry count for provider autodiscovery requests. The controller loop already retries on "
+            "each cycle; disabling SDK retries avoids multi-minute retry storms on slow upstreams."
+        ),
+    )
+
     @field_validator("backends", mode="before")
     @classmethod
     def validate_backends(cls, v: Any) -> dict[str, BackendConfig]:

--- a/services/core/models/src/nmp/core/models/controllers/models_controller.py
+++ b/services/core/models/src/nmp/core/models/controllers/models_controller.py
@@ -71,7 +71,10 @@ class ModelsController(Controller):
             backend_registry=backend_registry,
             controller_config=models_config.controller,
         )
-        self._provider_reconciler = ModelProviderReconciler(models_sdk=self._models_sdk)
+        self._provider_reconciler = ModelProviderReconciler(
+            models_sdk=self._models_sdk,
+            controller_config=models_config.controller,
+        )
 
         logger.info("Models Controller initialized")
         logger.info(f"Available backends: {', '.join(self._backend_registry.list_backends())}")

--- a/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
@@ -25,6 +25,7 @@ from nmp.core.models.app import (
     normalize_model_entity_name,
     parse_model_name_revision,
 )
+from nmp.core.models.config import ControllerConfig
 from nmp.core.models.controllers.context import ModelContext
 from nmp.core.models.schemas import BackendFormat, ModelProviderStatus
 
@@ -277,13 +278,18 @@ class ModelProviderReconciler:
     Model Entities are created and linked appropriately.
     """
 
-    def __init__(self, models_sdk: AsyncNeMoPlatform) -> None:
+    def __init__(self, models_sdk: AsyncNeMoPlatform, controller_config: ControllerConfig) -> None:
         """Initialize the provider reconciler.
 
         Args:
             models_sdk: SDK client for Models API interactions
+            controller_config: Models controller configuration (discovery timeout/retry policy)
         """
         self._models_sdk = models_sdk
+        self._controller_config = controller_config
+        self._discovery_sdk = models_sdk.with_options(
+            max_retries=controller_config.provider_discovery_max_retries,
+        )
 
     # -------------------------------------------------------------------------
     # Public entry point
@@ -580,10 +586,11 @@ class ModelProviderReconciler:
             # This intentionally uses the controller's service principal to perform
             # infrastructure reconciliation. User-level secret access remains guarded
             # at provider create/upsert validation and by IGW when proxying requests.
-            models_response = await self._models_sdk.inference.gateway.provider.get(
+            models_response = await self._discovery_sdk.inference.gateway.provider.get(
                 "v1/models",
                 workspace=provider.workspace,
                 name=provider.name,
+                timeout=self._controller_config.provider_discovery_timeout_seconds,
             )
 
             if not isinstance(models_response, dict) or "data" not in models_response:
@@ -625,11 +632,17 @@ class ModelProviderReconciler:
                 )
                 return DiscoveryNonCompliant()
             # Other 4xx/5xx (e.g. 502 with other detail, 429, 5xx) — treat as transient
-            logger.warning(f"Failed to get models from {provider_id} via gateway: {e}")
+            logger.debug(
+                "Failed to get models from provider via gateway",
+                extra={"provider": provider_id, "error": str(e), "status_code": e.status_code},
+            )
             return DiscoveryTransientError(f"Gateway error (HTTP {e.status_code})")
         except Exception as e:
             # Network errors, timeouts, etc. — do NOT clear served_models
-            logger.warning(f"Failed to get models from {provider_id} via gateway: {e}")
+            logger.debug(
+                "Failed to get models from provider via gateway",
+                extra={"provider": provider_id, "error": str(e)},
+            )
             return DiscoveryTransientError(f"Network error: {e}")
 
     # -------------------------------------------------------------------------

--- a/services/core/models/tests/unit/controllers/test_models_controller_unit.py
+++ b/services/core/models/tests/unit/controllers/test_models_controller_unit.py
@@ -8,6 +8,7 @@ import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from nmp.core.models.config import config as models_config
 from nmp.core.models.controllers.context import ModelContext
 from nmp.core.models.controllers.models_controller import NON_TERMINAL_STATES, ModelsController
 
@@ -35,6 +36,7 @@ def test_controller_initialization(mock_sdk_class_patch, mock_get_config_patch, 
     # Verify initialization
     assert_helpers.assert_controller_initialized(controller, mock_backend_registry)
     assert_helpers.assert_sdk_initialized_correctly(mock_sdk_class_patch)
+    assert controller._provider_reconciler._controller_config is models_config.controller
 
 
 def test_step_with_no_deployments(

--- a/services/core/models/tests/unit/controllers/test_provider_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_provider_reconciler.py
@@ -78,6 +78,25 @@ def _make_discoverable_provider(
     )
 
 
+def _configure_discovery_sdk(mock_models_sdk: MagicMock) -> MagicMock:
+    """Wire mock_models_sdk.with_options to return a discovery-scoped SDK mock."""
+    discovery_sdk = MagicMock()
+    discovery_sdk.inference.gateway.provider.get = AsyncMock(
+        return_value={"object": "list", "data": [{"id": "model-1"}]}
+    )
+    mock_models_sdk.with_options = MagicMock(return_value=discovery_sdk)
+    return discovery_sdk
+
+
+def _assert_discovery_failure_logged_at_debug_not_warning(caplog) -> None:
+    """Discovery transient failures must log at DEBUG, not WARNING."""
+    assert not any(r.levelname == "WARNING" and "Failed to get models" in r.getMessage() for r in caplog.records)
+    assert any(
+        r.levelname == "DEBUG" and "Failed to get models from provider via gateway" in r.getMessage()
+        for r in caplog.records
+    )
+
+
 @pytest.fixture
 def controller_config():
     """Default controller config for provider reconciler tests."""
@@ -158,85 +177,69 @@ async def test_discover_models_passes_configured_timeout(mock_models_sdk):
     )
 
 
+@pytest.mark.parametrize(
+    ("max_retries", "expect_get_call_kwargs"),
+    [
+        (0, None),
+        (
+            2,
+            {
+                "path": "v1/models",
+                "workspace": "test-ns",
+                "name": "test-provider",
+            },
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_discover_models_uses_discovery_sdk_with_configured_retries(mock_models_sdk):
-    """Discovery SDK should be created with controller_config.provider_discovery_max_retries."""
-    discovery_sdk = MagicMock()
-    discovery_sdk.inference.gateway.provider.get = AsyncMock(
-        return_value={"object": "list", "data": [{"id": "model-1"}]}
-    )
-    mock_models_sdk.with_options = MagicMock(return_value=discovery_sdk)
-
-    config = ControllerConfig(provider_discovery_max_retries=0)
+async def test_discover_models_uses_discovery_sdk_with_configured_retries(
+    mock_models_sdk, max_retries, expect_get_call_kwargs
+):
+    """Discovery SDK should honor controller_config.provider_discovery_max_retries."""
+    discovery_sdk = _configure_discovery_sdk(mock_models_sdk)
+    config = ControllerConfig(provider_discovery_max_retries=max_retries)
     reconciler = ModelProviderReconciler(models_sdk=mock_models_sdk, controller_config=config)
 
     await reconciler._discover_models(_make_discoverable_provider())
 
-    mock_models_sdk.with_options.assert_called_once_with(max_retries=0)
-    discovery_sdk.inference.gateway.provider.get.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_discover_models_uses_discovery_sdk_with_nonzero_retries(mock_models_sdk):
-    """Discovery SDK should honor a non-zero provider_discovery_max_retries override."""
-    discovery_sdk = MagicMock()
-    discovery_sdk.inference.gateway.provider.get = AsyncMock(
-        return_value={"object": "list", "data": [{"id": "model-1"}]}
-    )
-    mock_models_sdk.with_options = MagicMock(return_value=discovery_sdk)
-
-    config = ControllerConfig(provider_discovery_max_retries=2)
-    reconciler = ModelProviderReconciler(models_sdk=mock_models_sdk, controller_config=config)
-
-    await reconciler._discover_models(_make_discoverable_provider())
-
-    mock_models_sdk.with_options.assert_called_once_with(max_retries=2)
-    discovery_sdk.inference.gateway.provider.get.assert_called_once_with(
-        "v1/models",
-        workspace="test-ns",
-        name="test-provider",
-        timeout=config.provider_discovery_timeout_seconds,
-    )
-
-
-@pytest.mark.asyncio
-async def test_discover_models_transient_http_error_logs_debug_not_warning(reconciler, mock_models_sdk, caplog):
-    """Transient gateway HTTP errors must log at debug, not warning."""
-    mock_response = MagicMock()
-    mock_response.status_code = 502
-    mock_models_sdk.inference.gateway.provider.get = AsyncMock(
-        side_effect=APIStatusError(
-            "Error code: 502 - {'detail': 'Backend networking error: Connection refused'}",
-            response=mock_response,
-            body={"detail": "Backend networking error: Connection refused"},
+    mock_models_sdk.with_options.assert_called_once_with(max_retries=max_retries)
+    if expect_get_call_kwargs is None:
+        discovery_sdk.inference.gateway.provider.get.assert_called_once()
+    else:
+        discovery_sdk.inference.gateway.provider.get.assert_called_once_with(
+            expect_get_call_kwargs["path"],
+            workspace=expect_get_call_kwargs["workspace"],
+            name=expect_get_call_kwargs["name"],
+            timeout=config.provider_discovery_timeout_seconds,
         )
-    )
-
-    with caplog.at_level(logging.DEBUG):
-        result = await reconciler._discover_models(_make_discoverable_provider())
-
-    assert isinstance(result, DiscoveryTransientError)
-    assert not any(r.levelname == "WARNING" and "Failed to get models" in r.getMessage() for r in caplog.records)
-    assert any(
-        r.levelname == "DEBUG" and "Failed to get models from provider via gateway" in r.getMessage()
-        for r in caplog.records
-    )
 
 
+@pytest.mark.parametrize(
+    "discovery_side_effect",
+    [
+        pytest.param(
+            APIStatusError(
+                "Error code: 502 - {'detail': 'Backend networking error: Connection refused'}",
+                response=MagicMock(status_code=502),
+                body={"detail": "Backend networking error: Connection refused"},
+            ),
+            id="http_502",
+        ),
+        pytest.param(Exception("Request timed out."), id="network_timeout"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_discover_models_transient_exception_logs_debug_not_warning(reconciler, mock_models_sdk, caplog):
-    """Network/timeout exceptions during discovery must log at debug, not warning."""
-    mock_models_sdk.inference.gateway.provider.get = AsyncMock(side_effect=Exception("Request timed out."))
+async def test_discover_models_transient_errors_log_debug_not_warning(
+    reconciler, mock_models_sdk, caplog, discovery_side_effect
+):
+    """Transient gateway and network failures during discovery must log at debug, not warning."""
+    mock_models_sdk.inference.gateway.provider.get = AsyncMock(side_effect=discovery_side_effect)
 
     with caplog.at_level(logging.DEBUG):
         result = await reconciler._discover_models(_make_discoverable_provider())
 
     assert isinstance(result, DiscoveryTransientError)
-    assert not any(r.levelname == "WARNING" and "Failed to get models" in r.getMessage() for r in caplog.records)
-    assert any(
-        r.levelname == "DEBUG" and "Failed to get models from provider via gateway" in r.getMessage()
-        for r in caplog.records
-    )
+    _assert_discovery_failure_logged_at_debug_not_warning(caplog)
 
 
 @pytest.mark.asyncio
@@ -1845,8 +1848,6 @@ async def test_ensure_passthrough_virtual_model_ignores_conflict_error(reconcile
 @pytest.mark.asyncio
 async def test_ensure_passthrough_virtual_model_logs_warning_on_unexpected_error(reconciler, mock_models_sdk, caplog):
     """Unexpected exceptions are logged as warnings and must not propagate."""
-    import logging
-
     mock_models_sdk.inference.virtual_models.create = AsyncMock(side_effect=RuntimeError("network timeout"))
 
     with caplog.at_level(logging.WARNING):
@@ -2051,8 +2052,6 @@ async def test_cleanup_never_deletes_user_created_virtual_model(reconciler, mock
 @pytest.mark.asyncio
 async def test_cleanup_delete_failure_is_logged_and_non_fatal(reconciler, mock_models_sdk, caplog):
     """Delete failures are swallowed so the next reconcile cycle can retry."""
-    import logging
-
     mock_models_sdk.inference.virtual_models.list = MagicMock(
         return_value=_AsyncPaginator(
             [

--- a/services/core/models/tests/unit/controllers/test_provider_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_provider_reconciler.py
@@ -3,6 +3,7 @@
 
 """Unit tests for ModelProviderReconciler."""
 
+import logging
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,6 +12,7 @@ from nemo_platform import AsyncNeMoPlatform
 from nemo_platform._exceptions import APIStatusError, ConflictError, NotFoundError
 from nemo_platform.types.inference import ServedModelMapping
 from nemo_platform.types.inference.model_provider import ModelProvider
+from nmp.core.models.config import ControllerConfig
 from nmp.core.models.controllers.context import ModelContext
 from nmp.core.models.controllers.provider_reconciler import (
     PROVIDER_ERROR_RETRY_INTERVAL_SECONDS,
@@ -57,6 +59,31 @@ def test_infer_backend_format():
     assert _infer_backend_format("my-claude-like-model") == "OPENAI_CHAT"
 
 
+def _make_discoverable_provider(
+    *,
+    name: str = "test-provider",
+    workspace: str = "test-ns",
+    host_url: str = "https://test-provider.com/v1",
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+) -> ModelProvider:
+    """Build a ModelProvider suitable for autodiscovery unit tests."""
+    now = datetime.now(timezone.utc)
+    return ModelProvider(
+        name=name,
+        workspace=workspace,
+        host_url=host_url,
+        created_at=created_at or now,
+        updated_at=updated_at or now,
+    )
+
+
+@pytest.fixture
+def controller_config():
+    """Default controller config for provider reconciler tests."""
+    return ControllerConfig()
+
+
 @pytest.fixture
 def mock_models_sdk():
     """Create a mock AsyncNeMoPlatform SDK."""
@@ -66,13 +93,15 @@ def mock_models_sdk():
     sdk.inference.virtual_models.create = AsyncMock(return_value=None)
     sdk.inference.virtual_models.delete = AsyncMock(return_value=None)
     sdk.inference.virtual_models.list = MagicMock(return_value=_AsyncPaginator([]))
+    sdk.inference.gateway.provider.get = AsyncMock()
+    sdk.with_options = MagicMock(return_value=sdk)
     return sdk
 
 
 @pytest.fixture
-def reconciler(mock_models_sdk):
+def reconciler(mock_models_sdk, controller_config):
     """Create a ModelProviderReconciler instance."""
-    return ModelProviderReconciler(models_sdk=mock_models_sdk)
+    return ModelProviderReconciler(models_sdk=mock_models_sdk, controller_config=controller_config)
 
 
 # ============================================================================
@@ -81,7 +110,7 @@ def reconciler(mock_models_sdk):
 
 
 @pytest.mark.asyncio
-async def test_get_available_models_from_provider_success(reconciler, mock_models_sdk):
+async def test_get_available_models_from_provider_success(reconciler, mock_models_sdk, controller_config):
     """Test successfully getting models from OpenAI-compliant provider."""
     mock_models_sdk.inference.gateway.provider.get = AsyncMock(
         return_value={
@@ -94,13 +123,7 @@ async def test_get_available_models_from_provider_success(reconciler, mock_model
         }
     )
 
-    model_provider = ModelProvider(
-        name="test-provider",
-        workspace="test-ns",
-        host_url="https://test-provider.com/v1",
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-    )
+    model_provider = _make_discoverable_provider()
     result = await reconciler._discover_models(model_provider)
 
     assert isinstance(result, DiscoverySuccess)
@@ -109,6 +132,110 @@ async def test_get_available_models_from_provider_success(reconciler, mock_model
         "v1/models",
         workspace="test-ns",
         name="test-provider",
+        timeout=controller_config.provider_discovery_timeout_seconds,
+    )
+    mock_models_sdk.with_options.assert_called_once_with(
+        max_retries=controller_config.provider_discovery_max_retries,
+    )
+
+
+@pytest.mark.asyncio
+async def test_discover_models_passes_configured_timeout(mock_models_sdk):
+    """Discovery should honor controller_config.provider_discovery_timeout_seconds."""
+    mock_models_sdk.inference.gateway.provider.get = AsyncMock(
+        return_value={"object": "list", "data": [{"id": "model-1"}]}
+    )
+    config = ControllerConfig(provider_discovery_timeout_seconds=240)
+    reconciler = ModelProviderReconciler(models_sdk=mock_models_sdk, controller_config=config)
+
+    await reconciler._discover_models(_make_discoverable_provider())
+
+    mock_models_sdk.inference.gateway.provider.get.assert_called_once_with(
+        "v1/models",
+        workspace="test-ns",
+        name="test-provider",
+        timeout=240,
+    )
+
+
+@pytest.mark.asyncio
+async def test_discover_models_uses_discovery_sdk_with_configured_retries(mock_models_sdk):
+    """Discovery SDK should be created with controller_config.provider_discovery_max_retries."""
+    discovery_sdk = MagicMock()
+    discovery_sdk.inference.gateway.provider.get = AsyncMock(
+        return_value={"object": "list", "data": [{"id": "model-1"}]}
+    )
+    mock_models_sdk.with_options = MagicMock(return_value=discovery_sdk)
+
+    config = ControllerConfig(provider_discovery_max_retries=0)
+    reconciler = ModelProviderReconciler(models_sdk=mock_models_sdk, controller_config=config)
+
+    await reconciler._discover_models(_make_discoverable_provider())
+
+    mock_models_sdk.with_options.assert_called_once_with(max_retries=0)
+    discovery_sdk.inference.gateway.provider.get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_discover_models_uses_discovery_sdk_with_nonzero_retries(mock_models_sdk):
+    """Discovery SDK should honor a non-zero provider_discovery_max_retries override."""
+    discovery_sdk = MagicMock()
+    discovery_sdk.inference.gateway.provider.get = AsyncMock(
+        return_value={"object": "list", "data": [{"id": "model-1"}]}
+    )
+    mock_models_sdk.with_options = MagicMock(return_value=discovery_sdk)
+
+    config = ControllerConfig(provider_discovery_max_retries=2)
+    reconciler = ModelProviderReconciler(models_sdk=mock_models_sdk, controller_config=config)
+
+    await reconciler._discover_models(_make_discoverable_provider())
+
+    mock_models_sdk.with_options.assert_called_once_with(max_retries=2)
+    discovery_sdk.inference.gateway.provider.get.assert_called_once_with(
+        "v1/models",
+        workspace="test-ns",
+        name="test-provider",
+        timeout=config.provider_discovery_timeout_seconds,
+    )
+
+
+@pytest.mark.asyncio
+async def test_discover_models_transient_http_error_logs_debug_not_warning(reconciler, mock_models_sdk, caplog):
+    """Transient gateway HTTP errors must log at debug, not warning."""
+    mock_response = MagicMock()
+    mock_response.status_code = 502
+    mock_models_sdk.inference.gateway.provider.get = AsyncMock(
+        side_effect=APIStatusError(
+            "Error code: 502 - {'detail': 'Backend networking error: Connection refused'}",
+            response=mock_response,
+            body={"detail": "Backend networking error: Connection refused"},
+        )
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        result = await reconciler._discover_models(_make_discoverable_provider())
+
+    assert isinstance(result, DiscoveryTransientError)
+    assert not any(r.levelname == "WARNING" and "Failed to get models" in r.getMessage() for r in caplog.records)
+    assert any(
+        r.levelname == "DEBUG" and "Failed to get models from provider via gateway" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_discover_models_transient_exception_logs_debug_not_warning(reconciler, mock_models_sdk, caplog):
+    """Network/timeout exceptions during discovery must log at debug, not warning."""
+    mock_models_sdk.inference.gateway.provider.get = AsyncMock(side_effect=Exception("Request timed out."))
+
+    with caplog.at_level(logging.DEBUG):
+        result = await reconciler._discover_models(_make_discoverable_provider())
+
+    assert isinstance(result, DiscoveryTransientError)
+    assert not any(r.levelname == "WARNING" and "Failed to get models" in r.getMessage() for r in caplog.records)
+    assert any(
+        r.levelname == "DEBUG" and "Failed to get models from provider via gateway" in r.getMessage()
+        for r in caplog.records
     )
 
 

--- a/services/core/models/tests/unit/test_config.py
+++ b/services/core/models/tests/unit/test_config.py
@@ -3,6 +3,7 @@
 
 """Tests for Models service configuration."""
 
+import pytest
 from nmp.common.config import Runtime
 from nmp.core.models.config import (
     ControllerConfig,
@@ -16,6 +17,7 @@ from nmp.core.models.controllers.backends.registry import (
     K8sNimOperatorBackendConfigModel,
     NoneBackendConfigModel,
 )
+from pydantic import ValidationError
 
 
 def test_models_controller_config_defaults():
@@ -243,3 +245,44 @@ def test_error_deployment_ttl_in_module_config():
     assert hasattr(config.controller, "error_deployment_ttl_seconds")
     assert isinstance(config.controller.error_deployment_ttl_seconds, int)
     assert config.controller.error_deployment_ttl_seconds > 0
+
+
+# ============================================================================
+# Provider Discovery Config Tests
+# ============================================================================
+
+
+def test_provider_discovery_timeout_default():
+    """Provider discovery timeout defaults to 180 seconds for slow external catalogs."""
+    controller_config = ControllerConfig()
+    assert controller_config.provider_discovery_timeout_seconds == 180
+
+
+def test_provider_discovery_timeout_custom_override():
+    """Provider discovery timeout can be overridden."""
+    controller_config = ControllerConfig(provider_discovery_timeout_seconds=240)
+    assert controller_config.provider_discovery_timeout_seconds == 240
+
+
+def test_provider_discovery_max_retries_default():
+    """Provider discovery disables SDK retries by default."""
+    controller_config = ControllerConfig()
+    assert controller_config.provider_discovery_max_retries == 0
+
+
+def test_provider_discovery_config_in_module_config():
+    """Module-level config exposes provider discovery settings."""
+    assert config.controller.provider_discovery_timeout_seconds == 180
+    assert config.controller.provider_discovery_max_retries == 0
+
+
+def test_provider_discovery_timeout_rejects_zero():
+    """Provider discovery timeout must be at least one second."""
+    with pytest.raises(ValidationError):
+        ControllerConfig(provider_discovery_timeout_seconds=0)
+
+
+def test_provider_discovery_max_retries_rejects_negative():
+    """Provider discovery max retries must be non-negative."""
+    with pytest.raises(ValidationError):
+        ControllerConfig(provider_discovery_max_retries=-1)


### PR DESCRIPTION
## Summary

- Adds `provider_discovery_timeout_seconds` (default 180s) and `provider_discovery_max_retries` (default 0) to `ControllerConfig` for GET `/v1/models` autodiscovery via IGW
- Wires a discovery-scoped SDK client with zero SDK retries and passes the extended per-request timeout, eliminating multi-minute retry storms on slow NVIDIA Build catalog responses
- Downgrades duplicate transient discovery failure warnings in `_discover_models` to debug (READY providers still get status-appropriate info from `_on_transient_failure`)

Fixes [NVBugs 6215676](https://nvbugspro.nvidia.com/bug/6215676) / [AIRCORE-717](https://linear.app/nvidia/issue/AIRCORE-717/nvbugs-6215676-reduce-noisyslow-nvidia-build-provider-discovery).

## Test plan

- [x] `uv run --frozen pytest services/core/models/tests/unit/controllers/test_provider_reconciler.py services/core/models/tests/unit/test_config.py services/core/models/tests/unit/controllers/test_models_controller_unit.py::test_controller_initialization -v`
- [ ] Manual: with platform running and `default/nvidia-build` registered, confirm reconciliation no longer emits multi-minute `Retrying request` spam; discovery succeeds or fails once per cycle with quieter logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout and retry settings for provider model discovery via the inference gateway, allowing tuning for slow or large external provider responses (defaults provided).

* **Documentation**
  * Updated configuration reference to document the new provider discovery settings, their intended effects, and default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->