### PR TITLE
feat(cli): add nemo services rm/prune for ghost instance cleanup

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -108,7 +108,9 @@ nemo services [OPTIONS] COMMAND [ARGS]...
 * `stop`: Stop running platform services.
 * `restart`: Restart platform services.
 * `status`: Show status of the platform services instance for this...
-* `ls`: List all known service instances on this host.
+* `ls`: List service instances on this host.
+* `rm`: Remove a stopped instance record and its logs.
+* `prune`: Remove all stopped instance records on this host.
 * `logs`: Show or locate the service log file.
 
 #### nemo services run
@@ -262,13 +264,87 @@ nemo services status [OPTIONS]
 
 #### nemo services ls
 
-List all known service instances on this host.
+List service instances on this host.
+
+By default shows running instances only.  Use ``--all`` to include stopped
+records that still have logs on disk.
+
+**Examples:**
+
+```shell
+nemo services ls
+nemo services ls --all
+```
 
 **Usage:**
 
 ```shell
 nemo services ls [OPTIONS]
 ```
+
+**Options:**
+
+* `--all, -a`: Include stopped instance records (like docker ps -a).
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+#### nemo services rm
+
+Remove a stopped instance record and its logs.
+
+The scope must match a row from ``nemo services ls --all``.  Running
+instances are refused; stop them first.
+
+**Examples:**
+
+```shell
+nemo services rm abc12345-8080
+nemo services rm --instance abc12345-8080
+```
+
+**Usage:**
+
+```shell
+nemo services rm [OPTIONS] [SCOPE]
+```
+
+**Arguments:**
+
+* `<SCOPE>`: Instance scope from 'nemo services ls --all'.
+
+**Options:**
+
+* `--instance`: Instance scope (alternative to positional argument).
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+#### nemo services prune
+
+Remove all stopped instance records on this host.
+
+Stopped records may include service logs from prior runs.  Logs are
+deleted with the instance directory.
+
+**Examples:**
+
+```shell
+nemo services prune
+nemo services prune --force
+```
+
+**Usage:**
+
+```shell
+nemo services prune [OPTIONS]
+```
+
+**Options:**
+
+* `--force`: Remove without confirmation.
 
 **Help:**
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -109,8 +109,8 @@ nemo services [OPTIONS] COMMAND [ARGS]...
 * `restart`: Restart platform services.
 * `status`: Show status of the platform services instance for this...
 * `ls`: List service instances on this host.
-* `rm`: Remove a stopped instance record and its logs.
-* `prune`: Remove all stopped instance records on this host.
+* `rm`: Remove a stopped instance directory and its logs.
+* `prune`: Remove all stopped instance directories on this host.
 * `logs`: Show or locate the service log file.
 
 #### nemo services run
@@ -267,7 +267,7 @@ nemo services status [OPTIONS]
 List service instances on this host.
 
 By default shows running instances only.  Use ``--all`` to include stopped
-records that still have logs on disk.
+instance directories that still have logs on disk.
 
 **Examples:**
 
@@ -284,7 +284,7 @@ nemo services ls [OPTIONS]
 
 **Options:**
 
-* `--all, -a`: Include stopped instance records (like docker ps -a).
+* `--all, -a`: Include stopped instance directories (like docker ps -a).
 
 **Help:**
 
@@ -292,10 +292,14 @@ nemo services ls [OPTIONS]
 
 #### nemo services rm
 
-Remove a stopped instance record and its logs.
+Remove a stopped instance directory and its logs.
 
 The scope must match a row from ``nemo services ls --all``.  Running
 instances are refused; stop them first.
+
+Unlike ``run``/``start``, ``--instance`` on ``rm`` does not derive a scope
+from cwd and port — pass the exact scope string from ``ls --all``, either
+as the ``SCOPE`` positional or via ``--instance``.
 
 **Examples:**
 
@@ -316,7 +320,7 @@ nemo services rm [OPTIONS] [SCOPE]
 
 **Options:**
 
-* `--instance`: Instance scope (alternative to positional argument).
+* `--instance`: Scope from ``nemo services ls --all`` (same value as the ``SCOPE`` positional).
 
 **Help:**
 
@@ -324,9 +328,9 @@ nemo services rm [OPTIONS] [SCOPE]
 
 #### nemo services prune
 
-Remove all stopped instance records on this host.
+Remove all stopped instance directories on this host.
 
-Stopped records may include service logs from prior runs.  Logs are
+Stopped instance directories may include service logs from prior runs.  Logs are
 deleted with the instance directory.
 
 **Examples:**

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -297,9 +297,8 @@ Remove a stopped instance directory and its logs.
 The scope must match a row from ``nemo services ls --all``.  Running
 instances are refused; stop them first.
 
-Unlike ``run``/``start``, ``--instance`` on ``rm`` does not derive a scope
-from cwd and port — pass the exact scope string from ``ls --all``, either
-as the ``SCOPE`` positional or via ``--instance``.
+Unlike ``run``/``start``, ``--instance`` here does not derive a scope from
+cwd and port — it is an alternate spelling for the ``SCOPE`` argument.
 
 **Examples:**
 
@@ -320,7 +319,7 @@ nemo services rm [OPTIONS] [SCOPE]
 
 **Options:**
 
-* `--instance`: Scope from ``nemo services ls --all`` (same value as the ``SCOPE`` positional).
+* `--instance`: Scope from 'nemo services ls --all' (same value as the SCOPE positional).
 
 **Help:**
 

--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -203,7 +203,22 @@ nemo services run
 ### Managing services
 
 ```bash
+nemo services ls              # running instances only
+nemo services ls --all        # include stopped records (with logs on disk)
+nemo services rm <scope>      # remove one stopped instance record
+nemo services prune           # remove all stopped instance records
 curl -s http://localhost:8080/health/ready   # check if running
-cat ~/.local/state/nmp/instances/<scope>/services.log                 # view service output
-pkill -f "nemo services run"           # stop all services
+cat ~/.local/state/nmp/instances/<scope>/services.log   # view service output
+nemo services stop            # stop the running instance for this scope
+```
+
+### Stopped instance records cluttering `ls --all`
+
+After stopping or crashing local services, stopped scope directories can remain under `~/.local/state/nmp/instances/<scope>/`. Empty lock-only ghosts are cleaned automatically; records with service logs stay until you remove them:
+
+```bash
+nemo services ls --all        # see stopped scopes
+nemo services logs --instance <scope>   # inspect logs before removing
+nemo services rm <scope>      # remove one stopped record
+nemo services prune           # remove all stopped records
 ```

--- a/docs/get-started/setup.md
+++ b/docs/get-started/setup.md
@@ -204,21 +204,21 @@ nemo services run
 
 ```bash
 nemo services ls              # running instances only
-nemo services ls --all        # include stopped records (with logs on disk)
-nemo services rm <scope>      # remove one stopped instance record
-nemo services prune           # remove all stopped instance records
+nemo services ls --all        # include stopped instance directories (with logs on disk)
+nemo services rm <scope>      # remove one stopped instance directory
+nemo services prune           # remove all stopped instance directories
 curl -s http://localhost:8080/health/ready   # check if running
 cat ~/.local/state/nmp/instances/<scope>/services.log   # view service output
 nemo services stop            # stop the running instance for this scope
 ```
 
-### Stopped instance records cluttering `ls --all`
+### Stopped instance directories cluttering `ls --all`
 
-After stopping or crashing local services, stopped scope directories can remain under `~/.local/state/nmp/instances/<scope>/`. Empty lock-only ghosts are cleaned automatically; records with service logs stay until you remove them:
+After stopping or crashing local services, stopped scope directories can remain under `~/.local/state/nmp/instances/<scope>/`. Empty lock-only ghosts are cleaned automatically; directories with service logs stay until you remove them:
 
 ```bash
 nemo services ls --all        # see stopped scopes
 nemo services logs --instance <scope>   # inspect logs before removing
-nemo services rm <scope>      # remove one stopped record
-nemo services prune           # remove all stopped records
+nemo services rm <scope>      # remove one stopped instance directory
+nemo services prune           # remove all stopped instance directories
 ```

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/_process.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/_process.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import signal
 import socket
 import subprocess
@@ -174,6 +175,16 @@ class ForegroundInstanceError(Exception):
         super().__init__(
             f"Instance '{scope}' (pid {pid}) is running in the foreground. "
             "Use Ctrl-C in its terminal to stop it, or pass --force."
+        )
+
+
+class InstanceStillRunningError(Exception):
+    """Raised when ``rm`` targets a live instance."""
+
+    def __init__(self, scope: str) -> None:
+        self.scope = scope
+        super().__init__(
+            f"Instance '{scope}' is still running. Stop it first with: nemo services stop --instance {scope}"
         )
 
 
@@ -339,6 +350,46 @@ def remove_descriptor(scope: str, *, base_dir: Path | None = None) -> None:
         logger.debug("Could not remove descriptor %s", path, exc_info=True)
 
 
+def _scope_dir(scope: str, *, base_dir: Path | None = None) -> Path:
+    return _instances_dir(base_dir=base_dir) / _validate_scope(scope)
+
+
+def _is_log_file(path: Path) -> bool:
+    return path.name == LOG_FILENAME or path.name.startswith(f"{LOG_FILENAME}.")
+
+
+def _iter_log_files(scope_dir: Path):
+    if not scope_dir.is_dir():
+        return
+    for path in scope_dir.iterdir():
+        if path.is_file() and _is_log_file(path):
+            yield path
+
+
+def _has_preservable_logs(scope_dir: Path) -> bool:
+    """Return True if *scope_dir* contains non-empty service log files."""
+    return any(path.stat().st_size > 0 for path in _iter_log_files(scope_dir))
+
+
+def is_removable_ghost(
+    scope: str,
+    *,
+    base_dir: Path | None = None,
+    descriptor: InstanceDescriptor | None = None,
+) -> bool:
+    """True when a dead scope dir has no descriptor and no non-empty logs."""
+    if is_instance_alive(scope, base_dir=base_dir):
+        return False
+    if descriptor is not None:
+        return False
+    scope_dir = _scope_dir(scope, base_dir=base_dir)
+    if not scope_dir.is_dir():
+        return False
+    if (scope_dir / DESCRIPTOR_FILENAME).exists():
+        return False
+    return not _has_preservable_logs(scope_dir)
+
+
 # ---------------------------------------------------------------------------
 # PID validation via psutil
 # ---------------------------------------------------------------------------
@@ -376,8 +427,9 @@ class InstanceInfo:
 def list_instances(*, base_dir: Path | None = None) -> list[InstanceInfo]:
     """Scan all instance directories and return their status.
 
-    Side effect: removes stale descriptors for dead instances so that
-    subsequent calls (and ``ls`` output) don't show ghost entries.
+    Side effects:
+    - Removes stale descriptors for dead instances.
+    - Silently removes empty ghost directories (dead, no descriptor, no logs).
     """
     idir = _instances_dir(base_dir=base_dir)
     if not idir.exists():
@@ -392,8 +444,50 @@ def list_instances(*, base_dir: Path | None = None) -> list[InstanceInfo]:
         if not alive and desc is not None:
             remove_descriptor(scope, base_dir=base_dir)
             desc = None
+        if is_removable_ghost(scope, base_dir=base_dir, descriptor=desc):
+            try:
+                shutil.rmtree(child)
+            except OSError:
+                logger.debug("Could not remove ghost instance dir %s", child, exc_info=True)
+            else:
+                continue
         results.append(InstanceInfo(scope=scope, alive=alive, descriptor=desc))
     return results
