### PR TITLE
fix(agents): wait for entities before deployment controller reconcile

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/controller.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/controller.py
@@ -32,11 +32,12 @@ Lifecycle
 
 The framework manages the reconcile loop:
 
-1. ``on_startup()`` is called once before the first reconcile cycle.
-2. ``reconcile()`` is called repeatedly at ``interval_seconds`` intervals.
+1. Declared ``dependencies`` are polled via ``/status`` until each service is ready.
+2. ``on_startup()`` is called once before the first reconcile cycle.
+3. ``reconcile()`` is called repeatedly at ``interval_seconds`` intervals.
    The default implementation calls :meth:`list_objects` once per cycle and
    :meth:`reconcile_one` for each result with per-item error isolation.
-3. On SIGINT/SIGTERM the platform sets a stop signal, waits for the current
+4. On SIGINT/SIGTERM the platform sets a stop signal, waits for the current
    ``reconcile()`` call to complete, then calls ``on_shutdown()``.
 
 Plugin authors do **not** manage signals or threads — implement cleanup in

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/CONTROLLER.md
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/CONTROLLER.md
@@ -35,6 +35,8 @@ Platform startup
     ↓
 NemoControllerAdapter wraps NemoController instance
     ↓
+Wait for each name in dependencies (poll /status until services.ready)
+    ↓
 on_startup() — load config, build entity client, initialize backends
     ↓
 Loop begins (runs every interval_seconds):

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/plugin_adapter.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/plugin_adapter.py
@@ -24,8 +24,10 @@ from collections.abc import Callable
 from fastapi import FastAPI
 from nemo_platform_plugin.controller import NemoController
 from nemo_platform_plugin.service import NemoService
+from nmp.common.config import get_platform_config
 from nmp.common.controller import Controller, Loop, TimedLoopWaiter, TrackLastExecutionTime
 from nmp.common.service import RouterConfig, Service
+from nmp.common.service.api.health import wait_for_service_ready
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +128,38 @@ class NemoControllerAdapter(Controller):
             self._loop.close()
 
 
