### PR TITLE
docs: Fix NemoGuard casing in Models docs

### DIFF
--- a/docs/run-inference/tutorials/deploy-models.md
+++ b/docs/run-inference/tutorials/deploy-models.md
@@ -221,7 +221,7 @@ Deploy pre-built NIM containers from NGC.
     )
     ```
 
-### Deploy NemoGuard Jailbreak Detection
+### Deploy NemoGuard JailbreakDetect
 
 Deploy classification NIMs like NemoGuard for content safety. Uses the `/v1/classify` endpoint instead of chat completions.
 

--- a/docs/run-inference/tutorials/deploy-models.md
+++ b/docs/run-inference/tutorials/deploy-models.md
@@ -221,9 +221,9 @@ Deploy pre-built NIM containers from NGC.
     )
     ```
 
-### Deploy NeMo Guard Jailbreak Detection
+### Deploy NemoGuard Jailbreak Detection
 
-Deploy classification NIMs like NeMoGuard for content safety. Uses the `/v1/classify` endpoint instead of chat completions.
+Deploy classification NIMs like NemoGuard for content safety. Uses the `/v1/classify` endpoint instead of chat completions.
 
 
 === "CLI"


### PR DESCRIPTION
Fix `NeMoGuard` to `NemoGuard` in Models docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized naming and section heading in the deployment guide: updated the jailbreak-detection deployment heading for clearer, consistent product terminology across the model deployment documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->