### PR TITLE
refactor: make RAGAS output mapping explicit

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
@@ -268,11 +268,11 @@ class BaseRAGASMetric(MetricBase):
         translated_scores = {
             RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME.get(name, name): value for name, value in scores.items()
         }
-        for name in declared:
-            if name in scores:
-                translated_scores[name] = scores[name]
-
-        aligned = {name: translated_scores[name] for name in declared if name in translated_scores}
+        aligned = {
+            name: scores[name] if name in scores else translated_scores[name]
+            for name in declared
+            if name in scores or name in translated_scores
+        }
         return aligned if aligned else translated_scores
 
     def _get_llm_judge(self, client: httpx.AsyncClient | None = None) -> LangchainLLMWrapper | None:
@@ -356,14 +356,14 @@ class BaseRAGASMetric(MetricBase):
                 "RAGAS evaluate failed with parse/output error; returning NaN score",
                 extra={"error": str(error), "metric_type": self.type},
             )
-            return self._align_scores_to_output_spec(self._nan_scores_for_metrics(metrics))
+            return self._nan_scores_for_metrics(metrics)
         except (httpx.HTTPError, TimeoutError) as error:
             if self._ignore_request_failure():
                 self._log.warning(
                     "RAGAS judge inference failed and is ignored by metric policy; returning NaN score",
                     extra={"error": str(error), "metric_type": self.type},
                 )
-                return self._align_scores_to_output_spec(self._nan_scores_for_metrics(metrics))
+                return self._nan_scores_for_metrics(metrics)
             raise
         except Exception:
             raise
@@ -378,7 +378,7 @@ class BaseRAGASMetric(MetricBase):
                 "RAGAS evaluation returned no scores; returning NaN score",
                 extra={"metric_type": self.type},
             )
-            return self._align_scores_to_output_spec(self._nan_scores_for_metrics(metrics))
+            return self._nan_scores_for_metrics(metrics)
 
         invalid_score_names = _invalid_score_names(scores)
         if invalid_score_names:
@@ -389,7 +389,7 @@ class BaseRAGASMetric(MetricBase):
                     "invalid_score_names": sorted(invalid_score_names),
                 },
             )
-            return self._align_scores_to_output_spec(self._nan_scores_for_metrics(metrics))
+            return self._nan_scores_for_metrics(metrics)
 
         return self._align_scores_to_output_spec(scores)
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
@@ -53,6 +53,21 @@ DEFAULT_JUDGE_MAX_RETRIES = 3
 DEFAULT_JUDGE_MAX_WORKER = 1
 log = logging.getLogger(__name__)
 
+RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME: dict[str, str] = {
+    "agent_goal_accuracy": MetricType.AGENT_GOAL_ACCURACY.value,
+    "nv_accuracy": MetricType.ANSWER_ACCURACY.value,
+    "context_entity_recall": MetricType.CONTEXT_ENTITY_RECALL.value,
+    "context_precision": MetricType.CONTEXT_PRECISION.value,
+    "context_recall": MetricType.CONTEXT_RECALL.value,
+    "nv_context_relevance": MetricType.CONTEXT_RELEVANCE.value,
+    "faithfulness": MetricType.FAITHFULNESS.value,
+    "noise_sensitivity": MetricType.NOISE_SENSITIVITY.value,
+    "nv_response_groundedness": MetricType.RESPONSE_GROUNDEDNESS.value,
+    "answer_relevancy": MetricType.RESPONSE_RELEVANCY.value,
+    "tool_call_accuracy": MetricType.TOOL_CALL_ACCURACY.value,
+    "topic_adherence": MetricType.TOPIC_ADHERENCE.value,
+}
+
 
 # Lazy loaders for langchain classes (cached to avoid repeated imports)
 @cache
@@ -245,20 +260,20 @@ class BaseRAGASMetric(MetricBase):
         return {metric_name: float("nan") for metric_name in metric_names}
 
     def _align_scores_to_output_spec(self, scores: dict[str, float]) -> dict[str, float]:
-        """Map RAGAS internal metric keys (e.g. ``nv_accuracy``) to declared output names."""
+        """Map known RAGAS metric keys (e.g. ``nv_accuracy``) to declared output names."""
         declared = [output.name for output in self.output_spec()]
         if not declared or not scores:
             return scores
 
