### PR TITLE
feat(studio): Add input and tools for multiple chat interactions with Code Agent

### DIFF
--- a/services/studio/src/nmp/studio/coding_agent_mcp_tools.py
+++ b/services/studio/src/nmp/studio/coding_agent_mcp_tools.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MCP tool catalog for Studio coding-agent sessions."""
+
+from typing import Any
+
+CLAUDE_MCP_SERVER_NAME = "nemo_studio"
+
+APPROVAL_TOOL_NAME = "approval_prompt"
+STUDIO_LINK_TOOL_NAME = "studio_link"
+SELECT_AGENT_TOOL_NAME = "select_agent"
+SELECT_EVAL_CONFIG_TOOL_NAME = "select_eval_config"
+SELECT_DATASET_FILE_TOOL_NAME = "select_dataset_file"
+SELECT_MODEL_TOOL_NAME = "select_model"
+JOB_PROGRESS_TOOL_NAME = "job_progress"
+
+APPROVAL_TOOL: dict[str, Any] = {
+    "name": APPROVAL_TOOL_NAME,
+    "description": "Ask the human operator whether a tool call should be allowed.",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "tool_name": {"type": "string"},
+            "input": {"type": "object"},
+            "tool_use_id": {"type": "string"},
+        },
+        "required": ["tool_name", "input"],
+    },
+}
+
+SELECT_AGENT_TOOL: dict[str, Any] = {
+    "name": SELECT_AGENT_TOOL_NAME,
+    "description": (
+        "Ask the Studio user to choose an agent from a visual dropdown. "
+        "Use this instead of plain text prompting when a Studio workflow needs a concrete agent name."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "default_agent": {"type": "string"},
+        },
+        "additionalProperties": False,
+    },
+}
+
+SELECT_EVAL_CONFIG_TOOL: dict[str, Any] = {
+    "name": SELECT_EVAL_CONFIG_TOOL_NAME,
+    "description": (
+        "Ask the Studio user to choose an evaluation YAML file from a visual fileset file picker. "
+        "Use this instead of plain text prompting when an agent evaluation workflow needs an eval config. "
+        "Returns eval_config_fileset and eval_config. If the user does not have a config yet, "
+        "Studio may return needs_eval_config=true so you can help create one. "
+        "Studio may also return use_sample_eval_config=true with a sample eval_config and eval_config_fileset."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "agent": {"type": "string"},
+            "default_agent": {"type": "string"},
+            "accepted_file_types": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+        "additionalProperties": False,
+    },
+}
+
+SELECT_DATASET_FILE_TOOL: dict[str, Any] = {
+    "name": SELECT_DATASET_FILE_TOOL_NAME,
+    "description": (
+        "Ask the Studio user to choose a dataset file from a visual fileset file picker. "
+        "Use this instead of plain text prompting when a workflow needs source data, "
+        "for example while helping create an evaluation config. Returns dataset_fileset and dataset_path."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "accepted_file_types": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+        "additionalProperties": False,
+    },
+}
+
+SELECT_MODEL_TOOL: dict[str, Any] = {
+    "name": SELECT_MODEL_TOOL_NAME,
+    "description": (
+        "Ask the Studio user to choose a model from a visual model picker. "
+        "Use this instead of plain text prompting when a Studio workflow needs a concrete model name. "
+        "Returns model by default. You may pass output_key to request a different response key."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "default_model": {"type": "string"},
+            "output_key": {"type": "string"},
+            "display_label": {"type": "string"},
+            "field_label": {"type": "string"},
+            "placeholder": {"type": "string"},
+            "required_message": {"type": "string"},
+            "submit_label": {"type": "string"},
+        },
+        "additionalProperties": False,
+    },
+}
+
+JOB_PROGRESS_TOOL: dict[str, Any] = {
+    "name": JOB_PROGRESS_TOOL_NAME,
+    "description": (
+        "Show a compact Studio progress card for a long-running job. "
+        "Call this only after a real Studio job has been started and you know its job_name. "
+        "Pass job_type or source when known so Studio can link to the best detail page."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "job_name": {"type": "string"},
+            "job_type": {
+                "type": "string",
+                "description": (
+                    "Optional job category, such as customization, data_designer, "
+                    "safe_synthesizer, evaluator, or agent_evaluation."
+                ),
+            },
+            "source": {
+                "type": "string",
+                "description": "Optional platform job source, such as customization or data-designer.",
+            },
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "workspace": {"type": "string"},
+        },
+        "required": ["job_name"],
+        "additionalProperties": False,
+    },
+}
+
+MCP_TOOLS: list[dict[str, Any]] = [
+    APPROVAL_TOOL,
+    SELECT_AGENT_TOOL,
+    SELECT_EVAL_CONFIG_TOOL,
+    SELECT_DATASET_FILE_TOOL,
+    SELECT_MODEL_TOOL,
+    JOB_PROGRESS_TOOL,
+]
+
+STUDIO_UI_TOOL_NAMES = (
+    SELECT_AGENT_TOOL_NAME,
+    SELECT_EVAL_CONFIG_TOOL_NAME,
+    SELECT_DATASET_FILE_TOOL_NAME,
+    SELECT_MODEL_TOOL_NAME,
+    JOB_PROGRESS_TOOL_NAME,
+    STUDIO_LINK_TOOL_NAME,
+)
+
+STUDIO_CODING_AGENT_CONTEXT = "\n".join(
+    [
+        "You are running inside NeMo Studio's Code Agent chat.",
+        "NeMo Studio and the NeMo Platform API are already running for this workspace.",
+        "Do not spend time starting the platform or checking whether Studio is up unless the user asks.",
+        "Your local shell and file tools may be sandboxed; use the normal Studio approval flow when needed.",
+        (
+            "When you need to prompt the user for input, use a Studio UI tool instead of writing a "
+            "plain-text question whenever a suitable tool exists."
+        ),
+        (
+            "Use mcp__nemo_studio__select_agent for agent names, "
+            "mcp__nemo_studio__select_model for model names, "
+            "mcp__nemo_studio__select_dataset_file for dataset or source files, and "
+            "mcp__nemo_studio__select_eval_config for evaluation config files."
+        ),
+        (
+            "For broader clarification, multiple-choice, yes/no, or freeform questions, use Claude "
+            "Code's AskUserQuestion tool rather than writing a questionnaire in markdown."
+        ),
+        (
+            "Only fall back to plain chat questions when no suitable UI tool is available, the user "
+            "already provided the value, or the UI tool returns skipped or error."
+        ),
+        (
+            "Set UI tool titles, descriptions, display labels, and output_key values to match the "
+            "current workflow while keeping the tools reusable."
+        ),
+        (
+            "When you start a long-running Studio job and a matching progress/status MCP tool is "
+            "available, call it after job creation with the job id or name so Studio can render "
+            "progress inline. Use mcp__nemo_studio__job_progress for Studio jobs."
+        ),
+    ]
+)
+
+
+def qualified_mcp_tool_name(tool_name: str, server_name: str = CLAUDE_MCP_SERVER_NAME) -> str:
+    """Return Claude Code's fully qualified MCP tool name for a Studio tool."""
+    return f"mcp__{server_name}__{tool_name}"
+
+
+def allowed_mcp_tools(server_name: str = CLAUDE_MCP_SERVER_NAME) -> list[str]:
+    """Return the Studio UI tools Claude may call without an approval prompt."""
+    return [qualified_mcp_tool_name(tool_name, server_name) for tool_name in STUDIO_UI_TOOL_NAMES]
+
+
+def permission_prompt_tool(server_name: str = CLAUDE_MCP_SERVER_NAME) -> str:
+    """Return the fully qualified approval prompt tool name."""
+    return qualified_mcp_tool_name(APPROVAL_TOOL_NAME, server_name)

--- a/services/studio/src/nmp/studio/coding_agents.py
+++ b/services/studio/src/nmp/studio/coding_agents.py
@@ -23,6 +23,21 @@ from nmp.studio.coding_agent_skills import ClaudeSkillResponse, DuplicateSkillEr
 from pydantic import BaseModel, Field
 from starlette.routing import NoMatchFound
 
+from nmp.studio.coding_agent_mcp_tools import (
+    APPROVAL_TOOL_NAME,
+    CLAUDE_MCP_SERVER_NAME,
+    JOB_PROGRESS_TOOL_NAME,
+    MCP_TOOLS,
+    SELECT_AGENT_TOOL_NAME,
+    SELECT_DATASET_FILE_TOOL_NAME,
+    SELECT_EVAL_CONFIG_TOOL_NAME,
+    SELECT_MODEL_TOOL_NAME,
+    STUDIO_CODING_AGENT_CONTEXT,
+    STUDIO_LINK_TOOL_NAME,
+    allowed_mcp_tools,
+    permission_prompt_tool,
+)
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v2/coding-agents")
@@ -30,7 +45,6 @@ router = APIRouter(prefix="/v2/coding-agents")
 MCP_ROUTE_NAME = "studio_coding_agent_mcp"
 PUBLIC_MCP_ROUTE_NAME = "studio_coding_agent_public_mcp"
 PUBLIC_MCP_PATH = "/studio/api/coding-agents/mcp/{session_id}"
-CLAUDE_MCP_SERVER_NAME = "nemo_studio"
 
 CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
 SERVER_CWD = Path(os.getcwd()).resolve()
@@ -62,6 +76,13 @@ class PermissionDecision(BaseModel):
     updated_input: dict[str, Any] | None = None
 
 
+class AgentInputDecision(BaseModel):
+    """Studio's value for a pending local-agent UI input request."""
+
+    skipped: bool = False
+    value: dict[str, Any] | None = None
+
+
 class HistorySessionResponse(BaseModel):
     """Summary of a Claude session stored on disk."""
 
@@ -84,6 +105,7 @@ class SessionHistoryResponse(BaseModel):
 _initialized_sessions: set[str] = set()
 _session_streams: dict[str, asyncio.Queue[tuple[str, Any]]] = {}
 _pending_permissions: dict[str, tuple[str, asyncio.Future[dict[str, Any]]]] = {}
+_pending_agent_inputs: dict[str, tuple[str, asyncio.Future[dict[str, Any]]]] = {}
 
 
 @dataclass
@@ -97,25 +119,10 @@ class HistorySummary:
     tool_calls: list[str] = dataclass_field(default_factory=list)
 
 
-_APPROVAL_TOOL = {
-    "name": "approval_prompt",
-    "description": "Ask the human operator whether a tool call should be allowed.",
-    "inputSchema": {
-        "type": "object",
-        "properties": {
-            "tool_name": {"type": "string"},
-            "input": {"type": "object"},
-            "tool_use_id": {"type": "string"},
-        },
-        "required": ["tool_name", "input"],
-    },
-}
-
-
 def _mcp_tools_for_destinations(
     destinations: Mapping[str, studio_links.StudioLinkDestination],
 ) -> list[dict[str, Any]]:
-    return [_APPROVAL_TOOL, studio_links.tool_for_destinations(destinations)]
+    return [*MCP_TOOLS, studio_links.tool_for_destinations(destinations)]
 
 
 def mount_public_mcp_route(app: FastAPI) -> None:
@@ -441,13 +448,15 @@ def _extract_assistant_parts(content: Any) -> list[dict[str, Any]]:
             if isinstance(thinking, str) and thinking:
                 parts.append({"type": "thinking", "thinking": thinking})
         elif part_type == "tool_use":
-            parts.append(
-                {
-                    "type": "tool_use",
-                    "name": part.get("name") or "tool",
-                    "input": part.get("input") or {},
-                }
-            )
+            tool_use = {
+                "type": "tool_use",
+                "name": part.get("name") or "tool",
+                "input": part.get("input") or {},
+            }
+            tool_use_id = part.get("id")
+            if isinstance(tool_use_id, str) and tool_use_id:
+                tool_use["id"] = tool_use_id
+            parts.append(tool_use)
     return parts
 
 
@@ -590,8 +599,12 @@ def _build_claude_argv(
         "--verbose",
         "--mcp-config",
         mcp_config,
+        "--allowedTools",
+        ",".join(allowed_mcp_tools(CLAUDE_MCP_SERVER_NAME)),
+        "--append-system-prompt",
+        STUDIO_CODING_AGENT_CONTEXT,
         "--permission-prompt-tool",
-        f"mcp__{CLAUDE_MCP_SERVER_NAME}__approval_prompt",
+        permission_prompt_tool(CLAUDE_MCP_SERVER_NAME),
     ]
     if studio_system_prompt:
         argv.extend(["--append-system-prompt", studio_system_prompt])
@@ -646,6 +659,42 @@ async def _request_permission(session_id: str, args: dict[str, Any]) -> dict[str
             updated = args.get("input") or {}
         return {"behavior": "allow", "updatedInput": updated}
     return {"behavior": "deny", "message": decision.get("reason") or "denied by user"}
+
+
+async def _request_agent_input(session_id: str, kind: str, args: dict[str, Any]) -> dict[str, Any]:
+    queue = _session_streams.get(session_id)
+    if queue is None:
+        return {"status": "error", "message": "no active Studio coding-agent session"}
+
+    request_id = str(uuid.uuid4())
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[dict[str, Any]] = loop.create_future()
+    _pending_agent_inputs[request_id] = (session_id, future)
+
+    payload = json.dumps(
+        {
+            "request_id": request_id,
+            "kind": kind,
+            "input": args,
+        }
+    )
+    await queue.put(("input_request", payload))
+
+    try:
+        decision = await asyncio.wait_for(future, timeout=300)
+    except asyncio.TimeoutError:
+        return {"status": "error", "message": "input request timed out"}
+    finally:
+        _pending_agent_inputs.pop(request_id, None)
+
+    if decision.get("skipped"):
+        return {"status": "skipped"}
+
+    value = decision.get("value")
+    if isinstance(value, dict):
+        return {"status": "submitted", **value}
+
+    return {"status": "error", "message": "input request resolved without a value"}
 
 
 async def _pump_stdout(
@@ -745,6 +794,8 @@ async def _stream_claude(
                 yield _sse(payload)
             elif event_type == "permission_request":
                 yield _sse(payload, event="permission_request")
+            elif event_type == "input_request":
+                yield _sse(payload, event="input_request")
 
         returncode = await proc.wait()
         if stderr_task is not None:
@@ -794,6 +845,20 @@ async def resolve_permission(session_id: str, request_id: str, body: PermissionD
     pending_session_id, future = pending
     if pending_session_id != sid or future.done():
         raise HTTPException(status_code=404, detail="no such pending permission")
+    future.set_result(body.model_dump())
+    return {"ok": True}
+
+
+@router.post("/sessions/{session_id}/inputs/{request_id}")
+async def resolve_agent_input(session_id: str, request_id: str, body: AgentInputDecision) -> dict[str, bool]:
+    """Resolve a pending Claude UI input request."""
+    sid = _validate_session_id(session_id)
+    pending = _pending_agent_inputs.get(request_id)
+    if pending is None:
+        raise HTTPException(status_code=404, detail="no such pending input")
+    pending_session_id, future = pending
+    if pending_session_id != sid or future.done():
+        raise HTTPException(status_code=404, detail="no such pending input")
     future.set_result(body.model_dump())
     return {"ok": True}
 
@@ -850,7 +915,66 @@ async def mcp_endpoint(session_id: str, request: Request) -> Response:
         if not isinstance(args, dict):
             return JSONResponse(status_code=400, content={"detail": "tool arguments must be an object"})
 
-        if name == "approval_prompt":
+        if name == SELECT_AGENT_TOOL_NAME:
+            result = await _request_agent_input(sid, "agent", args)
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "content": [{"type": "text", "text": json.dumps(result)}],
+                    },
+                }
+            )
+
+        if name == SELECT_EVAL_CONFIG_TOOL_NAME:
+            result = await _request_agent_input(sid, "eval_config", args)
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "content": [{"type": "text", "text": json.dumps(result)}],
+                    },
+                }
+            )
+
+        if name == SELECT_DATASET_FILE_TOOL_NAME:
+            result = await _request_agent_input(sid, "dataset_file", args)
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "content": [{"type": "text", "text": json.dumps(result)}],
+                    },
+                }
+            )
+
+        if name == SELECT_MODEL_TOOL_NAME:
+            result = await _request_agent_input(sid, "model", args)
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "content": [{"type": "text", "text": json.dumps(result)}],
+                    },
+                }
+            )
+
+        if name == JOB_PROGRESS_TOOL_NAME:
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "content": [{"type": "text", "text": json.dumps({"status": "rendered"})}],
+                    },
+                }
+            )
+
+        if name == APPROVAL_TOOL_NAME:
             result = await _request_permission(sid, args)
             return JSONResponse(
                 {
@@ -862,7 +986,7 @@ async def mcp_endpoint(session_id: str, request: Request) -> Response:
                 }
             )
 
