### PR TITLE
feat(auditor): add filtering to target and config list endpoints (AIRCORE-387)

### DIFF
--- a/plugins/nemo-auditor/openapi/openapi.yaml
+++ b/plugins/nemo-auditor/openapi/openapi.yaml
@@ -55,7 +55,8 @@ paths:
       tags:
       - Auditor Configs
       summary: List Configs
-      description: List audit configs in the workspace.
+      description: List audit configs in the workspace with pagination and filter
+        support.
       operationId: list_configs_apis_auditor_v2_workspaces__workspace__configs_get
       parameters:
       - name: workspace
@@ -88,6 +89,18 @@ paths:
           type: string
           default: -created_at
           title: Sort
+      - in: query
+        name: filter
+        style: deepObject
+        required: false
+        explode: true
+        schema:
+          $ref: '#/components/schemas/ConfigFilter'
+        description: 'Filter results on various criteria. Supports bracket notation
+          (?filter[field][$op]=value), JSON ({"field":{"$op":"value"}}), and text
+          syntax (field:"value"). Operators: $eq (exact match), $like (substring),
+          $lt, $lte, $gt, $gte (comparison), $in, $nin (set membership), $and, $or,
+          $not (logical). Default operator is $eq.'
       responses:
         '200':
           description: Successful Response
@@ -240,7 +253,8 @@ paths:
       tags:
       - Auditor Targets
       summary: List Targets
-      description: List audit targets in the workspace.
+      description: List audit targets in the workspace with pagination and filter
+        support.
       operationId: list_targets_apis_auditor_v2_workspaces__workspace__targets_get
       parameters:
       - name: workspace
@@ -273,6 +287,18 @@ paths:
           type: string
           default: -created_at
           title: Sort
+      - in: query
+        name: filter
+        style: deepObject
+        required: false
+        explode: true
+        schema:
+          $ref: '#/components/schemas/TargetFilter'
+        description: 'Filter results on various criteria. Supports bracket notation
+          (?filter[field][$op]=value), JSON ({"field":{"$op":"value"}}), and text
+          syntax (field:"value"). Operators: $eq (exact match), $like (substring),
+          $lt, $lte, $gt, $gte (comparison), $in, $nin (set membership), $and, $or,
+          $not (logical). Default operator is $eq.'
       responses:
         '200':
           description: Successful Response
@@ -775,6 +801,28 @@ components:
       - parent
       title: AuditTarget
       description: Audit target (model under test) stored in the entity store.
+    ConfigFilter:
+      additionalProperties: false
+      description: Query filter for ``GET /v2/workspaces/{workspace}/configs``.
+      properties:
+        description:
+          description: Filter to configs with this description.
+          title: Description
+          type: string
+        project:
+          description: Filter to configs in this project.
+          title: Project
+          type: string
+        created_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Filter on creation time (supports $gte / $lte).
+        updated_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Filter on last-update time (supports $gte / $lte).
+      title: ConfigFilter
+      type: object
     CreateAuditConfigRequest:
       properties:
         name:
@@ -826,6 +874,21 @@ components:
       - model
       title: CreateAuditTargetRequest
       description: Request body for ``POST /v2/workspaces/{workspace}/targets``.
+    DatetimeFilter:
+      additionalProperties: false
+      properties:
+        $gte:
+          description: Filter for results greater than or equal to this datetime.
+          title: $Gte
+          format: date-time
+          type: string
+        $lte:
+          description: Filter for results less than or equal to this datetime.
+          title: $Lte
+          format: date-time
+          type: string
+      title: DatetimeFilter
+      type: object
     HTTPValidationError:
       properties:
         detail:
@@ -835,6 +898,36 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
+    TargetFilter:
+      additionalProperties: false
+      description: Query filter for ``GET /v2/workspaces/{workspace}/targets``.
+      properties:
+        type:
+          description: Filter to targets of this type (e.g., 'nim', 'openai').
+          title: Type
+          type: string
+        model:
+          description: Filter to targets using this model identifier.
+          title: Model
+          type: string
+        description:
+          description: Filter to targets with this description.
+          title: Description
+          type: string
+        project:
+          description: Filter to targets in this project.
+          title: Project
+          type: string
+        created_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Filter on creation time (supports $gte / $lte).
+        updated_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Filter on last-update time (supports $gte / $lte).
+      title: TargetFilter
+      type: object
     UpdateAuditConfigRequest:
       properties:
         description:

--- a/plugins/nemo-auditor/src/nemo_auditor/api/v2/_filters.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/api/v2/_filters.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Filter dependency helper for auditor list endpoints.
+
+``make_filter_obj_dep`` parses ``filter[field]=value`` deepObject query params
+into a validated dict.  On an unknown filter key it raises a raw
+:class:`pydantic.ValidationError` (``NemoFilter`` is ``extra="forbid"``), which
+FastAPI surfaces as a 500.  These endpoints wrap that dependency so a misspelled
+or unsupported filter key fails loudly with a 422 instead — typos must not be
+silently swallowed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+from fastapi import HTTPException
+from nmp.common.entities.filters import make_filter_obj_dep
+from pydantic import BaseModel, ValidationError
+from starlette.requests import Request
+
+
+def make_filter_dep(filter_model: type[BaseModel]) -> Callable[[Request], object]:
+    """Build a FastAPI dependency that validates filter params and 422s on typos."""
+    inner = make_filter_obj_dep(filter_model)
+
+    async def _dep(request: Request) -> object:
+        try:
+            # make_filter_obj_dep returns an async dependency; its declared
+            # return type is the (sync-looking) filter model, so cast to await it.
+            return await cast(Awaitable[object], inner(request))
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail=exc.errors(include_url=False),
+            ) from exc
+
+    return _dep