-        if all(name in scores for name in declared):
-            return {name: scores[name] for name in declared}
+        translated_scores = {
+            RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME.get(name, name): value for name, value in scores.items()
+        }
+        for name in declared:
+            if name in scores:
+                translated_scores[name] = scores[name]
 
-        undeclared = {name: value for name, value in scores.items() if name not in declared}
-        if len(declared) == 1 and len(undeclared) == 1:
-            return {declared[0]: next(iter(undeclared.values()))}
-
-        aligned = {name: scores[name] for name in declared if name in scores}
-        return aligned if aligned else scores
+        aligned = {name: translated_scores[name] for name in declared if name in translated_scores}
+        return aligned if aligned else translated_scores
 
     def _get_llm_judge(self, client: httpx.AsyncClient | None = None) -> LangchainLLMWrapper | None:
         """Get the LLM judge instance based on configuration."""

--- a/packages/nemo_evaluator_sdk/tests/metrics/ragas/test_ragas.py
+++ b/packages/nemo_evaluator_sdk/tests/metrics/ragas/test_ragas.py
@@ -121,10 +121,78 @@ def test_score_names_defaults_to_metric_type_value():
     assert output_names(metric) == [metric.type.value]
 
 
-def test_align_scores_maps_ragas_nv_metric_names_to_output_spec():
+@pytest.mark.parametrize(
+    "metric_class,params,ragas_score_name,sdk_score_name",
+    [
+        (
+            AgentGoalAccuracyMetric,
+            {"judge_model": MOCK_JUDGE_MODEL},
+            "agent_goal_accuracy",
+            MetricType.AGENT_GOAL_ACCURACY.value,
+        ),
+        (AnswerAccuracyMetric, {"judge_model": MOCK_JUDGE_MODEL}, "nv_accuracy", MetricType.ANSWER_ACCURACY.value),
+        (
+            ContextEntityRecallMetric,
+            {"judge_model": MOCK_JUDGE_MODEL},
+            "context_entity_recall",
+            MetricType.CONTEXT_ENTITY_RECALL.value,
+        ),
+        (
+            ContextPrecisionMetric,
+            {"judge_model": MOCK_JUDGE_MODEL},
+            "context_precision",
+            MetricType.CONTEXT_PRECISION.value,
+        ),
+        (ContextRecallMetric, {"judge_model": MOCK_JUDGE_MODEL}, "context_recall", MetricType.CONTEXT_RECALL.value),
+        (
+            ContextRelevanceMetric,
+            {"judge_model": MOCK_JUDGE_MODEL},
+            "nv_context_relevance",
+            MetricType.CONTEXT_RELEVANCE.value,
+        ),
+        (FaithfulnessMetric, {"judge_model": MOCK_JUDGE_MODEL}, "faithfulness", MetricType.FAITHFULNESS.value),
+        (
+            NoiseSensitivityMetric,
+            {"judge_model": MOCK_JUDGE_MODEL},
+            "noise_sensitivity",
+            MetricType.NOISE_SENSITIVITY.value,
+        ),
+        (
+            ResponseGroundednessMetric,
+            {"judge_model": MOCK_JUDGE_MODEL},
+            "nv_response_groundedness",
+            MetricType.RESPONSE_GROUNDEDNESS.value,
+        ),
+        (
+            ResponseRelevancyMetric,
+            {"judge_model": MOCK_JUDGE_MODEL, "embeddings_model": MOCK_EMBEDDINGS_MODEL},
+            "answer_relevancy",
+            MetricType.RESPONSE_RELEVANCY.value,
+        ),
+        (ToolCallAccuracyMetric, {}, "tool_call_accuracy", MetricType.TOOL_CALL_ACCURACY.value),
+        (
+            TopicAdherenceMetric,
+            {"metric_mode": "f1", "judge_model": MOCK_JUDGE_MODEL},
+            "topic_adherence",
+            MetricType.TOPIC_ADHERENCE.value,
+        ),
+    ],
+)
+def test_align_scores_maps_all_wrapped_ragas_metric_names_to_output_spec(
+    metric_class,
+    params,
+    ragas_score_name,
+    sdk_score_name,
+):
+    metric = metric_class(**params)
+    aligned = metric._align_scores_to_output_spec({ragas_score_name: 0.75})
+    assert aligned == {sdk_score_name: 0.75}
+
+
+def test_align_scores_does_not_guess_unknown_ragas_metric_name():
     metric = AnswerAccuracyMetric(judge_model=MOCK_JUDGE_MODEL)
