### PR TITLE
feat(studio): Experiments list page (FP-182)

### DIFF
--- a/web/packages/studio/src/constants/routes.ts
+++ b/web/packages/studio/src/constants/routes.ts
@@ -38,6 +38,7 @@ export const ROUTE_PARAMS = {
   jobName: 'jobName',
   /** Benchmark entity name segment under evaluation/benchmarks/:name */
   benchmarkName: 'benchmarkName',
+  experimentGroupId: 'experimentGroupId',
 } as const;
 
 // Just an alias to make the routes more readable
@@ -70,6 +71,7 @@ export const ROUTES = {
     evaluationResultDetails: `/workspaces/:${P.workspace}/evaluation/results/:${P.evaluationJobId}`,
     /** Empty landing page for the EXPERIMENT feature (gated by VITE_FF_EXPERIMENT). */
     experiment: `/workspaces/:${P.workspace}/experiment`,
+    experimentGroupDetail: `/workspaces/:${P.workspace}/experiment/:${P.experimentGroupId}`,
     customizationJobList: `/workspaces/:${P.workspace}/customizations`,
     customizationJobDetails: `/workspaces/:${P.workspace}/customizations/:${P.customizationJobName}`,
     newCustomizationJob: `/workspaces/:${P.workspace}/customizations/fine-tuned/new`,

--- a/web/packages/studio/src/routes/ExperimentGroupDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentGroupDetailRoute/index.tsx
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PageHeader, Stack } from '@nvidia/foundations-react-core';
+import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { type FC } from 'react';
+
+/** Placeholder for the experiment group detail page. */
+export const ExperimentGroupDetailRoute: FC = () => {
+  useBreadcrumbs({ items: [{ slotLabel: 'Experiments' }, { slotLabel: 'Detail' }] });
+
+  return (
+    <AccessibleTitle title="Experiment Group">
+      <Stack className="h-full" gap="density-2xl" padding="density-2xl">
+        <PageHeader
+          className="p-0"
+          slotHeading="Experiment Group"
+          slotDescription="Experiment group detail page."
+        />
+      </Stack>
+    </AccessibleTitle>
+  );
+};

--- a/web/packages/studio/src/routes/ExperimentRoute/ExperimentGroupCard.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/ExperimentGroupCard.tsx
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useListExperiments } from '@nemo/sdk/generated/platform/api';
+import type { ExperimentGroupResponse } from '@nemo/sdk/generated/platform/schema';
+import { Card, Divider, Text } from '@nvidia/foundations-react-core';
+import { Metric } from '@studio/routes/ExperimentRoute/Metric';
+import { UpdatedAt } from '@studio/routes/ExperimentRoute/UpdatedAt';
+import { getExperimentGroupDetailRoute } from '@studio/routes/utils';
+import { type FC } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface ExperimentGroupCardProps {
+  group: ExperimentGroupResponse;
+  workspace: string;
+}
+
+export const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group, workspace }) => {
+  const navigate = useNavigate();
+
+  const { data: experimentsData } = useListExperiments(workspace, {
+    filter: { experiment_group_id: group.id },
+    page_size: 100,
+  });
+
+  const experiments = experimentsData?.data ?? [];
+  const experimentCount = experimentsData?.pagination?.total_results ?? experiments.length;
+
+  // Collect evaluator names and average their means across experiments in this group
+  const evaluatorNames = [
+    ...new Set(experiments.flatMap((e) => Object.keys(e.aggregate_scores ?? {}))),
+  ];
+  const scoreEntries = evaluatorNames
+    .map((name) => {
+      const means = experiments
+        .map((e) => e.aggregate_scores?.[name]?.mean)
+        .filter((v): v is number => v !== undefined && v !== null);
+      const avg = means.length > 0 ? means.reduce((a, b) => a + b, 0) / means.length : null;
+      return { name, avg };
+    })
+    .filter((entry): entry is { name: string; avg: number } => entry.avg !== null);
+
+  return (
+    <Card
+      interactive
+      attributes={{ CardContent: { className: 'flex flex-row items-center gap-6 p-6' } }}
+      onClick={() => navigate(getExperimentGroupDetailRoute(workspace, group.id))}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          navigate(getExperimentGroupDetailRoute(workspace, group.id));
+        } else if (e.key === ' ') {
+          e.preventDefault();
+          navigate(getExperimentGroupDetailRoute(workspace, group.id));
+        }
+      }}
+    >
+      {/* Main info */}
+      <div className="flex flex-col items-start gap-2 flex-1">
+        <Text kind="title/sm">{group.name}</Text>
+        {group.description && (
+          <Text kind="body/regular/sm" className="text-secondary">
+            {group.description}
+          </Text>
+        )}
+        <div className="flex items-center gap-4">
+          {group.updated_at && <UpdatedAt datetime={group.updated_at} />}
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="flex shrink-0 items-center gap-6">
+        {scoreEntries.map(({ name, avg }) => (
+          <Metric key={name} title={name} value={`${(avg * 100).toFixed(1)}%`} />
+        ))}
+        {scoreEntries.length > 0 && <Divider orientation="vertical" />}
+        <Metric title="Experiments" value={String(experimentCount)} />
+      </div>
+    </Card>
+  );
+};

