### PR TITLE
feat(e2e): Add jobs e2e tests w/ fixes, mock inference provider

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -34,6 +34,22 @@ import httpx
 import pytest
 from nemo_platform import NeMoPlatform
 
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Enable mock inference provider for e2e tests.
+
+    Sets the env var and clears the Configuration cache so that
+    InferenceGatewayConfig picks up the new value. The cache must be
+    cleared because the config module evaluates ``get_service_config()``
+    at import time, which may run before this hook.
+    """
+    os.environ.setdefault("NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX", "igw-mock-")
+
+    from nemo_platform_plugin.config import Configuration
+
+    Configuration.clear_cache()
+
+
 logger = logging.getLogger(__name__)
 
 _HEALTH_TIMEOUT = 60
@@ -104,7 +120,7 @@ def _services() -> Iterator[str]:
     url = f"http://127.0.0.1:{port}"
 
     nemo_bin = str(Path(sys.executable).parent / "nemo")
-    args = [nemo_bin, "services", "run", "--service-group", "all", "--port", str(port)]
+    args = [nemo_bin, "services", "run", "--port", str(port)]
 
     logger.info("Starting nemo services on port %d", port)
 

--- a/e2e/test_inference.py
+++ b/e2e/test_inference.py
@@ -1,0 +1,378 @@
+"""E2E tests for the Inference Gateway with mock provider mode.
+
+These tests verify that mock provider mode works through the real platform
+subprocess, exercising provider CRUD, model entity routing, OpenAI routing,
+chat completions, streaming, and error simulation.
+
+Mock provider mode is enabled by the NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX
+env var set in conftest.py. Tests use ``add_mock_provider()`` from nmp.testing
+to create providers that return canned responses without a real inference backend.
+"""
+
+import json
+import uuid
+
+import pytest
+from nemo_platform import NeMoPlatform
+from nmp.testing import MockProviderResponse, add_mock_provider
+
+
+def _unique_name(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+# ---------------------------------------------------------------------------
+# Provider CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_provider_create_and_list(sdk: NeMoPlatform, workspace: str):
+    """Create a mock provider and verify it appears in the provider list."""
+    provider = add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=_unique_name("crud-provider"),
+        mock_response_body={"id": "chatcmpl-test", "choices": []},
+    )
+
+    providers = sdk.inference.providers.list(workspace=workspace)
+    names = [p.name for p in providers.data]
+    assert provider.name in names
+
+
+def test_provider_create_and_delete(sdk: NeMoPlatform, workspace: str):
+    """Create then delete a mock provider."""
+    provider = add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=_unique_name("delete-provider"),
+        mock_response_body={"id": "chatcmpl-test", "choices": []},
+    )
+
+    sdk.inference.providers.delete(workspace=workspace, name=provider.name)
+
+    providers = sdk.inference.providers.list(workspace=workspace)
+    names = [p.name for p in providers.data]
+    assert provider.name not in names
+
+
+# ---------------------------------------------------------------------------
+# Chat completions via provider route
+# ---------------------------------------------------------------------------
+
+
+def test_chat_completion_via_provider_route(sdk: NeMoPlatform, workspace: str):
+    """Send a chat completion request routed by provider name."""
+    chat_response = {
+        "id": "chatcmpl-provider",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello from provider route!"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+    }
+
+    provider = add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=_unique_name("provider-chat"),
+        mock_response_body=chat_response,
+    )
+
+    response = sdk.inference.gateway.provider.post(
+        "v1/chat/completions",
+        name=provider.name,
+        workspace=workspace,
+        body={"model": "test", "messages": [{"role": "user", "content": "Hi"}]},
+    )
+
+    assert response["id"] == "chatcmpl-provider"
+    assert response["choices"][0]["message"]["content"] == "Hello from provider route!"
+    assert response["usage"]["total_tokens"] == 12
+
+
+# ---------------------------------------------------------------------------
+# Chat completions via model entity route
+# ---------------------------------------------------------------------------
+
+
+def test_chat_completion_via_model_entity_route(sdk: NeMoPlatform, workspace: str):
+    """Send a chat completion request routed by model entity name."""
+    entity_name = _unique_name("model-entity")
+    chat_response = {
+        "id": "chatcmpl-model",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello from model route!"},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=entity_name,
+        mock_response_body=chat_response,
+    )
+
+    response = sdk.inference.gateway.model.post(
+        "v1/chat/completions",
+        name=entity_name,
+        workspace=workspace,
+        body={"model": "test", "messages": [{"role": "user", "content": "Hi"}]},
+    )
+
+    assert response["id"] == "chatcmpl-model"
+    assert response["choices"][0]["message"]["content"] == "Hello from model route!"
+
+
+# ---------------------------------------------------------------------------
+# Chat completions via OpenAI-compatible route
+# ---------------------------------------------------------------------------
+
+
+def test_chat_completion_via_openai_route(sdk: NeMoPlatform, workspace: str):
+    """Send a chat completion request via the OpenAI-compatible route."""
+    entity_name = _unique_name("openai-model")
+    chat_response = {
+        "id": "chatcmpl-openai",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello from OpenAI route!"},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=entity_name,
+        mock_response_body=chat_response,
+    )
+
+    response = sdk.inference.gateway.openai.post(
+        "v1/chat/completions",
+        workspace=workspace,
+        body={
+            "model": f"{workspace}/{entity_name}",
+            "messages": [{"role": "user", "content": "Hi"}],
+        },
+    )
+
+    assert response["id"] == "chatcmpl-openai"
+    assert response["choices"][0]["message"]["content"] == "Hello from OpenAI route!"
+
+
+# ---------------------------------------------------------------------------
+# Streaming chat completions
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_chat_completion(sdk: NeMoPlatform, workspace: str):
+    """Streaming chat completion returns SSE chunks with content."""
+    chat_response = {
+        "id": "chatcmpl-stream",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "streamed response"},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+    provider = add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=_unique_name("stream-provider"),
+        mock_response_body=chat_response,
+    )
+
+    # Make a raw streaming request via httpx
+    with sdk._client.stream(
+        "POST",
+        f"/apis/inference-gateway/v2/workspaces/{workspace}/provider/{provider.name}/-/v1/chat/completions",
+        json={
+            "model": "test",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stream": True,
+        },
+    ) as response:
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers.get("content-type", "")
+
+        chunks = []
+        for line in response.iter_lines():
+            if line.startswith("data: ") and line != "data: [DONE]":
+                chunks.append(json.loads(line[len("data: "):]))
+
+    assert len(chunks) > 0
+    # Reassemble streamed content
+    content = "".join(
+        chunk["choices"][0]["delta"].get("content", "")
+        for chunk in chunks
+        if chunk.get("choices")
+    )
+    assert "streamed" in content or "response" in content
+
+
+# ---------------------------------------------------------------------------
+# Model listing
+# ---------------------------------------------------------------------------
+
+
+def test_model_list_via_openai_route(sdk: NeMoPlatform, workspace: str):
+    """The OpenAI /v1/models endpoint lists models served by mock providers."""
+    entity_name = _unique_name("listable-model")
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=entity_name,
+        mock_response_body={"id": "chatcmpl-test", "choices": []},
+        served_models={entity_name: f"served-{entity_name}"},
+    )
+
+    models = sdk.inference.gateway.openai.v1.models.list(workspace=workspace)
+    model_ids = [m.id for m in models.data]
+    # The model entity should appear (as workspace/entity_name)
+    assert any(entity_name in mid for mid in model_ids)
+
+
+# ---------------------------------------------------------------------------
+# Error simulation
+# ---------------------------------------------------------------------------
+
+
+def test_mock_provider_error_simulation(sdk: NeMoPlatform, workspace: str):
+    """Mock providers can simulate HTTP error responses."""
+    from nemo_platform import InternalServerError
+
+    provider = add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=_unique_name("error-provider"),
+        mock_response_body={"error": {"message": "simulated failure", "type": "server_error"}},
+        mock_status=500,
+    )
+
+    with pytest.raises(InternalServerError) as exc_info:
+        sdk.inference.gateway.provider.post(
+            "v1/chat/completions",
+            name=provider.name,
+            workspace=workspace,
+            body={"model": "test", "messages": []},
+        )
+
+    assert exc_info.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Per-model sequential responses
+# ---------------------------------------------------------------------------
+
+
+def test_per_model_sequential_responses(sdk: NeMoPlatform, workspace: str):
+    """Mock providers support different sequential responses per model."""
+    entity_main = _unique_name("main-llm")
+    entity_safety = _unique_name("safety-llm")
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=_unique_name("multi-model"),
+        mock_response_body_by_model={
+            f"{workspace}/{entity_main}": [
+                MockProviderResponse(
+                    response_code=200,
+                    response_body={
+                        "id": "main-1",
+                        "choices": [{"message": {"role": "assistant", "content": "main response"}}],
+                    },
+                ),
+            ],
+            f"{workspace}/{entity_safety}": [
+                MockProviderResponse(
+                    response_code=200,
+                    response_body={
+                        "id": "safety-1",
+                        "choices": [{"message": {"role": "assistant", "content": '{"safe": true}'}}],
+                    },
+                ),
+                MockProviderResponse(
+                    response_code=200,
+                    response_body={
+                        "id": "safety-2",
+                        "choices": [{"message": {"role": "assistant", "content": '{"safe": false}'}}],
+                    },
+                ),
+            ],
+        },
+        served_models={entity_main: entity_main, entity_safety: entity_safety},
+    )
+
+    # Main model returns its response
+    resp = sdk.inference.gateway.model.post(
+        "v1/chat/completions",
+        name=entity_main,
+        workspace=workspace,
+        body={"model": f"{workspace}/{entity_main}", "messages": []},
+    )
+    assert resp["id"] == "main-1"
+
+    # Safety model returns first response, then second
+    resp1 = sdk.inference.gateway.model.post(
+        "v1/chat/completions",
+        name=entity_safety,
+        workspace=workspace,
+        body={"model": f"{workspace}/{entity_safety}", "messages": []},
+    )
+    assert resp1["id"] == "safety-1"
+
+    resp2 = sdk.inference.gateway.model.post(
+        "v1/chat/completions",
+        name=entity_safety,
+        workspace=workspace,
+        body={"model": f"{workspace}/{entity_safety}", "messages": []},
+    )
+    assert resp2["id"] == "safety-2"
+
+    # Third call clamps to last response
+    resp3 = sdk.inference.gateway.model.post(
+        "v1/chat/completions",
+        name=entity_safety,
+        workspace=workspace,
+        body={"model": f"{workspace}/{entity_safety}", "messages": []},
+    )
+    assert resp3["id"] == "safety-2"
+
+
+# ---------------------------------------------------------------------------
+# Virtual model CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_virtual_model_created_by_mock_provider(sdk: NeMoPlatform, workspace: str):
+    """add_mock_provider creates a passthrough VirtualModel for each served entity."""
+    entity_name = _unique_name("vm-check")
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=entity_name,
+        mock_response_body={"id": "chatcmpl-test", "choices": []},
+    )
+
+    vm = sdk.inference.virtual_models.retrieve(workspace=workspace, name=entity_name)
+    assert vm.name == entity_name
+    assert vm.autoprovisioned is True
+    assert vm.default_model_entity == f"{workspace}/{entity_name}"

--- a/e2e/test_inference.py
+++ b/e2e/test_inference.py
@@ -215,15 +215,11 @@ def test_streaming_chat_completion(sdk: NeMoPlatform, workspace: str):
         chunks = []
         for line in response.iter_lines():
             if line.startswith("data: ") and line != "data: [DONE]":
-                chunks.append(json.loads(line[len("data: "):]))
+                chunks.append(json.loads(line[len("data: ") :]))
 
     assert len(chunks) > 0
     # Reassemble streamed content
-    content = "".join(
-        chunk["choices"][0]["delta"].get("content", "")
-        for chunk in chunks
-        if chunk.get("choices")
-    )
+    content = "".join(chunk["choices"][0]["delta"].get("content", "") for chunk in chunks if chunk.get("choices"))
     assert "streamed" in content or "response" in content
 
 

--- a/e2e/test_jobs.py
+++ b/e2e/test_jobs.py
@@ -1,0 +1,526 @@
+"""E2E tests for platform jobs via the subprocess executor.
+
+These tests submit jobs with CPUExecutionProviderSpec (container image + command).
+In subprocess mode, the jobs service translates cpu/default steps to subprocess
+steps automatically — the container image is discarded and the command runs
+directly on the host.
+
+Ported from Platform-Deploy e2e/test_jobs.py, adapted for the SDK's TypedDict
+param types and filtered to tests that work without Docker.
+"""
+
+import uuid
+
+import pytest
+from nemo_platform import NeMoPlatform
+from nmp.testing.e2e import wait_for_job_logs, wait_for_platform_job
+
+JOB_SOURCE = "e2e-test-jobs"
+
+# The image is discarded by the cpu→subprocess translation, but must be
+# syntactically valid for the API to accept the CPUExecutionProvider.
+PLACEHOLDER_IMAGE = "placeholder:unused"
+
+pytestmark = [pytest.mark.timeout(600)]
+
+
+def _job_diagnostic_message(sdk: NeMoPlatform, job, workspace: str, prefix: str) -> str:
+    """Build a diagnostic message with job error details and logs for assertion failures."""
+    parts = [prefix]
+    if job.status_details:
+        parts.append(f"Status details: {job.status_details}")
+    if job.error_details:
+        parts.append(f"Error details: {job.error_details}")
+    try:
+        logs = sdk.jobs.get_logs(workspace=workspace, name=job.name)
+        if logs.data:
+            parts.append(f"Job logs ({len(logs.data)} entries):")
+            for entry in logs.data:
+                parts.append(f"  - {entry.message}")
+    except Exception as log_err:
+        parts.append(f"Could not fetch job logs: {log_err}")
+    return "\n".join(parts)
+
+
+def test_basic_platform_job_lifecycle(sdk: NeMoPlatform, workspace: str):
+    """Test a basic platform job lifecycle: create, run, complete.
+
+    Verifies the platform jobs system works end-to-end:
+    1. Create a job with a simple command
+    2. Wait for the job to complete
+    3. Verify job reaches completed status
+    4. Retrieve and check step logs
+    """
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "value"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "echo-step",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": ["echo", "Hello from e2e test!"],
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    completed_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert completed_job.status == "completed", _job_diagnostic_message(
+        sdk, completed_job, workspace, f"Job failed with status: {completed_job.status}"
+    )
+
+    step_logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=1, timeout=240)
+    all_messages = " ".join(log.message for log in step_logs.data)
+    assert "Hello from e2e test!" in all_messages, "Step logs do not contain expected output"
+
+
+def test_job_logs_across_multiple_batches(sdk: NeMoPlatform, workspace: str):
+    """Test that logs spanning multiple OTLP batches are correctly stored and retrieved.
+
+    The OTLP BatchProcessor batches logs before sending, so logs output with
+    delays between them will end up in different batches (and potentially
+    different parquet files).
+    """
+    num_logs = 5
+    delay_seconds = 2
+
+    log_command = "; ".join(
+        [f'echo "Log message {i} of {num_logs}"; sleep {delay_seconds}' for i in range(1, num_logs + 1)]
+    )
+
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "multi-batch-logs"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "multi-log-step",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": ["sh", "-c", log_command],
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    completed_job = wait_for_platform_job(sdk, job.name, workspace, timeout=120)
+    assert completed_job.status == "completed", _job_diagnostic_message(
+        sdk, completed_job, workspace, f"Job failed with status: {completed_job.status}"
+    )
+
+    step_logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=num_logs, timeout=120)
+
+    assert len(step_logs.data) >= num_logs, f"Expected at least {num_logs} logs, got {len(step_logs.data)}"
+
+    # Verify all log messages are present and in order
+    for i in range(1, num_logs + 1):
+        expected_message = f"Log message {i} of {num_logs}"
+        assert expected_message in step_logs.data[i - 1].message, (
+            f"Log {i} not found at expected position. "
+            f"Expected '{expected_message}', got '{step_logs.data[i - 1].message}'"
+        )
+
+
+def test_job_config_is_readable(sdk: NeMoPlatform, workspace: str):
+    """Test that a job can read its configuration via $NEMO_JOB_STEP_CONFIG_FILE_PATH."""
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "value"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "config-step",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": ["sh", "-c", "echo 'Step config:'; cat $NEMO_JOB_STEP_CONFIG_FILE_PATH;"],
+                        },
+                    },
+                    "config": {
+                        "message": "Hello from job config!",
+                    },
+                },
+            ],
+        },
+    )
+
+    completed_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert completed_job.status == "completed", _job_diagnostic_message(
+        sdk, completed_job, workspace, f"Job failed with status: {completed_job.status}"
+    )
+
+    step_logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=2, timeout=60)
+    all_messages = " ".join(log.message for log in step_logs.data)
+    assert "Hello from job config!" in all_messages, "Step logs do not show config was read"
+
+
+def test_job_passing_data_between_steps(sdk: NeMoPlatform, workspace: str):
+    """Test that data can be passed between job steps via persistent storage."""
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "value"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "generate-data-step",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": [
+                                "sh",
+                                "-c",
+                                "echo 'Data from first step' > $NEMO_JOB_PERSISTENT_JOB_STORAGE_PATH/data.txt",
+                            ],
+                        },
+                    },
+                },
+                {
+                    "name": "consume-data-step",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": [
+                                "sh",
+                                "-c",
+                                "echo 'Consuming data:'; cat $NEMO_JOB_PERSISTENT_JOB_STORAGE_PATH/data.txt",
+                            ],
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    completed_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert completed_job.status == "completed", _job_diagnostic_message(
+        sdk, completed_job, workspace, f"Job failed with status: {completed_job.status}"
+    )
+
+    step_logs = sdk.jobs.get_logs(workspace=workspace, name=job.name)
+    all_messages = " ".join(log.message for log in step_logs.data)
+    assert "Data from first step" in all_messages, "Second step did not receive data from first step"
+
+
+def test_job_using_secret_environment_variable(sdk: NeMoPlatform, workspace: str):
+    """Test that a job can use secret environment variables."""
+    secret_name = f"e2e-secret-{uuid.uuid4().hex[:8]}"
+    secret_value = "s3cret-val"
+
+    secret = sdk.secrets.create(workspace=workspace, name=secret_name, value=secret_value)
+    assert secret.name is not None, "Failed to create platform secret"
+
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "value"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "secret-envvar-step",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": ["sh", "-c", 'echo "Secret value is: $SECRET_ENV_VAR"'],
+                        },
+                    },
+                    "environment": [
+                        {
+                            "name": "SECRET_ENV_VAR",
+                            "from_secret": {"name": secret.name},
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    completed_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert completed_job.status == "completed", _job_diagnostic_message(
+        sdk, completed_job, workspace, f"Job failed with status: {completed_job.status}"
+    )
+
+    step_logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=1, timeout=120)
+    all_messages = " ".join(log.message for log in step_logs.data)
+    assert secret_value in all_messages, "Step logs do not show secret environment variable was used"
+
+
+def test_job_with_expected_failure(sdk: NeMoPlatform, workspace: str):
+    """Test that a job correctly reports failure when a step exits non-zero."""
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "value"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "failing-step",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": ["sh", "-c", "echo 'This step will fail'; exit 1;"],
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    completed_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert completed_job.status == "error", f"Job should have failed but has status: {completed_job.status}"
+
+    step_logs = wait_for_job_logs(sdk, job.name, workspace, min_log_count=1, timeout=30)
+    assert len(step_logs.data) == 1, "Expected one step log"
+    assert "This step will fail" in step_logs.data[0].message, "Step logs do not contain expected output"
+
+
+def test_job_cancel_immediately(sdk: NeMoPlatform, workspace: str):
+    """Test that a job can be created and then cancelled immediately."""
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "value"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "long-running-step",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": ["sh", "-c", "sleep 60"],
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    sdk.jobs.cancel(workspace=workspace, name=job.name)
+
+    cancelled_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert cancelled_job.status == "cancelled", _job_diagnostic_message(
+        sdk, cancelled_job, workspace, f"Job should have been cancelled but has status: {cancelled_job.status}"
+    )
+
+
+def test_job_cancel_once_active(sdk: NeMoPlatform, workspace: str):
+    """Test that an active job can be cancelled."""
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "value"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "long-running-step",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": ["sh", "-c", "sleep 300"],
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    active_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="active")
+    assert active_job.status == "active", _job_diagnostic_message(
+        sdk, active_job, workspace, f"Job did not become active, status: {active_job.status}"
+    )
+
+    sdk.jobs.cancel(workspace=workspace, name=job.name)
+
+    cancelled_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert cancelled_job.status == "cancelled", _job_diagnostic_message(
+        sdk, cancelled_job, workspace, f"Job should have been cancelled but has status: {cancelled_job.status}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests that require Docker backend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="Subprocess backend does not support pause/resume (no SIGSTOP/SIGCONT handling)")
+def test_job_pause_resume(sdk: NeMoPlatform, workspace: str):
+    """Test that a job can be paused and then resumed after being paused."""
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "value"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "long-running-step-pause-resume",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": ["sh", "-c", "sleep 300"],
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    active_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="active")
+    assert active_job.status == "active", f"Job did not become active, status: {active_job.status}"
+
+    sdk.jobs.pause(workspace=workspace, name=job.name)
+
+    paused_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="paused")
+    assert paused_job.status == "paused", f"Job should have been paused but has status: {paused_job.status}"
+
+    sdk.jobs.resume(workspace=workspace, name=job.name)
+
+    resumed_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="active")
+    assert resumed_job.status in ("active", "completed"), (
+        f"Job should have been resumed but has status: {resumed_job.status}"
+    )
+
+    completed_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert completed_job.status == "completed", f"Job failed with status: {completed_job.status}"
+
+
+@pytest.mark.skip(reason="Subprocess backend does not support pause/resume (no SIGSTOP/SIGCONT handling)")
+def test_job_pause_and_cancel(sdk: NeMoPlatform, workspace: str):
+    """Test that a job can be paused and then cancelled after being paused."""
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "value"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "long-running-step-pause-cancel",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": ["sh", "-c", "sleep 300"],
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    active_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="active")
+    assert active_job.status == "active", f"Job did not become active, status: {active_job.status}"
+
+    sdk.jobs.pause(workspace=workspace, name=job.name)
+
+    paused_job = wait_for_platform_job(sdk, job.name, workspace, status_to_check="paused")
+    assert paused_job.status == "paused", f"Job should have been paused but has status: {paused_job.status}"
+
+    sdk.jobs.cancel(workspace=workspace, name=job.name)
+
+    cancelled_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert cancelled_job.status == "cancelled", f"Job should have been cancelled but has status: {cancelled_job.status}"
+
+
+@pytest.mark.skip(reason="Docker-only: additional volumes require container volume mounts")
+def test_job_using_additional_volume(sdk: NeMoPlatform, workspace: str):
+    """Test that a job can use an additional volume to store data between steps."""
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "data-between-steps"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "write-data",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": [
+                                "sh", "-c",
+                                "echo 'Hello, World!' > /mnt/additional_storage/shared_data.txt; "
+                                "echo 'Successfully wrote data to persistent storage';",
+                            ],
+                        },
+                    },
+                },
+                {
+                    "name": "read-data",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": PLACEHOLDER_IMAGE,
+                            "command": [
+                                "sh", "-c",
+                                "cat /mnt/additional_storage/shared_data.txt; "
+                                "echo 'Successfully read data from persistent storage';",
+                            ],
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    completed_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert completed_job.status == "completed", f"Job failed with status: {completed_job.status}"
+
+    step_logs = sdk.jobs.get_logs(workspace=workspace, name=job.name)
+    assert len(step_logs.data) == 3, "Expected three step logs"
+    assert "Successfully wrote data to persistent storage" in step_logs.data[0].message
+    assert "Hello, World!" in step_logs.data[1].message
+    assert "Successfully read data from persistent storage" in step_logs.data[2].message
+
+
+@pytest.mark.skip(
+    reason="Docker-only: image validation is bypassed in subprocess mode "
+    "(cpu→subprocess translation discards the container image)"
+)
+@pytest.mark.parametrize("bad_image", ["__invalid_ubuntu:image", "ubuntu:does-not-exist-1234"])
+def test_job_invalid_image_format(sdk: NeMoPlatform, workspace: str, bad_image: str):
+    """Test that a job with a bad image fails appropriately."""
+    job = sdk.jobs.create(
+        workspace=workspace,
+        source=JOB_SOURCE,
+        spec={"test": "value"},
+        platform_spec={
+            "steps": [
+                {
+                    "name": "bad-image-step",
+                    "executor": {
+                        "provider": "cpu",
+                        "container": {
+                            "image": bad_image,
+                            "command": ["echo", "This should not run"],
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    completed_job = wait_for_platform_job(sdk, job.name, workspace)
+    assert completed_job.status == "error", f"Job should have failed but has status: {completed_job.status}"
+
+    job_status = sdk.jobs.get_status(workspace=workspace, name=job.name)
+    assert job_status.steps[0].status == "error", "Step should have failed"

--- a/e2e/test_jobs.py
+++ b/e2e/test_jobs.py
@@ -457,7 +457,8 @@ def test_job_using_additional_volume(sdk: NeMoPlatform, workspace: str):
                         "container": {
                             "image": PLACEHOLDER_IMAGE,
                             "command": [
-                                "sh", "-c",
+                                "sh",
+                                "-c",
                                 "echo 'Hello, World!' > /mnt/additional_storage/shared_data.txt; "
                                 "echo 'Successfully wrote data to persistent storage';",
                             ],
@@ -471,7 +472,8 @@ def test_job_using_additional_volume(sdk: NeMoPlatform, workspace: str):
                         "container": {
                             "image": PLACEHOLDER_IMAGE,
                             "command": [
-                                "sh", "-c",
+                                "sh",
+                                "-c",
                                 "cat /mnt/additional_storage/shared_data.txt; "
                                 "echo 'Successfully read data from persistent storage';",
                             ],

--- a/services/core/files/src/nmp/core/files/api/v2/otlp/endpoints.py
+++ b/services/core/files/src/nmp/core/files/api/v2/otlp/endpoints.py
@@ -196,9 +196,13 @@ async def upload_otlp_logs(
                         log_message = ""
                         if log_record.body:
                             log_message = extract_string_value(log_record.body)
-                        # Convert timestamp from nanoseconds to datetime
-                        # timeUnixNano is a string representation of nanoseconds since Unix epoch
+                        # Convert timestamp from nanoseconds to datetime.
+                        # timeUnixNano is a string representation of nanoseconds since Unix epoch.
+                        # Fall back to observedTimeUnixNano if timeUnixNano is missing or zero
+                        # (e.g. when the emitter omits the timestamp field).
                         timestamp_ns = int(log_record.timeUnixNano)
+                        if timestamp_ns == 0 and log_record.observedTimeUnixNano:
+                            timestamp_ns = int(log_record.observedTimeUnixNano)
                         timestamp = datetime.fromtimestamp(timestamp_ns / 1_000_000_000)
                         # Create log entry
                         log_entry = LogEntry(

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess_runtime.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess_runtime.py
@@ -9,6 +9,7 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from time import time_ns
 from typing import IO
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, unquote, urlparse
@@ -43,6 +44,7 @@ class SubprocessOtelLogger:
         severity_text = "INFO" if stream_name == "stdout" else "ERROR"
         self.logger.emit(
             body=message,
+            timestamp=time_ns(),
             severity_number=severity_number,
             severity_text=severity_text,
             attributes={"stream": stream_name},


### PR DESCRIPTION
## Summary

Adds e2e test coverage for the platform jobs system running on the subprocess executor, enables mock inference provider for e2e tests, and fixes a bug where subprocess job logs had epoch-zero timestamps causing wrong ordering.

**Part of the e2e test migration tracked by [AIRCORE-715](https://linear.app/nvidia/issue/AIRCORE-715).**

### Changes

**`e2e/conftest.py`**
- Removed `--service-group all` from the `nemo services run` args. Plain `nemo services run` starts all services *and* controllers via the default fallback. Passing `--service-group all` explicitly populated `selected_services`, which skipped the fallback that also starts controllers — meaning the jobs scheduler never ran and jobs stayed in `created` forever.
- Added `pytest_configure` hook that sets `NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX=igw-mock-` and clears the `Configuration` cache, so `add_mock_provider()` works in e2e tests.

**`e2e/test_jobs.py`** — 13 tests (8 passing, 5 skipped), ported from Platform-Deploy
- `test_basic_platform_job_lifecycle` — create, run, complete, check logs
- `test_job_logs_across_multiple_batches` — OTLP log capture across batches with ordering assertion
- `test_job_config_is_readable` — job reads config from `$NEMO_JOB_STEP_CONFIG_FILE_PATH`
- `test_job_passing_data_between_steps` — multi-step job with persistent storage
- `test_job_using_secret_environment_variable` — secret injected as env var
- `test_job_with_expected_failure` — non-zero exit → error status
- `test_job_cancel_immediately` — cancel right after creation
- `test_job_cancel_once_active` — wait for active, then cancel via SIGTERM
- `test_job_pause_resume` — **skipped**: subprocess backend has no SIGSTOP/SIGCONT handling ([AIRCORE-721](https://linear.app/nvidia/issue/AIRCORE-721))
- `test_job_pause_and_cancel` — **skipped**: same reason
- `test_job_using_additional_volume` — **skipped**: Docker-only (container volume mounts)
- `test_job_invalid_image_format` — **skipped**: image is discarded by cpu→subprocess translation

**`e2e/test_inference.py`** — 10 tests for mock inference provider
- Provider CRUD, chat completions via provider/model/OpenAI routes, streaming, model listing, error simulation, per-model sequential responses, virtual model creation

**`subprocess_runtime.py`** — bug fix
- `SubprocessOtelLogger.emit()` was not passing a `timestamp` to the OpenTelemetry logger. This caused `timeUnixNano=0` in the protobuf payload (protobuf defaults `None` to `0` for uint64). All logs got epoch-zero timestamps, so `ORDER BY timestamp` produced arbitrary ordering.
- Fix: pass `timestamp=time_ns()`.

**`otlp/endpoints.py`** — defensive fix
- If `timeUnixNano` is `0`, fall back to `observedTimeUnixNano` (which OpenTelemetry auto-populates). Protects against any other OTLP emitter that omits the timestamp.

### How jobs work in subprocess mode

Tests submit jobs with `CPUExecutionProviderSpec` (same as Docker). The jobs service's `translate_cpu_container_steps_to_subprocess()` automatically rewrites `cpu/default` steps to `subprocess/default` — discarding the container image and running the command directly on the host. This means the same test code works across both backends.

## Test plan

- [x] `uv run --frozen pytest e2e/ -v --run-e2e` — 22 passed, 5 skipped
- [x] `uv run --frozen pytest services/core/jobs/tests/controllers/test_subprocess_runtime.py -v` — 8 passed
- [x] Verified log ordering is correct after timestamp fix
- [x] Verified `test_health_ready` passes (was failing when `--service-group all` was used due to controllers not starting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test suite for Inference Gateway covering chat completions, streaming, model listing, and error handling.
  * Added extensive end-to-end test suite for job management covering lifecycle, cancellation, data passing between steps, and failure handling.

* **Chores**
  * Improved logging infrastructure with nanosecond-precision timestamps and enhanced timestamp parsing fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->