### PR TITLE
ci: run nightly releases on weekdays

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -2,7 +2,8 @@ name: "Release: Nightly"
 
 on:
   schedule:
-    - cron: "0 20 * * *"
+    # Runs Monday through Friday at 8:00 PM America/Los_Angeles.
+    - cron: "0 20 * * 1-5"
       timezone: "America/Los_Angeles"
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

This updates the nightly release workflow so scheduled nightlies run only on weekdays.

The automated schedule is now Monday through Friday at 8:00 PM in the existing `America/Los_Angeles` timezone. Manual workflow dispatch is unchanged, so a nightly release can still be started explicitly when needed.

## Why

The previous cron schedule ran every day, which also triggered automated weekend nightlies. Moving the scheduled trigger to weekdays keeps normal nightly release activity aligned with working days without changing the release bundle flow itself.

## Impact

Only the scheduled trigger in `.github/workflows/release-nightly.yaml` changed. The reusable release workflow, release cadence, inputs, and secrets wiring are unchanged.

## Validation

- Parsed `.github/workflows/release-nightly.yaml` as YAML.
- Ran `git diff --check` for the workflow change.
