### PR TITLE
fix(studio): dataset schema and file browser polish

### DIFF
--- a/web/packages/common/src/components/FileContentPreview/index.tsx
+++ b/web/packages/common/src/components/FileContentPreview/index.tsx
@@ -106,7 +106,7 @@ export const FileContentPreview: FC<FileContentPreviewProps> = ({
   // Markdown files - rendered
   if (isMarkdown) {
     return (
-      <div className="h-full overflow-auto p-4">
+      <div className="h-full overflow-auto rounded-lg border border-base bg-surface-raised p-4">
         <MarkdownContent content={content} />
       </div>
     );

--- a/web/packages/common/src/utils/jsonSchema/index.ts
+++ b/web/packages/common/src/utils/jsonSchema/index.ts
@@ -8,3 +8,4 @@ export { parseAndValidate, validateJsonSchemaDocument } from './validate';
 export type { ParseAndValidateResult, ValidationResult } from './validate';
 export { buildDatasetMetadata } from './dedupe';
 export type { PerFileInferred } from './dedupe';
+export { isSchemaAssignableFile } from './schemaAssignable';

--- a/web/packages/common/src/utils/jsonSchema/schemaAssignable.spec.ts
+++ b/web/packages/common/src/utils/jsonSchema/schemaAssignable.spec.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isSchemaAssignableFile } from '@nemo/common/src/utils/jsonSchema/schemaAssignable';
+
+describe('isSchemaAssignableFile', () => {
+  it.each(['data.json', 'rows.jsonl', 'subdir/sample.json', 'deep/nested/path/file.jsonl'])(
+    '%s -> true',
+    (path) => {
+      expect(isSchemaAssignableFile(path)).toBe(true);
+    }
+  );
+
+  it('matches uppercase extensions case-insensitively', () => {
+    expect(isSchemaAssignableFile('DATA.JSON')).toBe(true);
+    expect(isSchemaAssignableFile('rows.JsonL')).toBe(true);
+  });
+
+  it.each([
+    'README.md',
+    'LICENSE',
+    'image.png',
+    'config.yaml',
+    'train.parquet',
+    'rows.csv',
+    'archive.tar.gz',
+    'noext',
+  ])('%s -> false', (path) => {
+    expect(isSchemaAssignableFile(path)).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(isSchemaAssignableFile('')).toBe(false);
+  });
+});

--- a/web/packages/common/src/utils/jsonSchema/schemaAssignable.ts
+++ b/web/packages/common/src/utils/jsonSchema/schemaAssignable.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * External filesets (HuggingFace, NGC, mirrored S3) routinely contain many
+ * non-data files: README.md, LICENSE, images, scripts, model artifacts. None
+ * of those carry a JSON Schema, so the dataset detail UI uses this predicate
+ * to skip them in the Schema column, in the "Schema will be applied to N
+ * files" count, and anywhere else we iterate `filesList` for schema purposes.
+ *
+ * The naive heuristic covers what the inference pipeline supports today
+ * (`.json` / `.jsonl`). CSV / Parquet support is a separate ticket.
+ */
+
+const SCHEMA_ASSIGNABLE_EXTENSIONS = new Set(['json', 'jsonl']);
+
+export function isSchemaAssignableFile(path: string): boolean {
+  const ext = path.split('.').pop()?.toLowerCase();
+  return ext !== undefined && SCHEMA_ASSIGNABLE_EXTENSIONS.has(ext);
+}

--- a/web/packages/studio/src/api/datasets/constants.ts
+++ b/web/packages/studio/src/api/datasets/constants.ts
@@ -3,13 +3,57 @@
 
 export const ALLOWED_CONTENT_FILE_TYPES = new Set(['csv', 'json', 'jsonl', 'parquet']); // File types that the platform parses as structured data.
 
-// File types that Studio's FileContentPreview can render. Superset of ALLOWED_CONTENT_FILE_TYPES:
-// includes formats we can display but do not structurally manipulate.
-export const PREVIEWABLE_FILE_TYPES = new Set([
-  ...ALLOWED_CONTENT_FILE_TYPES,
-  'md',
-  'markdown',
-  'txt',
+// Extensions that are known binary formats. We skip the download and show a
+// "preview not available" message instead — downloading and rendering binary
+// content as text is both slow and meaningless.
+// Everything NOT in this set is treated as text and rendered in the plain-text
+// editor (the old allowlist was too restrictive; .gitattributes, .py, YAML,
+// shell scripts, etc. are all valid text previews).
+export const BINARY_FILE_EXTENSIONS = new Set([
+  // Images
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'bmp',
+  'webp',
+  'ico',
+  'svg',
+  'tiff',
+  'tif',
+  // Archives
+  'zip',
+  'tar',
+  'gz',
+  'bz2',
+  'xz',
+  'zst',
+  '7z',
+  'rar',
+  // ML model / weight formats
+  'bin',
+  'pt',
+  'pth',
+  'ckpt',
+  'safetensors',
+  'pkl',
+  'pickle',
+  'onnx',
+  'pb',
+  // Other binary
+  'pdf',
+  'arrow',
+  'npy',
+  'npz',
+  'h5',
+  'hdf5',
+  'db',
+  'sqlite',
+  'wasm',
+  'dll',
+  'so',
+  'dylib',
+  'exe',
 ]);
 
 export const COMPLETION_PROMPT_KEY_ORDER = ['prompt', 'instruction', 'question']; // Searches for a prompt in the following keys

--- a/web/packages/studio/src/api/datasets/constants.ts
+++ b/web/packages/studio/src/api/datasets/constants.ts
@@ -3,57 +3,33 @@
 
 export const ALLOWED_CONTENT_FILE_TYPES = new Set(['csv', 'json', 'jsonl', 'parquet']); // File types that the platform parses as structured data.
 
-// Extensions that are known binary formats. We skip the download and show a
-// "preview not available" message instead — downloading and rendering binary
-// content as text is both slow and meaningless.
-// Everything NOT in this set is treated as text and rendered in the plain-text
-// editor (the old allowlist was too restrictive; .gitattributes, .py, YAML,
-// shell scripts, etc. are all valid text previews).
+// Fast-path blocklist for extensions that are unambiguously binary. Files
+// matching these are rejected immediately without a HEAD request. Unknown
+// extensions fall through to Content-Type detection (see useIsBinaryFile).
+// Keep this list short — it's a hint, not an authoritative registry.
 export const BINARY_FILE_EXTENSIONS = new Set([
   // Images
   'png',
   'jpg',
   'jpeg',
   'gif',
-  'bmp',
   'webp',
   'ico',
-  'svg',
-  'tiff',
-  'tif',
   // Archives
   'zip',
   'tar',
   'gz',
-  'bz2',
-  'xz',
-  'zst',
-  '7z',
-  'rar',
-  // ML model / weight formats
-  'bin',
+  // ML weights / binary data
   'pt',
   'pth',
-  'ckpt',
   'safetensors',
   'pkl',
-  'pickle',
-  'onnx',
-  'pb',
-  // Other binary
-  'pdf',
-  'arrow',
+  'bin',
   'npy',
   'npz',
   'h5',
-  'hdf5',
-  'db',
-  'sqlite',
-  'wasm',
-  'dll',
-  'so',
-  'dylib',
-  'exe',
+  // Documents
+  'pdf',
 ]);
 
 export const COMPLETION_PROMPT_KEY_ORDER = ['prompt', 'instruction', 'question']; // Searches for a prompt in the following keys

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.spec.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.spec.ts
@@ -3,10 +3,14 @@
 
 import { datasetFileContentQueryOptions } from '@studio/api/datasets/useDatasetFileContent';
 
-vi.mock('@nemo/sdk/generated/platform/api', () => ({
-  filesHeadFile: vi.fn().mockResolvedValue(undefined),
-  filesDownloadFile: vi.fn().mockResolvedValue(new Blob(['# heading'])),
-}));
+vi.mock('@nemo/sdk/generated/platform/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nemo/sdk/generated/platform/api')>();
+  return {
+    ...actual,
+    filesHeadFile: vi.fn().mockResolvedValue(undefined),
+    filesDownloadFile: vi.fn().mockResolvedValue(new Blob(['# heading'])),
+  };
+});
 
 // customFetch now handles Range requests for text files. Return a Blob that
 // resolves to the expected text so the .text() call in the queryFn succeeds.

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.spec.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.spec.ts
@@ -8,21 +8,32 @@ vi.mock('@nemo/sdk/generated/platform/api', () => ({
   filesDownloadFile: vi.fn().mockResolvedValue(new Blob(['# heading'])),
 }));
 
+// customFetch now handles Range requests for text files. Return a Blob that
+// resolves to the expected text so the .text() call in the queryFn succeeds.
+vi.mock('@nemo/sdk/generated/fetchers/platform', () => ({
+  customFetch: vi.fn().mockResolvedValue(new Blob(['# heading'])),
+}));
+
 describe('useDatasetFileContent gate', () => {
   const baseParams = { workspace: 'ws', name: 'ds', path: 'README.md' };
 
-  it('allows .md files (preview superset)', async () => {
+  it('allows .md files and returns content via Range fetch', async () => {
     const { queryFn } = datasetFileContentQueryOptions(baseParams);
     await expect((queryFn as () => Promise<string>)()).resolves.toBe('# heading');
   });
 
-  it('rejects extensions outside PREVIEWABLE_FILE_TYPES', async () => {
-    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, path: 'app.exe' });
-    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/Unsupported file type/);
+  it('rejects files in the binary extension blocklist', async () => {
+    // .png is in BINARY_FILE_EXTENSIONS — should throw before any network call.
+    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, path: 'image.png' });
+    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(
+      /Text preview not available for binary files/
+    );
   });
 
-  it('rejects files with no extension', async () => {
+  it('allows files with no extension (treated as text)', async () => {
+    // Files with no extension (Makefile, LICENSE, etc.) are not in the blocklist
+    // and fall through to the Range fetch — treat as text.
     const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, path: 'noextension' });
-    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/Unsupported file type/);
+    await expect((queryFn as () => Promise<string>)()).resolves.toBe('# heading');
   });
 });

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { customFetch } from '@nemo/sdk/generated/fetchers/platform';
-import { filesDownloadFile, filesHeadFile } from '@nemo/sdk/generated/platform/api';
-import { EntityIdentifier } from '@studio/api/common/types';
+import {
+  filesDownloadFile,
+  filesHeadFile,
+  getFilesDownloadFileQueryKey,
+} from '@nemo/sdk/generated/platform/api';
+import type { EntityIdentifier } from '@studio/api/common/types';
 import { getDatasetFileContentQueryKey } from '@studio/api/datasets/invalidateDatasetCaches';
 import { isBinaryExtension } from '@studio/util/binaryFile';
 import { queryOptions, useQuery, UseQueryOptions, useSuspenseQuery } from '@tanstack/react-query';
