### PR TITLE
feat(eval): Modular AgentAttemptRuntime package for agentic-use

### DIFF
--- a/tests/agentic-use/runtimes/COMPLIANCE.md
+++ b/tests/agentic-use/runtimes/COMPLIANCE.md
@@ -15,7 +15,18 @@ Design reference: internal agent-eval SDK doc
 | BUILD — task image | **No** | `AgenticEvalOrchestrator` via `shared/environment_spec.py` (env spec / Dockerfile) + `shared/docker.py` |
 | VERIFY — pytest `test_outputs.py`, `reward.txt` | **Through env boundary** | `shared/verify.py` via `AgentEnvironmentHandle.run_verifier` (runtimes call it after the agent when `shared.run_verify=True`) |
 | CLI — task globs, manifests, summaries | **No** | Still `nat_runner.main` (not migrated) |
-| `result.json` contract | **No** (still produced by `nat_runner`) | Importable as an attempt via `shared/result_adapter.py` |
+| `result.json` contract | **No** (still produced by `nat_runner`) | Importable as an attempt via `shared/result_adapter.py`; scored offline via `AgenticEvalOrchestrator.score_captured_attempts` |
+
+## Task metrics (authored on the task)
+
+Per the SDK doc, metrics are concrete `Metric` instances **on the task**, not an
+orchestrator concern. `agentic_task_from_dir` defaults a task's `metrics` to
+`[AgentPhaseSuccessMetric()]` (override via the `metrics=` arg). The orchestrator
+only *appends* `VerifierRewardMetric` (a compatibility shim for the legacy pytest
+reward) when `run_verify=True`, and never replaces the task's own metric set.
+`inputs` carries only agent-facing material (`instruction`); runtime
+materialization (`task_dir`) lives in `task.metadata` so it can't leak into a
+metric scoring row.
 
 ## Backend → runtime class (one class per backend)
 
@@ -66,8 +77,9 @@ expects the portable `CapturedAgentAttempt` type.
 
 | `nat_runner` output | `AgentEvalAttempt` mapping | Status |
 |---------------------|----------------------------|--------|
+| staged task input filesystem | `evidence["initial_state"]` (filesystem, `role=initial_state`) | Implemented (emitted only when `inputs["filesystem"]` is set) |
 | `workspace/` | `evidence["final_state"]` (filesystem, `role=final_state`) | Implemented |
-| preserved platform/db state | `evidence["state"]` (filesystem, `role=platform_state`) | Implemented |
+| preserved platform/db state | `evidence["state"]` (filesystem, `role=platform_state`) — **NeMo-Platform extension, not a doc key** | Implemented |
 | `agent/trajectory.json` | `evidence["trace"]` (ATIF when normalized, else json) | Implemented |
 | `agent/` logs | `evidence["logs"]` (dir, `primary_log=nat_agent.log`) | Implemented |
 | `verifier/` logs | `evidence["verifier_logs"]` (added once verify phase runs) | Implemented (conditional) |
@@ -76,7 +88,12 @@ expects the portable `CapturedAgentAttempt` type.
 
 `result.json` mapping detail (`attempt_from_result`):
 
-- `result["agent"]` → attempt `status` (`ok`/`skipped` → `completed`, else `failed`).
+- `result["agent"]` → attempt `status` via `resolve_attempt_status`: `ok`/`skipped`
+  → `completed`, else `partial`. `failed` is **reserved** for genuine
+  attempt-production failures because the SDK's `AgentEvaluator` excludes
+  `status=="failed"` from scoring (it raises); an agent that ran but failed must
+  stay scorable so pass-rate gating counts it as a `0`. The live builder
+  (`shared/artifacts.py`) and this importer share the same helper.
 - `result["reward"]`/`result["passed"]` → `metadata` measurements (verifier reward
   stays a *measurement*, scored by `VerifierRewardMetric`, not the attempt status).
 - `result["metrics"]` (token/cost) → flattened into `metadata`.
@@ -86,7 +103,7 @@ expects the portable `CapturedAgentAttempt` type.
 
 | Doc section | Status in this package |
 |-------------|------------------------|
-| **B1** wrap `nat_runner` as attempt runtime(s) | In progress — AGENT phase extracted to per-backend runtimes (`workflow`, `aut` done; 3 CLI backends scaffolded); live VERIFY wired through the B2 boundary; `result.json` import path added via `shared/result_adapter.py`. Remaining: 3 CLI backends + converging `nat_runner.main` onto the orchestrator. Note: doc proposes one `NatRunnerAttemptRuntime`; we deliberately split per backend per user direction. |
+| **B1** wrap `nat_runner` as attempt runtime(s) | In progress — AGENT phase extracted to per-backend runtimes (`workflow`, `aut` done; 3 CLI backends scaffolded); live VERIFY wired through the B2 boundary; `result.json` import path added via `shared/result_adapter.py`, exposed as the first-class **stored-attempt scoring** path via `AgenticEvalOrchestrator.score_captured_attempts` (and `run_agent_eval.py --rescore-dir`) — no Docker/agent execution. Remaining: 3 CLI backends + converging `nat_runner.main` onto the orchestrator. Note: doc proposes one `NatRunnerAttemptRuntime`; we deliberately split per backend per user direction. |
 | **B2** `EnvironmentProvider` boundary | **Implemented** — `shared/environment.py` defines `AgentEnvironmentProvider`/`AgentEnvironmentHandle` below `AgentAttemptRuntime`; `DockerEnvironmentProvider` wraps `shared/docker.py`. `workflow` + `aut` runtimes execute through the boundary (provider is injectable). NeMo Gym/local providers can now be added without touching runtimes. |
 | **B3** standardize environment authoring | **Implemented (minimal)** — `shared/environment_spec.py` adds a declarative `environment.yaml` (`image` + `profile` + python `dependencies` + `setup`) with a `dockerfile:` escape hatch and backward-compatible auto-detection of `environment/Dockerfile`. `plan_task_build` resolves a spec to a `BuildPlan` (image-based specs generate a tiny derived Dockerfile); the orchestrator BUILD step uses it. `setup` steps are carried as plan/label metadata, not executed (runtime concern). |
 | **B4** productize results + CI | **Implemented** — SDK `persist_run` writes `tasks/attempts/results.jsonl`, `summary.json`, `report.html`; `shared/reporting.py` adds candidate-vs-baseline gating (pass-rate, token/cost, runtime tie-breaker) + deterministic provenance checks, persisted as `gate.json` by the orchestrator. `result.json` → attempt adapter + `VerifierRewardMetric` compatibility metric also done. |

--- a/tests/agentic-use/runtimes/COMPLIANCE.md
+++ b/tests/agentic-use/runtimes/COMPLIANCE.md
@@ -1,0 +1,121 @@
+# AgentAttemptRuntime compliance mapping
+
+This document maps `nat_runner.py` responsibilities to the agent-eval SDK
+design (see `CapturedAgentAttempt` in `shared/evaluator_agent_eval/schemas.py`
+and `AgentAttemptRuntime` in `nemo_evaluator_sdk.agent_eval`).
+
+Design reference: internal agent-eval SDK doc
+(`https://docs.google.com/document/d/1mA9Kl6LVJFlgbj5CGulUOiaGyliP7QhqBh7jKXFGifM`).
+
+## Scope split (per SDK design)
+
+| `nat_runner` responsibility | Belongs in `AgentAttemptRuntime`? | Current location |
+|----------------------------|-----------------------------------|------------------|
+| AGENT phase — run backend in Docker, capture logs/trajectory | **Yes** | `runtimes/<backend>/runtime.py` |
+| BUILD — task image | **No** | `AgenticEvalOrchestrator` via `shared/environment_spec.py` (env spec / Dockerfile) + `shared/docker.py` |
+| VERIFY — pytest `test_outputs.py`, `reward.txt` | **Through env boundary** | `shared/verify.py` via `AgentEnvironmentHandle.run_verifier` (runtimes call it after the agent when `shared.run_verify=True`) |
+| CLI — task globs, manifests, summaries | **No** | Still `nat_runner.main` (not migrated) |
+| `result.json` contract | **No** (still produced by `nat_runner`) | Importable as an attempt via `shared/result_adapter.py` |
+
+## Backend → runtime class (one class per backend)
+
+| `nat_runner --agent-backend` | Runtime class | Status |
+|------------------------------|---------------|--------|
+| `workflow` | `NatWorkflowAttemptRuntime` | Implemented |
+| `aut` | `AutAgentAttemptRuntime` | Implemented |
+| `claude-code` | `ClaudeCodeAgentAttemptRuntime` | Scaffold |
+| `codex` | `CodexAgentAttemptRuntime` | Scaffold |
+| `cursor-agent` | `CursorAgentAttemptRuntime` | Scaffold |
+
+## `nat_runner` function → module
+
+| Function | Runtime module |
+|----------|----------------|
+| `_build_workflow_agent_cmd` | `workflow/command.py` |
+| `_prepare_workflow_for_runtime` | `workflow/prep.py` |
+| `_build_aut_agent_cmd` | `aut/command.py` |
+| `_prepare_aut_config_for_runtime` | `aut/prep.py` |
+| `_agent_log_has_workflow_error` | `shared/agent_log.py` |
+| `run_verify_phase` | `shared/verify.py` (`build_verify_run_spec` + `run_verify` via `run_verifier`) |
+| `_docker_run`, `build_task_image` | `shared/docker.py` (`docker_run`, `build_dockerfile`, `build_task_image`) |
+| BUILD env resolution (`environment/Dockerfile`) | `shared/environment_spec.py` (`load_environment_spec`, `plan_task_build`) |
+| `_write_result` (`result.json`) | `shared/result_adapter.py` (import side only; `nat_runner` still writes it) |
+| pass-rate / token / runtime gate | `shared/reporting.py` (mirrors `passrate_token_policy_gate.py`) |
+| `_extract_usage_metrics` | `shared/usage.py` (delegates to `nat_runner` until deduped) |
+| `capture_agent_attempt` shape | `shared/artifacts.py` |
+| `run_agent_phase` | **Removed per backend** once all backends migrated |
+
+## Attempt record contract
+
+`AgentAttemptRuntime.run_tasks()` returns `AgentEvalAttempt` values whose metadata
+includes canonical `CapturedAgentAttempt` fields:
+
+- `agent_runtime`, `agent_model`
+- `exit_code`, `duration_ms`, `run_id`, `repo_revision` (when known)
+- Artifact paths: `agent_log_dir`, `workspace_dir`, `state_dir`, `atif_trajectory_path`
+- Phase outcome: `agent_ok`
+- Verifier outcome (when `run_verify=True`): `verify_status`, `passed`, `reward`,
+  `verifier_log_dir` (stamped by `shared/verify.py::apply_verify_to_metadata`)
+
+Use `to_captured_agent_attempt(task, attempt)` for verify/scoring code that
+expects the portable `CapturedAgentAttempt` type.
+
+## `nat_runner` artifact → `AgentEvalAttempt` evidence map (per design doc)
+
+`shared/artifacts.py::_evidence_descriptors` emits the documented keys:
+
+| `nat_runner` output | `AgentEvalAttempt` mapping | Status |
+|---------------------|----------------------------|--------|
+| `workspace/` | `evidence["final_state"]` (filesystem, `role=final_state`) | Implemented |
+| preserved platform/db state | `evidence["state"]` (filesystem, `role=platform_state`) | Implemented |
+| `agent/trajectory.json` | `evidence["trace"]` (ATIF when normalized, else json) | Implemented |
+| `agent/` logs | `evidence["logs"]` (dir, `primary_log=nat_agent.log`) | Implemented |
+| `verifier/` logs | `evidence["verifier_logs"]` (added once verify phase runs) | Implemented (conditional) |
+| `result.json` | attempt status + measurements + provenance + token/cost | Implemented — `shared/result_adapter.py::attempt_from_result` / `attempt_from_result_dir` |
+| final agent log/message | `AgentOutput.text` | Implemented |
+
+`result.json` mapping detail (`attempt_from_result`):
+
+- `result["agent"]` → attempt `status` (`ok`/`skipped` → `completed`, else `failed`).
+- `result["reward"]`/`result["passed"]` → `metadata` measurements (verifier reward
+  stays a *measurement*, scored by `VerifierRewardMetric`, not the attempt status).
+- `result["metrics"]` (token/cost) → flattened into `metadata`.
+- `result["provenance"]`, `candidate_id`, `candidate_params`, `image` → `metadata`.
+
+## Alignment with the design doc's implementation path
+
+| Doc section | Status in this package |
+|-------------|------------------------|
+| **B1** wrap `nat_runner` as attempt runtime(s) | In progress — AGENT phase extracted to per-backend runtimes (`workflow`, `aut` done; 3 CLI backends scaffolded); live VERIFY wired through the B2 boundary; `result.json` import path added via `shared/result_adapter.py`. Remaining: 3 CLI backends + converging `nat_runner.main` onto the orchestrator. Note: doc proposes one `NatRunnerAttemptRuntime`; we deliberately split per backend per user direction. |
+| **B2** `EnvironmentProvider` boundary | **Implemented** — `shared/environment.py` defines `AgentEnvironmentProvider`/`AgentEnvironmentHandle` below `AgentAttemptRuntime`; `DockerEnvironmentProvider` wraps `shared/docker.py`. `workflow` + `aut` runtimes execute through the boundary (provider is injectable). NeMo Gym/local providers can now be added without touching runtimes. |
+| **B3** standardize environment authoring | **Implemented (minimal)** — `shared/environment_spec.py` adds a declarative `environment.yaml` (`image` + `profile` + python `dependencies` + `setup`) with a `dockerfile:` escape hatch and backward-compatible auto-detection of `environment/Dockerfile`. `plan_task_build` resolves a spec to a `BuildPlan` (image-based specs generate a tiny derived Dockerfile); the orchestrator BUILD step uses it. `setup` steps are carried as plan/label metadata, not executed (runtime concern). |
+| **B4** productize results + CI | **Implemented** — SDK `persist_run` writes `tasks/attempts/results.jsonl`, `summary.json`, `report.html`; `shared/reporting.py` adds candidate-vs-baseline gating (pass-rate, token/cost, runtime tie-breaker) + deterministic provenance checks, persisted as `gate.json` by the orchestrator. `result.json` → attempt adapter + `VerifierRewardMetric` compatibility metric also done. |
+
+### B4 reporting / gating detail
+
+- **Persistence** (already SDK-native): `AgentEvaluator.run(config.output_dir=...)`
+  calls `agent_eval.persistence.persist_run`, writing `tasks.jsonl`,
+  `attempts.jsonl`, `results.jsonl`, `summary.json`, `benchmark.json`, `run.json`,
+  and (when `write_dashboard=True`) `report.html`.
+- **Gating** (`shared/reporting.py`): `summarize_run` aggregates pass-rate,
+  token totals/coverage, runtime totals, and run-level provenance from the typed
+  `AgentEvalRunResult` (metric scores first, attempt metadata as fallback).
+  `evaluate_gate` applies absolute thresholds and candidate-vs-baseline checks:
+  `min_pass_rate`, `no_pass_rate_regression_vs_baseline`,
+  `tokens_not_worse_than_baseline`, `runtime_tie_breaker_not_worse_than_baseline`,
+  `baseline_candidate_task_sets_match`, `commit_sha_consistent_within_run`,
+  `commit_sha_matches_baseline` (cross-commit guard). Semantics mirror
+  `passrate_token_policy_gate.py`, so summaries are interchangeable as baselines.
+- **Orchestrator wiring**: `AgenticOrchestratorConfig.write_gate` /
+  `gate_thresholds` / `baseline_summary_path` control emission of `gate.json`
+  next to the run bundle.
+
+### B2 boundary deviation (documented)
+
+The doc sketches `AgentEnvironmentHandle.run_agent(instruction, config) -> AgentEvalAttempt`.
+We instead use `run_agent(EnvRunSpec) -> EnvCommandResult` (and the symmetric
+`run_verifier`). Rationale: per-backend command/env/mount construction lives in the
+runtime, and attempt construction lives in `shared/artifacts.py`. Keeping the
+environment layer at "execute a command, return exit status" means a new provider
+(local, Harbor, NeMo Gym) only implements process execution — it never needs to
+know about backends or attempt schemas.

--- a/tests/agentic-use/runtimes/README.md
+++ b/tests/agentic-use/runtimes/README.md
@@ -74,15 +74,30 @@ Design-doc implementation path (see [COMPLIANCE.md](./COMPLIANCE.md) for detail)
 | B3 | Standardize environment authoring | Implemented (minimal) |
 | B4 | Productize results + CI (persistence, gating, provenance) | Implemented |
 
-## B1 — `result.json` import
+## B1 — `result.json` import + stored-attempt scoring
 
 `shared/result_adapter.py` imports an existing `nat_runner` run as an attempt:
 
 - `attempt_from_result_dir(output_dir)` reads `<output_dir>/result.json`.
 - `attempt_from_result(result_dict, output_dir=...)` projects a parsed record.
 
-The verifier outcome is scored by `VerifierRewardMetric` (compatibility metric)
-rather than baked into the attempt status.
+Stored-attempt scoring is the SDK's first-class path. Score captured runs
+without re-executing the agent (no Docker) via the orchestrator:
+
+```python
+await orchestrator.score_captured_attempts("my-task", result_dirs=["runs/abc"])
+# or:  python run_agent_eval.py --task my-task --rescore-dir runs/abc
+```
+
+An agent that ran but failed maps to `status="partial"` (still scorable), not
+`"failed"` — the SDK excludes `failed` from scoring, and a failed agent must
+still count as a `0` for gating. The verifier outcome is scored by
+`VerifierRewardMetric` (compatibility metric) rather than baked into the status.
+
+Metrics are authored **on the task** (`agentic_task_from_dir` defaults to
+`AgentPhaseSuccessMetric`); the orchestrator only *appends* `VerifierRewardMetric`
+when `run_verify=True`. `inputs` holds only agent-facing `instruction`;
+`task_dir` lives in `task.metadata`.
 
 ## B2 — Environment boundary
 

--- a/tests/agentic-use/runtimes/README.md
+++ b/tests/agentic-use/runtimes/README.md
@@ -1,0 +1,163 @@
+# Agentic-use AgentAttemptRuntime implementations
+
+Backend-specific runtimes extracted from `nat_runner.py` for use with
+`nemo_evaluator_sdk.agent_eval.AgentEvaluator`.
+
+## Layout
+
+```text
+runtimes/
+  shared/           # backend-agnostic building blocks:
+                    #   docker.py            Docker exec + build helpers
+                    #   environment.py       AgentEnvironmentProvider/Handle boundary (B2)
+                    #   environment_spec.py  environment.yaml authoring + build plans (B3)
+                    #   layout.py            per-run output layout
+                    #   task_loader.py       agentic-use task -> AgentEvalTask
+                    #   container_env.py     base container env vars
+                    #   artifacts.py         agent artifacts -> AgentEvalAttempt (+ evidence)
+                    #   result_adapter.py    nat_runner result.json -> AgentEvalAttempt (B1/B4)
+                    #   verify.py            live VERIFY via run_verifier
+                    #   reporting.py         summary + candidate/baseline gate (B4)
+                    #   metrics.py           AgentPhaseSuccessMetric, VerifierRewardMetric
+  workflow/         # NatWorkflowAttemptRuntime (implemented)
+  aut/              # AutAgentAttemptRuntime (implemented)
+  claude_code/      # ClaudeCodeAgentAttemptRuntime (scaffold)
+  codex/            # CodexAgentAttemptRuntime (scaffold)
+  cursor_agent/     # CursorAgentAttemptRuntime (scaffold)
+  orchestrator.py   # BUILD (env spec) + AgentEvaluator + gate; verify runs in the runtime
+```
+
+## Example: workflow backend
+
+From the repository root (requires Docker + built task image):
+
+```bash
+uv run python tests/agentic-use/runtimes/run_agent_eval.py \
+  --task workspace-basic-cli-easy \
+  --backend workflow \
+  --skip-build
+```
+
+Programmatic use:
+
+```python
+from runtimes import AgenticEvalOrchestrator, NatWorkflowAttemptRuntime
+from runtimes.shared.config import AgenticSharedConfig, WorkflowRuntimeConfig
+
+runtime = NatWorkflowAttemptRuntime(
+    WorkflowRuntimeConfig(shared=AgenticSharedConfig(nvidia_api_key=os.environ.get("NVIDIA_API_KEY")))
+)
+orchestrator = AgenticEvalOrchestrator(runtime)
+result = await orchestrator.run_agent_eval("workspace-basic-cli-easy")
+```
+
+See [COMPLIANCE.md](./COMPLIANCE.md) for the full `nat_runner` → runtime mapping.
+
+## Migration status
+
+Backend runtimes (one class per `nat_runner --agent-backend`):
+
+| Backend | Runtime class | Status |
+|---------|---------------|--------|
+| `workflow` | `NatWorkflowAttemptRuntime` | Implemented |
+| `aut` | `AutAgentAttemptRuntime` | Implemented |
+| `claude-code` | `ClaudeCodeAgentAttemptRuntime` | Scaffold |
+| `codex` | `CodexAgentAttemptRuntime` | Scaffold |
+| `cursor-agent` | `CursorAgentAttemptRuntime` | Scaffold |
+
+Design-doc implementation path (see [COMPLIANCE.md](./COMPLIANCE.md) for detail):
+
+| Phase | Item | Status |
+|-------|------|--------|
+| B1 | Wrap `nat_runner` as `AgentAttemptRuntime`(s) | In progress (workflow + aut done; 3 CLI backends scaffolded) |
+| B2 | `EnvironmentProvider` boundary | Implemented |
+| B3 | Standardize environment authoring | Implemented (minimal) |
+| B4 | Productize results + CI (persistence, gating, provenance) | Implemented |
+
+## B1 — `result.json` import
+
+`shared/result_adapter.py` imports an existing `nat_runner` run as an attempt:
+
+- `attempt_from_result_dir(output_dir)` reads `<output_dir>/result.json`.
+- `attempt_from_result(result_dict, output_dir=...)` projects a parsed record.
+
+The verifier outcome is scored by `VerifierRewardMetric` (compatibility metric)
+rather than baked into the attempt status.
+
+## B2 — Environment boundary
+
+Runtimes execute the agent through `shared/environment.py`
+(`AgentEnvironmentProvider` → `AgentEnvironmentHandle`) rather than calling
+Docker directly. `DockerEnvironmentProvider` is the default; inject another
+provider (local, Harbor, NeMo Gym) via the runtime's `environment=` argument
+without changing backend code.
+
+## B3 — Environment authoring
+
+Tasks can declare a reusable environment instead of hand-writing a Dockerfile.
+`shared/environment_spec.py` loads `environment.yaml` from the task dir:
+
+```yaml
+environment:
+  image: nemo-platform-agentic-base:2026.06
+  profile: evaluator-platform
+  dependencies:
+    python:
+      - pytest
+      - nemo-evaluator-sdk
+  setup:
+    - seed-providers
+```
+
+Dockerfile escape hatch:
+
+```yaml
+environment:
+  dockerfile: environment/Dockerfile
+```
+
+`load_environment_spec` falls back to detecting `environment/Dockerfile` so
+existing tasks keep working without a spec. `plan_task_build` resolves a spec to
+a `BuildPlan` (image-based specs generate a minimal `FROM <image>` + `pip install`
+Dockerfile); the orchestrator's BUILD step builds it. `setup` steps are recorded
+as metadata, not executed here (they are runtime concerns).
+
+## B4 — CI / reporting + gating
+
+The SDK persists the run bundle (`tasks.jsonl`, `attempts.jsonl`,
+`results.jsonl`, `summary.json`, `report.html`) when `output_dir` is set.
+`shared/reporting.py` adds the gate on top:
+
+```python
+from runtimes.shared.reporting import GateThresholds, evaluate_gate, load_baseline_summary, write_gate_report
+
+report = evaluate_gate(
+    run_result,
+    thresholds=GateThresholds(min_pass_rate=1.0, max_token_regression_pct=0.0),
+    baseline_summary=load_baseline_summary("baseline/gate.json"),
+)
+write_gate_report(report, run_result.output_dir)  # -> gate.json
+```
+
+The orchestrator emits `gate.json` automatically (`AgenticOrchestratorConfig.write_gate`,
+`gate_thresholds`, `baseline_summary_path`). Gate semantics match
+`passrate_token_policy_gate.py`, so summaries are interchangeable as baselines.
+
+## Live VERIFY phase (through the B2 boundary)
+
+`shared/verify.py` runs the task-local `tests/test_outputs.py` pytest verifier
+through `AgentEnvironmentHandle.run_verifier`, in the same prepared environment
+and against the same persisted workspace/state as the agent phase. Enable it via
+`AgenticSharedConfig(run_verify=True)`; the runtime stamps `reward`/`passed`/
+`verify_status` onto the attempt metadata, and the orchestrator attaches
+`VerifierRewardMetric` so the reward scores through the Evaluator SDK and feeds
+the gate.
+
+```python
+runtime = NatWorkflowAttemptRuntime(
+    WorkflowRuntimeConfig(shared=AgenticSharedConfig(run_verify=True)),
+)
+```
+
+Tasks without a `tests/test_outputs.py` skip verification (the spec builder
+returns `None`), matching `nat_runner` behavior.