--- a/web/packages/studio/src/routes/ExperimentRoute/Metric.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/Metric.tsx
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Text } from '@nvidia/foundations-react-core';
+import { type FC, type ReactNode } from 'react';
+
+interface MetricProps {
+  title: string;
+  value: ReactNode;
+  icon?: ReactNode;
+}
+
+export const Metric: FC<MetricProps> = ({ title, value, icon }) => (
+  <div className="flex flex-col items-center gap-[5px]">
+    <Text kind="label/semibold/sm" className="text-tertiary uppercase">
+      {title}
+    </Text>
+    <div className="flex items-center gap-1">
+      {icon && <span className="size-4 shrink-0 [&>svg]:size-4">{icon}</span>}
+      <Text kind="body/regular/xl">{value}</Text>
+    </div>
+  </div>
+);

--- a/web/packages/studio/src/routes/ExperimentRoute/Metric.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/Metric.tsx
@@ -11,7 +11,7 @@ interface MetricProps {
 }
 
 export const Metric: FC<MetricProps> = ({ title, value, icon }) => (
-  <div className="flex flex-col items-center gap-[5px]">
+  <div className="flex flex-col items-center gap-1.5">
     <Text kind="label/semibold/sm" className="text-tertiary uppercase">
       {title}
     </Text>

--- a/web/packages/studio/src/routes/ExperimentRoute/UpdatedAt.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/UpdatedAt.tsx
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useRelativeTimeSince } from '@nemo/common/src/components/RelativeTime';
+import { Text } from '@nvidia/foundations-react-core';
+import { type FC } from 'react';
+
+interface UpdatedAtProps {
+  datetime: string;
+}
+
+export const UpdatedAt: FC<UpdatedAtProps> = ({ datetime }) => {
+  const relative = useRelativeTimeSince(datetime);
+  return (
+    <Text kind="label/regular/xs" className="text-tertiary">
+      Updated {relative}
+    </Text>
+  );
+};

--- a/web/packages/studio/src/routes/ExperimentRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/index.tsx
@@ -1,16 +1,25 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
+import { useRelativeTimeSince } from '@nemo/common/src/components/RelativeTime';
 import { useListExperimentGroups, useListExperiments } from '@nemo/sdk/generated/platform/api';
 import type { ExperimentGroupResponse } from '@nemo/sdk/generated/platform/schema';
-import { PageHeader, Panel, Stack, StatusMessage, Text } from '@nvidia/foundations-react-core';
+import {
+  Divider,
+  PageHeader,
+  Skeleton,
+  Stack,
+  StatusMessage,
+  Tag,
+  Text,
+} from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { Loading } from '@studio/components/Layouts/Loading';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { Metric } from '@studio/routes/ExperimentRoute/Metric';
 import { keepPreviousData } from '@tanstack/react-query';
-import { CircleAlert } from 'lucide-react';
+import { CircleAlert, MessageSquareText } from 'lucide-react';
 import { type FC } from 'react';
 
 export const ExperimentRoute: FC = () => {
@@ -66,6 +75,19 @@ export const ExperimentRoute: FC = () => {
   );
 };
 
+interface UpdatedAtProps {
+  datetime: string;
+}
+
+const UpdatedAt: FC<UpdatedAtProps> = ({ datetime }) => {
+  const relative = useRelativeTimeSince(datetime);
+  return (
+    <Text kind="label/regular/xs" className="text-tertiary">
+      Updated {relative}
+    </Text>
+  );
+};
+
 interface ExperimentGroupCardProps {
   group: ExperimentGroupResponse;
   workspace: string;
@@ -79,53 +101,57 @@ const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group, workspace })
 
   const experiments = experimentsData?.data ?? [];
   const experimentCount = experimentsData?.pagination?.total_results ?? experiments.length;
