### PR TITLE
fix(anonymizer): Update tutorial

### DIFF
--- a/docs/anonymizer/tutorials/index.mdx
+++ b/docs/anonymizer/tutorials/index.mdx
@@ -83,7 +83,7 @@ When using Anonymizer as a NeMo Platform service:
 
 Complete [Setup](/documentation/get-started) to install NeMo Platform, run `nemo services run`, and configure an inference provider. The Anonymizer plugin is currently supported from the NeMo Platform monorepo workspace: run `make bootstrap` at the repo root, or `make bootstrap-python` / `uv sync` if you only need Python dependencies, so uv can resolve `nemo-anonymizer-plugin` and the workspace prerequisites `nmp-common`, `nemo-platform-plugin`, and `data-designer-nemo`.
 
-The root workspace includes the Anonymizer plugin, so `nemo services run` discovers it automatically and mounts `/apis/anonymizer/...` on the gateway. Standalone installation from a fresh environment outside the repo is not available yet; this page will include a standalone package-install path after the plugin and its prerequisites are published to the package index. Verify the CLI is registered:
+The root workspace includes the Anonymizer plugin, so `nemo services run` discovers it automatically and mounts `/apis/anonymizer/...` on the gateway. Standalone installation from a fresh environment outside the repo is not available. Verify the CLI is registered:
 
 ```bash
 nemo anonymizer --help

--- a/docs/anonymizer/tutorials/index.mdx
+++ b/docs/anonymizer/tutorials/index.mdx
@@ -55,16 +55,18 @@ sdk = NeMoPlatform(
 )
 anonymizer = sdk.anonymizer
 
-preview = anonymizer.preview(PreviewRequest(
-    config=config,
-    data=AnonymizerInputSpec(
-        source=f"fileset://{WORKSPACE}/anonymizer-inputs#anonymizer-input.csv",
-        text_column="biography",
-        id_column="id",
-    ),
-    model_configs=model_configs,
-    num_records=10,
-))
+preview = anonymizer.preview(
+    PreviewRequest(
+        config=config,
+        data=AnonymizerInputSpec(
+            source=f"fileset://{WORKSPACE}/anonymizer-inputs#anonymizer-input.csv",
+            text_column="biography",
+            id_column="id",
+        ),
+        model_configs=model_configs,
+        num_records=10,
+    )
+)
 ```
 
 ## Service-Specific Considerations
@@ -79,7 +81,9 @@ When using Anonymizer as a NeMo Platform service:
 
 ## Prerequisites
 
-Complete [Setup](/documentation/get-started) to install NeMo Platform, run `nemo services run`, and configure an inference provider. The root workspace includes the Anonymizer plugin, so `nemo services run` discovers it automatically and mounts `/apis/anonymizer/...` on the gateway — no separate plugin install step is needed. Verify the CLI is registered:
+Complete [Setup](/documentation/get-started) to install NeMo Platform, run `nemo services run`, and configure an inference provider. The Anonymizer plugin is currently supported from the NeMo Platform monorepo workspace: run `make bootstrap` at the repo root, or `make bootstrap-python` / `uv sync` if you only need Python dependencies, so uv can resolve `nemo-anonymizer-plugin` and the workspace prerequisites `nmp-common`, `nemo-platform-plugin`, and `data-designer-nemo`.
+
+The root workspace includes the Anonymizer plugin, so `nemo services run` discovers it automatically and mounts `/apis/anonymizer/...` on the gateway. Standalone installation from a fresh environment outside the repo is not available yet; this page will include a standalone package-install path after the plugin and its prerequisites are published to the package index. Verify the CLI is registered:
 
 ```bash
 nemo anonymizer --help


### PR DESCRIPTION
## Summary

- Clarifies Anonymizer tutorial prerequisites for the current monorepo-only plugin install path.
- Points users to `make bootstrap` as the primary setup path, with `make bootstrap-python` / `uv sync` as Python-only alternatives.
- Names the workspace prerequisites: `nmp-common`, `nemo-platform-plugin`, and `data-designer-nemo`.
- Notes that standalone installation will be documented after the plugin and prerequisites are published.

## Testing

- [x] `uv run --frozen pytest docs/_scripts/test_format_code_blocks.py docs/_scripts/test_lint_notebooks.py -q`
- [x] `uv run --frozen python docs/_scripts/format_code_blocks.py --docs-dir docs docs/anonymizer/tutorials/index.md --check`
- [x] Verified a clean temp environment outside the repo cannot resolve `nemo-anonymizer-plugin` from the package index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Anonymizer tutorials to show a clearer, multi-line preview example while preserving existing configuration and usage details for inputs and model settings.
  * Revised the NeMo Platform service Prerequisites wording to clarify plugin setup: the Anonymizer plugin is supported from the monorepo workspace and standalone installation outside the repo is not available; CLI registration verification remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->