### PR TITLE
fix(plat): Bind to 127.0.0.1 rather than 0.0.0.0

### DIFF
--- a/docs/set-up/config-reference.md
+++ b/docs/set-up/config-reference.md
@@ -48,8 +48,8 @@ service:
   log_level: INFO
   # Scheme for the {{platform_name}} service. | default: 'http'
   scheme: http
-  # Host for the {{platform_name}} service. | default: '0.0.0.0'
-  host: 0.0.0.0
+  # Host for the {{platform_name}} service. | default: '127.0.0.1'
+  host: 127.0.0.1
   # Port for the {{platform_name}} service. | default: 8080
   port: 8080
 ```

--- a/packages/nmp_common/src/nmp/common/config/base.py
+++ b/packages/nmp_common/src/nmp/common/config/base.py
@@ -59,7 +59,7 @@ class CommonServiceConfig(create_service_config_class("service")):
         "INFO", alias="LOG_LEVEL", description="Logging level for the NeMo Platform."
     )
     scheme: str = Field(default="http", description="Scheme for the NeMo Platform service.")
-    host: str = Field(default="0.0.0.0", description="Host for the NeMo Platform service.")
+    host: str = Field(default="127.0.0.1", description="Host for the NeMo Platform service.")
     port: int = Field(default=8080, description="Port for the NeMo Platform service.")
 
     def get_host_url(self) -> str:

--- a/packages/nmp_common/tests/config/fixtures/simple.yaml
+++ b/packages/nmp_common/tests/config/fixtures/simple.yaml
@@ -4,5 +4,5 @@ platform:
 service:
   log_level: "INFO"
   log_format: "plain"
-  host: "0.0.0.0"
+  host: "127.0.0.1"
   port: 8000

--- a/packages/nmp_common/tests/nmp_common/test_common_config.py
+++ b/packages/nmp_common/tests/nmp_common/test_common_config.py
@@ -170,7 +170,7 @@ class TestCommonServiceConfig:
 
         assert config.log_level == "INFO"
         assert config.log_format == "plain"
-        assert config.host == "0.0.0.0"
+        assert config.host == "127.0.0.1"
         assert config.port == 8080
 
     def test_common_service_config_global_settings_key(self):


### PR DESCRIPTION
## Summary

Resolves [AIRCORE-750](https://linear.app/nvidia/issue/AIRCORE-750): Default `CommonServiceConfig.host` to `127.0.0.1` instead of `0.0.0.0`.

`0.0.0.0` binds to all network interfaces, which can accidentally expose the service on public interfaces. `127.0.0.1` (loopback only) is a safer default. Deployments needing external access can override via `NMP_SERVICE_HOST` env var or config file.

### Changed files

- **`packages/nmp_common/src/nmp/common/config/base.py`** — Changed `CommonServiceConfig.host` default from `"0.0.0.0"` to `"127.0.0.1"`
- **`packages/nmp_common/tests/nmp_common/test_common_config.py`** — Updated test assertion to expect `"127.0.0.1"`
- **`packages/nmp_common/tests/config/fixtures/simple.yaml`** — Updated fixture to use `"127.0.0.1"`
- **`docs/set-up/config-reference.md`** — Updated docs to reflect new default

### Not changed (intentionally)

- `nmp_platform_runner` server/CLI defaults (`run_server`, `resolve_run_configuration`) — separate entry points with their own `host` parameters; already have logic to translate `0.0.0.0` → `127.0.0.1` for internal clients
- `safe_synthesizer` plugin config — separate config class, separate concern
- Individual service `main.py` files — those hardcode `host="0.0.0.0"` for `uvicorn.run()` directly, appropriate for containerized deployments

## Test plan

- [x] `TestCommonServiceConfig` tests pass (6/6)
- [ ] Verify `nemo services run` still works with the new default (manual)
- [ ] Verify Docker/k8s deployments that override `NMP_SERVICE_HOST` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Updated default service host binding configuration to localhost address.

* **Documentation**
  * Updated platform configuration reference documentation to reflect new default values.

* **Tests**
  * Updated test fixtures and test assertions to verify configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->