--- a/plugins/nemo-auditor/src/nemo_auditor/api/v2/configs.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/api/v2/configs.py
@@ -12,7 +12,8 @@ treats the ``data`` payload as opaque.
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from nemo_auditor.api.v2.schemas import CreateAuditConfigRequest, UpdateAuditConfigRequest
+from nemo_auditor.api.v2._filters import make_filter_dep
+from nemo_auditor.api.v2.schemas import ConfigFilter, CreateAuditConfigRequest, UpdateAuditConfigRequest
 from nemo_auditor.entities import AuditConfig
 from nemo_platform_plugin.entity_client import (
     NemoEntitiesClient,
@@ -20,10 +21,13 @@ from nemo_platform_plugin.entity_client import (
     NemoEntityNotFoundError,
     get_entity_client,
 )
+from nemo_platform_plugin.jobs.openapi_utils import generate_openapi_extra_params
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+_config_filter_dep = make_filter_dep(ConfigFilter)
 
 
 @router.post("/configs", response_model=AuditConfig, status_code=201, tags=["Auditor Configs"])
@@ -54,15 +58,21 @@ async def create_config(
         raise HTTPException(status_code=500, detail="Failed to create audit config.") from exc
 
 
-@router.get("/configs", tags=["Auditor Configs"])
+@router.get(
+    "/configs",
+    tags=["Auditor Configs"],
+    openapi_extra=generate_openapi_extra_params(filter_schema=ConfigFilter),
+)
 async def list_configs(
     workspace: str,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
     sort: str = Query(default="-created_at"),
+    filter: ConfigFilter = Depends(_config_filter_dep),
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
 ) -> dict:
-    """List audit configs in the workspace."""
+    """List audit configs in the workspace with pagination and filter support."""
+    filter_dict = filter if isinstance(filter, dict) else filter.model_dump(exclude_none=True)
     try:
         result = await entity_client.list(
             AuditConfig,
@@ -70,6 +80,7 @@ async def list_configs(
             page=page,
             page_size=page_size,
             sort=sort,
+            filter_obj=filter_dict or None,
         )
     except Exception as exc:
         logger.exception("Failed to list audit configs in workspace '%s'", workspace)
@@ -78,6 +89,7 @@ async def list_configs(
         "data": [c.model_dump(mode="json") for c in result.data],
         "pagination": result.pagination.model_dump() if result.pagination else None,
         "sort": sort,
+        "filter": filter or None,
     }
 
 

--- a/plugins/nemo-auditor/src/nemo_auditor/api/v2/schemas.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/api/v2/schemas.py
@@ -20,6 +20,7 @@ from nemo_auditor.entities import (
     AuditRunData,
     AuditSystemData,
 )
+from nemo_platform_plugin.schema import DatetimeFilter, NemoFilter
 from pydantic import BaseModel, Field
 
 
@@ -61,3 +62,58 @@ class UpdateAuditTargetRequest(BaseModel):
     type: str = Field(description="Target type (e.g., 'nim', 'openai').")
     model: str = Field(description="Model identifier.")
     options: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Filters — extend NemoFilter so extra fields are rejected (extra="forbid")
+# ---------------------------------------------------------------------------
+
+
+class TargetFilter(NemoFilter):
+    """Query filter for ``GET /v2/workspaces/{workspace}/targets``."""
+
+    type: str | None = Field(
+        default=None,
+        description="Filter to targets of this type (e.g., 'nim', 'openai').",
+    )
+    model: str | None = Field(
+        default=None,
+        description="Filter to targets using this model identifier.",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Filter to targets with this description.",
+    )
+    project: str | None = Field(
+        default=None,
+        description="Filter to targets in this project.",
+    )
+    created_at: DatetimeFilter | None = Field(
+        default=None,
+        description="Filter on creation time (supports $gte / $lte).",
+    )
+    updated_at: DatetimeFilter | None = Field(
+        default=None,
+        description="Filter on last-update time (supports $gte / $lte).",
+    )
+
+
+class ConfigFilter(NemoFilter):
+    """Query filter for ``GET /v2/workspaces/{workspace}/configs``."""
+
+    description: str | None = Field(
+        default=None,
+        description="Filter to configs with this description.",
+    )
+    project: str | None = Field(
+        default=None,
+        description="Filter to configs in this project.",
+    )
+    created_at: DatetimeFilter | None = Field(
+        default=None,
+        description="Filter on creation time (supports $gte / $lte).",
+    )
+    updated_at: DatetimeFilter | None = Field(
+        default=None,
+        description="Filter on last-update time (supports $gte / $lte).",
+    )

--- a/plugins/nemo-auditor/src/nemo_auditor/api/v2/targets.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/api/v2/targets.py
@@ -66,11 +66,11 @@ async def list_targets(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
     sort: str = Query(default="-created_at"),
-    filter: TargetFilter = Depends(_target_filter_dep),
+    parsed_filter: TargetFilter = Depends(_target_filter_dep),
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
 ) -> dict:
     """List audit targets in the workspace with pagination and filter support."""
-    filter_dict = filter if isinstance(filter, dict) else filter.model_dump(exclude_none=True)
+    filter_dict = parsed_filter if isinstance(parsed_filter, dict) else parsed_filter.model_dump(exclude_none=True)
     try:
         result = await entity_client.list(
             AuditTarget,
@@ -87,7 +87,7 @@ async def list_targets(
         "data": [t.model_dump(mode="json") for t in result.data],
         "pagination": result.pagination.model_dump() if result.pagination else None,
         "sort": sort,
-        "filter": filter or None,
+        "filter": parsed_filter or None,
     }
 
 

--- a/plugins/nemo-auditor/src/nemo_auditor/api/v2/targets.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/api/v2/targets.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from nemo_auditor.api.v2.schemas import CreateAuditTargetRequest, UpdateAuditTargetRequest
+from nemo_auditor.api.v2._filters import make_filter_dep
+from nemo_auditor.api.v2.schemas import CreateAuditTargetRequest, TargetFilter, UpdateAuditTargetRequest
 from nemo_auditor.entities import AuditTarget
 from nemo_platform_plugin.entity_client import (
     NemoEntitiesClient,
@@ -19,10 +20,13 @@ from nemo_platform_plugin.entity_client import (
     NemoEntityNotFoundError,
     get_entity_client,
 )
+from nemo_platform_plugin.jobs.openapi_utils import generate_openapi_extra_params
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+_target_filter_dep = make_filter_dep(TargetFilter)
 
 
 @router.post("/targets", response_model=AuditTarget, status_code=201, tags=["Auditor Targets"])
@@ -52,15 +56,21 @@ async def create_target(
         raise HTTPException(status_code=500, detail="Failed to create audit target.") from exc
 
 
-@router.get("/targets", tags=["Auditor Targets"])
+@router.get(
+    "/targets",
+    tags=["Auditor Targets"],
+    openapi_extra=generate_openapi_extra_params(filter_schema=TargetFilter),
+)
 async def list_targets(
     workspace: str,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
     sort: str = Query(default="-created_at"),
+    filter: TargetFilter = Depends(_target_filter_dep),
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
 ) -> dict:
-    """List audit targets in the workspace."""
+    """List audit targets in the workspace with pagination and filter support."""
+    filter_dict = filter if isinstance(filter, dict) else filter.model_dump(exclude_none=True)
     try:
         result = await entity_client.list(
             AuditTarget,
@@ -68,6 +78,7 @@ async def list_targets(
             page=page,
             page_size=page_size,
             sort=sort,
+            filter_obj=filter_dict or None,
         )
     except Exception as exc:
         logger.exception("Failed to list audit targets in workspace '%s'", workspace)
@@ -76,6 +87,7 @@ async def list_targets(
         "data": [t.model_dump(mode="json") for t in result.data],
         "pagination": result.pagination.model_dump() if result.pagination else None,
         "sort": sort,
+        "filter": filter or None,
     }
 
 

--- a/plugins/nemo-auditor/tests/test_api_configs.py
+++ b/plugins/nemo-auditor/tests/test_api_configs.py
@@ -211,3 +211,59 @@ class TestDeleteConfig:
         mock_entity_client.delete = AsyncMock(side_effect=NemoEntityNotFoundError("nope"))
         resp = client.delete("/apis/auditor/v2/workspaces/default/configs/missing")
         assert resp.status_code == 404
+
+
+class TestListConfigsFiltering:
+    def test_filter_by_description_forwards_filter_obj(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([_make_config("a", description="prod")]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/configs?filter[description]=prod")
+        assert resp.status_code == 200, resp.text
+        kwargs = mock_entity_client.list.await_args.kwargs
+        assert kwargs["filter_obj"] == {"description": "prod"}
+        body = resp.json()
+        assert body["filter"] == {"description": "prod"}
+        assert [c["name"] for c in body["data"]] == ["a"]
+
+    def test_filter_by_project_narrows(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/configs?filter[project]=team-a")
+        assert resp.status_code == 200, resp.text
+        assert mock_entity_client.list.await_args.kwargs["filter_obj"] == {"project": "team-a"}
+
+    def test_filter_created_at_range_parses_gte_lte(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([]))
+        resp = client.get(
+            "/apis/auditor/v2/workspaces/default/configs"
+            "?filter[created_at][$gte]=2024-01-01T00:00:00Z"
+            "&filter[created_at][$lte]=2024-12-31T00:00:00Z"
+        )
+        assert resp.status_code == 200, resp.text
+        filter_obj = mock_entity_client.list.await_args.kwargs["filter_obj"]
+        assert set(filter_obj["created_at"].keys()) == {"$gte", "$lte"}
+        assert filter_obj["created_at"]["$gte"].startswith("2024-01-01")
+        assert filter_obj["created_at"]["$lte"].startswith("2024-12-31")
+
+    def test_unknown_filter_key_returns_422(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/configs?filter[bogus]=x")
+        assert resp.status_code == 422
+
+    def test_empty_filter_forwards_none(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([_make_config("a"), _make_config("b")]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/configs")
+        assert resp.status_code == 200, resp.text
+        kwargs = mock_entity_client.list.await_args.kwargs
+        assert kwargs["filter_obj"] is None
+        body = resp.json()
+        assert [c["name"] for c in body["data"]] == ["a", "b"]
+        assert body["filter"] is None
+
+    def test_response_still_has_data_pagination_sort(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([_make_config("a")]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/configs?filter[description]=prod&sort=name")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "data" in body
+        assert "pagination" in body
+        assert body["sort"] == "name"
+        assert body["filter"] == {"description": "prod"}

--- a/plugins/nemo-auditor/tests/test_api_targets.py
+++ b/plugins/nemo-auditor/tests/test_api_targets.py
@@ -155,3 +155,72 @@ class TestDeleteTarget:
         mock_entity_client.delete = AsyncMock(side_effect=NemoEntityNotFoundError("nope"))
         resp = client.delete("/apis/auditor/v2/workspaces/default/targets/missing")
         assert resp.status_code == 404
+
+
+class TestListTargetsFiltering:
+    def test_filter_by_type_forwards_filter_obj(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([_make_target("a", type="nim")]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/targets?filter[type]=nim")
+        assert resp.status_code == 200, resp.text
+        kwargs = mock_entity_client.list.await_args.kwargs
+        assert kwargs["filter_obj"] == {"type": "nim"}
+        body = resp.json()
+        assert body["filter"] == {"type": "nim"}
+        assert [t["name"] for t in body["data"]] == ["a"]
+
+    def test_filter_by_model_forwards_filter_obj(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([_make_target("a")]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/targets?filter[model]=meta/llama-3.1-8b-instruct")
+        assert resp.status_code == 200, resp.text
+        kwargs = mock_entity_client.list.await_args.kwargs
+        assert kwargs["filter_obj"] == {"model": "meta/llama-3.1-8b-instruct"}
+
+    def test_filter_by_description_forwards_filter_obj(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/targets?filter[description]=prod")
+        assert resp.status_code == 200, resp.text
+        assert mock_entity_client.list.await_args.kwargs["filter_obj"] == {"description": "prod"}
+
+    def test_filter_by_project_narrows(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/targets?filter[project]=team-a")
+        assert resp.status_code == 200, resp.text
+        assert mock_entity_client.list.await_args.kwargs["filter_obj"] == {"project": "team-a"}
+
+    def test_filter_created_at_range_parses_gte_lte(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([]))
+        resp = client.get(
+            "/apis/auditor/v2/workspaces/default/targets"
+            "?filter[created_at][$gte]=2024-01-01T00:00:00Z"
+            "&filter[created_at][$lte]=2024-12-31T00:00:00Z"
+        )
+        assert resp.status_code == 200, resp.text
+        filter_obj = mock_entity_client.list.await_args.kwargs["filter_obj"]
+        assert set(filter_obj["created_at"].keys()) == {"$gte", "$lte"}
+        assert filter_obj["created_at"]["$gte"].startswith("2024-01-01")
+        assert filter_obj["created_at"]["$lte"].startswith("2024-12-31")
+
+    def test_unknown_filter_key_returns_422(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/targets?filter[bogus]=x")
+        assert resp.status_code == 422
+
+    def test_empty_filter_forwards_none(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([_make_target("a"), _make_target("b")]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/targets")
+        assert resp.status_code == 200, resp.text
+        kwargs = mock_entity_client.list.await_args.kwargs
+        assert kwargs["filter_obj"] is None
+        body = resp.json()
+        assert [t["name"] for t in body["data"]] == ["a", "b"]
+        assert body["filter"] is None
+
+    def test_response_still_has_data_pagination_sort(self, client, mock_entity_client) -> None:
+        mock_entity_client.list = AsyncMock(return_value=_list_response([_make_target("a")]))
+        resp = client.get("/apis/auditor/v2/workspaces/default/targets?filter[type]=nim&sort=name")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "data" in body
+        assert "pagination" in body
+        assert body["sort"] == "name"
+        assert body["filter"] == {"type": "nim"}


### PR DESCRIPTION
## What

The auditor plugin's target and config list endpoints previously supported only `page` / `page_size` / `sort`. This adds query filtering through the standard plugin idiom.

- New `TargetFilter` (`type`, `model`, `description`, `project`, `created_at`, `updated_at`) and `ConfigFilter` (`description`, `project`, `created_at`, `updated_at`) in `api/v2/schemas.py` — both `NemoFilter` subclasses (`extra="forbid"`), with `DatetimeFilter` range support on the timestamps.
- `list_targets` / `list_configs` now take a `filter[...]` dependency (`make_filter_obj_dep`) and forward `filter_obj` to `entity_client.list`.
- A small auditor-local `_filters.make_filter_dep` wrapper maps the raw pydantic `ValidationError` raised on an unknown filter key to HTTP 422 — the platform registers no handler for it, so the bare dependency would surface a 500. Shared infra is untouched.

## Compatibility

Additive. With no filter the call is identical to before; `page` / `page_size` / `sort` and the response shape are unchanged (a `filter` echo key is added). Misspelled filter keys now return 422 (intended).

## Tests

15 new tests (8 target / 7 config): per-field filtering, `project` narrowing, `created_at` `$gte`/`$lte` ranges, 422 on unknown key, and an empty-filter regression. Plugin suite green (40 passed).

## Remaining before merge

Run `make refresh-openapi` to regenerate `plugins/nemo-auditor/openapi/openapi.yaml` (spec-from-Pydantic; no Stainless — auditor ships hand-written SDK resources).

AIRCORE-387


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add schema-driven filtering to config and target list endpoints, including date-range support; applied filters are forwarded to storage and echoed in list responses. OpenAPI now documents filter parameters and schemas.

* **Bug Fixes**
  * Unknown or misspelled filter keys now return HTTP 422 with clearer validation details.

* **Tests**
  * New tests covering config and target list filtering: parameter forwarding, range parsing, error handling, and response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->