### PR TITLE
fix(studio): Regen SDK schema without duplicate operations

### DIFF
--- a/web/packages/sdk/orval/operationNameOverride.test.ts
+++ b/web/packages/sdk/orval/operationNameOverride.test.ts
@@ -163,6 +163,111 @@ describe('operationNameOverride', () => {
     ).toBe('auditGetJobStatus');
   });
 
+  // --- Noun-first job-subtype collections ("jobs_{subtype}") ---
+  // Agent jobs and data-designer mount each job type at /jobs/{subtype}, so the
+  // action noun comes first and the subtype trails it. Each subtype must yield a
+  // distinct name; previously they all collapsed onto "createJob"/"listJobs"/etc.
+
+  it('agents create analyze job', () => {
+    expect(
+      operationNameOverride({
+        operationId: 'create_job_apis_agents_v2_workspaces__workspace__jobs_analyze_post',
+      })
+    ).toBe('agentsCreateAnalyzeJob');
+  });
+
+  it('agents create evaluate job', () => {
+    expect(
+      operationNameOverride({
+        operationId: 'create_job_apis_agents_v2_workspaces__workspace__jobs_evaluate_post',
+      })
+    ).toBe('agentsCreateEvaluateJob');
+  });
+
+  it('agents create evaluate-suite job', () => {
+    expect(
+      operationNameOverride({
+        operationId: 'create_job_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite_post',
+      })
+    ).toBe('agentsCreateEvaluateSuiteJob');
+  });
+
+  it('agents create optimize job', () => {
+    expect(
+      operationNameOverride({
+        operationId: 'create_job_apis_agents_v2_workspaces__workspace__jobs_optimize_post',
+      })
+    ).toBe('agentsCreateOptimizeJob');
+  });
+
+  it('agents create optimize-skills job', () => {
+    expect(
+      operationNameOverride({
+        operationId: 'create_job_apis_agents_v2_workspaces__workspace__jobs_optimize_skills_post',
+      })
+    ).toBe('agentsCreateOptimizeSkillsJob');
+  });
+
+  it('agents list evaluate jobs', () => {
+    expect(
+      operationNameOverride({
+        operationId: 'list_jobs_apis_agents_v2_workspaces__workspace__jobs_evaluate_get',
+      })
+    ).toBe('agentsListEvaluateJobs');
+  });
+
+  it('agents get optimize-skills job', () => {
+    expect(
+      operationNameOverride({
+        operationId:
+          'get_job_apis_agents_v2_workspaces__workspace__jobs_optimize_skills__name__get',
+      })
+    ).toBe('agentsGetOptimizeSkillsJob');
+  });
+
+  it('agents get evaluate-suite job result (sub-resource)', () => {
+    expect(
+      operationNameOverride({
+        operationId:
+          'get_job_result_apis_agents_v2_workspaces__workspace__jobs_evaluate_suite__job__results__name__get',
+      })
+    ).toBe('agentsGetEvaluateSuiteJobResult');
+  });
+
+  it('agents list analyze job results (sub-resource)', () => {
+    expect(
+      operationNameOverride({
+        operationId:
+          'list_job_results_apis_agents_v2_workspaces__workspace__jobs_analyze__name__results_get',
+      })
+    ).toBe('agentsListAnalyzeJobResults');
+  });
+
+  it('data-designer create job stays stable (dedupes the "create" subtype)', () => {
+    expect(
+      operationNameOverride({
+        operationId: 'create_job_apis_data_designer_v2_workspaces__workspace__jobs_create_post',
+      })
+    ).toBe('dataDesignerCreateJob');
+  });
+
+  it('data-designer list create jobs', () => {
+    expect(
+      operationNameOverride({
+        operationId: 'list_jobs_apis_data_designer_v2_workspaces__workspace__jobs_create_get',
+      })
+    ).toBe('dataDesignerListCreateJobs');
+  });
+
+  it('data-designer cancel create job', () => {
+    expect(
+      operationNameOverride({
+        operationId:
+          'cancel_job_apis_data_designer_v2_workspaces__workspace__jobs_create__name__cancel_post',
+      })
+    ).toBe('dataDesignerCancelCreateJob');
+  });
+
   it('drops the redundant intake prefix', () => {
     expect(
       operationNameOverride({

--- a/web/packages/sdk/orval/operationNameOverride.ts
+++ b/web/packages/sdk/orval/operationNameOverride.ts
@@ -86,12 +86,24 @@ const extractAllPathResources = (pathPart: string): string[] => {
 
 /**
  * Qualifies the action resource using path information for disambiguation.
- * When the path is more specific than the action, the path qualifier is prepended.
+ * When the path is more specific than the action, the path qualifier is added.
+ *
+ * Two collection shapes are handled:
+ *   - Subtype-first ("{subtype}_jobs"), used by evaluation — the qualifier
+ *     precedes the action noun and is prepended.
+ *   - Noun-first ("jobs_{subtype}"), used by agent jobs and data-designer —
+ *     the subtype trails the action noun and is moved in front so each
+ *     subtype yields a distinct name. Without this, every subtype under one
+ *     service collapses to the same generated name (e.g. all of
+ *     analyze/evaluate/evaluate-suite/optimize/optimize-skills -> "createJob").
  *
  * e.g., actionResource="job", pathResource="benchmark_jobs" -> "benchmark_job"
  * e.g., actionResource="benchmark", pathResource="benchmarks" -> "benchmark"
  * e.g., actionResource="job_result_aggregate_scores", pathResource="benchmark_jobs"
  *       -> "benchmark_job_result_aggregate_scores"
+ * e.g., actionResource="job", pathResource="jobs_analyze" -> "analyze_job"
+ * e.g., actionResource="job_result", pathResource="jobs_evaluate_suite"
+ *       -> "evaluate_suite_job_result"
  */
 const qualifyResource = (actionResource: string, pathResource: string): string => {
   if (!actionResource || !pathResource) return actionResource;
@@ -99,17 +111,36 @@ const qualifyResource = (actionResource: string, pathResource: string): string =
   const actionWords = actionResource.split('_');
   const pathWords = pathResource.split('_');
 
-  // Singularize the last path word for comparison
-  const singPathWords = pathWords.map((w, i) => (i === pathWords.length - 1 ? singularize(w) : w));
+  // Singularize every path word so plural collections (e.g. "jobs") match the
+  // singular action noun (e.g. "job"). Singularizing only the last word missed
+  // the noun-first "jobs_<subtype>" shape, where the noun isn't last.
+  const singPathWords = pathWords.map(singularize);
 
-  // Find where the first action word appears in the singularized path
+  // Find where the first action word (the resource noun) appears in the path.
   const firstActionSingular = singularize(actionWords[0]);
   const matchIndex = singPathWords.indexOf(firstActionSingular);
 
   if (matchIndex > 0) {
-    // Path has qualifier words before the action resource — prepend them
+    // Path has qualifier words before the action resource — prepend them.
+    // e.g. "benchmark_jobs" + "job" -> "benchmark_job"
     const qualifiers = pathWords.slice(0, matchIndex);
     return [...qualifiers, ...actionWords].join('_');
+  }
+
+  if (matchIndex === 0 && pathWords.length > 1) {
+    // The action noun leads the path. Any trailing path words that aren't
+    // already part of the action resource are the subtype — move them in
+    // front. Words already covered by the action (the flat-endpoint case,
+    // where path and action describe the same resource) are dropped, leaving
+    // the name unchanged.
+    // e.g. "jobs_analyze" + "job" -> "analyze_job"
+    //      "jobs_evaluate_suite" + "job_result" -> "evaluate_suite_job_result"
+    //      "metric_job_results" + "metric_job_results" -> "metric_job_results"
+    const actionSet = new Set(actionWords.map(singularize));
+    const subtype = pathWords.slice(1).filter((w) => !actionSet.has(singularize(w)));
+    if (subtype.length > 0) {
+      return [...subtype, ...actionWords].join('_');
+    }
   }
 
   return actionResource;

--- a/web/packages/studio/src/components/dataViews/DataDesignerJobsDataView/DeleteJobModal.tsx
+++ b/web/packages/studio/src/components/dataViews/DataDesignerJobsDataView/DeleteJobModal.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  getDataDesignerListJobsQueryKey,
-  useDataDesignerDeleteJob,
+  getDataDesignerListCreateJobsQueryKey,
+  useDataDesignerDeleteCreateJob,
 } from '@nemo/sdk/generated/data-designer/api';
 import type { CreateJob as DataDesignerJob } from '@nemo/sdk/generated/data-designer/schema';
 import { DeleteConfirmationModal } from '@studio/components/DeleteConfirmationModal';
@@ -21,11 +21,11 @@ export const DeleteJobModal: FC<DeleteJobModalProps> = ({ jobs, onClose }) => {
   const workspace = useWorkspaceFromPath();
   const [deleteError, setDeleteError] = useState<string | undefined>(undefined);
 
-  const deleteJobMutation = useDataDesignerDeleteJob({
+  const deleteJobMutation = useDataDesignerDeleteCreateJob({
     mutation: {
       onSuccess: () =>
         queryClient.resetQueries({
-          queryKey: getDataDesignerListJobsQueryKey(workspace),
+          queryKey: getDataDesignerListCreateJobsQueryKey(workspace),
         }),
     },
   });

--- a/web/packages/studio/src/components/dataViews/DataDesignerJobsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/DataDesignerJobsDataView/index.tsx
@@ -15,9 +15,9 @@ import { CJobCancellableStatuses } from '@nemo/common/src/constants/query';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
 import { getSortParam } from '@nemo/common/src/utils/query';
 import {
-  getDataDesignerListJobsQueryKey,
-  useDataDesignerCancelJob,
-  useDataDesignerListJobs,
+  getDataDesignerListCreateJobsQueryKey,
+  useDataDesignerCancelCreateJob,
+  useDataDesignerListCreateJobs,
 } from '@nemo/sdk/generated/data-designer/api';
 import type {
   CreateJob as DataDesignerJob,
@@ -50,11 +50,11 @@ export const DataDesignerJobsDataView: FC = () => {
   const [deleteJobs, setDeleteJobs] = useState<DataDesignerJob[]>([]);
   const [cancelError, setCancelError] = useState<string | undefined>(undefined);
 
-  const cancelJobMutation = useDataDesignerCancelJob({
+  const cancelJobMutation = useDataDesignerCancelCreateJob({
     mutation: {
       onSuccess: () => {
         queryClient.resetQueries({
-          queryKey: getDataDesignerListJobsQueryKey(workspace),
+          queryKey: getDataDesignerListCreateJobsQueryKey(workspace),
         });
         setCancelError(undefined);
       },
@@ -78,7 +78,7 @@ export const DataDesignerJobsDataView: FC = () => {
     [cancelJobMutation]
   );
 
-  const { data: dataDesignerResponse, isLoading } = useDataDesignerListJobs(
+  const { data: dataDesignerResponse, isLoading } = useDataDesignerListCreateJobs(
     workspace,
     {
       sort: getSortParam(dataViewState.sorting.state) as DataDesignerJobsSortField,

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection.tsx
@@ -7,7 +7,7 @@ import { KVPair } from '@nemo/common/src/components/KVPair';
 import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
 import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
-import { useDataDesignerListJobResults } from '@nemo/sdk/generated/data-designer/api';
+import { useDataDesignerListCreateJobResults } from '@nemo/sdk/generated/data-designer/api';
 import type { CreateJob as DataDesignerJob } from '@nemo/sdk/generated/data-designer/schema';
 import {
   getFilesListFilesetFilesQueryKey,
@@ -54,15 +54,12 @@ export const JobOutputFilesetSection: FC<JobOutputFilesetSectionProps> = ({
 
   const isTerminal = job.status != null && PlatformJobTerminalStatuses.includes(job.status);
 
-  const { data: resultsResponse, isLoading: isResultsLoading } = useDataDesignerListJobResults(
-    workspace,
-    jobName,
-    {
+  const { data: resultsResponse, isLoading: isResultsLoading } =
+    useDataDesignerListCreateJobResults(workspace, jobName, {
       query: {
         refetchInterval: isTerminal ? false : 3000,
       },
-    }
-  );
+    });
 
   const artifactsResult = useMemo(() => {
     const data = resultsResponse?.data;

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
@@ -4,7 +4,7 @@
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
 import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
-import { useDataDesignerGetJob } from '@nemo/sdk/generated/data-designer/api';
+import { useDataDesignerGetCreateJob } from '@nemo/sdk/generated/data-designer/api';
 import { Button, Card, Stack, Text } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { Loading } from '@studio/components/Layouts/Loading';
@@ -27,7 +27,7 @@ export const DataDesignerJobDetailsRoute: FC = () => {
     isLoading,
     isError,
     refetch,
-  } = useDataDesignerGetJob(workspace, dataDesignerJobName, {
+  } = useDataDesignerGetCreateJob(workspace, dataDesignerJobName, {
     query: {
       refetchInterval: (query) => {
         const status = query.state.data?.status;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive coverage for job-subtype routing, including noun-first naming shapes and data-designer naming stability across create/list/cancel flows.

* **Improvements**
  * Refined API operation naming so resources are disambiguated more reliably (better, more consistent operation names).
  * Switched data-designer job flows to use the "create jobs" variant — listing, cancellation, deletion reset logic, job details, and artifact retrieval now follow the create-jobs path for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->