### PR TITLE
ci: update parallelism of unit tests

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,3 @@
-
 rules:
   custom:
     - name: "input-names-kebab-case"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,9 @@ jobs:
         with:
           python-version: "3.11"
           enable-cache: true
+      - name: Check runner size
+        run: lscpu
+        shell: bash
       - name: Run unit tests
         run: make test-unit-ci
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,15 +160,12 @@ jobs:
         with:
           python-version: "3.11"
           enable-cache: true
-      - name: Check runner size
-        run: lscpu
-        shell: bash
       - name: Run unit tests
         run: make test-unit-ci
         env:
           EXTRA: cpu
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          PYTEST_WORKERS: "2"
+          PYTEST_WORKERS: "4"
           _TYPER_FORCE_DISABLE_TERMINAL: "1"
       - name: Upload test artifacts
         if: always()
@@ -216,7 +213,7 @@ jobs:
         env:
           EXTRA: cpu
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          PYTEST_WORKERS: "2"
+          PYTEST_WORKERS: "4"
           _TYPER_FORCE_DISABLE_TERMINAL: "1"
       - name: Upload test artifacts
         if: always()


### PR DESCRIPTION
Initially this is just testing the behavior of things. Then, hopefully we can tweak the paralellism and make things faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased parallel test workers in CI from 2 to 4 to speed up Python test runs.
  * Added a CI linting rule to enforce kebab-case naming for action inputs, improving workflow consistency and preventing naming errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->