-    aligned = metric._align_scores_to_output_spec({"nv_accuracy": 0.75})
-    assert aligned == {"answer_accuracy": 0.75}
+    aligned = metric._align_scores_to_output_spec({"unexpected_ragas_name": 0.75})
+    assert aligned == {"unexpected_ragas_name": 0.75}
 
 
 def test_nan_scores_use_declared_output_spec_names():
@@ -171,7 +239,7 @@ async def test_topic_adherence_metric():
     )
 
     mock_evaluate = MagicMock()
-    mock_evaluate.return_value.scores = [{"topic_relevance": 0.85}]
+    mock_evaluate.return_value.scores = [{"topic_adherence": 0.85}]
     with patch("nemo_evaluator_sdk.metrics.ragas.base.get_evaluate_function", return_value=mock_evaluate):
         result = await compute_scores(metric, MOCK_ITEM, MOCK_SAMPLE)
         assert isinstance(result, MetricResult)
@@ -408,7 +476,7 @@ def test_run_evaluate_returns_nan_on_empty_scores():
     metric = TopicAdherenceMetric(metric_mode="f1", judge_model=MOCK_JUDGE_MODEL)
 
     ragas_metric = MagicMock()
-    ragas_metric.name = "topic_relevance"
+    ragas_metric.name = "topic_adherence"
     result = MagicMock()
     result.scores = []
     mock_evaluate = MagicMock(return_value=result)
@@ -425,7 +493,7 @@ def test_run_evaluate_strict_mode_returns_nan_on_json_parse_error():
     metric = TopicAdherenceMetric(metric_mode="f1", judge_model=MOCK_JUDGE_MODEL)
 
     ragas_metric = MagicMock()
-    ragas_metric.name = "topic_relevance"
+    ragas_metric.name = "topic_adherence"
 
     mock_evaluate = MagicMock(side_effect=JSONDecodeError("invalid json", "", 0))
     with patch("nemo_evaluator_sdk.metrics.ragas.base.get_evaluate_function", return_value=mock_evaluate):
@@ -440,9 +508,9 @@ def test_run_evaluate_returns_nan_on_invalid_scores():
     metric = TopicAdherenceMetric(metric_mode="f1", judge_model=MOCK_JUDGE_MODEL)
 
     ragas_metric = MagicMock()
-    ragas_metric.name = "topic_relevance"
+    ragas_metric.name = "topic_adherence"
     result = MagicMock()
-    result.scores = [{"topic_relevance": float("nan")}]
+    result.scores = [{"topic_adherence": float("nan")}]
     mock_evaluate = MagicMock(return_value=result)
 
     with patch("nemo_evaluator_sdk.metrics.ragas.base.get_evaluate_function", return_value=mock_evaluate):
@@ -457,11 +525,11 @@ def test_run_evaluate_handles_mixed_invalid_score_types_without_typeerror():
     metric = TopicAdherenceMetric(metric_mode="f1", judge_model=MOCK_JUDGE_MODEL)
 
     result = MagicMock()
-    result.scores = [{"topic_relevance": True, "aux_score": 1, "aux_float": 0.25, "aux_string": "invalid"}]
+    result.scores = [{"topic_adherence": True, "aux_score": 1, "aux_float": 0.25, "aux_string": "invalid"}]
     mock_evaluate = MagicMock(return_value=result)
 
     ragas_metric = MagicMock()
-    ragas_metric.name = "topic_relevance"
+    ragas_metric.name = "topic_adherence"
 
     with patch("nemo_evaluator_sdk.metrics.ragas.base.get_evaluate_function", return_value=mock_evaluate):
         scores = metric._run_evaluate(dataset=MagicMock(), metrics=[ragas_metric])
@@ -474,11 +542,11 @@ def test_run_evaluate_succeeds_on_valid_scores():
     metric = TopicAdherenceMetric(metric_mode="f1", judge_model=MOCK_JUDGE_MODEL)
 
     success = MagicMock()
-    success.scores = [{"topic_relevance": 0.82}]
+    success.scores = [{"topic_adherence": 0.82}]
     mock_evaluate = MagicMock(return_value=success)
 
     ragas_metric = MagicMock()
-    ragas_metric.name = "topic_relevance"
+    ragas_metric.name = "topic_adherence"
 
     with patch("nemo_evaluator_sdk.metrics.ragas.base.get_evaluate_function", return_value=mock_evaluate):
         scores = metric._run_evaluate(dataset=MagicMock(), metrics=[ragas_metric])