-  const datasetNames = [...new Set(experiments.map((e) => e.dataset_name).filter(Boolean))];
-  const agentNames = [...new Set(experiments.map((e) => e.agent_name).filter(Boolean))];
+
+  // Collect evaluator names and average their means across experiments in this group
+  const evaluatorNames = [
+    ...new Set(experiments.flatMap((e) => Object.keys(e.aggregate_scores ?? {}))),
+  ];
+  const scoreEntries = evaluatorNames
+    .map((name) => {
+      const means = experiments
+        .map((e) => e.aggregate_scores?.[name]?.mean)
+        .filter((v): v is number => v !== undefined && v !== null);
+      const avg = means.length > 0 ? means.reduce((a, b) => a + b, 0) / means.length : null;
+      return { name, avg };
+    })
+    .filter((entry): entry is { name: string; avg: number } => entry.avg !== null);
 
   return (
-    <Panel elevation="low">
-      <Stack gap="density-sm">
+    <div className="flex items-center gap-6 rounded bg-surface px-5 py-[18px]">
+      {/* Slot 1: Status — no backend field yet, skeleton holds the space */}
+      <Skeleton className="h-6 w-20 shrink-0" />
+
+      {/* Slot 2: Main info */}
+      <div className="flex flex-col items-start gap-[7px] flex-1">
         <Text kind="title/sm">{group.name}</Text>
         {group.description && (
           <Text kind="body/regular/sm" className="text-secondary">
             {group.description}
           </Text>
         )}
-        <Stack direction="row" gap="density-xl">
-          <Stack gap="density-xxs">
-            <Text kind="label/bold/xs" className="text-tertiary uppercase">
-              Experiments
-            </Text>
-            <Text kind="body/regular/sm">{experimentCount}</Text>
-          </Stack>
-          {agentNames.length > 0 && (
-            <Stack gap="density-xxs">
-              <Text kind="label/bold/xs" className="text-tertiary uppercase">
-                Agent
-              </Text>
-              <Text kind="body/regular/sm">{agentNames.join(', ')}</Text>
-            </Stack>
-          )}
-          {datasetNames.length > 0 && (
-            <Stack gap="density-xxs">
-              <Text kind="label/bold/xs" className="text-tertiary uppercase">
-                Dataset
-              </Text>
-              <Text kind="body/regular/sm">{datasetNames.join(', ')}</Text>
-            </Stack>
-          )}
-          {group.updated_at && (
-            <Stack gap="density-xxs">
-              <Text kind="label/bold/xs" className="text-tertiary uppercase">
-                Updated
-              </Text>
-              <Text kind="body/regular/sm">
-                <RelativeTime datetime={group.updated_at} />
-              </Text>
-            </Stack>
-          )}
-        </Stack>
-      </Stack>
-    </Panel>
+        <div className="flex items-center gap-4">
+          <Tag kind="outline" color="gray" readOnly>
+            {experimentCount} Experiments
+          </Tag>
+          {/* UserPill: no author field on ExperimentGroupResponse yet */}
+          <Skeleton className="h-6 w-24 rounded-full" />
+          {group.updated_at && <UpdatedAt datetime={group.updated_at} />}
+        </div>
+      </div>
+
+      {/* Slot 3: Stats */}
+      <div className="flex shrink-0 items-center gap-6">
+        {/* Variable evaluator score metrics */}
+        {scoreEntries.map(({ name, avg }) => (
+          <Metric key={name} title={name} value={`${(avg * 100).toFixed(1)}%`} />
+        ))}
+
+        {/* Pipe — only shown when there are scores to separate */}
+        {scoreEntries.length > 0 && <Divider orientation="vertical" />}
+
+        <Metric title="Experiments" value={String(experimentCount)} />
+        <Metric title="Feedback" icon={<MessageSquareText />} value="—" />
+      </div>
+    </div>
   );
 };

--- a/web/packages/studio/src/routes/ExperimentRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
-import { useListExperimentGroups } from '@nemo/sdk/generated/platform/api';
+import { useListExperimentGroups, useListExperiments } from '@nemo/sdk/generated/platform/api';
 import type { ExperimentGroupResponse } from '@nemo/sdk/generated/platform/schema';
 import { PageHeader, Panel, Stack, StatusMessage, Text } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
@@ -57,7 +57,7 @@ export const ExperimentRoute: FC = () => {
         ) : (
           <Stack gap="density-md">
             {groups.map((group: ExperimentGroupResponse) => (
-              <ExperimentGroupCard key={group.id} group={group} />
+              <ExperimentGroupCard key={group.id} group={group} workspace={workspace} />
             ))}
           </Stack>
         )}
@@ -68,22 +68,64 @@ export const ExperimentRoute: FC = () => {
 
 interface ExperimentGroupCardProps {
   group: ExperimentGroupResponse;
+  workspace: string;
 }
 
-const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group }) => (
-  <Panel elevation="low">
-    <Stack gap="density-sm">
-      <Text kind="title/sm">{group.name}</Text>
-      {group.description && (
-        <Text kind="body/regular/sm" className="text-secondary">
-          {group.description}
-        </Text>
-      )}
-      {group.updated_at && (
-        <Text kind="body/regular/xs" className="text-tertiary">
-          Updated <RelativeTime datetime={group.updated_at} />
-        </Text>
-      )}
-    </Stack>
-  </Panel>
-);
+const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group, workspace }) => {
+  const { data: experimentsData } = useListExperiments(workspace, {
+    filter: { experiment_group_id: group.id },
+    page_size: 100,
+  });
+
+  const experiments = experimentsData?.data ?? [];
+  const experimentCount = experimentsData?.pagination?.total_results ?? experiments.length;
+  const datasetNames = [...new Set(experiments.map((e) => e.dataset_name).filter(Boolean))];
+  const agentNames = [...new Set(experiments.map((e) => e.agent_name).filter(Boolean))];
+
+  return (
+    <Panel elevation="low">
+      <Stack gap="density-sm">
+        <Text kind="title/sm">{group.name}</Text>
+        {group.description && (
+          <Text kind="body/regular/sm" className="text-secondary">
+            {group.description}
+          </Text>
+        )}
+        <Stack direction="row" gap="density-xl">
+          <Stack gap="density-xxs">
+            <Text kind="label/bold/xs" className="text-tertiary uppercase">
+              Experiments
+            </Text>
+            <Text kind="body/regular/sm">{experimentCount}</Text>
+          </Stack>
+          {agentNames.length > 0 && (
+            <Stack gap="density-xxs">
+              <Text kind="label/bold/xs" className="text-tertiary uppercase">
+                Agent
+              </Text>
+              <Text kind="body/regular/sm">{agentNames.join(', ')}</Text>
+            </Stack>
+          )}
+          {datasetNames.length > 0 && (
+            <Stack gap="density-xxs">
+              <Text kind="label/bold/xs" className="text-tertiary uppercase">
+                Dataset
+              </Text>
+              <Text kind="body/regular/sm">{datasetNames.join(', ')}</Text>
+            </Stack>
+          )}
+          {group.updated_at && (
+            <Stack gap="density-xxs">
+              <Text kind="label/bold/xs" className="text-tertiary uppercase">
+                Updated
+              </Text>
+              <Text kind="body/regular/sm">
+                <RelativeTime datetime={group.updated_at} />
+              </Text>
+            </Stack>
+          )}
+        </Stack>
+      </Stack>
+    </Panel>
+  );
+};