+
+
+def remove_instance(scope: str, *, base_dir: Path | None = None) -> bool:
+    """Remove an instance scope directory.
+
+    Returns False if the scope did not exist or could not be removed.
+    """
+    scope = _validate_scope(scope)
+    if is_instance_alive(scope, base_dir=base_dir):
+        raise InstanceStillRunningError(scope)
+    scope_dir = _scope_dir(scope, base_dir=base_dir)
+    if not scope_dir.is_dir():
+        return False
+    with contextlib.suppress(OSError):
+        shutil.rmtree(scope_dir)
+    return not scope_dir.is_dir()
+
+
+def list_stopped_scopes(*, base_dir: Path | None = None) -> list[str]:
+    """Return scope names for instances that are not alive."""
+    return [info.scope for info in list_instances(base_dir=base_dir) if not info.alive]
+
+
+def prune_instances(*, base_dir: Path | None = None) -> list[str]:
+    """Remove all stopped instance directories.  Returns removed scope names."""
+    removed: list[str] = []
+    for scope in list_stopped_scopes(base_dir=base_dir):
+        if remove_instance(scope, base_dir=base_dir):
+            removed.append(scope)
+    return removed
+
+
+def instance_log_bytes(scope: str, *, base_dir: Path | None = None) -> int:
+    """Total bytes across ``services.log`` and rotated logs for *scope*."""
+    return sum(path.stat().st_size for path in _iter_log_files(_scope_dir(scope, base_dir=base_dir)))
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
@@ -17,17 +17,22 @@ from nemo_platform_ext.cli.commands.services._process import (
     ForegroundInstanceError,
     InstanceAlreadyRunningError,
     InstanceDescriptor,
+    InstanceInfo,
+    InstanceStillRunningError,
     PortConflict,
     acquire_lock,
     check_port_available_for_start,
     compute_scope,
     format_port_conflict,
     get_create_time,
+    instance_log_bytes,
     is_instance_alive,
     list_instances,
     log_path_for,
+    prune_instances,
     read_descriptor,
     remove_descriptor,
+    remove_instance,
     start_background,
     stop_instance,
     write_descriptor,
@@ -437,6 +442,7 @@ def stop_services_cmd(
         noun = "process" if n == 1 else "processes"
         msg += f" and {n} child {noun}"
     typer.echo(msg)
+    typer.echo(f"Instance record kept (logs preserved). Remove with: nemo services rm {scope}")
 
 
 # ---------------------------------------------------------------------------
@@ -646,22 +652,13 @@ def status_services(
         typer.echo(f"Log:      {log}")
 
 
-# ---------------------------------------------------------------------------
-# ls (list instances)
-# ---------------------------------------------------------------------------
+def _format_log_size(num_bytes: int) -> str:
+    if num_bytes < 1024:
+        return f"{num_bytes}B"
+    return f"{num_bytes / 1024:.1f}KB"
 
 
-@services_app.command("ls")
-def ls_services() -> None:
-    """List all known service instances on this host."""
-    base_dir_str = _effective_base_dir()
-    base_dir = Path(base_dir_str) if base_dir_str else None
-
-    instances = list_instances(base_dir=base_dir)
-    if not instances:
-        typer.echo("No instances found.")
-        return
-
+def _print_instance_table(instances: list[InstanceInfo]) -> None:
     typer.echo(f"{'SCOPE':<25} {'STATUS':<10} {'PID':<10} {'ADDRESS':<25} {'MODE':<12}")
     for info in instances:
         status = "running" if info.alive else "stopped"
@@ -669,6 +666,167 @@ def ls_services() -> None:
         addr = f"{info.descriptor.host}:{info.descriptor.port}" if info.descriptor else "-"
         mode = info.descriptor.mode if info.descriptor else "-"
         typer.echo(f"{info.scope:<25} {status:<10} {pid:<10} {addr:<25} {mode:<12}")
+
+
+def _resolve_rm_scope(scope: str | None, instance: str | None) -> str:
+    effective_scope = scope or instance
+    if effective_scope is None:
+        typer.echo("Scope required. Usage: nemo services rm <scope>", err=True)
+        raise typer.Exit(1)
+    if scope is not None and instance is not None and scope != instance:
+        raise typer.BadParameter("Cannot pass different values for SCOPE and --instance.")
+    return effective_scope
+
+
+# ---------------------------------------------------------------------------
+# ls (list instances)
+# ---------------------------------------------------------------------------
+
+
+@services_app.command("ls")
+def ls_services(
+    show_all: Annotated[
+        bool,
+        typer.Option("--all", "-a", help="Include stopped instance records (like docker ps -a)."),
+    ] = False,
+) -> None:
+    """List service instances on this host.
+
+    By default shows running instances only.  Use ``--all`` to include stopped
+    records that still have logs on disk.
+
+    Examples:
+      nemo services ls
+      nemo services ls --all
+    """
+    base_dir_str = _effective_base_dir()
+    base_dir = Path(base_dir_str) if base_dir_str else None
+
+    instances = list_instances(base_dir=base_dir)
+    if show_all:
+        visible = instances
+        if not visible:
+            typer.echo("No instances found.")
+            return
+        _print_instance_table(visible)
+        stopped = [info for info in visible if not info.alive]
+        if stopped:
+            typer.echo(
+                f"\n{len(stopped)} stopped instance(s). "
+                "Remove with: nemo services prune  (or: nemo services rm <scope>)"
+            )
+        return
+
+    running = [info for info in instances if info.alive]
+    if not running:
+        stopped_count = sum(1 for info in instances if not info.alive)
+        if stopped_count:
+            typer.echo("No running instances.")
+            typer.echo(
+                f"{stopped_count} stopped instance(s) on disk. "
+                "List with: nemo services ls --all  |  Remove with: nemo services prune"
+            )
+        else:
+            typer.echo("No running instances.")
+        return
+
+    _print_instance_table(running)
+
+
+# ---------------------------------------------------------------------------
+# rm (remove stopped instance record)
+# ---------------------------------------------------------------------------
+
+
+@services_app.command("rm")
+def rm_services(
+    scope: Annotated[
+        str | None,
+        typer.Argument(help="Instance scope from 'nemo services ls --all'."),
+    ] = None,
+    instance: Annotated[
+        str | None,
+        typer.Option("--instance", help="Instance scope (alternative to positional argument)."),
+    ] = None,
+) -> None:
+    """Remove a stopped instance record and its logs.
+
+    The scope must match a row from ``nemo services ls --all``.  Running
+    instances are refused; stop them first.
+
+    Examples:
+      nemo services rm abc12345-8080
+      nemo services rm --instance abc12345-8080
+    """
+    effective_scope = _resolve_rm_scope(scope, instance)
+    base_dir_str = _effective_base_dir()
+    base_dir = Path(base_dir_str) if base_dir_str else None
+
+    try:
+        removed = remove_instance(effective_scope, base_dir=base_dir)
+    except InstanceStillRunningError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from None
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from None
+
+    if not removed:
+        typer.echo(f"No instance record found for scope '{effective_scope}'.", err=True)
+        raise typer.Exit(1)
+    typer.echo(f"Removed instance '{effective_scope}'.")
+
+
+# ---------------------------------------------------------------------------
+# prune (remove all stopped instance records)
+# ---------------------------------------------------------------------------
+
+
+@services_app.command("prune")
+def prune_services(
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Remove without confirmation."),
+    ] = False,
+) -> None:
+    """Remove all stopped instance records on this host.
+
+    Stopped records may include service logs from prior runs.  Logs are
+    deleted with the instance directory.
+
+    Examples:
+      nemo services prune
+      nemo services prune --force
+    """
+    base_dir_str = _effective_base_dir()
+    base_dir = Path(base_dir_str) if base_dir_str else None
+
+    stopped = [info for info in list_instances(base_dir=base_dir) if not info.alive]
+    if not stopped:
+        typer.echo("No stopped instances to remove.")
+        return
+
+    typer.echo("The following stopped instance(s) will be removed:")
+    for info in stopped:
+        log_bytes = instance_log_bytes(info.scope, base_dir=base_dir)
+        if log_bytes:
+            typer.echo(f"  {info.scope}  (logs: {_format_log_size(log_bytes)})")
+        else:
+            typer.echo(f"  {info.scope}  (no logs)")
+
+    if not force and not typer.confirm("Remove stopped instances?", default=False):
+        typer.echo("Prune cancelled.")
+        return
+
+    removed = prune_instances(base_dir=base_dir)
+    if not removed:
+        typer.echo("No stopped instances to remove.")
+        return
+    if len(removed) == 1:
+        typer.echo(f"Removed stopped instance: {removed[0]}")
+    else:
+        scopes = ", ".join(removed)
+        typer.echo(f"Removed {len(removed)} stopped instance(s): {scopes}")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
@@ -442,7 +442,7 @@ def stop_services_cmd(
         noun = "process" if n == 1 else "processes"
         msg += f" and {n} child {noun}"
     typer.echo(msg)
-    typer.echo(f"Instance record kept (logs preserved). Remove with: nemo services rm {scope}")
+    typer.echo(f"Instance directory kept (logs preserved). Remove with: nemo services rm {scope}")
 
 
 # ---------------------------------------------------------------------------
@@ -662,9 +662,11 @@ def _print_instance_table(instances: list[InstanceInfo]) -> None:
     typer.echo(f"{'SCOPE':<25} {'STATUS':<10} {'PID':<10} {'ADDRESS':<25} {'MODE':<12}")
     for info in instances:
         status = "running" if info.alive else "stopped"
-        pid = str(info.descriptor.pid) if info.descriptor else "-"
-        addr = f"{info.descriptor.host}:{info.descriptor.port}" if info.descriptor else "-"
-        mode = info.descriptor.mode if info.descriptor else "-"
+        pid = addr = mode = "-"
+        if info.descriptor:
+            pid = str(info.descriptor.pid)
+            addr = f"{info.descriptor.host}:{info.descriptor.port}"
+            mode = info.descriptor.mode
         typer.echo(f"{info.scope:<25} {status:<10} {pid:<10} {addr:<25} {mode:<12}")
 
 
@@ -687,13 +689,13 @@ def _resolve_rm_scope(scope: str | None, instance: str | None) -> str:
 def ls_services(
     show_all: Annotated[
         bool,
-        typer.Option("--all", "-a", help="Include stopped instance records (like docker ps -a)."),
+        typer.Option("--all", "-a", help="Include stopped instance directories (like docker ps -a)."),
     ] = False,
 ) -> None:
     """List service instances on this host.
 
     By default shows running instances only.  Use ``--all`` to include stopped
-    records that still have logs on disk.
+    instance directories that still have logs on disk.
 
     Examples:
       nemo services ls
@@ -711,10 +713,8 @@ def ls_services(
         _print_instance_table(visible)
         stopped = [info for info in visible if not info.alive]
         if stopped:
-            typer.echo(
-                f"\n{len(stopped)} stopped instance(s). "
-                "Remove with: nemo services prune  (or: nemo services rm <scope>)"
-            )
+            noun = "stopped instance directory" if len(stopped) == 1 else "stopped instance directories"
+            typer.echo(f"\n{len(stopped)} {noun}. Remove with: nemo services prune  (or: nemo services rm <scope>)")
         return
 
     running = [info for info in instances if info.alive]
@@ -722,8 +722,9 @@ def ls_services(
         stopped_count = sum(1 for info in instances if not info.alive)
         if stopped_count:
             typer.echo("No running instances.")
+            noun = "stopped instance directory" if stopped_count == 1 else "stopped instance directories"
             typer.echo(
-                f"{stopped_count} stopped instance(s) on disk. "
+                f"{stopped_count} {noun} on disk. "
                 "List with: nemo services ls --all  |  Remove with: nemo services prune"
             )
         else:
@@ -734,7 +735,7 @@ def ls_services(
 
 
 # ---------------------------------------------------------------------------
-# rm (remove stopped instance record)
+# rm (remove stopped instance directory)
 # ---------------------------------------------------------------------------
 
 
@@ -746,13 +747,19 @@ def rm_services(
     ] = None,
     instance: Annotated[
         str | None,
-        typer.Option("--instance", help="Instance scope (alternative to positional argument)."),
+        typer.Option(
+            "--instance",
+            help="Scope from 'nemo services ls --all' (same value as the SCOPE positional).",
+        ),
     ] = None,
 ) -> None:
-    """Remove a stopped instance record and its logs.
+    """Remove a stopped instance directory and its logs.
 
     The scope must match a row from ``nemo services ls --all``.  Running
     instances are refused; stop them first.
+
+    Unlike ``run``/``start``, ``--instance`` here does not derive a scope from
+    cwd and port — it is an alternate spelling for the ``SCOPE`` argument.
 
     Examples:
       nemo services rm abc12345-8080
@@ -772,13 +779,13 @@ def rm_services(
         raise typer.Exit(1) from None
 
     if not removed:
-        typer.echo(f"No instance record found for scope '{effective_scope}'.", err=True)
+        typer.echo(f"No stopped instance directory found for scope '{effective_scope}'.", err=True)
         raise typer.Exit(1)
     typer.echo(f"Removed instance '{effective_scope}'.")
 
 
 # ---------------------------------------------------------------------------
-# prune (remove all stopped instance records)
+# prune (remove all stopped instance directories)
 # ---------------------------------------------------------------------------
 
 
@@ -789,9 +796,9 @@ def prune_services(
         typer.Option("--force", help="Remove without confirmation."),
     ] = False,
 ) -> None:
-    """Remove all stopped instance records on this host.
+    """Remove all stopped instance directories on this host.
 
-    Stopped records may include service logs from prior runs.  Logs are
+    Stopped instance directories may include service logs from prior runs.  Logs are
     deleted with the instance directory.
 
     Examples:
@@ -803,10 +810,10 @@ def prune_services(
 
     stopped = [info for info in list_instances(base_dir=base_dir) if not info.alive]
     if not stopped:
-        typer.echo("No stopped instances to remove.")
+        typer.echo("No stopped instance directories to remove.")
         return
 
-    typer.echo("The following stopped instance(s) will be removed:")
+    typer.echo("The following stopped instance directories will be removed:")
     for info in stopped:
         log_bytes = instance_log_bytes(info.scope, base_dir=base_dir)
         if log_bytes:
@@ -814,19 +821,19 @@ def prune_services(
         else:
             typer.echo(f"  {info.scope}  (no logs)")
 
-    if not force and not typer.confirm("Remove stopped instances?", default=False):
+    if not force and not typer.confirm("Remove stopped instance directories?", default=False):
         typer.echo("Prune cancelled.")
         return
 
     removed = prune_instances(base_dir=base_dir)
     if not removed:
-        typer.echo("No stopped instances to remove.")
+        typer.echo("No stopped instance directories to remove.")
         return
     if len(removed) == 1:
-        typer.echo(f"Removed stopped instance: {removed[0]}")
+        typer.echo(f"Removed stopped instance directory: {removed[0]}")
     else:
         scopes = ", ".join(removed)
-        typer.echo(f"Removed {len(removed)} stopped instance(s): {scopes}")
+        typer.echo(f"Removed {len(removed)} stopped instance directories: {scopes}")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-status/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-status/SKILL.md
@@ -105,7 +105,7 @@ Status is itself a verification: the commands together prove the platform is rea
 |---|---|---|
 | `PLATFORM_DOWN` from probe | Nothing bound to :8080 | Route to `nemo-setup`; do not run the other three commands |
 | `PLATFORM_WEDGED` from probe | Listener exists, but `/health/ready` is not returning 200 — likely a crashed, partially-started, or not-ready platform | Tail `.venv/bin/nemo services logs -n 100` and surface the error. Common cause is a stale instance lock; the user can clear it with `nemo services stop --force` then re-run `nemo services run`. |
-| `nemo services ls` shows stopped rows with `-` for PID/address | Stopped instance record on disk (logs may remain) | Run `nemo services ls --all` for the full list. Remove with `nemo services prune` or `nemo services rm <scope>`. Cross-check liveness with `lsof -iTCP:8080 -sTCP:LISTEN`. |
+| `.venv/bin/nemo services ls` shows stopped rows with `-` for PID/address | Stopped instance directory on disk (logs may remain) | Run `.venv/bin/nemo services ls --all` for the full list. Remove with `.venv/bin/nemo services prune` or `.venv/bin/nemo services rm <scope>`. Cross-check liveness with `lsof -iTCP:8080 -sTCP:LISTEN`. |
 | `agents deployments list` returns "no such command" | Agents plugin not installed | Note in the summary: "Agents: plugin not installed"; do not fail the dashboard |
 | `inference providers list` empty | Provider not registered | Route to `nemo-setup` Step 4 (configure) |
 | `models list` empty for more than 60s after setup | Model discovery still running | Re-run after 30s; report the wait time |
@@ -115,6 +115,6 @@ Status is itself a verification: the commands together prove the platform is rea
 
 - **Read-only means read-only.** Never run `create`, `delete`, `stop`, or any state-changing command from this skill, even if the dashboard suggests something is broken. Route to setup or teardown for state changes.
 - **`agents deployments list` requires the agents plugin.** If it returns "no such command", the user has not installed the agents plugin yet; note that explicitly rather than failing silently.
-- **`nemo services ls` defaults to running instances only.** Use `nemo services ls --all` to see stopped records that still have logs on disk. Remove them with `nemo services prune` or `nemo services rm <scope>`. For liveness, cross-check against `lsof -iTCP:8080 -sTCP:LISTEN`.
+- **`.venv/bin/nemo services ls` defaults to running instances only.** Use `.venv/bin/nemo services ls --all` to see stopped instance directories that still have logs on disk. Remove them with `.venv/bin/nemo services prune` or `.venv/bin/nemo services rm <scope>`. For liveness, cross-check against `lsof -iTCP:8080 -sTCP:LISTEN`.
 - **Status is a snapshot.** A model still discovering will show as missing. Re-run after 30 seconds if the user just finished setup.
 - **Use `.venv/bin/nemo`, not bare `nemo`.** Bash sessions do not carry venv activation across calls.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-status/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-status/SKILL.md
@@ -105,7 +105,7 @@ Status is itself a verification: the commands together prove the platform is rea
 |---|---|---|
 | `PLATFORM_DOWN` from probe | Nothing bound to :8080 | Route to `nemo-setup`; do not run the other three commands |
 | `PLATFORM_WEDGED` from probe | Listener exists, but `/health/ready` is not returning 200 — likely a crashed, partially-started, or not-ready platform | Tail `.venv/bin/nemo services logs -n 100` and surface the error. Common cause is a stale instance lock; the user can clear it with `nemo services stop --force` then re-run `nemo services run`. |
-| `nemo services ls` shows `running` with empty PID/address column | Held instance lock, no live process | Advisory only — trust the `lsof` probe above. Tell the user the lock is stale; offer `nemo services stop --force` to clear it. |
+| `nemo services ls` shows stopped rows with `-` for PID/address | Stopped instance record on disk (logs may remain) | Run `nemo services ls --all` for the full list. Remove with `nemo services prune` or `nemo services rm <scope>`. Cross-check liveness with `lsof -iTCP:8080 -sTCP:LISTEN`. |
 | `agents deployments list` returns "no such command" | Agents plugin not installed | Note in the summary: "Agents: plugin not installed"; do not fail the dashboard |
 | `inference providers list` empty | Provider not registered | Route to `nemo-setup` Step 4 (configure) |
 | `models list` empty for more than 60s after setup | Model discovery still running | Re-run after 30s; report the wait time |
@@ -115,6 +115,6 @@ Status is itself a verification: the commands together prove the platform is rea
 
 - **Read-only means read-only.** Never run `create`, `delete`, `stop`, or any state-changing command from this skill, even if the dashboard suggests something is broken. Route to setup or teardown for state changes.
 - **`agents deployments list` requires the agents plugin.** If it returns "no such command", the user has not installed the agents plugin yet; note that explicitly rather than failing silently.
-- **`nemo services status` and `nemo services ls` lie about liveness.** After a `nemo services run` process dies, the instance lock at `~/.local/state/nemo/instances/<scope>.lock` sticks around. Both commands keep reporting `running` against that stale lock with no PID and no address. Always cross-check against `lsof -iTCP:8080 -sTCP:LISTEN` before believing them.
+- **`nemo services ls` defaults to running instances only.** Use `nemo services ls --all` to see stopped records that still have logs on disk. Remove them with `nemo services prune` or `nemo services rm <scope>`. For liveness, cross-check against `lsof -iTCP:8080 -sTCP:LISTEN`.
 - **Status is a snapshot.** A model still discovering will show as missing. Re-run after 30 seconds if the user just finished setup.
 - **Use `.venv/bin/nemo`, not bare `nemo`.** Bash sessions do not carry venv activation across calls.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-teardown/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-teardown/SKILL.md
@@ -32,10 +32,10 @@ Use `lsof` as ground truth. Do not trust `nemo services status` or `nemo service
 lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 && echo "RUNNING" || echo "ALREADY_STOPPED"
 ```
 
-If `ALREADY_STOPPED`: the platform is not serving. There may still be a stale lock under `~/.local/state/nemo/instances/` from a crashed previous run. Tell the user that, and offer:
+If `ALREADY_STOPPED`: the platform is not serving. Stopped instance records may still exist under `~/.local/state/nmp/instances/`. Tell the user that, and offer:
 
 - Option 3 (full cleanup of venv + `agents/` + data dir) only if they explicitly want it.
-- Otherwise, just clear the stale lock with `nemo services stop --force` so the next `nemo services run` doesn't refuse to start.
+- Otherwise, list stopped records with `nemo services ls --all` and remove them with `nemo services prune` (or `nemo services rm <scope>` for one scope). Logs are preserved until removal.
 
 ## Step 1: Snapshot state (what's about to be affected)
 
@@ -43,6 +43,7 @@ Show the user EVERYTHING that's currently on this platform so they can decide wh
 
 ```bash
 .venv/bin/nemo services ls
+.venv/bin/nemo services ls --all
 .venv/bin/nemo agents deployments list 2>/dev/null
 .venv/bin/nemo files filesets list 2>/dev/null
 .venv/bin/nemo jobs list 2>/dev/null
@@ -171,12 +172,12 @@ Verification passes only when `lsof` reports nothing on :8080 and (for options 2
 | `services stop` errors with "no instance" but `lsof` shows a listener | Lock state and reality diverged (foreground process with no registered instance, or instance was started in a different working directory / port scope) | Run `nemo services ls` to see what scopes the CLI knows about; the listener may belong to a different scope. Identify the PID from `lsof -iTCP:8080 -sTCP:LISTEN` and ask the user before sending SIGTERM. |
 | `services stop` says "stopped" but `lsof` still shows a listener | Process didn't honor SIGTERM in time | Re-run `nemo services stop --timeout 60`; if still alive, surface the PID and ask the user. Do not silently SIGKILL. |
 | `rm -rf` data dir fails with permission denied | Data dir owned by a different user, or a process still has it open | Surface the error; do not retry with sudo. Confirm `lsof -iTCP:8080` is empty and `lsof +D "$DATA_DIR" 2>/dev/null` shows nothing before retrying. |
-| `nemo services ls` shows `running` with empty PID/address after teardown | Stale lock leftover from a crashed `services run` | `nemo services stop --force` clears the lock. Then re-verify with `lsof`. |
+| `nemo services ls --all` shows stopped rows after teardown | Stopped instance records with logs remain on disk | `nemo services prune` removes them. Re-verify with `lsof`. |
 | User says "I changed my mind" mid-step | Confirmation came back ambiguous | Stop immediately; re-prompt. |
 
 ## Gotchas
 
-- **`lsof` is ground truth.** `nemo services status` and `nemo services ls` report stale "running" from held instance locks after the underlying process has died. Always cross-check against `lsof -iTCP:8080 -sTCP:LISTEN` before believing them.
+- **`lsof` is ground truth for whether the platform is serving.** `nemo services ls` defaults to running instances; use `nemo services ls --all` for stopped records on disk. Cross-check against `lsof -iTCP:8080 -sTCP:LISTEN` before believing either command.
 - **Foreground vs background instances.** `nemo services run` runs in the foreground and is protected from `nemo services stop` (stop refuses unless `--force`). `nemo services start` runs in the background and is the right target for `stop`. If `stop` refuses, ask the user where they ran `services run` so they can Ctrl-C it themselves.
 - **Wipe AFTER stop, not before.** On macOS especially, running `rm -rf ~/.local/share/nemo` while a `nemo services run` process is still alive leaves the running process holding the old inode while a freshly-spawned platform sees the new (empty) inode. Always confirm `lsof -iTCP:8080` is empty before the wipe.
 - **No `pkill`.** Don't grep for "nemo-platform" or "nemo services" and send SIGTERM blindly — the kernel doesn't know which instance is the user's and which belongs to a coworker on the same box. Use `nemo services stop` (or, with user confirmation, kill a specific PID surfaced by `lsof`).

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-teardown/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-teardown/SKILL.md
@@ -32,10 +32,10 @@ Use `lsof` as ground truth. Do not trust `nemo services status` or `nemo service
 lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 && echo "RUNNING" || echo "ALREADY_STOPPED"
 ```
 
-If `ALREADY_STOPPED`: the platform is not serving. Stopped instance records may still exist under `~/.local/state/nmp/instances/`. Tell the user that, and offer:
+If `ALREADY_STOPPED`: the platform is not serving. Stopped instance directories may still exist under `~/.local/state/nmp/instances/`. Tell the user that, and offer:
 
 - Option 3 (full cleanup of venv + `agents/` + data dir) only if they explicitly want it.
-- Otherwise, list stopped records with `nemo services ls --all` and remove them with `nemo services prune` (or `nemo services rm <scope>` for one scope). Logs are preserved until removal.
+- Otherwise, list stopped instance directories with `.venv/bin/nemo services ls --all` and remove them with `.venv/bin/nemo services prune` (or `.venv/bin/nemo services rm <scope>` for one scope). Logs are preserved until removal.
 
 ## Step 1: Snapshot state (what's about to be affected)
 
@@ -172,12 +172,12 @@ Verification passes only when `lsof` reports nothing on :8080 and (for options 2
 | `services stop` errors with "no instance" but `lsof` shows a listener | Lock state and reality diverged (foreground process with no registered instance, or instance was started in a different working directory / port scope) | Run `nemo services ls` to see what scopes the CLI knows about; the listener may belong to a different scope. Identify the PID from `lsof -iTCP:8080 -sTCP:LISTEN` and ask the user before sending SIGTERM. |
 | `services stop` says "stopped" but `lsof` still shows a listener | Process didn't honor SIGTERM in time | Re-run `nemo services stop --timeout 60`; if still alive, surface the PID and ask the user. Do not silently SIGKILL. |
 | `rm -rf` data dir fails with permission denied | Data dir owned by a different user, or a process still has it open | Surface the error; do not retry with sudo. Confirm `lsof -iTCP:8080` is empty and `lsof +D "$DATA_DIR" 2>/dev/null` shows nothing before retrying. |
-| `nemo services ls --all` shows stopped rows after teardown | Stopped instance records with logs remain on disk | `nemo services prune` removes them. Re-verify with `lsof`. |
+| `nemo services ls --all` shows stopped rows after teardown | Stopped instance directories with logs remain on disk | `nemo services prune` removes them. Re-verify with `lsof`. |
 | User says "I changed my mind" mid-step | Confirmation came back ambiguous | Stop immediately; re-prompt. |
 
 ## Gotchas
 
-- **`lsof` is ground truth for whether the platform is serving.** `nemo services ls` defaults to running instances; use `nemo services ls --all` for stopped records on disk. Cross-check against `lsof -iTCP:8080 -sTCP:LISTEN` before believing either command.
+- **`lsof` is ground truth for whether the platform is serving.** `nemo services ls` defaults to running instances; use `nemo services ls --all` for stopped instance directories on disk. Cross-check against `lsof -iTCP:8080 -sTCP:LISTEN` before believing either command.
 - **Foreground vs background instances.** `nemo services run` runs in the foreground and is protected from `nemo services stop` (stop refuses unless `--force`). `nemo services start` runs in the background and is the right target for `stop`. If `stop` refuses, ask the user where they ran `services run` so they can Ctrl-C it themselves.
 - **Wipe AFTER stop, not before.** On macOS especially, running `rm -rf ~/.local/share/nemo` while a `nemo services run` process is still alive leaves the running process holding the old inode while a freshly-spawned platform sees the new (empty) inode. Always confirm `lsof -iTCP:8080` is empty before the wipe.
 - **No `pkill`.** Don't grep for "nemo-platform" or "nemo services" and send SIGTERM blindly — the kernel doesn't know which instance is the user's and which belongs to a coworker on the same box. Use `nemo services stop` (or, with user confirmation, kill a specific PID surfaced by `lsof`).

--- a/packages/nemo_platform_ext/tests/cli/commands/test_services.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_services.py
@@ -34,6 +34,13 @@ _PROCESS_MODULE = "nemo_platform_ext.cli.commands.services._process"
 _CLI_MODULE = "nemo_platform_ext.cli.commands.services.cli"
 
 
+def _seed_stopped_scope(base_dir: Path, scope: str, *, log_content: str = "x\n") -> Path:
+    """Create a stopped instance directory with service logs."""
+    d = instance_dir(scope, base_dir=base_dir)
+    (d / "services.log").write_text(log_content)
+    return d
+
+
 _original_find_spec = __import__("importlib").util.find_spec
 
 
@@ -66,7 +73,7 @@ def test_services_group_is_registered():
 def test_services_help_lists_all_commands():
     result = runner.invoke(app, ["services", "--help"])
     assert result.exit_code == 0
-    for cmd in ("run", "start", "stop", "restart", "status", "ls", "logs"):
+    for cmd in ("run", "start", "stop", "restart", "status", "ls", "logs", "rm", "prune"):
         assert cmd in result.stdout, f"'{cmd}' not in help output"
 
 
@@ -303,9 +310,11 @@ class TestServicesStop:
 
     def test_stops_running_services(self, base_dir: Path):
         with patch(f"{_CLI_MODULE}.stop_instance", return_value=StopResult(stopped_pids=[12345])):
-            result = runner.invoke(app, ["services", "stop", "--instance", "test"])
+            with patch(f"{_CLI_MODULE}.compute_scope", return_value="stop-scope"):
+                result = runner.invoke(app, ["services", "stop", "--instance", "stop-scope"])
         assert result.exit_code == 0
         assert "12345" in result.stdout
+        assert "nemo services rm stop-scope" in result.stdout
 
     def test_stop_timeout_option(self, base_dir: Path):
         with patch(f"{_CLI_MODULE}.stop_instance", return_value=StopResult(stopped_pids=[])) as mock_stop:
@@ -532,7 +541,7 @@ class TestServicesLs:
     def test_no_instances(self, base_dir: Path):
         result = runner.invoke(app, ["services", "ls"])
         assert result.exit_code == 0
-        assert "No instances" in result.stdout
+        assert "No running instances" in result.stdout
 
     def test_lists_running_instance(self, base_dir: Path):
         scope = "ls-test"
@@ -555,6 +564,129 @@ class TestServicesLs:
         assert result.exit_code == 0
         assert scope in result.stdout
         assert "running" in result.stdout
+
+    def test_hides_stopped_by_default(self, base_dir: Path):
+        _seed_stopped_scope(base_dir, "stopped-hidden")
+
+        result = runner.invoke(app, ["services", "ls"])
+        assert result.exit_code == 0
+        assert "stopped-hidden" not in result.stdout
+        assert "1 stopped instance(s)" in result.stdout
+        assert "ls --all" in result.stdout
+
+    def test_all_shows_stopped_with_footer(self, base_dir: Path):
+        _seed_stopped_scope(base_dir, "stopped-visible")
+
+        result = runner.invoke(app, ["services", "ls", "--all"])
+        assert result.exit_code == 0
+        assert "stopped-visible" in result.stdout
+        assert "stopped" in result.stdout
+        assert "nemo services prune" in result.stdout
+
+    def test_all_no_instances(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "ls", "--all"])
+        assert result.exit_code == 0
+        assert "No instances found" in result.stdout
+
+    def test_mixed_running_and_stopped(self, base_dir: Path):
+        running_scope = "running-mixed"
+        fd = acquire_lock(running_scope, base_dir=base_dir)
+        write_descriptor(
+            InstanceDescriptor(
+                pid=os.getpid(),
+                scope=running_scope,
+                host="127.0.0.1",
+                port=8080,
+                mode="background",
+                create_time=1.0,
+            ),
+            base_dir=base_dir,
+        )
+        _seed_stopped_scope(base_dir, "stopped-mixed")
+
+        try:
+            default = runner.invoke(app, ["services", "ls"])
+            all_rows = runner.invoke(app, ["services", "ls", "--all"])
+        finally:
+            os.close(fd)
+
+        assert default.exit_code == 0
+        assert running_scope in default.stdout
+        assert "stopped-mixed" not in default.stdout
+
+        assert all_rows.exit_code == 0
+        assert running_scope in all_rows.stdout
+        assert "stopped-mixed" in all_rows.stdout
+        assert "nemo services prune" in all_rows.stdout
+
+
+class TestServicesRm:
+    @pytest.mark.parametrize(
+        ("scope", "args"),
+        [
+            ("rm-cli", ["services", "rm", "rm-cli"]),
+            ("rm-flag", ["services", "rm", "--instance", "rm-flag"]),
+        ],
+    )
+    def test_rm_removes_stopped_scope(self, base_dir: Path, scope: str, args: list[str]) -> None:
+        d = _seed_stopped_scope(base_dir, scope)
+
+        result = runner.invoke(app, args)
+        assert result.exit_code == 0
+        assert f"Removed instance '{scope}'" in result.stdout
+        assert not d.exists()
+
+    def test_rm_not_found(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "rm", "missing-scope"])
+        assert result.exit_code == 1
+        assert "No instance record found" in result.stderr
+
+    def test_rm_refuses_running(self, base_dir: Path):
+        fd = acquire_lock("running-rm-cli", base_dir=base_dir)
+        try:
+            result = runner.invoke(app, ["services", "rm", "running-rm-cli"])
+        finally:
+            os.close(fd)
+        assert result.exit_code == 1
+        assert "still running" in result.stderr
+
+    def test_rm_requires_scope(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "rm"])
+        assert result.exit_code == 1
+        assert "Scope required" in result.stderr
+
+    def test_rm_rejects_invalid_scope(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "rm", "../escape"])
+        assert result.exit_code == 1
+        assert "Invalid instance scope" in result.stderr
+
+    def test_rm_rejects_conflicting_scope_args(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "rm", "scope-a", "--instance", "scope-b"])
+        assert result.exit_code != 0
+        assert "Cannot pass different values" in result.stderr
+
+
+class TestServicesPrune:
+    def test_prune_force_removes_stopped(self, base_dir: Path):
+        d = _seed_stopped_scope(base_dir, "prune-me")
+
+        result = runner.invoke(app, ["services", "prune", "--force"])
+        assert result.exit_code == 0
+        assert "prune-me" in result.stdout
+        assert not d.exists()
+
+    def test_prune_noop_when_clean(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "prune", "--force"])
+        assert result.exit_code == 0
+        assert "No stopped instances" in result.stdout
+
+    def test_prune_cancelled(self, base_dir: Path):
+        d = _seed_stopped_scope(base_dir, "keep-me")
+
+        result = runner.invoke(app, ["services", "prune"], input="n\n")
+        assert result.exit_code == 0
+        assert "Prune cancelled" in result.stdout
+        assert d.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_ext/tests/cli/commands/test_services.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_services.py
@@ -571,7 +571,7 @@ class TestServicesLs:
         result = runner.invoke(app, ["services", "ls"])
         assert result.exit_code == 0
         assert "stopped-hidden" not in result.stdout
-        assert "1 stopped instance(s)" in result.stdout
+        assert "1 stopped instance directory" in result.stdout
         assert "ls --all" in result.stdout
 
     def test_all_shows_stopped_with_footer(self, base_dir: Path):
@@ -639,7 +639,7 @@ class TestServicesRm:
     def test_rm_not_found(self, base_dir: Path):
         result = runner.invoke(app, ["services", "rm", "missing-scope"])
         assert result.exit_code == 1
-        assert "No instance record found" in result.stderr
+        assert "No stopped instance directory found" in result.stderr
 
     def test_rm_refuses_running(self, base_dir: Path):
         fd = acquire_lock("running-rm-cli", base_dir=base_dir)
@@ -678,7 +678,7 @@ class TestServicesPrune:
     def test_prune_noop_when_clean(self, base_dir: Path):
         result = runner.invoke(app, ["services", "prune", "--force"])
         assert result.exit_code == 0
-        assert "No stopped instances" in result.stdout
+        assert "No stopped instance directories" in result.stdout
 
     def test_prune_cancelled(self, base_dir: Path):
         d = _seed_stopped_scope(base_dir, "keep-me")

--- a/packages/nemo_platform_ext/tests/cli/commands/test_services_lifecycle.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_services_lifecycle.py
@@ -26,6 +26,7 @@ import time
 from pathlib import Path
 
 import pytest
+from nemo_platform_ext.cli.app import app
 from nemo_platform_ext.cli.commands.services._process import (
     InstanceDescriptor,
     PortConflict,
@@ -36,10 +37,15 @@ from nemo_platform_ext.cli.commands.services._process import (
     is_instance_alive,
     is_port_bindable,
     list_instances,
+    prune_instances,
     read_descriptor,
+    remove_instance,
     stop_instance,
     write_descriptor,
 )
+from typer.testing import CliRunner
+
+_runner = CliRunner()
 
 _STARTUP_TIMEOUT = 15
 _SHUTDOWN_TIMEOUT = 5
@@ -527,6 +533,101 @@ class TestEndToEndHealthPolling:
             if proc.poll() is None:
                 proc.kill()
                 proc.wait(timeout=5)
+
+
+class TestInstanceCleanup:
+    """Integration tests for rm/prune and post-stop instance directories."""
+
+    def test_stop_leaves_record_until_rm(self, tmp_path: Path, monkeypatch) -> None:
+        base_dir = tmp_path / "state"
+        scope = "stop-then-rm"
+        monkeypatch.setenv("_NMP_STATE_DIR", str(base_dir))
+
+        proc = _spawn_platform(tmp_path / "scripts", base_dir, scope)
+        try:
+            stop_instance(scope, base_dir=base_dir, timeout=5.0)
+            proc.wait(timeout=_SHUTDOWN_TIMEOUT)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+        scope_dir = instance_dir(scope, base_dir=base_dir)
+        (scope_dir / "services.log").write_text("post-stop log\n")
+        instances = list_instances(base_dir=base_dir)
+        assert len(instances) == 1
+        assert instances[0].alive is False
+
+        assert remove_instance(scope, base_dir=base_dir) is True
+        assert not scope_dir.exists()
+
+    def test_stop_then_rm_via_cli(self, tmp_path: Path, monkeypatch) -> None:
+        base_dir = tmp_path / "state"
+        scope = "stop-then-rm-cli"
+        monkeypatch.setenv("_NMP_STATE_DIR", str(base_dir))
+
+        proc = _spawn_platform(tmp_path / "scripts-rm-cli", base_dir, scope)
+        try:
+            stop_instance(scope, base_dir=base_dir, timeout=5.0)
+            proc.wait(timeout=_SHUTDOWN_TIMEOUT)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+        scope_dir = instance_dir(scope, base_dir=base_dir)
+        (scope_dir / "services.log").write_text("post-stop log\n")
+        assert scope_dir.exists()
+
+        result = _runner.invoke(app, ["services", "rm", scope])
+        assert result.exit_code == 0
+        assert f"Removed instance '{scope}'" in result.stdout
+        assert not scope_dir.exists()
+
+    def test_sigkill_crash_then_prune(self, tmp_path: Path) -> None:
+        base_dir = tmp_path / "state"
+        scope = "crash-prune"
+        proc = _spawn_platform(tmp_path / "run1", base_dir, scope)
+        os.kill(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=_SHUTDOWN_TIMEOUT)
+
+        scope_dir = instance_dir(scope, base_dir=base_dir)
+        (scope_dir / "services.log").write_text("crash log\n")
+
+        removed = prune_instances(base_dir=base_dir)
+        assert scope in removed
+        assert not scope_dir.exists()
+
+    def test_prune_skips_running(self, tmp_path: Path) -> None:
+        base_dir = tmp_path / "state"
+        running = _spawn_platform(tmp_path / "run-a", base_dir, "scope-running")
+        stopped_dir = instance_dir("scope-stopped", base_dir=base_dir)
+        (stopped_dir / "services.log").write_text("x\n")
+        try:
+            removed = prune_instances(base_dir=base_dir)
+            assert removed == ["scope-stopped"]
+            assert is_instance_alive("scope-running", base_dir=base_dir)
+            assert not stopped_dir.exists()
+        finally:
+            os.kill(running.pid, signal.SIGTERM)
+            running.wait(timeout=_SHUTDOWN_TIMEOUT)
+
+    def test_logs_available_before_rm_not_after(self, tmp_path: Path, monkeypatch) -> None:
+        base_dir = tmp_path / "state"
+        scope = "logs-rm"
+        monkeypatch.setenv("_NMP_STATE_DIR", str(base_dir))
+        d = instance_dir(scope, base_dir=base_dir)
+        (d / "services.log").write_text("debug line\n")
+
+        before = _runner.invoke(app, ["services", "logs", "--instance", scope])
+        assert before.exit_code == 0
+        assert "debug line" in before.stdout
+
+        remove_instance(scope, base_dir=base_dir)
+
+        after = _runner.invoke(app, ["services", "logs", "--instance", scope])
+        assert after.exit_code == 0
+        assert "No log file" in after.stdout
 
 
 class TestPortAvailability:

--- a/packages/nemo_platform_ext/tests/cli/commands/test_services_process.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_services_process.py
@@ -18,16 +18,22 @@ from nemo_platform_ext.cli.commands.services._process import (
     ForegroundInstanceError,
     InstanceAlreadyRunningError,
     InstanceDescriptor,
+    InstanceStillRunningError,
     _pid_alive,
     _snapshot_children,
     _sweep_orphans,
     acquire_lock,
     compute_scope,
     instance_dir,
+    instance_log_bytes,
     is_instance_alive,
+    is_removable_ghost,
     list_instances,
+    list_stopped_scopes,
+    prune_instances,
     read_descriptor,
     remove_descriptor,
+    remove_instance,
     rotate_log,
     start_background,
     stop_instance,
@@ -268,10 +274,164 @@ class TestListInstances:
         write_descriptor(desc, base_dir=base_dir)
 
         instances = list_instances(base_dir=base_dir)
+        assert instances == []
+        assert not d.exists()
+
+    def test_stale_descriptor_with_logs_stays_listed(self, base_dir: Path) -> None:
+        d = instance_dir("dead-with-logs", base_dir=base_dir)
+        desc = InstanceDescriptor(
+            pid=999999,
+            scope="dead-with-logs",
+            host="127.0.0.1",
+            port=8080,
+            mode="background",
+            create_time=1.0,
+        )
+        write_descriptor(desc, base_dir=base_dir)
+        (d / "services.log").write_text("crash output\n")
+
+        instances = list_instances(base_dir=base_dir)
         assert len(instances) == 1
+        assert instances[0].scope == "dead-with-logs"
         assert instances[0].alive is False
         assert instances[0].descriptor is None
-        assert not (d / "instance.json").exists()
+        assert d.exists()
+
+    def test_auto_removes_lock_only_ghost(self, base_dir: Path) -> None:
+        d = instance_dir("ghost-lock", base_dir=base_dir)
+        (d / "services.lock").touch()
+
+        instances = list_instances(base_dir=base_dir)
+        assert instances == []
+        assert not d.exists()
+
+    def test_keeps_stopped_instance_with_logs(self, base_dir: Path) -> None:
+        d = instance_dir("stopped-logs", base_dir=base_dir)
+        (d / "services.lock").touch()
+        (d / "services.log").write_text("crash output\n")
+
+        instances = list_instances(base_dir=base_dir)
+        assert len(instances) == 1
+        assert instances[0].scope == "stopped-logs"
+        assert instances[0].alive is False
+        assert instances[0].descriptor is None
+        assert d.exists()
+
+    def test_keeps_stopped_instance_with_rotated_logs_only(self, base_dir: Path) -> None:
+        d = instance_dir("rotated-logs", base_dir=base_dir)
+        (d / "services.lock").touch()
+        (d / "services.log.20250101T000000Z").write_text("old boot\n")
+
+        instances = list_instances(base_dir=base_dir)
+        assert len(instances) == 1
+        assert instances[0].scope == "rotated-logs"
+
+    def test_empty_services_log_is_still_a_ghost(self, base_dir: Path) -> None:
+        d = instance_dir("empty-log", base_dir=base_dir)
+        (d / "services.lock").touch()
+        (d / "services.log").touch()
+
+        instances = list_instances(base_dir=base_dir)
+        assert instances == []
+        assert not d.exists()
+
+    def test_running_instance_not_auto_removed(self, base_dir: Path) -> None:
+        fd = acquire_lock("alive-ghost-check", base_dir=base_dir)
+        try:
+            instances = list_instances(base_dir=base_dir)
+            assert len(instances) == 1
+            assert instances[0].alive is True
+        finally:
+            os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# remove_instance / prune_instances
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveInstance:
+    def test_removes_dead_scope_dir(self, base_dir: Path) -> None:
+        d = instance_dir("rm-me", base_dir=base_dir)
+        (d / "services.log").write_text("logs\n")
+
+        assert remove_instance("rm-me", base_dir=base_dir) is True
+        assert not d.exists()
+
+    def test_missing_scope_returns_false(self, base_dir: Path) -> None:
+        assert remove_instance("missing", base_dir=base_dir) is False
+
+    def test_refuses_running_instance(self, base_dir: Path) -> None:
+        fd = acquire_lock("running-rm", base_dir=base_dir)
+        try:
+            with pytest.raises(InstanceStillRunningError, match="running-rm"):
+                remove_instance("running-rm", base_dir=base_dir)
+        finally:
+            os.close(fd)
+
+    def test_rejects_invalid_scope(self, base_dir: Path) -> None:
+        with pytest.raises(ValueError, match="Invalid instance scope"):
+            remove_instance("../escape", base_dir=base_dir)
+
+    def test_returns_false_when_rmtree_fails(self, base_dir: Path) -> None:
+        d = instance_dir("rmtree-fail", base_dir=base_dir)
+        (d / "services.log").write_text("logs\n")
+
+        with patch(
+            "nemo_platform_ext.cli.commands.services._process.shutil.rmtree",
+            side_effect=OSError("permission denied"),
+        ):
+            assert remove_instance("rmtree-fail", base_dir=base_dir) is False
+        assert d.exists()
+
+
+class TestPruneInstances:
+    def test_removes_all_stopped_scopes(self, base_dir: Path) -> None:
+        alive_fd = acquire_lock("alive-prune", base_dir=base_dir)
+        stopped = instance_dir("stopped-prune", base_dir=base_dir)
+        (stopped / "services.log").write_text("x\n")
+        try:
+            removed = prune_instances(base_dir=base_dir)
+            assert removed == ["stopped-prune"]
+            assert not stopped.exists()
+            assert is_instance_alive("alive-prune", base_dir=base_dir)
+        finally:
+            os.close(alive_fd)
+
+    def test_noop_when_empty(self, base_dir: Path) -> None:
+        assert prune_instances(base_dir=base_dir) == []
+
+
+class TestInstanceLogBytes:
+    def test_sums_active_and_rotated_logs(self, base_dir: Path) -> None:
+        d = instance_dir("log-bytes", base_dir=base_dir)
+        (d / "services.log").write_text("abc")
+        (d / "services.log.old").write_text("de")
+
+        assert instance_log_bytes("log-bytes", base_dir=base_dir) == 5
+
+
+class TestIsRemovableGhost:
+    def test_true_for_lock_only(self, base_dir: Path) -> None:
+        d = instance_dir("ghost", base_dir=base_dir)
+        (d / "services.lock").touch()
+        assert is_removable_ghost("ghost", base_dir=base_dir) is True
+
+    def test_false_when_logs_present(self, base_dir: Path) -> None:
+        d = instance_dir("not-ghost", base_dir=base_dir)
+        (d / "services.log").write_text("data\n")
+        assert is_removable_ghost("not-ghost", base_dir=base_dir) is False
+
+
+class TestListStoppedScopes:
+    def test_lists_only_stopped(self, base_dir: Path) -> None:
+        fd = acquire_lock("up", base_dir=base_dir)
+        down = instance_dir("down", base_dir=base_dir)
+        (down / "services.log").write_text("x\n")
+        try:
+            assert list_stopped_scopes(base_dir=base_dir) == ["down"]
+        finally:
+            os.close(fd)
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/_process.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/_process.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import signal
 import socket
 import subprocess
@@ -174,6 +175,16 @@ class ForegroundInstanceError(Exception):
         super().__init__(
             f"Instance '{scope}' (pid {pid}) is running in the foreground. "
             "Use Ctrl-C in its terminal to stop it, or pass --force."
+        )
+
+
+class InstanceStillRunningError(Exception):
+    """Raised when ``rm`` targets a live instance."""
+
+    def __init__(self, scope: str) -> None:
+        self.scope = scope
+        super().__init__(
+            f"Instance '{scope}' is still running. Stop it first with: nemo services stop --instance {scope}"
         )
 
 
@@ -339,6 +350,46 @@ def remove_descriptor(scope: str, *, base_dir: Path | None = None) -> None:
         logger.debug("Could not remove descriptor %s", path, exc_info=True)
 
 
+def _scope_dir(scope: str, *, base_dir: Path | None = None) -> Path:
+    return _instances_dir(base_dir=base_dir) / _validate_scope(scope)
+
+
+def _is_log_file(path: Path) -> bool:
+    return path.name == LOG_FILENAME or path.name.startswith(f"{LOG_FILENAME}.")
+
+
+def _iter_log_files(scope_dir: Path):
+    if not scope_dir.is_dir():
+        return
+    for path in scope_dir.iterdir():
+        if path.is_file() and _is_log_file(path):
+            yield path
+
+
+def _has_preservable_logs(scope_dir: Path) -> bool:
+    """Return True if *scope_dir* contains non-empty service log files."""
+    return any(path.stat().st_size > 0 for path in _iter_log_files(scope_dir))
+
+
+def is_removable_ghost(
+    scope: str,
+    *,
+    base_dir: Path | None = None,
+    descriptor: InstanceDescriptor | None = None,
+) -> bool:
+    """True when a dead scope dir has no descriptor and no non-empty logs."""
+    if is_instance_alive(scope, base_dir=base_dir):
+        return False
+    if descriptor is not None:
+        return False
+    scope_dir = _scope_dir(scope, base_dir=base_dir)
+    if not scope_dir.is_dir():
+        return False
+    if (scope_dir / DESCRIPTOR_FILENAME).exists():
+        return False
+    return not _has_preservable_logs(scope_dir)
+
+
 # ---------------------------------------------------------------------------
 # PID validation via psutil
 # ---------------------------------------------------------------------------
@@ -376,8 +427,9 @@ class InstanceInfo:
 def list_instances(*, base_dir: Path | None = None) -> list[InstanceInfo]:
     """Scan all instance directories and return their status.
 
-    Side effect: removes stale descriptors for dead instances so that
-    subsequent calls (and ``ls`` output) don't show ghost entries.
+    Side effects:
+    - Removes stale descriptors for dead instances.
+    - Silently removes empty ghost directories (dead, no descriptor, no logs).
     """
     idir = _instances_dir(base_dir=base_dir)
     if not idir.exists():
@@ -392,8 +444,50 @@ def list_instances(*, base_dir: Path | None = None) -> list[InstanceInfo]:
         if not alive and desc is not None:
             remove_descriptor(scope, base_dir=base_dir)
             desc = None
+        if is_removable_ghost(scope, base_dir=base_dir, descriptor=desc):
+            try:
+                shutil.rmtree(child)
+            except OSError:
+                logger.debug("Could not remove ghost instance dir %s", child, exc_info=True)
+            else:
+                continue
         results.append(InstanceInfo(scope=scope, alive=alive, descriptor=desc))
     return results
+
+
+def remove_instance(scope: str, *, base_dir: Path | None = None) -> bool:
+    """Remove an instance scope directory.
+
+    Returns False if the scope did not exist or could not be removed.
+    """
+    scope = _validate_scope(scope)
+    if is_instance_alive(scope, base_dir=base_dir):
+        raise InstanceStillRunningError(scope)
+    scope_dir = _scope_dir(scope, base_dir=base_dir)
+    if not scope_dir.is_dir():
+        return False
+    with contextlib.suppress(OSError):
+        shutil.rmtree(scope_dir)
+    return not scope_dir.is_dir()
+
+
+def list_stopped_scopes(*, base_dir: Path | None = None) -> list[str]:
+    """Return scope names for instances that are not alive."""
+    return [info.scope for info in list_instances(base_dir=base_dir) if not info.alive]
+
+
+def prune_instances(*, base_dir: Path | None = None) -> list[str]:
+    """Remove all stopped instance directories.  Returns removed scope names."""
+    removed: list[str] = []
+    for scope in list_stopped_scopes(base_dir=base_dir):
+        if remove_instance(scope, base_dir=base_dir):
+            removed.append(scope)
+    return removed
+
+
+def instance_log_bytes(scope: str, *, base_dir: Path | None = None) -> int:
+    """Total bytes across ``services.log`` and rotated logs for *scope*."""
+    return sum(path.stat().st_size for path in _iter_log_files(_scope_dir(scope, base_dir=base_dir)))
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
@@ -17,17 +17,22 @@ from nemo_platform.cli.commands.services._process import (
     ForegroundInstanceError,
     InstanceAlreadyRunningError,
     InstanceDescriptor,
+    InstanceInfo,
+    InstanceStillRunningError,
     PortConflict,
     acquire_lock,
     check_port_available_for_start,
     compute_scope,
     format_port_conflict,
     get_create_time,
+    instance_log_bytes,
     is_instance_alive,
     list_instances,
     log_path_for,
+    prune_instances,
     read_descriptor,
     remove_descriptor,
+    remove_instance,
     start_background,
     stop_instance,
     write_descriptor,
@@ -437,6 +442,7 @@ def stop_services_cmd(
         noun = "process" if n == 1 else "processes"
         msg += f" and {n} child {noun}"
     typer.echo(msg)
+    typer.echo(f"Instance record kept (logs preserved). Remove with: nemo services rm {scope}")
 
 
 # ---------------------------------------------------------------------------
@@ -646,22 +652,13 @@ def status_services(
         typer.echo(f"Log:      {log}")
 
 
-# ---------------------------------------------------------------------------
-# ls (list instances)
-# ---------------------------------------------------------------------------
+def _format_log_size(num_bytes: int) -> str:
+    if num_bytes < 1024:
+        return f"{num_bytes}B"
+    return f"{num_bytes / 1024:.1f}KB"
 
 
-@services_app.command("ls")
-def ls_services() -> None:
-    """List all known service instances on this host."""
-    base_dir_str = _effective_base_dir()
-    base_dir = Path(base_dir_str) if base_dir_str else None
-
-    instances = list_instances(base_dir=base_dir)
-    if not instances:
-        typer.echo("No instances found.")
-        return
-
+def _print_instance_table(instances: list[InstanceInfo]) -> None:
     typer.echo(f"{'SCOPE':<25} {'STATUS':<10} {'PID':<10} {'ADDRESS':<25} {'MODE':<12}")
     for info in instances:
         status = "running" if info.alive else "stopped"
@@ -669,6 +666,167 @@ def ls_services() -> None:
         addr = f"{info.descriptor.host}:{info.descriptor.port}" if info.descriptor else "-"
         mode = info.descriptor.mode if info.descriptor else "-"
         typer.echo(f"{info.scope:<25} {status:<10} {pid:<10} {addr:<25} {mode:<12}")
+
+
+def _resolve_rm_scope(scope: str | None, instance: str | None) -> str:
+    effective_scope = scope or instance
+    if effective_scope is None:
+        typer.echo("Scope required. Usage: nemo services rm <scope>", err=True)
+        raise typer.Exit(1)
+    if scope is not None and instance is not None and scope != instance:
+        raise typer.BadParameter("Cannot pass different values for SCOPE and --instance.")
+    return effective_scope
+
+
+# ---------------------------------------------------------------------------
+# ls (list instances)
+# ---------------------------------------------------------------------------
+
+
+@services_app.command("ls")
+def ls_services(
+    show_all: Annotated[
+        bool,
+        typer.Option("--all", "-a", help="Include stopped instance records (like docker ps -a)."),
+    ] = False,
+) -> None:
+    """List service instances on this host.
+
+    By default shows running instances only.  Use ``--all`` to include stopped
+    records that still have logs on disk.
+
+    Examples:
+      nemo services ls
+      nemo services ls --all
+    """
+    base_dir_str = _effective_base_dir()
+    base_dir = Path(base_dir_str) if base_dir_str else None
+
+    instances = list_instances(base_dir=base_dir)
+    if show_all:
+        visible = instances
+        if not visible:
+            typer.echo("No instances found.")
+            return
+        _print_instance_table(visible)
+        stopped = [info for info in visible if not info.alive]
+        if stopped:
+            typer.echo(
+                f"\n{len(stopped)} stopped instance(s). "
+                "Remove with: nemo services prune  (or: nemo services rm <scope>)"
+            )
+        return
+
+    running = [info for info in instances if info.alive]
+    if not running:
+        stopped_count = sum(1 for info in instances if not info.alive)
+        if stopped_count:
+            typer.echo("No running instances.")
+            typer.echo(
+                f"{stopped_count} stopped instance(s) on disk. "
+                "List with: nemo services ls --all  |  Remove with: nemo services prune"
+            )
+        else:
+            typer.echo("No running instances.")
+        return
+
+    _print_instance_table(running)
+
+
+# ---------------------------------------------------------------------------
+# rm (remove stopped instance record)
+# ---------------------------------------------------------------------------
+
+
+@services_app.command("rm")
+def rm_services(
+    scope: Annotated[
+        str | None,
+        typer.Argument(help="Instance scope from 'nemo services ls --all'."),
+    ] = None,
+    instance: Annotated[
+        str | None,
+        typer.Option("--instance", help="Instance scope (alternative to positional argument)."),
+    ] = None,
+) -> None:
+    """Remove a stopped instance record and its logs.
+
+    The scope must match a row from ``nemo services ls --all``.  Running
+    instances are refused; stop them first.
+
+    Examples:
+      nemo services rm abc12345-8080
+      nemo services rm --instance abc12345-8080
+    """
+    effective_scope = _resolve_rm_scope(scope, instance)
+    base_dir_str = _effective_base_dir()
+    base_dir = Path(base_dir_str) if base_dir_str else None
+
+    try:
+        removed = remove_instance(effective_scope, base_dir=base_dir)
+    except InstanceStillRunningError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from None
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from None
+
+    if not removed:
+        typer.echo(f"No instance record found for scope '{effective_scope}'.", err=True)
+        raise typer.Exit(1)
+    typer.echo(f"Removed instance '{effective_scope}'.")
+
+
+# ---------------------------------------------------------------------------
+# prune (remove all stopped instance records)
+# ---------------------------------------------------------------------------
+
+
+@services_app.command("prune")
+def prune_services(
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Remove without confirmation."),
+    ] = False,
+) -> None:
+    """Remove all stopped instance records on this host.
+
+    Stopped records may include service logs from prior runs.  Logs are
+    deleted with the instance directory.
+
+    Examples:
+      nemo services prune
+      nemo services prune --force
+    """
+    base_dir_str = _effective_base_dir()
+    base_dir = Path(base_dir_str) if base_dir_str else None
+
+    stopped = [info for info in list_instances(base_dir=base_dir) if not info.alive]
+    if not stopped:
+        typer.echo("No stopped instances to remove.")
+        return
+
+    typer.echo("The following stopped instance(s) will be removed:")
+    for info in stopped:
+        log_bytes = instance_log_bytes(info.scope, base_dir=base_dir)
+        if log_bytes:
+            typer.echo(f"  {info.scope}  (logs: {_format_log_size(log_bytes)})")
+        else:
+            typer.echo(f"  {info.scope}  (no logs)")
+
+    if not force and not typer.confirm("Remove stopped instances?", default=False):
+        typer.echo("Prune cancelled.")
+        return
+
+    removed = prune_instances(base_dir=base_dir)
+    if not removed:
+        typer.echo("No stopped instances to remove.")
+        return
+    if len(removed) == 1:
+        typer.echo(f"Removed stopped instance: {removed[0]}")
+    else:
+        scopes = ", ".join(removed)
+        typer.echo(f"Removed {len(removed)} stopped instance(s): {scopes}")
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
@@ -442,7 +442,7 @@ def stop_services_cmd(
         noun = "process" if n == 1 else "processes"
         msg += f" and {n} child {noun}"
     typer.echo(msg)
-    typer.echo(f"Instance record kept (logs preserved). Remove with: nemo services rm {scope}")
+    typer.echo(f"Instance directory kept (logs preserved). Remove with: nemo services rm {scope}")
 
 
 # ---------------------------------------------------------------------------
@@ -662,9 +662,11 @@ def _print_instance_table(instances: list[InstanceInfo]) -> None:
     typer.echo(f"{'SCOPE':<25} {'STATUS':<10} {'PID':<10} {'ADDRESS':<25} {'MODE':<12}")
     for info in instances:
         status = "running" if info.alive else "stopped"
-        pid = str(info.descriptor.pid) if info.descriptor else "-"
-        addr = f"{info.descriptor.host}:{info.descriptor.port}" if info.descriptor else "-"
-        mode = info.descriptor.mode if info.descriptor else "-"
+        pid = addr = mode = "-"
+        if info.descriptor:
+            pid = str(info.descriptor.pid)
+            addr = f"{info.descriptor.host}:{info.descriptor.port}"
+            mode = info.descriptor.mode
         typer.echo(f"{info.scope:<25} {status:<10} {pid:<10} {addr:<25} {mode:<12}")
 
 
@@ -687,13 +689,13 @@ def _resolve_rm_scope(scope: str | None, instance: str | None) -> str:
 def ls_services(
     show_all: Annotated[
         bool,
-        typer.Option("--all", "-a", help="Include stopped instance records (like docker ps -a)."),
+        typer.Option("--all", "-a", help="Include stopped instance directories (like docker ps -a)."),
     ] = False,
 ) -> None:
     """List service instances on this host.
 
     By default shows running instances only.  Use ``--all`` to include stopped
-    records that still have logs on disk.
+    instance directories that still have logs on disk.
 
     Examples:
       nemo services ls
@@ -711,8 +713,9 @@ def ls_services(
         _print_instance_table(visible)
         stopped = [info for info in visible if not info.alive]
         if stopped:
+            noun = "stopped instance directory" if len(stopped) == 1 else "stopped instance directories"
             typer.echo(
-                f"\n{len(stopped)} stopped instance(s). "
+                f"\n{len(stopped)} {noun}. "
                 "Remove with: nemo services prune  (or: nemo services rm <scope>)"
             )
         return
@@ -722,8 +725,9 @@ def ls_services(
         stopped_count = sum(1 for info in instances if not info.alive)
         if stopped_count:
             typer.echo("No running instances.")
+            noun = "stopped instance directory" if stopped_count == 1 else "stopped instance directories"
             typer.echo(
-                f"{stopped_count} stopped instance(s) on disk. "
+                f"{stopped_count} {noun} on disk. "
                 "List with: nemo services ls --all  |  Remove with: nemo services prune"
             )
         else:
@@ -734,7 +738,7 @@ def ls_services(
 
 
 # ---------------------------------------------------------------------------
-# rm (remove stopped instance record)
+# rm (remove stopped instance directory)
 # ---------------------------------------------------------------------------
 
 
@@ -746,13 +750,19 @@ def rm_services(
     ] = None,
     instance: Annotated[
         str | None,
-        typer.Option("--instance", help="Instance scope (alternative to positional argument)."),
+        typer.Option(
+            "--instance",
+            help="Scope from 'nemo services ls --all' (same value as the SCOPE positional).",
+        ),
     ] = None,
 ) -> None:
-    """Remove a stopped instance record and its logs.
+    """Remove a stopped instance directory and its logs.
 
     The scope must match a row from ``nemo services ls --all``.  Running
     instances are refused; stop them first.
+
+    Unlike ``run``/``start``, ``--instance`` here does not derive a scope from
+    cwd and port — it is an alternate spelling for the ``SCOPE`` argument.
 
     Examples:
       nemo services rm abc12345-8080
@@ -772,13 +782,13 @@ def rm_services(
         raise typer.Exit(1) from None
 
     if not removed:
-        typer.echo(f"No instance record found for scope '{effective_scope}'.", err=True)
+        typer.echo(f"No stopped instance directory found for scope '{effective_scope}'.", err=True)
         raise typer.Exit(1)
     typer.echo(f"Removed instance '{effective_scope}'.")
 
 
 # ---------------------------------------------------------------------------
-# prune (remove all stopped instance records)
+# prune (remove all stopped instance directories)
 # ---------------------------------------------------------------------------
 
 
@@ -789,9 +799,9 @@ def prune_services(
         typer.Option("--force", help="Remove without confirmation."),
     ] = False,
 ) -> None:
-    """Remove all stopped instance records on this host.
+    """Remove all stopped instance directories on this host.
 
-    Stopped records may include service logs from prior runs.  Logs are
+    Stopped instance directories may include service logs from prior runs.  Logs are
     deleted with the instance directory.
 
     Examples:
@@ -803,10 +813,10 @@ def prune_services(
 
     stopped = [info for info in list_instances(base_dir=base_dir) if not info.alive]
     if not stopped:
-        typer.echo("No stopped instances to remove.")
+        typer.echo("No stopped instance directories to remove.")
         return
 
-    typer.echo("The following stopped instance(s) will be removed:")
+    typer.echo("The following stopped instance directories will be removed:")
     for info in stopped:
         log_bytes = instance_log_bytes(info.scope, base_dir=base_dir)
         if log_bytes:
@@ -814,19 +824,19 @@ def prune_services(
         else:
             typer.echo(f"  {info.scope}  (no logs)")
 
-    if not force and not typer.confirm("Remove stopped instances?", default=False):
+    if not force and not typer.confirm("Remove stopped instance directories?", default=False):
         typer.echo("Prune cancelled.")
         return
 
     removed = prune_instances(base_dir=base_dir)
     if not removed:
-        typer.echo("No stopped instances to remove.")
+        typer.echo("No stopped instance directories to remove.")
         return
     if len(removed) == 1:
-        typer.echo(f"Removed stopped instance: {removed[0]}")
+        typer.echo(f"Removed stopped instance directory: {removed[0]}")
     else:
         scopes = ", ".join(removed)
-        typer.echo(f"Removed {len(removed)} stopped instance(s): {scopes}")
+        typer.echo(f"Removed {len(removed)} stopped instance directories: {scopes}")
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/cli.py
@@ -714,10 +714,7 @@ def ls_services(
         stopped = [info for info in visible if not info.alive]
         if stopped:
             noun = "stopped instance directory" if len(stopped) == 1 else "stopped instance directories"
-            typer.echo(
-                f"\n{len(stopped)} {noun}. "
-                "Remove with: nemo services prune  (or: nemo services rm <scope>)"
-            )
+            typer.echo(f"\n{len(stopped)} {noun}. Remove with: nemo services prune  (or: nemo services rm <scope>)")
         return
 
     running = [info for info in instances if info.alive]

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-status/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-status/SKILL.md
@@ -105,7 +105,7 @@ Status is itself a verification: the commands together prove the platform is rea
 |---|---|---|
 | `PLATFORM_DOWN` from probe | Nothing bound to :8080 | Route to `nemo-setup`; do not run the other three commands |
 | `PLATFORM_WEDGED` from probe | Listener exists, but `/health/ready` is not returning 200 — likely a crashed, partially-started, or not-ready platform | Tail `.venv/bin/nemo services logs -n 100` and surface the error. Common cause is a stale instance lock; the user can clear it with `nemo services stop --force` then re-run `nemo services run`. |
-| `nemo services ls` shows stopped rows with `-` for PID/address | Stopped instance record on disk (logs may remain) | Run `nemo services ls --all` for the full list. Remove with `nemo services prune` or `nemo services rm <scope>`. Cross-check liveness with `lsof -iTCP:8080 -sTCP:LISTEN`. |
+| `.venv/bin/nemo services ls` shows stopped rows with `-` for PID/address | Stopped instance directory on disk (logs may remain) | Run `.venv/bin/nemo services ls --all` for the full list. Remove with `.venv/bin/nemo services prune` or `.venv/bin/nemo services rm <scope>`. Cross-check liveness with `lsof -iTCP:8080 -sTCP:LISTEN`. |
 | `agents deployments list` returns "no such command" | Agents plugin not installed | Note in the summary: "Agents: plugin not installed"; do not fail the dashboard |
 | `inference providers list` empty | Provider not registered | Route to `nemo-setup` Step 4 (configure) |
 | `models list` empty for more than 60s after setup | Model discovery still running | Re-run after 30s; report the wait time |
@@ -115,6 +115,6 @@ Status is itself a verification: the commands together prove the platform is rea
 
 - **Read-only means read-only.** Never run `create`, `delete`, `stop`, or any state-changing command from this skill, even if the dashboard suggests something is broken. Route to setup or teardown for state changes.
 - **`agents deployments list` requires the agents plugin.** If it returns "no such command", the user has not installed the agents plugin yet; note that explicitly rather than failing silently.
-- **`nemo services ls` defaults to running instances only.** Use `nemo services ls --all` to see stopped records that still have logs on disk. Remove them with `nemo services prune` or `nemo services rm <scope>`. For liveness, cross-check against `lsof -iTCP:8080 -sTCP:LISTEN`.
+- **`.venv/bin/nemo services ls` defaults to running instances only.** Use `.venv/bin/nemo services ls --all` to see stopped instance directories that still have logs on disk. Remove them with `.venv/bin/nemo services prune` or `.venv/bin/nemo services rm <scope>`. For liveness, cross-check against `lsof -iTCP:8080 -sTCP:LISTEN`.
 - **Status is a snapshot.** A model still discovering will show as missing. Re-run after 30 seconds if the user just finished setup.
 - **Use `.venv/bin/nemo`, not bare `nemo`.** Bash sessions do not carry venv activation across calls.

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-status/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-status/SKILL.md
@@ -105,7 +105,7 @@ Status is itself a verification: the commands together prove the platform is rea
 |---|---|---|
 | `PLATFORM_DOWN` from probe | Nothing bound to :8080 | Route to `nemo-setup`; do not run the other three commands |
 | `PLATFORM_WEDGED` from probe | Listener exists, but `/health/ready` is not returning 200 — likely a crashed, partially-started, or not-ready platform | Tail `.venv/bin/nemo services logs -n 100` and surface the error. Common cause is a stale instance lock; the user can clear it with `nemo services stop --force` then re-run `nemo services run`. |
-| `nemo services ls` shows `running` with empty PID/address column | Held instance lock, no live process | Advisory only — trust the `lsof` probe above. Tell the user the lock is stale; offer `nemo services stop --force` to clear it. |
+| `nemo services ls` shows stopped rows with `-` for PID/address | Stopped instance record on disk (logs may remain) | Run `nemo services ls --all` for the full list. Remove with `nemo services prune` or `nemo services rm <scope>`. Cross-check liveness with `lsof -iTCP:8080 -sTCP:LISTEN`. |
 | `agents deployments list` returns "no such command" | Agents plugin not installed | Note in the summary: "Agents: plugin not installed"; do not fail the dashboard |
 | `inference providers list` empty | Provider not registered | Route to `nemo-setup` Step 4 (configure) |
 | `models list` empty for more than 60s after setup | Model discovery still running | Re-run after 30s; report the wait time |
@@ -115,6 +115,6 @@ Status is itself a verification: the commands together prove the platform is rea
 
 - **Read-only means read-only.** Never run `create`, `delete`, `stop`, or any state-changing command from this skill, even if the dashboard suggests something is broken. Route to setup or teardown for state changes.
 - **`agents deployments list` requires the agents plugin.** If it returns "no such command", the user has not installed the agents plugin yet; note that explicitly rather than failing silently.
-- **`nemo services status` and `nemo services ls` lie about liveness.** After a `nemo services run` process dies, the instance lock at `~/.local/state/nemo/instances/<scope>.lock` sticks around. Both commands keep reporting `running` against that stale lock with no PID and no address. Always cross-check against `lsof -iTCP:8080 -sTCP:LISTEN` before believing them.
+- **`nemo services ls` defaults to running instances only.** Use `nemo services ls --all` to see stopped records that still have logs on disk. Remove them with `nemo services prune` or `nemo services rm <scope>`. For liveness, cross-check against `lsof -iTCP:8080 -sTCP:LISTEN`.
 - **Status is a snapshot.** A model still discovering will show as missing. Re-run after 30 seconds if the user just finished setup.
 - **Use `.venv/bin/nemo`, not bare `nemo`.** Bash sessions do not carry venv activation across calls.

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-teardown/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-teardown/SKILL.md
@@ -32,10 +32,10 @@ Use `lsof` as ground truth. Do not trust `nemo services status` or `nemo service
 lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 && echo "RUNNING" || echo "ALREADY_STOPPED"
 ```
 
-If `ALREADY_STOPPED`: the platform is not serving. There may still be a stale lock under `~/.local/state/nemo/instances/` from a crashed previous run. Tell the user that, and offer:
+If `ALREADY_STOPPED`: the platform is not serving. Stopped instance records may still exist under `~/.local/state/nmp/instances/`. Tell the user that, and offer:
 
 - Option 3 (full cleanup of venv + `agents/` + data dir) only if they explicitly want it.
-- Otherwise, just clear the stale lock with `nemo services stop --force` so the next `nemo services run` doesn't refuse to start.
+- Otherwise, list stopped records with `nemo services ls --all` and remove them with `nemo services prune` (or `nemo services rm <scope>` for one scope). Logs are preserved until removal.
 
 ## Step 1: Snapshot state (what's about to be affected)
 
@@ -43,6 +43,7 @@ Show the user EVERYTHING that's currently on this platform so they can decide wh
 
 ```bash
 .venv/bin/nemo services ls
+.venv/bin/nemo services ls --all
 .venv/bin/nemo agents deployments list 2>/dev/null
 .venv/bin/nemo files filesets list 2>/dev/null
 .venv/bin/nemo jobs list 2>/dev/null
@@ -171,12 +172,12 @@ Verification passes only when `lsof` reports nothing on :8080 and (for options 2
 | `services stop` errors with "no instance" but `lsof` shows a listener | Lock state and reality diverged (foreground process with no registered instance, or instance was started in a different working directory / port scope) | Run `nemo services ls` to see what scopes the CLI knows about; the listener may belong to a different scope. Identify the PID from `lsof -iTCP:8080 -sTCP:LISTEN` and ask the user before sending SIGTERM. |
 | `services stop` says "stopped" but `lsof` still shows a listener | Process didn't honor SIGTERM in time | Re-run `nemo services stop --timeout 60`; if still alive, surface the PID and ask the user. Do not silently SIGKILL. |
 | `rm -rf` data dir fails with permission denied | Data dir owned by a different user, or a process still has it open | Surface the error; do not retry with sudo. Confirm `lsof -iTCP:8080` is empty and `lsof +D "$DATA_DIR" 2>/dev/null` shows nothing before retrying. |
-| `nemo services ls` shows `running` with empty PID/address after teardown | Stale lock leftover from a crashed `services run` | `nemo services stop --force` clears the lock. Then re-verify with `lsof`. |
+| `nemo services ls --all` shows stopped rows after teardown | Stopped instance records with logs remain on disk | `nemo services prune` removes them. Re-verify with `lsof`. |
 | User says "I changed my mind" mid-step | Confirmation came back ambiguous | Stop immediately; re-prompt. |
 
 ## Gotchas
 
-- **`lsof` is ground truth.** `nemo services status` and `nemo services ls` report stale "running" from held instance locks after the underlying process has died. Always cross-check against `lsof -iTCP:8080 -sTCP:LISTEN` before believing them.
+- **`lsof` is ground truth for whether the platform is serving.** `nemo services ls` defaults to running instances; use `nemo services ls --all` for stopped records on disk. Cross-check against `lsof -iTCP:8080 -sTCP:LISTEN` before believing either command.
 - **Foreground vs background instances.** `nemo services run` runs in the foreground and is protected from `nemo services stop` (stop refuses unless `--force`). `nemo services start` runs in the background and is the right target for `stop`. If `stop` refuses, ask the user where they ran `services run` so they can Ctrl-C it themselves.
 - **Wipe AFTER stop, not before.** On macOS especially, running `rm -rf ~/.local/share/nemo` while a `nemo services run` process is still alive leaves the running process holding the old inode while a freshly-spawned platform sees the new (empty) inode. Always confirm `lsof -iTCP:8080` is empty before the wipe.
 - **No `pkill`.** Don't grep for "nemo-platform" or "nemo services" and send SIGTERM blindly — the kernel doesn't know which instance is the user's and which belongs to a coworker on the same box. Use `nemo services stop` (or, with user confirmation, kill a specific PID surfaced by `lsof`).

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-teardown/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-teardown/SKILL.md
@@ -32,10 +32,10 @@ Use `lsof` as ground truth. Do not trust `nemo services status` or `nemo service
 lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 && echo "RUNNING" || echo "ALREADY_STOPPED"
 ```
 
-If `ALREADY_STOPPED`: the platform is not serving. Stopped instance records may still exist under `~/.local/state/nmp/instances/`. Tell the user that, and offer:
+If `ALREADY_STOPPED`: the platform is not serving. Stopped instance directories may still exist under `~/.local/state/nmp/instances/`. Tell the user that, and offer:
 
 - Option 3 (full cleanup of venv + `agents/` + data dir) only if they explicitly want it.
-- Otherwise, list stopped records with `nemo services ls --all` and remove them with `nemo services prune` (or `nemo services rm <scope>` for one scope). Logs are preserved until removal.
+- Otherwise, list stopped instance directories with `.venv/bin/nemo services ls --all` and remove them with `.venv/bin/nemo services prune` (or `.venv/bin/nemo services rm <scope>` for one scope). Logs are preserved until removal.
 
 ## Step 1: Snapshot state (what's about to be affected)
 
@@ -172,12 +172,12 @@ Verification passes only when `lsof` reports nothing on :8080 and (for options 2
 | `services stop` errors with "no instance" but `lsof` shows a listener | Lock state and reality diverged (foreground process with no registered instance, or instance was started in a different working directory / port scope) | Run `nemo services ls` to see what scopes the CLI knows about; the listener may belong to a different scope. Identify the PID from `lsof -iTCP:8080 -sTCP:LISTEN` and ask the user before sending SIGTERM. |
 | `services stop` says "stopped" but `lsof` still shows a listener | Process didn't honor SIGTERM in time | Re-run `nemo services stop --timeout 60`; if still alive, surface the PID and ask the user. Do not silently SIGKILL. |
 | `rm -rf` data dir fails with permission denied | Data dir owned by a different user, or a process still has it open | Surface the error; do not retry with sudo. Confirm `lsof -iTCP:8080` is empty and `lsof +D "$DATA_DIR" 2>/dev/null` shows nothing before retrying. |
-| `nemo services ls --all` shows stopped rows after teardown | Stopped instance records with logs remain on disk | `nemo services prune` removes them. Re-verify with `lsof`. |
+| `nemo services ls --all` shows stopped rows after teardown | Stopped instance directories with logs remain on disk | `nemo services prune` removes them. Re-verify with `lsof`. |
 | User says "I changed my mind" mid-step | Confirmation came back ambiguous | Stop immediately; re-prompt. |
 
 ## Gotchas
 
-- **`lsof` is ground truth for whether the platform is serving.** `nemo services ls` defaults to running instances; use `nemo services ls --all` for stopped records on disk. Cross-check against `lsof -iTCP:8080 -sTCP:LISTEN` before believing either command.
+- **`lsof` is ground truth for whether the platform is serving.** `nemo services ls` defaults to running instances; use `nemo services ls --all` for stopped instance directories on disk. Cross-check against `lsof -iTCP:8080 -sTCP:LISTEN` before believing either command.
 - **Foreground vs background instances.** `nemo services run` runs in the foreground and is protected from `nemo services stop` (stop refuses unless `--force`). `nemo services start` runs in the background and is the right target for `stop`. If `stop` refuses, ask the user where they ran `services run` so they can Ctrl-C it themselves.
 - **Wipe AFTER stop, not before.** On macOS especially, running `rm -rf ~/.local/share/nemo` while a `nemo services run` process is still alive leaves the running process holding the old inode while a freshly-spawned platform sees the new (empty) inode. Always confirm `lsof -iTCP:8080` is empty before the wipe.
 - **No `pkill`.** Don't grep for "nemo-platform" or "nemo services" and send SIGTERM blindly — the kernel doesn't know which instance is the user's and which belongs to a coworker on the same box. Use `nemo services stop` (or, with user confirmation, kill a specific PID surfaced by `lsof`).

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services.py
@@ -34,6 +34,13 @@ _PROCESS_MODULE = "nemo_platform.cli.commands.services._process"
 _CLI_MODULE = "nemo_platform.cli.commands.services.cli"
 
 
+def _seed_stopped_scope(base_dir: Path, scope: str, *, log_content: str = "x\n") -> Path:
+    """Create a stopped instance directory with service logs."""
+    d = instance_dir(scope, base_dir=base_dir)
+    (d / "services.log").write_text(log_content)
+    return d
+
+
 _original_find_spec = __import__("importlib").util.find_spec
 
 
@@ -66,7 +73,7 @@ def test_services_group_is_registered():
 def test_services_help_lists_all_commands():
     result = runner.invoke(app, ["services", "--help"])
     assert result.exit_code == 0
-    for cmd in ("run", "start", "stop", "restart", "status", "ls", "logs"):
+    for cmd in ("run", "start", "stop", "restart", "status", "ls", "logs", "rm", "prune"):
         assert cmd in result.stdout, f"'{cmd}' not in help output"
 
 
@@ -303,9 +310,11 @@ class TestServicesStop:
 
     def test_stops_running_services(self, base_dir: Path):
         with patch(f"{_CLI_MODULE}.stop_instance", return_value=StopResult(stopped_pids=[12345])):
-            result = runner.invoke(app, ["services", "stop", "--instance", "test"])
+            with patch(f"{_CLI_MODULE}.compute_scope", return_value="stop-scope"):
+                result = runner.invoke(app, ["services", "stop", "--instance", "stop-scope"])
         assert result.exit_code == 0
         assert "12345" in result.stdout
+        assert "nemo services rm stop-scope" in result.stdout
 
     def test_stop_timeout_option(self, base_dir: Path):
         with patch(f"{_CLI_MODULE}.stop_instance", return_value=StopResult(stopped_pids=[])) as mock_stop:
@@ -532,7 +541,7 @@ class TestServicesLs:
     def test_no_instances(self, base_dir: Path):
         result = runner.invoke(app, ["services", "ls"])
         assert result.exit_code == 0
-        assert "No instances" in result.stdout
+        assert "No running instances" in result.stdout
 
     def test_lists_running_instance(self, base_dir: Path):
         scope = "ls-test"
@@ -555,6 +564,129 @@ class TestServicesLs:
         assert result.exit_code == 0
         assert scope in result.stdout
         assert "running" in result.stdout
+
+    def test_hides_stopped_by_default(self, base_dir: Path):
+        _seed_stopped_scope(base_dir, "stopped-hidden")
+
+        result = runner.invoke(app, ["services", "ls"])
+        assert result.exit_code == 0
+        assert "stopped-hidden" not in result.stdout
+        assert "1 stopped instance(s)" in result.stdout
+        assert "ls --all" in result.stdout
+
+    def test_all_shows_stopped_with_footer(self, base_dir: Path):
+        _seed_stopped_scope(base_dir, "stopped-visible")
+
+        result = runner.invoke(app, ["services", "ls", "--all"])
+        assert result.exit_code == 0
+        assert "stopped-visible" in result.stdout
+        assert "stopped" in result.stdout
+        assert "nemo services prune" in result.stdout
+
+    def test_all_no_instances(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "ls", "--all"])
+        assert result.exit_code == 0
+        assert "No instances found" in result.stdout
+
+    def test_mixed_running_and_stopped(self, base_dir: Path):
+        running_scope = "running-mixed"
+        fd = acquire_lock(running_scope, base_dir=base_dir)
+        write_descriptor(
+            InstanceDescriptor(
+                pid=os.getpid(),
+                scope=running_scope,
+                host="127.0.0.1",
+                port=8080,
+                mode="background",
+                create_time=1.0,
+            ),
+            base_dir=base_dir,
+        )
+        _seed_stopped_scope(base_dir, "stopped-mixed")
+
+        try:
+            default = runner.invoke(app, ["services", "ls"])
+            all_rows = runner.invoke(app, ["services", "ls", "--all"])
+        finally:
+            os.close(fd)
+
+        assert default.exit_code == 0
+        assert running_scope in default.stdout
+        assert "stopped-mixed" not in default.stdout
+
+        assert all_rows.exit_code == 0
+        assert running_scope in all_rows.stdout
+        assert "stopped-mixed" in all_rows.stdout
+        assert "nemo services prune" in all_rows.stdout
+
+
+class TestServicesRm:
+    @pytest.mark.parametrize(
+        ("scope", "args"),
+        [
+            ("rm-cli", ["services", "rm", "rm-cli"]),
+            ("rm-flag", ["services", "rm", "--instance", "rm-flag"]),
+        ],
+    )
+    def test_rm_removes_stopped_scope(self, base_dir: Path, scope: str, args: list[str]) -> None:
+        d = _seed_stopped_scope(base_dir, scope)
+
+        result = runner.invoke(app, args)
+        assert result.exit_code == 0
+        assert f"Removed instance '{scope}'" in result.stdout
+        assert not d.exists()
+
+    def test_rm_not_found(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "rm", "missing-scope"])
+        assert result.exit_code == 1
+        assert "No instance record found" in result.stderr
+
+    def test_rm_refuses_running(self, base_dir: Path):
+        fd = acquire_lock("running-rm-cli", base_dir=base_dir)
+        try:
+            result = runner.invoke(app, ["services", "rm", "running-rm-cli"])
+        finally:
+            os.close(fd)
+        assert result.exit_code == 1
+        assert "still running" in result.stderr
+
+    def test_rm_requires_scope(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "rm"])
+        assert result.exit_code == 1
+        assert "Scope required" in result.stderr
+
+    def test_rm_rejects_invalid_scope(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "rm", "../escape"])
+        assert result.exit_code == 1
+        assert "Invalid instance scope" in result.stderr
+
+    def test_rm_rejects_conflicting_scope_args(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "rm", "scope-a", "--instance", "scope-b"])
+        assert result.exit_code != 0
+        assert "Cannot pass different values" in result.stderr
+
+
+class TestServicesPrune:
+    def test_prune_force_removes_stopped(self, base_dir: Path):
+        d = _seed_stopped_scope(base_dir, "prune-me")
+
+        result = runner.invoke(app, ["services", "prune", "--force"])
+        assert result.exit_code == 0
+        assert "prune-me" in result.stdout
+        assert not d.exists()
+
+    def test_prune_noop_when_clean(self, base_dir: Path):
+        result = runner.invoke(app, ["services", "prune", "--force"])
+        assert result.exit_code == 0
+        assert "No stopped instances" in result.stdout
+
+    def test_prune_cancelled(self, base_dir: Path):
+        d = _seed_stopped_scope(base_dir, "keep-me")
+
+        result = runner.invoke(app, ["services", "prune"], input="n\n")
+        assert result.exit_code == 0
+        assert "Prune cancelled" in result.stdout
+        assert d.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services.py
@@ -571,7 +571,7 @@ class TestServicesLs:
         result = runner.invoke(app, ["services", "ls"])
         assert result.exit_code == 0
         assert "stopped-hidden" not in result.stdout
-        assert "1 stopped instance(s)" in result.stdout
+        assert "1 stopped instance directory" in result.stdout
         assert "ls --all" in result.stdout
 
     def test_all_shows_stopped_with_footer(self, base_dir: Path):
@@ -639,7 +639,7 @@ class TestServicesRm:
     def test_rm_not_found(self, base_dir: Path):
         result = runner.invoke(app, ["services", "rm", "missing-scope"])
         assert result.exit_code == 1
-        assert "No instance record found" in result.stderr
+        assert "No stopped instance directory found" in result.stderr
 
     def test_rm_refuses_running(self, base_dir: Path):
         fd = acquire_lock("running-rm-cli", base_dir=base_dir)
@@ -678,7 +678,7 @@ class TestServicesPrune:
     def test_prune_noop_when_clean(self, base_dir: Path):
         result = runner.invoke(app, ["services", "prune", "--force"])
         assert result.exit_code == 0
-        assert "No stopped instances" in result.stdout
+        assert "No stopped instance directories" in result.stdout
 
     def test_prune_cancelled(self, base_dir: Path):
         d = _seed_stopped_scope(base_dir, "keep-me")

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_lifecycle.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_lifecycle.py
@@ -26,6 +26,7 @@ import time
 from pathlib import Path
 
 import pytest
+from nemo_platform.cli.app import app
 from nemo_platform.cli.commands.services._process import (
     InstanceDescriptor,
     PortConflict,
@@ -36,10 +37,15 @@ from nemo_platform.cli.commands.services._process import (
     is_instance_alive,
     is_port_bindable,
     list_instances,
+    prune_instances,
     read_descriptor,
+    remove_instance,
     stop_instance,
     write_descriptor,
 )
+from typer.testing import CliRunner
+
+_runner = CliRunner()
 
 _STARTUP_TIMEOUT = 15
 _SHUTDOWN_TIMEOUT = 5
@@ -527,6 +533,101 @@ class TestEndToEndHealthPolling:
             if proc.poll() is None:
                 proc.kill()
                 proc.wait(timeout=5)
+
+
+class TestInstanceCleanup:
+    """Integration tests for rm/prune and post-stop instance directories."""
+
+    def test_stop_leaves_record_until_rm(self, tmp_path: Path, monkeypatch) -> None:
+        base_dir = tmp_path / "state"
+        scope = "stop-then-rm"
+        monkeypatch.setenv("_NMP_STATE_DIR", str(base_dir))
+
+        proc = _spawn_platform(tmp_path / "scripts", base_dir, scope)
+        try:
+            stop_instance(scope, base_dir=base_dir, timeout=5.0)
+            proc.wait(timeout=_SHUTDOWN_TIMEOUT)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+        scope_dir = instance_dir(scope, base_dir=base_dir)
+        (scope_dir / "services.log").write_text("post-stop log\n")
+        instances = list_instances(base_dir=base_dir)
+        assert len(instances) == 1
+        assert instances[0].alive is False
+
+        assert remove_instance(scope, base_dir=base_dir) is True
+        assert not scope_dir.exists()
+
+    def test_stop_then_rm_via_cli(self, tmp_path: Path, monkeypatch) -> None:
+        base_dir = tmp_path / "state"
+        scope = "stop-then-rm-cli"
+        monkeypatch.setenv("_NMP_STATE_DIR", str(base_dir))
+
+        proc = _spawn_platform(tmp_path / "scripts-rm-cli", base_dir, scope)
+        try:
+            stop_instance(scope, base_dir=base_dir, timeout=5.0)
+            proc.wait(timeout=_SHUTDOWN_TIMEOUT)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+        scope_dir = instance_dir(scope, base_dir=base_dir)
+        (scope_dir / "services.log").write_text("post-stop log\n")
+        assert scope_dir.exists()
+
+        result = _runner.invoke(app, ["services", "rm", scope])
+        assert result.exit_code == 0
+        assert f"Removed instance '{scope}'" in result.stdout
+        assert not scope_dir.exists()
+
+    def test_sigkill_crash_then_prune(self, tmp_path: Path) -> None:
+        base_dir = tmp_path / "state"
+        scope = "crash-prune"
+        proc = _spawn_platform(tmp_path / "run1", base_dir, scope)
+        os.kill(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=_SHUTDOWN_TIMEOUT)
+
+        scope_dir = instance_dir(scope, base_dir=base_dir)
+        (scope_dir / "services.log").write_text("crash log\n")
+
+        removed = prune_instances(base_dir=base_dir)
+        assert scope in removed
+        assert not scope_dir.exists()
+
+    def test_prune_skips_running(self, tmp_path: Path) -> None:
+        base_dir = tmp_path / "state"
+        running = _spawn_platform(tmp_path / "run-a", base_dir, "scope-running")
+        stopped_dir = instance_dir("scope-stopped", base_dir=base_dir)
+        (stopped_dir / "services.log").write_text("x\n")
+        try:
+            removed = prune_instances(base_dir=base_dir)
+            assert removed == ["scope-stopped"]
+            assert is_instance_alive("scope-running", base_dir=base_dir)
+            assert not stopped_dir.exists()
+        finally:
+            os.kill(running.pid, signal.SIGTERM)
+            running.wait(timeout=_SHUTDOWN_TIMEOUT)
+
+    def test_logs_available_before_rm_not_after(self, tmp_path: Path, monkeypatch) -> None:
+        base_dir = tmp_path / "state"
+        scope = "logs-rm"
+        monkeypatch.setenv("_NMP_STATE_DIR", str(base_dir))
+        d = instance_dir(scope, base_dir=base_dir)
+        (d / "services.log").write_text("debug line\n")
+
+        before = _runner.invoke(app, ["services", "logs", "--instance", scope])
+        assert before.exit_code == 0
+        assert "debug line" in before.stdout
+
+        remove_instance(scope, base_dir=base_dir)
+
+        after = _runner.invoke(app, ["services", "logs", "--instance", scope])
+        assert after.exit_code == 0
+        assert "No log file" in after.stdout
 
 
 class TestPortAvailability:

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_process.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_process.py
@@ -18,16 +18,22 @@ from nemo_platform.cli.commands.services._process import (
     ForegroundInstanceError,
     InstanceAlreadyRunningError,
     InstanceDescriptor,
+    InstanceStillRunningError,
     _pid_alive,
     _snapshot_children,
     _sweep_orphans,
     acquire_lock,
     compute_scope,
     instance_dir,
+    instance_log_bytes,
     is_instance_alive,
+    is_removable_ghost,
     list_instances,
+    list_stopped_scopes,
+    prune_instances,
     read_descriptor,
     remove_descriptor,
+    remove_instance,
     rotate_log,
     start_background,
     stop_instance,
@@ -268,10 +274,164 @@ class TestListInstances:
         write_descriptor(desc, base_dir=base_dir)
 
         instances = list_instances(base_dir=base_dir)
+        assert instances == []
+        assert not d.exists()
+
+    def test_stale_descriptor_with_logs_stays_listed(self, base_dir: Path) -> None:
+        d = instance_dir("dead-with-logs", base_dir=base_dir)
+        desc = InstanceDescriptor(
+            pid=999999,
+            scope="dead-with-logs",
+            host="127.0.0.1",
+            port=8080,
+            mode="background",
+            create_time=1.0,
+        )
+        write_descriptor(desc, base_dir=base_dir)
+        (d / "services.log").write_text("crash output\n")
+
+        instances = list_instances(base_dir=base_dir)
         assert len(instances) == 1
+        assert instances[0].scope == "dead-with-logs"
         assert instances[0].alive is False
         assert instances[0].descriptor is None
-        assert not (d / "instance.json").exists()
+        assert d.exists()
+
+    def test_auto_removes_lock_only_ghost(self, base_dir: Path) -> None:
+        d = instance_dir("ghost-lock", base_dir=base_dir)
+        (d / "services.lock").touch()
+
+        instances = list_instances(base_dir=base_dir)
+        assert instances == []
+        assert not d.exists()
+
+    def test_keeps_stopped_instance_with_logs(self, base_dir: Path) -> None:
+        d = instance_dir("stopped-logs", base_dir=base_dir)
+        (d / "services.lock").touch()
+        (d / "services.log").write_text("crash output\n")
+
+        instances = list_instances(base_dir=base_dir)
+        assert len(instances) == 1
+        assert instances[0].scope == "stopped-logs"
+        assert instances[0].alive is False
+        assert instances[0].descriptor is None
+        assert d.exists()
+
+    def test_keeps_stopped_instance_with_rotated_logs_only(self, base_dir: Path) -> None:
+        d = instance_dir("rotated-logs", base_dir=base_dir)
+        (d / "services.lock").touch()
+        (d / "services.log.20250101T000000Z").write_text("old boot\n")
+
+        instances = list_instances(base_dir=base_dir)
+        assert len(instances) == 1
+        assert instances[0].scope == "rotated-logs"
+
+    def test_empty_services_log_is_still_a_ghost(self, base_dir: Path) -> None:
+        d = instance_dir("empty-log", base_dir=base_dir)
+        (d / "services.lock").touch()
+        (d / "services.log").touch()
+
+        instances = list_instances(base_dir=base_dir)
+        assert instances == []
+        assert not d.exists()
+
+    def test_running_instance_not_auto_removed(self, base_dir: Path) -> None:
+        fd = acquire_lock("alive-ghost-check", base_dir=base_dir)
+        try:
+            instances = list_instances(base_dir=base_dir)
+            assert len(instances) == 1
+            assert instances[0].alive is True
+        finally:
+            os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# remove_instance / prune_instances
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveInstance:
+    def test_removes_dead_scope_dir(self, base_dir: Path) -> None:
+        d = instance_dir("rm-me", base_dir=base_dir)
+        (d / "services.log").write_text("logs\n")
+
+        assert remove_instance("rm-me", base_dir=base_dir) is True
+        assert not d.exists()
+
+    def test_missing_scope_returns_false(self, base_dir: Path) -> None:
+        assert remove_instance("missing", base_dir=base_dir) is False
+
+    def test_refuses_running_instance(self, base_dir: Path) -> None:
+        fd = acquire_lock("running-rm", base_dir=base_dir)
+        try:
+            with pytest.raises(InstanceStillRunningError, match="running-rm"):
+                remove_instance("running-rm", base_dir=base_dir)
+        finally:
+            os.close(fd)
+
+    def test_rejects_invalid_scope(self, base_dir: Path) -> None:
+        with pytest.raises(ValueError, match="Invalid instance scope"):
+            remove_instance("../escape", base_dir=base_dir)
+
+    def test_returns_false_when_rmtree_fails(self, base_dir: Path) -> None:
+        d = instance_dir("rmtree-fail", base_dir=base_dir)
+        (d / "services.log").write_text("logs\n")
+
+        with patch(
+            "nemo_platform.cli.commands.services._process.shutil.rmtree",
+            side_effect=OSError("permission denied"),
+        ):
+            assert remove_instance("rmtree-fail", base_dir=base_dir) is False
+        assert d.exists()
+
+
+class TestPruneInstances:
+    def test_removes_all_stopped_scopes(self, base_dir: Path) -> None:
+        alive_fd = acquire_lock("alive-prune", base_dir=base_dir)
+        stopped = instance_dir("stopped-prune", base_dir=base_dir)
+        (stopped / "services.log").write_text("x\n")
+        try:
+            removed = prune_instances(base_dir=base_dir)
+            assert removed == ["stopped-prune"]
+            assert not stopped.exists()
+            assert is_instance_alive("alive-prune", base_dir=base_dir)
+        finally:
+            os.close(alive_fd)
+
+    def test_noop_when_empty(self, base_dir: Path) -> None:
+        assert prune_instances(base_dir=base_dir) == []
+
+
+class TestInstanceLogBytes:
+    def test_sums_active_and_rotated_logs(self, base_dir: Path) -> None:
+        d = instance_dir("log-bytes", base_dir=base_dir)
+        (d / "services.log").write_text("abc")
+        (d / "services.log.old").write_text("de")
+
+        assert instance_log_bytes("log-bytes", base_dir=base_dir) == 5
+
+
+class TestIsRemovableGhost:
+    def test_true_for_lock_only(self, base_dir: Path) -> None:
+        d = instance_dir("ghost", base_dir=base_dir)
+        (d / "services.lock").touch()
+        assert is_removable_ghost("ghost", base_dir=base_dir) is True
+
+    def test_false_when_logs_present(self, base_dir: Path) -> None:
+        d = instance_dir("not-ghost", base_dir=base_dir)
+        (d / "services.log").write_text("data\n")
+        assert is_removable_ghost("not-ghost", base_dir=base_dir) is False
+
+
+class TestListStoppedScopes:
+    def test_lists_only_stopped(self, base_dir: Path) -> None:
+        fd = acquire_lock("up", base_dir=base_dir)
+        down = instance_dir("down", base_dir=base_dir)
+        (down / "services.log").write_text("x\n")
+        try:
+            assert list_stopped_scopes(base_dir=base_dir) == ["down"]
+        finally:
+            os.close(fd)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `nemo services rm <scope>` and `nemo services prune [--force]` to remove stopped instance records (Docker-style cleanup for NVBugs 6235652 / AIRCORE-716)
- Change `nemo services ls` default to running instances only; use `ls --all` for stopped records with logs preserved until explicit removal
- Auto-remove empty ghost dirs (dead, no descriptor, no non-empty logs) during `list_instances`; update setup docs, CLI reference, and teardown/status skills

## Test plan

- [x] `uv run --frozen pytest packages/nemo_platform_ext/tests/cli/commands/test_services*.py` — 133 passed
- [x] `uv run --frozen pytest sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services*.py` — 133 passed
- [x] Manual: stop a local platform instance, confirm `ls --all` shows stopped row, `rm` removes it
- [x] Manual: accumulate multiple stopped scopes, confirm `prune` preview + confirm removes all stopped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `nemo services ls` defaults to running instances; `--all` shows stopped records.
  * Added `nemo services rm <scope>` to remove individual stopped instance records (refuses running instances).
  * Added `nemo services prune` to remove all stopped records (confirmation/--force) and report per-instance log sizes.
  * `stop` now notes that stopped instance records/logs are preserved and how to remove them.

* **Bug Fixes**
  * Automatic cleanup of stale/ghost instance directories that contain no preservable logs.

* **Documentation**
  * CLI, setup, and skill docs updated with examples and guidance.

* **Tests**
  * New and expanded CLI and lifecycle tests for listing, removal, pruning, and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->