@@ -493,7 +561,7 @@ def test_run_evaluate_tolerant_mode_returns_nan_on_jsondecodeerror():
     metric = TopicAdherenceMetric(metric_mode="f1", judge_model=MOCK_JUDGE_MODEL)
 
     ragas_metric = MagicMock()
-    ragas_metric.name = "topic_relevance"
+    ragas_metric.name = "topic_adherence"
     parse_error = JSONDecodeError("malformed JSON payload", "", 0)
     mock_evaluate = MagicMock(side_effect=parse_error)
 
@@ -514,7 +582,7 @@ def test_run_evaluate_inference_error_raises_when_ignore_flag_disabled():
     inference_error = httpx.ConnectError("connection failed", request=httpx.Request("POST", "https://example.com"))
     mock_evaluate = MagicMock(side_effect=inference_error)
     ragas_metric = MagicMock()
-    ragas_metric.name = "topic_relevance"
+    ragas_metric.name = "topic_adherence"
 
     with patch("nemo_evaluator_sdk.metrics.ragas.base.get_evaluate_function", return_value=mock_evaluate):
         with pytest.raises(httpx.ConnectError, match="connection failed"):
@@ -531,7 +599,7 @@ def test_run_evaluate_inference_error_returns_nan_when_ignore_flag_enabled():
     inference_error = httpx.ConnectError("connection failed", request=httpx.Request("POST", "https://example.com"))
     mock_evaluate = MagicMock(side_effect=inference_error)
     ragas_metric = MagicMock()
-    ragas_metric.name = "topic_relevance"
+    ragas_metric.name = "topic_adherence"
 
     with patch("nemo_evaluator_sdk.metrics.ragas.base.get_evaluate_function", return_value=mock_evaluate):
         scores = metric._run_evaluate(dataset=MagicMock(), metrics=[ragas_metric])
@@ -643,19 +711,18 @@ async def test_metric_result_format():
     )
 
     mock_evaluate = MagicMock()
-    mock_evaluate.return_value.scores = [{"topic_relevance": 0.85, "another_score": 0.9}]
+    mock_evaluate.return_value.scores = [{"topic_adherence": 0.85, "another_score": 0.9}]
     with patch("nemo_evaluator_sdk.metrics.ragas.base.get_evaluate_function", return_value=mock_evaluate):
         result = await compute_scores(metric, MOCK_ITEM, MOCK_SAMPLE)
 
         # MetricResult.outputs is a list of MetricOutput.
         assert isinstance(result, MetricResult)
         assert isinstance(result.outputs, list)
-        assert len(result.outputs) == 2
+        assert len(result.outputs) == 1
 
         # Check that outputs have name and value.
         score_dict = {s.name: s.value for s in result.outputs}
-        assert score_dict["topic_relevance"] == 0.85
-        assert score_dict["another_score"] == 0.9
+        assert score_dict["topic_adherence"] == 0.85
 
 
 @pytest.mark.asyncio

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/ragas/base.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/ragas/base.py
@@ -268,11 +268,11 @@ class BaseRAGASMetric(MetricBase):
         translated_scores = {
             RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME.get(name, name): value for name, value in scores.items()
         }
-        for name in declared:
-            if name in scores:
-                translated_scores[name] = scores[name]
-
-        aligned = {name: translated_scores[name] for name in declared if name in translated_scores}
+        aligned = {
+            name: scores[name] if name in scores else translated_scores[name]
+            for name in declared
+            if name in scores or name in translated_scores
+        }
         return aligned if aligned else translated_scores
 
     def _get_llm_judge(self, client: httpx.AsyncClient | None = None) -> LangchainLLMWrapper | None:
@@ -356,14 +356,14 @@ class BaseRAGASMetric(MetricBase):
                 "RAGAS evaluate failed with parse/output error; returning NaN score",
                 extra={"error": str(error), "metric_type": self.type},
             )
-            return self._align_scores_to_output_spec(self._nan_scores_for_metrics(metrics))
+            return self._nan_scores_for_metrics(metrics)
         except (httpx.HTTPError, TimeoutError) as error:
             if self._ignore_request_failure():
                 self._log.warning(
                     "RAGAS judge inference failed and is ignored by metric policy; returning NaN score",
                     extra={"error": str(error), "metric_type": self.type},
                 )