--- a/web/packages/studio/src/routes/ExperimentRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/index.tsx
@@ -1,12 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useRelativeTimeSince } from '@nemo/common/src/components/RelativeTime';
-import { useListExperimentGroups, useListExperiments } from '@nemo/sdk/generated/platform/api';
+import { useListExperimentGroups } from '@nemo/sdk/generated/platform/api';
 import type { ExperimentGroupResponse } from '@nemo/sdk/generated/platform/schema';
 import {
-  Card,
-  Divider,
   PageHeader,
   PaginationArrowButton,
   PaginationControlsGroup,
@@ -24,12 +21,10 @@ import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { Loading } from '@studio/components/Layouts/Loading';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
-import { Metric } from '@studio/routes/ExperimentRoute/Metric';
-import { getExperimentGroupDetailRoute } from '@studio/routes/utils';
+import { ExperimentGroupCard } from '@studio/routes/ExperimentRoute/ExperimentGroupCard';
 import { keepPreviousData } from '@tanstack/react-query';
 import { CircleAlert } from 'lucide-react';
 import { type FC, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 const DEFAULT_PAGE_SIZE = 5;
 
@@ -121,89 +116,5 @@ export const ExperimentRoute: FC = () => {
         )}
       </Stack>
     </AccessibleTitle>
-  );
-};
-
-interface UpdatedAtProps {
-  datetime: string;
-}
-
-const UpdatedAt: FC<UpdatedAtProps> = ({ datetime }) => {
-  const relative = useRelativeTimeSince(datetime);
-  return (
-    <Text kind="label/regular/xs" className="text-tertiary">
-      Updated {relative}
-    </Text>
-  );
-};
-
-interface ExperimentGroupCardProps {
-  group: ExperimentGroupResponse;
-  workspace: string;
-}
-
-const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group, workspace }) => {
-  const navigate = useNavigate();
-
-  const { data: experimentsData } = useListExperiments(workspace, {
-    filter: { experiment_group_id: group.id },
-    page_size: 100,
-  });
-
-  const experiments = experimentsData?.data ?? [];
-  const experimentCount = experimentsData?.pagination?.total_results ?? experiments.length;
-
-  // Collect evaluator names and average their means across experiments in this group
-  const evaluatorNames = [
-    ...new Set(experiments.flatMap((e) => Object.keys(e.aggregate_scores ?? {}))),
-  ];
-  const scoreEntries = evaluatorNames
-    .map((name) => {
-      const means = experiments
-        .map((e) => e.aggregate_scores?.[name]?.mean)
-        .filter((v): v is number => v !== undefined && v !== null);
-      const avg = means.length > 0 ? means.reduce((a, b) => a + b, 0) / means.length : null;
-      return { name, avg };
-    })
-    .filter((entry): entry is { name: string; avg: number } => entry.avg !== null);
-
-  return (
-    <Card
-      interactive
-      attributes={{ CardContent: { className: 'flex flex-row items-center gap-6 p-6' } }}
-      onClick={() => navigate(getExperimentGroupDetailRoute(workspace, group.id))}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter') {
-          navigate(getExperimentGroupDetailRoute(workspace, group.id));
-        } else if (e.key === ' ') {
-          e.preventDefault();
-          navigate(getExperimentGroupDetailRoute(workspace, group.id));
-        }
-      }}
-    >
-      {/* Main info */}
-      <div className="flex flex-col items-start gap-[7px] flex-1">
-        <Text kind="title/sm">{group.name}</Text>
-        {group.description && (
-          <Text kind="body/regular/sm" className="text-secondary">
-            {group.description}
-          </Text>
-        )}
-        <div className="flex items-center gap-4">
-          {group.updated_at && <UpdatedAt datetime={group.updated_at} />}
-        </div>
-      </div>
-
-      {/* Stats */}
-      <div className="flex shrink-0 items-center gap-6">
-        {scoreEntries.map(({ name, avg }) => (
-          <Metric key={name} title={name} value={`${(avg * 100).toFixed(1)}%`} />
-        ))}
-        {scoreEntries.length > 0 && <Divider orientation="vertical" />}
-        <Metric title="Experiments" value={String(experimentCount)} />
-      </div>
-    </Card>
   );
 };