-        if name == "studio_link":
+        if name == STUDIO_LINK_TOOL_NAME:
             workspace = _trimmed_string(request.query_params.get("workspace"))
             studio_base_url = _trimmed_string(request.query_params.get("studio_base_url"))
             enabled_destinations = studio_links.enabled_destinations_from_request(request)

--- a/services/studio/src/nmp/studio/coding_agents.py
+++ b/services/studio/src/nmp/studio/coding_agents.py
@@ -105,6 +105,7 @@ _initialized_sessions: set[str] = set()
 _session_streams: dict[str, asyncio.Queue[tuple[str, Any]]] = {}
 _pending_permissions: dict[str, tuple[str, asyncio.Future[dict[str, Any]]]] = {}
 _pending_agent_inputs: dict[str, tuple[str, asyncio.Future[dict[str, Any]]]] = {}
+_AGENT_INPUT_RESPONSE_RESERVED_KEYS = frozenset({"message", "status"})
 
 
 @dataclass
@@ -691,6 +692,12 @@ async def _request_agent_input(session_id: str, kind: str, args: dict[str, Any])
 
     value = decision.get("value")
     if isinstance(value, dict):
+        reserved_keys = sorted(_AGENT_INPUT_RESPONSE_RESERVED_KEYS.intersection(value))
+        if reserved_keys:
+            return {
+                "status": "error",
+                "message": f"input value included reserved keys: {', '.join(reserved_keys)}",
+            }
         return {"status": "submitted", **value}
 
     return {"status": "error", "message": "input request resolved without a value"}

--- a/services/studio/src/nmp/studio/coding_agents.py
+++ b/services/studio/src/nmp/studio/coding_agents.py
@@ -19,10 +19,6 @@ from urllib.parse import urlencode, urlparse
 from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from nmp.studio import studio_links
-from nmp.studio.coding_agent_skills import ClaudeSkillResponse, DuplicateSkillError, list_claude_skill_responses
-from pydantic import BaseModel, Field
-from starlette.routing import NoMatchFound
-
 from nmp.studio.coding_agent_mcp_tools import (
     APPROVAL_TOOL_NAME,
     CLAUDE_MCP_SERVER_NAME,
@@ -37,6 +33,9 @@ from nmp.studio.coding_agent_mcp_tools import (
     allowed_mcp_tools,
     permission_prompt_tool,
 )
+from nmp.studio.coding_agent_skills import ClaudeSkillResponse, DuplicateSkillError, list_claude_skill_responses
+from pydantic import BaseModel, Field
+from starlette.routing import NoMatchFound
 
 logger = logging.getLogger(__name__)
 

--- a/services/studio/tests/unit/test_coding_agents.py
+++ b/services/studio/tests/unit/test_coding_agents.py
@@ -1020,6 +1020,26 @@ async def test_resolve_agent_input_sets_result_for_owning_session():
     assert future.result() == {"skipped": False, "value": {"agent": "react-agent"}}
 
 
+async def test_request_agent_input_rejects_reserved_response_keys():
+    session_id = str(uuid.uuid4())
+    coding_agents._session_streams[session_id] = asyncio.Queue()
+
+    request_task = asyncio.create_task(coding_agents._request_agent_input(session_id, "agent", {}))
+    _, payload = await coding_agents._session_streams[session_id].get()
+    request_id = json.loads(payload)["request_id"]
+
+    await coding_agents.resolve_agent_input(
+        session_id,
+        request_id,
+        coding_agents.AgentInputDecision(value={"agent": "react-agent", "status": "submitted"}),
+    )
+
+    assert await request_task == {
+        "status": "error",
+        "message": "input value included reserved keys: status",
+    }
+
+
 def test_platform_route_stream_uses_public_mcp_callback(monkeypatch: pytest.MonkeyPatch):
     service = StudioService()
     app = FastAPI()

--- a/services/studio/tests/unit/test_coding_agents.py
+++ b/services/studio/tests/unit/test_coding_agents.py
@@ -816,6 +816,7 @@ def test_mcp_studio_link_returns_started_evaluation_result_markdown(service_clie
         "markdown": "[Evaluation result eval run 01](/workspaces/default/evaluation/results/eval%20run%2001)",
     }
 
+
 def test_mcp_rejects_malformed_json(service_client: TestClient):
     session_id = str(uuid.uuid4())
 

--- a/services/studio/tests/unit/test_coding_agents.py
+++ b/services/studio/tests/unit/test_coding_agents.py
@@ -25,10 +25,12 @@ def reset_coding_agent_state():
     coding_agents._initialized_sessions.clear()
     coding_agents._session_streams.clear()
     coding_agents._pending_permissions.clear()
+    coding_agents._pending_agent_inputs.clear()
     yield
     coding_agents._initialized_sessions.clear()
     coding_agents._session_streams.clear()
     coding_agents._pending_permissions.clear()
+    coding_agents._pending_agent_inputs.clear()
 
 
 @pytest.fixture
@@ -117,6 +119,16 @@ def test_build_claude_argv_uses_new_session_then_resume_flag():
     assert argv[:3] == ["claude", "-p", "hello"]
     assert "--output-format" in argv
     assert "stream-json" in argv
+    assert "--allowedTools" in argv
+    allowed_tools = argv[argv.index("--allowedTools") + 1].split(",")
+    assert f"mcp__{coding_agents.CLAUDE_MCP_SERVER_NAME}__select_agent" in allowed_tools
+    assert f"mcp__{coding_agents.CLAUDE_MCP_SERVER_NAME}__select_eval_config" in allowed_tools
+    assert f"mcp__{coding_agents.CLAUDE_MCP_SERVER_NAME}__select_dataset_file" in allowed_tools
+    assert f"mcp__{coding_agents.CLAUDE_MCP_SERVER_NAME}__select_model" in allowed_tools
+    assert f"mcp__{coding_agents.CLAUDE_MCP_SERVER_NAME}__job_progress" in allowed_tools
+    assert f"mcp__{coding_agents.CLAUDE_MCP_SERVER_NAME}__studio_link" in allowed_tools
+    assert "--append-system-prompt" in argv
+    assert argv[argv.index("--append-system-prompt") + 1] == coding_agents.STUDIO_CODING_AGENT_CONTEXT
     assert "--permission-prompt-tool" in argv
     assert f"mcp__{coding_agents.CLAUDE_MCP_SERVER_NAME}__approval_prompt" in argv
     assert "--append-system-prompt" in argv
@@ -228,7 +240,7 @@ def test_list_and_get_history_sessions(
                 "parts": [
                     {"type": "thinking", "thinking": "checking"},
                     {"type": "text", "text": "done"},
-                    {"type": "tool_use", "name": "Bash", "input": {"command": "pwd"}},
+                    {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "pwd"}},
                 ],
             },
         ],
@@ -348,12 +360,18 @@ def test_mcp_initialize_and_tools_list(service_client: TestClient):
     assert initialize_response.status_code == 200
     assert initialize_response.json()["result"]["serverInfo"]["name"] == "nemo-studio-permissions"
     assert tools_response.status_code == 200
-    assert tools_response.json()["result"]["tools"][0]["name"] == "approval_prompt"
-    assert {tool["name"] for tool in tools_response.json()["result"]["tools"]} == {
+    tools = tools_response.json()["result"]["tools"]
+    assert tools[0]["name"] == "approval_prompt"
+    assert {tool["name"] for tool in tools} == {
         "approval_prompt",
+        "select_agent",
+        "select_eval_config",
+        "select_dataset_file",
+        "select_model",
+        "job_progress",
         "studio_link",
     }
-    studio_link_tool = next(tool for tool in tools_response.json()["result"]["tools"] if tool["name"] == "studio_link")
+    studio_link_tool = next(tool for tool in tools if tool["name"] == "studio_link")
     assert "Default to using this for Studio-related responses" in studio_link_tool["description"]
     assert "After creating an agent, use destination='agent_chat'" in studio_link_tool["description"]
     assert "chat with or try a model" not in studio_link_tool["description"]
@@ -798,7 +816,6 @@ def test_mcp_studio_link_returns_started_evaluation_result_markdown(service_clie
         "markdown": "[Evaluation result eval run 01](/workspaces/default/evaluation/results/eval%20run%2001)",
     }
 
-
 def test_mcp_rejects_malformed_json(service_client: TestClient):
     session_id = str(uuid.uuid4())
 
@@ -857,6 +874,101 @@ def test_mcp_tools_call_denies_without_active_stream(service_client: TestClient)
     }
 
 