-                return self._align_scores_to_output_spec(self._nan_scores_for_metrics(metrics))
+                return self._nan_scores_for_metrics(metrics)
             raise
         except Exception:
             raise
@@ -378,7 +378,7 @@ class BaseRAGASMetric(MetricBase):
                 "RAGAS evaluation returned no scores; returning NaN score",
                 extra={"metric_type": self.type},
             )
-            return self._align_scores_to_output_spec(self._nan_scores_for_metrics(metrics))
+            return self._nan_scores_for_metrics(metrics)
 
         invalid_score_names = _invalid_score_names(scores)
         if invalid_score_names:
@@ -389,7 +389,7 @@ class BaseRAGASMetric(MetricBase):
                     "invalid_score_names": sorted(invalid_score_names),
                 },
             )
-            return self._align_scores_to_output_spec(self._nan_scores_for_metrics(metrics))
+            return self._nan_scores_for_metrics(metrics)
 
         return self._align_scores_to_output_spec(scores)
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/ragas/base.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/ragas/base.py
@@ -53,6 +53,21 @@ DEFAULT_JUDGE_MAX_RETRIES = 3
 DEFAULT_JUDGE_MAX_WORKER = 1
 log = logging.getLogger(__name__)
 
+RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME: dict[str, str] = {
+    "agent_goal_accuracy": MetricType.AGENT_GOAL_ACCURACY.value,
+    "nv_accuracy": MetricType.ANSWER_ACCURACY.value,
+    "context_entity_recall": MetricType.CONTEXT_ENTITY_RECALL.value,
+    "context_precision": MetricType.CONTEXT_PRECISION.value,
+    "context_recall": MetricType.CONTEXT_RECALL.value,
+    "nv_context_relevance": MetricType.CONTEXT_RELEVANCE.value,
+    "faithfulness": MetricType.FAITHFULNESS.value,
+    "noise_sensitivity": MetricType.NOISE_SENSITIVITY.value,
+    "nv_response_groundedness": MetricType.RESPONSE_GROUNDEDNESS.value,
+    "answer_relevancy": MetricType.RESPONSE_RELEVANCY.value,
+    "tool_call_accuracy": MetricType.TOOL_CALL_ACCURACY.value,
+    "topic_adherence": MetricType.TOPIC_ADHERENCE.value,
+}
+
 
 # Lazy loaders for langchain classes (cached to avoid repeated imports)
 @cache
@@ -245,20 +260,20 @@ class BaseRAGASMetric(MetricBase):
         return {metric_name: float("nan") for metric_name in metric_names}
 
     def _align_scores_to_output_spec(self, scores: dict[str, float]) -> dict[str, float]:
-        """Map RAGAS internal metric keys (e.g. ``nv_accuracy``) to declared output names."""
+        """Map known RAGAS metric keys (e.g. ``nv_accuracy``) to declared output names."""
         declared = [output.name for output in self.output_spec()]
         if not declared or not scores:
             return scores
 
-        if all(name in scores for name in declared):
-            return {name: scores[name] for name in declared}
+        translated_scores = {
+            RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME.get(name, name): value for name, value in scores.items()
+        }
+        for name in declared:
+            if name in scores:
+                translated_scores[name] = scores[name]
 
-        undeclared = {name: value for name, value in scores.items() if name not in declared}
-        if len(declared) == 1 and len(undeclared) == 1:
-            return {declared[0]: next(iter(undeclared.values()))}
-
-        aligned = {name: scores[name] for name in declared if name in scores}
-        return aligned if aligned else scores
+        aligned = {name: translated_scores[name] for name in declared if name in translated_scores}
+        return aligned if aligned else translated_scores
 
     def _get_llm_judge(self, client: httpx.AsyncClient | None = None) -> LangchainLLMWrapper | None:
         """Get the LLM judge instance based on configuration."""


### PR DESCRIPTION
## Summary
- Replace shape-based RAGAS output fallback with a full explicit RAGAS-to-SDK output name map.
- Mirror the adapter change into the vendored SDK copy.
- Expand RAGAS tests to cover every wrapped metric name and prove unknown names are not guessed.

## Validation
- uv run --frozen pytest packages/nemo_evaluator_sdk/tests/metrics/ragas/test_ragas.py -q
- uv run --frozen ruff check packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py packages/nemo_evaluator_sdk/tests/metrics/ragas/test_ragas.py
- git diff --check