### PR TITLE
ci: do not require DCO for repository members

### DIFF
--- a/.github/dco.yaml
+++ b/.github/dco.yaml
@@ -1,0 +1,3 @@
+require:
+  members: false
+


### PR DESCRIPTION
In principle, DCO is for external contributors to the project. While we could leave it as a requirement for everyone, this would relax it for project members. This is the configuration used by the dynamo project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Developer Certificate of Origin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->