--- a/tests/agentic-use/runtimes/__init__.py
+++ b/tests/agentic-use/runtimes/__init__.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend-specific AgentAttemptRuntime implementations for agentic-use evals."""
+
+from runtimes.aut.runtime import AutAgentAttemptRuntime
+from runtimes.claude_code.runtime import ClaudeCodeAgentAttemptRuntime
+from runtimes.codex.runtime import CodexAgentAttemptRuntime
+from runtimes.cursor_agent.runtime import CursorAgentAttemptRuntime
+from runtimes.orchestrator import AgenticEvalOrchestrator, AgenticOrchestratorConfig, runtime_for_backend
+from runtimes.shared.environment import (
+    AgentEnvironmentHandle,
+    AgentEnvironmentProvider,
+    DockerEnvironmentHandle,
+    DockerEnvironmentProvider,
+    EnvCommandResult,
+    EnvRunSpec,
+)
+from runtimes.shared.environment_spec import (
+    BuildPlan,
+    EnvironmentSpec,
+    execute_build_plan,
+    load_environment_spec,
+    plan_task_build,
+    render_derived_dockerfile,
+)
+from runtimes.shared.metrics import AgentPhaseSuccessMetric, VerifierRewardMetric
+from runtimes.shared.reporting import (
+    GateCheck,
+    GateReport,
+    GateThresholds,
+    evaluate_gate,
+    load_baseline_summary,
+    summarize_run,
+    write_gate_report,
+)
+from runtimes.shared.result_adapter import attempt_from_result, attempt_from_result_dir
+from runtimes.shared.verify import (
+    VerifierOutcome,
+    apply_verify_to_metadata,
+    build_verify_run_spec,
+    maybe_run_verify,
+    run_verify,
+)
+from runtimes.workflow.runtime import NatWorkflowAttemptRuntime
+
+__all__ = [
+    "AgentEnvironmentHandle",
+    "AgentEnvironmentProvider",
+    "AgentPhaseSuccessMetric",
+    "AgenticEvalOrchestrator",
+    "AgenticOrchestratorConfig",
+    "AutAgentAttemptRuntime",
+    "BuildPlan",
+    "ClaudeCodeAgentAttemptRuntime",
+    "CodexAgentAttemptRuntime",
+    "CursorAgentAttemptRuntime",
+    "DockerEnvironmentHandle",
+    "DockerEnvironmentProvider",
+    "EnvCommandResult",
+    "EnvRunSpec",
+    "EnvironmentSpec",
+    "GateCheck",
+    "GateReport",
+    "GateThresholds",
+    "NatWorkflowAttemptRuntime",
+    "VerifierOutcome",
+    "VerifierRewardMetric",
+    "apply_verify_to_metadata",
+    "attempt_from_result",
+    "attempt_from_result_dir",
+    "build_verify_run_spec",
+    "evaluate_gate",
+    "execute_build_plan",
+    "load_baseline_summary",
+    "load_environment_spec",
+    "maybe_run_verify",
+    "plan_task_build",
+    "render_derived_dockerfile",
+    "run_verify",
+    "runtime_for_backend",
+    "summarize_run",
+    "write_gate_report",
+]

--- a/tests/agentic-use/runtimes/aut/__init__.py
+++ b/tests/agentic-use/runtimes/aut/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from runtimes.aut.runtime import AutAgentAttemptRuntime
+
+__all__ = ["AutAgentAttemptRuntime"]

--- a/tests/agentic-use/runtimes/aut/command.py
+++ b/tests/agentic-use/runtimes/aut/command.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build the container command for the AUT backend."""
+
+from __future__ import annotations
+
+import textwrap
+
+from runtimes.shared.constants import NAT_TRACE_EXPORT_SCRIPT_CONTAINER_PATH
+
+
+def build_aut_agent_cmd(instruction_container: str) -> list[str]:
+    """Build the ``bash -c`` command that drives the AUT (deep-agent) backend."""
+    return [
+        "bash",
+        "-c",
+        textwrap.dedent(f"""\
+            set -euo pipefail
+            EFFECTIVE_AUT_AGENT_CONFIG="${{AUT_AGENT_CONFIG}}"
+            if [ -n "${{AUT_AGENT_CONFIG}}" ] && [ -n "${{NVIDIA_API_KEY:-}}" -o -n "${{ANTHROPIC_API_KEY:-}}" ]; then
+              /app/.venv/bin/python -c "from pathlib import Path; import os; text = Path(os.environ['AUT_AGENT_CONFIG']).read_text(); text = text.replace('\\${{NVIDIA_API_KEY}}', os.environ.get('NVIDIA_API_KEY', '')); text = text.replace('\\${{ANTHROPIC_API_KEY}}', os.environ.get('ANTHROPIC_API_KEY', '')); Path('/tmp/aut_agent.resolved.yml').write_text(text)"
+              EFFECTIVE_AUT_AGENT_CONFIG="/tmp/aut_agent.resolved.yml"
+            fi
+            if /app/.venv/bin/nemo agents get "${{AUT_AGENT_NAME}}" >/tmp/aut_get_before.log 2>&1; then
+              if [ -n "${{EFFECTIVE_AUT_AGENT_CONFIG}}" ]; then
+                echo "AUT '${{AUT_AGENT_NAME}}' already exists; recreating from AUT_AGENT_CONFIG."
+                /app/.venv/bin/nemo agents undeploy --agent "${{AUT_AGENT_NAME}}" >/tmp/aut_undeploy_before_recreate.log 2>&1 || true
+                /app/.venv/bin/nemo agents delete "${{AUT_AGENT_NAME}}" >/tmp/aut_delete_before_recreate.log 2>&1 || true
+                /app/.venv/bin/nemo agents create --name "${{AUT_AGENT_NAME}}" --agent-config "${{EFFECTIVE_AUT_AGENT_CONFIG}}" >/tmp/aut_create.log 2>&1
+              else
+                echo "AUT '${{AUT_AGENT_NAME}}' already exists."
+              fi
+            else
+              if [ -z "${{EFFECTIVE_AUT_AGENT_CONFIG}}" ]; then
+                echo "AUT agent '${{AUT_AGENT_NAME}}' not found and no AUT_AGENT_CONFIG was provided." >&2
+                echo "Set --aut-agent-config or AUT_AGENT_CONFIG so the runner can create the agent." >&2
+                echo "Expected resolved config path in container env: '${{AUT_AGENT_CONFIG:-<unset>}}'" >&2
+                cp /tmp/aut_get_before.log /logs/agent/aut_get_before.log 2>/dev/null || true
+                exit 1
+              fi
+              /app/.venv/bin/nemo agents create --name "${{AUT_AGENT_NAME}}" --agent-config "${{EFFECTIVE_AUT_AGENT_CONFIG}}" >/tmp/aut_create.log 2>&1
+            fi
+            if [ "${{AUT_SEED_PROVIDERS:-1}}" = "1" ]; then
+              /app/.venv/bin/python /app/tests/agentic-use/seed_providers.py \
+                --manifest /app/tests/agentic-use/providers.yaml \
+                --base-url "${{NMP_BASE_URL:-http://localhost:8080}}" \
+                2>&1 | tee /tmp/aut_provider_seed.log
+            fi
+            collect_aut_diagnostics() {{
+              local restore_errexit=0
+              case "$-" in
+                *e*) restore_errexit=1 ;;
+              esac
+              set +e
+              /app/.venv/bin/nemo agents deployments list >/tmp/aut_deployments.list.json 2>&1
+              cp /tmp/aut_deployments.list.json /logs/agent/aut_deployments.list.json 2>/dev/null || true
+              dep_name=$(
+                /app/.venv/bin/python -c "import json,sys; data=json.load(sys.stdin).get('data', []); match=next((d.get('name') for d in data if d.get('agent') == '${{AUT_AGENT_NAME}}'), ''); print(match)" </tmp/aut_deployments.list.json 2>/dev/null
+              )
+              if [ -n "$dep_name" ]; then
+                /app/.venv/bin/nemo agents deployments get "$dep_name" >/tmp/aut_deployment.get.json 2>&1
+                cp /tmp/aut_deployment.get.json /logs/agent/aut_deployment.get.json 2>/dev/null || true
+              fi
+              cp /tmp/aut_create.log /logs/agent/aut_create.log 2>/dev/null || true
+              cp /tmp/aut_get_before.log /logs/agent/aut_get_before.log 2>/dev/null || true
+              cp /tmp/aut_provider_seed.log /logs/agent/aut_provider_seed.log 2>/dev/null || true
+              cp /tmp/aut_undeploy.log /logs/agent/aut_undeploy.log 2>/dev/null || true
+              cp /tmp/aut_undeploy_before_recreate.log /logs/agent/aut_undeploy_before_recreate.log 2>/dev/null || true
+              cp /tmp/aut_delete_before_recreate.log /logs/agent/aut_delete_before_recreate.log 2>/dev/null || true
+              cp /tmp/nmp-api.log /logs/agent/nmp-api.log 2>/dev/null || true
+              mkdir -p /logs/agent/nat_subprocess_logs 2>/dev/null || true
+              if [ -d /logs/agent/nat_subprocess_logs ]; then
+                ( /app/.venv/bin/nemo agents logs --agent "${{AUT_AGENT_NAME}}" --path 2>/dev/null | while read -r aut_log_path; do
+                  if [ -n "$aut_log_path" ] && [ -f "$aut_log_path" ]; then
+                    cp "$aut_log_path" /logs/agent/nat_subprocess_logs/ 2>/dev/null || true
+                  fi
+                done ) || true
+              fi
+              if [ "$restore_errexit" -eq 1 ]; then
+                set -e
+              fi
+              return 0
+            }}
+            cleanup() {{
+              cleanup_rc=$?
+              set +e
+              collect_aut_diagnostics
+              /app/.venv/bin/nemo agents undeploy --agent "${{AUT_AGENT_NAME}}" >/tmp/aut_undeploy_after.log 2>&1 || true
+              cp /tmp/aut_undeploy_after.log /logs/agent/aut_undeploy_after.log 2>/dev/null || true
+              cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
+              exit "$cleanup_rc"
+            }}
+            trap cleanup EXIT
+            /app/.venv/bin/nemo agents undeploy --agent "${{AUT_AGENT_NAME}}" >/tmp/aut_undeploy.log 2>&1 || true
+            /app/.venv/bin/nemo agents deploy --agent "${{AUT_AGENT_NAME}}"
+            /app/.venv/bin/nemo agents deployments wait --agent "${{AUT_AGENT_NAME}}"
+            dep_endpoint=$(
+              /app/.venv/bin/nemo agents deployments list 2>/dev/null | /app/.venv/bin/python -c "import json,sys; data=json.load(sys.stdin).get('data', []); match=next((d.get('endpoint') for d in data if d.get('agent') == '${{AUT_AGENT_NAME}}' and d.get('status') == 'running' and d.get('endpoint')), ''); print(match)"
+            )
+            if [ -z "$dep_endpoint" ]; then
+              echo "No running AUT deployment endpoint found for agent '${{AUT_AGENT_NAME}}'." >&2
+              exit 1
+            fi
+            health_wait="${{AUT_HEALTH_WAIT_SECONDS:-60}}"
+            aut_healthy=0
+            for i in $(seq 1 "$health_wait"); do
+              if curl -sf "$dep_endpoint/health" >/dev/null 2>&1; then
+                aut_healthy=1
+                break
+              fi
+              sleep 1
+            done
+            if [ "$aut_healthy" -ne 1 ]; then
+              echo "AUT deployment did not become healthy within $health_wait seconds: $dep_endpoint" >&2
+              exit 1
+            fi
+            set +e
+            /app/.venv/bin/python {NAT_TRACE_EXPORT_SCRIPT_CONTAINER_PATH} invoke-aut \
+              --endpoint "$dep_endpoint" \
+              --instruction {instruction_container} \
+              --output-dir /logs/agent \
+              --timeout "${{AUT_INVOKE_HTTP_TIMEOUT:-600}}" \
+              2>&1 | tee /tmp/nat_agent.log
+            rc=${{PIPESTATUS[0]}}
+            set -e
+            if [ $rc -ne 0 ]; then
+              collect_aut_diagnostics
+            fi
+            exit $rc
+        """),
+    ]

--- a/tests/agentic-use/runtimes/aut/prep.py
+++ b/tests/agentic-use/runtimes/aut/prep.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare AUT agent configs for container execution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from runtimes.shared.constants import DEFAULT_LOCAL_NMP_BASE_URL
+
+
+def prepare_aut_config_for_runtime(
+    config_path: Path,
+    output_dir: Path,
+    *,
+    nat_model: str | None = None,
+    nmp_base_url: str = DEFAULT_LOCAL_NMP_BASE_URL,
+    workspace: str = "default",
+) -> Path:
+    """Prepare AUT config for IGW-routed container runtime."""
+    from nemo_agents_plugin.utils import inject_gateway_url
+
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    if nat_model:
+        for llm_cfg in config.get("llms", {}).values():
+            if isinstance(llm_cfg, dict) and llm_cfg.get("_type") in ("openai", "nim"):
+                llm_cfg["model_name"] = nat_model
+                break
+
+    config = inject_gateway_url(config, workspace, base_url=nmp_base_url)
+
+    rewritten = output_dir / "aut.runtime.yml"
+    with rewritten.open("w", encoding="utf-8") as handle:
+        yaml.dump(config, handle, default_flow_style=False, sort_keys=False)
+    return rewritten

--- a/tests/agentic-use/runtimes/aut/runtime.py
+++ b/tests/agentic-use/runtimes/aut/runtime.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AUT (agent-under-test) backend as an AgentAttemptRuntime."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from nemo_evaluator_sdk.agent_eval.types import AgentEvalAttempt, AgentEvalRunConfig, AgentEvalTask
+
+from runtimes.aut.command import build_aut_agent_cmd
+from runtimes.aut.prep import prepare_aut_config_for_runtime
+from runtimes.shared.agent_log import agent_log_has_workflow_error
+from runtimes.shared.artifacts import build_agent_eval_attempt
+from runtimes.shared.config import AutRuntimeConfig
+from runtimes.shared.constants import (
+    DOCKER_SOCKET_CONTAINER_PATH,
+    DOCKER_SOCKET_HOST_PATH,
+    INSTRUCTION_CONTAINER_PATH,
+    REPO_ROOT,
+)
+from runtimes.shared.container_env import base_container_env
+from runtimes.shared.environment import (
+    AgentEnvironmentProvider,
+    DockerEnvironmentProvider,
+    EnvRunSpec,
+)
+from runtimes.shared.layout import AgenticRunLayout, resolve_run_layout
+from runtimes.shared.task_loader import task_agent_timeout_sec
+from runtimes.shared.verify import apply_verify_to_metadata, maybe_run_verify
+
+RUNTIME_NAME = "aut"
+AUT_CONFIG_CONTAINER_PATH = "/tmp/aut_agent.yml"
+
+
+class AutAgentAttemptRuntime:
+    """Run agentic-use tasks via a deployed platform agent-under-test."""
+
+    def __init__(
+        self,
+        config: AutRuntimeConfig,
+        *,
+        environment: AgentEnvironmentProvider | None = None,
+    ) -> None:
+        if not config.aut_agent_name:
+            raise ValueError("AutAgentAttemptRuntime requires aut_agent_name")
+        self.config = config
+        self.environment = environment or DockerEnvironmentProvider()
+
+    async def run_tasks(
+        self,
+        tasks: Sequence[AgentEvalTask],
+        config: AgentEvalRunConfig | None = None,
+    ) -> list[AgentEvalAttempt]:
+        attempts: list[AgentEvalAttempt] = []
+        for task in tasks:
+            layout = resolve_run_layout(task, self.config.shared, config)
+            shared = self.config.shared
+            handle = await self.environment.prepare(task, config)
+            try:
+                result = await handle.run_agent(self._agent_run_spec(task, layout))
+
+                agent_ok = result.ok
+                log_path = layout.agent_log_dir / "nat_agent.log"
+                log_text = log_path.read_text(encoding="utf-8", errors="replace") if log_path.is_file() else ""
+                if agent_ok and log_text and agent_log_has_workflow_error(log_text):
+                    agent_ok = False
+
+                verify_outcome = await maybe_run_verify(
+                    handle,
+                    enabled=shared.run_verify and agent_ok,
+                    task_dir=Path(str(task.inputs["task_dir"])),
+                    layout=layout,
+                    nmp_base_url=shared.nmp_base_url,
+                    agent_backend=RUNTIME_NAME,
+                    agent_model=self._resolved_model(),
+                    smoke_workspace=shared.smoke_workspace,
+                    timeout_sec=shared.timeout_sec + 120,
+                    extra_args=list(shared.docker_extra_args),
+                )
+            finally:
+                await handle.close()
+
+            attempt = build_agent_eval_attempt(
+                task=task,
+                layout=layout,
+                runtime_name=RUNTIME_NAME,
+                agent_model=self._resolved_model(),
+                exit_code=result.exit_code,
+                agent_ok=agent_ok,
+                run_id=config.run_id if config is not None else None,
+            )
+            apply_verify_to_metadata(attempt.metadata, verify_outcome)
+            attempts.append(attempt)
+        return attempts
+
+    def _resolved_model(self) -> str:
+        return self.config.agent_model or "unknown"
+
+    def _agent_run_spec(self, task: AgentEvalTask, layout: AgenticRunLayout) -> EnvRunSpec:
+        task_dir = Path(str(task.inputs["task_dir"]))
+        shared = self.config.shared
+        task_timeout = task_agent_timeout_sec(task_dir)
+        timeout_sec = max(shared.timeout_sec, task_timeout or 0)
+
+        env = base_container_env(shared, timeout_sec=timeout_sec)
+        if shared.nvidia_api_key:
+            env["NVIDIA_API_KEY"] = shared.nvidia_api_key
+        if self.config.anthropic_api_key:
+            env["ANTHROPIC_API_KEY"] = self.config.anthropic_api_key
+        if self.config.aut_seed_providers and self.config.inference_nvidia_api_key:
+            env["INFERENCE_NVIDIA_API_KEY"] = self.config.inference_nvidia_api_key
+        if self.config.agent_model:
+            env["NAT_MODEL"] = self.config.agent_model
+
+        env["AUT_AGENT_NAME"] = self.config.aut_agent_name
+        env["AUT_SEED_PROVIDERS"] = "1" if self.config.aut_seed_providers else "0"
+        env["AUT_HEALTH_WAIT_SECONDS"] = str(self.config.aut_health_wait_seconds)
+
+        aut_config_host: Path | None = None
+        if self.config.aut_agent_config is not None:
+            aut_config_path = Path(self.config.aut_agent_config)
+            if not aut_config_path.is_absolute():
+                aut_config_path = (REPO_ROOT / aut_config_path).resolve()
+            if not aut_config_path.exists():
+                raise FileNotFoundError(f"AUT config not found: {aut_config_path}")
+            aut_config_host = prepare_aut_config_for_runtime(
+                aut_config_path,
+                layout.agent_log_dir,
+                nat_model=self.config.agent_model,
+                nmp_base_url=shared.nmp_base_url,
+            )
+            env["AUT_AGENT_CONFIG"] = AUT_CONFIG_CONTAINER_PATH
+        else:
+            env["AUT_AGENT_CONFIG"] = ""
+
+        mounts = [
+            (str(layout.instruction_path), INSTRUCTION_CONTAINER_PATH),
+            (str(layout.agent_log_dir), "/logs/agent"),
+            (str(layout.workspace_dir), "/app/workspace"),
+            (str(layout.state_dir), "/data"),
+        ]
+        if aut_config_host is not None:
+            mounts.append((str(aut_config_host), AUT_CONFIG_CONTAINER_PATH))
+        if DOCKER_SOCKET_HOST_PATH.exists():
+            mounts.append((str(DOCKER_SOCKET_HOST_PATH), DOCKER_SOCKET_CONTAINER_PATH))
+
+        return EnvRunSpec(
+            command=build_aut_agent_cmd(INSTRUCTION_CONTAINER_PATH),
+            env=env,
+            mounts=mounts,
+            timeout=timeout_sec + 120,
+            extra_args=list(shared.docker_extra_args),
+        )

