### PR TITLE
ci(studio): add SDK gen check for OpenAPI spec changes (ASTD-218)

### DIFF
--- a/.github/actions/changes/action.yaml
+++ b/.github/actions/changes/action.yaml
@@ -39,6 +39,7 @@ runs:
         filters: |
           openapi:
             - 'openapi/**'
+            - 'plugins/*/openapi/**'
           tests:
             - 'tests/**'
             - 'pytest.ini'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -531,8 +531,6 @@ jobs:
         run: pnpm --filter @nemo/sdk gen:all-force
       - name: Typecheck SDK generated output
         run: pnpm --filter @nemo/sdk typecheck
-      - name: Typecheck studio against generated SDK
-        run: pnpm --filter nemo-studio-ui typecheck
 
   web-studio-deps:
     name: Web studio deps check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -504,6 +504,34 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+  web-sdk-gen:
+    name: Web SDK generation check
+    needs: [changes]
+    if: >
+      !cancelled() && (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs.openapi == 'true' ||
+        needs.changes.outputs.web-studio == 'true'
+      )
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+        shell: bash
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+      - name: Install pnpm via corepack
+        run: npm i -g corepack@0.31.0 && corepack enable pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Generate SDK from OpenAPI specs
+        run: pnpm --filter @nemo/sdk gen:all-force
+      - name: Typecheck studio against generated SDK
+        run: pnpm --filter nemo-studio-ui typecheck
+
   web-studio-deps:
     name: Web studio deps check
     needs: [changes]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -529,6 +529,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Generate SDK from OpenAPI specs
         run: pnpm --filter @nemo/sdk gen:all-force
+      - name: Typecheck SDK generated output
+        run: pnpm --filter @nemo/sdk typecheck
       - name: Typecheck studio against generated SDK
         run: pnpm --filter nemo-studio-ui typecheck
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -768,6 +768,7 @@ jobs:
       - web-test
       - web-format
       - web-lint
+      - web-sdk-gen
       - web-studio-deps
       - web-studio-e2e
       - benchmark-guardrails

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     hooks:
       - id: config-reference-docs
         name: Check config reference doc is up to date
-        entry: bash -c 'uv run generate-config-docs && git diff --exit-code docs/set-up/config-reference.md'
+        entry: bash -c 'uv run generate-config-docs && git diff --exit-code docs/set-up/config-reference.mdx'
         language: system
         pass_filenames: false
         files: |
@@ -63,7 +63,7 @@ repos:
             script/generate_config_docs\.py|
             packages/nmp_common/.*|
             services/.*/src/.*/config\.py|
-            docs/set-up/config-reference\.md
+            docs/set-up/config-reference\.mdx
           )$
 
   - repo: https://github.com/norwoodj/helm-docs


### PR DESCRIPTION
## Summary

- Add `web-sdk-gen` CI job: force-regenerates the TypeScript SDK from all OpenAPI specs, then typechecks `nemo-studio-ui` against the result
- Expand `studio-ci.yaml` trigger paths to include `openapi/**` and `plugins/*/openapi/**` so PRs that change OpenAPI specs outside `web/` run Studio CI

## Root cause

PR #66 broke `main` because 4 new `add_job_routes()` calls produced duplicate OpenAPI operationIds, generating duplicate TypeScript function names. `studio-ci.yaml` only triggered on `web/**` changes, so the Studio SDK failure was invisible until after merge. PR #219 was the 2-hour hotfix.

## How this prevents recurrence

Any PR that changes `plugins/*/openapi/**` or `openapi/**` now triggers `web-sdk-gen`. The job fails if `gen:all-force` produces TypeScript that doesn't compile — catching duplicate operationIds, schema regressions, or any other OpenAPI change that breaks the Studio SDK.

## Test plan

- [ ] Verify `web-sdk-gen` job appears in CI on this PR
- [ ] Confirm the job passes (current specs are clean)
- [ ] Manually verify: introduce a duplicate operationId in a plugin OpenAPI spec, confirm `web-sdk-gen` fails

Fixes ASTD-218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now detects OpenAPI changes in plugin specifications and triggers relevant tasks.
  * CI added an automated workflow to regenerate and type-check the TypeScript SDK when API or web studio sources change; its result is included in overall CI status.
  * Pre-commit hook updated to validate the documentation file with the .mdx extension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->