@@ -71,8 +75,13 @@ export const datasetFileContentQueryOptions = ({
       } else {
         const start = range ? range[0] : 0;
         const end = range ? range[1] : FILE_PREVIEW_MAX_BYTES - 1;
+        const [fileUrl] = getFilesDownloadFileQueryKey(
+          encodeURIComponent(workspace!),
+          encodeURIComponent(name),
+          encodeURIComponent(path)
+        );
         const blob = await customFetch<Blob>({
-          url: `/apis/files/v2/workspaces/${encodeURIComponent(workspace!)}/filesets/${encodeURIComponent(name)}/-/${encodeURIComponent(path)}`,
+          url: fileUrl,
           method: 'GET',
           responseType: 'blob',
           headers: { Range: `bytes=${start}-${end}` },

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -1,14 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { customFetch } from '@nemo/sdk/generated/fetchers/platform';
 import { filesDownloadFile, filesHeadFile } from '@nemo/sdk/generated/platform/api';
 import { EntityIdentifier } from '@studio/api/common/types';
 import { getDatasetFileContentQueryKey } from '@studio/api/datasets/invalidateDatasetCaches';
-import { PLATFORM_BASE_URL } from '@studio/constants/environment';
 import { isBinaryExtension } from '@studio/util/binaryFile';
 import { queryOptions, useQuery, UseQueryOptions, useSuspenseQuery } from '@tanstack/react-query';
 import { parquetRead } from 'hyparquet';
-import { useAuth } from 'react-oidc-context';
 
 // Cap text-file preview at 512 KB. Enough to show meaningful JSONL content
 // while preventing OOM crashes on multi-GB external dataset shards.
@@ -17,7 +16,6 @@ const FILE_PREVIEW_MAX_BYTES = 512 * 1024;
 interface UseDatasetFileContentParams extends Required<EntityIdentifier> {
   path: string;
   range?: [number, number];
-  accessToken?: string;
 }
 
 export type UseDatasetFilesOptions = Omit<UseQueryOptions<string, Error>, 'queryFn' | 'queryKey'> &
@@ -28,7 +26,6 @@ export const datasetFileContentQueryOptions = ({
   name,
   path,
   range,
-  accessToken,
 }: UseDatasetFileContentParams) =>
   queryOptions<string, Error>({
     staleTime: Infinity, // We should prevent refetching full files (costly) unless directly invalidated
@@ -72,25 +69,15 @@ export const datasetFileContentQueryOptions = ({
           throw new Error('Invalid response while downloading parquet file');
         }
       } else {
-        const end = range ? range[1] : FILE_PREVIEW_MAX_BYTES - 1;
         const start = range ? range[0] : 0;
-        const fileUrl = [
-          PLATFORM_BASE_URL,
-          '/apis/files/v2/workspaces/',
-          encodeURIComponent(workspace!),
-          '/filesets/',
-          encodeURIComponent(name),
-          '/-/',
-          encodeURIComponent(path),
-        ].join('');
-        const headers: Record<string, string> = {
-          Range: `bytes=${start}-${end}`,
-        };
-        if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
-        const res = await fetch(fileUrl, { headers });
-        if (!res.ok && res.status !== 206)
-          throw new Error('Invalid response while downloading file');
-        return res.text();
+        const end = range ? range[1] : FILE_PREVIEW_MAX_BYTES - 1;
+        const blob = await customFetch<Blob>({
+          url: `/apis/files/v2/workspaces/${encodeURIComponent(workspace!)}/filesets/${encodeURIComponent(name)}/-/${encodeURIComponent(path)}`,
+          method: 'GET',
+          responseType: 'blob',
+          headers: { Range: `bytes=${start}-${end}` },
+        });
+        return blob.text();
       }
     },
   });
@@ -102,10 +89,8 @@ export const useDatasetFileContent = ({
   range,
   ...options
 }: UseDatasetFilesOptions) => {
-  const auth = useAuth();
-  const accessToken = auth.user?.access_token;
   return useQuery({
-    ...datasetFileContentQueryOptions({ workspace, name, path, range, accessToken }),
+    ...datasetFileContentQueryOptions({ workspace, name, path, range }),
     enabled: Boolean(workspace && name && path),
     ...options,
   });

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -3,9 +3,9 @@
 
 import { filesDownloadFile, filesHeadFile } from '@nemo/sdk/generated/platform/api';
 import { EntityIdentifier } from '@studio/api/common/types';
-import { BINARY_FILE_EXTENSIONS } from '@studio/api/datasets/constants';
 import { getDatasetFileContentQueryKey } from '@studio/api/datasets/invalidateDatasetCaches';
 import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import { isBinaryExtension } from '@studio/util/binaryFile';
 import { queryOptions, useQuery, UseQueryOptions, useSuspenseQuery } from '@tanstack/react-query';
 import { parquetRead } from 'hyparquet';
 import { useAuth } from 'react-oidc-context';
@@ -37,8 +37,7 @@ export const datasetFileContentQueryOptions = ({
       ...(range ? range.map((bound) => String(bound)) : []),
     ],
     queryFn: async () => {
-      const ext = path.split('.').at(-1)?.toLowerCase();
-      if (ext && BINARY_FILE_EXTENSIONS.has(ext)) {
+      if (isBinaryExtension(path)) {
         throw new Error('Text preview not available for binary files.');
       }
 

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -3,14 +3,21 @@
 
 import { filesDownloadFile, filesHeadFile } from '@nemo/sdk/generated/platform/api';
 import { EntityIdentifier } from '@studio/api/common/types';
-import { PREVIEWABLE_FILE_TYPES } from '@studio/api/datasets/constants';
+import { BINARY_FILE_EXTENSIONS } from '@studio/api/datasets/constants';
 import { getDatasetFileContentQueryKey } from '@studio/api/datasets/invalidateDatasetCaches';
+import { PLATFORM_BASE_URL } from '@studio/constants/environment';
 import { queryOptions, useQuery, UseQueryOptions, useSuspenseQuery } from '@tanstack/react-query';
 import { parquetRead } from 'hyparquet';
+import { useAuth } from 'react-oidc-context';
+
+// Cap text-file preview at 512 KB. Enough to show meaningful JSONL content
+// while preventing OOM crashes on multi-GB external dataset shards.
+const FILE_PREVIEW_MAX_BYTES = 512 * 1024;
 
 interface UseDatasetFileContentParams extends Required<EntityIdentifier> {
   path: string;
   range?: [number, number];
+  accessToken?: string;
 }
 
 export type UseDatasetFilesOptions = Omit<UseQueryOptions<string, Error>, 'queryFn' | 'queryKey'> &
@@ -21,6 +28,7 @@ export const datasetFileContentQueryOptions = ({
   name,
   path,
   range,
+  accessToken,
 }: UseDatasetFileContentParams) =>
   queryOptions<string, Error>({
     staleTime: Infinity, // We should prevent refetching full files (costly) unless directly invalidated
@@ -29,10 +37,9 @@ export const datasetFileContentQueryOptions = ({
       ...(range ? range.map((bound) => String(bound)) : []),
     ],
     queryFn: async () => {
-      if (!path.includes('.') || !PREVIEWABLE_FILE_TYPES.has(path.split('.').at(-1)!)) {
-        throw new Error(
-          `Unsupported file type. Currently supports: ${[...PREVIEWABLE_FILE_TYPES].join(', ')}`
-        );
+      const ext = path.split('.').at(-1)?.toLowerCase();
+      if (ext && BINARY_FILE_EXTENSIONS.has(ext)) {
+        throw new Error('Text preview not available for binary files.');
       }
 
       // Check if file exists
@@ -66,16 +73,25 @@ export const datasetFileContentQueryOptions = ({
           throw new Error('Invalid response while downloading parquet file');
         }
       } else {
-        const blob = await filesDownloadFile(workspace!, name, path);
-        if (!blob) throw new Error('Invalid response while downloading file');
-
-        // Handle range requests for non-parquet files
-        if (range) {
-          const slicedBlob = blob.slice(range[0], range[1]);
-          return slicedBlob.text();
-        }
-
-        return blob.text();
+        const end = range ? range[1] : FILE_PREVIEW_MAX_BYTES - 1;
+        const start = range ? range[0] : 0;
+        const fileUrl = [
+          PLATFORM_BASE_URL,
+          '/apis/files/v2/workspaces/',
+          encodeURIComponent(workspace!),
+          '/filesets/',
+          encodeURIComponent(name),
+          '/-/',
+          encodeURIComponent(path),
+        ].join('');
+        const headers: Record<string, string> = {
+          Range: `bytes=${start}-${end}`,
+        };
+        if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
+        const res = await fetch(fileUrl, { headers });
+        if (!res.ok && res.status !== 206)
+          throw new Error('Invalid response while downloading file');
+        return res.text();
       }
     },
   });
@@ -87,8 +103,10 @@ export const useDatasetFileContent = ({
   range,
   ...options
 }: UseDatasetFilesOptions) => {
+  const auth = useAuth();
+  const accessToken = auth.user?.access_token;
   return useQuery({
-    ...datasetFileContentQueryOptions({ workspace, name, path, range }),
+    ...datasetFileContentQueryOptions({ workspace, name, path, range, accessToken }),
     enabled: Boolean(workspace && name && path),
     ...options,
   });

--- a/web/packages/studio/src/components/FilesetFilePreviewPanel/FilesetFilePreviewContent/index.spec.tsx
+++ b/web/packages/studio/src/components/FilesetFilePreviewPanel/FilesetFilePreviewContent/index.spec.tsx
@@ -9,6 +9,10 @@ vi.mock('@studio/providers/workers/useWorkers', () => ({
   useWorkers: () => ({ createWorker: vi.fn() }),
 }));
 
+vi.mock('@studio/components/filesets/hooks/useIsBinaryFile', () => ({
+  useIsBinaryFile: () => ({ isBinary: false, isLoading: false }),
+}));
+
 const baseProps = {
   workspace: 'default',
   filesetName: 'test-dataset',

--- a/web/packages/studio/src/components/FilesetFilePreviewPanel/FilesetFilePreviewContent/index.tsx
+++ b/web/packages/studio/src/components/FilesetFilePreviewPanel/FilesetFilePreviewContent/index.tsx
@@ -3,11 +3,17 @@
 
 import { FileContentPreview } from '@nemo/common/src/components/FileContentPreview';
 import { useFilesListFilesetFiles } from '@nemo/sdk/generated/platform/api';
-import { Stack } from '@nvidia/foundations-react-core';
+import { Flex, Stack, Text } from '@nvidia/foundations-react-core';
+import { BINARY_FILE_EXTENSIONS } from '@studio/api/datasets/constants';
 import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
 import { FilesetFilePreviewHeader } from '@studio/components/FilesetFilePreviewPanel/components/FilesetFilePreviewHeader';
 import type { FileSystemFile } from '@studio/components/FilesTable/utils';
 import { useMemo, type FC } from 'react';
+
+function isBinaryPath(path: string): boolean {
+  const ext = path.split('.').at(-1)?.toLowerCase();
+  return ext !== undefined && BINARY_FILE_EXTENSIONS.has(ext);
+}
 
 export interface FilesetFilePreviewContentProps {
   // Fileset context
@@ -62,6 +68,8 @@ export const FilesetFilePreviewContent: FC<FilesetFilePreviewContentProps> = ({
   hideHeader = false,
   enabled = true,
 }) => {
+  const binary = isBinaryPath(filePath);
+
   const {
     data: internalContent,
     isLoading: internalLoading,
@@ -70,7 +78,7 @@ export const FilesetFilePreviewContent: FC<FilesetFilePreviewContentProps> = ({
     workspace,
     name: filesetName,
     path: filePath,
-    enabled: !externalContent && enabled,
+    enabled: !externalContent && enabled && !binary,
   });
 
   const { data: allFilesResponse } = useFilesListFilesetFiles(workspace, filesetName, undefined, {
@@ -85,15 +93,22 @@ export const FilesetFilePreviewContent: FC<FilesetFilePreviewContentProps> = ({
     externalFile ?? (allFiles?.find((f) => f.path === filePath) as FileSystemFile | undefined);
 
   const body = useMemo(
-    () => (
-      <FileContentPreview
-        file={{ path: filePath }}
-        content={fileContent}
-        isLoading={isLoading}
-        error={error ?? null}
-      />
-    ),
-    [filePath, fileContent, isLoading, error]
+    () =>
+      binary ? (
+        <Flex align="center" justify="center" className="h-full">
+          <Text kind="body/regular/md" className="text-fg-subdued">
+            Text preview not available for binary files.
+          </Text>
+        </Flex>
+      ) : (
+        <FileContentPreview
+          file={{ path: filePath }}
+          content={fileContent}
+          isLoading={isLoading}
+          error={error ?? null}
+        />
+      ),
+    [binary, filePath, fileContent, isLoading, error]
   );
 
   if (hideHeader) {

--- a/web/packages/studio/src/components/FilesetFilePreviewPanel/FilesetFilePreviewContent/index.tsx
+++ b/web/packages/studio/src/components/FilesetFilePreviewPanel/FilesetFilePreviewContent/index.tsx
@@ -77,7 +77,7 @@ export const FilesetFilePreviewContent: FC<FilesetFilePreviewContentProps> = ({
     workspace,
     name: filesetName,
     path: filePath,
-    enabled: !externalContent && enabled && !binary && !isBinaryLoading,
+    enabled: externalContent === undefined && enabled && !binary && !isBinaryLoading,
   });
 
   const { data: allFilesResponse } = useFilesListFilesetFiles(workspace, filesetName, undefined, {

--- a/web/packages/studio/src/components/FilesetFilePreviewPanel/FilesetFilePreviewContent/index.tsx
+++ b/web/packages/studio/src/components/FilesetFilePreviewPanel/FilesetFilePreviewContent/index.tsx
@@ -4,16 +4,11 @@
 import { FileContentPreview } from '@nemo/common/src/components/FileContentPreview';
 import { useFilesListFilesetFiles } from '@nemo/sdk/generated/platform/api';
 import { Flex, Stack, Text } from '@nvidia/foundations-react-core';
-import { BINARY_FILE_EXTENSIONS } from '@studio/api/datasets/constants';
 import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
 import { FilesetFilePreviewHeader } from '@studio/components/FilesetFilePreviewPanel/components/FilesetFilePreviewHeader';
+import { useIsBinaryFile } from '@studio/components/filesets/hooks/useIsBinaryFile';
 import type { FileSystemFile } from '@studio/components/FilesTable/utils';
 import { useMemo, type FC } from 'react';
-
-function isBinaryPath(path: string): boolean {
-  const ext = path.split('.').at(-1)?.toLowerCase();
-  return ext !== undefined && BINARY_FILE_EXTENSIONS.has(ext);
-}
 
 export interface FilesetFilePreviewContentProps {
   // Fileset context
@@ -68,7 +63,11 @@ export const FilesetFilePreviewContent: FC<FilesetFilePreviewContentProps> = ({
   hideHeader = false,
   enabled = true,
 }) => {
-  const binary = isBinaryPath(filePath);
+  const { isBinary: binary, isLoading: isBinaryLoading } = useIsBinaryFile(
+    workspace,
+    filesetName,
+    filePath
+  );
 
   const {
     data: internalContent,
@@ -78,7 +77,7 @@ export const FilesetFilePreviewContent: FC<FilesetFilePreviewContentProps> = ({
     workspace,
     name: filesetName,
     path: filePath,
-    enabled: !externalContent && enabled && !binary,
+    enabled: !externalContent && enabled && !binary && !isBinaryLoading,
   });
 
   const { data: allFilesResponse } = useFilesListFilesetFiles(workspace, filesetName, undefined, {
@@ -104,11 +103,11 @@ export const FilesetFilePreviewContent: FC<FilesetFilePreviewContentProps> = ({
         <FileContentPreview
           file={{ path: filePath }}
           content={fileContent}
-          isLoading={isLoading}
+          isLoading={isBinaryLoading || isLoading}
           error={error ?? null}
         />
       ),
-    [binary, filePath, fileContent, isLoading, error]
+    [binary, isBinaryLoading, filePath, fileContent, isLoading, error]
   );
 
   if (hideHeader) {

--- a/web/packages/studio/src/components/FilesetFilePreviewPanel/index.spec.tsx
+++ b/web/packages/studio/src/components/FilesetFilePreviewPanel/index.spec.tsx
@@ -12,6 +12,10 @@ vi.mock('@studio/providers/workers/useWorkers', () => ({
   }),
 }));
 
+vi.mock('@studio/components/filesets/hooks/useIsBinaryFile', () => ({
+  useIsBinaryFile: () => ({ isBinary: false, isLoading: false }),
+}));
+
 describe('FilesetFilePreviewPanel', () => {
   const defaultProps = {
     open: true,

--- a/web/packages/studio/src/components/filesets/hooks/useDownloadFileHead.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useDownloadFileHead.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import { useCallback } from 'react';
+import { useAuth } from 'react-oidc-context';
+
+export interface DownloadFileHeadArgs {
+  workspace: string;
+  datasetName: string;
+  path: string;
+  /** Number of bytes to fetch. Defaults to 65536 (64 KB). */
+  bytes?: number;
+}
+
+/**
+ * Returns a callback that fetches the first N bytes of a fileset file via an
+ * HTTP Range request. Useful for schema inference or content sniffing without
+ * downloading large files in full.
+ *
+ * Resolves to `null` on any transport or HTTP error.
+ */
+export function useDownloadFileHead() {
+  const auth = useAuth();
+
+  return useCallback(
+    async ({
+      workspace,
+      datasetName,
+      path,
+      bytes = 65536,
+    }: DownloadFileHeadArgs): Promise<ArrayBuffer | null> => {
+      const url = [
+        PLATFORM_BASE_URL,
+        '/apis/files/v2/workspaces/',
+        encodeURIComponent(workspace),
+        '/filesets/',
+        encodeURIComponent(datasetName),
+        '/-/',
+        encodeURIComponent(path),
+      ].join('');
+
+      const headers: Record<string, string> = {
+        Range: `bytes=0-${bytes - 1}`,
+      };
+      if (auth.user?.access_token) {
+        headers.Authorization = `Bearer ${auth.user.access_token}`;
+      }
+
+      try {
+        const res = await fetch(url, { headers });
+        // 200 (server ignores range) and 206 (partial content) are both usable.
+        if (!res.ok && res.status !== 206) return null;
+        return res.arrayBuffer();
+      } catch {
+        return null;
+      }
+    },
+    [auth.user?.access_token]
+  );
+}

--- a/web/packages/studio/src/components/filesets/hooks/useDownloadFileHead.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useDownloadFileHead.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { customFetch } from '@nemo/sdk/generated/fetchers/platform';
+import { getFilesDownloadFileQueryKey } from '@nemo/sdk/generated/platform/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
@@ -33,12 +34,17 @@ export function useDownloadFileHead() {
       bytes = 65536,
     }: DownloadFileHeadArgs): Promise<ArrayBuffer | null> => {
       try {
+        const sdkQueryKey = getFilesDownloadFileQueryKey(
+          encodeURIComponent(workspace),
+          encodeURIComponent(datasetName),
+          encodeURIComponent(path)
+        );
         const blob = await queryClient.fetchQuery({
-          queryKey: ['file-range', workspace, datasetName, path, bytes],
+          queryKey: [...sdkQueryKey, 'range', bytes],
           staleTime: Infinity,
           queryFn: () =>
             customFetch<Blob>({
-              url: `/apis/files/v2/workspaces/${encodeURIComponent(workspace)}/filesets/${encodeURIComponent(datasetName)}/-/${encodeURIComponent(path)}`,
+              url: sdkQueryKey[0],
               method: 'GET',
               responseType: 'blob',
               headers: { Range: `bytes=0-${bytes - 1}` },

--- a/web/packages/studio/src/components/filesets/hooks/useDownloadFileHead.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useDownloadFileHead.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import { customFetch } from '@nemo/sdk/generated/fetchers/platform';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
-import { useAuth } from 'react-oidc-context';
 
 export interface DownloadFileHeadArgs {
   workspace: string;
@@ -15,13 +15,15 @@ export interface DownloadFileHeadArgs {
 
 /**
  * Returns a callback that fetches the first N bytes of a fileset file via an
- * HTTP Range request. Useful for schema inference or content sniffing without
- * downloading large files in full.
+ * HTTP Range request. Results are cached by TanStack Query so repeated calls
+ * for the same file (e.g. schema inference after a preview) return instantly.
+ *
+ * Auth is handled automatically by the Axios interceptor in customFetch.
  *
  * Resolves to `null` on any transport or HTTP error.
  */
 export function useDownloadFileHead() {
-  const auth = useAuth();
+  const queryClient = useQueryClient();
 
   return useCallback(
     async ({
@@ -30,32 +32,23 @@ export function useDownloadFileHead() {
       path,
       bytes = 65536,
     }: DownloadFileHeadArgs): Promise<ArrayBuffer | null> => {
-      const url = [
-        PLATFORM_BASE_URL,
-        '/apis/files/v2/workspaces/',
-        encodeURIComponent(workspace),
-        '/filesets/',
-        encodeURIComponent(datasetName),
-        '/-/',
-        encodeURIComponent(path),
-      ].join('');
-
-      const headers: Record<string, string> = {
-        Range: `bytes=0-${bytes - 1}`,
-      };
-      if (auth.user?.access_token) {
-        headers.Authorization = `Bearer ${auth.user.access_token}`;
-      }
-
       try {
-        const res = await fetch(url, { headers });
-        // 200 (server ignores range) and 206 (partial content) are both usable.
-        if (!res.ok && res.status !== 206) return null;
-        return res.arrayBuffer();
+        const blob = await queryClient.fetchQuery({
+          queryKey: ['file-range', workspace, datasetName, path, bytes],
+          staleTime: Infinity,
+          queryFn: () =>
+            customFetch<Blob>({
+              url: `/apis/files/v2/workspaces/${encodeURIComponent(workspace)}/filesets/${encodeURIComponent(datasetName)}/-/${encodeURIComponent(path)}`,
+              method: 'GET',
+              responseType: 'blob',
+              headers: { Range: `bytes=0-${bytes - 1}` },
+            }),
+        });
+        return blob.arrayBuffer();
       } catch {
         return null;
       }
     },
-    [auth.user?.access_token]
+    [queryClient]
   );
 }

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { BINARY_FILE_EXTENSIONS } from '@studio/api/datasets/constants';
 import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import { isBinaryExtension } from '@studio/util/binaryFile';
 import { useQuery } from '@tanstack/react-query';
 import { useAuth } from 'react-oidc-context';
 
@@ -26,8 +26,7 @@ export function useIsBinaryFile(
 ): { isBinary: boolean; isLoading: boolean } {
   const auth = useAuth();
 
-  const ext = filePath?.split('.').at(-1)?.toLowerCase();
-  const blocklisted = ext !== undefined && BINARY_FILE_EXTENSIONS.has(ext);
+  const blocklisted = filePath !== undefined && isBinaryExtension(filePath);
 
   const { data: headBinary, isPending } = useQuery({
     queryKey: ['file-content-type', workspace, filesetName, filePath],

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
@@ -4,6 +4,7 @@
 // Importing from the SDK fetchers module activates the Axios interceptor that
 // injects the OIDC Bearer token, so axios.head() calls below are auth-aware.
 import '@nemo/sdk/generated/fetchers/platform';
+import { getFilesDownloadFileQueryKey } from '@nemo/sdk/generated/platform/api';
 import { isBinaryExtension } from '@studio/util/binaryFile';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
@@ -35,9 +36,12 @@ export function useIsBinaryFile(
       try {
         // axios.head() is auth-aware via the interceptor registered when
         // '@nemo/sdk/generated/fetchers/platform' is imported above.
-        const res = await axios.head(
-          `/apis/files/v2/workspaces/${encodeURIComponent(workspace)}/filesets/${encodeURIComponent(filesetName)}/-/${encodeURIComponent(filePath)}`
+        const [fileUrl] = getFilesDownloadFileQueryKey(
+          encodeURIComponent(workspace),
+          encodeURIComponent(filesetName),
+          encodeURIComponent(filePath)
         );
+        const res = await axios.head(fileUrl);
         const ct = String(res.headers['content-type'] ?? '');
         return !isTextContentType(ct);
       } catch {

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BINARY_FILE_EXTENSIONS } from '@studio/api/datasets/constants';
+import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from 'react-oidc-context';
+
+/**
+ * Determine whether a fileset file should be treated as binary (no text preview).
+ *
+ * Strategy (three tiers):
+ *   1. Extension in `BINARY_FILE_EXTENSIONS` → binary immediately, no network.
+ *   2. Extension not in blocklist → HEAD request; `Content-Type` header decides.
+ *      - `text/*` or known text application types → not binary.
+ *      - Everything else → binary.
+ *   3. HEAD fails / no Content-Type → assume text (fail-open for preview).
+ *
+ * Returns `{ isBinary, isLoading }`. `isLoading` is true only during the HEAD
+ * request (tier-2 path); tier-1 resolves synchronously.
+ */
+export function useIsBinaryFile(
+  workspace: string,
+  filesetName: string,
+  filePath: string | undefined
+): { isBinary: boolean; isLoading: boolean } {
+  const auth = useAuth();
+
+  const ext = filePath?.split('.').at(-1)?.toLowerCase();
+  const blocklisted = ext !== undefined && BINARY_FILE_EXTENSIONS.has(ext);
+
+  const { data: headBinary, isPending } = useQuery({
+    queryKey: ['file-content-type', workspace, filesetName, filePath],
+    queryFn: async (): Promise<boolean> => {
+      if (!filePath) return false;
+      const url = [
+        PLATFORM_BASE_URL,
+        '/apis/files/v2/workspaces/',
+        encodeURIComponent(workspace),
+        '/filesets/',
+        encodeURIComponent(filesetName),
+        '/-/',
+        encodeURIComponent(filePath),
+      ].join('');
+      try {
+        const res = await fetch(url, {
+          method: 'HEAD',
+          headers: auth.user?.access_token
+            ? { Authorization: `Bearer ${auth.user.access_token}` }
+            : {},
+        });
+        const ct = res.headers.get('content-type') ?? '';
+        return !isTextContentType(ct);
+      } catch {
+        return false; // fail-open: assume text
+      }
+    },
+    enabled: !!filePath && !blocklisted,
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  if (blocklisted) return { isBinary: true, isLoading: false };
+  if (!filePath) return { isBinary: false, isLoading: false };
+  return { isBinary: headBinary ?? false, isLoading: isPending };
+}
+
+const TEXT_CONTENT_TYPES = [
+  'text/',
+  'application/json',
+  'application/xml',
+  'application/javascript',
+  'application/typescript',
+  'application/yaml',
+  'application/x-yaml',
+  'application/toml',
+  'application/csv',
+  'application/x-sh',
+];
+
+function isTextContentType(ct: string): boolean {
+  const lower = ct.toLowerCase();
+  return TEXT_CONTENT_TYPES.some((prefix) => lower.includes(prefix));
+}

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+// Importing from the SDK fetchers module activates the Axios interceptor that
+// injects the OIDC Bearer token, so axios.head() calls below are auth-aware.
+import '@nemo/sdk/generated/fetchers/platform';
 import { isBinaryExtension } from '@studio/util/binaryFile';
 import { useQuery } from '@tanstack/react-query';
-import { useAuth } from 'react-oidc-context';
+import axios from 'axios';
 
 /**
  * Determine whether a fileset file should be treated as binary (no text preview).
@@ -24,31 +26,19 @@ export function useIsBinaryFile(
   filesetName: string,
   filePath: string | undefined
 ): { isBinary: boolean; isLoading: boolean } {
-  const auth = useAuth();
-
   const blocklisted = filePath !== undefined && isBinaryExtension(filePath);
 
   const { data: headBinary, isPending } = useQuery({
     queryKey: ['file-content-type', workspace, filesetName, filePath],
     queryFn: async (): Promise<boolean> => {
       if (!filePath) return false;
-      const url = [
-        PLATFORM_BASE_URL,
-        '/apis/files/v2/workspaces/',
-        encodeURIComponent(workspace),
-        '/filesets/',
-        encodeURIComponent(filesetName),
-        '/-/',
-        encodeURIComponent(filePath),
-      ].join('');
       try {
-        const res = await fetch(url, {
-          method: 'HEAD',
-          headers: auth.user?.access_token
-            ? { Authorization: `Bearer ${auth.user.access_token}` }
-            : {},
-        });
-        const ct = res.headers.get('content-type') ?? '';
+        // axios.head() is auth-aware via the interceptor registered when
+        // '@nemo/sdk/generated/fetchers/platform' is imported above.
+        const res = await axios.head(
+          `/apis/files/v2/workspaces/${encodeURIComponent(workspace)}/filesets/${encodeURIComponent(filesetName)}/-/${encodeURIComponent(filePath)}`
+        );
+        const ct = String(res.headers['content-type'] ?? '');
         return !isTextContentType(ct);
       } catch {
         return false; // fail-open: assume text

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
@@ -78,6 +78,8 @@ const TEXT_CONTENT_TYPES = [
 ];
 
 function isTextContentType(ct: string): boolean {
-  const lower = ct.toLowerCase();
-  return TEXT_CONTENT_TYPES.some((prefix) => lower.includes(prefix));
+  // Extract the MIME type token only (strip "; charset=..." parameters) before
+  // matching, so parameter values can't accidentally trigger a false positive.
+  const mimeToken = ct.split(';')[0].trim().toLowerCase();
+  return TEXT_CONTENT_TYPES.some((prefix) => mimeToken.startsWith(prefix));
 }

--- a/web/packages/studio/src/routes/FilesetDetailRoute/DatasetSchemaEditor/index.tsx
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/DatasetSchemaEditor/index.tsx
@@ -9,6 +9,7 @@ import {
   buildDatasetMetadata,
   canonicalJson,
   inferJsonSchema,
+  isSchemaAssignableFile,
   parseAndValidate,
   type PerFileInferred,
 } from '@nemo/common/src/utils/jsonSchema';
@@ -366,7 +367,10 @@ export const DatasetSchemaEditor: FC<DatasetSchemaEditorProps> = ({
   //   Show All view: diff parsed metadata against `savedMetadata` and count
   //   files whose RESOLVED schema would change.
   const sharedReferrerCount = useMemo(() => {
-    const files = filesList ?? [];
+    // Only data files (`.json` / `.jsonl`) carry a schema in this UI. Non-data
+    // files inflated the "Schema is used by N files" count on external
+    // datasets where READMEs, images, and other artifacts dominate the tree.
+    const files = (filesList ?? []).filter((f) => isSchemaAssignableFile(f.path));
     if (selectedSchema === SHOW_ALL_VALUE) {
       const parsed = parseAndValidate(text);
       if (!parsed.valid) return 0;

--- a/web/packages/studio/src/routes/FilesetDetailRoute/DatasetSchemaEditor/index.tsx
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/DatasetSchemaEditor/index.tsx
@@ -23,7 +23,7 @@ import type {
   FilesetOutput,
 } from '@nemo/sdk/generated/platform/schema';
 import { Button, Flex, Stack, TableToolbar, Text } from '@nvidia/foundations-react-core';
-import { useDownloadFileAsArrayBuffer } from '@studio/components/filesets/hooks/useDownloadFileAsArrayBuffer';
+import { useDownloadFileHead } from '@studio/components/filesets/hooks/useDownloadFileHead';
 import {
   DEFAULT_SCHEMA_VALUE,
   SchemaSelectControl,
@@ -287,7 +287,7 @@ export const DatasetSchemaEditor: FC<DatasetSchemaEditorProps> = ({
   const [isInferring, setIsInferring] = useState(false);
   const [inferError, setInferError] = useState<string | null>(null);
 
-  const downloadFile = useDownloadFileAsArrayBuffer();
+  const downloadFileHead = useDownloadFileHead();
 
   const supportedExistingFiles = useMemo(
     () =>
@@ -318,7 +318,7 @@ export const DatasetSchemaEditor: FC<DatasetSchemaEditorProps> = ({
       for (const file of supportedExistingFiles.slice(0, INFER_FROM_EXISTING_MAX_FILES)) {
         const format = detectFormatFromPath(file.path);
         if (!format) continue;
-        const buffer = await downloadFile({ workspace, datasetName, path: file.path });
+        const buffer = await downloadFileHead({ workspace, datasetName, path: file.path });
         if (!buffer) continue;
         const textContent = decoder.decode(buffer);
         const blob = new File([textContent], file.path);
@@ -350,7 +350,8 @@ export const DatasetSchemaEditor: FC<DatasetSchemaEditorProps> = ({
     } finally {
       setIsInferring(false);
     }
-  }, [supportedExistingFiles, downloadFile, workspace, datasetName]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- workspace/datasetName captured inside downloadFileHead's own useCallback
+  }, [supportedExistingFiles, downloadFileHead]);
 
   const { mutateAsync: updateMetadata, isPending: isSaving } = useFilesUpdateFilesetMetadata();
   const queryClient = useQueryClient();

--- a/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/index.tsx
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useQueryParams } from '@nemo/common/src/hooks/useQueryParams';
-import { isSchemaAssignableFile } from '@nemo/common/src/utils/jsonSchema';
 import {
   FilesetPurpose,
   type FilesetFileOutput,
@@ -16,6 +15,7 @@ import {
 } from '@studio/components/filesets/FilesetFileExplorer';
 import { QUERY_PARAMETERS } from '@studio/routes/constants';
 import { DatasetSchemaEditor } from '@studio/routes/FilesetDetailRoute/DatasetSchemaEditor';
+import { getSchemaCellLabel } from '@studio/routes/FilesetDetailRoute/FilesTab/schemaColumn';
 import { useCallback, useMemo, type FC } from 'react';
 
 export interface FilesTabProps {
@@ -101,23 +101,12 @@ export const FilesTab: FC<FilesTabProps> = ({
   const datasetMetadata = fileset.metadata?.dataset;
   const extraColumns = useMemo<ExtraColumn[] | undefined>(() => {
     if (!showSchemaEditor) return undefined;
-    const schemasByPath = datasetMetadata?.schemas_by_path ?? {};
-    const rootSchema = datasetMetadata?.schema;
     return [
       {
         header: 'Schema',
         width: 140,
-        cell: (node) => {
-          if (node.type !== 'file') return null;
-          // Skip non-data files (README, images, scripts, etc.) — they do
-          // not carry a schema even when the dataset has one set.
-          if (!isSchemaAssignableFile(node.path)) return null;
-          const mapped = schemasByPath[node.path];
-          if (typeof mapped === 'string') return mapped;
-          if (mapped && typeof mapped === 'object') return null;
-          if (typeof rootSchema === 'string') return rootSchema;
-          return null;
-        },
+        cell: (node) =>
+          node.type === 'file' ? getSchemaCellLabel(node.path, datasetMetadata) : null,
       },
     ];
   }, [showSchemaEditor, datasetMetadata]);

--- a/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/index.tsx
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useQueryParams } from '@nemo/common/src/hooks/useQueryParams';
+import { isSchemaAssignableFile } from '@nemo/common/src/utils/jsonSchema';
 import {
   FilesetPurpose,
   type FilesetFileOutput,
@@ -108,6 +109,9 @@ export const FilesTab: FC<FilesTabProps> = ({
         width: 140,
         cell: (node) => {
           if (node.type !== 'file') return null;
+          // Skip non-data files (README, images, scripts, etc.) — they do
+          // not carry a schema even when the dataset has one set.
+          if (!isSchemaAssignableFile(node.path)) return null;
           const mapped = schemasByPath[node.path];
           if (typeof mapped === 'string') return mapped;
           if (mapped && typeof mapped === 'object') return null;

--- a/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/index.tsx
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useQueryParams } from '@nemo/common/src/hooks/useQueryParams';
+import { isSchemaAssignableFile } from '@nemo/common/src/utils/jsonSchema';
 import {
   FilesetPurpose,
   type FilesetFileOutput,
@@ -131,7 +132,7 @@ export const FilesTab: FC<FilesTabProps> = ({
       className="w-full h-full min-h-0"
       data-testid="fileset-files-tab"
     >
-      <Flex direction="col" className="flex-1 min-w-0 min-h-0">
+      <Flex direction="col" className="flex-1 min-w-0 min-h-0 h-full">
         {selectedFilePath ? (
           <div className="w-full h-full min-h-0" data-testid="fileset-files-tab-preview">
             <FilesetFilePreviewContent
@@ -145,7 +146,7 @@ export const FilesTab: FC<FilesTabProps> = ({
             />
           </div>
         ) : (
-          <div className="flex-1 min-h-0 overflow-auto">
+          <div className="h-full min-h-0">
             <FilesetFileExplorer
               workspace={workspace}
               datasetName={filesetName}
@@ -161,11 +162,11 @@ export const FilesTab: FC<FilesTabProps> = ({
           </div>
         )}
       </Flex>
-      {showSchemaEditor && (
-        <div
-          className="w-[480px] shrink-0 h-full min-h-0 flex flex-col p-density-lg"
-          data-testid="fileset-files-tab-right-panel"
-        >
+      <div
+        className="w-[480px] shrink-0 h-full min-h-0 flex flex-col px-density-lg pb-density-lg"
+        data-testid="fileset-files-tab-right-panel"
+      >
+        {showSchemaEditor && !(selectedFilePath && !isSchemaAssignableFile(selectedFilePath)) && (
           <DatasetSchemaEditor
             workspace={workspace}
             datasetName={filesetName}
@@ -173,8 +174,8 @@ export const FilesTab: FC<FilesTabProps> = ({
             filesList={files}
             selectedFilePath={selectedFilePath}
           />
-        </div>
-      )}
+        )}
+      </div>
     </Flex>
   );
 };

--- a/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/schemaColumn.spec.ts
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/schemaColumn.spec.ts
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { DatasetMetadataContent } from '@nemo/sdk/generated/platform/schema';
+import { getSchemaCellLabel } from '@studio/routes/FilesetDetailRoute/FilesTab/schemaColumn';
+
+const inlineSchema = { type: 'object', properties: { id: { type: 'string' } } };
+
+describe('getSchemaCellLabel', () => {
+  it('returns null for non-data file paths', () => {
+    const meta: DatasetMetadataContent = {
+      schema: 'schema_1',
+      schema_defs: { schema_1: inlineSchema },
+    };
+    expect(getSchemaCellLabel('README.md', meta)).toBe(null);
+    expect(getSchemaCellLabel('assets/logo.png', meta)).toBe(null);
+    expect(getSchemaCellLabel('data/train.parquet', meta)).toBe(null);
+  });
+
+  it('returns the schema key when schemas_by_path maps the file to a string ref', () => {
+    const meta: DatasetMetadataContent = {
+      schema_defs: { schema_1: inlineSchema, schema_2: inlineSchema },
+      schemas_by_path: { 'data/a.jsonl': 'schema_2' },
+    };
+    expect(getSchemaCellLabel('data/a.jsonl', meta)).toBe('schema_2');
+  });
+
+  it('returns null when schemas_by_path maps the file to an inline object (hand-edited edge case)', () => {
+    const meta: DatasetMetadataContent = {
+      schemas_by_path: { 'data/b.jsonl': inlineSchema },
+    };
+    expect(getSchemaCellLabel('data/b.jsonl', meta)).toBe(null);
+  });
+
+  it('falls back to the root schema key when root is a string ref and no per-file mapping', () => {
+    const meta: DatasetMetadataContent = {
+      schema: 'schema_1',
+      schema_defs: { schema_1: inlineSchema },
+    };
+    expect(getSchemaCellLabel('train.jsonl', meta)).toBe('schema_1');
+  });
+
+  it('returns "default" when root schema is inline and no per-file mapping', () => {
+    const meta: DatasetMetadataContent = {
+      schema: inlineSchema,
+    };
+    expect(getSchemaCellLabel('train.jsonl', meta)).toBe('default');
+  });
+
+  it('returns null when no per-file mapping and no root schema', () => {
+    const meta: DatasetMetadataContent = {
+      schema_defs: { schema_1: inlineSchema },
+    };
+    expect(getSchemaCellLabel('train.jsonl', meta)).toBe(null);
+  });
+
+  it('returns null when metadata is undefined', () => {
+    expect(getSchemaCellLabel('train.jsonl', undefined)).toBe(null);
+  });
+
+  it('returns null when root schema is null (backend cleared-schema state)', () => {
+    // Backend Pydantic type is `dict | str | None` — null means "cleared",
+    // which serializes to JSON null. Distinct from the field being absent.
+    const meta = { schema: null } as unknown as DatasetMetadataContent;
+    expect(getSchemaCellLabel('train.jsonl', meta)).toBe(null);
+  });
+
+  it('matches case-insensitive json/jsonl extensions', () => {
+    const meta: DatasetMetadataContent = { schema: inlineSchema };
+    expect(getSchemaCellLabel('TRAIN.JSONL', meta)).toBe('default');
+    expect(getSchemaCellLabel('data.Json', meta)).toBe('default');
+  });
+});

--- a/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/schemaColumn.ts
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/schemaColumn.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isSchemaAssignableFile } from '@nemo/common/src/utils/jsonSchema';
+import type { DatasetMetadataContent } from '@nemo/sdk/generated/platform/schema';
+
+/**
+ * Resolve the Schema-column label for one file row.
+ *
+ *   `.json` / `.jsonl` only — non-data files (README, images, scripts) return
+ *   null because they cannot carry a schema even when one is set.
+ *
+ *   Mapping precedence:
+ *     1. `schemas_by_path[path]` is a string ref      -> show that key
+ *     2. `schemas_by_path[path]` is an inline object  -> "(inline)"
+ *     3. No per-file mapping + root schema is a ref   -> show that key
+ *     4. No per-file mapping + root schema is inline  -> "default"
+ *     5. Otherwise                                    -> null (blank cell)
+ */
+export function getSchemaCellLabel(
+  filePath: string,
+  metadata: DatasetMetadataContent | undefined
+): string | null {
+  if (!isSchemaAssignableFile(filePath)) return null;
+  const mapped = metadata?.schemas_by_path?.[filePath];
+  if (typeof mapped === 'string') return mapped;
+  // Inline objects in schemas_by_path are only produced by hand-editing the
+  // raw JSON via the advanced "Show All" view — not by normal inference/save
+  // flows. No useful label to show; fall through to the root-schema default.
+  if (mapped && typeof mapped === 'object') return null;
+  const rootSchema = metadata?.schema;
+  if (typeof rootSchema === 'string') return rootSchema;
+  if (rootSchema !== undefined && rootSchema !== null) return 'default';
+  return null;
+}

--- a/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/schemaColumn.ts
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/FilesTab/schemaColumn.ts
@@ -12,7 +12,7 @@ import type { DatasetMetadataContent } from '@nemo/sdk/generated/platform/schema
  *
  *   Mapping precedence:
  *     1. `schemas_by_path[path]` is a string ref      -> show that key
- *     2. `schemas_by_path[path]` is an inline object  -> "(inline)"
+ *     2. `schemas_by_path[path]` is an inline object  -> null (no label)
  *     3. No per-file mapping + root schema is a ref   -> show that key
  *     4. No per-file mapping + root schema is inline  -> "default"
  *     5. Otherwise                                    -> null (blank cell)
@@ -24,9 +24,9 @@ export function getSchemaCellLabel(
   if (!isSchemaAssignableFile(filePath)) return null;
   const mapped = metadata?.schemas_by_path?.[filePath];
   if (typeof mapped === 'string') return mapped;
-  // Inline objects in schemas_by_path are only produced by hand-editing the
-  // raw JSON via the advanced "Show All" view — not by normal inference/save
-  // flows. No useful label to show; fall through to the root-schema default.
+  // Inline objects in schemas_by_path have no $ref key to display — they are
+  // anonymous, hand-crafted schemas from the "Show All" JSON editor. Return
+  // null (blank cell) because there is no meaningful label to show.
   if (mapped && typeof mapped === 'object') return null;
   const rootSchema = metadata?.schema;
   if (typeof rootSchema === 'string') return rootSchema;

--- a/web/packages/studio/src/util/binaryFile.ts
+++ b/web/packages/studio/src/util/binaryFile.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BINARY_FILE_EXTENSIONS } from '@studio/api/datasets/constants';
+
+/** True when the file path has an extension in the known-binary blocklist. */
+export function isBinaryExtension(path: string): boolean {
+  const ext = path.split('.').at(-1)?.toLowerCase();
+  return ext !== undefined && BINARY_FILE_EXTENSIONS.has(ext);
+}


### PR DESCRIPTION

<img width="1481" height="977" alt="Screenshot 2026-06-04 at 11 12 39 AM" src="https://github.com/user-attachments/assets/df6a2288-9afa-45e4-91fb-ebc3dd8b2224" />

  ## Summary

  Polish pass on dataset schema detection and file preview for external datasets (HuggingFace, NGC, S3
  mirrors), which contain many non-data files and large JSONL shards that broke the previous assumptions.

  **Schema column**
  - `isSchemaAssignableFile(path)` util (`@nemo/common`) — true for `.json` / `.jsonl` only. Non-data
  files (README, images, scripts) show a blank Schema cell instead of a misleading `default` marker.
  - `getSchemaCellLabel(path, metadata)` extracted as a pure helper with its own spec — covers string ref
  / inline / root-ref / inline-root-`default` / blank cases. Fixes the pre-existing bug where inline
  root schema showed blank instead of `default`.
  - `sharedReferrerCount` in `DatasetSchemaEditor` now filters to schema-assignable files only, so the
  "used by N files" confirm modal no longer inflates N with non-data files.

  **Schema inference (Generate button)**
  - Replaced full-file download with `useDownloadFileHead` — fetches the first 64 KB per file via HTTP
  `Range: bytes=0-65535`. Reduces per-file download from ~1 GB to 66 KB for large external shards.

  **File preview**
  - `BINARY_FILE_EXTENSIONS` blocklist replaces the old allowlist (`PREVIEWABLE_FILE_TYPES`). Text files
  of any extension (`.gitattributes`, `.py`, `.yaml`, shell scripts, etc.) render in the plain-text
  editor instead of returning "Unsupported file type". Genuinely binary formats (images, archives, model
  weights) show "Text preview not available for binary files" immediately without a download.
  - Preview is now capped at **512 KB** via HTTP Range, preventing OOM crashes on 1 GB JSONL shards.
  `useDatasetFileContent` sends a `Range` header instead of slicing the blob post-download.
  - Non-data files no longer show "Schema not applicable" — the schema panel is simply hidden.
  - Markdown preview gets `bg-surface-raised border rounded-lg` card styling, matching the JSON code
  editor.

  **Right panel layout**
  - Removed top padding from the right panel so the schema editor aligns with the top of the adjacent
  file browser / preview panel.

  **Breadcrumb fix**
  - `Breadcrumbs/index.tsx` strips `?` and `#` from `href` on all breadcrumb links. Previously,
  navigating from `?tab=files` to the Filesets list carried `?tab=files` into the list URL.

  ## Files

  **New**
  - `web/packages/common/src/utils/jsonSchema/schemaAssignable.ts` + `.spec.ts`
  - `web/packages/studio/src/routes/DatasetDetailRoute/FilesTab/schemaColumn.ts` + `.spec.ts`
  - `web/packages/studio/src/components/filesets/hooks/useDownloadFileHead.ts`

  **Modified**
  - `web/packages/common/src/components/FileContentPreview/index.tsx`
  - `web/packages/common/src/components/Breadcrumbs/index.tsx`
  - `web/packages/studio/src/api/datasets/constants.ts`
  - `web/packages/studio/src/api/datasets/useDatasetFileContent.ts`
  - `web/packages/studio/src/components/FilesetFilePreviewPanel/FilesetFilePreviewContent/index.tsx`
  - `web/packages/studio/src/routes/DatasetDetailRoute/DatasetSchemaEditor/index.tsx`
  - `web/packages/studio/src/routes/DatasetDetailRoute/FilesTab/index.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Binary-file detection that shows "Text preview not available for binary files."
  * Dataset schema editor now appears only for JSON/JSONL files

* **Improvements**
  * Byte-range fetching and HEAD-based checks for safer, faster text previews
  * Markdown preview receives bordered/raised styling
  * Schema column shows explicit labels and respects per-file/root mappings

* **Tests**
  * Added unit tests for schema-assignable detection, schema-label logic, and preview handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->