--- a/tests/agentic-use/runtimes/aut/runtime.py
+++ b/tests/agentic-use/runtimes/aut/runtime.py
@@ -71,7 +71,7 @@ class AutAgentAttemptRuntime:
                 verify_outcome = await maybe_run_verify(
                     handle,
                     enabled=shared.run_verify and agent_ok,
-                    task_dir=Path(str(task.inputs["task_dir"])),
+                    task_dir=Path(str(task.metadata["task_dir"])),
                     layout=layout,
                     nmp_base_url=shared.nmp_base_url,
                     agent_backend=RUNTIME_NAME,
@@ -100,7 +100,7 @@ class AutAgentAttemptRuntime:
         return self.config.agent_model or "unknown"
 
     def _agent_run_spec(self, task: AgentEvalTask, layout: AgenticRunLayout) -> EnvRunSpec:
-        task_dir = Path(str(task.inputs["task_dir"]))
+        task_dir = Path(str(task.metadata["task_dir"]))
         shared = self.config.shared
         task_timeout = task_agent_timeout_sec(task_dir)
         timeout_sec = max(shared.timeout_sec, task_timeout or 0)

--- a/tests/agentic-use/runtimes/claude_code/__init__.py
+++ b/tests/agentic-use/runtimes/claude_code/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from runtimes.claude_code.runtime import ClaudeCodeAgentAttemptRuntime
+
+__all__ = ["ClaudeCodeAgentAttemptRuntime"]

--- a/tests/agentic-use/runtimes/claude_code/runtime.py
+++ b/tests/agentic-use/runtimes/claude_code/runtime.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Claude Code backend — scaffold for phase 3."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from nemo_evaluator_sdk.agent_eval.types import AgentEvalAttempt, AgentEvalRunConfig, AgentEvalTask
+
+from runtimes.shared.config import ClaudeCodeRuntimeConfig
+
+
+class ClaudeCodeAgentAttemptRuntime:
+    """Run agentic-use tasks via Claude Code CLI."""
+
+    def __init__(self, config: ClaudeCodeRuntimeConfig) -> None:
+        self.config = config
+
+    async def run_tasks(
+        self,
+        tasks: Sequence[AgentEvalTask],
+        config: AgentEvalRunConfig | None = None,
+    ) -> list[AgentEvalAttempt]:
+        raise NotImplementedError("ClaudeCodeAgentAttemptRuntime: implement in phase 3")

--- a/tests/agentic-use/runtimes/codex/__init__.py
+++ b/tests/agentic-use/runtimes/codex/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from runtimes.codex.runtime import CodexAgentAttemptRuntime
+
+__all__ = ["CodexAgentAttemptRuntime"]

--- a/tests/agentic-use/runtimes/codex/runtime.py
+++ b/tests/agentic-use/runtimes/codex/runtime.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Codex backend — scaffold for phase 3."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from nemo_evaluator_sdk.agent_eval.types import AgentEvalAttempt, AgentEvalRunConfig, AgentEvalTask
+
+from runtimes.shared.config import CodexRuntimeConfig
+
+
+class CodexAgentAttemptRuntime:
+    """Run agentic-use tasks via Codex CLI."""
+
+    def __init__(self, config: CodexRuntimeConfig) -> None:
+        self.config = config
+
+    async def run_tasks(
+        self,
+        tasks: Sequence[AgentEvalTask],
+        config: AgentEvalRunConfig | None = None,
+    ) -> list[AgentEvalAttempt]:
+        raise NotImplementedError("CodexAgentAttemptRuntime: implement in phase 3")

--- a/tests/agentic-use/runtimes/cursor_agent/__init__.py
+++ b/tests/agentic-use/runtimes/cursor_agent/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from runtimes.cursor_agent.runtime import CursorAgentAttemptRuntime
+
+__all__ = ["CursorAgentAttemptRuntime"]

--- a/tests/agentic-use/runtimes/cursor_agent/runtime.py
+++ b/tests/agentic-use/runtimes/cursor_agent/runtime.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cursor Agent backend — scaffold for phase 3."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from nemo_evaluator_sdk.agent_eval.types import AgentEvalAttempt, AgentEvalRunConfig, AgentEvalTask
+
+from runtimes.shared.config import CursorAgentRuntimeConfig
+
+
+class CursorAgentAttemptRuntime:
+    """Run agentic-use tasks via Cursor Agent CLI."""
+
+    def __init__(self, config: CursorAgentRuntimeConfig) -> None:
+        self.config = config
+
+    async def run_tasks(
+        self,
+        tasks: Sequence[AgentEvalTask],
+        config: AgentEvalRunConfig | None = None,
+    ) -> list[AgentEvalAttempt]:
+        raise NotImplementedError("CursorAgentAttemptRuntime: implement in phase 3")

--- a/tests/agentic-use/runtimes/orchestrator.py
+++ b/tests/agentic-use/runtimes/orchestrator.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Orchestrate BUILD + AgentEvaluator + VERIFY for agentic-use tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from nemo_evaluator_sdk.agent_eval import AgentEvalRunConfig, AgentEvaluator
+from nemo_evaluator_sdk.agent_eval.types import AgentAttemptRuntime, AgentEvalRunResult
+from nemo_evaluator_sdk.metrics.protocol import Metric
+
+from runtimes.shared.docker import docker_image_exists
+from runtimes.shared.environment_spec import execute_build_plan, plan_task_build
+from runtimes.shared.layout import task_image_tag
+from runtimes.shared.metrics import AgentPhaseSuccessMetric, VerifierRewardMetric
+from runtimes.shared.reporting import GateThresholds, evaluate_gate, load_baseline_summary, write_gate_report
+from runtimes.shared.task_loader import agentic_task_from_dir
+
+
+@dataclass(frozen=True)
+class AgenticOrchestratorConfig:
+    skip_build: bool = False
+    skip_verify: bool = False
+    write_dashboard: bool = True
+    write_gate: bool = True
+    gate_thresholds: GateThresholds | None = None
+    baseline_summary_path: Path | None = None
+
+
+class AgenticEvalOrchestrator:
+    """Run agentic-use tasks through AgentEvaluator and optional verify phase."""
+
+    def __init__(
+        self,
+        runtime: AgentAttemptRuntime,
+        *,
+        config: AgenticOrchestratorConfig | None = None,
+    ) -> None:
+        self.runtime = runtime
+        self.config = config or AgenticOrchestratorConfig()
+
+    async def run_agent_eval(
+        self,
+        task_name: str,
+        *,
+        output_dir: Path | None = None,
+        run_id: str | None = None,
+    ) -> AgentEvalRunResult:
+        """Build the task image when needed, run the agent runtime, return SDK result."""
+        task = agentic_task_from_dir(task_name)
+        task = task.model_copy(update={"metrics": self._task_metrics()})
+        image_tag = task_image_tag(task.id)
+        self._ensure_task_image(task.inputs["task_dir"], image_tag)
+
+        result = await AgentEvaluator().run(
+            tasks=[task],
+            target=self.runtime,
+            config=AgentEvalRunConfig(
+                output_dir=output_dir,
+                run_id=run_id,
+                parallelism=1,
+                write_dashboard=self.config.write_dashboard,
+                benchmark={"benchmark": "agentic-use", "task": task_name},
+            ),
+        )
+
+        if self.config.write_gate and result.output_dir is not None:
+            baseline = (
+                load_baseline_summary(self.config.baseline_summary_path)
+                if self.config.baseline_summary_path is not None
+                else None
+            )
+            report = evaluate_gate(
+                result,
+                thresholds=self.config.gate_thresholds,
+                baseline_summary=baseline,
+            )
+            write_gate_report(report, result.output_dir)
+
+        return result
+
+    def _task_metrics(self) -> list[Metric]:
+        """Attach the verifier compatibility metric when verify is enabled."""
+        metrics: list[Metric] = [AgentPhaseSuccessMetric()]
+        if self._verify_enabled():
+            metrics.append(VerifierRewardMetric())
+        return metrics
+
+    def _verify_enabled(self) -> bool:
+        runtime_config = getattr(self.runtime, "config", None)
+        shared = getattr(runtime_config, "shared", None)
+        return bool(getattr(shared, "run_verify", False))
+
+    def _ensure_task_image(self, task_dir: str | Path, image_tag: str) -> None:
+        if self.config.skip_build:
+            if not docker_image_exists(image_tag):
+                raise RuntimeError(
+                    f"--skip-build requested but task image {image_tag!r} is not available locally. "
+                    "Run without skip_build to build the task image first."
+                )
+            return
+        execute_build_plan(plan_task_build(Path(task_dir), image_tag))
+
+
+def runtime_for_backend(
+    backend: str,
+    *,
+    shared_kwargs: dict[str, Any] | None = None,
+    backend_kwargs: dict[str, Any] | None = None,
+) -> AgentAttemptRuntime:
+    """Select a concrete runtime by backend name (CLI helper only)."""
+    from runtimes.aut.runtime import AutAgentAttemptRuntime
+    from runtimes.claude_code.runtime import ClaudeCodeAgentAttemptRuntime
+    from runtimes.codex.runtime import CodexAgentAttemptRuntime
+    from runtimes.cursor_agent.runtime import CursorAgentAttemptRuntime
+    from runtimes.shared.config import (
+        AgenticSharedConfig,
+        AutRuntimeConfig,
+        ClaudeCodeRuntimeConfig,
+        CodexRuntimeConfig,
+        CursorAgentRuntimeConfig,
+        WorkflowRuntimeConfig,
+    )
+    from runtimes.workflow.runtime import NatWorkflowAttemptRuntime
+
+    shared = AgenticSharedConfig(**(shared_kwargs or {}))
+    backend_kwargs = backend_kwargs or {}
+
+    match backend:
+        case "workflow":
+            return NatWorkflowAttemptRuntime(WorkflowRuntimeConfig(shared=shared, **backend_kwargs))
+        case "aut":
+            return AutAgentAttemptRuntime(AutRuntimeConfig(shared=shared, **backend_kwargs))
+        case "claude-code":
+            return ClaudeCodeAgentAttemptRuntime(ClaudeCodeRuntimeConfig(shared=shared, **backend_kwargs))
+        case "codex":
+            return CodexAgentAttemptRuntime(CodexRuntimeConfig(shared=shared, **backend_kwargs))
+        case "cursor-agent":
+            return CursorAgentAttemptRuntime(CursorAgentRuntimeConfig(shared=shared, **backend_kwargs))
+        case _:
+            raise ValueError(f"Unsupported agent backend: {backend!r}")

--- a/tests/agentic-use/runtimes/orchestrator.py
+++ b/tests/agentic-use/runtimes/orchestrator.py
@@ -5,19 +5,25 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from nemo_evaluator_sdk.agent_eval import AgentEvalRunConfig, AgentEvaluator
-from nemo_evaluator_sdk.agent_eval.types import AgentAttemptRuntime, AgentEvalRunResult
+from nemo_evaluator_sdk.agent_eval.types import (
+    AgentAttemptRuntime,
+    AgentEvalRunResult,
+    AgentEvalTask,
+)
 from nemo_evaluator_sdk.metrics.protocol import Metric
 
 from runtimes.shared.docker import docker_image_exists
 from runtimes.shared.environment_spec import execute_build_plan, plan_task_build
 from runtimes.shared.layout import task_image_tag
-from runtimes.shared.metrics import AgentPhaseSuccessMetric, VerifierRewardMetric
+from runtimes.shared.metrics import VerifierRewardMetric
 from runtimes.shared.reporting import GateThresholds, evaluate_gate, load_baseline_summary, write_gate_report
+from runtimes.shared.result_adapter import attempt_from_result_dir
 from runtimes.shared.task_loader import agentic_task_from_dir
 
 
@@ -52,9 +58,9 @@ class AgenticEvalOrchestrator:
     ) -> AgentEvalRunResult:
         """Build the task image when needed, run the agent runtime, return SDK result."""
         task = agentic_task_from_dir(task_name)
-        task = task.model_copy(update={"metrics": self._task_metrics()})
+        task = task.model_copy(update={"metrics": self._metrics_for_task(task)})
         image_tag = task_image_tag(task.id)
-        self._ensure_task_image(task.inputs["task_dir"], image_tag)
+        self._ensure_task_image(task.metadata["task_dir"], image_tag)
 
         result = await AgentEvaluator().run(
             tasks=[task],
@@ -68,25 +74,65 @@ class AgenticEvalOrchestrator:
             ),
         )
 
-        if self.config.write_gate and result.output_dir is not None:
-            baseline = (
-                load_baseline_summary(self.config.baseline_summary_path)
-                if self.config.baseline_summary_path is not None
-                else None
-            )
-            report = evaluate_gate(
-                result,
-                thresholds=self.config.gate_thresholds,
-                baseline_summary=baseline,
-            )
-            write_gate_report(report, result.output_dir)
-
+        self._maybe_write_gate(result)
         return result
 
-    def _task_metrics(self) -> list[Metric]:
-        """Attach the verifier compatibility metric when verify is enabled."""
-        metrics: list[Metric] = [AgentPhaseSuccessMetric()]
-        if self._verify_enabled():
+    async def score_captured_attempts(
+        self,
+        task_name: str,
+        *,
+        result_dirs: Sequence[str | Path],
+        output_dir: Path | None = None,
+        run_id: str | None = None,
+    ) -> AgentEvalRunResult:
+        """Score already-captured ``result.json`` runs without re-running the agent.
+
+        This is the SDK's first-class *stored-attempt* path: it imports each
+        ``nat_runner`` output directory via :func:`attempt_from_result_dir` and
+        scores them through :class:`AgentEvaluator`, so metrics can be exercised
+        (and runs rescored) with no Docker/agent execution.
+        """
+        task = agentic_task_from_dir(task_name)
+        task = task.model_copy(update={"metrics": self._metrics_for_task(task)})
+        attempts = [attempt_from_result_dir(result_dir, task=task) for result_dir in result_dirs]
+
+        result = await AgentEvaluator().run(
+            tasks=[task],
+            attempts=attempts,
+            config=AgentEvalRunConfig(
+                output_dir=output_dir,
+                run_id=run_id,
+                parallelism=1,
+                write_dashboard=self.config.write_dashboard,
+                benchmark={"benchmark": "agentic-use", "task": task_name, "mode": "offline"},
+            ),
+        )
+
+        self._maybe_write_gate(result)
+        return result
+
+    def _maybe_write_gate(self, result: AgentEvalRunResult) -> None:
+        if not (self.config.write_gate and result.output_dir is not None):
+            return
+        baseline = (
+            load_baseline_summary(self.config.baseline_summary_path)
+            if self.config.baseline_summary_path is not None
+            else None
+        )
+        report = evaluate_gate(result, thresholds=self.config.gate_thresholds, baseline_summary=baseline)
+        write_gate_report(report, result.output_dir)
+
+    def _metrics_for_task(self, task: AgentEvalTask) -> list[Metric]:
+        """Honor task-authored metrics; only *append* a compatibility metric.
+
+        Metrics originate on the task (see ``agentic_task_from_dir``). When the
+        live verify phase is enabled we append :class:`VerifierRewardMetric` so
+        the legacy pytest reward is scored too — but we never replace the task's
+        own metric set, and we avoid duplicating a metric the task already
+        declares (the SDK rejects duplicate metric types).
+        """
+        metrics: list[Metric] = list(task.metrics)
+        if self._verify_enabled() and not any(isinstance(metric, VerifierRewardMetric) for metric in metrics):
             metrics.append(VerifierRewardMetric())
         return metrics
 

--- a/tests/agentic-use/runtimes/run_agent_eval.py
+++ b/tests/agentic-use/runtimes/run_agent_eval.py
@@ -34,6 +34,13 @@ async def _main() -> int:
     parser.add_argument("--agent-model", default=os.environ.get("NAT_AGENT_MODEL"))
     parser.add_argument("--aut-agent-name", default=os.environ.get("AUT_AGENT_NAME", ""))
     parser.add_argument("--aut-agent-config", type=Path, default=None)
+    parser.add_argument(
+        "--rescore-dir",
+        type=Path,
+        action="append",
+        default=None,
+        help="Score existing result.json run dir(s) offline instead of running the agent (repeatable).",
+    )
     args = parser.parse_args()
 
     shared = AgenticSharedConfig(
@@ -50,7 +57,14 @@ async def _main() -> int:
         runtime,
         config=AgenticOrchestratorConfig(skip_build=args.skip_build),
     )
-    result = await orchestrator.run_agent_eval(args.task, output_dir=args.output_dir)
+    if args.rescore_dir:
+        result = await orchestrator.score_captured_attempts(
+            args.task,
+            result_dirs=args.rescore_dir,
+            output_dir=args.output_dir,
+        )
+    else:
+        result = await orchestrator.run_agent_eval(args.task, output_dir=args.output_dir)
 
     print(f"run_id: {result.run_id}")
     print(f"attempts: {len(result.attempts)}")

