### PR TITLE
fix(web): remove pnpm devDependency to unblock Volta users

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -47,7 +47,6 @@
     "globals": "^15.15.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
-    "pnpm": "^10.32.1",
     "prettier": "^3.6.2",
     "tsx": "catalog:",
     "typescript-eslint": "^8.59.0"

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -240,9 +240,6 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
-      pnpm:
-        specifier: ^10.32.1
-        version: 10.32.1
       prettier:
         specifier: ^3.6.2
         version: 3.8.1
@@ -6208,11 +6205,6 @@ packages:
   playwright@1.58.2:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
     engines: {node: '>=18'}
-    hasBin: true
-
-  pnpm@10.32.1:
-    resolution: {integrity: sha512-pwaTjw6JrBRWtlY+q07fHR+vM2jRGR/FxZeQ6W3JGORFarLmfWE94QQ9LoyB+HMD5rQNT/7KnfFe8a1Wc0jyvg==}
-    engines: {node: '>=18.12'}
     hasBin: true
 
   postcss-prefix-selector@2.1.1:
@@ -13079,8 +13071,6 @@ snapshots:
       playwright-core: 1.58.2
     optionalDependencies:
       fsevents: 2.3.2
-
-  pnpm@10.32.1: {}
 
   postcss-prefix-selector@2.1.1(postcss@8.5.14):
     dependencies:


### PR DESCRIPTION
## Summary

Removes `"pnpm": "^10.32.1"` from `web/package.json` devDependencies and updates `web/pnpm-lock.yaml` to match. The `engines`, `preinstall`, and `packageManager` fields continue to enforce pnpm usage and version, so the devDep entry was redundant with all three.

This is the `nemo-platform` port of [NVIDIA-NeMo/Platform#668](https://github.com/NVIDIA-NeMo/Platform/pull/668). Fixes [AIRCORE-689](https://linear.app/nvidia/issue/AIRCORE-689/volta-users-blocked-from-make-bootstrap-studio-on-fresh-clone).

## What was going wrong

When a new user clones this repo and runs `make bootstrap-studio`, the install fails with a confusing error from Volta (a popular Node version manager):

> `Volta error: Could not locate executable pnpm in your project.`

The error then tells the user to upgrade Node via `pnpm env use --global 22.18.0`, but that command doesn't work either, because Volta installs pnpm in a way that doesn't let pnpm manage Node. The user is stuck in a loop where the error message is misleading and the suggested fix doesn't apply. The user's Node and pnpm versions are actually correct.

<img width="1439" height="514" alt="cdd441d1-5464-42a1-b3f4-c3dc174db938" src="https://github.com/user-attachments/assets/10f84156-02e9-4fbc-bd6d-61ace53c0a62" />


## Why it happens

`web/package.json` declared pnpm in its own `devDependencies`:

```json
"devDependencies": {
  ...
  "pnpm": "^10.32.1",
  ...
}
```

Volta's pnpm shim treats any package.json that lists pnpm as a dependency (dev or regular) as a project that owns its own pnpm. The shim demands pnpm live inside the project at `node_modules/.bin/pnpm` and refuses to delegate to the globally-installed pnpm until that path exists.

That creates a chicken-and-egg problem on a fresh clone:

1. The user has pnpm 10.32.1 installed globally (via Volta), exactly the right version.
2. Volta sees `pnpm` in devDependencies and demands a copy of pnpm inside the project.
3. The only way to get pnpm inside the project is to run `pnpm install`, which creates `node_modules/`.
4. But Volta blocks `pnpm install` from running until `node_modules/` already exists.

The user can never get past step 2. The bootstrap fails.

## Who hits this

Anyone using Volta on a fresh clone. Volta is one of the most common Node setups on Mac and Linux developer machines. Users who installed pnpm a different way (Homebrew, the standalone pnpm installer, or Corepack alone) do not see this, which is why it didn't surface earlier.

## The fix

Remove the `"pnpm": "^10.32.1"` line from `web/package.json` devDependencies, and update `web/pnpm-lock.yaml` to match. Three other mechanisms still enforce pnpm usage and version:

- `engines.pnpm: ">=10.32.1"` — read by `script/verify-node-version.sh` and by pnpm itself with `engine-strict`.
- `scripts.preinstall: "npx only-allow pnpm"` — refuses npm/yarn invocations.
- `packageManager: "pnpm@10.32.1"` — Corepack's pin for the exact version.

## Test plan (verified on this repo)

- [x] Reproduced the Volta block on a fresh `origin/main` worktree: `cd web && CI=true pnpm install --frozen-lockfile` → `Volta error: Could not locate executable pnpm in your project.`
- [x] After removing the devDep and regenerating the lockfile, the same command delegates to global pnpm and `--frozen-lockfile` accepts the lockfile (no mismatch — the same check CI runs).
- [x] Lockfile diff is exactly the three pnpm blocks (importer entry, package resolution, snapshot): 10 deletions, 0 additions, no unrelated version churn.
- [ ] Reviewer: on a fresh clone with Volta-managed Node and pnpm 10.32.1+, `make bootstrap-studio` completes through codegen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a declared development dependency for the pnpm package manager from the web project manifest.
  * No runtime behavior or user-facing functionality is expected to change; engine and package manager metadata remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->