--- a/web/packages/studio/src/routes/ExperimentRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/index.tsx
@@ -1,29 +1,89 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PageHeader, Stack } from '@nvidia/foundations-react-core';
+import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
+import { useListExperimentGroups } from '@nemo/sdk/generated/platform/api';
+import type { ExperimentGroupResponse } from '@nemo/sdk/generated/platform/schema';
+import { PageHeader, Panel, Stack, StatusMessage, Text } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { Loading } from '@studio/components/Layouts/Loading';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
-import { FC } from 'react';
+import { keepPreviousData } from '@tanstack/react-query';
+import { CircleAlert } from 'lucide-react';
+import { type FC } from 'react';
 
-/**
- * Empty landing page for the EXPERIMENT feature.
- *
- * Reached from the "Experiment" item in the Evaluate side-nav group and gated
- * behind the `experiment` feature flag (VITE_FF_EXPERIMENT, default false).
- */
 export const ExperimentRoute: FC = () => {
-  useBreadcrumbs({ items: [{ slotLabel: 'Experiment' }] });
+  useBreadcrumbs({ items: [{ slotLabel: 'Experiments' }] });
+
+  const workspace = useWorkspaceFromPath();
+
+  const { data, isLoading, error } = useListExperimentGroups(
+    workspace,
+    { page: 1, page_size: 50 },
+    { query: { placeholderData: keepPreviousData } }
+  );
+
+  if (isLoading) {
+    return <Loading description="Loading experiments..." />;
+  }
+
+  if (error) {
+    return (
+      <StatusMessage
+        className="mx-auto mt-density-2xl"
+        size="medium"
+        slotMedia={<CircleAlert width={65} height={65} />}
+        slotHeading="Error loading experiments"
+        slotSubheading={error.message}
+      />
+    );
+  }
+
+  const groups = data?.data ?? [];
 
   return (
-    <AccessibleTitle title="Experiment">
-      <Stack className="h-full" gap="density-2xl" padding="density-2xl">
+    <AccessibleTitle title="Experiments">
+      <Stack className="h-full overflow-auto" gap="density-2xl" padding="density-2xl">
         <PageHeader
           className="p-0"
-          slotHeading="Experiment"
-          slotDescription="This is a placeholder landing page for the Experiment feature."
+          slotHeading="Experiments"
+          slotDescription="Result ledger for offline optimization. Review results down to the trace level."
         />
+        {groups.length === 0 ? (
+          <Text kind="body/regular/md" className="text-secondary">
+            No experiment groups yet.
+          </Text>
+        ) : (
+          <Stack gap="density-md">
+            {groups.map((group: ExperimentGroupResponse) => (
+              <ExperimentGroupCard key={group.id} group={group} />
+            ))}
+          </Stack>
+        )}
       </Stack>
     </AccessibleTitle>
   );
 };
+
+interface ExperimentGroupCardProps {
+  group: ExperimentGroupResponse;
+}
+
+const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group }) => (
+  <Panel elevation="low">
+    <Stack gap="density-sm">
+      <Text kind="title/sm">{group.name}</Text>
+      {group.description && (
+        <Text kind="body/regular/sm" className="text-secondary">
+          {group.description}
+        </Text>
+      )}
+      {group.updated_at && (
+        <Text kind="body/regular/xs" className="text-tertiary">
+          Updated <RelativeTime datetime={group.updated_at} />
+        </Text>
+      )}
+    </Stack>
+  </Panel>
+);