--- a/tests/agentic-use/runtimes/run_agent_eval.py
+++ b/tests/agentic-use/runtimes/run_agent_eval.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run one agentic-use task through AgentEvaluator + a backend runtime."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+AGENTIC_USE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(AGENTIC_USE_DIR))
+sys.path.insert(0, str(AGENTIC_USE_DIR / "shared"))
+
+from runtimes import AgenticEvalOrchestrator, AgenticOrchestratorConfig, runtime_for_backend
+from runtimes.shared.config import AgenticSharedConfig
+
+
+async def _main() -> int:
+    parser = argparse.ArgumentParser(description="Run agentic-use task via AgentAttemptRuntime.")
+    parser.add_argument("--task", required=True, help="Task directory name under tests/agentic-use/")
+    parser.add_argument(
+        "--backend",
+        default="workflow",
+        choices=["workflow", "aut", "claude-code", "codex", "cursor-agent"],
+    )
+    parser.add_argument("--skip-build", action="store_true")
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--nmp-base-url", default=os.environ.get("NMP_BASE_URL", "http://localhost:8080"))
+    parser.add_argument("--agent-model", default=os.environ.get("NAT_AGENT_MODEL"))
+    parser.add_argument("--aut-agent-name", default=os.environ.get("AUT_AGENT_NAME", ""))
+    parser.add_argument("--aut-agent-config", type=Path, default=None)
+    args = parser.parse_args()
+
+    shared = AgenticSharedConfig(
+        nmp_base_url=args.nmp_base_url,
+        nvidia_api_key=os.environ.get("NVIDIA_API_KEY"),
+    )
+    backend_kwargs: dict[str, object] = {"agent_model": args.agent_model}
+    if args.backend == "aut":
+        backend_kwargs["aut_agent_name"] = args.aut_agent_name
+        backend_kwargs["aut_agent_config"] = args.aut_agent_config
+
+    runtime = runtime_for_backend(args.backend, shared_kwargs=shared.__dict__, backend_kwargs=backend_kwargs)
+    orchestrator = AgenticEvalOrchestrator(
+        runtime,
+        config=AgenticOrchestratorConfig(skip_build=args.skip_build),
+    )
+    result = await orchestrator.run_agent_eval(args.task, output_dir=args.output_dir)
+
+    print(f"run_id: {result.run_id}")
+    print(f"attempts: {len(result.attempts)}")
+    print(f"overall_score: {result.summary.overall_score}")
+    print(f"metric_scores: {result.summary.metric_scores}")
+    if result.attempts:
+        attempt = result.attempts[0]
+        print(f"agent_ok: {attempt.metadata.get('agent_ok')}")
+        print(f"run_dir: {attempt.metadata.get('run_dir')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/tests/agentic-use/runtimes/shared/__init__.py
+++ b/tests/agentic-use/runtimes/shared/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared infrastructure for agentic-use runtimes."""

--- a/tests/agentic-use/runtimes/shared/agent_log.py
+++ b/tests/agentic-use/runtimes/shared/agent_log.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agent log parsing helpers shared by backend runtimes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def iter_agent_log_json_payloads(agent_log: str) -> list[dict[str, Any]]:
+    """Return JSON dict payloads embedded in an agent log, newest-first after the full log."""
+    candidates = [agent_log.strip()]
+    lines = [line.strip() for line in agent_log.splitlines() if line.strip()]
+    if lines:
+        candidates.append(lines[-1])
+        candidates.extend(reversed(lines))
+
+    payloads: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            payloads.append(parsed)
+    return payloads
+
+
+def agent_log_has_workflow_error(agent_log: str) -> bool:
+    """Detect AUT workflow errors returned as successful HTTP JSON payloads."""
+    for payload in iter_agent_log_json_payloads(agent_log):
+        if payload.get("code") == "workflow_error":
+            return True
+    return False

--- a/tests/agentic-use/runtimes/shared/artifacts.py
+++ b/tests/agentic-use/runtimes/shared/artifacts.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Convert captured agent artifacts into AgentEvalAttempt values."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from evaluator_agent_eval.artifacts import AgentArtifacts
+from evaluator_agent_eval.schemas import (
+    AgentAttemptInput,
+    AgentAttemptMetadata,
+    AgentAttemptOutput,
+    AgentAttemptTrace,
+    CapturedAgentAttempt,
+)
+from nemo_evaluator_sdk.agent_eval.types import AgentEvalAttempt, AgentEvalTask, AgentOutput
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+
+from runtimes.shared.config import AgenticRuntimeName
+from runtimes.shared.layout import AgenticRunLayout
+from runtimes.shared.usage import extract_usage_metrics
+
+
+def build_agent_eval_attempt(
+    *,
+    task: AgentEvalTask,
+    layout: AgenticRunLayout,
+    runtime_name: AgenticRuntimeName,
+    agent_model: str,
+    exit_code: int,
+    agent_ok: bool,
+    run_id: str | None = None,
+    repo_revision: str | None = None,
+    duration_ms: int | None = None,
+) -> AgentEvalAttempt:
+    """Build an SDK attempt from on-disk agent artifacts.
+
+    Metadata uses the same canonical keys as :class:`CapturedAgentAttempt`
+    (``agent_runtime``, ``agent_model``, ``exit_code``, …) so verify/scoring
+    helpers can consume attempts without a second adapter.
+    """
+    artifacts = AgentArtifacts.from_dir(layout.agent_log_dir, workspace_dir=layout.workspace_dir)
+    log_text = _read_agent_log(layout.agent_log_dir)
+    usage = extract_usage_metrics(log_text)
+    duration = duration_ms if duration_ms is not None else usage.get("duration_ms")
+
+    output_text = artifacts.final_answer.text if artifacts.final_answer.extracted else None
+    raw_log_paths = _raw_log_paths(artifacts.agent_log_dir)
+    descriptors = _evidence_descriptors(layout, artifacts)
+
+    metadata: dict[str, object] = {
+        # Canonical CapturedAgentAttempt fields
+        "agent_runtime": runtime_name,
+        "agent_model": agent_model,
+        "agent_runtime_version": None,
+        "repo_revision": repo_revision,
+        "run_id": run_id,
+        "exit_code": exit_code,
+        "duration_ms": duration,
+        # SDK / orchestration extensions
+        "model_id": agent_model,
+        "target_name": agent_model,
+        "attempt_id": f"{task.id}:{runtime_name}",
+        "agent_ok": agent_ok,
+        "agent_log_dir": str(layout.agent_log_dir),
+        "workspace_dir": str(layout.workspace_dir),
+        "state_dir": str(layout.state_dir),
+        "run_dir": str(layout.run_dir),
+        "instruction_path": task.metadata.get("instruction_path"),
+        "final_answer_extracted": artifacts.final_answer.extracted,
+        "final_answer_source": artifacts.final_answer.source,
+        "raw_log_paths": raw_log_paths,
+        "atif_trajectory_path": str(artifacts.atif_trajectory_path) if artifacts.atif_trajectory_path else None,
+        **usage,
+    }
+
+    status = "completed"
+    if output_text:
+        output = AgentOutput(text=output_text)
+    elif agent_ok:
+        output = AgentOutput(text=log_text.strip() or "")
+    else:
+        output = AgentOutput(text=log_text.strip() or "(agent phase failed)")
+
+    return AgentEvalAttempt(
+        id=f"{task.id}:{runtime_name}",
+        task_id=task.id,
+        status=status,
+        output=output,
+        evidence=CandidateEvidence(descriptors=descriptors) if descriptors else None,
+        metadata=metadata,
+    )
+
+
+def to_captured_agent_attempt(task: AgentEvalTask, attempt: AgentEvalAttempt) -> CapturedAgentAttempt:
+    """Project an SDK attempt onto the portable CapturedAgentAttempt schema."""
+    metadata = attempt.metadata
+    trace_path = metadata.get("atif_trajectory_path")
+    return CapturedAgentAttempt(
+        task_id=attempt.task_id,
+        input=AgentAttemptInput(
+            instruction_text=task.intent,
+            instruction_path=str(metadata.get("instruction_path")) if metadata.get("instruction_path") else None,
+        ),
+        output=AgentAttemptOutput(
+            final_text=attempt.output.text if attempt.output is not None else "",
+            final_answer_extracted=bool(metadata.get("final_answer_extracted")),
+            final_answer_source=str(metadata.get("final_answer_source"))
+            if metadata.get("final_answer_source") is not None
+            else None,
+            raw_log_paths=list(metadata.get("raw_log_paths") or []),
+        ),
+        metadata=AgentAttemptMetadata(
+            agent_runtime=str(metadata.get("agent_runtime", "unknown")),
+            agent_model=str(metadata.get("agent_model", "unknown")),
+            agent_runtime_version=str(metadata["agent_runtime_version"])
+            if metadata.get("agent_runtime_version") is not None
+            else None,
+            repo_revision=str(metadata["repo_revision"]) if metadata.get("repo_revision") is not None else None,
+            run_id=str(metadata["run_id"]) if metadata.get("run_id") is not None else None,
+            exit_code=int(metadata["exit_code"]) if isinstance(metadata.get("exit_code"), int) else None,
+            duration_ms=int(metadata["duration_ms"]) if isinstance(metadata.get("duration_ms"), int | float) else None,
+        ),
+        trace=AgentAttemptTrace(atif_path=str(trace_path)) if trace_path else None,
+    )
+
+
+def _evidence_descriptors(layout: AgenticRunLayout, artifacts: AgentArtifacts) -> dict[str, EvidenceDescriptor]:
+    """Build the evidence map specified by the agent-eval SDK design doc.
+
+    Keys follow the documented ``nat_runner`` → ``AgentEvalAttempt`` mapping:
+    ``final_state`` (workspace), ``trace`` (trajectory, ATIF-normalized),
+    ``logs`` (agent log dir), and ``verifier_logs`` (verifier log dir).
+    """
+    descriptors: dict[str, EvidenceDescriptor] = {}
+
+    # agent/trajectory.json → evidence["trace"], preferably ATIF-normalized.
+    if artifacts.atif_trajectory_path is not None:
+        descriptors["trace"] = EvidenceDescriptor(
+            kind="trace",
+            format="atif" if artifacts.atif_trajectory_path.name.startswith("atif") else "json",
+            ref=str(artifacts.atif_trajectory_path),
+        )
+
+    # agent/ logs → evidence["logs"].
+    descriptors["logs"] = EvidenceDescriptor(
+        kind="logs",
+        format="dir",
+        ref=str(layout.agent_log_dir),
+        metadata={"primary_log": "nat_agent.log"},
+    )
+
+    # workspace/ → evidence["final_state"] filesystem descriptor.
+    descriptors["final_state"] = EvidenceDescriptor(
+        kind="filesystem",
+        format="dir",
+        ref=str(layout.workspace_dir),
+        metadata={"role": "final_state"},
+    )
+
+    # Preserved platform/database state across agent + verifier phases.
+    descriptors["state"] = EvidenceDescriptor(
+        kind="filesystem",
+        format="dir",
+        ref=str(layout.state_dir),
+        metadata={"role": "platform_state"},
+    )
+
+    # verifier/ logs → evidence["verifier_logs"] (present once verify phase runs).
+    verifier_log_dir = layout.run_dir / "verifier"
+    if verifier_log_dir.exists():
+        descriptors["verifier_logs"] = EvidenceDescriptor(
+            kind="logs",
+            format="dir",
+            ref=str(verifier_log_dir),
+            metadata={"role": "verifier"},
+        )
+
+    return descriptors
+
+
+def _raw_log_paths(agent_log_dir: Path) -> list[str]:
+    if not agent_log_dir.is_dir():
+        return []
+    return [str(path.relative_to(agent_log_dir)) for path in sorted(agent_log_dir.iterdir()) if path.is_file()]
+
+
+def _read_agent_log(agent_log_dir: Path) -> str:
+    log_path = agent_log_dir / "nat_agent.log"
+    if log_path.is_file():
+        return log_path.read_text(encoding="utf-8", errors="replace")
+    return ""

--- a/tests/agentic-use/runtimes/shared/artifacts.py
+++ b/tests/agentic-use/runtimes/shared/artifacts.py
@@ -15,12 +15,32 @@ from evaluator_agent_eval.schemas import (
     AgentAttemptTrace,
     CapturedAgentAttempt,
 )
-from nemo_evaluator_sdk.agent_eval.types import AgentEvalAttempt, AgentEvalTask, AgentOutput
+from nemo_evaluator_sdk.agent_eval.types import (
+    AgentEvalAttempt,
+    AgentEvalAttemptStatus,
+    AgentEvalTask,
+    AgentOutput,
+)
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
 
 from runtimes.shared.config import AgenticRuntimeName
 from runtimes.shared.layout import AgenticRunLayout
 from runtimes.shared.usage import extract_usage_metrics
+
+
+def resolve_attempt_status(agent_ok: bool) -> AgentEvalAttemptStatus:
+    """Map an agent-phase outcome to a *scorable* attempt status.
+
+    The SDK's :class:`AgentEvaluator` excludes ``status=="failed"`` from scoring
+    (it raises). An agent that ran but failed must still be scored — e.g. as a
+    ``0`` by :class:`AgentPhaseSuccessMetric` — so that pass-rate gating counts
+    it rather than dropping it. We therefore use ``"partial"`` for an
+    executed-but-unsuccessful agent and reserve ``"failed"`` for genuine
+    attempt-*production* failures (which a runtime surfaces by raising, not by
+    emitting an unscorable attempt). This keeps the live builder and the
+    ``result.json`` importer consistent.
+    """
+    return "completed" if agent_ok else "partial"
 
 
 def build_agent_eval_attempt(
@@ -48,7 +68,10 @@ def build_agent_eval_attempt(
 
     output_text = artifacts.final_answer.text if artifacts.final_answer.extracted else None
     raw_log_paths = _raw_log_paths(artifacts.agent_log_dir)
-    descriptors = _evidence_descriptors(layout, artifacts)
+    initial_state = task.inputs.get("filesystem")
+    descriptors = _evidence_descriptors(
+        layout, artifacts, initial_state_ref=str(initial_state) if initial_state else None
+    )
 
     metadata: dict[str, object] = {
         # Canonical CapturedAgentAttempt fields
@@ -76,7 +99,7 @@ def build_agent_eval_attempt(
         **usage,
     }
 
-    status = "completed"
+    status = resolve_attempt_status(agent_ok)
     if output_text:
         output = AgentOutput(text=output_text)
     elif agent_ok:
@@ -127,14 +150,31 @@ def to_captured_agent_attempt(task: AgentEvalTask, attempt: AgentEvalAttempt) ->
     )
 
 
-def _evidence_descriptors(layout: AgenticRunLayout, artifacts: AgentArtifacts) -> dict[str, EvidenceDescriptor]:
+def _evidence_descriptors(
+    layout: AgenticRunLayout,
+    artifacts: AgentArtifacts,
+    *,
+    initial_state_ref: str | None = None,
+) -> dict[str, EvidenceDescriptor]:
     """Build the evidence map specified by the agent-eval SDK design doc.
 
-    Keys follow the documented ``nat_runner`` → ``AgentEvalAttempt`` mapping:
+    Doc keys: ``initial_state`` (task input filesystem, when staged),
     ``final_state`` (workspace), ``trace`` (trajectory, ATIF-normalized),
     ``logs`` (agent log dir), and ``verifier_logs`` (verifier log dir).
+
+    ``state`` is a NeMo-Platform-specific *extension* (not a doc key): it carries
+    the preserved platform/database state across the agent + verifier phases.
     """
     descriptors: dict[str, EvidenceDescriptor] = {}
+
+    # task input filesystem → evidence["initial_state"] (only when a seed was staged).
+    if initial_state_ref:
+        descriptors["initial_state"] = EvidenceDescriptor(
+            kind="filesystem",
+            format="dir",
+            ref=initial_state_ref,
+            metadata={"role": "initial_state"},
+        )
 
     # agent/trajectory.json → evidence["trace"], preferably ATIF-normalized.
     if artifacts.atif_trajectory_path is not None:
@@ -160,12 +200,12 @@ def _evidence_descriptors(layout: AgenticRunLayout, artifacts: AgentArtifacts) -
         metadata={"role": "final_state"},
     )
 
-    # Preserved platform/database state across agent + verifier phases.
+    # Platform extension (non-doc key): preserved platform/db state across phases.
     descriptors["state"] = EvidenceDescriptor(
         kind="filesystem",
         format="dir",
         ref=str(layout.state_dir),
-        metadata={"role": "platform_state"},
+        metadata={"role": "platform_state", "extension": "nemo-platform"},
     )
 
     # verifier/ logs → evidence["verifier_logs"] (present once verify phase runs).

--- a/tests/agentic-use/runtimes/shared/config.py
+++ b/tests/agentic-use/runtimes/shared/config.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration models for agentic-use runtimes."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from runtimes.shared.constants import AGENTIC_USE_DIR, DEFAULT_LOCAL_NMP_BASE_URL, DEFAULT_TIMEOUT_SEC, REPO_ROOT
+
+AgenticRuntimeName = Literal["aut", "workflow", "claude-code", "codex", "cursor-agent"]
+
+
+@dataclass(frozen=True)
+class AgenticSharedConfig:
+    """Settings common to every agentic-use runtime."""
+
+    tasks_dir: Path = AGENTIC_USE_DIR
+    jobs_dir: Path | None = None
+    repo_root: Path = REPO_ROOT
+    nmp_base_url: str = DEFAULT_LOCAL_NMP_BASE_URL
+    timeout_sec: int = DEFAULT_TIMEOUT_SEC
+    nvidia_api_key: str | None = None
+    docker_extra_args: list[str] = field(default_factory=list)
+    run_verify: bool = False
+    smoke_workspace: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkflowRuntimeConfig:
+    """Configuration for :class:`NatWorkflowAttemptRuntime`."""
+
+    shared: AgenticSharedConfig = field(default_factory=AgenticSharedConfig)
+    agent_model: str | None = None
+
+
+@dataclass(frozen=True)
+class AutRuntimeConfig:
+    """Configuration for :class:`AutAgentAttemptRuntime`."""
+
+    shared: AgenticSharedConfig = field(default_factory=AgenticSharedConfig)
+    aut_agent_name: str = ""
+    aut_agent_config: Path | None = None
+    aut_seed_providers: bool = True
+    agent_model: str | None = None
+    anthropic_api_key: str | None = None
+    inference_nvidia_api_key: str | None = None
+    aut_health_wait_seconds: int = int(os.environ.get("NAT_AUT_HEALTH_WAIT_SECONDS", "60"))
+
+
+@dataclass(frozen=True)
+class ClaudeCodeRuntimeConfig:
+    """Configuration for :class:`ClaudeCodeAgentAttemptRuntime`."""
+
+    shared: AgenticSharedConfig = field(default_factory=AgenticSharedConfig)
+    agent_model: str | None = None
+    agent_params: dict[str, Any] = field(default_factory=dict)
+    anthropic_api_key: str | None = None
+    anthropic_base_url: str = "https://inference-api.nvidia.com"
+
+
+@dataclass(frozen=True)
+class CodexRuntimeConfig:
+    """Configuration for :class:`CodexAgentAttemptRuntime`."""
+
+    shared: AgenticSharedConfig = field(default_factory=AgenticSharedConfig)
+    agent_model: str | None = None
+    agent_params: dict[str, Any] = field(default_factory=dict)
+    codex_auth_json: Path | None = None
+
+
+@dataclass(frozen=True)
+class CursorAgentRuntimeConfig:
+    """Configuration for :class:`CursorAgentAttemptRuntime`."""
+
+    shared: AgenticSharedConfig = field(default_factory=AgenticSharedConfig)
+    agent_model: str | None = None
+    agent_params: dict[str, Any] = field(default_factory=dict)

--- a/tests/agentic-use/runtimes/shared/constants.py
+++ b/tests/agentic-use/runtimes/shared/constants.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared constants for agentic-use AgentAttemptRuntime implementations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+AGENTIC_USE_DIR = Path(__file__).resolve().parents[2]
+REPO_ROOT = AGENTIC_USE_DIR.parents[1]
+SHARED_DIR = AGENTIC_USE_DIR / "shared"
+EVALUATOR_SDK_SRC = REPO_ROOT / "packages" / "nemo_evaluator_sdk" / "src"
+
+NAT_TRACE_EXPORT_SCRIPT_CONTAINER_PATH = "/app/tests/agentic-use/scripts/nat_trace_export.py"
+DEFAULT_LOCAL_NMP_BASE_URL = "http://localhost:8080"
+DEFAULT_TIMEOUT_SEC = 600
+FILES_STORAGE_CONFIG = '{"type":"local","path":"/data/files_storage"}'
+PLATFORM_CONFIG_PATH = "/app/packages/nmp_platform/config/local.yaml"
+DOCKER_SOCKET_HOST_PATH = Path("/var/run/docker.sock")
+DOCKER_SOCKET_CONTAINER_PATH = "/var/run/docker.sock"
+
+INSTRUCTION_CONTAINER_PATH = "/tmp/nat_instruction.md"
+WORKFLOW_CONTAINER_PATH = "/tmp/nat_workflow.yml"

--- a/tests/agentic-use/runtimes/shared/container_env.py
+++ b/tests/agentic-use/runtimes/shared/container_env.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared container environment helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from runtimes.shared.config import AgenticSharedConfig
+from runtimes.shared.constants import (
+    DOCKER_SOCKET_CONTAINER_PATH,
+    DOCKER_SOCKET_HOST_PATH,
+    FILES_STORAGE_CONFIG,
+    PLATFORM_CONFIG_PATH,
+)
+
+
+def base_container_env(shared: AgenticSharedConfig, *, timeout_sec: int) -> dict[str, str]:
+    """Environment variables shared by all agentic-use container runs."""
+    env: dict[str, str] = {
+        "NMP_BASE_URL": shared.nmp_base_url,
+        "AGENTIC_USE_WORKSPACE_DIR": "/app/workspace",
+        "DATABASE_DIALECT": "sqlite",
+        "DATABASE_PATH": "/data/nmp-platform.db",
+        "NMP_FILES_DEFAULT_STORAGE_CONFIG": FILES_STORAGE_CONFIG,
+        "NMP_CONFIG_FILE_PATH": PLATFORM_CONFIG_PATH,
+        "NEMO_AGENTS_GATEWAY_READ_TIMEOUT": str(timeout_sec),
+        "NEMO_AGENTS_INVOKE_TIMEOUT": str(timeout_sec),
+        "AUT_INVOKE_HTTP_TIMEOUT": str(timeout_sec),
+    }
+    if DOCKER_SOCKET_HOST_PATH.exists():
+        env["DOCKER_HOST"] = f"unix://{DOCKER_SOCKET_CONTAINER_PATH}"
+    return env
+
+
+def with_candidate_params(env: dict[str, str], agent_params: dict[str, Any]) -> dict[str, str]:
+    if agent_params:
+        env = dict(env)
+        env["NAT_CANDIDATE_PARAMS"] = json.dumps(agent_params, sort_keys=True)
+    return env

--- a/tests/agentic-use/runtimes/shared/docker.py
+++ b/tests/agentic-use/runtimes/shared/docker.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Docker helpers for agentic-use runtimes."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Sequence
+
+
+def redact_cmd_for_logging(cmd: Sequence[str]) -> list[str]:
+    """Redact secret values in command logs."""
+    redacted: list[str] = []
+    sensitive_markers = ("KEY", "TOKEN", "SECRET", "PASSWORD")
+    for token in cmd:
+        if "=" not in token:
+            redacted.append(token)
+            continue
+        left, right = token.split("=", 1)
+        env_key = left.split()[-1] if left else left
+        if any(marker in env_key.upper() for marker in sensitive_markers):
+            redacted.append(f"{left}=***REDACTED***")
+        else:
+            redacted.append(f"{left}={right}")
+    return redacted
+
+
+def docker_run(
+    image: str,
+    command: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    mounts: list[tuple[str, str]] | None = None,
+    workdir: str | None = None,
+    remove: bool = True,
+    timeout: int | None = None,
+    extra_args: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command inside a Docker container."""
+    cmd = ["docker", "run"]
+    if remove:
+        cmd.append("--rm")
+    if workdir:
+        cmd += ["-w", workdir]
+
+    for key, value in (env or {}).items():
+        cmd += ["-e", f"{key}={value}"]
+
+    for host_path, container_path in mounts or []:
+        cmd += ["-v", f"{host_path}:{container_path}"]
+
+    docker_extra = (extra_args or []) + (os.environ.get("DOCKER_EXTRA_ARGS", "").split() or [])
+    cmd += docker_extra
+    cmd.append(image)
+    cmd += command
+
+    print(f"[agentic-runtime] $ {' '.join(redact_cmd_for_logging(cmd))}")
+    kwargs: dict[str, object] = {"check": False, "text": True}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    return subprocess.run(cmd, **kwargs)
+
+
+def docker_image_exists(tag: str) -> bool:
+    """Return True when a Docker image tag exists locally."""
+    result = subprocess.run(["docker", "image", "inspect", tag], capture_output=True, text=True, check=False)
+    return result.returncode == 0
+
+
+def build_dockerfile(dockerfile: os.PathLike[str], context_dir: os.PathLike[str], tag: str) -> None:
+    """Build a Docker image from an explicit Dockerfile + build context."""
+    cmd = ["docker", "build", "-f", str(dockerfile), "-t", tag, str(context_dir)]
+    print(f"[agentic-runtime] $ {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+
+
+def build_task_image(task_dir: os.PathLike[str], tag: str) -> None:
+    """Build a task-specific Docker image from environment/Dockerfile."""
+    from pathlib import Path
+
+    root = Path(task_dir)
+    env_dockerfile = root / "environment" / "Dockerfile"
+    if not env_dockerfile.exists():
+        raise FileNotFoundError(f"No environment/Dockerfile found in {root}")
+    build_dockerfile(env_dockerfile, env_dockerfile.parent, tag)

--- a/tests/agentic-use/runtimes/shared/environment.py
+++ b/tests/agentic-use/runtimes/shared/environment.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Environment provider boundary for agentic-use runtimes.
+
+This is the design-doc's ``EnvironmentProvider`` boundary (section B2): it sits
+*below* :class:`AgentAttemptRuntime` so a runtime never needs to know whether
+the agent/verifier execute under Docker, locally, Harbor, or NeMo Gym. Today the
+only implementation is :class:`DockerEnvironmentProvider`, which wraps
+``shared/docker.py``.
+
+Deviation from the doc sketch: the doc proposes ``run_agent(instruction, config)
+-> AgentEvalAttempt``. We keep the boundary at "execute a command in the
+prepared environment" (returning an :class:`EnvCommandResult`) because each
+backend builds its own command/env/mounts, and attempt construction is owned by
+``shared/artifacts.py``. This keeps command-building and attempt-shaping out of
+the environment layer so new providers only implement process execution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from nemo_evaluator_sdk.agent_eval.types import AgentEvalRunConfig, AgentEvalTask
+
+from runtimes.shared.docker import docker_run
+from runtimes.shared.layout import task_image_tag
+
+
+@dataclass(frozen=True)
+class EnvCommandResult:
+    """Outcome of running a single command inside a prepared environment."""
+
+    exit_code: int
+    timed_out: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.exit_code == 0 and not self.timed_out
+
+
+@dataclass
+class EnvRunSpec:
+    """How to execute one command inside an environment handle."""
+
+    command: list[str]
+    env: dict[str, str] = field(default_factory=dict)
+    mounts: list[tuple[str, str]] = field(default_factory=list)
+    workdir: str | None = None
+    timeout: int | None = None
+    extra_args: list[str] = field(default_factory=list)
+
+
+@runtime_checkable
+class AgentEnvironmentHandle(Protocol):
+    """A prepared, single-task environment that can run agent/verifier commands."""
+
+    async def run_agent(self, spec: EnvRunSpec) -> EnvCommandResult: ...
+
+    async def run_verifier(self, spec: EnvRunSpec) -> EnvCommandResult: ...
+
+    async def close(self) -> None: ...
+
+
+@runtime_checkable
+class AgentEnvironmentProvider(Protocol):
+    """Creates per-task environment handles. Pluggable: Docker now, Gym later."""
+
+    async def prepare(
+        self,
+        task: AgentEvalTask,
+        config: AgentEvalRunConfig | None = None,
+    ) -> AgentEnvironmentHandle: ...
+
+
+class DockerEnvironmentHandle:
+    """Docker-backed environment handle bound to one task image."""
+
+    def __init__(self, image: str) -> None:
+        self.image = image
+
+    async def run_agent(self, spec: EnvRunSpec) -> EnvCommandResult:
+        return await self._run(spec)
+
+    async def run_verifier(self, spec: EnvRunSpec) -> EnvCommandResult:
+        return await self._run(spec)
+
+    async def _run(self, spec: EnvRunSpec) -> EnvCommandResult:
+        try:
+            result = await asyncio.to_thread(
+                docker_run,
+                self.image,
+                spec.command,
+                env=spec.env,
+                mounts=spec.mounts,
+                workdir=spec.workdir,
+                timeout=spec.timeout,
+                extra_args=spec.extra_args,
+            )
+        except subprocess.TimeoutExpired:
+            return EnvCommandResult(exit_code=124, timed_out=True)
+        return EnvCommandResult(exit_code=result.returncode)
+
+    async def close(self) -> None:
+        # `docker run --rm` cleans up the container; nothing persistent to release.
+        return None
+
+
+class DockerEnvironmentProvider:
+    """Default provider that maps each task to its built Docker image."""
+
+    def __init__(self, *, image_tag_fn: Callable[[str], str] = task_image_tag) -> None:
+        self._image_tag_fn = image_tag_fn
+
+    async def prepare(
+        self,
+        task: AgentEvalTask,
+        config: AgentEvalRunConfig | None = None,
+    ) -> DockerEnvironmentHandle:
+        del config
+        return DockerEnvironmentHandle(self._image_tag_fn(task.id))

--- a/tests/agentic-use/runtimes/shared/environment_spec.py
+++ b/tests/agentic-use/runtimes/shared/environment_spec.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable environment authoring for agentic-use tasks (design-doc B3).
+
+Moves task authoring away from an implicit "Dockerfile per task" toward a small,
+declarative ``environment.yaml`` spec, while keeping a Dockerfile escape hatch.
+
+Spec shape (``environment.yaml`` in the task dir)::
+
+    environment:
+      image: nemo-platform-agentic-base:2026.06
+      profile: evaluator-platform
+      dependencies:
+        python:
+          - pytest
+          - nemo-evaluator-sdk
+      setup:
+        - seed-providers
+        - create-workspace
+
+Escape hatch::
+
+    environment:
+      dockerfile: environment/Dockerfile
+
+Resolution is deliberately minimal: a spec is turned into a :class:`BuildPlan`
+(a Dockerfile + build context + target tag). The Dockerfile path is used as-is;
+an ``image``-based spec generates a tiny derived Dockerfile (``FROM <image>`` plus
+optional ``pip install``). ``setup`` steps are carried as plan metadata — they are
+runtime concerns (e.g. seed-providers) handled outside the image build — so this
+module does not execute them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+ENVIRONMENT_SPEC_FILENAME = "environment.yaml"
+DEFAULT_DOCKERFILE_RELPATH = "environment/Dockerfile"
+
+
+@dataclass(frozen=True)
+class EnvironmentSpec:
+    """Declarative environment for one task (or a Dockerfile escape hatch)."""
+
+    image: str | None = None
+    profile: str | None = None
+    python_dependencies: list[str] = field(default_factory=list)
+    setup: list[str] = field(default_factory=list)
+    dockerfile: Path | None = None
+
+    def __post_init__(self) -> None:
+        if self.dockerfile is None and self.image is None:
+            raise ValueError("environment spec requires either 'image' or 'dockerfile'")
+
+
+def load_environment_spec(task_dir: str | Path) -> EnvironmentSpec:
+    """Load a task's environment spec.
+
+    Resolution order:
+    1. ``environment.yaml`` in the task dir (declarative spec, preferred).
+    2. ``environment/Dockerfile`` (backward-compatible escape hatch so existing
+       tasks work without authoring a spec).
+    """
+    root = Path(task_dir)
+    spec_path = root / ENVIRONMENT_SPEC_FILENAME
+    if spec_path.is_file():
+        return _parse_spec(yaml.safe_load(spec_path.read_text(encoding="utf-8")) or {}, root)
+
+    dockerfile = root / DEFAULT_DOCKERFILE_RELPATH
+    if dockerfile.is_file():
+        return EnvironmentSpec(dockerfile=dockerfile)
+
+    raise FileNotFoundError(
+        f"No environment defined for task {root}: expected {ENVIRONMENT_SPEC_FILENAME} or {DEFAULT_DOCKERFILE_RELPATH}"
+    )
+
+
+def _parse_spec(payload: dict, task_dir: Path) -> EnvironmentSpec:
+    data = payload.get("environment", payload) if isinstance(payload, dict) else {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid environment spec in {task_dir}: expected a mapping")
+
+    dockerfile_value = data.get("dockerfile")
+    dockerfile = None
+    if dockerfile_value:
+        dockerfile = Path(dockerfile_value)
+        if not dockerfile.is_absolute():
+            dockerfile = (task_dir / dockerfile).resolve()
+        if not dockerfile.is_file():
+            raise FileNotFoundError(f"environment.dockerfile not found: {dockerfile}")
+
+    dependencies = data.get("dependencies") or {}
+    python_deps = dependencies.get("python") if isinstance(dependencies, dict) else None
+
+    return EnvironmentSpec(
+        image=data.get("image"),
+        profile=data.get("profile"),
+        python_dependencies=list(python_deps or []),
+        setup=list(data.get("setup") or []),
+        dockerfile=dockerfile,
+    )
+
+
+@dataclass(frozen=True)
+class BuildPlan:
+    """A resolved, executable Docker build for one task."""
+
+    image_tag: str
+    dockerfile: Path
+    context_dir: Path
+    generated: bool
+    base_image: str | None = None
+    setup: list[str] = field(default_factory=list)
+
+
+def plan_task_build(
+    task_dir: str | Path,
+    image_tag: str,
+    *,
+    spec: EnvironmentSpec | None = None,
+    generated_dir: Path | None = None,
+) -> BuildPlan:
+    """Resolve a task's environment spec into a concrete :class:`BuildPlan`.
+
+    For the Dockerfile escape hatch the existing Dockerfile/context is used. For
+    an ``image``-based spec a minimal derived Dockerfile is written under
+    ``generated_dir`` (defaults to ``<task_dir>/.agentic-build``).
+    """
+    root = Path(task_dir)
+    spec = spec or load_environment_spec(root)
+
+    if spec.dockerfile is not None:
+        return BuildPlan(
+            image_tag=image_tag,
+            dockerfile=spec.dockerfile,
+            context_dir=spec.dockerfile.parent,
+            generated=False,
+            setup=list(spec.setup),
+        )
+
+    # image-based spec: generate a tiny derived Dockerfile.
+    context_dir = generated_dir if generated_dir is not None else (root / ".agentic-build")
+    context_dir.mkdir(parents=True, exist_ok=True)
+    dockerfile = context_dir / "Dockerfile"
+    dockerfile.write_text(render_derived_dockerfile(spec), encoding="utf-8")
+    return BuildPlan(
+        image_tag=image_tag,
+        dockerfile=dockerfile,
+        context_dir=context_dir,
+        generated=True,
+        base_image=spec.image,
+        setup=list(spec.setup),
+    )
+
+
+def execute_build_plan(plan: BuildPlan) -> None:
+    """Build the Docker image described by ``plan``."""
+    from runtimes.shared.docker import build_dockerfile
+
+    build_dockerfile(plan.dockerfile, plan.context_dir, plan.image_tag)
+
+
+def render_derived_dockerfile(spec: EnvironmentSpec) -> str:
+    """Render a minimal derived Dockerfile from an image-based spec."""
+    if spec.image is None:
+        raise ValueError("cannot render a derived Dockerfile without a base image")
+    lines = [f"FROM {spec.image}"]
+    if spec.profile:
+        lines.append(f"LABEL com.nvidia.agentic.profile={spec.profile}")
+    if spec.python_dependencies:
+        deps = " ".join(spec.python_dependencies)
+        lines.append(f"RUN pip install --no-cache-dir {deps}")
+    if spec.setup:
+        # Setup steps are runtime concerns; record them for provenance only.
+        lines.append(f'LABEL com.nvidia.agentic.setup="{",".join(spec.setup)}"')
+    return "\n".join(lines) + "\n"

--- a/tests/agentic-use/runtimes/shared/layout.py
+++ b/tests/agentic-use/runtimes/shared/layout.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Output directory layout for agentic-use runtime runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from nemo_evaluator_sdk.agent_eval.types import AgentEvalRunConfig, AgentEvalTask
+
+from runtimes.shared.config import AgenticSharedConfig
+
+
+@dataclass(frozen=True)
+class AgenticRunLayout:
+    """Filesystem layout for one task run."""
+
+    run_dir: Path
+    agent_log_dir: Path
+    workspace_dir: Path
+    state_dir: Path
+    instruction_path: Path
+
+
+def default_jobs_dir(shared: AgenticSharedConfig) -> Path:
+    if shared.jobs_dir is not None:
+        return shared.jobs_dir
+    return shared.repo_root / "nat-jobs"
+
+
+def new_run_dir(jobs_dir: Path, task_id: str) -> Path:
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = jobs_dir / f"{timestamp}-{task_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def resolve_run_layout(
+    task: AgentEvalTask,
+    shared: AgenticSharedConfig,
+    config: AgentEvalRunConfig | None = None,
+) -> AgenticRunLayout:
+    """Resolve or create the on-disk layout for one task attempt."""
+    if config is not None and config.output_dir is not None:
+        run_dir = Path(config.output_dir)
+    else:
+        run_dir = new_run_dir(default_jobs_dir(shared), task.id)
+
+    agent_log_dir = run_dir / "agent"
+    workspace_dir = run_dir / "workspace"
+    state_dir = run_dir / "state"
+    agent_log_dir.mkdir(parents=True, exist_ok=True)
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    instruction_path = agent_log_dir / "instruction.md"
+    instruction_path.write_text(task.intent, encoding="utf-8")
+
+    return AgenticRunLayout(
+        run_dir=run_dir,
+        agent_log_dir=agent_log_dir,
+        workspace_dir=workspace_dir,
+        state_dir=state_dir,
+        instruction_path=instruction_path,
+    )
+
+
+def task_image_tag(task_id: str) -> str:
+    return f"nmp-nat-{task_id}:latest"

--- a/tests/agentic-use/runtimes/shared/metrics.py
+++ b/tests/agentic-use/runtimes/shared/metrics.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Default metrics for agentic-use agent-eval runs."""
+
+from __future__ import annotations
+
+from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
+
+
+class AgentPhaseSuccessMetric:
+    """Score 1.0 when the agent phase exited successfully, else 0.0."""
+
+    @property
+    def type(self) -> str:
+        return "agentic_use_agent_phase"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.continuous_score("agent_phase_success")]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        agent_ok = bool(input.candidate.metadata.get("agent_ok"))
+        return MetricResult(
+            outputs=[MetricOutput(name="agent_phase_success", value=1.0 if agent_ok else 0.0)],
+        )
+
+
+class VerifierRewardMetric:
+    """Compatibility metric mirroring the legacy pytest verifier reward.
+
+    Reads the verifier outcome that ``nat_runner`` records in ``result.json``
+    (projected onto attempt metadata as ``reward``/``passed``) so existing
+    ``tests/test_outputs.py`` verifiers can score through the Evaluator SDK
+    while task-specific metrics are authored.
+    """
+
+    @property
+    def type(self) -> str:
+        return "agentic_use_verifier_reward"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.continuous_score("verifier_reward")]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        metadata = input.candidate.metadata
+        reward = metadata.get("reward")
+        if reward is None:
+            reward = 1.0 if metadata.get("passed") else 0.0
+        return MetricResult(
+            outputs=[MetricOutput(name="verifier_reward", value=float(reward))],
+        )

--- a/tests/agentic-use/runtimes/shared/reporting.py
+++ b/tests/agentic-use/runtimes/shared/reporting.py
@@ -1,0 +1,457 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic gating + provenance comparison over an agent-eval run bundle.
+
+This closes the design-doc B4 "CI/reporting" gap. Persistence of
+``tasks.jsonl``/``attempts.jsonl``/``results.jsonl``/``summary.json``/``report.html``
+is already handled by the SDK (``agent_eval.persistence.persist_run`` /
+``write_dashboard``); this module adds the missing piece: a candidate-vs-baseline
+gate (pass-rate, token/cost, runtime tie-breaker) plus deterministic provenance
+checks.
+
+The semantics intentionally mirror ``passrate_token_policy_gate.py`` so a summary
+produced here is interchangeable with the legacy gate's baseline summary. The
+difference is the input: this operates on a typed :class:`AgentEvalRunResult`
+(metric scores + attempt metadata) instead of scanning ``result.json`` files.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from nemo_evaluator_sdk.agent_eval.types import AgentEvalAttempt, AgentEvalRunResult, AgentEvalTaskResult
+
+# Metric outputs, in priority order, that represent a task's pass/reward signal.
+DEFAULT_REWARD_OUTPUTS: tuple[str, ...] = ("verifier_reward", "agent_phase_success")
+
+# Provenance fields collapsed into a single run-level summary (matches the
+# legacy gate so baselines are interchangeable).
+_PROVENANCE_FIELDS: tuple[str, ...] = (
+    "commit_sha",
+    "commit_short",
+    "commit_dirty",
+    "branch",
+    "remote_url",
+    "agentic_base_image_digest",
+    "pinned",
+    "pinned_to_commit",
+    "pinned_image_tag",
+)
+
+
+@dataclass(frozen=True)
+class GateThresholds:
+    """Knobs controlling the candidate gate (defaults are the strict CI policy)."""
+
+    min_pass_rate: float = 1.0
+    require_token_metrics: bool = False
+    max_pass_rate_drop: float = 0.0
+    max_token_regression_pct: float = 0.0
+    max_runtime_regression_pct: float = 0.0
+    allow_cross_commit: bool = False
+
+
+@dataclass
+class GateCheck:
+    name: str
+    passed: bool
+    details: str
+
+
+@dataclass
+class GateReport:
+    gate_passed: bool
+    summary: dict[str, Any]
+    checks: list[GateCheck] = field(default_factory=list)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "gate_passed": self.gate_passed,
+            "summary": self.summary,
+            "checks": [asdict(check) for check in self.checks],
+        }
+
+
+def evaluate_gate(
+    result: AgentEvalRunResult,
+    *,
+    thresholds: GateThresholds | None = None,
+    baseline_summary: dict[str, Any] | None = None,
+    reward_outputs: tuple[str, ...] = DEFAULT_REWARD_OUTPUTS,
+) -> GateReport:
+    """Summarize a run and apply gate checks, optionally against a baseline."""
+    thresholds = thresholds or GateThresholds()
+    summary = summarize_run(result, reward_outputs=reward_outputs)
+    checks = run_gate_checks(summary, thresholds=thresholds, baseline_summary=baseline_summary)
+    return GateReport(gate_passed=all(check.passed for check in checks), summary=summary, checks=checks)
+
+
+def write_gate_report(report: GateReport, output_dir: str | Path, *, filename: str = "gate.json") -> Path:
+    """Persist the gate report alongside the SDK run bundle."""
+    path = Path(output_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    gate_path = path / filename
+    gate_path.write_text(json.dumps(report.to_payload(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return gate_path
+
+
+def load_baseline_summary(path: str | Path) -> dict[str, Any]:
+    """Load + normalize a baseline summary (raw summary or a prior gate.json)."""
+    source = Path(path)
+    payload = json.loads(source.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Baseline summary must be a JSON object: {source}")
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else payload
+    _validate_baseline_summary(summary, source)
+    return summary
+
+
+def summarize_run(
+    result: AgentEvalRunResult,
+    *,
+    reward_outputs: tuple[str, ...] = DEFAULT_REWARD_OUTPUTS,
+) -> dict[str, Any]:
+    """Aggregate pass-rate, token, runtime, and provenance for one run."""
+    attempts_by_task: dict[str, AgentEvalAttempt] = {attempt.task_id: attempt for attempt in result.attempts}
+    reward_by_task = _rewards_by_task(result.results, reward_outputs)
+    task_ids = sorted({task.id for task in result.tasks} | set(attempts_by_task))
+
+    passed = 0
+    token_sum = 0
+    token_count = 0
+    token_unavailable: list[str] = []
+    runtime_sum = 0.0
+    runtime_count = 0
+    runtime_unavailable: list[str] = []
+    provenance_inputs: list[dict[str, Any]] = []
+
+    for task_id in task_ids:
+        attempt = attempts_by_task.get(task_id)
+        metadata = attempt.metadata if attempt is not None else {}
+
+        reward_value = _task_reward(task_id, reward_by_task, metadata)
+        if reward_value >= 1.0:
+            passed += 1
+
+        total_tokens = metadata.get("total_tokens")
+        if isinstance(total_tokens, int):
+            token_sum += total_tokens
+            token_count += 1
+        else:
+            token_unavailable.append(task_id)
+
+        runtime_sec = _task_runtime_sec(metadata)
+        if runtime_sec is not None:
+            runtime_sum += runtime_sec
+            runtime_count += 1
+        else:
+            runtime_unavailable.append(task_id)
+
+        prov = metadata.get("provenance")
+        if isinstance(prov, dict):
+            provenance_inputs.append(prov)
+
+    total = len(task_ids)
+    return {
+        "run_id": result.run_id,
+        "benchmark": result.benchmark,
+        "total_tasks": total,
+        "passed_tasks": passed,
+        "pass_rate": (passed / total) if total else 0.0,
+        "task_names": task_ids,
+        "total_tokens_sum": token_sum if token_count else None,
+        "avg_total_tokens": (token_sum / token_count) if token_count else None,
+        "token_metrics_coverage": (token_count / total) if total else 0.0,
+        "token_metrics_available_tasks": token_count,
+        "token_metrics_unavailable_tasks": sorted(token_unavailable),
+        "runtime_sec_sum": runtime_sum if runtime_count else None,
+        "avg_runtime_sec": (runtime_sum / runtime_count) if runtime_count else None,
+        "runtime_metrics_coverage": (runtime_count / total) if total else 0.0,
+        "runtime_metrics_available_tasks": runtime_count,
+        "runtime_metrics_unavailable_tasks": sorted(runtime_unavailable),
+        "provenance": _aggregate_provenance(provenance_inputs),
+    }
+
+
+def run_gate_checks(
+    summary: dict[str, Any],
+    *,
+    thresholds: GateThresholds,
+    baseline_summary: dict[str, Any] | None = None,
+) -> list[GateCheck]:
+    """Apply absolute + relative (vs baseline) gate checks to a summary."""
+    checks: list[GateCheck] = []
+    total_tasks = int(summary["total_tasks"])
+    pass_rate = float(summary["pass_rate"])
+    provenance = summary.get("provenance") or {}
+
+    checks.append(GateCheck("non_empty_result_set", total_tasks > 0, f"total_tasks={total_tasks}"))
+    checks.append(
+        GateCheck(
+            "min_pass_rate",
+            pass_rate >= thresholds.min_pass_rate,
+            f"pass_rate={pass_rate:.3f}, min_pass_rate={thresholds.min_pass_rate:.3f}",
+        )
+    )
+    checks.append(_commit_consistency_check(provenance))
+
+    if thresholds.require_token_metrics:
+        token_coverage = float(summary["token_metrics_coverage"])
+        runtime_coverage = float(summary["runtime_metrics_coverage"])
+        checks.append(
+            GateCheck(
+                "token_metrics_available_for_all_tasks",
+                token_coverage == 1.0,
+                f"token_metrics_coverage={token_coverage:.3f}",
+            )
+        )
+        checks.append(
+            GateCheck(
+                "runtime_metrics_available_for_all_tasks",
+                runtime_coverage == 1.0,
+                f"runtime_metrics_coverage={runtime_coverage:.3f}",
+            )
+        )
+
+    if baseline_summary is not None:
+        checks.extend(_baseline_checks(summary, baseline_summary, thresholds))
+
+    return checks
+
+
+def _baseline_checks(
+    summary: dict[str, Any],
+    baseline_summary: dict[str, Any],
+    thresholds: GateThresholds,
+) -> list[GateCheck]:
+    checks: list[GateCheck] = []
+    pass_rate = float(summary["pass_rate"])
+    total_tokens_sum = summary["total_tokens_sum"]
+    runtime_sec_sum = summary["runtime_sec_sum"]
+    provenance = summary.get("provenance") or {}
+
+    # Regression checks only make sense when both runs measured the same tasks.
+    baseline_tasks = baseline_summary.get("task_names")
+    candidate_tasks = summary.get("task_names")
+    task_sets_comparable = True
+    if isinstance(baseline_tasks, list) and isinstance(candidate_tasks, list):
+        comparable = sorted(baseline_tasks) == sorted(candidate_tasks)
+        task_sets_comparable = comparable
+        checks.append(
+            GateCheck(
+                "baseline_candidate_task_sets_match",
+                comparable,
+                (
+                    f"both runs measured {len(candidate_tasks)} tasks"
+                    if comparable
+                    else f"baseline={sorted(baseline_tasks)} candidate={sorted(candidate_tasks)}; "
+                    "regression checks short-circuited"
+                ),
+            )
+        )
+    else:
+        checks.append(
+            GateCheck(
+                "baseline_candidate_task_sets_match",
+                True,
+                "task_names not present on baseline and/or candidate; skipping equality guard",
+            )
+        )
+
+    checks.append(_cross_commit_check(provenance, baseline_summary, thresholds.allow_cross_commit))
+
+    if not task_sets_comparable:
+        return checks
+
+    baseline_pass_rate = float(baseline_summary.get("pass_rate", 0.0))
+    checks.append(
+        GateCheck(
+            "no_pass_rate_regression_vs_baseline",
+            pass_rate >= baseline_pass_rate - thresholds.max_pass_rate_drop,
+            f"pass_rate={pass_rate:.3f}, baseline={baseline_pass_rate:.3f}, max_drop={thresholds.max_pass_rate_drop:.3f}",
+        )
+    )
+
+    baseline_tokens = baseline_summary.get("total_tokens_sum")
+    if isinstance(total_tokens_sum, int) and isinstance(baseline_tokens, int):
+        max_allowed = baseline_tokens * (1.0 + thresholds.max_token_regression_pct / 100.0)
+        checks.append(
+            GateCheck(
+                "tokens_not_worse_than_baseline",
+                total_tokens_sum <= max_allowed,
+                f"total_tokens_sum={total_tokens_sum}, baseline={baseline_tokens}, "
+                f"max_regression_pct={thresholds.max_token_regression_pct:.2f}",
+            )
+        )
+    else:
+        checks.append(
+            GateCheck(
+                "tokens_not_worse_than_baseline",
+                False,
+                "Missing token totals for candidate or baseline; cannot run deterministic token comparison.",
+            )
+        )
+
+    # Runtime is only a tie-breaker when token totals match exactly.
+    baseline_runtime = baseline_summary.get("runtime_sec_sum")
+    tokens_tied = (
+        isinstance(total_tokens_sum, int) and isinstance(baseline_tokens, int) and total_tokens_sum == baseline_tokens
+    )
+    if not tokens_tied:
+        checks.append(
+            GateCheck(
+                "runtime_tie_breaker_not_worse_than_baseline",
+                True,
+                "Not applicable (token totals differ from baseline).",
+            )
+        )
+    elif isinstance(runtime_sec_sum, int | float) and isinstance(baseline_runtime, int | float):
+        max_allowed_runtime = float(baseline_runtime) * (1.0 + thresholds.max_runtime_regression_pct / 100.0)
+        checks.append(
+            GateCheck(
+                "runtime_tie_breaker_not_worse_than_baseline",
+                float(runtime_sec_sum) <= max_allowed_runtime,
+                f"runtime_sec_sum={float(runtime_sec_sum):.3f}, baseline={float(baseline_runtime):.3f}, "
+                f"max_regression_pct={thresholds.max_runtime_regression_pct:.2f}",
+            )
+        )
+    else:
+        checks.append(
+            GateCheck(
+                "runtime_tie_breaker_not_worse_than_baseline",
+                False,
+                "Token totals tied with baseline but runtime totals missing; cannot run tie-breaker.",
+            )
+        )
+
+    return checks
+
+
+def _commit_consistency_check(provenance: dict[str, Any]) -> GateCheck:
+    commit_observed = provenance.get("commit_sha_observed")
+    if isinstance(commit_observed, list) and len(commit_observed) > 1:
+        return GateCheck(
+            "commit_sha_consistent_within_run",
+            False,
+            f"Multiple commit_sha values observed across tasks: {commit_observed}. Re-run from a single commit.",
+        )
+    commit_sha = provenance.get("commit_sha")
+    if commit_sha:
+        return GateCheck(
+            "commit_sha_consistent_within_run",
+            True,
+            f"commit={provenance.get('commit_short') or commit_sha[:12]}, branch={provenance.get('branch') or 'detached'}",
+        )
+    return GateCheck(
+        "commit_sha_consistent_within_run",
+        True,
+        "provenance not recorded (legacy artifacts); skipping commit consistency check.",
+    )
+
+
+def _cross_commit_check(
+    provenance: dict[str, Any],
+    baseline_summary: dict[str, Any],
+    allow_cross_commit: bool,
+) -> GateCheck:
+    baseline_commit = (baseline_summary.get("provenance") or {}).get("commit_sha")
+    candidate_commit = provenance.get("commit_sha")
+    if not (baseline_commit and candidate_commit):
+        return GateCheck(
+            "commit_sha_matches_baseline",
+            True,
+            "commit_sha not present on baseline and/or candidate; skipping cross-commit guard.",
+        )
+    commits_match = baseline_commit == candidate_commit
+    if commits_match:
+        detail = f"both runs at commit={baseline_commit[:12]}"
+    elif allow_cross_commit:
+        detail = (
+            f"baseline={baseline_commit[:12]} != candidate={candidate_commit[:12]}; "
+            "comparison allowed by allow_cross_commit (numbers may not be apples-to-apples)."
+        )
+    else:
+        detail = (
+            f"baseline={baseline_commit[:12]} != candidate={candidate_commit[:12]}. "
+            "Re-run candidate at the baseline commit, or set allow_cross_commit."
+        )
+    return GateCheck("commit_sha_matches_baseline", commits_match or allow_cross_commit, detail)
+
+
+def _rewards_by_task(results: list[AgentEvalTaskResult], reward_outputs: tuple[str, ...]) -> dict[str, float]:
+    rewards: dict[str, float] = {}
+    for task_result in results:
+        for output_name in reward_outputs:
+            value = _numeric_output(task_result, output_name)
+            if value is not None:
+                # Highest-priority output wins; don't overwrite with later metrics.
+                rewards.setdefault(task_result.task_id, value)
+                break
+    return rewards
+
+
+def _numeric_output(task_result: AgentEvalTaskResult, name: str) -> float | None:
+    for output in task_result.outputs:
+        if output.name == name:
+            try:
+                return float(output.value)
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _task_reward(task_id: str, reward_by_task: dict[str, float], metadata: dict[str, Any]) -> float:
+    if task_id in reward_by_task:
+        return reward_by_task[task_id]
+    reward = metadata.get("reward")
+    if reward is not None:
+        try:
+            return float(reward)
+        except (TypeError, ValueError):
+            return 0.0
+    return 1.0 if metadata.get("passed") is True else 0.0
+
+
+def _task_runtime_sec(metadata: dict[str, Any]) -> float | None:
+    runtime_sec = metadata.get("runtime_sec")
+    if isinstance(runtime_sec, int | float):
+        return float(runtime_sec)
+    duration_ms = metadata.get("duration_ms")
+    if isinstance(duration_ms, int | float):
+        return float(duration_ms) / 1000.0
+    return None
+
+
+def _aggregate_provenance(provenances: list[dict[str, Any]]) -> dict[str, Any]:
+    observed: dict[str, set[Any]] = {field_name: set() for field_name in _PROVENANCE_FIELDS}
+    for prov in provenances:
+        for field_name in _PROVENANCE_FIELDS:
+            value = prov.get(field_name)
+            if value is not None:
+                observed[field_name].add(value)
+
+    aggregated: dict[str, Any] = {"available": bool(provenances)}
+    for field_name in _PROVENANCE_FIELDS:
+        values = observed[field_name]
+        if len(values) == 1:
+            aggregated[field_name] = next(iter(values))
+        else:
+            aggregated[field_name] = None
+            if len(values) > 1:
+                aggregated[f"{field_name}_observed"] = sorted(map(str, values))
+    return aggregated
+
+
+def _validate_baseline_summary(summary: dict[str, Any], source: Path) -> None:
+    missing = [key for key in ("pass_rate", "total_tokens_sum", "runtime_sec_sum") if key not in summary]
+    if missing:
+        raise ValueError(
+            f"Baseline summary {source} is missing required key(s): {', '.join(missing)}. "
+            "Expected a raw summary object or a gate.json with a `summary`."
+        )
+    if not isinstance(summary.get("pass_rate"), int | float):
+        raise ValueError(f"Baseline summary {source} has invalid `pass_rate`; expected a number.")

--- a/tests/agentic-use/runtimes/shared/result_adapter.py
+++ b/tests/agentic-use/runtimes/shared/result_adapter.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Adapt ``nat_runner`` ``result.json`` records into ``AgentEvalAttempt`` values.
+
+This bridges the existing ``nat_runner`` output contract (see
+``nat_runner._write_result``) onto the agent-eval SDK so a run that already
+produced ``result.json`` can be imported as an attempt without re-executing the
+agent. Per the design doc, ``result.json`` carries the attempt *status*,
+*measurements* (reward + token/cost), and *provenance*.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from evaluator_agent_eval.artifacts import AgentArtifacts
+from nemo_evaluator_sdk.agent_eval.types import AgentEvalAttempt, AgentEvalTask, AgentOutput
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence
+
+from runtimes.shared.artifacts import _evidence_descriptors  # reuse documented evidence map
+from runtimes.shared.layout import AgenticRunLayout
+
+# Token/cost measurement keys carried in result.json["metrics"].
+_METRIC_KEYS = (
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+    "cache_creation_tokens",
+    "cache_read_tokens",
+    "n_assistant_messages",
+    "cost_usd",
+    "num_turns",
+    "duration_ms",
+    "token_metrics_status",
+    "token_metrics_note",
+)
+
+
+def attempt_from_result_dir(output_dir: str | Path, *, task: AgentEvalTask | None = None) -> AgentEvalAttempt:
+    """Load ``<output_dir>/result.json`` and build an attempt from it."""
+    output_dir = Path(output_dir)
+    result_path = output_dir / "result.json"
+    if not result_path.is_file():
+        raise FileNotFoundError(f"result.json not found in {output_dir}")
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    return attempt_from_result(result, output_dir=output_dir, task=task)
+
+
+def attempt_from_result(
+    result: dict[str, Any],
+    *,
+    output_dir: str | Path | None = None,
+    task: AgentEvalTask | None = None,
+) -> AgentEvalAttempt:
+    """Project a ``result.json`` dict onto :class:`AgentEvalAttempt`.
+
+    The attempt ``status`` reflects whether the agent produced a usable
+    response (``agent`` phase outcome). Pass/fail from the verifier is recorded
+    as a *measurement* in metadata (``reward``/``passed``) so scoring metrics —
+    not the runtime — remain the source of truth.
+    """
+    task_id = str(result.get("task") or (task.id if task is not None else "unknown"))
+    backend = str(result.get("agent_backend") or "unknown")
+    resolved_dir = Path(output_dir) if output_dir is not None else Path(str(result.get("output_dir") or "."))
+    layout = _layout_from_result_dir(resolved_dir)
+
+    agent_phase = str(result.get("agent") or "")
+    status = "completed" if agent_phase in {"ok", "skipped"} else "failed"
+
+    output_text, final_extracted, final_source = _resolve_output_text(layout)
+    if not output_text:
+        output_text = "(agent phase failed)" if status == "failed" else ""
+
+    descriptors = _evidence_descriptors(
+        layout, AgentArtifacts.from_dir(layout.agent_log_dir, workspace_dir=layout.workspace_dir)
+    )
+
+    metrics = dict(result.get("metrics") or {})
+    metadata: dict[str, Any] = {
+        # Canonical CapturedAgentAttempt-style provenance fields.
+        "agent_runtime": backend,
+        "agent_model": result.get("agent_model"),
+        "run_id": (result.get("provenance") or {}).get("run_id"),
+        "exit_code": 0 if agent_phase in {"ok", "skipped"} else 1,
+        "duration_ms": metrics.get("duration_ms"),
+        # Phase outcomes from result.json.
+        "agent_ok": agent_phase in {"ok", "skipped"},
+        "build_status": result.get("build"),
+        "agent_status": result.get("agent"),
+        "verify_status": result.get("verify"),
+        # Measurements (verifier reward is a measurement, not attempt status).
+        "passed": result.get("passed"),
+        "reward": result.get("reward"),
+        "runtime_sec": result.get("runtime_sec"),
+        "verifier_scores": result.get("verifier_scores"),
+        # Provenance + candidate identity.
+        "provenance": result.get("provenance"),
+        "candidate_id": result.get("candidate_id"),
+        "candidate_params": result.get("candidate_params"),
+        "image": result.get("image"),
+        "output_dir": str(resolved_dir),
+        # Artifact discovery helpers.
+        "agent_log_dir": str(layout.agent_log_dir),
+        "workspace_dir": str(layout.workspace_dir),
+        "state_dir": str(layout.state_dir),
+        "final_answer_extracted": final_extracted,
+        "final_answer_source": final_source,
+    }
+    metadata.update({key: metrics.get(key) for key in _METRIC_KEYS})
+
+    return AgentEvalAttempt(
+        id=f"{task_id}:{backend}",
+        task_id=task_id,
+        status=status,
+        output=AgentOutput(text=output_text),
+        evidence=CandidateEvidence(descriptors=descriptors) if descriptors else None,
+        metadata=metadata,
+    )
+
+
+def _layout_from_result_dir(output_dir: Path) -> AgenticRunLayout:
+    agent_log_dir = output_dir / "agent"
+    return AgenticRunLayout(
+        run_dir=output_dir,
+        agent_log_dir=agent_log_dir,
+        workspace_dir=output_dir / "workspace",
+        state_dir=output_dir / "state",
+        instruction_path=agent_log_dir / "instruction.md",
+    )
+
+
+def _resolve_output_text(layout: AgenticRunLayout) -> tuple[str, bool, str | None]:
+    if not layout.agent_log_dir.is_dir():
+        return "", False, None
+    artifacts = AgentArtifacts.from_dir(layout.agent_log_dir, workspace_dir=layout.workspace_dir)
+    if artifacts.final_answer.extracted and artifacts.final_answer.text:
+        return artifacts.final_answer.text, True, artifacts.final_answer.source
+    log_path = layout.agent_log_dir / "nat_agent.log"
+    if log_path.is_file():
+        return log_path.read_text(encoding="utf-8", errors="replace").strip(), False, None
+    return "", False, None

--- a/tests/agentic-use/runtimes/shared/result_adapter.py
+++ b/tests/agentic-use/runtimes/shared/result_adapter.py
@@ -20,7 +20,7 @@ from evaluator_agent_eval.artifacts import AgentArtifacts
 from nemo_evaluator_sdk.agent_eval.types import AgentEvalAttempt, AgentEvalTask, AgentOutput
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence
 
-from runtimes.shared.artifacts import _evidence_descriptors  # reuse documented evidence map
+from runtimes.shared.artifacts import _evidence_descriptors, resolve_attempt_status  # reuse documented helpers
 from runtimes.shared.layout import AgenticRunLayout
 
 # Token/cost measurement keys carried in result.json["metrics"].
@@ -68,11 +68,12 @@ def attempt_from_result(
     layout = _layout_from_result_dir(resolved_dir)
 
     agent_phase = str(result.get("agent") or "")
-    status = "completed" if agent_phase in {"ok", "skipped"} else "failed"
+    agent_ok = agent_phase in {"ok", "skipped"}
+    status = resolve_attempt_status(agent_ok)
 
     output_text, final_extracted, final_source = _resolve_output_text(layout)
     if not output_text:
-        output_text = "(agent phase failed)" if status == "failed" else ""
+        output_text = "" if agent_ok else "(agent phase failed)"
 
     descriptors = _evidence_descriptors(
         layout, AgentArtifacts.from_dir(layout.agent_log_dir, workspace_dir=layout.workspace_dir)
@@ -84,10 +85,10 @@ def attempt_from_result(
         "agent_runtime": backend,
         "agent_model": result.get("agent_model"),
         "run_id": (result.get("provenance") or {}).get("run_id"),
-        "exit_code": 0 if agent_phase in {"ok", "skipped"} else 1,
+        "exit_code": 0 if agent_ok else 1,
         "duration_ms": metrics.get("duration_ms"),
         # Phase outcomes from result.json.
-        "agent_ok": agent_phase in {"ok", "skipped"},
+        "agent_ok": agent_ok,
         "build_status": result.get("build"),
         "agent_status": result.get("agent"),
         "verify_status": result.get("verify"),

--- a/tests/agentic-use/runtimes/shared/task_loader.py
+++ b/tests/agentic-use/runtimes/shared/task_loader.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Map agentic-use task directories to AgentEvalTask values."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from nemo_evaluator_sdk.agent_eval.types import AgentEvalTask
+
+from runtimes.shared.constants import AGENTIC_USE_DIR
+
+
+def load_task_toml(task_dir: Path) -> dict[str, object]:
+    task_toml = task_dir / "task.toml"
+    if not task_toml.exists():
+        return {}
+    try:
+        with task_toml.open("rb") as handle:
+            data = tomllib.load(handle)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def task_agent_timeout_sec(task_dir: Path) -> int | None:
+    data = load_task_toml(task_dir)
+    agent = data.get("agent")
+    if not isinstance(agent, dict):
+        return None
+    timeout_value = agent.get("timeout_sec")
+    if isinstance(timeout_value, (int, float)) and timeout_value > 0:
+        return int(timeout_value)
+    return None
+
+
+def agentic_task_from_dir(task_dir: str | Path, *, tasks_root: Path | None = None) -> AgentEvalTask:
+    """Build an :class:`AgentEvalTask` from an agentic-use task directory."""
+    root = Path(tasks_root or AGENTIC_USE_DIR)
+    task_path = Path(task_dir)
+    if not task_path.is_absolute():
+        task_path = (root / task_path).resolve()
+
+    instruction_path = task_path / "instruction.md"
+    if not instruction_path.exists():
+        raise FileNotFoundError(f"instruction.md not found in {task_path}")
+
+    instruction = instruction_path.read_text(encoding="utf-8")
+    task_toml = load_task_toml(task_path)
+
+    return AgentEvalTask(
+        id=task_path.name,
+        intent=instruction,
+        inputs={
+            "prompt": instruction,
+            "task_dir": str(task_path),
+        },
+        metrics=[],
+        metadata={
+            "benchmark": "agentic-use",
+            "task_toml": task_toml,
+            "instruction_path": str(instruction_path),
+        },
+    )

--- a/tests/agentic-use/runtimes/shared/task_loader.py
+++ b/tests/agentic-use/runtimes/shared/task_loader.py
@@ -9,8 +9,10 @@ import tomllib
 from pathlib import Path
 
 from nemo_evaluator_sdk.agent_eval.types import AgentEvalTask
+from nemo_evaluator_sdk.metrics.protocol import Metric
 
 from runtimes.shared.constants import AGENTIC_USE_DIR
+from runtimes.shared.metrics import AgentPhaseSuccessMetric
 
 
 def load_task_toml(task_dir: Path) -> dict[str, object]:
@@ -36,8 +38,20 @@ def task_agent_timeout_sec(task_dir: Path) -> int | None:
     return None
 
 
-def agentic_task_from_dir(task_dir: str | Path, *, tasks_root: Path | None = None) -> AgentEvalTask:
-    """Build an :class:`AgentEvalTask` from an agentic-use task directory."""
+def agentic_task_from_dir(
+    task_dir: str | Path,
+    *,
+    tasks_root: Path | None = None,
+    metrics: list[Metric] | None = None,
+) -> AgentEvalTask:
+    """Build an :class:`AgentEvalTask` from an agentic-use task directory.
+
+    ``inputs`` carries only agent-facing material (``instruction``) per the SDK
+    design doc; runtime materialization details such as ``task_dir`` live in
+    ``metadata`` so they cannot leak into metric scoring rows. Metrics are
+    authored *on the task* (defaulting to :class:`AgentPhaseSuccessMetric`); the
+    orchestrator only appends compatibility metrics, it does not own the set.
+    """
     root = Path(tasks_root or AGENTIC_USE_DIR)
     task_path = Path(task_dir)
     if not task_path.is_absolute():
@@ -54,13 +68,13 @@ def agentic_task_from_dir(task_dir: str | Path, *, tasks_root: Path | None = Non
         id=task_path.name,
         intent=instruction,
         inputs={
-            "prompt": instruction,
-            "task_dir": str(task_path),
+            "instruction": instruction,
         },
-        metrics=[],
+        metrics=metrics if metrics is not None else [AgentPhaseSuccessMetric()],
         metadata={
             "benchmark": "agentic-use",
             "task_toml": task_toml,
             "instruction_path": str(instruction_path),
+            "task_dir": str(task_path),
         },
     )

--- a/tests/agentic-use/runtimes/shared/usage.py
+++ b/tests/agentic-use/runtimes/shared/usage.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Token usage extraction from agent logs.
+
+Reuses the proven implementation from ``nat_runner.py`` until the legacy
+runner delegates here and the duplicate can be removed.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class TokenMetrics(TypedDict):
+    prompt_tokens: int | None
+    completion_tokens: int | None
+    total_tokens: int | None
+    cache_creation_tokens: int | None
+    cache_read_tokens: int | None
+    n_assistant_messages: int | None
+    cost_usd: float | None
+    num_turns: int | None
+    duration_ms: float | None
+
+
+def extract_usage_metrics(agent_log: str) -> dict[str, int | float | None]:
+    """Extract token usage metrics from an agent log."""
+    import nat_runner
+
+    metrics = nat_runner._extract_usage_metrics(agent_log)
+    return dict(metrics)

--- a/tests/agentic-use/runtimes/shared/verify.py
+++ b/tests/agentic-use/runtimes/shared/verify.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live VERIFY phase executed through the environment boundary.
+
+Ports ``nat_runner.run_verify_phase`` onto :meth:`AgentEnvironmentHandle.run_verifier`
+so the task-local ``tests/test_outputs.py`` pytest verifier runs in the *same*
+prepared environment (and against the same persisted workspace/state) as the
+agent phase. The resulting reward is stamped onto the attempt metadata so the
+``VerifierRewardMetric`` compatibility metric scores it through the Evaluator SDK.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from runtimes.shared.constants import (
+    DOCKER_SOCKET_CONTAINER_PATH,
+    DOCKER_SOCKET_HOST_PATH,
+    EVALUATOR_SDK_SRC,
+    FILES_STORAGE_CONFIG,
+    PLATFORM_CONFIG_PATH,
+    SHARED_DIR,
+)
+from runtimes.shared.environment import AgentEnvironmentHandle, EnvRunSpec
+from runtimes.shared.layout import AgenticRunLayout
+
+
+@dataclass(frozen=True)
+class VerifierOutcome:
+    """Result of the live verifier phase for one task."""
+
+    ran: bool
+    passed: bool
+    reward: int
+    exit_code: int
+    stdout: str
+    verifier_log_dir: Path | None
+
+
+def verifier_log_dir(layout: AgenticRunLayout) -> Path:
+    return layout.run_dir / "verifier"
+
+
+def build_verify_run_spec(
+    task_dir: Path,
+    layout: AgenticRunLayout,
+    *,
+    nmp_base_url: str,
+    agent_backend: str,
+    agent_model: str,
+    smoke_workspace: str | None = None,
+    timeout_sec: int | None = None,
+    extra_args: list[str] | None = None,
+) -> EnvRunSpec | None:
+    """Build the verifier ``EnvRunSpec`` mirroring ``nat_runner.run_verify_phase``.
+
+    Returns ``None`` when the task has no ``tests/test_outputs.py`` (nothing to
+    verify), matching the runner's behavior.
+    """
+    tests_dir = task_dir / "tests"
+    if not (tests_dir / "test_outputs.py").exists():
+        return None
+
+    log_dir = verifier_log_dir(layout)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    layout.workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    smoke_seed_cmd = ""
+    smoke_cleanup_cmd = ""
+    if smoke_workspace:
+        smoke_seed_cmd = textwrap.dedent("""\
+            /app/.venv/bin/nemo workspaces create "${SMOKE_WORKSPACE}" \
+              --description "Seeded by agentic runtime smoke mode" >/dev/null 2>&1 || true
+        """)
+        smoke_cleanup_cmd = textwrap.dedent("""\
+            /app/.venv/bin/nemo workspaces delete "${SMOKE_WORKSPACE}" >/dev/null 2>&1 || true
+        """)
+
+    verify_cmd = [
+        "bash",
+        "-c",
+        textwrap.dedent(f"""\
+            export PYTHONPATH="/app/tests/agentic-use/shared:/app/packages/nemo_evaluator_sdk/src:${{PYTHONPATH}}"
+            export NAT_AGENT=1
+            {smoke_seed_cmd}
+            /app/.venv/bin/python -m pytest /tests/test_outputs.py -rA -v 2>&1 | tee /logs/verifier/test-stdout.txt
+            EXIT=${{PIPESTATUS[0]}}
+            {smoke_cleanup_cmd}
+            if [ $EXIT -eq 0 ]; then echo 1; else echo 0; fi > /logs/verifier/reward.txt
+            exit $EXIT
+        """),
+    ]
+
+    env: dict[str, str] = {
+        "NMP_BASE_URL": nmp_base_url,
+        "NAT_AGENT": "1",
+        "NAT_AGENT_BACKEND": agent_backend,
+        "NAT_AGENT_MODEL": agent_model,
+        "AGENTIC_USE_TASK_DIR": "/task",
+        "AGENTIC_USE_WORKSPACE_DIR": "/app/workspace",
+        "SMOKE_WORKSPACE": smoke_workspace or "",
+        "DATABASE_DIALECT": "sqlite",
+        "DATABASE_PATH": "/data/nmp-platform.db",
+        "NMP_FILES_DEFAULT_STORAGE_CONFIG": FILES_STORAGE_CONFIG,
+        "NMP_CONFIG_FILE_PATH": PLATFORM_CONFIG_PATH,
+    }
+    if DOCKER_SOCKET_HOST_PATH.exists():
+        env["DOCKER_HOST"] = f"unix://{DOCKER_SOCKET_CONTAINER_PATH}"
+
+    mounts: list[tuple[str, str]] = [
+        (str(tests_dir), "/tests"),
+        (str(task_dir), "/task"),
+        (str(layout.workspace_dir), "/app/workspace"),
+        (str(SHARED_DIR), "/app/tests/agentic-use/shared:ro"),
+        (str(EVALUATOR_SDK_SRC), "/app/packages/nemo_evaluator_sdk/src:ro"),
+        (str(layout.agent_log_dir), "/logs/agent"),
+        (str(log_dir), "/logs/verifier"),
+        # Persist platform/db state across AGENT and VERIFY containers.
+        (str(layout.state_dir), "/data"),
+    ]
+    if DOCKER_SOCKET_HOST_PATH.exists():
+        mounts.append((str(DOCKER_SOCKET_HOST_PATH), DOCKER_SOCKET_CONTAINER_PATH))
+
+    return EnvRunSpec(
+        command=verify_cmd,
+        env=env,
+        mounts=mounts,
+        timeout=timeout_sec,
+        extra_args=list(extra_args or []),
+    )
+
+
+async def run_verify(
+    handle: AgentEnvironmentHandle,
+    spec: EnvRunSpec,
+    layout: AgenticRunLayout,
+) -> VerifierOutcome:
+    """Execute the verifier through the environment handle and collect reward."""
+    result = await handle.run_verifier(spec)
+    log_dir = verifier_log_dir(layout)
+    passed = result.ok
+
+    stdout = ""
+    stdout_path = log_dir / "test-stdout.txt"
+    if stdout_path.is_file():
+        stdout = stdout_path.read_text(encoding="utf-8", errors="replace")
+
+    reward_path = log_dir / "reward.txt"
+    if reward_path.is_file():
+        reward = 1 if reward_path.read_text(encoding="utf-8").strip() == "1" else 0
+    else:
+        reward = 1 if passed else 0
+        reward_path.write_text("1\n" if passed else "0\n", encoding="utf-8")
+
+    return VerifierOutcome(
+        ran=True,
+        passed=passed,
+        reward=reward,
+        exit_code=result.exit_code,
+        stdout=stdout,
+        verifier_log_dir=log_dir,
+    )
+
+
+async def maybe_run_verify(
+    handle: AgentEnvironmentHandle,
+    *,
+    enabled: bool,
+    task_dir: Path,
+    layout: AgenticRunLayout,
+    nmp_base_url: str,
+    agent_backend: str,
+    agent_model: str,
+    smoke_workspace: str | None = None,
+    timeout_sec: int | None = None,
+    extra_args: list[str] | None = None,
+) -> VerifierOutcome:
+    """Run the verifier through ``handle`` when enabled and a verifier exists."""
+    if not enabled:
+        return VerifierOutcome(ran=False, passed=False, reward=0, exit_code=0, stdout="", verifier_log_dir=None)
+    spec = build_verify_run_spec(
+        task_dir,
+        layout,
+        nmp_base_url=nmp_base_url,
+        agent_backend=agent_backend,
+        agent_model=agent_model,
+        smoke_workspace=smoke_workspace,
+        timeout_sec=timeout_sec,
+        extra_args=extra_args,
+    )
+    if spec is None:
+        return VerifierOutcome(ran=False, passed=False, reward=0, exit_code=0, stdout="", verifier_log_dir=None)
+    return await run_verify(handle, spec, layout)
+
+
+def apply_verify_to_metadata(metadata: dict[str, Any], outcome: VerifierOutcome) -> None:
+    """Stamp verifier reward/status onto attempt metadata for scoring + gating."""
+    if not outcome.ran:
+        metadata.setdefault("verify_status", "skipped")
+        return
+    metadata["verify_status"] = "ok" if outcome.passed else "failed"
+    metadata["passed"] = outcome.passed
+    metadata["reward"] = outcome.reward
+    metadata["verifier_log_dir"] = str(outcome.verifier_log_dir) if outcome.verifier_log_dir else None

--- a/tests/agentic-use/runtimes/workflow/__init__.py
+++ b/tests/agentic-use/runtimes/workflow/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NAT workflow runtime."""
+
+from runtimes.workflow.runtime import NatWorkflowAttemptRuntime
+
+__all__ = ["NatWorkflowAttemptRuntime"]

--- a/tests/agentic-use/runtimes/workflow/command.py
+++ b/tests/agentic-use/runtimes/workflow/command.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build the container command for the NAT workflow backend."""
+
+from __future__ import annotations
+
+import textwrap
+
+from runtimes.shared.constants import NAT_TRACE_EXPORT_SCRIPT_CONTAINER_PATH
+
+
+def build_workflow_agent_cmd(workflow_container: str, instruction_container: str) -> list[str]:
+    """Build the ``bash -c`` command that runs the ``nat run`` workflow backend."""
+    return [
+        "bash",
+        "-c",
+        textwrap.dedent(f"""\
+            /app/.venv/bin/nat run \\
+              --config_file {workflow_container} \\
+              --input "$(cat {instruction_container})" \\
+              2>&1 | tee /tmp/nat_agent.log
+            EXIT=${{PIPESTATUS[0]}}
+            cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
+            if [ -f /logs/agent/intermediate_steps.jsonl ]; then
+              /app/.venv/bin/python {NAT_TRACE_EXPORT_SCRIPT_CONTAINER_PATH} convert-jsonl \\
+                --input /logs/agent/intermediate_steps.jsonl \\
+                --output /logs/agent/trajectory.json \\
+                >> /tmp/nat_agent.log 2>&1
+              CONVERT_EXIT=$?
+              cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
+              if [ $EXIT -eq 0 ] && [ $CONVERT_EXIT -ne 0 ]; then
+                exit $CONVERT_EXIT
+              fi
+            elif [ $EXIT -eq 0 ]; then
+              echo "NAT telemetry exporter did not create /logs/agent/intermediate_steps.jsonl" | tee -a /tmp/nat_agent.log
+              cp /tmp/nat_agent.log /logs/agent/nat_agent.log 2>/dev/null || true
+              exit 1
+            fi
+            exit $EXIT
+        """),
+    ]

--- a/tests/agentic-use/runtimes/workflow/prep.py
+++ b/tests/agentic-use/runtimes/workflow/prep.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare NAT workflow files for container execution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def prepare_workflow_for_runtime(
+    workflow_path: Path,
+    output_dir: Path,
+    nmp_base_url: str,
+    *,
+    nat_model: str | None = None,
+) -> Path:
+    """Prepare a NAT workflow file compatible with current NAT schema."""
+    text = workflow_path.read_text(encoding="utf-8")
+    text = text.replace("http://localhost:8080", nmp_base_url)
+    if nat_model:
+        text = text.replace(
+            "model_name: nvidia/llama-3.1-nemotron-70b-instruct",
+            f"model_name: {nat_model}",
+            1,
+        )
+
+    if "_type: mcp_client" in text or "_type: per_user_mcp_client" in text:
+        if "\nfunction_groups:\n" not in text and "\nfunctions:\n" in text:
+            text = text.replace("\nfunctions:\n", "\nfunction_groups:\n", 1)
+
+    config = yaml.safe_load(text)
+    if not isinstance(config, dict):
+        raise ValueError(f"Workflow config must be a mapping: {workflow_path}")
+    general = config.setdefault("general", {})
+    if not isinstance(general, dict):
+        raise ValueError(f"Workflow general config must be a mapping: {workflow_path}")
+    telemetry = general.setdefault("telemetry", {})
+    if not isinstance(telemetry, dict):
+        raise ValueError(f"Workflow telemetry config must be a mapping: {workflow_path}")
+    tracing = telemetry.setdefault("tracing", {})
+    if not isinstance(tracing, dict):
+        raise ValueError(f"Workflow telemetry tracing config must be a mapping: {workflow_path}")
+    tracing["agentic_use_file_trace"] = {
+        "_type": "file",
+        "output_path": "/logs/agent/intermediate_steps.jsonl",
+        "project": "agentic-use",
+        "mode": "overwrite",
+        "cleanup_on_init": True,
+    }
+
+    text = yaml.dump(config, default_flow_style=False, sort_keys=False)
+    rewritten = output_dir / "workflow.runtime.yml"
+    rewritten.write_text(text, encoding="utf-8")
+    return rewritten

--- a/tests/agentic-use/runtimes/workflow/runtime.py
+++ b/tests/agentic-use/runtimes/workflow/runtime.py
@@ -55,7 +55,7 @@ class NatWorkflowAttemptRuntime:
                 verify_outcome = await maybe_run_verify(
                     handle,
                     enabled=shared.run_verify and result.ok,
-                    task_dir=Path(str(task.inputs["task_dir"])),
+                    task_dir=Path(str(task.metadata["task_dir"])),
                     layout=layout,
                     nmp_base_url=shared.nmp_base_url,
                     agent_backend=RUNTIME_NAME,
@@ -83,7 +83,7 @@ class NatWorkflowAttemptRuntime:
         return self.config.agent_model or "unknown"
 
     def _agent_run_spec(self, task: AgentEvalTask, layout: AgenticRunLayout) -> EnvRunSpec:
-        task_dir = Path(str(task.inputs["task_dir"]))
+        task_dir = Path(str(task.metadata["task_dir"]))
         workflow_path = task_dir / "workflow.yml"
         if not workflow_path.exists():
             raise FileNotFoundError(f"workflow.yml not found in {task_dir}")

--- a/tests/agentic-use/runtimes/workflow/runtime.py
+++ b/tests/agentic-use/runtimes/workflow/runtime.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NAT workflow backend as an AgentAttemptRuntime."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from nemo_evaluator_sdk.agent_eval.types import AgentEvalAttempt, AgentEvalRunConfig, AgentEvalTask
+
+from runtimes.shared.artifacts import build_agent_eval_attempt
+from runtimes.shared.config import WorkflowRuntimeConfig
+from runtimes.shared.constants import INSTRUCTION_CONTAINER_PATH, WORKFLOW_CONTAINER_PATH
+from runtimes.shared.container_env import base_container_env
+from runtimes.shared.environment import (
+    AgentEnvironmentProvider,
+    DockerEnvironmentProvider,
+    EnvRunSpec,
+)
+from runtimes.shared.layout import AgenticRunLayout, resolve_run_layout
+from runtimes.shared.task_loader import task_agent_timeout_sec
+from runtimes.shared.verify import apply_verify_to_metadata, maybe_run_verify
+from runtimes.workflow.command import build_workflow_agent_cmd
+from runtimes.workflow.prep import prepare_workflow_for_runtime
+
+RUNTIME_NAME = "workflow"
+
+
+class NatWorkflowAttemptRuntime:
+    """Run agentic-use tasks via task-local ``nat run`` workflows."""
+
+    def __init__(
+        self,
+        config: WorkflowRuntimeConfig,
+        *,
+        environment: AgentEnvironmentProvider | None = None,
+    ) -> None:
+        self.config = config
+        self.environment = environment or DockerEnvironmentProvider()
+
+    async def run_tasks(
+        self,
+        tasks: Sequence[AgentEvalTask],
+        config: AgentEvalRunConfig | None = None,
+    ) -> list[AgentEvalAttempt]:
+        attempts: list[AgentEvalAttempt] = []
+        for task in tasks:
+            layout = resolve_run_layout(task, self.config.shared, config)
+            shared = self.config.shared
+            handle = await self.environment.prepare(task, config)
+            try:
+                result = await handle.run_agent(self._agent_run_spec(task, layout))
+                verify_outcome = await maybe_run_verify(
+                    handle,
+                    enabled=shared.run_verify and result.ok,
+                    task_dir=Path(str(task.inputs["task_dir"])),
+                    layout=layout,
+                    nmp_base_url=shared.nmp_base_url,
+                    agent_backend=RUNTIME_NAME,
+                    agent_model=self._resolved_model(),
+                    smoke_workspace=shared.smoke_workspace,
+                    timeout_sec=shared.timeout_sec + 120,
+                    extra_args=list(shared.docker_extra_args),
+                )
+            finally:
+                await handle.close()
+
+            attempt = build_agent_eval_attempt(
+                task=task,
+                layout=layout,
+                runtime_name=RUNTIME_NAME,
+                agent_model=self._resolved_model(),
+                exit_code=result.exit_code,
+                agent_ok=result.ok,
+            )
+            apply_verify_to_metadata(attempt.metadata, verify_outcome)
+            attempts.append(attempt)
+        return attempts
+
+    def _resolved_model(self) -> str:
+        return self.config.agent_model or "unknown"
+
+    def _agent_run_spec(self, task: AgentEvalTask, layout: AgenticRunLayout) -> EnvRunSpec:
+        task_dir = Path(str(task.inputs["task_dir"]))
+        workflow_path = task_dir / "workflow.yml"
+        if not workflow_path.exists():
+            raise FileNotFoundError(f"workflow.yml not found in {task_dir}")
+
+        shared = self.config.shared
+        task_timeout = task_agent_timeout_sec(task_dir)
+        timeout_sec = max(shared.timeout_sec, task_timeout or 0)
+
+        workflow_host = prepare_workflow_for_runtime(
+            workflow_path,
+            layout.agent_log_dir,
+            shared.nmp_base_url,
+            nat_model=self.config.agent_model,
+        )
+
+        env = base_container_env(shared, timeout_sec=timeout_sec)
+        if shared.nvidia_api_key:
+            env["NVIDIA_API_KEY"] = shared.nvidia_api_key
+        if self.config.agent_model:
+            env["NAT_MODEL"] = self.config.agent_model
+
+        mounts = [
+            (str(layout.instruction_path), INSTRUCTION_CONTAINER_PATH),
+            (str(layout.agent_log_dir), "/logs/agent"),
+            (str(layout.workspace_dir), "/app/workspace"),
+            (str(workflow_host), WORKFLOW_CONTAINER_PATH),
+            (str(layout.state_dir), "/data"),
+        ]
+
+        return EnvRunSpec(
+            command=build_workflow_agent_cmd(WORKFLOW_CONTAINER_PATH, INSTRUCTION_CONTAINER_PATH),
+            env=env,
+            mounts=mounts,
+            timeout=timeout_sec + 120,
+            extra_args=list(shared.docker_extra_args),
+        )

--- a/tests/agentic-use/tests/test_agentic_runtimes.py
+++ b/tests/agentic-use/tests/test_agentic_runtimes.py
@@ -48,7 +48,11 @@ def test_agentic_task_from_dir_loads_instruction() -> None:
     task = agentic_task_from_dir(WORKSPACE_BASIC, tasks_root=TASKS_DIR)
     assert task.id == "workspace-basic-cli-easy"
     assert "workspace" in task.intent.lower()
-    assert task.inputs["task_dir"] == str(WORKSPACE_BASIC.resolve())
+    # inputs stays agent-facing; runtime materialization (task_dir) lives in metadata.
+    assert task.inputs == {"instruction": task.intent}
+    assert task.metadata["task_dir"] == str(WORKSPACE_BASIC.resolve())
+    # metrics are authored on the task, not injected by the orchestrator.
+    assert [metric.type for metric in task.metrics] == ["agentic_use_agent_phase"]
 
 
 class _FakeEnvHandle:
@@ -213,7 +217,7 @@ def test_attempt_from_result_maps_status_and_measurements(tmp_path: Path) -> Non
     assert {"logs", "final_state", "state"} <= set(attempt.evidence.descriptors)
 
 
-def test_attempt_from_result_marks_failed_agent(tmp_path: Path) -> None:
+def test_attempt_from_result_marks_unsuccessful_agent_partial(tmp_path: Path) -> None:
     from runtimes.shared.result_adapter import attempt_from_result
 
     output_dir = tmp_path / "run"
@@ -221,9 +225,47 @@ def test_attempt_from_result_marks_failed_agent(tmp_path: Path) -> None:
     result = {"task": "demo", "agent_backend": "aut", "agent": "failed", "passed": False, "reward": 0}
 
     attempt = attempt_from_result(result, output_dir=output_dir)
-    assert attempt.status == "failed"
+    # An agent that ran but failed stays *scorable* ("partial"); the SDK excludes
+    # "failed" from scoring, so we reserve it for true production failures.
+    assert attempt.status == "partial"
     assert attempt.metadata["agent_ok"] is False
     assert attempt.output is not None
+
+
+@pytest.mark.asyncio
+async def test_score_captured_attempts_offline(tmp_path: Path) -> None:
+    import json
+
+    from runtimes.orchestrator import AgenticEvalOrchestrator
+    from runtimes.workflow.runtime import NatWorkflowAttemptRuntime
+
+    run_dir = tmp_path / "run"
+    (run_dir / "agent").mkdir(parents=True)
+    (run_dir / "workspace").mkdir()
+    (run_dir / "agent" / "nat_agent.log").write_text("done", encoding="utf-8")
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task": WORKSPACE_BASIC.name,
+                "agent_backend": "workflow",
+                "agent": "ok",
+                "passed": True,
+                "reward": 1,
+                "metrics": {"total_tokens": 10},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    orchestrator = AgenticEvalOrchestrator(
+        NatWorkflowAttemptRuntime(WorkflowRuntimeConfig(shared=AgenticSharedConfig(jobs_dir=tmp_path))),
+    )
+    # Stored-attempt path: no Docker / agent execution, scores result.json directly.
+    result = await orchestrator.score_captured_attempts(WORKSPACE_BASIC.name, result_dirs=[run_dir])
+
+    assert [metric.type for metric in result.tasks[0].metrics] == ["agentic_use_agent_phase"]
+    assert result.attempts[0].status == "completed"
+    assert any(r.metric_type == "agentic_use_agent_phase" for r in result.results)
 
 
 @pytest.mark.asyncio

--- a/tests/agentic-use/tests/test_agentic_runtimes.py
+++ b/tests/agentic-use/tests/test_agentic_runtimes.py
@@ -1,0 +1,522 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for agentic-use AgentAttemptRuntime implementations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+import yaml
+from runtimes.shared.config import AgenticSharedConfig, WorkflowRuntimeConfig
+from runtimes.shared.environment import EnvCommandResult, EnvRunSpec
+from runtimes.shared.layout import resolve_run_layout, task_image_tag
+from runtimes.shared.task_loader import agentic_task_from_dir
+from runtimes.workflow.command import build_workflow_agent_cmd
+from runtimes.workflow.prep import prepare_workflow_for_runtime
+from runtimes.workflow.runtime import NatWorkflowAttemptRuntime
+
+TASKS_DIR = Path(__file__).resolve().parents[1]
+WORKSPACE_BASIC = TASKS_DIR / "workspace-basic-cli-easy"
+
+
+def test_build_workflow_agent_cmd_matches_nat_runner_shape() -> None:
+    cmd = build_workflow_agent_cmd("/tmp/nat_workflow.yml", "/tmp/nat_instruction.md")
+    assert cmd[0] == "bash"
+    assert "nat run" in cmd[2]
+    assert "/tmp/nat_workflow.yml" in cmd[2]
+    assert "intermediate_steps.jsonl" in cmd[2]
+
+
+def test_prepare_workflow_for_runtime_injects_trace_exporter(tmp_path: Path) -> None:
+    workflow_path = WORKSPACE_BASIC / "workflow.yml"
+    prepared = prepare_workflow_for_runtime(
+        workflow_path,
+        tmp_path,
+        "http://platform.test:9090",
+        nat_model="test/model",
+    )
+    config = yaml.safe_load(prepared.read_text(encoding="utf-8"))
+    tracing = config["general"]["telemetry"]["tracing"]
+    assert tracing["agentic_use_file_trace"]["output_path"] == "/logs/agent/intermediate_steps.jsonl"
+    assert "http://platform.test:9090" in prepared.read_text(encoding="utf-8")
+
+
+def test_agentic_task_from_dir_loads_instruction() -> None:
+    task = agentic_task_from_dir(WORKSPACE_BASIC, tasks_root=TASKS_DIR)
+    assert task.id == "workspace-basic-cli-easy"
+    assert "workspace" in task.intent.lower()
+    assert task.inputs["task_dir"] == str(WORKSPACE_BASIC.resolve())
+
+
+class _FakeEnvHandle:
+    def __init__(self, captured: dict[str, object], on_run: Callable[[EnvRunSpec], None] | None = None) -> None:
+        self._captured = captured
+        self._on_run = on_run
+
+    async def run_agent(self, spec: EnvRunSpec) -> EnvCommandResult:
+        self._captured["command"] = spec.command
+        self._captured["env"] = spec.env
+        self._captured["mounts"] = spec.mounts
+        if self._on_run is not None:
+            self._on_run(spec)
+        return EnvCommandResult(exit_code=0)
+
+    async def run_verifier(self, spec: EnvRunSpec) -> EnvCommandResult:
+        return EnvCommandResult(exit_code=0)
+
+    async def close(self) -> None:
+        return None
+
+
+class _FakeEnvProvider:
+    def __init__(self, captured: dict[str, object], on_run: Callable[[EnvRunSpec], None] | None = None) -> None:
+        self._captured = captured
+        self._on_run = on_run
+
+    async def prepare(self, task: object, config: object = None) -> _FakeEnvHandle:
+        self._captured["image"] = task_image_tag(task.id)  # type: ignore[attr-defined]
+        return _FakeEnvHandle(self._captured, self._on_run)
+
+
+@pytest.mark.asyncio
+async def test_workflow_runtime_run_tasks_with_mocked_env(tmp_path: Path) -> None:
+    task = agentic_task_from_dir(WORKSPACE_BASIC, tasks_root=TASKS_DIR)
+    layout = resolve_run_layout(task, AgenticSharedConfig(jobs_dir=tmp_path))
+    captured: dict[str, object] = {}
+
+    def write_log(_spec: EnvRunSpec) -> None:
+        (layout.agent_log_dir / "nat_agent.log").write_text('{"usage":{"input_tokens":1,"output_tokens":2}}')
+
+    runtime = NatWorkflowAttemptRuntime(
+        WorkflowRuntimeConfig(shared=AgenticSharedConfig(jobs_dir=tmp_path)),
+        environment=_FakeEnvProvider(captured, on_run=write_log),
+    )
+    attempts = await runtime.run_tasks([task.model_copy(update={"inputs": {**task.inputs}})])
+
+    assert len(attempts) == 1
+    assert attempts[0].metadata["agent_ok"] is True
+    assert attempts[0].metadata["agent_runtime"] == "workflow"
+    assert captured["image"] == "nmp-nat-workspace-basic-cli-easy:latest"
+    assert "nat run" in captured["command"][2]  # type: ignore[index]
+
+
+def test_runtime_for_backend_selects_workflow() -> None:
+    from runtimes import runtime_for_backend
+
+    runtime = runtime_for_backend("workflow")
+    assert isinstance(runtime, NatWorkflowAttemptRuntime)
+
+
+def test_runtime_for_backend_rejects_unknown() -> None:
+    from runtimes import runtime_for_backend
+
+    with pytest.raises(ValueError, match="Unsupported"):
+        runtime_for_backend("unknown-backend")
+
+
+def test_build_agent_eval_attempt_metadata_matches_captured_schema(tmp_path: Path) -> None:
+    from runtimes.shared.artifacts import build_agent_eval_attempt, to_captured_agent_attempt
+    from runtimes.shared.layout import AgenticRunLayout
+
+    task = agentic_task_from_dir(WORKSPACE_BASIC, tasks_root=TASKS_DIR)
+    layout = AgenticRunLayout(
+        run_dir=tmp_path,
+        agent_log_dir=tmp_path / "agent",
+        workspace_dir=tmp_path / "workspace",
+        state_dir=tmp_path / "state",
+        instruction_path=tmp_path / "agent" / "instruction.md",
+    )
+    layout.agent_log_dir.mkdir(parents=True)
+    (layout.agent_log_dir / "nat_agent.log").write_text("done", encoding="utf-8")
+
+    attempt = build_agent_eval_attempt(
+        task=task,
+        layout=layout,
+        runtime_name="workflow",
+        agent_model="test-model",
+        exit_code=0,
+        agent_ok=True,
+        run_id="run-1",
+    )
+    captured = to_captured_agent_attempt(task, attempt)
+
+    assert attempt.metadata["agent_runtime"] == "workflow"
+    assert attempt.metadata["agent_model"] == "test-model"
+    assert captured.metadata.agent_runtime == "workflow"
+    assert captured.metadata.agent_model == "test-model"
+    assert captured.metadata.run_id == "run-1"
+
+    # Evidence keys must follow the documented nat_runner -> AgentEvalAttempt map.
+    assert attempt.evidence is not None
+    evidence_names = set(attempt.evidence.descriptors)
+    assert {"logs", "final_state", "state"} <= evidence_names
+    assert attempt.evidence.descriptors["final_state"].metadata["role"] == "final_state"
+    assert attempt.evidence.descriptors["logs"].ref == str(layout.agent_log_dir)
+
+
+@pytest.mark.asyncio
+async def test_aut_runtime_run_tasks_with_mocked_env(tmp_path: Path) -> None:
+    from runtimes.aut.runtime import AutAgentAttemptRuntime
+    from runtimes.shared.config import AutRuntimeConfig
+
+    task = agentic_task_from_dir(WORKSPACE_BASIC, tasks_root=TASKS_DIR)
+    captured: dict[str, object] = {}
+
+    runtime = AutAgentAttemptRuntime(
+        AutRuntimeConfig(
+            shared=AgenticSharedConfig(jobs_dir=tmp_path),
+            aut_agent_name="test-agent",
+        ),
+        environment=_FakeEnvProvider(captured),
+    )
+    attempts = await runtime.run_tasks([task])
+    assert attempts[0].metadata["agent_runtime"] == "aut"
+    assert attempts[0].metadata["agent_ok"] is True
+    assert captured["env"]["AUT_AGENT_NAME"] == "test-agent"  # type: ignore[index]
+
+
+def test_attempt_from_result_maps_status_and_measurements(tmp_path: Path) -> None:
+    from runtimes.shared.result_adapter import attempt_from_result
+
+    output_dir = tmp_path / "20260101T000000Z-demo"
+    (output_dir / "agent").mkdir(parents=True)
+    (output_dir / "workspace").mkdir()
+    (output_dir / "state").mkdir()
+    (output_dir / "agent" / "nat_agent.log").write_text("final answer", encoding="utf-8")
+    result = {
+        "task": "demo",
+        "agent_backend": "workflow",
+        "agent_model": "test-model",
+        "agent": "ok",
+        "verify": "ok",
+        "passed": True,
+        "reward": 1,
+        "runtime_sec": 12.5,
+        "metrics": {"total_tokens": 42, "duration_ms": 900, "token_metrics_status": "available"},
+        "provenance": {"run_id": "run-9", "commit": "abc123"},
+        "candidate_id": "cand-1",
+    }
+
+    attempt = attempt_from_result(result, output_dir=output_dir)
+
+    assert attempt.task_id == "demo"
+    assert attempt.status == "completed"
+    assert attempt.metadata["reward"] == 1
+    assert attempt.metadata["passed"] is True
+    assert attempt.metadata["total_tokens"] == 42
+    assert attempt.metadata["run_id"] == "run-9"
+    assert attempt.metadata["candidate_id"] == "cand-1"
+    assert attempt.evidence is not None
+    assert {"logs", "final_state", "state"} <= set(attempt.evidence.descriptors)
+
+
+def test_attempt_from_result_marks_failed_agent(tmp_path: Path) -> None:
+    from runtimes.shared.result_adapter import attempt_from_result
+
+    output_dir = tmp_path / "run"
+    (output_dir / "agent").mkdir(parents=True)
+    result = {"task": "demo", "agent_backend": "aut", "agent": "failed", "passed": False, "reward": 0}
+
+    attempt = attempt_from_result(result, output_dir=output_dir)
+    assert attempt.status == "failed"
+    assert attempt.metadata["agent_ok"] is False
+    assert attempt.output is not None
+
+
+@pytest.mark.asyncio
+async def test_verifier_reward_metric_reads_metadata() -> None:
+    from nemo_evaluator_sdk.metrics.protocol import CandidateOutput, DatasetRow, MetricInput
+    from runtimes.shared.metrics import VerifierRewardMetric
+
+    metric = VerifierRewardMetric()
+    candidate = CandidateOutput(output_text="x", metadata={"reward": 1})
+    result = await metric.compute_scores(MetricInput(row=DatasetRow(data={}), candidate=candidate))
+    assert result.outputs[0].value == 1.0
+
+
+def _make_run_result(*, reward: float, total_tokens: int, runtime_sec: float, commit: str = "abc123"):
+    from nemo_evaluator_sdk.agent_eval.types import (
+        AgentEvalAttempt,
+        AgentEvalRunResult,
+        AgentEvalSummary,
+        AgentEvalTask,
+        AgentEvalTaskResult,
+        AgentOutput,
+    )
+    from nemo_evaluator_sdk.metrics.protocol import MetricOutput
+
+    task = AgentEvalTask(id="demo", intent="do it", inputs={})
+    attempt = AgentEvalAttempt(
+        id="demo:workflow",
+        task_id="demo",
+        status="completed",
+        output=AgentOutput(text="ok"),
+        metadata={
+            "total_tokens": total_tokens,
+            "runtime_sec": runtime_sec,
+            "provenance": {"commit_sha": commit, "commit_short": commit[:7]},
+        },
+    )
+    task_result = AgentEvalTaskResult(
+        task_id="demo",
+        attempt_id="demo:workflow",
+        metric_type="agentic_use_verifier_reward",
+        outputs=[MetricOutput(name="verifier_reward", value=reward)],
+    )
+    return AgentEvalRunResult(
+        run_id="run-1",
+        tasks=[task],
+        attempts=[attempt],
+        results=[task_result],
+        summary=AgentEvalSummary(),
+    )
+
+
+def test_summarize_run_aggregates_pass_tokens_runtime_provenance() -> None:
+    from runtimes.shared.reporting import summarize_run
+
+    summary = summarize_run(_make_run_result(reward=1.0, total_tokens=120, runtime_sec=4.5))
+
+    assert summary["total_tasks"] == 1
+    assert summary["pass_rate"] == 1.0
+    assert summary["total_tokens_sum"] == 120
+    assert summary["runtime_sec_sum"] == 4.5
+    assert summary["token_metrics_coverage"] == 1.0
+    assert summary["provenance"]["commit_sha"] == "abc123"
+
+
+def test_evaluate_gate_passes_then_flags_token_regression(tmp_path: Path) -> None:
+    from runtimes.shared.reporting import GateThresholds, evaluate_gate, write_gate_report
+
+    baseline = _make_run_result(reward=1.0, total_tokens=100, runtime_sec=4.0)
+    candidate = _make_run_result(reward=1.0, total_tokens=200, runtime_sec=4.0)
+
+    baseline_report = evaluate_gate(baseline, thresholds=GateThresholds())
+    assert baseline_report.gate_passed is True
+
+    candidate_report = evaluate_gate(
+        candidate,
+        thresholds=GateThresholds(),
+        baseline_summary=baseline_report.summary,
+    )
+    assert candidate_report.gate_passed is False
+    token_check = next(c for c in candidate_report.checks if c.name == "tokens_not_worse_than_baseline")
+    assert token_check.passed is False
+
+    gate_path = write_gate_report(candidate_report, tmp_path)
+    assert gate_path.exists()
+    assert "gate_passed" in gate_path.read_text(encoding="utf-8")
+
+
+def test_evaluate_gate_blocks_cross_commit_comparison() -> None:
+    from runtimes.shared.reporting import GateThresholds, evaluate_gate
+
+    baseline = _make_run_result(reward=1.0, total_tokens=100, runtime_sec=4.0, commit="aaa111")
+    candidate = _make_run_result(reward=1.0, total_tokens=100, runtime_sec=4.0, commit="bbb222")
+
+    baseline_summary = evaluate_gate(baseline, thresholds=GateThresholds()).summary
+    report = evaluate_gate(candidate, thresholds=GateThresholds(), baseline_summary=baseline_summary)
+
+    cross = next(c for c in report.checks if c.name == "commit_sha_matches_baseline")
+    assert cross.passed is False
+    assert report.gate_passed is False
+
+    allowed = evaluate_gate(
+        candidate,
+        thresholds=GateThresholds(allow_cross_commit=True),
+        baseline_summary=baseline_summary,
+    )
+    cross_allowed = next(c for c in allowed.checks if c.name == "commit_sha_matches_baseline")
+    assert cross_allowed.passed is True
+
+
+def test_build_verify_run_spec_shape(tmp_path: Path) -> None:
+    from runtimes.shared.layout import AgenticRunLayout
+    from runtimes.shared.verify import build_verify_run_spec
+
+    layout = AgenticRunLayout(
+        run_dir=tmp_path,
+        agent_log_dir=tmp_path / "agent",
+        workspace_dir=tmp_path / "workspace",
+        state_dir=tmp_path / "state",
+        instruction_path=tmp_path / "agent" / "instruction.md",
+    )
+    spec = build_verify_run_spec(
+        WORKSPACE_BASIC,
+        layout,
+        nmp_base_url="http://platform.test:8080",
+        agent_backend="workflow",
+        agent_model="test-model",
+    )
+    assert spec is not None
+    assert spec.command[0] == "bash"
+    assert "pytest /tests/test_outputs.py" in spec.command[2]
+    assert spec.env["NAT_AGENT_BACKEND"] == "workflow"
+    assert (str(WORKSPACE_BASIC / "tests"), "/tests") in spec.mounts
+    assert (tmp_path / "verifier").exists()
+
+
+def test_build_verify_run_spec_returns_none_without_tests(tmp_path: Path) -> None:
+    from runtimes.shared.layout import AgenticRunLayout
+    from runtimes.shared.verify import build_verify_run_spec
+
+    task_dir = tmp_path / "no-tests-task"
+    task_dir.mkdir()
+    layout = AgenticRunLayout(
+        run_dir=tmp_path / "run",
+        agent_log_dir=tmp_path / "run" / "agent",
+        workspace_dir=tmp_path / "run" / "workspace",
+        state_dir=tmp_path / "run" / "state",
+        instruction_path=tmp_path / "run" / "agent" / "instruction.md",
+    )
+    spec = build_verify_run_spec(task_dir, layout, nmp_base_url="x", agent_backend="aut", agent_model="m")
+    assert spec is None
+
+
+@pytest.mark.asyncio
+async def test_run_verify_reads_reward_file(tmp_path: Path) -> None:
+    from runtimes.shared.environment import EnvCommandResult, EnvRunSpec
+    from runtimes.shared.layout import AgenticRunLayout
+    from runtimes.shared.verify import run_verify
+
+    layout = AgenticRunLayout(
+        run_dir=tmp_path,
+        agent_log_dir=tmp_path / "agent",
+        workspace_dir=tmp_path / "workspace",
+        state_dir=tmp_path / "state",
+        instruction_path=tmp_path / "agent" / "instruction.md",
+    )
+    (tmp_path / "verifier").mkdir()
+
+    class _Handle:
+        async def run_agent(self, spec: EnvRunSpec) -> EnvCommandResult:
+            return EnvCommandResult(exit_code=0)
+
+        async def run_verifier(self, spec: EnvRunSpec) -> EnvCommandResult:
+            (tmp_path / "verifier" / "reward.txt").write_text("1\n")
+            (tmp_path / "verifier" / "test-stdout.txt").write_text("PASSED")
+            return EnvCommandResult(exit_code=0)
+
+        async def close(self) -> None:
+            return None
+
+    outcome = await run_verify(_Handle(), EnvRunSpec(command=["bash"]), layout)
+    assert outcome.ran is True
+    assert outcome.passed is True
+    assert outcome.reward == 1
+    assert "PASSED" in outcome.stdout
+
+
+@pytest.mark.asyncio
+async def test_workflow_runtime_runs_verify_through_handle(tmp_path: Path) -> None:
+    from runtimes.shared.verify import verifier_log_dir
+
+    task = agentic_task_from_dir(WORKSPACE_BASIC, tasks_root=TASKS_DIR)
+    layout = resolve_run_layout(task, AgenticSharedConfig(jobs_dir=tmp_path))
+    phases: list[str] = []
+
+    class _Handle:
+        async def run_agent(self, spec: EnvRunSpec) -> EnvCommandResult:
+            phases.append("agent")
+            (layout.agent_log_dir / "nat_agent.log").write_text("ok")
+            return EnvCommandResult(exit_code=0)
+
+        async def run_verifier(self, spec: EnvRunSpec) -> EnvCommandResult:
+            phases.append("verify")
+            (verifier_log_dir(layout) / "reward.txt").write_text("1\n")
+            return EnvCommandResult(exit_code=0)
+
+        async def close(self) -> None:
+            return None
+
+    class _Provider:
+        async def prepare(self, task: object, config: object = None) -> _Handle:
+            return _Handle()
+
+    runtime = NatWorkflowAttemptRuntime(
+        WorkflowRuntimeConfig(shared=AgenticSharedConfig(jobs_dir=tmp_path, run_verify=True)),
+        environment=_Provider(),
+    )
+    attempts = await runtime.run_tasks([task.model_copy(update={"inputs": {**task.inputs}})])
+
+    assert phases == ["agent", "verify"]
+    assert attempts[0].metadata["verify_status"] == "ok"
+    assert attempts[0].metadata["reward"] == 1
+    assert attempts[0].metadata["passed"] is True
+
+
+def test_load_environment_spec_prefers_yaml(tmp_path: Path) -> None:
+    from runtimes.shared.environment_spec import load_environment_spec
+
+    (tmp_path / "environment.yaml").write_text(
+        "environment:\n"
+        "  image: nemo-agentic-base:2026.06\n"
+        "  profile: evaluator-platform\n"
+        "  dependencies:\n"
+        "    python:\n"
+        "      - pytest\n"
+        "      - nemo-evaluator-sdk\n"
+        "  setup:\n"
+        "    - seed-providers\n",
+        encoding="utf-8",
+    )
+    spec = load_environment_spec(tmp_path)
+    assert spec.image == "nemo-agentic-base:2026.06"
+    assert spec.profile == "evaluator-platform"
+    assert spec.python_dependencies == ["pytest", "nemo-evaluator-sdk"]
+    assert spec.setup == ["seed-providers"]
+    assert spec.dockerfile is None
+
+
+def test_load_environment_spec_falls_back_to_dockerfile(tmp_path: Path) -> None:
+    from runtimes.shared.environment_spec import load_environment_spec
+
+    env_dir = tmp_path / "environment"
+    env_dir.mkdir()
+    (env_dir / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+
+    spec = load_environment_spec(tmp_path)
+    assert spec.dockerfile == env_dir / "Dockerfile"
+    assert spec.image is None
+
+
+def test_load_environment_spec_missing_raises(tmp_path: Path) -> None:
+    from runtimes.shared.environment_spec import load_environment_spec
+
+    with pytest.raises(FileNotFoundError):
+        load_environment_spec(tmp_path)
+
+
+def test_plan_task_build_dockerfile_escape_hatch(tmp_path: Path) -> None:
+    from runtimes.shared.environment_spec import plan_task_build
+
+    env_dir = tmp_path / "environment"
+    env_dir.mkdir()
+    (env_dir / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+
+    plan = plan_task_build(tmp_path, "task-img:latest")
+    assert plan.generated is False
+    assert plan.dockerfile == env_dir / "Dockerfile"
+    assert plan.context_dir == env_dir
+    assert plan.image_tag == "task-img:latest"
+
+
+def test_plan_task_build_generates_derived_dockerfile(tmp_path: Path) -> None:
+    from runtimes.shared.environment_spec import plan_task_build
+
+    (tmp_path / "environment.yaml").write_text(
+        "environment:\n  image: base:1\n  dependencies:\n    python: [pytest]\n  setup: [seed-providers]\n",
+        encoding="utf-8",
+    )
+    generated = tmp_path / "build"
+    plan = plan_task_build(tmp_path, "task-img:latest", generated_dir=generated)
+
+    assert plan.generated is True
+    assert plan.base_image == "base:1"
+    assert plan.setup == ["seed-providers"]
+    content = plan.dockerfile.read_text(encoding="utf-8")
+    assert content.startswith("FROM base:1")
+    assert "pip install --no-cache-dir pytest" in content


### PR DESCRIPTION
## Summary

Decomposes the monolithic `tests/agentic-use/nat_runner.py` lifecycle into a reusable `runtimes/` package that implements the NeMo Evaluator SDK `AgentAttemptRuntime` protocol, then aligns it with the agent-eval SDK design docs (SDK API sketch + ACES-vs-`nat_runner` runtime options).

`nat_runner.py` is intentionally left untouched — this lands the new package alongside it; converging the CLI is a follow-up.

### Commit 1 — `feat`: modular AgentAttemptRuntime package
- `shared/`: docker, layout, artifacts, task loading, constants, container env, agent-log parsing, usage helpers.
- Per-backend runtimes: `workflow` + `aut` implemented; `claude_code`, `codex`, `cursor_agent` scaffolded.
- `AgenticEvalOrchestrator` coordinating BUILD / AGENT / VERIFY.
- **B2** `EnvironmentProvider` boundary (`shared/environment.py`) decoupling runtimes from the execution environment (Docker today; Harbor/NeMo Gym pluggable).
- **B3** declarative environment authoring via `environment.yaml` with a Dockerfile escape hatch (`shared/environment_spec.py`).
- **B1** `result.json` → `AgentEvalAttempt` adapter (`shared/result_adapter.py`).
- Live **VERIFY** phase wired through the env handle (`shared/verify.py`).
- **B4** deterministic gating + provenance comparison (`shared/reporting.py`).
- Compatibility metrics incl. `VerifierRewardMetric` (`shared/metrics.py`).
- `README.md` + `COMPLIANCE.md` documenting the design-doc mapping; unit/integration tests.

### Commit 2 — `refactor`: align task/metric/status with SDK design
Closes the cheap, high-alignment gaps found reviewing the package against the docs:
- **Metrics on the task** — `agentic_task_from_dir` authors `metrics=[AgentPhaseSuccessMetric()]`; the orchestrator only *appends* `VerifierRewardMetric` (when `run_verify=True`) instead of owning the set.
- **Scorable status** — shared `resolve_attempt_status` used by both the live builder and the importer. `ran-but-failed → "partial"` (still scorable); `"failed"` reserved for true production failures, since `AgentEvaluator` excludes `failed` from scoring and a failed agent must still count toward pass-rate gating.
- **Stored-attempt scoring** (SDK's first-class path) — `AgenticEvalOrchestrator.score_captured_attempts` + `run_agent_eval --rescore-dir` score captured `result.json` runs with no Docker/agent execution.
- **Inputs side-channel** — `inputs` now carries only agent-facing `instruction`; `task_dir` moved to `task.metadata` so it can't leak into a metric scoring row.
- **Evidence keys** — emit the doc's `initial_state` (when a seed filesystem is staged); label the platform-specific `state` key as a non-doc extension.

## Known follow-ups (documented in the feat commit message)
- `metric-over-evidence` (next milestone): author a task-specific metric that reads `candidate.evidence` instead of the verifier reward in metadata.
- `runner-duplication`: decide cutover vs wrap for `nat_runner.py`.
- Deferred: provider-owned artifact capture (await NeMo Gym API), executing B3 `setup` steps, remaining 3 CLI backends.

## Test plan
- [x] `uv run --frozen pytest tests/agentic-use/tests/test_agentic_runtimes.py` — 24 passed
- [x] `uv run ruff check` / `ruff format --check` on the package — clean (pre-existing `sys.path` `E402` in `run_agent_eval.py` only)
- [x] `uv run --frozen ty check tests/agentic-use/runtimes` — no new diagnostics
- [ ] CI on `profbench-mvp-2`