### PR TITLE
chore(platform-seed): remove evaluator seed dependency

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -438,7 +438,6 @@ platform-seed-service = [
   "nmp-common",
   "nmp-auth",
   "nmp-guardrails",
-  "nmp-evaluator",
 ]
 
 # Generated from [tool.bundle-package]; do not edit by hand.

--- a/services/platform-seed/README.md
+++ b/services/platform-seed/README.md
@@ -1,10 +1,10 @@
 # Platform seed task
 
-Platform-centric seeding for NeMo Platform: auth role bindings (platform admin, wildcard default/system), guardrails config store, evaluator system metrics/benchmarks, and plugin-contributed seed jobs discovered from `nemo.seed`. This codebase provides the **task** (run via `nemo-platform run task --task nmp.platform_seed` or as a K8s Job). Optionally, the platform API can run the same seed once at startup when `platform.seed_on_startup` is true in the platform config (or `NMP_SEED_ON_STARTUP=true`). There is no standalone seed service.
+Platform-centric seeding for NeMo Platform: auth role bindings (platform admin, wildcard default/system), guardrails config store, the default model provider, and plugin-contributed seed jobs discovered from `nemo.seed`. This codebase provides the **task** (run via `nemo-platform run task --task nmp.platform_seed` or as a K8s Job). Optionally, the platform API can run the same seed once at startup when `platform.seed_on_startup` is true in the platform config (or `NMP_SEED_ON_STARTUP=true`). There is no standalone seed service.
 
 **Layout** (aligned with hello-world): one package `nmp.platform_seed` with `config.py` and `tasks/seed/` for the task (run.py, __main__.py). The task can be run as `python -m nmp.platform_seed` or `python -m nmp.platform_seed.tasks.seed`.
 
-The task uses the same platform config as the rest of the platform (e.g. `NMP_CONFIG_FILE_PATH` and `Configuration.get_platform_config()`) to resolve service URLs. It uses `get_async_platform_sdk()` from the SDK factory for API calls. When run as a K8s Job or after boot, the task waits for dependencies using the same pattern as services: `async_wait_for_dependencies()` polls each dependency’s `/status` using `platform_config.get_service_url(service_name)`, so service APIs may live at different URLs. Dependency list: entities, auth, files.
+The task uses the same platform config as the rest of the platform (e.g. `NMP_CONFIG_FILE_PATH` and `get_platform_config()`) to resolve service URLs. It uses `get_async_platform_sdk()` from the SDK factory for API calls. When run as a K8s Job or after boot, the task waits for dependencies using the same pattern as services: `async_wait_for_dependencies()` polls each dependency’s `/status` using `platform_config.get_service_url(service_name)`, so service APIs may live at different URLs. Dependency list: entities, auth, files.
 
 ## Usage
 