+def _wait_for_controller_dependencies(
+    controller_cls: type[NemoController],
+    stop_signal: threading.Event,
+) -> bool:
+    """Poll until declared service dependencies are ready.
+
+    Returns False when shutdown is requested during the wait; True otherwise
+    (including when a dependency times out — the caller may proceed anyway).
+    """
+    dependencies = list(controller_cls.dependencies)
+    if not dependencies:
+        return True
+
+    platform_config = get_platform_config()
+    for dep in dependencies:
+        if wait_for_service_ready(platform_config, dep, stop_signal):
+            continue
+        if stop_signal.is_set():
+            logger.info(
+                "Shutdown requested before %r dependency %r became ready",
+                controller_cls.name,
+                dep,
+            )
+            return False
+        logger.warning(
+            "Plugin controller %r dependency %r did not become ready in time — starting anyway",
+            controller_cls.name,
+            dep,
+        )
+    return True
+
+
 def make_controller_run_func(controller_cls: type[NemoController]) -> Callable[[threading.Event], None]:
     """Return a ``run(stop_signal)`` function that drives a :class:`NemoController`.
 
@@ -136,11 +170,12 @@ def make_controller_run_func(controller_cls: type[NemoController]) -> Callable[[
     Lifecycle inside the returned function:
 
     1. Instantiate *controller_cls*.
-    2. Call ``on_startup()`` on the adapter's event loop.
-    3. Wrap in :class:`~nmp.common.controller.Loop` with a
+    2. Wait for each service in ``dependencies`` via ``wait_for_service_ready``.
+    3. Call ``on_startup()`` on the adapter's event loop.
+    4. Wrap in :class:`~nmp.common.controller.Loop` with a
        :class:`~nmp.common.controller.TimedLoopWaiter` honouring *stop_signal*.
-    4. Start the loop thread and join it (blocking until stop).
-    5. The loop's ``shutdown_func`` calls :meth:`NemoControllerAdapter.shutdown`
+    5. Start the loop thread and join it (blocking until stop).
+    6. The loop's ``shutdown_func`` calls :meth:`NemoControllerAdapter.shutdown`
        which runs ``on_shutdown()`` and closes the event loop.
 
     Args:
@@ -154,7 +189,10 @@ def make_controller_run_func(controller_cls: type[NemoController]) -> Callable[[
         controller = controller_cls()
         adapter = NemoControllerAdapter(controller)
 
-        # Run on_startup before the reconcile loop begins.
+        if not _wait_for_controller_dependencies(controller_cls, stop_signal):
+            adapter._loop.close()
+            return
+
         try:
             adapter._loop.run_until_complete(controller.on_startup())
         except Exception:

--- a/packages/nmp_platform_runner/tests/test_plugin_adapter.py
+++ b/packages/nmp_platform_runner/tests/test_plugin_adapter.py
@@ -1,10 +1,26 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+import threading
+import time
+from typing import ClassVar
+from unittest.mock import MagicMock
+
+import pytest
 from fastapi import APIRouter, Request
+from nemo_platform_plugin.controller import NemoController
 from nemo_platform_plugin.service import NemoService, RouterSpec
-from nmp.platform_runner.plugin_adapter import NemoServiceAdapter
+from nmp.platform_runner.plugin_adapter import NemoServiceAdapter, make_controller_run_func
 from starlette.responses import JSONResponse
+
+_WAIT_POLL_INTERVAL = 0.01
+_WAIT_DEADLINE_SECONDS = 2.0
+
+# Per-test observation lists (cleared by autouse fixture; avoids class-level flake under xdist).
+_list_objects_calls: list[float] = []
+_on_startup_calls: list[float] = []
 
 
 class _StubService(NemoService):
@@ -27,6 +43,63 @@ class _ServiceWithExceptionHandlers(NemoService):
         return {ValueError: handle_value_error}
 
 
+class _StubController(NemoController):
+    """Minimal controller for make_controller_run_func tests."""
+
+    name = "test-controller"
+    dependencies: ClassVar[list[str]] = []
+
+    def __init__(self) -> None:
+        self._interval_seconds = 3600.0
+
+    @property
+    def interval_seconds(self) -> float:
+        return self._interval_seconds
+
+    async def on_startup(self) -> None:
+        _on_startup_calls.append(time.monotonic())
+
+    async def list_objects(self) -> list:
+        _list_objects_calls.append(time.monotonic())
+        return []
+
+    async def reconcile_one(self, obj: object) -> None:
+        pass
+
+
+class _StubControllerWithDeps(_StubController):
+    dependencies: ClassVar[list[str]] = ["entities"]
+
+
+@pytest.fixture(autouse=True)
+def _clear_stub_controller_call_history() -> None:
+    _list_objects_calls.clear()
+    _on_startup_calls.clear()
+
+
+@pytest.fixture
+def patch_get_platform_config(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_config = MagicMock()
+    monkeypatch.setattr(
+        "nmp.platform_runner.plugin_adapter.get_platform_config",
+        MagicMock(return_value=mock_config),
+    )
+    return mock_config
+
+
+def _run_controller_until_list_objects(
+    controller_cls: type[NemoController],
+    stop_signal: threading.Event,
+) -> threading.Thread:
+    run_func = make_controller_run_func(controller_cls)
+    thread = threading.Thread(target=run_func, args=(stop_signal,), daemon=True)
+    thread.start()
+    deadline = time.monotonic() + _WAIT_DEADLINE_SECONDS
+    while time.monotonic() < deadline and not _list_objects_calls:
+        time.sleep(_WAIT_POLL_INTERVAL)
+    return thread
+
+
 def test_adapter_without_exception_handlers():
     adapter = NemoServiceAdapter(_StubService())
     app = adapter.create_app()
@@ -37,3 +110,105 @@ def test_adapter_registers_exception_handlers():
     adapter = NemoServiceAdapter(_ServiceWithExceptionHandlers())
     app = adapter.create_app()
     assert ValueError in app.exception_handlers
+
+
+@pytest.mark.usefixtures("patch_get_platform_config")
+def test_controller_waits_for_dependencies_before_on_startup_and_reconcile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """on_startup and reconcile must not run until wait_for_service_ready returns True."""
+    wait_started = threading.Event()
+    wait_can_proceed = threading.Event()
+
+    def mock_wait(_config, service_name, _stop_signal, timeout=60.0, poll_interval=0.5):
+        assert service_name == "entities"
+        wait_started.set()
+        return wait_can_proceed.wait(timeout=_WAIT_DEADLINE_SECONDS)
+
+    monkeypatch.setattr(
+        "nmp.platform_runner.plugin_adapter.wait_for_service_ready",
+        mock_wait,
+    )
+
+    stop_signal = threading.Event()
+    run_func = make_controller_run_func(_StubControllerWithDeps)
+    thread = threading.Thread(target=run_func, args=(stop_signal,), daemon=True)
+    thread.start()
+
+    assert wait_started.wait(timeout=_WAIT_DEADLINE_SECONDS)
+    assert _on_startup_calls == []
+    assert _list_objects_calls == []
+
+    wait_can_proceed.set()
+    deadline = time.monotonic() + _WAIT_DEADLINE_SECONDS
+    while time.monotonic() < deadline and not _on_startup_calls:
+        time.sleep(_WAIT_POLL_INTERVAL)
+    assert _on_startup_calls
+
+    deadline = time.monotonic() + _WAIT_DEADLINE_SECONDS
+    while time.monotonic() < deadline and not _list_objects_calls:
+        time.sleep(_WAIT_POLL_INTERVAL)
+    assert _list_objects_calls
+
+    stop_signal.set()
+    thread.join(timeout=_WAIT_DEADLINE_SECONDS)
+
+
+@pytest.mark.usefixtures("patch_get_platform_config")
+def test_controller_exits_early_on_stop_during_dependency_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When stop_signal is set during dependency wait, reconcile must not run."""
+
+    def mock_wait(_config, _service_name, stop_signal, timeout=60.0, poll_interval=0.5):
+        stop_signal.set()
+        return False
+
+    monkeypatch.setattr(
+        "nmp.platform_runner.plugin_adapter.wait_for_service_ready",
+        mock_wait,
+    )
+
+    stop_signal = threading.Event()
+    run_func = make_controller_run_func(_StubControllerWithDeps)
+    run_func(stop_signal)
+
+    assert _on_startup_calls == []
+    assert _list_objects_calls == []
+
+
+@pytest.mark.usefixtures("patch_get_platform_config")
+def test_controller_starts_after_dependency_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a dependency times out without shutdown, reconcile still starts."""
+    monkeypatch.setattr(
+        "nmp.platform_runner.plugin_adapter.wait_for_service_ready",
+        lambda *_args, **_kwargs: False,
+    )
+
+    stop_signal = threading.Event()
+    thread = _run_controller_until_list_objects(_StubControllerWithDeps, stop_signal)
+
+    stop_signal.set()
+    thread.join(timeout=_WAIT_DEADLINE_SECONDS)
+
+    assert _list_objects_calls
+
+
+def test_controller_skips_wait_when_no_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Controllers with empty dependencies must not call wait_for_service_ready."""
+    mock_wait = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "nmp.platform_runner.plugin_adapter.wait_for_service_ready",
+        mock_wait,
+    )
+
+    stop_signal = threading.Event()
+    thread = _run_controller_until_list_objects(_StubController, stop_signal)
+
+    stop_signal.set()
+    thread.join(timeout=_WAIT_DEADLINE_SECONDS)
+
+    mock_wait.assert_not_called()
+    assert _list_objects_calls

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import cast
+from typing import ClassVar, cast
 
 from nemo_agents_plugin.config import ControllerConfig
 from nemo_agents_plugin.entities import AgentDeployment
