### PR TITLE
docs: update Fern custom domain to docs.nvidia.com/nemo-platform

### DIFF
--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -1,6 +1,6 @@
 instances:
 - url: nemo-platform.docs.buildwithfern.com/nemo/platform
-  custom-domain: docs.nvidia.com/nemo/platform
+  custom-domain: docs.nvidia.com/nemo-platform
   multi-source: true
 title: NVIDIA NeMo Platform
 global-theme: nvidia


### PR DESCRIPTION
Updates the Fern `custom-domain` in `docs/fern/docs.yml` from `docs.nvidia.com/nemo/platform` to `docs.nvidia.com/nemo-platform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation platform configuration for improved domain routing and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->