+def test_mcp_tools_call_job_progress_returns_rendered(service_client: TestClient):
+    session_id = str(uuid.uuid4())
+
+    response = service_client.post(
+        f"/v2/coding-agents/mcp/{session_id}",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "job_progress",
+                "arguments": {
+                    "job_name": "eval-job-1",
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    result_text = response.json()["result"]["content"][0]["text"]
+    assert json.loads(result_text) == {"status": "rendered"}
+
+
+def test_mcp_tools_call_select_agent_denies_without_active_stream(service_client: TestClient):
+    session_id = str(uuid.uuid4())
+
+    response = service_client.post(
+        f"/v2/coding-agents/mcp/{session_id}",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "select_agent",
+                "arguments": {"title": "Select an agent"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    result_text = response.json()["result"]["content"][0]["text"]
+    assert json.loads(result_text) == {
+        "status": "error",
+        "message": "no active Studio coding-agent session",
+    }
+
+
+def test_mcp_tools_call_select_dataset_file_denies_without_active_stream(service_client: TestClient):
+    session_id = str(uuid.uuid4())
+
+    response = service_client.post(
+        f"/v2/coding-agents/mcp/{session_id}",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "select_dataset_file",
+                "arguments": {"title": "Select a dataset"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    result_text = response.json()["result"]["content"][0]["text"]
+    assert json.loads(result_text) == {
+        "status": "error",
+        "message": "no active Studio coding-agent session",
+    }
+
+
+def test_mcp_tools_call_select_model_denies_without_active_stream(service_client: TestClient):
+    session_id = str(uuid.uuid4())
+
+    response = service_client.post(
+        f"/v2/coding-agents/mcp/{session_id}",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "select_model",
+                "arguments": {"title": "Select a model"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    result_text = response.json()["result"]["content"][0]["text"]
+    assert json.loads(result_text) == {
+        "status": "error",
+        "message": "no active Studio coding-agent session",
+    }
+
+
 async def test_resolve_permission_rejects_cross_session_request():
     owner_session_id = str(uuid.uuid4())
     other_session_id = str(uuid.uuid4())
@@ -889,6 +1001,22 @@ async def test_resolve_permission_sets_result_for_owning_session():
 
     assert response == {"ok": True}
     assert future.result() == {"approved": True, "reason": None, "updated_input": None}
+
+
+async def test_resolve_agent_input_sets_result_for_owning_session():
+    session_id = str(uuid.uuid4())
+    request_id = str(uuid.uuid4())
+    future = asyncio.get_running_loop().create_future()
+    coding_agents._pending_agent_inputs[request_id] = (session_id, future)
+
+    response = await coding_agents.resolve_agent_input(
+        session_id,
+        request_id,
+        coding_agents.AgentInputDecision(value={"agent": "react-agent"}),
+    )
+
+    assert response == {"ok": True}
+    assert future.result() == {"skipped": False, "value": {"agent": "react-agent"}}
 
 
 def test_platform_route_stream_uses_public_mcp_callback(monkeypatch: pytest.MonkeyPatch):
@@ -1027,7 +1155,15 @@ def test_public_mcp_route_is_mounted_before_static_fallback():
     )
 
     assert response.status_code == 200
-    assert response.json()["result"]["tools"][0]["name"] == "approval_prompt"
+    assert [tool["name"] for tool in response.json()["result"]["tools"]] == [
+        "approval_prompt",
+        "select_agent",
+        "select_eval_config",
+        "select_dataset_file",
+        "select_model",
+        "job_progress",
+        "studio_link",
+    ]
 
 
 def test_coding_agent_routes_are_available_by_default():

--- a/web/packages/common/src/components/ModelSelectV2/ModelDropdown.tsx
+++ b/web/packages/common/src/components/ModelSelectV2/ModelDropdown.tsx
@@ -42,6 +42,7 @@ interface ModelDropdownProps {
   defaultModelType?: ModelType;
   hideAdapters?: boolean;
   fullWidth?: boolean;
+  dropdownSide?: 'top' | 'bottom';
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -57,6 +58,7 @@ export const ModelDropdown: FC<ModelDropdownProps> = ({
   defaultModelType = 'custom',
   hideAdapters = false,
   fullWidth = false,
+  dropdownSide = 'bottom',
   open,
   onOpenChange,
 }) => {
@@ -143,7 +145,7 @@ export const ModelDropdown: FC<ModelDropdownProps> = ({
       </DropdownTrigger>
       <DropdownContent
         align="start"
-        side="bottom"
+        side={dropdownSide}
         data-testid="model-select-v2-content"
         className="min-w-[360px]"
         style={{ width: 360 }} // eslint-disable-line no-restricted-syntax -- KUI DropdownContent needs explicit width

--- a/web/packages/common/src/components/ModelSelectV2/ModelSelectV2.tsx
+++ b/web/packages/common/src/components/ModelSelectV2/ModelSelectV2.tsx
@@ -19,6 +19,7 @@ export const ModelSelectV2: FC<ModelSelectV2Props> = ({
   showParams = false,
   hideAdapters = false,
   fullWidth = false,
+  dropdownSide,
   inferenceParams,
   onInferenceParamsChange,
   onOpenChange,
@@ -50,6 +51,7 @@ export const ModelSelectV2: FC<ModelSelectV2Props> = ({
       defaultModelType={defaultModelType}
       hideAdapters={hideAdapters}
       fullWidth={fullWidth}
+      dropdownSide={dropdownSide}
       open={modelOpen}
       onOpenChange={handleModelOpenChange}
     />

--- a/web/packages/common/src/components/ModelSelectV2/types.ts
+++ b/web/packages/common/src/components/ModelSelectV2/types.ts
@@ -41,6 +41,8 @@ export interface ModelSelectV2Props {
   hideAdapters?: boolean;
   /** Make the component fill the width of its container */
   fullWidth?: boolean;
+  /** Preferred side for the dropdown content */
+  dropdownSide?: 'top' | 'bottom';
   /** Current inference parameter values */
   inferenceParams?: Partial<InferenceParams>;
   /** Called when the user changes any inference parameter */

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/AgentBlockingInputFrame.tsx
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/AgentBlockingInputFrame.tsx
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Button, Flex, Stack, Text } from '@nvidia/foundations-react-core';
+import type { AgentBlockingInputFrameProps } from '@studio/components/agents/AgentBlockingInput/types';
+import { Send } from 'lucide-react';
+import type { FC } from 'react';
+
+const subduedButtonFocusClassName =
+  'focus-visible:[outline:1px_solid_var(--border-color-interaction-base)] focus-visible:[outline-offset:-1px] focus-visible:[box-shadow:none]';
+
+export const AgentBlockingInputFrame: FC<AgentBlockingInputFrameProps> = ({
+  children,
+  isSubmitting = false,
+  onSecondaryAction,
+  onSkip,
+  onSubmit,
+  request,
+  secondaryActions,
+  secondaryActionLabel,
+  submitDisabled = false,
+  submitLabel = 'Submit',
+}) => (
+  <Flex
+    direction="col"
+    role="group"
+    aria-label={request.title}
+    className="w-full rounded-xl border border-base bg-surface-base p-density-md outline-none"
+    data-testid="agent-blocking-input"
+  >
+    <Stack gap="density-md">
+      <Stack gap="density-xs">
+        <Text kind="body/semibold/md" className="block">
+          {request.title}
+        </Text>
+        {request.description ? (
+          <Text kind="body/regular/sm" className="block text-fg-secondary">
+            {request.description}
+          </Text>
+        ) : null}
+      </Stack>
+      {children}
+      <Flex align="center" justify="end" gap="density-sm">
+        {secondaryActions?.map((action) => (
+          <Button
+            key={action.label}
+            type="button"
+            kind="tertiary"
+            color="neutral"
+            disabled={isSubmitting || action.disabled}
+            className={subduedButtonFocusClassName}
+            onClick={() => void action.onClick()}
+          >
+            <Text kind="label/regular/sm">{action.label}</Text>
+          </Button>
+        ))}
+        {onSecondaryAction && secondaryActionLabel ? (
+          <Button
+            type="button"
+            kind="tertiary"
+            color="neutral"
+            disabled={isSubmitting}
+            className={subduedButtonFocusClassName}
+            onClick={() => void onSecondaryAction()}
+          >
+            <Text kind="label/regular/sm">{secondaryActionLabel}</Text>
+          </Button>
+        ) : null}
+        {onSkip ? (
+          <Button
+            type="button"
+            kind="tertiary"
+            color="neutral"
+            disabled={isSubmitting}
+            className={subduedButtonFocusClassName}
+            onClick={() => void onSkip()}
+          >
+            <Text kind="label/regular/sm">Skip</Text>
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          color="brand"
+          size="small"
+          disabled={isSubmitting || submitDisabled}
+          className={subduedButtonFocusClassName}
+          aria-label={submitLabel}
+          onClick={() => void onSubmit()}
+        >
+          <Send size={16} />
+        </Button>
+      </Flex>
+    </Stack>
+  </Flex>
+);

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/AgentSelectBlockingInput.tsx
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/AgentSelectBlockingInput.tsx
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
+import { AgentBlockingInputFrame } from '@studio/components/agents/AgentBlockingInput/AgentBlockingInputFrame';
+import { fetchAgentsForSelect } from '@studio/components/agents/AgentBlockingInput/agentQueries';
+import type {
+  AgentBlockingInputRequest,
+  AgentBlockingInputStatus,
+  AgentBlockingInputSubmission,
+} from '@studio/components/agents/AgentBlockingInput/types';
+import { getStringValue } from '@studio/components/agents/AgentBlockingInput/utils';
+import { useQuery } from '@tanstack/react-query';
+import { type FC, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const agentSelectSchema = z.object({
+  agent: z.string().trim().min(1, 'Agent is required'),
+});
+
+type AgentSelectFormData = z.infer<typeof agentSelectSchema>;
+
+interface AgentSelectBlockingInputProps {
+  readonly input?: Record<string, unknown>;
+  readonly onSkip?: () => Promise<void> | void;
+  readonly onSubmit: (submission: AgentBlockingInputSubmission) => Promise<void> | void;
+  readonly request: AgentBlockingInputRequest;
+  readonly status?: AgentBlockingInputStatus;
+  readonly workspace: string;
+}
+
+export const AgentSelectBlockingInput: FC<AgentSelectBlockingInputProps> = ({
+  input = {},
+  onSkip,
+  onSubmit,
+  request,
+  status = 'pending',
+  workspace,
+}) => {
+  const defaultAgent =
+    getStringValue(input, 'default_agent') ?? getStringValue(input, 'agent') ?? '';
+  const isSubmitting = status === 'submitting';
+  const { control, handleSubmit } = useForm<AgentSelectFormData>({
+    defaultValues: { agent: defaultAgent },
+    resolver: zodResolver(agentSelectSchema),
+    disabled: isSubmitting,
+  });
+  const { data: agents = [], isLoading } = useQuery({
+    queryKey: ['agent-blocking-input', 'agents', workspace],
+    queryFn: ({ signal }) => fetchAgentsForSelect(workspace, signal),
+    enabled: !!workspace,
+  });
+  const items = useMemo(() => {
+    const agentItems = agents.flatMap((agent) =>
+      agent.name ? [{ value: agent.name, children: agent.name }] : []
+    );
+    if (defaultAgent && !agentItems.some((item) => item.value === defaultAgent)) {
+      return [{ value: defaultAgent, children: defaultAgent }, ...agentItems];
+    }
+    return agentItems;
+  }, [agents, defaultAgent]);
+
+  const submit = handleSubmit((data) => {
+    void onSubmit({
+      displayText: `Selected agent: ${data.agent}`,
+      value: { agent: data.agent },
+    });
+  });
+
+  return (
+    <AgentBlockingInputFrame
+      isSubmitting={isSubmitting}
+      onSkip={onSkip}
+      onSubmit={submit}
+      request={request}
+      submitDisabled={!items.length}
+      submitLabel="Select agent"
+    >
+      <ControlledSelect
+        useControllerProps={{
+          control,
+          name: 'agent',
+        }}
+        loading={isLoading}
+        items={items}
+        formFieldProps={{
+          slotLabel: 'Agent',
+        }}
+      />
+    </AgentBlockingInputFrame>
+  );
+};

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/EvalConfigBlockingInput.spec.tsx
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/EvalConfigBlockingInput.spec.tsx
@@ -109,15 +109,7 @@ describe('EvalConfigBlockingInput', () => {
       (action) => action.label === 'Use sample config'
     );
     expect(sampleAction?.disabled).toBe(true);
-
-    await sampleAction?.onClick();
-    expect(onSubmit).toHaveBeenCalledWith({
-      displayText: 'Use sample evaluation config',
-      value: {
-        use_sample_eval_config: true,
-        eval_config: SAMPLE_EVAL_CONFIG_PATH,
-      },
-    });
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it('emits a needs_eval_config payload from the "I don\'t have a config" secondary action', async () => {

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/EvalConfigBlockingInput.spec.tsx
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/EvalConfigBlockingInput.spec.tsx
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { EvalConfigBlockingInput } from '@studio/components/agents/AgentBlockingInput/EvalConfigBlockingInput';
+import type {
+  AgentBlockingInputRequest,
+  AgentBlockingInputSecondaryAction,
+  AgentBlockingInputSubmission,
+} from '@studio/components/agents/AgentBlockingInput/types';
+import { SAMPLE_EVAL_CONFIG_PATH } from '@studio/routes/agents/AgentSuggestionsRoute/constants';
+import { render } from '@testing-library/react';
+
+interface CapturedFilesetProps {
+  readonly onSecondaryAction?: () => Promise<void> | void;
+  readonly secondaryActions?: readonly AgentBlockingInputSecondaryAction[];
+}
+
+const captured: { props: CapturedFilesetProps | null } = { props: null };
+
+vi.mock('@studio/components/agents/AgentBlockingInput/FilesetFileBlockingInput', () => ({
+  FilesetFileBlockingInput: (props: CapturedFilesetProps) => {
+    captured.props = props;
+    return <div data-testid="fileset-file-blocking-input" />;
+  },
+}));
+
+const request: AgentBlockingInputRequest = {
+  id: 'request-1',
+  title: 'Select an evaluation config',
+};
+
+beforeEach(() => {
+  captured.props = null;
+});
+
+describe('EvalConfigBlockingInput', () => {
+  it('emits a sample-config payload that includes the agent and its eval fileset', async () => {
+    const onSubmit = vi.fn<(submission: AgentBlockingInputSubmission) => void>();
+
+    render(
+      <EvalConfigBlockingInput
+        input={{ agent: 'react-agent' }}
+        request={request}
+        workspace="default"
+        onSubmit={onSubmit}
+      />
+    );
+
+    const sampleAction = captured.props?.secondaryActions?.find(
+      (action) => action.label === 'Use sample config'
+    );
+    expect(sampleAction).toBeDefined();
+    expect(sampleAction?.disabled).toBe(false);
+
+    await sampleAction?.onClick();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      displayText: 'Use sample evaluation config',
+      value: {
+        use_sample_eval_config: true,
+        agent: 'react-agent',
+        eval_config: SAMPLE_EVAL_CONFIG_PATH,
+        eval_config_fileset: 'react-agent-eval',
+      },
+    });
+  });
+
+  it('falls back to default_agent when no agent is supplied', async () => {
+    const onSubmit = vi.fn<(submission: AgentBlockingInputSubmission) => void>();
+
+    render(
+      <EvalConfigBlockingInput
+        input={{ default_agent: 'tool-agent' }}
+        request={request}
+        workspace="default"
+        onSubmit={onSubmit}
+      />
+    );
+
+    const sampleAction = captured.props?.secondaryActions?.find(
+      (action) => action.label === 'Use sample config'
+    );
+    await sampleAction?.onClick();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      displayText: 'Use sample evaluation config',
+      value: {
+        use_sample_eval_config: true,
+        agent: 'tool-agent',
+        eval_config: SAMPLE_EVAL_CONFIG_PATH,
+        eval_config_fileset: 'tool-agent-eval',
+      },
+    });
+  });
+
+  it('disables the sample-config action and omits agent fields when no agent is known', async () => {
+    const onSubmit = vi.fn<(submission: AgentBlockingInputSubmission) => void>();
+
+    render(
+      <EvalConfigBlockingInput
+        input={{}}
+        request={request}
+        workspace="default"
+        onSubmit={onSubmit}
+      />
+    );
+
+    const sampleAction = captured.props?.secondaryActions?.find(
+      (action) => action.label === 'Use sample config'
+    );
+    expect(sampleAction?.disabled).toBe(true);
+
+    await sampleAction?.onClick();
+    expect(onSubmit).toHaveBeenCalledWith({
+      displayText: 'Use sample evaluation config',
+      value: {
+        use_sample_eval_config: true,
+        eval_config: SAMPLE_EVAL_CONFIG_PATH,
+      },
+    });
+  });
+
+  it('emits a needs_eval_config payload from the "I don\'t have a config" secondary action', async () => {
+    const onSubmit = vi.fn<(submission: AgentBlockingInputSubmission) => void>();
+
+    render(
+      <EvalConfigBlockingInput
+        input={{ agent: 'react-agent' }}
+        request={request}
+        workspace="default"
+        onSubmit={onSubmit}
+      />
+    );
+
+    await captured.props?.onSecondaryAction?.();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      displayText: "I don't have an evaluation config yet",
+      value: { needs_eval_config: true },
+    });
+  });
+});

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/EvalConfigBlockingInput.tsx
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/EvalConfigBlockingInput.tsx
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { FilesetFileBlockingInput } from '@studio/components/agents/AgentBlockingInput/FilesetFileBlockingInput';
+import type { FilesetFileBlockingInputProps } from '@studio/components/agents/AgentBlockingInput/types';
+import { getStringValue } from '@studio/components/agents/AgentBlockingInput/utils';
+import { SAMPLE_EVAL_CONFIG_PATH } from '@studio/routes/agents/AgentSuggestionsRoute/constants';
+import { evalFilesetForAgent } from '@studio/routes/agents/AgentSuggestionsRoute/utils';
+import type { FC } from 'react';
+
+const DEFAULT_ACCEPTED_FILE_TYPES = ['.yml', '.yaml'] as const;
+
+export const EvalConfigBlockingInput: FC<FilesetFileBlockingInputProps> = (props) => {
+  const input = props.input ?? {};
+  const agent = getStringValue(input, 'agent') ?? getStringValue(input, 'default_agent');
+  const sampleConfigFileset = agent ? evalFilesetForAgent(agent) : undefined;
+
+  return (
+    <FilesetFileBlockingInput
+      {...props}
+      defaultAcceptedFileTypes={[...DEFAULT_ACCEPTED_FILE_TYPES]}
+      missingSelectionMessage="Pick an eval YAML inside an existing fileset"
+      secondaryActions={[
+        {
+          disabled: !agent,
+          label: 'Use sample config',
+          onClick: () =>
+            props.onSubmit({
+              displayText: 'Use sample evaluation config',
+              value: {
+                use_sample_eval_config: true,
+                ...(agent ? { agent } : {}),
+                eval_config: SAMPLE_EVAL_CONFIG_PATH,
+                ...(sampleConfigFileset ? { eval_config_fileset: sampleConfigFileset } : {}),
+              },
+            }),
+        },
+      ]}
+      secondaryActionLabel="I don't have a config"
+      onSecondaryAction={() =>
+        props.onSubmit({
+          displayText: "I don't have an evaluation config yet",
+          value: { needs_eval_config: true },
+        })
+      }
+      selectionDisplayLabel="Selected eval config"
+      submitLabel="Select eval config"
+      toValue={({ name, objectPath }) => ({
+        eval_config: objectPath,
+        eval_config_fileset: name,
+      })}
+    />
+  );
+};

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/FilesetFileBlockingInput.tsx
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/FilesetFileBlockingInput.tsx
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ControlledDatasetFileSelect } from '@nemo/common/src/components/DatasetFileSelect/ControlledDatasetFileSelect';
+import type { AcceptedFileType } from '@nemo/common/src/components/DatasetFileSelect/DatasetFileSelect';
+import { parseFilesetLocation } from '@nemo/common/src/components/DatasetFileSelect/parseFilesetLocation';
+import { Stack } from '@nvidia/foundations-react-core';
+import { AgentBlockingInputFrame } from '@studio/components/agents/AgentBlockingInput/AgentBlockingInputFrame';
+import type {
+  AgentBlockingInputSecondaryAction,
+  FilesetFileBlockingInputProps,
+} from '@studio/components/agents/AgentBlockingInput/types';
+import { getAcceptedFileTypes } from '@studio/components/agents/AgentBlockingInput/utils';
+import { type FC, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const getFilesetFileBlockingInputSchema = (missingSelectionMessage: string) =>
+  z.object({
+    datasetFile: z
+      .string()
+      .nullable()
+      .refine(
+        (value) => {
+          if (typeof value !== 'string') return false;
+          const parsed = parseFilesetLocation(value);
+          return !!parsed?.name.trim() && !!parsed.objectPath.trim();
+        },
+        { message: missingSelectionMessage }
+      ),
+  });
+
+type FilesetFileFormData = z.infer<ReturnType<typeof getFilesetFileBlockingInputSchema>>;
+
+interface FilesetFileBlockingInputBaseProps extends FilesetFileBlockingInputProps {
+  readonly defaultAcceptedFileTypes: AcceptedFileType[];
+  readonly missingSelectionMessage: string;
+  readonly onSecondaryAction?: () => Promise<void> | void;
+  readonly secondaryActions?: readonly AgentBlockingInputSecondaryAction[];
+  readonly secondaryActionLabel?: string;
+  readonly selectionDisplayLabel: string;
+  readonly submitLabel: string;
+  readonly toValue: (parsed: { name: string; objectPath: string }) => Record<string, unknown>;
+}
+
+export const FilesetFileBlockingInput: FC<FilesetFileBlockingInputBaseProps> = ({
+  defaultAcceptedFileTypes,
+  input = {},
+  missingSelectionMessage,
+  onSecondaryAction,
+  onSkip,
+  onSubmit,
+  request,
+  secondaryActions,
+  secondaryActionLabel,
+  selectionDisplayLabel,
+  status = 'pending',
+  submitLabel,
+  toValue,
+  workspace,
+}) => {
+  const isSubmitting = status === 'submitting';
+  const schema = useMemo(
+    () => getFilesetFileBlockingInputSchema(missingSelectionMessage),
+    [missingSelectionMessage]
+  );
+  const {
+    clearErrors,
+    control,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<FilesetFileFormData>({
+    defaultValues: { datasetFile: null },
+    resolver: zodResolver(schema),
+    disabled: isSubmitting,
+  });
+  const acceptedFileTypes = getAcceptedFileTypes(input, defaultAcceptedFileTypes);
+
+  const submit = handleSubmit((data) => {
+    const parsed =
+      typeof data.datasetFile === 'string' ? parseFilesetLocation(data.datasetFile) : null;
+    if (!parsed?.name.trim() || !parsed.objectPath.trim()) return;
+
+    void onSubmit({
+      displayText: `${selectionDisplayLabel}: ${parsed.name}/${parsed.objectPath}`,
+      value: toValue({ name: parsed.name, objectPath: parsed.objectPath }),
+    });
+  });
+
+  return (
+    <AgentBlockingInputFrame
+      isSubmitting={isSubmitting}
+      onSecondaryAction={onSecondaryAction}
+      onSkip={onSkip}
+      onSubmit={submit}
+      request={request}
+      secondaryActions={secondaryActions}
+      secondaryActionLabel={secondaryActionLabel}
+      submitLabel={submitLabel}
+    >
+      <Stack className="max-h-[45vh] overflow-y-auto pr-density-sm">
+        <ControlledDatasetFileSelect
+          useControllerProps={{
+            control,
+            name: 'datasetFile',
+          }}
+          acceptedFileTypes={acceptedFileTypes}
+          invalidFileMode="disable"
+          setError={(error) => setError('datasetFile', error)}
+          clearError={() => clearErrors('datasetFile')}
+          workspace={workspace}
+          inline
+          autoCommit
+          formFieldProps={{
+            slotError: errors.datasetFile?.message,
+          }}
+        />
+      </Stack>
+    </AgentBlockingInputFrame>
+  );
+};

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/ModelSelectBlockingInput.spec.tsx
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/ModelSelectBlockingInput.spec.tsx
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ModelSelectBlockingInput } from '@studio/components/agents/AgentBlockingInput/ModelSelectBlockingInput';
+import type { AgentBlockingInputSubmission } from '@studio/components/agents/AgentBlockingInput/types';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@studio/components/evaluation/JudgeModelSelect', async () => {
+  const { useFormContext } =
+    await vi.importActual<typeof import('react-hook-form')>('react-hook-form');
+
+  return {
+    JudgeModelSelect: ({ formFieldName }: { readonly formFieldName: string }) => {
+      const form = useFormContext();
+      const selectedModel = form.watch(formFieldName);
+
+      return (
+        <>
+          <span data-testid="selected-model">{selectedModel}</span>
+          <button type="button" onClick={() => form.setValue(formFieldName, 'stale-model')}>
+            Select stale model
+          </button>
+        </>
+      );
+    },
+  };
+});
+
+describe('ModelSelectBlockingInput', () => {
+  it('resets the selected model when the blocking request changes', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn<(submission: AgentBlockingInputSubmission) => void>();
+    const { rerender } = render(
+      <ModelSelectBlockingInput
+        input={{ default_model: 'first-model' }}
+        request={{ id: 'request-1', title: 'Select model' }}
+        onSubmit={onSubmit}
+      />
+    );
+
+    expect(screen.getByTestId('selected-model')).toHaveTextContent('first-model');
+
+    await user.click(screen.getByRole('button', { name: 'Select stale model' }));
+    expect(screen.getByTestId('selected-model')).toHaveTextContent('stale-model');
+
+    rerender(
+      <ModelSelectBlockingInput
+        input={{ default_model: 'second-model' }}
+        request={{ id: 'request-2', title: 'Select model' }}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('selected-model')).toHaveTextContent('second-model')
+    );
+  });
+});

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/ModelSelectBlockingInput.tsx
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/ModelSelectBlockingInput.tsx
@@ -10,7 +10,7 @@ import type {
 } from '@studio/components/agents/AgentBlockingInput/types';
 import { getOutputKey, getStringValue } from '@studio/components/agents/AgentBlockingInput/utils';
 import { JudgeModelSelect } from '@studio/components/evaluation/JudgeModelSelect';
-import { type FC, useMemo } from 'react';
+import { type FC, useEffect, useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -52,9 +52,14 @@ export const ModelSelectBlockingInput: FC<ModelSelectBlockingInputProps> = ({
     disabled: isSubmitting,
   });
   const selectedModel = form.watch('model');
+  const { reset } = form;
+
+  useEffect(() => {
+    reset({ model: defaultModel });
+  }, [defaultModel, request.id, reset]);
 
   const submit = form.handleSubmit((data) => {
-    void onSubmit({
+    return onSubmit({
       displayText: `${displayLabel}: ${data.model}`,
       value: { [outputKey]: data.model },
     });

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/ModelSelectBlockingInput.tsx
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/ModelSelectBlockingInput.tsx
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { AgentBlockingInputFrame } from '@studio/components/agents/AgentBlockingInput/AgentBlockingInputFrame';
+import type {
+  AgentBlockingInputRequest,
+  AgentBlockingInputStatus,
+  AgentBlockingInputSubmission,
+} from '@studio/components/agents/AgentBlockingInput/types';
+import { getOutputKey, getStringValue } from '@studio/components/agents/AgentBlockingInput/utils';
+import { JudgeModelSelect } from '@studio/components/evaluation/JudgeModelSelect';
+import { type FC, useMemo } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const getModelSelectSchema = (requiredMessage: string) =>
+  z.object({
+    model: z.string().trim().min(1, requiredMessage),
+  });
+
+type ModelSelectFormData = z.infer<ReturnType<typeof getModelSelectSchema>>;
+
+interface ModelSelectBlockingInputProps {
+  readonly input?: Record<string, unknown>;
+  readonly onSkip?: () => Promise<void> | void;
+  readonly onSubmit: (submission: AgentBlockingInputSubmission) => Promise<void> | void;
+  readonly request: AgentBlockingInputRequest;
+  readonly status?: AgentBlockingInputStatus;
+}
+
+export const ModelSelectBlockingInput: FC<ModelSelectBlockingInputProps> = ({
+  input = {},
+  onSkip,
+  onSubmit,
+  request,
+  status = 'pending',
+}) => {
+  const defaultModel =
+    getStringValue(input, 'default_model') ?? getStringValue(input, 'model') ?? '';
+  const outputKey = getOutputKey(input, 'model');
+  const displayLabel = getStringValue(input, 'display_label') ?? 'Selected model';
+  const fieldLabel = getStringValue(input, 'field_label') ?? 'Model';
+  const placeholder = getStringValue(input, 'placeholder') ?? 'Select a model';
+  const requiredMessage = getStringValue(input, 'required_message') ?? 'Model is required';
+  const submitLabel = getStringValue(input, 'submit_label') ?? 'Select model';
+  const isSubmitting = status === 'submitting';
+  const schema = useMemo(() => getModelSelectSchema(requiredMessage), [requiredMessage]);
+  const form = useForm<ModelSelectFormData>({
+    defaultValues: { model: defaultModel },
+    resolver: zodResolver(schema),
+    disabled: isSubmitting,
+  });
+  const selectedModel = form.watch('model');
+
+  const submit = form.handleSubmit((data) => {
+    void onSubmit({
+      displayText: `${displayLabel}: ${data.model}`,
+      value: { [outputKey]: data.model },
+    });
+  });
+
+  return (
+    <AgentBlockingInputFrame
+      isSubmitting={isSubmitting}
+      onSkip={onSkip}
+      onSubmit={submit}
+      request={request}
+      submitDisabled={!selectedModel}
+      submitLabel={submitLabel}
+    >
+      <FormProvider {...form}>
+        <JudgeModelSelect<ModelSelectFormData>
+          formFieldName="model"
+          placeholder={placeholder}
+          slotLabel={fieldLabel}
+          requiredMessage={requiredMessage}
+          dropdownSide="top"
+          required
+        />
+      </FormProvider>
+    </AgentBlockingInputFrame>
+  );
+};

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/agentQueries.ts
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/agentQueries.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { agentsListAgents } from '@nemo/sdk/generated/agents/api';
+import type { Agent } from '@nemo/sdk/generated/agents/schema';
+
+const AGENTS_PAGE_SIZE = 100;
+
+export const fetchAgentsForSelect = async (
+  workspace: string,
+  signal: AbortSignal
+): Promise<Agent[]> => {
+  const allAgents: Agent[] = [];
+  let page = 1;
+
+  while (true) {
+    const response = await agentsListAgents(
+      workspace,
+      { page, page_size: AGENTS_PAGE_SIZE, sort: 'name' },
+      signal
+    );
+    const batch = response.data ?? [];
+    allAgents.push(...batch);
+
+    const totalPages = response.pagination?.total_pages;
+    if (totalPages ? page >= totalPages : batch.length < AGENTS_PAGE_SIZE) break;
+    page += 1;
+  }
+
+  return allAgents;
+};

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/index.ts
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/index.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { AgentBlockingInputFrame } from '@studio/components/agents/AgentBlockingInput/AgentBlockingInputFrame';
+export { AgentSelectBlockingInput } from '@studio/components/agents/AgentBlockingInput/AgentSelectBlockingInput';
+export { EvalConfigBlockingInput } from '@studio/components/agents/AgentBlockingInput/EvalConfigBlockingInput';
+export { FilesetFileBlockingInput } from '@studio/components/agents/AgentBlockingInput/FilesetFileBlockingInput';
+export { ModelSelectBlockingInput } from '@studio/components/agents/AgentBlockingInput/ModelSelectBlockingInput';
+export type {
+  AgentBlockingInputFrameProps,
+  AgentBlockingInputRequest,
+  AgentBlockingInputSecondaryAction,
+  AgentBlockingInputStatus,
+  AgentBlockingInputSubmission,
+  FilesetFileBlockingInputProps,
+} from '@studio/components/agents/AgentBlockingInput/types';

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/types.ts
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/types.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ReactNode } from 'react';
+
+export type AgentBlockingInputStatus = 'pending' | 'submitting';
+
+export interface AgentBlockingInputRequest {
+  readonly description?: string;
+  readonly id: string;
+  readonly title: string;
+}
+
+export interface AgentBlockingInputSubmission {
+  readonly displayText: string;
+  readonly value: Record<string, unknown>;
+}
+
+export interface AgentBlockingInputSecondaryAction {
+  readonly disabled?: boolean;
+  readonly label: string;
+  readonly onClick: () => Promise<void> | void;
+}
+
+export interface AgentBlockingInputFrameProps {
+  readonly children: ReactNode;
+  readonly isSubmitting?: boolean;
+  readonly onSecondaryAction?: () => Promise<void> | void;
+  readonly onSkip?: () => Promise<void> | void;
+  readonly onSubmit: () => Promise<void> | void;
+  readonly request: AgentBlockingInputRequest;
+  readonly secondaryActions?: readonly AgentBlockingInputSecondaryAction[];
+  readonly secondaryActionLabel?: string;
+  readonly submitDisabled?: boolean;
+  readonly submitLabel?: string;
+}
+
+export interface FilesetFileBlockingInputProps {
+  readonly input?: Record<string, unknown>;
+  readonly onSkip?: () => Promise<void> | void;
+  readonly onSubmit: (submission: AgentBlockingInputSubmission) => Promise<void> | void;
+  readonly request: AgentBlockingInputRequest;
+  readonly status?: AgentBlockingInputStatus;
+  readonly workspace: string;
+}

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/utils.ts
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/utils.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AcceptedFileType } from '@nemo/common/src/components/DatasetFileSelect/DatasetFileSelect';
+
+const ALLOWED_ACCEPTED_FILE_TYPES = new Set<AcceptedFileType>([
+  '.json',
+  '.jsonl',
+  '.csv',
+  '.parquet',
+  '.yml',
+  '.yaml',
+]);
+
+const isAcceptedFileType = (value: string): value is AcceptedFileType =>
+  ALLOWED_ACCEPTED_FILE_TYPES.has(value as AcceptedFileType);
+
+export const getStringValue = (input: Record<string, unknown>, key: string): string | undefined => {
+  const value = input[key];
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+export const getOutputKey = (input: Record<string, unknown>, fallback: string): string => {
+  const outputKey = getStringValue(input, 'output_key') ?? getStringValue(input, 'value_key');
+  if (!outputKey || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(outputKey)) return fallback;
+  return outputKey;
+};
+
+export const getAcceptedFileTypes = (
+  input: Record<string, unknown>,
+  fallback: AcceptedFileType[]
+): AcceptedFileType[] => {
+  const raw = input.accepted_file_types;
+  if (!Array.isArray(raw)) return fallback;
+  const accepted = raw.filter(
+    (item): item is AcceptedFileType => typeof item === 'string' && isAcceptedFileType(item)
+  );
+  return accepted.length ? accepted : fallback;
+};

--- a/web/packages/studio/src/components/dataViews/JobsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/JobsDataView/index.tsx
@@ -23,24 +23,13 @@ import {
   JOB_SOURCE,
   SOURCE_OPTIONS,
 } from '@studio/components/dataViews/JobsDataView/constants';
+import { getJobDetailRoute } from '@studio/components/dataViews/JobsDataView/utils';
 import { ErrorPanel } from '@studio/components/ErrorPanel';
-import {
-  CUSTOMIZER_ENABLED,
-  DATA_DESIGNER_ENABLED,
-  EVALUATOR_ENABLED,
-  SAFE_SYNTHESIZER_ENABLED,
-} from '@studio/constants/environment';
+import { CUSTOMIZER_ENABLED } from '@studio/constants/environment';
 import { LINK_DOCS_JOBS } from '@studio/constants/links';
 import { STATUS_FILTER_OPTIONS } from '@studio/constants/platformJobs';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { iconColorClass } from '@studio/routes/constants';
-import {
-  getDataDesignerJobDetailsRoute,
-  getEvaluationResultDetailsRoute,
-  getSafeSynthesizerJobRoute,
-  getWorkspaceCustomizationJobDetailsRoute,
-  getWorkspaceJobDetailRoute,
-} from '@studio/routes/utils';
 import { keepPreviousData } from '@tanstack/react-query';
 import { ChartBar, Cog, LayoutList, ListChecks, Sliders, Sparkles } from 'lucide-react';
 import { ComponentProps, type ReactNode } from 'react';
@@ -66,34 +55,6 @@ const SOURCE_DISPLAY: Record<string, { label: string; icon: ReactNode }> = {
 };
 
 const STATUS_OPTIONS_WITH_ALL = [{ value: '', label: 'All' }, ...STATUS_FILTER_OPTIONS];
-
-const SOURCE_DETAIL_ROUTE: Record<
-  string,
-  { enabled: boolean; getRoute: (workspace: string, jobName: string) => string }
-> = {
-  [JOB_SOURCE.CUSTOMIZATION]: {
-    enabled: CUSTOMIZER_ENABLED,
-    getRoute: getWorkspaceCustomizationJobDetailsRoute,
-  },
-  [JOB_SOURCE.DATA_DESIGNER]: {
-    enabled: DATA_DESIGNER_ENABLED,
-    getRoute: getDataDesignerJobDetailsRoute,
-  },
-  [JOB_SOURCE.SAFE_SYNTHESIZER]: {
-    enabled: SAFE_SYNTHESIZER_ENABLED,
-    getRoute: getSafeSynthesizerJobRoute,
-  },
-  [JOB_SOURCE.EVALUATOR_METRICS]: {
-    enabled: EVALUATOR_ENABLED,
-    getRoute: getEvaluationResultDetailsRoute,
-  },
-};
-
-const getJobDetailRoute = (job: PlatformJobResponse, workspace: string): string => {
-  const genericRoute = getWorkspaceJobDetailRoute(workspace, job.name);
-  const entry = job.source ? SOURCE_DETAIL_ROUTE[job.source] : undefined;
-  return entry?.enabled ? entry.getRoute(workspace, job.name) : genericRoute;
-};
 
 export const JobsDataView = () => {
   const workspace = useWorkspaceFromPath();

--- a/web/packages/studio/src/components/dataViews/JobsDataView/utils.ts
+++ b/web/packages/studio/src/components/dataViews/JobsDataView/utils.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { JOB_SOURCE } from '@studio/components/dataViews/JobsDataView/constants';
+import {
+  CUSTOMIZER_ENABLED,
+  DATA_DESIGNER_ENABLED,
+  EVALUATOR_ENABLED,
+  SAFE_SYNTHESIZER_ENABLED,
+} from '@studio/constants/environment';
+import {
+  getDataDesignerJobDetailsRoute,
+  getEvaluationResultDetailsRoute,
+  getSafeSynthesizerJobRoute,
+  getWorkspaceCustomizationJobDetailsRoute,
+  getWorkspaceJobDetailRoute,
+} from '@studio/routes/utils';
+
+interface JobDetailRouteJob {
+  readonly name: string;
+  readonly source?: string | null;
+}
+
+const SOURCE_DETAIL_ROUTE: Record<
+  string,
+  { readonly enabled: boolean; readonly getRoute: (workspace: string, jobName: string) => string }
+> = {
+  [JOB_SOURCE.CUSTOMIZATION]: {
+    enabled: CUSTOMIZER_ENABLED,
+    getRoute: getWorkspaceCustomizationJobDetailsRoute,
+  },
+  [JOB_SOURCE.DATA_DESIGNER]: {
+    enabled: DATA_DESIGNER_ENABLED,
+    getRoute: getDataDesignerJobDetailsRoute,
+  },
+  [JOB_SOURCE.SAFE_SYNTHESIZER]: {
+    enabled: SAFE_SYNTHESIZER_ENABLED,
+    getRoute: getSafeSynthesizerJobRoute,
+  },
+  [JOB_SOURCE.EVALUATOR_METRICS]: {
+    enabled: EVALUATOR_ENABLED,
+    getRoute: getEvaluationResultDetailsRoute,
+  },
+};
+
+export const getJobDetailRoute = (job: JobDetailRouteJob, workspace: string): string => {
+  const genericRoute = getWorkspaceJobDetailRoute(workspace, job.name);
+  const entry = job.source ? SOURCE_DETAIL_ROUTE[job.source] : undefined;
+  return entry?.enabled ? entry.getRoute(workspace, job.name) : genericRoute;
+};

--- a/web/packages/studio/src/components/evaluation/JudgeModelSelect.tsx
+++ b/web/packages/studio/src/components/evaluation/JudgeModelSelect.tsx
@@ -14,6 +14,9 @@ import { type FieldValues, type Path, useController, useFormContext } from 'reac
 export interface JudgeModelSelectProps<TFieldValues extends FieldValues = FieldValues> {
   required?: boolean;
   placeholder?: string;
+  slotLabel?: string;
+  requiredMessage?: string;
+  dropdownSide?: 'top' | 'bottom';
   formFieldName: Path<TFieldValues>;
   showParams?: boolean;
   inferenceParams?: Partial<InferenceParams>;
@@ -27,6 +30,9 @@ export interface JudgeModelSelectProps<TFieldValues extends FieldValues = FieldV
 export const JudgeModelSelect = <TFieldValues extends FieldValues = FieldValues>({
   required = false,
   placeholder = 'Select a judge model',
+  slotLabel = 'Judge Model',
+  requiredMessage = 'Judge model is required',
+  dropdownSide,
   formFieldName,
   showParams = false,
   inferenceParams,
@@ -40,7 +46,7 @@ export const JudgeModelSelect = <TFieldValues extends FieldValues = FieldValues>
   const { field, fieldState } = useController({
     control,
     name: formFieldName,
-    rules: required ? { required: 'Judge model is required' } : undefined,
+    rules: required ? { required: requiredMessage } : undefined,
   });
 
   const { data: judgeModels, isLoading, error } = useJudgeModels({ enabled: !disabled });
@@ -60,7 +66,7 @@ export const JudgeModelSelect = <TFieldValues extends FieldValues = FieldValues>
   };
 
   return (
-    <FormField slotLabel="Judge Model" slotError={fieldState.error?.message} required={required}>
+    <FormField slotLabel={slotLabel} slotError={fieldState.error?.message} required={required}>
       <ModelSelectV2
         value={value}
         onValueChange={handleValueChange}
@@ -72,6 +78,7 @@ export const JudgeModelSelect = <TFieldValues extends FieldValues = FieldValues>
         inferenceParams={inferenceParams}
         onInferenceParamsChange={onInferenceParamsChange}
         onOpenChange={handleOpenChange}
+        dropdownSide={dropdownSide}
         fullWidth
       />
     </FormField>

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/BlockingInputComposer.spec.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/BlockingInputComposer.spec.tsx
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getBlockingInputRequest } from '@studio/routes/agents/ClaudeCodeChatRoute/blockingInputRequest';
+import type {
+  ClaudeCodeInputRequest,
+  ClaudeCodeInputRequestKind,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+
+const makeRequest = (
+  kind: ClaudeCodeInputRequestKind,
+  input: Record<string, unknown> = {}
+): ClaudeCodeInputRequest => ({
+  requestId: 'request-1',
+  kind,
+  input,
+});
+
+describe('getBlockingInputRequest', () => {
+  it.each([
+    ['agent', 'Select an agent', 'Choose the agent the workflow should use.'],
+    ['eval_config', 'Select an evaluation config', 'Choose a YAML file from a fileset.'],
+    ['dataset_file', 'Select a dataset', 'Choose a dataset file from a fileset.'],
+    ['model', 'Select a model', 'Choose the model this workflow should use.'],
+  ] as const)('returns default copy for kind %s', (kind, expectedTitle, expectedDescription) => {
+    expect(getBlockingInputRequest(makeRequest(kind))).toEqual({
+      id: 'request-1',
+      title: expectedTitle,
+      description: expectedDescription,
+    });
+  });
+
+  it('prefers caller-supplied title and description over defaults', () => {
+    expect(
+      getBlockingInputRequest(
+        makeRequest('model', { title: 'Pick a judge', description: 'For LLM-as-judge scoring' })
+      )
+    ).toEqual({
+      id: 'request-1',
+      title: 'Pick a judge',
+      description: 'For LLM-as-judge scoring',
+    });
+  });
+
+  it('ignores blank caller-supplied strings and uses defaults', () => {
+    expect(
+      getBlockingInputRequest(makeRequest('agent', { title: '   ', description: '' }))
+    ).toEqual({
+      id: 'request-1',
+      title: 'Select an agent',
+      description: 'Choose the agent the workflow should use.',
+    });
+  });
+});

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/BlockingInputComposer.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/BlockingInputComposer.tsx
@@ -31,6 +31,7 @@ export const BlockingInputComposer: FC<BlockingInputComposerProps> = ({
   onSkip,
 }) => {
   const request = getBlockingInputRequest(inputRequest);
+  const requestKey = request.id;
   const sharedProps = {
     input: inputRequest.input,
     request,
@@ -41,12 +42,13 @@ export const BlockingInputComposer: FC<BlockingInputComposerProps> = ({
 
   switch (inputRequest.kind) {
     case 'agent':
-      return <AgentSelectBlockingInput {...sharedProps} workspace={workspace} />;
+      return <AgentSelectBlockingInput key={requestKey} {...sharedProps} workspace={workspace} />;
     case 'eval_config':
-      return <EvalConfigBlockingInput {...sharedProps} workspace={workspace} />;
+      return <EvalConfigBlockingInput key={requestKey} {...sharedProps} workspace={workspace} />;
     case 'dataset_file':
       return (
         <FilesetFileBlockingInput
+          key={requestKey}
           {...sharedProps}
           defaultAcceptedFileTypes={[...DEFAULT_DATASET_FILE_TYPES]}
           missingSelectionMessage="Pick a dataset file inside an existing fileset"
@@ -60,7 +62,7 @@ export const BlockingInputComposer: FC<BlockingInputComposerProps> = ({
         />
       );
     case 'model':
-      return <ModelSelectBlockingInput {...sharedProps} />;
+      return <ModelSelectBlockingInput key={requestKey} {...sharedProps} />;
     default: {
       const exhaustiveCheck: never = inputRequest.kind;
       return exhaustiveCheck;

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/BlockingInputComposer.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/BlockingInputComposer.tsx
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AgentSelectBlockingInput,
+  EvalConfigBlockingInput,
+  FilesetFileBlockingInput,
+  ModelSelectBlockingInput,
+  type AgentBlockingInputStatus,
+  type AgentBlockingInputSubmission,
+} from '@studio/components/agents/AgentBlockingInput';
+import { getBlockingInputRequest } from '@studio/routes/agents/ClaudeCodeChatRoute/blockingInputRequest';
+import type { ClaudeCodeInputRequest } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import { type FC } from 'react';
+
+interface BlockingInputComposerProps {
+  readonly inputRequest: ClaudeCodeInputRequest;
+  readonly inputStatus: AgentBlockingInputStatus;
+  readonly workspace: string;
+  readonly onSubmit: (submission: AgentBlockingInputSubmission) => Promise<void> | void;
+  readonly onSkip: () => Promise<void> | void;
+}
+
+const DEFAULT_DATASET_FILE_TYPES = ['.json', '.jsonl', '.csv', '.parquet'] as const;
+
+export const BlockingInputComposer: FC<BlockingInputComposerProps> = ({
+  inputRequest,
+  inputStatus,
+  workspace,
+  onSubmit,
+  onSkip,
+}) => {
+  const request = getBlockingInputRequest(inputRequest);
+  const sharedProps = {
+    input: inputRequest.input,
+    request,
+    status: inputStatus,
+    onSubmit,
+    onSkip,
+  };
+
+  switch (inputRequest.kind) {
+    case 'agent':
+      return <AgentSelectBlockingInput {...sharedProps} workspace={workspace} />;
+    case 'eval_config':
+      return <EvalConfigBlockingInput {...sharedProps} workspace={workspace} />;
+    case 'dataset_file':
+      return (
+        <FilesetFileBlockingInput
+          {...sharedProps}
+          defaultAcceptedFileTypes={[...DEFAULT_DATASET_FILE_TYPES]}
+          missingSelectionMessage="Pick a dataset file inside an existing fileset"
+          selectionDisplayLabel="Selected dataset"
+          submitLabel="Select dataset"
+          toValue={({ name, objectPath }) => ({
+            dataset_fileset: name,
+            dataset_path: objectPath,
+          })}
+          workspace={workspace}
+        />
+      );
+    case 'model':
+      return <ModelSelectBlockingInput {...sharedProps} />;
+    default: {
+      const exhaustiveCheck: never = inputRequest.kind;
+      return exhaustiveCheck;
+    }
+  }
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeToolCallPart.spec.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeToolCallPart.spec.tsx
@@ -2,9 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ClaudeCodeToolCallPart } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeToolCallPart';
+import {
+  CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME,
+  CLAUDE_CODE_JOB_PROGRESS_TOOL_NAME,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/jobProgressConsts';
 import { CLAUDE_CODE_SUBTLE_TOOL_GROUP_NAME } from '@studio/routes/agents/ClaudeCodeChatRoute/toolParts';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/JobProgressToolCall', () => ({
+  JobProgressToolCall: ({ args }: { args: Record<string, unknown> }) => (
+    <div data-testid="mock-job-progress">{String(args.job_name)}</div>
+  ),
+}));
 
 interface SubtleToolCase {
   readonly args: Record<string, string>;
@@ -399,4 +409,25 @@ describe('ClaudeCodeToolCallPart', () => {
     expectSubtleToolBlock(subtleBlock);
     expect(screen.queryByTestId('claude-code-tool-call')).not.toBeInTheDocument();
   });
+
+  it.each([CLAUDE_CODE_JOB_PROGRESS_TOOL_NAME, CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME])(
+    'renders %s as a rich job progress tool call',
+    (toolName) => {
+      render(
+        <ClaudeCodeToolCallPart
+          addResult={vi.fn()}
+          args={{ job_name: 'studio-job-1' }}
+          argsText='{"job_name":"studio-job-1"}'
+          resume={vi.fn()}
+          status={{ type: 'complete' }}
+          toolCallId="toolu_job"
+          toolName={toolName}
+          type="tool-call"
+        />
+      );
+
+      expect(screen.getByTestId('mock-job-progress')).toHaveTextContent('studio-job-1');
+      expect(screen.queryByTestId('claude-code-tool-call-subtle')).not.toBeInTheDocument();
+    }
+  );
 });

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeToolCallPart.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeToolCallPart.tsx
@@ -3,8 +3,10 @@
 
 import type { ToolCallMessagePartComponent } from '@assistant-ui/react';
 import { Text } from '@nvidia/foundations-react-core';
+import { JobProgressToolCall } from '@studio/routes/agents/ClaudeCodeChatRoute/JobProgressToolCall';
 import {
   CLAUDE_CODE_SUBTLE_TOOL_GROUP_NAME,
+  isClaudeCodeJobProgressToolName,
   isClaudeCodeSubtleToolCallName,
   toClaudeCodeToolArgs,
   type ClaudeCodeToolArgs,
@@ -622,6 +624,10 @@ export const ClaudeCodeToolCallPart: ToolCallMessagePartComponent<ClaudeCodeTool
   toolName,
 }) => {
   const isRunning = status.type === 'running';
+
+  if (isClaudeCodeJobProgressToolName(toolName)) {
+    return <JobProgressToolCall args={args} />;
+  }
 
   if (toolName === CLAUDE_CODE_SUBTLE_TOOL_GROUP_NAME) {
     const subtleActions = getSubtleToolGroupActions(args);

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/JobProgressToolCall.spec.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/JobProgressToolCall.spec.tsx
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { jobsGetJob } from '@nemo/sdk/generated/platform/api';
+import type { PlatformJobResponse } from '@nemo/sdk/generated/platform/schema';
+import { ROUTES } from '@studio/constants/routes';
+import { JOB_PROGRESS_JOB_TYPE } from '@studio/routes/agents/ClaudeCodeChatRoute/jobProgressConsts';
+import { JobProgressToolCall } from '@studio/routes/agents/ClaudeCodeChatRoute/JobProgressToolCall';
+import type { ClaudeCodeToolArgs } from '@studio/routes/agents/ClaudeCodeChatRoute/toolParts';
+import { getClaudeCodeChatRoute } from '@studio/routes/utils';
+import { renderRoute, screen } from '@studio/tests/util/render';
+
+vi.mock('@nemo/sdk/generated/platform/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@nemo/sdk/generated/platform/api')>()),
+  jobsGetJob: vi.fn(),
+}));
+
+const jobsGetJobMock = vi.mocked(jobsGetJob);
+const workspace = 'default';
+
+const createJob = (overrides: Partial<PlatformJobResponse> = {}): PlatformJobResponse =>
+  ({
+    attempt_id: 'attempt-1',
+    description: 'Import data into the workspace',
+    fileset: 'fileset-1',
+    id: 'job-id-1',
+    name: 'studio-job-1',
+    platform_spec: {},
+    source: 'platform',
+    status: 'completed',
+    workspace,
+    ...overrides,
+  }) as PlatformJobResponse;
+
+const renderToolCall = (args: ClaudeCodeToolArgs) =>
+  renderRoute(<JobProgressToolCall args={args} />, {
+    history: getClaudeCodeChatRoute(workspace),
+    routes: [
+      {
+        path: ROUTES.workspace.claudeCodeChat,
+        element: <JobProgressToolCall args={args} />,
+      },
+    ],
+  });
+
+beforeEach(() => {
+  jobsGetJobMock.mockReset().mockResolvedValue(createJob());
+});
+
+describe('JobProgressToolCall', () => {
+  it('renders status for the job id supplied by the tool call', async () => {
+    renderToolCall({ job_name: 'studio-job-1' });
+
+    expect(await screen.findByText('studio-job-1')).toBeInTheDocument();
+    expect(jobsGetJobMock).toHaveBeenCalledWith(workspace, 'studio-job-1', expect.any(AbortSignal));
+    expect(await screen.findByText('Import data into the workspace')).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: 'View details' })).toHaveAttribute(
+      'href',
+      '/workspaces/default/jobs/studio-job-1'
+    );
+  });
+
+  it('links agent evaluation jobs to the agent evaluation details page when requested', async () => {
+    jobsGetJobMock.mockResolvedValue(
+      createJob({ description: 'Evaluate an agent', name: 'eval-job-1', source: 'evaluator' })
+    );
+
+    renderToolCall({
+      job_name: 'eval-job-1',
+      job_type: JOB_PROGRESS_JOB_TYPE.AGENT_EVALUATION,
+    });
+
+    expect(await screen.findByText('eval-job-1')).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: 'View details' })).toHaveAttribute(
+      'href',
+      '/workspaces/default/agents/evaluations/eval-job-1'
+    );
+  });
+
+  it('shows a recoverable missing-job state', async () => {
+    jobsGetJobMock.mockRejectedValue({ response: { status: 404 } });
+
+    renderToolCall({ job_name: 'missing-job' });
+
+    expect(await screen.findByText('Job "missing-job" could not be found.')).toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/JobProgressToolCall.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/JobProgressToolCall.tsx
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
+import { jobsGetJob } from '@nemo/sdk/generated/platform/api';
+import { Banner, Button, Card, Flex, Spinner, Stack, Text } from '@nvidia/foundations-react-core';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import type { ClaudeCodeToolArgs } from '@studio/routes/agents/ClaudeCodeChatRoute/toolParts';
+import {
+  getJobProgressDetailRoute,
+  getJobProgressRefetchInterval,
+  getStringArg,
+  isJobProgressNotFoundError,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/utils/jobProgress';
+import { useQuery } from '@tanstack/react-query';
+import { ClipboardList } from 'lucide-react';
+import { type FC } from 'react';
+import { Link } from 'react-router-dom';
+
+interface JobProgressToolCallProps {
+  readonly args: ClaudeCodeToolArgs;
+}
+
+export const JobProgressToolCall: FC<JobProgressToolCallProps> = ({ args }) => {
+  const routeWorkspace = useWorkspaceFromPath();
+  const workspace = getStringArg(args, 'workspace') ?? routeWorkspace;
+  const jobName = getStringArg(args, 'job_name') ?? getStringArg(args, 'name');
+  const jobType = getStringArg(args, 'job_type') ?? getStringArg(args, 'type');
+  const source = getStringArg(args, 'source');
+  const fallbackTitle = getStringArg(args, 'title');
+  const fallbackDescription = getStringArg(args, 'description');
+
+  const {
+    data: job,
+    error,
+    isLoading,
+  } = useQuery({
+    queryKey: ['claude-code', 'job-progress', workspace, jobName],
+    queryFn: ({ signal }) => jobsGetJob(workspace, jobName ?? '', signal),
+    enabled: !!workspace && !!jobName,
+    refetchInterval: (query) =>
+      getJobProgressRefetchInterval({
+        status: query.state.data?.status,
+        jobMissing: isJobProgressNotFoundError(query.state.error),
+      }),
+    retry: (failureCount, queryError) =>
+      !isJobProgressNotFoundError(queryError) && failureCount < 3,
+  });
+
+  const isMissingJob = isJobProgressNotFoundError(error);
+  const displayName = job?.name ?? jobName ?? fallbackTitle ?? 'Job progress';
+  const description = job?.description || fallbackDescription || job?.source || source;
+  const detailRoute = jobName
+    ? getJobProgressDetailRoute({ job, jobName, jobType, source, workspace })
+    : undefined;
+
+  return (
+    <Card
+      className="my-density-md h-fit w-full max-w-full border border-base bg-surface-raised shadow-none"
+      data-testid="job-progress-tool-call"
+    >
+      <Stack gap="density-md">
+        <Flex align="center" justify="between" gap="density-md" wrap="wrap">
+          <Flex align="center" gap="density-sm" className="min-w-0">
+            <Flex
+              align="center"
+              justify="center"
+              className="size-8 shrink-0 rounded bg-surface-sunken text-secondary"
+            >
+              <ClipboardList aria-hidden className="size-4" />
+            </Flex>
+            <Stack gap="density-xs" className="min-w-0">
+              <Text kind="label/bold/md" className="truncate">
+                {displayName}
+              </Text>
+              <Text kind="body/regular/sm" color="secondary" className="truncate">
+                {description ?? 'Job progress'}
+              </Text>
+            </Stack>
+          </Flex>
+          {job ? <StatusBadge status={job.status} /> : null}
+        </Flex>
+
+        {isLoading ? (
+          <Flex align="center" gap="density-sm">
+            <Spinner size="small" aria-label="Loading job..." />
+            <Text kind="body/regular/sm" color="secondary">
+              Loading job...
+            </Text>
+          </Flex>
+        ) : null}
+
+        {error && !isMissingJob ? (
+          <Banner kind="inline" status="error">
+            {error instanceof Error ? error.message : 'Failed to load job'}
+          </Banner>
+        ) : null}
+
+        {!isLoading && jobName && isMissingJob ? (
+          <Banner kind="inline" status="warning">
+            Job "{jobName}" could not be found.
+          </Banner>
+        ) : null}
+
+        {detailRoute ? (
+          <Flex justify="end">
+            <Button kind="secondary" asChild>
+              <Link to={detailRoute}>View details</Link>
+            </Button>
+          </Flex>
+        ) : null}
+      </Stack>
+    </Card>
+  );
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.spec.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.spec.ts
@@ -3,7 +3,9 @@
 
 import { BASE_URL } from '@studio/constants/environment';
 import {
+  getClaudeCodeSessionHistory,
   listClaudeCodeSkills,
+  resolveClaudeCodeInput,
   resolveClaudeCodePermission,
   streamClaudeCodeMessage,
 } from '@studio/routes/agents/ClaudeCodeChatRoute/api';
@@ -32,6 +34,7 @@ describe('Claude Code API helpers', () => {
       signal: new AbortController().signal,
       handlers: {
         onClaudeEvent: vi.fn(),
+        onInputRequest: vi.fn(),
         onPermissionRequest: vi.fn(),
         onDone: vi.fn(),
         onError: vi.fn(),
@@ -78,6 +81,7 @@ describe('Claude Code API helpers', () => {
       signal: new AbortController().signal,
       handlers: {
         onClaudeEvent: vi.fn(),
+        onInputRequest: vi.fn(),
         onPermissionRequest,
         onDone: vi.fn(),
         onError: vi.fn(),
@@ -116,6 +120,7 @@ describe('Claude Code API helpers', () => {
       signal: new AbortController().signal,
       handlers: {
         onClaudeEvent: vi.fn(),
+        onInputRequest: vi.fn(),
         onPermissionRequest,
         onDone: vi.fn(),
         onError,
@@ -152,6 +157,7 @@ describe('Claude Code API helpers', () => {
       signal: new AbortController().signal,
       handlers: {
         onClaudeEvent: vi.fn(),
+        onInputRequest: vi.fn(),
         onPermissionRequest,
         onDone: vi.fn(),
         onError,
@@ -219,5 +225,182 @@ describe('Claude Code API helpers', () => {
         installed: false,
       },
     ]);
+  });
+
+  it('emits structured blocking input requests from SSE events', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          [
+            'event: input_request',
+            'data: {"request_id":"request-1","kind":"agent","input":{"title":"Pick agent"}}',
+            '',
+          ].join('\n'),
+          { status: 200 }
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onInputRequest = vi.fn();
+
+    await streamClaudeCodeMessage({
+      sessionId: 'session-1',
+      message: 'pick agent',
+      signal: new AbortController().signal,
+      handlers: {
+        onClaudeEvent: vi.fn(),
+        onInputRequest,
+        onPermissionRequest: vi.fn(),
+        onDone: vi.fn(),
+        onError: vi.fn(),
+      },
+    });
+
+    expect(onInputRequest).toHaveBeenCalledWith({
+      requestId: 'request-1',
+      kind: 'agent',
+      input: { title: 'Pick agent' },
+    });
+  });
+
+  it('emits structured dataset file input requests from SSE events', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          [
+            'event: input_request',
+            'data: {"request_id":"request-1","kind":"dataset_file","input":{"title":"Pick dataset"}}',
+            '',
+          ].join('\n'),
+          { status: 200 }
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onInputRequest = vi.fn();
+
+    await streamClaudeCodeMessage({
+      sessionId: 'session-1',
+      message: 'pick dataset',
+      signal: new AbortController().signal,
+      handlers: {
+        onClaudeEvent: vi.fn(),
+        onInputRequest,
+        onPermissionRequest: vi.fn(),
+        onDone: vi.fn(),
+        onError: vi.fn(),
+      },
+    });
+
+    expect(onInputRequest).toHaveBeenCalledWith({
+      requestId: 'request-1',
+      kind: 'dataset_file',
+      input: { title: 'Pick dataset' },
+    });
+  });
+
+  it('emits structured model input requests from SSE events', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          [
+            'event: input_request',
+            'data: {"request_id":"request-1","kind":"model","input":{"title":"Pick model"}}',
+            '',
+          ].join('\n'),
+          { status: 200 }
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onInputRequest = vi.fn();
+
+    await streamClaudeCodeMessage({
+      sessionId: 'session-1',
+      message: 'pick model',
+      signal: new AbortController().signal,
+      handlers: {
+        onClaudeEvent: vi.fn(),
+        onInputRequest,
+        onPermissionRequest: vi.fn(),
+        onDone: vi.fn(),
+        onError: vi.fn(),
+      },
+    });
+
+    expect(onInputRequest).toHaveBeenCalledWith({
+      requestId: 'request-1',
+      kind: 'model',
+      input: { title: 'Pick model' },
+    });
+  });
+
+  it('posts blocking input decisions using the backend input shape', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await resolveClaudeCodeInput({
+      sessionId: 'session-1',
+      requestId: 'request-1',
+      decision: {
+        value: { agent: 'react-agent' },
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/sessions/session-1/inputs/request-1'),
+      expect.objectContaining({
+        body: JSON.stringify({
+          skipped: undefined,
+          value: { agent: 'react-agent' },
+        }),
+        method: 'POST',
+      })
+    );
+  });
+
+  it('preserves tool use ids from session history', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          session_id: 'session-1',
+          items: [
+            {
+              kind: 'assistant',
+              parts: [
+                {
+                  type: 'tool_use',
+                  id: 'toolu_job',
+                  name: 'job_progress',
+                  input: { job_name: 'studio-job-1' },
+                },
+              ],
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(getClaudeCodeSessionHistory('session-1')).resolves.toEqual({
+      session_id: 'session-1',
+      items: [
+        {
+          kind: 'assistant',
+          parts: [
+            {
+              type: 'tool_use',
+              id: 'toolu_job',
+              name: 'job_progress',
+              input: { job_name: 'studio-job-1' },
+            },
+          ],
+        },
+      ],
+    });
   });
 });

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.ts
@@ -6,6 +6,8 @@ import { parseJsonObject, parseSseChunk } from '@studio/routes/agents/ClaudeCode
 import type {
   ClaudeCodeAssistantHistoryPart,
   ClaudeCodeHistorySession,
+  ClaudeCodeInputDecision,
+  ClaudeCodeInputRequest,
   ClaudeCodePermissionDecision,
   ClaudeCodePermissionRequest,
   ClaudeCodeSessionHistory,
@@ -132,6 +134,7 @@ const parseAssistantPart = (value: unknown): ClaudeCodeAssistantHistoryPart | un
   if (value.type === 'tool_use') {
     return {
       type: 'tool_use',
+      id: getString(value.id) || undefined,
       name: getString(value.name) || 'tool',
       input: isRecord(value.input) ? value.input : {},
     };
@@ -235,6 +238,25 @@ const parsePermissionRequest = (payload: unknown): ClaudeCodePermissionRequest |
   };
 };
 
+const parseInputRequest = (payload: unknown): ClaudeCodeInputRequest | undefined => {
+  if (!isRecord(payload) || typeof payload.request_id !== 'string') return undefined;
+  if (
+    payload.kind !== 'agent' &&
+    payload.kind !== 'eval_config' &&
+    payload.kind !== 'dataset_file' &&
+    payload.kind !== 'model'
+  ) {
+    return undefined;
+  }
+  if (!isRecord(payload.input) || Array.isArray(payload.input)) return undefined;
+
+  return {
+    requestId: payload.request_id,
+    kind: payload.kind,
+    input: payload.input,
+  };
+};
+
 const handleSseEvent = (
   event: { event?: string; data: string },
   handlers: ClaudeCodeStreamHandlers
@@ -256,6 +278,16 @@ const handleSseEvent = (
       return false;
     }
     handlers.onPermissionRequest(request);
+    return true;
+  }
+
+  if (event.event === 'input_request') {
+    const request = parseInputRequest(parseJsonObject(event.data));
+    if (!request) {
+      handlers.onError(new Error('Claude Code input request was malformed'));
+      return false;
+    }
+    handlers.onInputRequest(request);
     return true;
   }
 
@@ -291,6 +323,31 @@ export const resolveClaudeCodePermission = async ({
     throw new Error(
       await getResponseErrorMessage(response, 'Failed to resolve Claude Code permission')
     );
+  }
+};
+
+export const resolveClaudeCodeInput = async ({
+  decision,
+  requestId,
+  sessionId,
+}: {
+  decision: ClaudeCodeInputDecision;
+  requestId: string;
+  sessionId: string;
+}): Promise<void> => {
+  const response = await fetch(claudeCodeApiUrl(`/sessions/${sessionId}/inputs/${requestId}`), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      skipped: decision.skipped,
+      value: decision.value,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await getResponseErrorMessage(response, 'Failed to resolve Claude Code input'));
   }
 };
 

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/blockingInputRequest.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/blockingInputRequest.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getStringValue } from '@studio/components/agents/AgentBlockingInput/utils';
+import type { ClaudeCodeInputRequest } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+
+const DEFAULTS_BY_KIND: Record<
+  ClaudeCodeInputRequest['kind'],
+  { readonly title: string; readonly description: string }
+> = {
+  agent: {
+    title: 'Select an agent',
+    description: 'Choose the agent the workflow should use.',
+  },
+  eval_config: {
+    title: 'Select an evaluation config',
+    description: 'Choose a YAML file from a fileset.',
+  },
+  dataset_file: {
+    title: 'Select a dataset',
+    description: 'Choose a dataset file from a fileset.',
+  },
+  model: {
+    title: 'Select a model',
+    description: 'Choose the model this workflow should use.',
+  },
+};
+
+export const getBlockingInputRequest = (request: ClaudeCodeInputRequest) => {
+  const defaults = DEFAULTS_BY_KIND[request.kind];
+  return {
+    id: request.requestId,
+    title: getStringValue(request.input, 'title') ?? defaults.title,
+    description: getStringValue(request.input, 'description') ?? defaults.description,
+  };
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.tsx
@@ -6,6 +6,7 @@ import { AssistantChatThread } from '@nemo/common/src/components/AssistantChat/A
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { Banner, Stack, Text } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { type AgentBlockingInputSubmission } from '@studio/components/agents/AgentBlockingInput';
 import { AgentDecisionInput } from '@studio/components/agents/AgentDecisionInput';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
@@ -13,6 +14,7 @@ import {
   getClaudeCodeSessionHistory,
   getClaudeCodeSessionHistoryQueryKey,
 } from '@studio/routes/agents/ClaudeCodeChatRoute/api';
+import { BlockingInputComposer } from '@studio/routes/agents/ClaudeCodeChatRoute/BlockingInputComposer';
 import { ClaudeCodeLayout } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeLayout';
 import { ClaudeCodeStudioLink } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeStudioLink';
 import { ClaudeCodeToolCallPart } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeToolCallPart';
@@ -94,9 +96,13 @@ const ClaudeCodeChatSurface: FC<ClaudeCodeChatSurfaceProps> = ({
     decisionRequest,
     decisionStatus,
     handleReset,
+    inputRequest,
+    inputStatus,
+    resolveInputRequest,
     resolveDecisionRequest,
     runtime,
     sessionId,
+    skipInputRequest,
     skipDecisionRequest,
     submitPrompt,
   } = useClaudeCodeChatRuntime({
@@ -114,6 +120,16 @@ const ClaudeCodeChatSurface: FC<ClaudeCodeChatSurfaceProps> = ({
     }
   }, [handleReset, initialSessionId, navigate, workspace]);
 
+  const handleInputSubmit = useCallback(
+    async (submission: AgentBlockingInputSubmission) => {
+      await resolveInputRequest({
+        decision: { value: submission.value },
+        displayText: submission.displayText,
+      });
+    },
+    [resolveInputRequest]
+  );
+
   useBreadcrumbs({
     items: [
       { slotLabel: 'Dashboard', href: getWorkspaceDashboardRoute(workspace) },
@@ -130,7 +146,7 @@ const ClaudeCodeChatSurface: FC<ClaudeCodeChatSurfaceProps> = ({
   }, [initialPrompt, location.pathname, location.search, navigate, submitPrompt]);
 
   useLayoutEffect(() => {
-    if (!decisionRequest) return undefined;
+    if (!decisionRequest && !inputRequest) return undefined;
 
     const viewport = chatViewportRef.current;
     if (!viewport) return undefined;
@@ -140,7 +156,7 @@ const ClaudeCodeChatSurface: FC<ClaudeCodeChatSurfaceProps> = ({
     });
 
     return () => window.cancelAnimationFrame(frame);
-  }, [decisionRequest]);
+  }, [decisionRequest, inputRequest]);
 
   return (
     <ClaudeCodeLayout activeSessionId={activeSessionId}>
@@ -161,7 +177,7 @@ const ClaudeCodeChatSurface: FC<ClaudeCodeChatSurfaceProps> = ({
                 }}
                 placeholder="Ask Claude Code to work in this workspace"
                 onReset={handleChatReset}
-                showRunningIndicator={!decisionRequest}
+                showRunningIndicator={!decisionRequest && !inputRequest}
                 messageContentProps={{ markdownLinkComponent: ClaudeCodeStudioLink }}
                 emptyState={{
                   slotHeading: 'Start a Claude Code session',
@@ -176,6 +192,14 @@ const ClaudeCodeChatSurface: FC<ClaudeCodeChatSurfaceProps> = ({
                       status={decisionStatus}
                       onSubmit={resolveDecisionRequest}
                       onSkip={skipDecisionRequest}
+                    />
+                  ) : inputRequest ? (
+                    <BlockingInputComposer
+                      inputRequest={inputRequest}
+                      inputStatus={inputStatus}
+                      workspace={workspace}
+                      onSubmit={handleInputSubmit}
+                      onSkip={skipInputRequest}
                     />
                   ) : undefined
                 }

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/jobProgressConsts.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/jobProgressConsts.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { JOB_SOURCE } from '@studio/components/dataViews/JobsDataView/constants';
+
+export const CLAUDE_CODE_JOB_PROGRESS_TOOL_NAME = 'job_progress';
+export const CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME = 'mcp__nemo_studio__job_progress';
+
+export const JOB_PROGRESS_JOB_TYPE = {
+  AGENT_EVALUATION: 'agent_evaluation',
+  CUSTOMIZATION: 'customization',
+  DATA_DESIGNER: 'data_designer',
+  EVALUATOR: 'evaluator',
+  SAFE_SYNTHESIZER: 'safe_synthesizer',
+} as const;
+
+export const JOB_PROGRESS_JOB_TYPE_SOURCE: Record<string, string> = {
+  [JOB_PROGRESS_JOB_TYPE.CUSTOMIZATION]: JOB_SOURCE.CUSTOMIZATION,
+  customizer: JOB_SOURCE.CUSTOMIZATION,
+  [JOB_PROGRESS_JOB_TYPE.DATA_DESIGNER]: JOB_SOURCE.DATA_DESIGNER,
+  'data-designer': JOB_SOURCE.DATA_DESIGNER,
+  [JOB_PROGRESS_JOB_TYPE.SAFE_SYNTHESIZER]: JOB_SOURCE.SAFE_SYNTHESIZER,
+  'safe-synthesizer': JOB_SOURCE.SAFE_SYNTHESIZER,
+  [JOB_PROGRESS_JOB_TYPE.EVALUATOR]: JOB_SOURCE.EVALUATOR_METRICS,
+  evaluation: JOB_SOURCE.EVALUATOR_METRICS,
+  evaluator_metrics: JOB_SOURCE.EVALUATOR_METRICS,
+  'evaluator-metrics': JOB_SOURCE.EVALUATOR_METRICS,
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/stream.spec.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/stream.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME } from '@studio/routes/agents/ClaudeCodeChatRoute/jobProgressConsts';
 import {
   getAssistantPartsFromClaudeEvent,
   getAssistantTextFromClaudeEvent,
@@ -149,6 +150,48 @@ describe('Claude Code stream utilities', () => {
             { args: { file_path: 'README.md' }, toolCallId: 'toolu_read', toolName: 'Read' },
           ],
         },
+      },
+    ]);
+  });
+
+  it('keeps the job progress card out of subtle streamed tool groups', () => {
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', id: 'toolu_bash', name: 'Bash', input: { command: 'pwd' } },
+          {
+            type: 'tool_use',
+            id: 'toolu_job',
+            name: CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME,
+            input: { job_name: 'studio-job-1' },
+          },
+          { type: 'tool_use', id: 'toolu_read', name: 'Read', input: { file_path: 'README.md' } },
+        ],
+      },
+    };
+
+    expect(getAssistantPartsFromClaudeEvent(event)).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'toolu_bash',
+        toolName: 'Bash',
+        args: { command: 'pwd' },
+        argsText: '{"command":"pwd"}',
+      },
+      {
+        type: 'tool-call',
+        toolCallId: 'toolu_job',
+        toolName: CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME,
+        args: { job_name: 'studio-job-1' },
+        argsText: '{"job_name":"studio-job-1"}',
+      },
+      {
+        type: 'tool-call',
+        toolCallId: 'toolu_read',
+        toolName: 'Read',
+        args: { file_path: 'README.md' },
+        argsText: '{"file_path":"README.md"}',
       },
     ]);
   });

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/toolParts.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/toolParts.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ThreadAssistantMessagePart, ThreadMessageLike } from '@assistant-ui/react';
+import {
+  CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME,
+  CLAUDE_CODE_JOB_PROGRESS_TOOL_NAME,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/jobProgressConsts';
 
 type ClaudeCodeToolCallPart = Extract<ThreadAssistantMessagePart, { type: 'tool-call' }>;
 export type ClaudeCodeToolArgs = ClaudeCodeToolCallPart['args'];
@@ -11,8 +15,14 @@ export const CLAUDE_CODE_SUBTLE_TOOL_GROUP_NAME = 'ClaudeCodeSubtleToolGroup';
 
 const FILE_CHANGE_TOOL_CALL_NAMES = new Set(['Edit', 'MultiEdit', 'Write']);
 
+export const isClaudeCodeJobProgressToolName = (toolName: string): boolean =>
+  toolName === CLAUDE_CODE_JOB_PROGRESS_TOOL_NAME ||
+  toolName === CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME;
+
 export const isClaudeCodeSubtleToolCallName = (toolName: string): boolean =>
-  toolName !== CLAUDE_CODE_SUBTLE_TOOL_GROUP_NAME && !FILE_CHANGE_TOOL_CALL_NAMES.has(toolName);
+  toolName !== CLAUDE_CODE_SUBTLE_TOOL_GROUP_NAME &&
+  !FILE_CHANGE_TOOL_CALL_NAMES.has(toolName) &&
+  !isClaudeCodeJobProgressToolName(toolName);
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/types.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/types.ts
@@ -3,6 +3,7 @@
 
 export interface ClaudeCodeStreamHandlers {
   onClaudeEvent: (event: unknown) => void;
+  onInputRequest: (request: ClaudeCodeInputRequest) => void;
   onPermissionRequest: (request: ClaudeCodePermissionRequest) => void;
   onDone: () => void;
   onError: (error: Error) => void;
@@ -19,6 +20,19 @@ export interface ClaudeCodePermissionDecision {
   approved: boolean;
   reason?: string;
   updatedInput?: Record<string, unknown>;
+}
+
+export type ClaudeCodeInputRequestKind = 'agent' | 'eval_config' | 'dataset_file' | 'model';
+
+export interface ClaudeCodeInputRequest {
+  requestId: string;
+  kind: ClaudeCodeInputRequestKind;
+  input: Record<string, unknown>;
+}
+
+export interface ClaudeCodeInputDecision {
+  skipped?: boolean;
+  value?: Record<string, unknown>;
 }
 
 export interface ClaudeCodeChatRouteState {
@@ -57,6 +71,7 @@ export interface ClaudeCodeAssistantTextPart {
 
 export interface ClaudeCodeAssistantToolUsePart {
   type: 'tool_use';
+  id?: string;
   name: string;
   input: Record<string, unknown>;
 }

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.spec.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.spec.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   appendUserMessage: vi.fn(),
   createClaudeCodeSession: vi.fn(),
   invalidateQueries: vi.fn(),
+  resolveClaudeCodeInput: vi.fn(),
   resolveClaudeCodePermission: vi.fn(),
   streamClaudeCodeMessage: vi.fn(),
   submitPrompt: vi.fn(),
@@ -16,6 +17,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/api', () => ({
   CLAUDE_CODE_HISTORY_SESSIONS_QUERY_KEY: ['claude-code', 'history', 'sessions'],
   createClaudeCodeSession: mocks.createClaudeCodeSession,
+  resolveClaudeCodeInput: mocks.resolveClaudeCodeInput,
   resolveClaudeCodePermission: mocks.resolveClaudeCodePermission,
   streamClaudeCodeMessage: mocks.streamClaudeCodeMessage,
 }));
@@ -52,6 +54,14 @@ vi.mock('@tanstack/react-query', () => ({
 
 const renderUseClaudeCodeChatRuntime = (options?: Parameters<typeof useClaudeCodeChatRuntime>[0]) =>
   renderHook(() => useClaudeCodeChatRuntime(options));
+
+interface PermissionRequestTestHandlers {
+  onPermissionRequest: (request: unknown) => void;
+}
+
+interface InputRequestTestHandlers {
+  onInputRequest: (request: unknown) => void;
+}
 
 describe('useClaudeCodeChatRuntime', () => {
   beforeEach(() => {
@@ -146,6 +156,194 @@ describe('useClaudeCodeChatRuntime', () => {
 
     expect(mocks.appendUserMessage).toHaveBeenCalledWith('Use rg instead');
     expect(result.current.decisionRequest).toBeNull();
+
+    await act(async () => {
+      finishStream();
+      await submitPromise;
+    });
+  });
+
+  it('does not clear a newer permission request when an older permission resolution completes', async () => {
+    let finishStream!: () => void;
+    let permissionHandlers!: PermissionRequestTestHandlers;
+    let resolvePermission!: () => void;
+    let resolvePromise!: Promise<void>;
+    let submitPromise!: Promise<void>;
+    mocks.createClaudeCodeSession.mockResolvedValue('session-1');
+    mocks.streamClaudeCodeMessage.mockImplementation(
+      async ({ handlers }: { handlers: PermissionRequestTestHandlers }) => {
+        permissionHandlers = handlers;
+        handlers.onPermissionRequest({
+          requestId: 'request-1',
+          toolName: 'Bash',
+          input: { command: 'ls' },
+        });
+        await new Promise<void>((resolve) => {
+          finishStream = resolve;
+        });
+      }
+    );
+    mocks.resolveClaudeCodePermission.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePermission = resolve;
+        })
+    );
+
+    const { result } = renderUseClaudeCodeChatRuntime();
+
+    act(() => {
+      submitPromise = result.current.submitPrompt('List files');
+    });
+    await waitFor(() =>
+      expect(result.current.decisionRequest).toEqual(expect.objectContaining({ id: 'request-1' }))
+    );
+
+    act(() => {
+      resolvePromise = result.current.resolveDecisionRequest(result.current.decisionChoices[0]);
+    });
+    await waitFor(() => expect(result.current.decisionStatus).toBe('submitting'));
+
+    act(() => {
+      permissionHandlers.onPermissionRequest({
+        requestId: 'request-2',
+        toolName: 'Bash',
+        input: { command: 'pwd' },
+      });
+    });
+    expect(result.current.decisionRequest).toEqual(expect.objectContaining({ id: 'request-2' }));
+
+    await act(async () => {
+      resolvePermission();
+      await resolvePromise;
+    });
+
+    expect(result.current.decisionRequest).toEqual(expect.objectContaining({ id: 'request-2' }));
+
+    await act(async () => {
+      finishStream();
+      await submitPromise;
+    });
+  });
+
+  it('resolves blocking input requests and appends the selected value after success', async () => {
+    let finishStream!: () => void;
+    let submitPromise!: Promise<void>;
+    mocks.createClaudeCodeSession.mockResolvedValue('session-1');
+    mocks.streamClaudeCodeMessage.mockImplementation(
+      async ({ handlers }: { handlers: { onInputRequest: (request: unknown) => void } }) => {
+        handlers.onInputRequest({
+          requestId: 'request-1',
+          kind: 'agent',
+          input: { title: 'Select an agent' },
+        });
+        await new Promise<void>((resolve) => {
+          finishStream = resolve;
+        });
+      }
+    );
+    mocks.resolveClaudeCodeInput.mockResolvedValue(undefined);
+
+    const { result } = renderUseClaudeCodeChatRuntime();
+
+    act(() => {
+      submitPromise = result.current.submitPrompt('Evaluate an agent');
+    });
+    await waitFor(() =>
+      expect(result.current.inputRequest).toEqual(
+        expect.objectContaining({
+          requestId: 'request-1',
+          kind: 'agent',
+        })
+      )
+    );
+
+    await act(async () => {
+      await result.current.resolveInputRequest({
+        decision: { value: { agent: 'react-agent' } },
+        displayText: 'Selected agent: react-agent',
+      });
+    });
+
+    expect(mocks.resolveClaudeCodeInput).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      requestId: 'request-1',
+      decision: { value: { agent: 'react-agent' } },
+    });
+    expect(mocks.appendUserMessage).toHaveBeenCalledWith('Selected agent: react-agent');
+    expect(result.current.inputRequest).toBeNull();
+
+    await act(async () => {
+      finishStream();
+      await submitPromise;
+    });
+  });
+
+  it('does not clear a newer input request when an older input resolution completes', async () => {
+    let finishStream!: () => void;
+    let inputHandlers!: InputRequestTestHandlers;
+    let resolveInput!: () => void;
+    let resolvePromise!: Promise<void>;
+    let submitPromise!: Promise<void>;
+    mocks.createClaudeCodeSession.mockResolvedValue('session-1');
+    mocks.streamClaudeCodeMessage.mockImplementation(
+      async ({ handlers }: { handlers: InputRequestTestHandlers }) => {
+        inputHandlers = handlers;
+        handlers.onInputRequest({
+          requestId: 'request-1',
+          kind: 'agent',
+          input: { title: 'Select an agent' },
+        });
+        await new Promise<void>((resolve) => {
+          finishStream = resolve;
+        });
+      }
+    );
+    mocks.resolveClaudeCodeInput.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInput = resolve;
+        })
+    );
+
+    const { result } = renderUseClaudeCodeChatRuntime();
+
+    act(() => {
+      submitPromise = result.current.submitPrompt('Evaluate an agent');
+    });
+    await waitFor(() =>
+      expect(result.current.inputRequest).toEqual(
+        expect.objectContaining({ requestId: 'request-1' })
+      )
+    );
+
+    act(() => {
+      resolvePromise = result.current.resolveInputRequest({
+        decision: { value: { agent: 'react-agent' } },
+        displayText: 'Selected agent: react-agent',
+      });
+    });
+    await waitFor(() => expect(result.current.inputStatus).toBe('submitting'));
+
+    act(() => {
+      inputHandlers.onInputRequest({
+        requestId: 'request-2',
+        kind: 'dataset_file',
+        input: { title: 'Select a dataset' },
+      });
+    });
+    expect(result.current.inputRequest).toEqual(
+      expect.objectContaining({ requestId: 'request-2' })
+    );
+
+    await act(async () => {
+      resolveInput();
+      await resolvePromise;
+    });
+
+    expect(result.current.inputRequest).toEqual(
+      expect.objectContaining({ requestId: 'request-2' })
+    );
 
     await act(async () => {
       finishStream();

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.ts
@@ -15,11 +15,16 @@ import type {
 import {
   CLAUDE_CODE_HISTORY_SESSIONS_QUERY_KEY,
   createClaudeCodeSession,
+  resolveClaudeCodeInput,
   resolveClaudeCodePermission,
   streamClaudeCodeMessage,
 } from '@studio/routes/agents/ClaudeCodeChatRoute/api';
 import { getAssistantPartsFromClaudeEvent } from '@studio/routes/agents/ClaudeCodeChatRoute/stream';
-import type { ClaudeCodePermissionRequest } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import type {
+  ClaudeCodeInputDecision,
+  ClaudeCodeInputRequest,
+  ClaudeCodePermissionRequest,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/types';
 import { useCustomAssistantChatRuntime } from '@studio/routes/agents/ClaudeCodeChatRoute/useCustomAssistantChatRuntime';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
@@ -195,8 +200,11 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
   const [decisionRequest, setDecisionRequest] = useState<AgentDecisionRequest | null>(null);
   const [decisionChoices, setDecisionChoices] = useState<readonly AgentDecisionChoice[]>([]);
   const [decisionStatus, setDecisionStatus] = useState<AgentDecisionInputStatus>('pending');
+  const [inputRequest, setInputRequest] = useState<ClaudeCodeInputRequest | null>(null);
+  const [inputStatus, setInputStatus] = useState<AgentDecisionInputStatus>('pending');
   const sessionIdRef = useRef<string | null>(options?.initialSessionId ?? null);
   const permissionRequestRef = useRef<ClaudeCodePermissionRequest | null>(null);
+  const inputRequestRef = useRef<ClaudeCodeInputRequest | null>(null);
   const activeDecisionRef = useRef<ActiveDecisionState | null>(null);
   const onError = options?.onError;
 
@@ -209,12 +217,22 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
     return nextSessionId;
   }, []);
 
-  const clearApprovalRequest = useCallback(() => {
+  const clearPermissionRequest = useCallback((requestId?: string) => {
+    if (requestId && permissionRequestRef.current?.requestId !== requestId) return;
+
     permissionRequestRef.current = null;
     activeDecisionRef.current = null;
     setDecisionRequest(null);
     setDecisionChoices([]);
     setDecisionStatus('pending');
+  }, []);
+
+  const clearInputRequest = useCallback((requestId?: string) => {
+    if (requestId && inputRequestRef.current?.requestId !== requestId) return;
+
+    inputRequestRef.current = null;
+    setInputRequest(null);
+    setInputStatus('pending');
   }, []);
 
   const setAskUserQuestionDecision = useCallback(
@@ -235,6 +253,7 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
       const actionDescription =
         typeof request.input.description === 'string' ? request.input.description : undefined;
 
+      clearInputRequest();
       permissionRequestRef.current = request;
       activeDecisionRef.current = { kind: 'permission' };
       setDecisionStatus('pending');
@@ -263,7 +282,18 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
       });
       setDecisionChoices(PERMISSION_CHOICES);
     },
-    [setAskUserQuestionDecision]
+    [clearInputRequest, setAskUserQuestionDecision]
+  );
+
+  const handleInputRequest = useCallback(
+    (request: ClaudeCodeInputRequest) => {
+      clearPermissionRequest();
+
+      inputRequestRef.current = request;
+      setInputStatus('pending');
+      setInputRequest(request);
+    },
+    [clearPermissionRequest]
   );
 
   const {
@@ -276,7 +306,8 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
     initialMessages: options?.initialMessages,
     onError,
     onRun: async ({ prompt, signal, appendAssistantParts, prepareForUserInput, isCurrentRun }) => {
-      clearApprovalRequest();
+      clearPermissionRequest();
+      clearInputRequest();
       const activeSessionId = await ensureSessionId();
       let doneReceived = false;
 
@@ -297,6 +328,11 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
               prepareForUserInput();
               handlePermissionRequest(request);
             },
+            onInputRequest: (request) => {
+              if (signal.aborted || !isCurrentRun()) return;
+              prepareForUserInput();
+              handleInputRequest(request);
+            },
             onDone: () => {
               doneReceived = true;
             },
@@ -307,12 +343,52 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
         });
         void queryClient.invalidateQueries({ queryKey: CLAUDE_CODE_HISTORY_SESSIONS_QUERY_KEY });
       } finally {
-        if (isCurrentRun()) clearApprovalRequest();
+        if (isCurrentRun()) {
+          clearPermissionRequest();
+          clearInputRequest();
+        }
       }
 
       return { status: doneReceived ? COMPLETE_STATUS : CANCELLED_STATUS };
     },
   });
+
+  const resolveInputRequest = useCallback(
+    async ({
+      decision,
+      displayText,
+    }: {
+      decision: ClaudeCodeInputDecision;
+      displayText?: string;
+    }) => {
+      const activeSessionId = sessionIdRef.current;
+      const activeRequest = inputRequestRef.current;
+      if (!activeSessionId || !activeRequest) return;
+
+      const trimmedDisplayText = displayText?.trim();
+      setInputStatus('submitting');
+
+      try {
+        await resolveClaudeCodeInput({
+          sessionId: activeSessionId,
+          requestId: activeRequest.requestId,
+          decision,
+        });
+        if (!decision.skipped && trimmedDisplayText) {
+          appendUserMessage(trimmedDisplayText);
+        }
+        clearInputRequest(activeRequest.requestId);
+      } catch (error: unknown) {
+        if (inputRequestRef.current?.requestId === activeRequest.requestId) {
+          setInputStatus('pending');
+        }
+        const errorMessage =
+          error instanceof Error ? error.message : 'Failed to resolve Claude Code input';
+        onError?.(new Error(errorMessage));
+      }
+    },
+    [appendUserMessage, clearInputRequest, onError]
+  );
 
   const submitActiveDecision = useCallback(
     async ({
@@ -344,15 +420,17 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
         if (!approved && trimmedDisplayText) {
           appendUserMessage(trimmedDisplayText);
         }
-        clearApprovalRequest();
+        clearPermissionRequest(activeRequest.requestId);
       } catch (error: unknown) {
-        setDecisionStatus('pending');
+        if (permissionRequestRef.current?.requestId === activeRequest.requestId) {
+          setDecisionStatus('pending');
+        }
         const errorMessage =
           error instanceof Error ? error.message : 'Failed to resolve Claude Code permission';
         onError?.(new Error(errorMessage));
       }
     },
-    [appendUserMessage, clearApprovalRequest, onError]
+    [appendUserMessage, clearPermissionRequest, onError]
   );
 
   const resolveAskUserQuestionDecision = useCallback(
@@ -412,22 +490,31 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
     await submitActiveDecision({ approved: false, reason: 'Skipped by user' });
   }, [submitActiveDecision]);
 
+  const skipInputRequest = useCallback(async () => {
+    await resolveInputRequest({ decision: { skipped: true } });
+  }, [resolveInputRequest]);
+
   const handleReset = useCallback(() => {
     sessionIdRef.current = null;
     setSessionId(null);
-    clearApprovalRequest();
+    clearPermissionRequest();
+    clearInputRequest();
     resetThread();
-  }, [clearApprovalRequest, resetThread]);
+  }, [clearInputRequest, clearPermissionRequest, resetThread]);
 
   return {
     decisionChoices,
     decisionRequest,
     decisionStatus,
     handleReset,
+    inputRequest,
+    inputStatus,
     isRunning,
+    resolveInputRequest,
     resolveDecisionRequest,
     runtime,
     sessionId,
+    skipInputRequest,
     skipDecisionRequest,
     submitPrompt,
   };

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/util.spec.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/util.spec.ts
@@ -211,7 +211,7 @@ describe('Claude Code utilities', () => {
             { type: 'tool_use', name: 'Bash', input: { command: 'pwd' } },
             {
               type: 'tool_use',
-              id: 'toolu_job',
+              id: ' toolu_job ',
               name: CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME,
               input: { job_name: 'studio-job-1' },
             },

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/util.spec.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/util.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME } from '@studio/routes/agents/ClaudeCodeChatRoute/jobProgressConsts';
 import { CLAUDE_CODE_SUBTLE_TOOL_GROUP_NAME } from '@studio/routes/agents/ClaudeCodeChatRoute/toolParts';
 import type { ClaudeCodeSessionHistory } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
 import {
@@ -195,6 +196,44 @@ describe('Claude Code utilities', () => {
             ],
           },
         },
+      ],
+    });
+  });
+
+  it('keeps stored job progress tool calls visible in history', () => {
+    const history: ClaudeCodeSessionHistory = {
+      session_id: 'session-1',
+      items: [
+        { kind: 'user', text: 'evaluate my agent' },
+        {
+          kind: 'assistant',
+          parts: [
+            { type: 'tool_use', name: 'Bash', input: { command: 'pwd' } },
+            {
+              type: 'tool_use',
+              id: 'toolu_job',
+              name: CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME,
+              input: { job_name: 'studio-job-1' },
+            },
+            { type: 'tool_use', name: 'Read', input: { file_path: 'README.md' } },
+          ],
+        },
+      ],
+    };
+
+    const messages = getClaudeCodeHistoryMessages(history);
+
+    expect(messages[1]).toMatchObject({
+      role: 'assistant',
+      content: [
+        { type: 'tool-call', toolName: 'Bash' },
+        {
+          type: 'tool-call',
+          toolCallId: 'toolu_job',
+          toolName: CLAUDE_CODE_JOB_PROGRESS_MCP_TOOL_NAME,
+          args: { job_name: 'studio-job-1' },
+        },
+        { type: 'tool-call', toolName: 'Read' },
       ],
     });
   });

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/util.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/util.ts
@@ -36,10 +36,14 @@ const getAssistantMessagePart = (
   if (part.type === 'text') return { type: 'text', text: part.text };
   if (part.type === 'tool_use') {
     const toolName = part.name || 'tool';
+    const toolCallId =
+      typeof part.id === 'string' && part.id.trim()
+        ? part.id
+        : `claude-history-tool-${assistantMessageId}-${toolName}-${index}`;
 
     return createClaudeCodeToolCallPart({
       input: part.input,
-      toolCallId: `claude-history-tool-${assistantMessageId}-${toolName}-${index}`,
+      toolCallId,
       toolName,
     });
   }

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/util.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/util.ts
@@ -36,10 +36,9 @@ const getAssistantMessagePart = (
   if (part.type === 'text') return { type: 'text', text: part.text };
   if (part.type === 'tool_use') {
     const toolName = part.name || 'tool';
+    const trimmedId = typeof part.id === 'string' ? part.id.trim() : '';
     const toolCallId =
-      typeof part.id === 'string' && part.id.trim()
-        ? part.id
-        : `claude-history-tool-${assistantMessageId}-${toolName}-${index}`;
+      trimmedId || `claude-history-tool-${assistantMessageId}-${toolName}-${index}`;
 
     return createClaudeCodeToolCallPart({
       input: part.input,

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/utils/jobProgress.spec.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/utils/jobProgress.spec.ts
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getJobRefetchInterval } from '@nemo/common/src/utils/query';
+import type { PlatformJobResponse } from '@nemo/sdk/generated/platform/schema';
+import { getJobDetailRoute } from '@studio/components/dataViews/JobsDataView/utils';
+import { JOB_PROGRESS_JOB_TYPE } from '@studio/routes/agents/ClaudeCodeChatRoute/jobProgressConsts';
+import {
+  getJobProgressDetailRoute,
+  getJobProgressRefetchInterval,
+  getStringArg,
+  isJobProgressNotFoundError,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/utils/jobProgress';
+import { getAgentEvaluationDetailRoute } from '@studio/routes/utils';
+
+vi.mock('@nemo/common/src/utils/query', () => ({
+  getJobRefetchInterval: vi.fn(),
+}));
+
+vi.mock('@studio/components/dataViews/JobsDataView/utils', () => ({
+  getJobDetailRoute: vi.fn(),
+}));
+
+vi.mock('@studio/routes/utils', () => ({
+  getAgentEvaluationDetailRoute: vi.fn(),
+}));
+
+const getJobRefetchIntervalMock = vi.mocked(getJobRefetchInterval);
+const getJobDetailRouteMock = vi.mocked(getJobDetailRoute);
+const getAgentEvaluationDetailRouteMock = vi.mocked(getAgentEvaluationDetailRoute);
+
+const createJob = (overrides: Partial<PlatformJobResponse> = {}): PlatformJobResponse =>
+  ({
+    attempt_id: 'attempt-1',
+    fileset: 'fileset-1',
+    id: 'job-id-1',
+    name: 'studio-job-1',
+    platform_spec: {},
+    source: 'platform',
+    status: 'active',
+    workspace: 'default',
+    ...overrides,
+  }) as PlatformJobResponse;
+
+beforeEach(() => {
+  getJobRefetchIntervalMock.mockReset().mockReturnValue(5_000);
+  getJobDetailRouteMock.mockReset().mockReturnValue('/jobs/studio-job-1');
+  getAgentEvaluationDetailRouteMock
+    .mockReset()
+    .mockReturnValue('/workspaces/default/agents/evaluations/eval-job-1');
+});
+
+describe('getStringArg', () => {
+  it('returns trimmed string arguments and ignores empty or non-string values', () => {
+    expect(getStringArg({ title: '  Job title  ' }, 'title')).toBe('Job title');
+    expect(getStringArg({ title: '  ' }, 'title')).toBeUndefined();
+    expect(getStringArg({ title: 42 }, 'title')).toBeUndefined();
+  });
+});
+
+describe('isJobProgressNotFoundError', () => {
+  it('detects 404 errors from either top-level or response status fields', () => {
+    expect(isJobProgressNotFoundError({ status: 404 })).toBe(true);
+    expect(isJobProgressNotFoundError({ response: { status: 404 } })).toBe(true);
+  });
+
+  it('ignores non-404 errors', () => {
+    expect(isJobProgressNotFoundError(new Error('boom'))).toBe(false);
+    expect(isJobProgressNotFoundError({ response: { status: 500 } })).toBe(false);
+    expect(isJobProgressNotFoundError(undefined)).toBe(false);
+  });
+});
+
+describe('getJobProgressRefetchInterval', () => {
+  it('stops polling when the job is missing', () => {
+    expect(getJobProgressRefetchInterval({ jobMissing: true, status: 'active' })).toBe(false);
+    expect(getJobRefetchIntervalMock).not.toHaveBeenCalled();
+  });
+
+  it('delegates active job polling intervals to the shared job helper', () => {
+    expect(getJobProgressRefetchInterval({ jobMissing: false, status: 'active' })).toBe(5_000);
+    expect(getJobRefetchIntervalMock).toHaveBeenCalledWith('active');
+  });
+});
+
+describe('getJobProgressDetailRoute', () => {
+  it('links agent evaluation jobs to the agent evaluation detail page', () => {
+    expect(
+      getJobProgressDetailRoute({
+        jobName: 'eval-job-1',
+        jobType: JOB_PROGRESS_JOB_TYPE.AGENT_EVALUATION,
+        workspace: 'default',
+      })
+    ).toBe('/workspaces/default/agents/evaluations/eval-job-1');
+
+    expect(getAgentEvaluationDetailRouteMock).toHaveBeenCalledWith('default', 'eval-job-1');
+  });
+
+  it('uses the Jobs table route helper for platform job sources', () => {
+    const job = createJob({ name: 'designer-job-1', source: 'data-designer' });
+
+    expect(
+      getJobProgressDetailRoute({
+        job,
+        jobName: 'designer-job-1',
+        workspace: 'default',
+      })
+    ).toBe('/jobs/studio-job-1');
+
+    expect(getJobDetailRouteMock).toHaveBeenCalledWith(
+      { name: 'designer-job-1', source: 'data-designer' },
+      'default'
+    );
+  });
+
+  it('maps known job_type values to Jobs table sources when a job has not loaded yet', () => {
+    getJobProgressDetailRoute({
+      jobName: 'safe-job-1',
+      jobType: JOB_PROGRESS_JOB_TYPE.SAFE_SYNTHESIZER,
+      workspace: 'default',
+    });
+
+    expect(getJobDetailRouteMock).toHaveBeenCalledWith(
+      { name: 'safe-job-1', source: 'safe-synthesizer' },
+      'default'
+    );
+  });
+});

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/utils/jobProgress.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/utils/jobProgress.ts
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getJobRefetchInterval } from '@nemo/common/src/utils/query';
+import type { PlatformJobResponse, PlatformJobStatus } from '@nemo/sdk/generated/platform/schema';
+import { getJobDetailRoute } from '@studio/components/dataViews/JobsDataView/utils';
+import {
+  JOB_PROGRESS_JOB_TYPE,
+  JOB_PROGRESS_JOB_TYPE_SOURCE,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/jobProgressConsts';
+import { getAgentEvaluationDetailRoute } from '@studio/routes/utils';
+
+interface JobProgressRefetchIntervalArgs {
+  readonly jobMissing: boolean;
+  readonly status?: PlatformJobStatus;
+}
+
+interface JobProgressDetailRouteArgs {
+  readonly job?: PlatformJobResponse | null;
+  readonly jobName: string;
+  readonly jobType?: string;
+  readonly source?: string;
+  readonly workspace: string;
+}
+
+export const isJobProgressNotFoundError = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) return false;
+  const maybeError = error as {
+    readonly response?: { readonly status?: number };
+    readonly status?: number;
+  };
+  return maybeError.status === 404 || maybeError.response?.status === 404;
+};
+
+const normalizeLookupValue = (value: string | undefined): string | undefined => {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+};
+
+export const getStringArg = (args: Record<string, unknown>, key: string): string | undefined => {
+  const value = args[key];
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+export const getJobProgressRefetchInterval = ({
+  jobMissing,
+  status,
+}: JobProgressRefetchIntervalArgs): number | false => {
+  if (jobMissing) return false;
+  return getJobRefetchInterval(status);
+};
+
+export const getJobProgressDetailRoute = ({
+  job,
+  jobName,
+  jobType,
+  source,
+  workspace,
+}: JobProgressDetailRouteArgs): string => {
+  const normalizedJobType = normalizeLookupValue(jobType);
+  if (normalizedJobType === JOB_PROGRESS_JOB_TYPE.AGENT_EVALUATION) {
+    return getAgentEvaluationDetailRoute(workspace, jobName);
+  }
+
+  const sourceOverride =
+    normalizeLookupValue(source) ??
+    (normalizedJobType ? JOB_PROGRESS_JOB_TYPE_SOURCE[normalizedJobType] : undefined);
+
+  return getJobDetailRoute(
+    {
+      name: job?.name ?? jobName,
+      source: job?.source ?? sourceOverride,
+    },
+    workspace
+  );
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive blocking input flows in Claude Code chats (select agent, eval config, dataset file, or model) with UI components and submit/skip actions.
  * Job progress cards surfaced inline in agent conversations with detail links and status badges.
  * Model dropdown positioning made configurable; judge-model selector labels/messages are configurable.

* **Chores**
  * Expanded test coverage and utilities for input-request handling, streaming input events, and job-progress behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->