@@ -50,6 +50,7 @@ class AgentDeploymentController(NemoController):
     """
 
     name = "agents-deployment"
+    dependencies: ClassVar[list[str]] = ["entities"]
 
     def __init__(self) -> None:
         self._backend: RunnerBackend | None = None

--- a/plugins/nemo-agents/tests/unit/test_runner_controller.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_controller.py
@@ -27,6 +27,10 @@ from nemo_agents_plugin.runner.backend import DeploymentInfo
 from nemo_agents_plugin.runner.controller import AgentDeploymentController
 
 
+def test_agent_deployment_controller_declares_entities_dependency() -> None:
+    assert AgentDeploymentController.dependencies == ["entities"]
+
+
 def _make_controller() -> tuple[AgentDeploymentController, Any]:
     """Build a controller with stubbed backend / entities / save.
 


### PR DESCRIPTION
## Summary

- Enforce `NemoController.dependencies` in `make_controller_run_func` by polling `/status` via `wait_for_service_ready` before `on_startup()` and the reconcile loop.
- Declare `dependencies = ["entities"]` on `AgentDeploymentController` so the agents deployment controller does not call the entities API before the platform is listening.

Fixes noisy `httpx.ConnectError` tracebacks during `nemo services run` / setup when `controller-plugin-agents-deployment` reconciles before uvicorn is ready ([AIRCORE-720](https://linear.app/nvidia/issue/AIRCORE-720/agents-deployment-controller-hits-entities-api-before-platform-is)).

## Test plan

- [x] `uv run --frozen pytest packages/nmp_platform_runner/tests/test_plugin_adapter.py plugins/nemo-agents/tests/unit/test_runner_controller.py -v`
- [ ] Manual: `nemo services run` — confirm no `ConnectError` traceback from `agents-deployment` during startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Controllers now wait for declared platform dependencies to become ready before running, and can abort startup if shutdown is requested during that wait.
  * Agent deployment controller now declares an "entities" dependency.

* **Documentation**
  * Controller lifecycle docs updated to show the dependency-readiness step before startup.

* **Tests**
  * Added tests covering dependency-wait behavior, timeouts, early exit on shutdown, and controllers with no dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->