--- a/web/packages/studio/src/routes/ExperimentRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/index.tsx
@@ -7,6 +7,14 @@ import type { ExperimentGroupResponse } from '@nemo/sdk/generated/platform/schem
 import {
   Divider,
   PageHeader,
+  PaginationArrowButton,
+  PaginationControlsGroup,
+  PaginationItemRangeText,
+  PaginationNavigationGroup,
+  PaginationPageCountText,
+  PaginationPageInput,
+  PaginationPageSizeSelect,
+  PaginationRoot,
   Skeleton,
   Stack,
   StatusMessage,
@@ -20,16 +28,20 @@ import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { Metric } from '@studio/routes/ExperimentRoute/Metric';
 import { keepPreviousData } from '@tanstack/react-query';
 import { CircleAlert, MessageSquareText } from 'lucide-react';
-import { type FC } from 'react';
+import { type FC, useState } from 'react';
+
+const DEFAULT_PAGE_SIZE = 5;
 
 export const ExperimentRoute: FC = () => {
   useBreadcrumbs({ items: [{ slotLabel: 'Experiments' }] });
 
   const workspace = useWorkspaceFromPath();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
 
   const { data, isLoading, error } = useListExperimentGroups(
     workspace,
-    { page: 1, page_size: 50 },
+    { page, page_size: pageSize },
     { query: { placeholderData: keepPreviousData } }
   );
 
@@ -50,6 +62,7 @@ export const ExperimentRoute: FC = () => {
   }
 
   const groups = data?.data ?? [];
+  const totalResults = data?.pagination?.total_results ?? 0;
 
   return (
     <AccessibleTitle title="Experiments">
@@ -64,11 +77,44 @@ export const ExperimentRoute: FC = () => {
             No experiment groups yet.
           </Text>
         ) : (
-          <Stack gap="density-md">
-            {groups.map((group: ExperimentGroupResponse) => (
-              <ExperimentGroupCard key={group.id} group={group} workspace={workspace} />
-            ))}
-          </Stack>
+          <div className="flex flex-col flex-1 min-w-0 min-h-0">
+            <div className="flex-1 overflow-auto">
+              <Stack gap="density-md">
+                {groups.map((group: ExperimentGroupResponse) => (
+                  <ExperimentGroupCard key={group.id} group={group} workspace={workspace} />
+                ))}
+              </Stack>
+            </div>
+            {totalResults > 0 && (
+              <PaginationRoot
+                totalItems={totalResults}
+                page={page}
+                pageSize={pageSize}
+                pageSizeOptions={[5, 10, 20, 50]}
+                onPageChange={setPage}
+                onPageSizeChange={(size) => {
+                  setPageSize(size);
+                  setPage(1);
+                }}
+              >
+                <PaginationControlsGroup>
+                  <Text>Items per page</Text>
+                  <PaginationPageSizeSelect />
+                  <PaginationItemRangeText />
+                </PaginationControlsGroup>
+                <PaginationNavigationGroup className="gap-2">
+                  <PaginationArrowButton direction="first" />
+                  <PaginationArrowButton direction="previous" />
+                  <PaginationPageInput />
+                  <PaginationPageCountText
+                    pageCountTextFormatFn={(pageMeta) => `of ${pageMeta.total}`}
+                  />
+                  <PaginationArrowButton direction="next" />
+                  <PaginationArrowButton direction="last" />
+                </PaginationNavigationGroup>
+              </PaginationRoot>
+            )}
+          </div>
         )}
       </Stack>
     </AccessibleTitle>
@@ -117,7 +163,7 @@ const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group, workspace })
     .filter((entry): entry is { name: string; avg: number } => entry.avg !== null);
 
   return (
-    <div className="flex items-center gap-6 rounded bg-surface px-5 py-[18px]">
+    <div className="flex items-center gap-6 rounded bg-surface py-[18px]">
       {/* Slot 1: Status — no backend field yet, skeleton holds the space */}
       <Skeleton className="h-6 w-20 shrink-0" />
 

--- a/web/packages/studio/src/routes/ExperimentRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/index.tsx
@@ -6,6 +6,7 @@ import { useListExperimentGroups, useListExperiments } from '@nemo/sdk/generated
 import type { ExperimentGroupResponse } from '@nemo/sdk/generated/platform/schema';
 import {
   Divider,
+  Panel,
   PageHeader,
   PaginationArrowButton,
   PaginationControlsGroup,
@@ -15,10 +16,8 @@ import {
   PaginationPageInput,
   PaginationPageSizeSelect,
   PaginationRoot,
-  Skeleton,
   Stack,
   StatusMessage,
-  Tag,
   Text,
 } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
@@ -26,9 +25,11 @@ import { Loading } from '@studio/components/Layouts/Loading';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { Metric } from '@studio/routes/ExperimentRoute/Metric';
+import { getExperimentGroupDetailRoute } from '@studio/routes/utils';
 import { keepPreviousData } from '@tanstack/react-query';
-import { CircleAlert, MessageSquareText } from 'lucide-react';
+import { CircleAlert } from 'lucide-react';
 import { type FC, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const DEFAULT_PAGE_SIZE = 5;
 
@@ -65,12 +66,12 @@ export const ExperimentRoute: FC = () => {
   const totalResults = data?.pagination?.total_results ?? 0;
 
   return (
-    <AccessibleTitle title="Experiments">
+    <AccessibleTitle title="Experiment groups">
       <Stack className="h-full overflow-auto" gap="density-2xl" padding="density-2xl">
         <PageHeader
           className="p-0"
-          slotHeading="Experiments"
-          slotDescription="Result ledger for offline optimization. Review results down to the trace level."
+          slotHeading="Experiment groups"
+          slotDescription="Manage groups for online optimization. Review reports down to the frame level."
         />
         {groups.length === 0 ? (
           <Text kind="body/regular/md" className="text-secondary">
@@ -86,33 +87,35 @@ export const ExperimentRoute: FC = () => {
               </Stack>
             </div>
             {totalResults > 0 && (
-              <PaginationRoot
-                totalItems={totalResults}
-                page={page}
-                pageSize={pageSize}
-                pageSizeOptions={[5, 10, 20, 50]}
-                onPageChange={setPage}
-                onPageSizeChange={(size) => {
-                  setPageSize(size);
-                  setPage(1);
-                }}
-              >
-                <PaginationControlsGroup>
-                  <Text>Items per page</Text>
-                  <PaginationPageSizeSelect />
-                  <PaginationItemRangeText />
-                </PaginationControlsGroup>
-                <PaginationNavigationGroup className="gap-2">
-                  <PaginationArrowButton direction="first" />
-                  <PaginationArrowButton direction="previous" />
-                  <PaginationPageInput />
-                  <PaginationPageCountText
-                    pageCountTextFormatFn={(pageMeta) => `of ${pageMeta.total}`}
-                  />
-                  <PaginationArrowButton direction="next" />
-                  <PaginationArrowButton direction="last" />
-                </PaginationNavigationGroup>
-              </PaginationRoot>
+              <div className="flex justify-center">
+                <PaginationRoot
+                  totalItems={totalResults}
+                  page={page}
+                  pageSize={pageSize}
+                  pageSizeOptions={[5, 10, 20, 50]}
+                  onPageChange={setPage}
+                  onPageSizeChange={(size) => {
+                    setPageSize(size);
+                    setPage(1);
+                  }}
+                >
+                  <PaginationControlsGroup>
+                    <Text>Items per page</Text>
+                    <PaginationPageSizeSelect />
+                    <PaginationItemRangeText />
+                  </PaginationControlsGroup>
+                  <PaginationNavigationGroup className="gap-2">
+                    <PaginationArrowButton direction="first" />
+                    <PaginationArrowButton direction="previous" />
+                    <PaginationPageInput />
+                    <PaginationPageCountText
+                      pageCountTextFormatFn={(pageMeta) => `of ${pageMeta.total}`}
+                    />
+                    <PaginationArrowButton direction="next" />
+                    <PaginationArrowButton direction="last" />
+                  </PaginationNavigationGroup>
+                </PaginationRoot>
+              </div>
             )}
           </div>
         )}
@@ -140,6 +143,8 @@ interface ExperimentGroupCardProps {
 }
 
 const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group, workspace }) => {
+  const navigate = useNavigate();
+
   const { data: experimentsData } = useListExperiments(workspace, {
     filter: { experiment_group_id: group.id },
     page_size: 100,
@@ -163,11 +168,18 @@ const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group, workspace })
     .filter((entry): entry is { name: string; avg: number } => entry.avg !== null);
 
   return (
-    <div className="flex items-center gap-6 rounded bg-surface py-[18px]">
-      {/* Slot 1: Status — no backend field yet, skeleton holds the space */}
-      <Skeleton className="h-6 w-20 shrink-0" />
-
-      {/* Slot 2: Main info */}
+    <Panel
+      className="cursor-pointer hover:bg-surface-raised transition-colors"
+      attributes={{ PanelContent: { className: 'flex flex-row items-center gap-6' } }}
+      onClick={() => navigate(getExperimentGroupDetailRoute(workspace, group.id))}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ')
+          navigate(getExperimentGroupDetailRoute(workspace, group.id));
+      }}
+    >
+      {/* Main info */}
       <div className="flex flex-col items-start gap-[7px] flex-1">
         <Text kind="title/sm">{group.name}</Text>
         {group.description && (
@@ -176,28 +188,18 @@ const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group, workspace })
           </Text>
         )}
         <div className="flex items-center gap-4">
-          <Tag kind="outline" color="gray" readOnly>
-            {experimentCount} Experiments
-          </Tag>
-          {/* UserPill: no author field on ExperimentGroupResponse yet */}
-          <Skeleton className="h-6 w-24 rounded-full" />
           {group.updated_at && <UpdatedAt datetime={group.updated_at} />}
         </div>
       </div>
 
-      {/* Slot 3: Stats */}
+      {/* Stats */}
       <div className="flex shrink-0 items-center gap-6">
-        {/* Variable evaluator score metrics */}
         {scoreEntries.map(({ name, avg }) => (
           <Metric key={name} title={name} value={`${(avg * 100).toFixed(1)}%`} />
         ))}
-
-        {/* Pipe — only shown when there are scores to separate */}
         {scoreEntries.length > 0 && <Divider orientation="vertical" />}
-
         <Metric title="Experiments" value={String(experimentCount)} />
-        <Metric title="Feedback" icon={<MessageSquareText />} value="—" />
       </div>
-    </div>
+    </Panel>
   );
 };

