### PR TITLE
feat(studio): experiment group creation modal

### DIFF
--- a/web/packages/studio/src/components/ExperimentGroupCreateModal/constants.ts
+++ b/web/packages/studio/src/components/ExperimentGroupCreateModal/constants.ts
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+import { CreateExperimentGroupBody } from '@nemo/sdk/generated/platform/zod/experiment-groups/createExperimentGroup';
+import { workspaceInputSchema } from '@studio/constants/zod';
+
+// Override the SDK-generated `name` validation — the generated zod uses the DTO's loose
+// string pattern; we validate against the stricter workspace-name rules so the user sees
+// a useful inline error instead of a 422 toast.
+export const experimentGroupCreateSchema = CreateExperimentGroupBody.extend({
+  name: workspaceInputSchema,
+});
+
+export type ExperimentGroupCreateFormFields = typeof experimentGroupCreateSchema._type;

--- a/web/packages/studio/src/components/ExperimentGroupCreateModal/index.tsx
+++ b/web/packages/studio/src/components/ExperimentGroupCreateModal/index.tsx
@@ -11,7 +11,7 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { FormModal, FormModalProps } from '@nemo/common/src/components/FormModal';
+import { FormModal, type FormModalProps } from '@nemo/common/src/components/FormModal';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import {
   getListExperimentGroupsQueryKey,
@@ -37,8 +37,8 @@ import {
 import { handleFormErrorsGeneric } from '@studio/util/forms/error';
 import { AxiosError } from 'axios';
 import { Plus } from 'lucide-react';
-import { FC } from 'react';
-import { SubmitHandler, useForm } from 'react-hook-form';
+import type { FC } from 'react';
+import { useForm, type SubmitHandler } from 'react-hook-form';
 
 export interface ExperimentGroupCreateModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
   workspace: string;

--- a/web/packages/studio/src/components/ExperimentGroupCreateModal/index.tsx
+++ b/web/packages/studio/src/components/ExperimentGroupCreateModal/index.tsx
@@ -166,7 +166,7 @@ export const ExperimentGroupCreateModal: FC<ExperimentGroupCreateModalProps> = (
                 {...register('description')}
               />
             </FormField>
-            <Button aria-label="Add evaluator">
+            <Button aria-label="Add evaluator" disabled>
               <Plus />
               Add evaluator
             </Button>

--- a/web/packages/studio/src/components/ExperimentGroupCreateModal/index.tsx
+++ b/web/packages/studio/src/components/ExperimentGroupCreateModal/index.tsx
@@ -1,0 +1,199 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { FormModal, FormModalProps } from '@nemo/common/src/components/FormModal';
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import {
+  getListExperimentGroupsQueryKey,
+  useCreateExperimentGroup,
+} from '@nemo/sdk/generated/platform/api';
+import {
+  Button,
+  CodeSnippet,
+  FormField,
+  Stack,
+  TabsContent,
+  TabsList,
+  TabsRoot,
+  TabsTrigger,
+  TextArea,
+  TextInput,
+} from '@nvidia/foundations-react-core';
+import { queryClient } from '@studio/api/queryClient';
+import {
+  experimentGroupCreateSchema,
+  type ExperimentGroupCreateFormFields,
+} from '@studio/components/ExperimentGroupCreateModal/constants';
+import { handleFormErrorsGeneric } from '@studio/util/forms/error';
+import { AxiosError } from 'axios';
+import { Plus } from 'lucide-react';
+import { FC } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+export interface ExperimentGroupCreateModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
+  workspace: string;
+}
+
+export const ExperimentGroupCreateModal: FC<ExperimentGroupCreateModalProps> = ({
+  open,
+  onClose,
+  workspace,
+}) => {
+  const {
+    reset,
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    setValue,
+    setError,
+  } = useForm<ExperimentGroupCreateFormFields>({
+    resolver: zodResolver(experimentGroupCreateSchema),
+    mode: 'onChange',
+  });
+
+  const formDisabled = isSubmitting;
+
+  const toast = useToast();
+
+  const { mutateAsync: createExperimentGroup } = useCreateExperimentGroup({
+    mutation: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: getListExperimentGroupsQueryKey(workspace) });
+      },
+    },
+  });
+
+  const resetAndClose = () => {
+    reset();
+    onClose();
+  };
+
+  const onSubmit: SubmitHandler<ExperimentGroupCreateFormFields> = async (data) => {
+    try {
+      await createExperimentGroup({
+        workspace,
+        data: {
+          name: data.name,
+          description: data.description,
+        },
+      });
+      resetAndClose();
+    } catch (error) {
+      const errorDetail =
+        error instanceof AxiosError && error.response?.data?.detail
+          ? error.response.data.detail
+          : undefined;
+
+      if (errorDetail === `Experiment group ${data.name} already exists.`) {
+        setError('name', { message: errorDetail });
+      } else {
+        let errorMessage: string;
+        if (Array.isArray(errorDetail) && errorDetail.length > 0 && errorDetail[0].msg) {
+          errorMessage = errorDetail[0].msg;
+        } else if (errorDetail && typeof errorDetail === 'string') {
+          errorMessage = errorDetail;
+        } else if (error instanceof Error) {
+          errorMessage = error.message;
+        } else {
+          errorMessage = 'Unknown error';
+        }
+
+        toast.error(`Failed to create experiment group: ${errorMessage}`);
+      }
+    }
+  };
+
+  return (
+    <FormModal
+      title="Create experiment group"
+      instruction="Group experiments to allow easy comparison of top level and test cases"
+      submitButtonText="Create"
+      disabled={formDisabled}
+      loading={isSubmitting}
+      onSubmit={handleSubmit(
+        onSubmit,
+        handleFormErrorsGeneric({ title: 'Experiment Group Create Form Errors' })
+      )}
+      onClose={resetAndClose}
+      open={open}
+      className="w-[800px] min-h-[400px]"
+    >
+      <TabsRoot defaultValue="create" className="w-full min-w-0">
+        <TabsList>
+          <TabsTrigger value="create">Create experiment</TabsTrigger>
+          <TabsTrigger value="coding-agent">Coding agent</TabsTrigger>
+          <TabsTrigger value="cli">CLI command</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="create" className="px-0 w-full">
+          <Stack gap="density-2xl" className="w-full">
+            <FormField
+              slotLabel="Name"
+              slotError={errors.name?.message}
+              status={errors.name && 'error'}
+            >
+              <TextInput
+                autoFocus
+                disabled={formDisabled}
+                status={errors.name && 'error'}
+                {...register('name')}
+                onChange={(e) =>
+                  setValue('name', (e.target as HTMLInputElement).value.replace(/[\s-]+/g, '-'), {
+                    shouldValidate: true,
+                  })
+                }
+              />
+            </FormField>
+
+            <FormField
+              slotLabel="Description (optional)"
+              slotError={errors.description?.message}
+              status={errors.description && 'error'}
+            >
+              <TextArea
+                disabled={formDisabled}
+                status={errors.description && 'error'}
+                {...register('description')}
+              />
+            </FormField>
+            <Button aria-label="Add evaluator">
+              <Plus />
+              Add evaluator
+            </Button>
+          </Stack>
+        </TabsContent>
+
+        <TabsContent value="coding-agent" className="px-0 w-full">
+          <CodeSnippet
+            className="min-w-full"
+            value="To be determined"
+            language="text"
+            kind="block"
+          />
+        </TabsContent>
+
+        <TabsContent value="cli" className="px-0 w-full">
+          <CodeSnippet
+            className="min-w-full"
+            value={
+              'nemo exp run --group --dataset support-bench-v3\n' +
+              '  --evaluators correctness,helpfulness,groundedness,tool-error'
+            }
+            language="bash"
+            kind="block"
+          />
+        </TabsContent>
+      </TabsRoot>
+    </FormModal>
+  );
+};