@@ -21,11 +21,9 @@ The task uses the same platform config as the rest of the platform (e.g. `NMP_CO
 | `NMP_PLATFORM_SEED_AUDITOR_ENABLED` | true | Seed auditor configs |
 | `NMP_PLATFORM_SEED_AUTH_ENABLED` | true | Seed auth role bindings (platform admin, wildcard default/system) |
 | `NMP_PLATFORM_SEED_GUARDRAILS_ENABLED` | true | Seed guardrail configs |
-| `NMP_PLATFORM_SEED_EVALUATOR_ENABLED` | true | Register system metrics/benchmarks |
 | `NMP_PLATFORM_SEED_MODEL_PROVIDER_ENABLED` | true | Seed nvidia-build model provider |
 | `NMP_PLATFORM_SEED_<PLUGIN_NAME>_ENABLED` | true | Enable or disable an individual plugin seed job discovered under `nemo.seed` (`<PLUGIN_NAME>` is the seed job name uppercased with non-alphanumeric characters replaced by `_`) |
 | `NMP_PLATFORM_SEED_GUARDRAILS_CONFIG_STORE_PATH` | (from `CONFIG_STORE_PATH`) | Guardrails config store path |
-| `NMP_PLATFORM_SEED_EVALUATOR_RECREATE_EXISTING` | false | Recreate existing system entities |
 | `NMP_PLATFORM_SEED_WAIT_FOR_READY_ENABLED` | true | Wait for dependency services (entities, auth, files) via /status before seeding |
 | `NMP_PLATFORM_SEED_WAIT_FOR_READY_RETRIES` | 60 | Max readiness checks per dependency (total timeout = retries × interval) |
 | `NMP_PLATFORM_SEED_WAIT_FOR_READY_INTERVAL_SECONDS` | 5.0 | Seconds between readiness checks |

--- a/services/platform-seed/pyproject.toml
+++ b/services/platform-seed/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
   "nmp-common",
   "nmp-auth",
   "nmp-guardrails",
-  "nmp-evaluator",
 ]
 
 [project.scripts]
@@ -19,7 +18,6 @@ platform-seed = "nmp.platform_seed.__main__:main"
 nmp-common = { workspace = true }
 nmp-auth = { workspace = true }
 nmp-guardrails = { workspace = true }
-nmp-evaluator = { workspace = true }
 
 [dependency-groups]
 dev = [

--- a/services/platform-seed/src/nmp/platform_seed/__init__.py
+++ b/services/platform-seed/src/nmp/platform_seed/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Platform seeding: guardrails configs, evaluator system entities, data designer filesets."""
+"""Platform seeding for built-in and plugin-contributed seed jobs."""
 
 from nmp.platform_seed.config import PlatformSeedConfig
 from nmp.platform_seed.tasks.seed import (

--- a/services/platform-seed/src/nmp/platform_seed/config.py
+++ b/services/platform-seed/src/nmp/platform_seed/config.py
@@ -32,16 +32,11 @@ class PlatformSeedConfig(BaseSettings):
         description="Seed auth role bindings",
     )
     guardrails_enabled: bool = Field(default=True, description="Seed guardrail configs from config store")
-    evaluator_enabled: bool = Field(default=True, description="Register system metrics and benchmarks")
     model_provider_enabled: bool = Field(default=True, description="Seed the default nvidia-build model provider")
 
     guardrails_config_store_path: Path = Field(
         default_factory=lambda: Path(os.getenv("CONFIG_STORE_PATH", "/dev/null")),
         description="Path to guardrails config store directory",
-    )
-    evaluator_recreate_existing: bool = Field(
-        default=False,
-        description="Recreate/replace existing system metrics and benchmarks",
     )
     wait_for_ready_enabled: bool = Field(
         default=True,

--- a/services/platform-seed/src/nmp/platform_seed/tasks/seed/__init__.py
+++ b/services/platform-seed/src/nmp/platform_seed/tasks/seed/__init__.py
@@ -9,7 +9,6 @@ from nmp.platform_seed.tasks.seed.run import (
     run,
     run_platform_seed,
     run_platform_seed_from_startup,
-    seed_evaluator,
     seed_guardrails,
 )
 
@@ -19,6 +18,5 @@ __all__ = [
     "run",
     "run_platform_seed",
     "run_platform_seed_from_startup",
-    "seed_evaluator",
     "seed_guardrails",
 ]

--- a/services/platform-seed/src/nmp/platform_seed/tasks/seed/run.py
+++ b/services/platform-seed/src/nmp/platform_seed/tasks/seed/run.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform.resources.entities import AsyncEntitiesResource
 from nemo_platform_plugin.discovery import discover_seed_jobs
-from nmp.common.config import Configuration
+from nmp.common.config import get_platform_config
 from nmp.common.entities import EntityClient
 from nmp.common.sdk_factory import get_async_platform_sdk
 from nmp.common.service.api.health import async_wait_for_dependencies
@@ -28,7 +28,6 @@ class PlatformSeedResult:
 
     auth_ok: bool = False
     guardrails_ok: bool = False
-    evaluator_ok: bool = False
     models_ok: bool = False
     plugin_results: dict[str, bool] = field(default_factory=dict)
     errors: list[str] = field(default_factory=list)
@@ -45,20 +44,6 @@ async def seed_guardrails(entity_client: EntityClient, config: PlatformSeedConfi
     await populate_config_store(entity_client, config.guardrails_config_store_path)
 
     logger.info("Guardrails config store populated")
-
-
-async def seed_evaluator(entity_client: EntityClient, config: PlatformSeedConfig) -> None:
-    """Register evaluator system metrics and benchmarks. Idempotent."""
-    from nmp.evaluator.api.v2.benchmarks.manager import BenchmarksManager
-    from nmp.evaluator.api.v2.metrics.manager import MetricsManager
-
-    metrics_manager = MetricsManager(entity_client, as_service="platform-seed")
-    benchmarks_manager = BenchmarksManager(entity_client, as_service="platform-seed")
-    await asyncio.gather(
-        metrics_manager.register_system_metrics(config.evaluator_recreate_existing),
-        benchmarks_manager.register_system_benchmarks(config.evaluator_recreate_existing),
-    )
-    logger.info("Evaluator system metrics and benchmarks registered")
 
 
 async def seed_auth(entity_client: EntityClient, config: PlatformSeedConfig) -> None:
@@ -165,15 +150,6 @@ async def run_platform_seed(
             logger.exception(msg)
             result.errors.append(msg)
 
-    if config.evaluator_enabled:
-        try:
-            await seed_evaluator(entity_client, config)
-            result.evaluator_ok = True
-        except Exception as e:
-            msg = f"Evaluator seed failed: {e}"
-            logger.exception(msg)
-            result.errors.append(msg)
-
     if config.model_provider_enabled:
         try:
             await seed_model_provider(sdk)
@@ -204,7 +180,7 @@ async def run_platform_seed_from_startup() -> bool:
         return True
 
     try:
-        platform_config = Configuration.get_platform_config()
+        platform_config = get_platform_config()
     except Exception as e:
         logger.error("Failed to load platform config: %s", e)
         return False

--- a/services/platform-seed/tests/test_platform_seed_runner.py
+++ b/services/platform-seed/tests/test_platform_seed_runner.py
@@ -36,7 +36,6 @@ def config_enabled():
         enabled=True,
         auth_enabled=False,
         guardrails_enabled=False,
-        evaluator_enabled=False,
         model_provider_enabled=False,
         guardrails_config_store_path=Path("/tmp/config-store"),
     )
@@ -48,7 +47,6 @@ async def test_run_platform_seed_disabled(config_disabled, entity_client, sdk):
     result = await run_platform_seed(entity_client, sdk, config_disabled)
     assert result.auth_ok is False
     assert result.guardrails_ok is False
-    assert result.evaluator_ok is False
     assert result.models_ok is False
     assert result.plugin_results == {}
     assert result.errors == []
@@ -64,7 +62,6 @@ async def test_run_platform_seed_guardrails_only(config_enabled, entity_client, 
         mock_populate.assert_called_once_with(entity_client, config_enabled.guardrails_config_store_path)
         assert result.auth_ok is False
         assert result.guardrails_ok is True
-        assert result.evaluator_ok is False
         assert result.errors == []
 
 
@@ -72,49 +69,17 @@ async def test_run_platform_seed_guardrails_only(config_enabled, entity_client, 
 async def test_run_platform_seed_guardrails_failure(config_enabled, entity_client, sdk):
     """Guardrails seed failure is recorded and other steps still run."""
     config_enabled.guardrails_enabled = True
-    config_enabled.evaluator_enabled = True
 
     with patch(
         "nmp.guardrails.app.utils.config_store.populate_config_store",
         new_callable=AsyncMock,
         side_effect=RuntimeError("bad"),
     ):
-        with patch("nmp.evaluator.api.v2.metrics.manager.MetricsManager") as MockMM:
-            with patch("nmp.evaluator.api.v2.benchmarks.manager.BenchmarksManager") as MockBM:
-                mock_mm = MagicMock()
-                mock_mm.register_system_metrics = AsyncMock()
-                mock_bm = MagicMock()
-                mock_bm.register_system_benchmarks = AsyncMock()
-                MockMM.return_value = mock_mm
-                MockBM.return_value = mock_bm
-
-                result = await run_platform_seed(entity_client, sdk, config_enabled)
+        result = await run_platform_seed(entity_client, sdk, config_enabled)
 
     assert result.guardrails_ok is False
-    assert result.evaluator_ok is True
     assert len(result.errors) == 1
     assert "Guardrails" in result.errors[0]
-
-
-@pytest.mark.asyncio
-async def test_run_platform_seed_evaluator_called(config_enabled, entity_client, sdk):
-    """Evaluator seed is called when evaluator_enabled is True."""
-    config_enabled.evaluator_enabled = True
-
-    with patch("nmp.evaluator.api.v2.metrics.manager.MetricsManager") as MockMM:
-        with patch("nmp.evaluator.api.v2.benchmarks.manager.BenchmarksManager") as MockBM:
-            mock_mm = MagicMock()
-            mock_mm.register_system_metrics = AsyncMock()
-            mock_bm = MagicMock()
-            mock_bm.register_system_benchmarks = AsyncMock()
-            MockMM.return_value = mock_mm
-            MockBM.return_value = mock_bm
-
-            result = await run_platform_seed(entity_client, sdk, config_enabled)
-
-    assert result.evaluator_ok is True
-    mock_mm.register_system_metrics.assert_called_once()
-    mock_bm.register_system_benchmarks.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -4250,7 +4250,6 @@ all = [
     { name = "ngcsdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nmp-evaluator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-guardrails", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nvidia-nat-config-optimizer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nvidia-nat-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4645,7 +4644,6 @@ nmp-common = [
 platform-seed-service = [
     { name = "nmp-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nmp-evaluator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-guardrails", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 plugins = [
@@ -4735,7 +4733,6 @@ services = [
     { name = "ngcsdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nmp-evaluator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-guardrails", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nvidia-nat-config-optimizer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nvidia-nat-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -5100,9 +5097,6 @@ requires-dist = [
     { name = "nmp-common", marker = "extra == 'secrets-service'", editable = "packages/nmp_common" },
     { name = "nmp-common", marker = "extra == 'services'", editable = "packages/nmp_common" },
     { name = "nmp-common", marker = "extra == 'studio-service'", editable = "packages/nmp_common" },
-    { name = "nmp-evaluator", marker = "extra == 'all'", editable = "services/evaluator" },
-    { name = "nmp-evaluator", marker = "extra == 'platform-seed-service'", editable = "services/evaluator" },
-    { name = "nmp-evaluator", marker = "extra == 'services'", editable = "services/evaluator" },
     { name = "nmp-guardrails", marker = "extra == 'all'", editable = "services/guardrails" },
     { name = "nmp-guardrails", marker = "extra == 'platform-seed-service'", editable = "services/guardrails" },
     { name = "nmp-guardrails", marker = "extra == 'services'", editable = "services/guardrails" },
@@ -7247,7 +7241,6 @@ source = { editable = "services/platform-seed" }
 dependencies = [
     { name = "nmp-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nmp-evaluator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-guardrails", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
@@ -7262,7 +7255,6 @@ dev = [
 requires-dist = [
     { name = "nmp-auth", editable = "services/core/auth" },
     { name = "nmp-common", editable = "packages/nmp_common" },
-    { name = "nmp-evaluator", editable = "services/evaluator" },
     { name = "nmp-guardrails", editable = "services/guardrails" },
 ]
 


### PR DESCRIPTION
## Summary
- remove legacy evaluator seeding from platform-seed
- drop platform-seed's direct nmp-evaluator dependency
- update platform-seed docs, focused runner tests, and the minimal lock metadata needed for uv lock --check

## Validation
- uv run --frozen pytest services/platform-seed/tests/test_platform_seed_runner.py -q
- uv run --frozen ruff check services/platform-seed/src/nmp/platform_seed services/platform-seed/tests/test_platform_seed_runner.py
- uv run --frozen ruff format --check services/platform-seed/src/nmp/platform_seed services/platform-seed/tests/test_platform_seed_runner.py
- uv run --frozen ty check services/platform-seed/src/nmp/platform_seed services/platform-seed/tests/test_platform_seed_runner.py
- uv lock --check

## Notes
- uv.lock was updated with only the stale nmp-evaluator dependency entries removed; non-target wheel artifact records were left intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed evaluator seeding and related dependencies from the platform-seed service. The service now focuses on seeding auth role bindings, guardrails configuration, default model provider setup, and plugin-contributed seed jobs.

* **Documentation**
  * Updated platform-seed documentation to reflect the removal of evaluator-related seeding responsibilities and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->