--- a/web/packages/studio/src/routes/ExperimentRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/index.tsx
@@ -5,8 +5,8 @@ import { useRelativeTimeSince } from '@nemo/common/src/components/RelativeTime';
 import { useListExperimentGroups, useListExperiments } from '@nemo/sdk/generated/platform/api';
 import type { ExperimentGroupResponse } from '@nemo/sdk/generated/platform/schema';
 import {
+  Card,
   Divider,
-  Panel,
   PageHeader,
   PaginationArrowButton,
   PaginationControlsGroup,
@@ -87,7 +87,7 @@ export const ExperimentRoute: FC = () => {
               </Stack>
             </div>
             {totalResults > 0 && (
-              <div className="flex justify-center">
+              <div className="mx-auto w-full max-w-[1200px]">
                 <PaginationRoot
                   totalItems={totalResults}
                   page={page}
@@ -168,9 +168,9 @@ const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group, workspace })
     .filter((entry): entry is { name: string; avg: number } => entry.avg !== null);
 
   return (
-    <Panel
-      className="cursor-pointer hover:bg-surface-raised transition-colors"
-      attributes={{ PanelContent: { className: 'flex flex-row items-center gap-6' } }}
+    <Card
+      interactive
+      attributes={{ CardContent: { className: 'flex flex-row items-center gap-6 p-6' } }}
       onClick={() => navigate(getExperimentGroupDetailRoute(workspace, group.id))}
       role="button"
       tabIndex={0}
@@ -204,6 +204,6 @@ const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group, workspace })
         {scoreEntries.length > 0 && <Divider orientation="vertical" />}
         <Metric title="Experiments" value={String(experimentCount)} />
       </div>
-    </Panel>
+    </Card>
   );
 };