--- a/web/packages/studio/src/routes/ExperimentRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/index.tsx
@@ -4,6 +4,7 @@
 import { useListExperimentGroups } from '@nemo/sdk/generated/platform/api';
 import type { ExperimentGroupResponse } from '@nemo/sdk/generated/platform/schema';
 import {
+  Button,
   PageHeader,
   PaginationArrowButton,
   PaginationControlsGroup,
@@ -18,6 +19,7 @@ import {
   Text,
 } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { ExperimentGroupCreateModal } from '@studio/components/ExperimentGroupCreateModal';
 import { Loading } from '@studio/components/Layouts/Loading';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
@@ -34,6 +36,7 @@ export const ExperimentRoute: FC = () => {
   const workspace = useWorkspaceFromPath();
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
   const { data, isLoading, error } = useListExperimentGroups(
     workspace,
@@ -67,6 +70,16 @@ export const ExperimentRoute: FC = () => {
           className="p-0"
           slotHeading="Experiment groups"
           slotDescription="Manage groups for online optimization. Review reports down to the frame level."
+          slotActions={
+            <Button color="brand" onClick={() => setIsCreateModalOpen(true)}>
+              New experiment group
+            </Button>
+          }
+        />
+        <ExperimentGroupCreateModal
+          open={isCreateModalOpen}
+          onClose={() => setIsCreateModalOpen(false)}
+          workspace={workspace}
         />
         {groups.length === 0 ? (
           <Text kind="body/regular/md" className="text-secondary">


### PR DESCRIPTION
Closes #FP-207

# Summary

The Experiment Groups page had no way to create a group from the UI. This adds a "New experiment group" button to the `PageHeader` that opens a tabbed creation modal with three views: a form tab (name required, description optional), and placeholder tabs for a coding agent snippet and a CLI command.

The form is backed by `useCreateExperimentGroup` from the generated SDK, with Zod validation that overrides the loose SDK-generated schema with the stricter workspace-name rules (alphanumeric + `.-_`, 1–255 chars) so field errors surface inline rather than as a 422 toast. On success the groups list is invalidated via `getListExperimentGroupsQueryKey`. Duplicate-name 409s are handled as inline name field errors.

# Test plan
- [ ] Navigate to Experiments in the sidebar → confirm "New experiment group" button is visible in the page header
- [ ] Click the button → modal opens with "Create experiment", "Coding agent", and "CLI command" tabs
- [ ] Submit with empty name → confirm name field shows a validation error and Create is blocked
- [ ] Fill in name only → click Create → group appears in the list
- [ ] Fill in name + description → click Create → group appears with description
- [ ] Submit a duplicate name → confirm inline error on the name field (not a toast)
- [ ] Click Cancel or close → modal closes and list is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal dialog to create experiment groups with a form-based interface
  * "New experiment group" button added to the experiment page
  * Name field automatically normalizes characters and spaces
  * Optional description field
  * Inline field validation with clear error messaging
  * Tabbed modal content (Create, Coding agent, CLI) with code snippet placeholders
  * Submission shows loading state and prevents duplicate actions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->