--- a/web/packages/studio/src/routes/ExperimentRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/index.tsx
@@ -175,8 +175,12 @@ const ExperimentGroupCard: FC<ExperimentGroupCardProps> = ({ group, workspace })
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ')
+        if (e.key === 'Enter') {
           navigate(getExperimentGroupDetailRoute(workspace, group.id));
+        } else if (e.key === ' ') {
+          e.preventDefault();
+          navigate(getExperimentGroupDetailRoute(workspace, group.id));
+        }
       }}
     >
       {/* Main info */}

--- a/web/packages/studio/src/routes/index.tsx
+++ b/web/packages/studio/src/routes/index.tsx
@@ -165,6 +165,11 @@ const ExperimentRoute = lazy(() =>
     default: module.ExperimentRoute,
   }))
 );
+const ExperimentGroupDetailRoute = lazy(() =>
+  import('@studio/routes/ExperimentGroupDetailRoute').then((module) => ({
+    default: module.ExperimentGroupDetailRoute,
+  }))
+);
 const NoMatchRoute = lazy(() =>
   import('@studio/routes/NoMatchRoute').then((module) => ({ default: module.NoMatchRoute }))
 );
@@ -603,6 +608,11 @@ export const routes: RouteObject[] = [
                   path: ROUTES.workspace.experiment,
                   element: <ExperimentRoute />,
                   errorElement: <ErrorPanel title="Experiment" />,
+                },
+                {
+                  path: ROUTES.workspace.experimentGroupDetail,
+                  element: <ExperimentGroupDetailRoute />,
+                  errorElement: <ErrorPanel title="Experiment Group" />,
                 },
               ]),
               ...gateCustomizationRoutes([

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -314,6 +314,10 @@ export const getExperimentRoute = (workspace: string) => {
   return generatePath(ROUTES.workspace.experiment, { workspace });
 };
 
+export const getExperimentGroupDetailRoute = (workspace: string, experimentGroupId: string) => {
+  return generatePath(ROUTES.workspace.experimentGroupDetail, { workspace, experimentGroupId });
+};
+
 export const getPromptTuningFormRoute = (workspace: string, options?: { model?: string }) => {
   const basePath = generatePath(ROUTES.workspace.promptTuningForm, { workspace });
   if (options?.model) {

--- a/web/packages/studio/src/tests/title-change.spec.tsx
+++ b/web/packages/studio/src/tests/title-change.spec.tsx
@@ -34,6 +34,7 @@ const pathParams = {
   [RP.agentEvalJobName]: 'test-agent-eval-job',
   [RP.jobName]: 'test-job',
   [RP.benchmarkName]: 'test-benchmark',
+  [RP.experimentGroupId]: 'test-experiment-group',
 };
 
 describe('AccessibleTitleE2E', () => {


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/40ff626f-428b-4340-a25f-b9df0ed82986

- Builds the Experiments list page showing experiment groups from the backend
- Cards display group name, description, evaluator score metrics, and experiment count
- `Panel` component with CSS hover elevation for clickability affordance
- Cards link to a stub `ExperimentGroupDetailRoute` (detail page is future work)
- Controlled pagination with page-size select (5/10/20/50 options), item range text, and nav arrows
- Aligned with v0 Figma mocks: flat card layout, centered pagination, dropped Status/User/Feedback placeholders

## Test plan

- [ ] Visit `/workspaces/default/experiment` with `VITE_FF_EXPERIMENT=true`
- [ ] Experiment groups load and display with evaluator score metrics
- [ ] Pagination works — changing page and page size fetches correct data
- [ ] Clicking a card navigates to the detail stub route
- [ ] Hover state shows elevated panel background
- [ ] Empty state ("No experiment groups yet.") renders without pagination

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experiment Groups listing page showing average evaluator metrics, experiment counts, and "Updated…" timestamps
  * Experiment Group detail page with breadcrumb navigation and dedicated layout
  * Clickable, keyboard-accessible cards that navigate to group detail pages (deep-linkable URLs)
  * Pagination for browsing experiment groups
  * Compact metric display on group cards for titles, values, and icons
  * Deep-link route and URL helper added for experiment group detail pages
* **Tests**
  * Route-related tests updated to cover the new experiment group route parameter
<!-- end of auto-generated comment: release notes by coderabbit.ai -->