### PR TITLE
feat(studio): v0 experiment detail page

### DIFF
--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -106,7 +106,6 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
     [experimentsData]
   );
 
-<<<<<<< HEAD
   const makeColumns = useCallback<
     ComponentProps<typeof DataViewRoot<ExperimentRow>>['makeColumns']
   >(
@@ -223,12 +222,13 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
     []
   );
 
-  const { wrapColumns, onClick: rowClickHandler, className: rowClickClassName } = useRowClick(
-    (row: ExperimentRow) => {
-      navigate(getExperimentDetailRoute(workspace, experimentGroupName, row.name));
-    },
-    tableData
-  );
+  const {
+    wrapColumns,
+    onClick: rowClickHandler,
+    className: rowClickClassName,
+  } = useRowClick((row: ExperimentRow) => {
+    navigate(getExperimentDetailRoute(workspace, experimentGroupName, row.name));
+  }, tableData);
 
   if (groupError) {
     return <ErrorMessage message="Failed to load experiment group." />;

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -7,7 +7,6 @@ import {
   EditColumnsMenu,
 } from '@nemo/common/src/components/DataView/internal';
 import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
-import { useRowClick } from '@nemo/common/src/components/DataView/useRowClick';
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
@@ -222,14 +221,6 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
     []
   );
 
-  const {
-    wrapColumns,
-    onClick: rowClickHandler,
-    className: rowClickClassName,
-  } = useRowClick((row: ExperimentRow) => {
-    navigate(getExperimentDetailRoute(workspace, experimentGroupName, row.name));
-  }, tableData);
-
   if (groupError) {
     return <ErrorMessage message="Failed to load experiment group." />;
   }
@@ -241,8 +232,11 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
   return (
     <StudioDataView
       dataViewState={dataViewState}
-      makeColumns={wrapColumns(makeColumns)}
+      makeColumns={makeColumns}
       searchField="name"
+      onRowClick={(row) =>
+        navigate(getExperimentDetailRoute(workspace, experimentGroupName, row.name))
+      }
       toolbarSlotEnd={
         <EditColumnsMenu
           kind="secondary"
@@ -262,8 +256,6 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
           data: tableData,
           totalCount,
           requestStatus: isGroupLoading || (isLoading && !experimentsData) ? 'loading' : undefined,
-          onClick: rowClickHandler,
-          className: rowClickClassName,
         },
         DataViewTableContent: {
           renderEmptyState: () => (

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -7,6 +7,7 @@ import {
   EditColumnsMenu,
 } from '@nemo/common/src/components/DataView/internal';
 import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
+import { useRowClick } from '@nemo/common/src/components/DataView/useRowClick';
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
@@ -20,10 +21,12 @@ import type {
 } from '@nemo/sdk/generated/platform/schema';
 import { Text, Tooltip } from '@nvidia/foundations-react-core';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { getExperimentDetailRoute } from '@studio/routes/utils';
 import { tooltipClassName } from '@studio/styles/common';
 import { keepPreviousData } from '@tanstack/react-query';
 import { Columns3 } from 'lucide-react';
 import { type ComponentProps, type FC, useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export type ExperimentRow = ExperimentResponse & { id: string };
 
@@ -49,6 +52,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
   experimentGroupName,
 }) => {
   const workspace = useWorkspaceFromPath();
+  const navigate = useNavigate();
   const {
     data: group,
     isLoading: isGroupLoading,
@@ -102,6 +106,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
     [experimentsData]
   );
 
+<<<<<<< HEAD
   const makeColumns = useCallback<
     ComponentProps<typeof DataViewRoot<ExperimentRow>>['makeColumns']
   >(
@@ -218,6 +223,13 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
     []
   );
 
+  const { wrapColumns, onClick: rowClickHandler, className: rowClickClassName } = useRowClick(
+    (row: ExperimentRow) => {
+      navigate(getExperimentDetailRoute(workspace, experimentGroupName, row.name));
+    },
+    tableData
+  );
+
   if (groupError) {
     return <ErrorMessage message="Failed to load experiment group." />;
   }
@@ -229,7 +241,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
   return (
     <StudioDataView
       dataViewState={dataViewState}
-      makeColumns={makeColumns}
+      makeColumns={wrapColumns(makeColumns)}
       searchField="name"
       toolbarSlotEnd={
         <EditColumnsMenu
@@ -250,6 +262,8 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
           data: tableData,
           totalCount,
           requestStatus: isGroupLoading || (isLoading && !experimentsData) ? 'loading' : undefined,
+          onClick: rowClickHandler,
+          className: rowClickClassName,
         },
         DataViewTableContent: {
           renderEmptyState: () => (

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/Empty.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/Empty.tsx
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
+import {
+  Button,
+  CodeSnippet,
+  TabsContent,
+  TabsList,
+  TabsRoot,
+  TabsTrigger,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { LINK_DOCS_EXPERIMENTS_CLI } from '@studio/constants/links';
+import { Bot, ChevronRight, File, FlaskConical, Terminal } from 'lucide-react';
+
+interface EmptyProps {
+  experimentGroupName: string;
+  datasetName: string;
+}
+
+export const Empty = ({ experimentGroupName, datasetName }: EmptyProps) => {
+  const cliCommand =
+    `nemo exp run \\\n` +
+    `  --group "${experimentGroupName}" \\\n` +
+    `  --dataset "${datasetName}" \\\n` +
+    `  --evaluators correctness,helpfulness,groundedness,tool-error`;
+
+  return (
+    <TableEmptyState
+      icon={<FlaskConical className="size-12" />}
+      header="No test cases"
+      emptyMessage="Run an experiment to see test case results."
+      actions={
+        <div className="w-[560px] border border-base rounded-lg overflow-hidden">
+          <TabsRoot defaultValue="cli">
+            <TabsList className="px-density-md">
+              <TabsTrigger value="coding-agent">
+                <Bot className="size-4" />
+                Coding agent
+              </TabsTrigger>
+              <TabsTrigger value="cli">
+                <Terminal className="size-4" />
+                CLI command
+              </TabsTrigger>
+            </TabsList>
+            <div className="px-density-md pb-density-md flex flex-col gap-density-sm">
+              <TabsContent value="coding-agent" className="px-0 pb-0 w-full">
+                <CodeSnippet
+                  value="To be determined"
+                  language="text"
+                  kind="block"
+                  className="w-full whitespace-pre-line"
+                />
+              </TabsContent>
+              <TabsContent value="cli" className="px-0 pb-0">
+                <CodeSnippet value={cliCommand} language="bash" kind="block" className="w-full" />
+              </TabsContent>
+              <Button
+                asChild
+                color="neutral"
+                kind="tertiary"
+                size="small"
+                className="w-full justify-start"
+              >
+                <a href={LINK_DOCS_EXPERIMENTS_CLI} target="_blank" rel="noreferrer">
+                  <File className="!text-brand" />
+                  <Text className="flex-1">CLI docs — learn more</Text>
+                  <ChevronRight />
+                </a>
+              </Button>
+            </div>
+          </TabsRoot>
+        </div>
+      }
+    />
+  );
+};

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -7,19 +7,30 @@ import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
 import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
-import { useListExperimentSessions } from '@nemo/sdk/generated/platform/api';
+import { useGetExperiment, useListExperimentSessions } from '@nemo/sdk/generated/platform/api';
 import type { ExperimentSessionResponse } from '@nemo/sdk/generated/platform/schema';
-import { Text, Tooltip } from '@nvidia/foundations-react-core';
+import {
+  Button,
+  CodeSnippet,
+  TabsContent,
+  TabsList,
+  TabsRoot,
+  TabsTrigger,
+  Text,
+  Tooltip,
+} from '@nvidia/foundations-react-core';
+import { LINK_DOCS_EXPERIMENTS_CLI } from '@studio/constants/links';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { tooltipClassName } from '@studio/styles/common';
 import { keepPreviousData } from '@tanstack/react-query';
-import { FlaskConical } from 'lucide-react';
+import { ChevronRight, File, FlaskConical } from 'lucide-react';
 import { type ComponentProps, type FC, useMemo } from 'react';
 
 type SessionRow = ExperimentSessionResponse & { _rowId: string };
 
 interface ExperimentSessionsDataViewProps {
   experimentName: string;
+  experimentGroupName: string;
 }
 
 const mapStatusForBadge = (status: ExperimentSessionResponse['status']) =>
@@ -34,9 +45,11 @@ const formatEvaluatorScores = (scores: ExperimentSessionResponse['evaluator_scor
 
 export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = ({
   experimentName,
+  experimentGroupName,
 }) => {
   const workspace = useWorkspaceFromPath();
   const dataViewState = useStudioDataViewState({});
+  const { data: experiment } = useGetExperiment(workspace, experimentName);
 
   const page = dataViewState.pagination.state.pageIndex + 1;
   const pageSize = dataViewState.pagination.state.pageSize;
@@ -171,13 +184,62 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
           requestStatus: isLoading && !sessionsData ? 'loading' : undefined,
         },
         DataViewTableContent: {
-          renderEmptyState: () => (
-            <TableEmptyState
-              icon={<FlaskConical className="size-12" />}
-              header="No test cases"
-              emptyMessage="No test case sessions recorded for this experiment yet."
-            />
-          ),
+          renderEmptyState: () => {
+            const dataset = experiment?.dataset_name ?? '<dataset>';
+            const cliCommand =
+              `nemo exp run \\\n` +
+              `  --group "${experimentGroupName}" \\\n` +
+              `  --dataset "${dataset}" \\\n` +
+              `  --evaluators correctness,helpfulness,groundedness,tool-error`;
+            return (
+              <TableEmptyState
+                icon={<FlaskConical className="size-12" />}
+                header="No test cases"
+                emptyMessage="Run an experiment to see test case results."
+                actions={
+                  <div className="w-[560px] border border-base rounded-lg overflow-hidden">
+                    <TabsRoot defaultValue="cli">
+                      <TabsList className="px-density-md">
+                        <TabsTrigger value="coding-agent">Coding agent</TabsTrigger>
+                        <TabsTrigger value="cli">CLI command</TabsTrigger>
+                      </TabsList>
+                      <div className="px-density-md pb-density-md flex flex-col gap-density-sm">
+                        <TabsContent value="coding-agent" className="px-0 pb-0 w-full">
+                          <CodeSnippet
+                            value="To be determined"
+                            language="text"
+                            kind="block"
+                            className="w-full whitespace-pre-line"
+                          />
+                        </TabsContent>
+                        <TabsContent value="cli" className="px-0 pb-0">
+                          <CodeSnippet
+                            value={cliCommand}
+                            language="bash"
+                            kind="block"
+                            className="w-full"
+                          />
+                        </TabsContent>
+                        <Button
+                          asChild
+                          color="neutral"
+                          kind="tertiary"
+                          size="small"
+                          className="w-full justify-start"
+                        >
+                          <a href={LINK_DOCS_EXPERIMENTS_CLI} target="_blank" rel="noreferrer">
+                            <File className="!text-brand" />
+                            <Text className="flex-1">CLI docs — learn more</Text>
+                            <ChevronRight />
+                          </a>
+                        </Button>
+                      </div>
+                    </TabsRoot>
+                  </div>
+                }
+              />
+            );
+          },
         },
       }}
     />

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -23,7 +23,7 @@ import { LINK_DOCS_EXPERIMENTS_CLI } from '@studio/constants/links';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { tooltipClassName } from '@studio/styles/common';
 import { keepPreviousData } from '@tanstack/react-query';
-import { ChevronRight, File, FlaskConical } from 'lucide-react';
+import { Bot, ChevronRight, File, FlaskConical, Terminal } from 'lucide-react';
 import { type ComponentProps, type FC, useMemo } from 'react';
 
 type SessionRow = ExperimentSessionResponse & { _rowId: string };
@@ -200,8 +200,14 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
                   <div className="w-[560px] border border-base rounded-lg overflow-hidden">
                     <TabsRoot defaultValue="cli">
                       <TabsList className="px-density-md">
-                        <TabsTrigger value="coding-agent">Coding agent</TabsTrigger>
-                        <TabsTrigger value="cli">CLI command</TabsTrigger>
+                        <TabsTrigger value="coding-agent">
+                          <Bot className="size-4" />
+                          Coding agent
+                        </TabsTrigger>
+                        <TabsTrigger value="cli">
+                          <Terminal className="size-4" />
+                          CLI command
+                        </TabsTrigger>
                       </TabsList>
                       <div className="px-density-md pb-density-md flex flex-col gap-density-sm">
                         <TabsContent value="coding-agent" className="px-0 pb-0 w-full">

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Root as DataViewRoot } from '@nemo/common/src/components/DataView/internal';
+import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
+import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
+import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
+import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
+import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
+import { useListExperimentSessions } from '@nemo/sdk/generated/platform/api';
+import type { ExperimentSessionResponse } from '@nemo/sdk/generated/platform/schema';
+import { Text, Tooltip } from '@nvidia/foundations-react-core';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { tooltipClassName } from '@studio/styles/common';
+import { keepPreviousData } from '@tanstack/react-query';
+import { FlaskConical } from 'lucide-react';
+import { type ComponentProps, type FC, useMemo } from 'react';
+
+type SessionRow = ExperimentSessionResponse & { _rowId: string };
+
+interface ExperimentSessionsDataViewProps {
+  experimentName: string;
+}
+
+const mapStatusForBadge = (status: ExperimentSessionResponse['status']) =>
+  status === 'success' ? 'completed' : status;
+
+const formatEvaluatorScores = (scores: ExperimentSessionResponse['evaluator_scores']): string => {
+  if (!scores || Object.keys(scores).length === 0) return '-';
+  return Object.entries(scores)
+    .map(([name, value]) => `${name}: ${(value * 100).toFixed(1)}%`)
+    .join(', ');
+};
+
+export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = ({
+  experimentName,
+}) => {
+  const workspace = useWorkspaceFromPath();
+  const dataViewState = useStudioDataViewState({});
+
+  const page = dataViewState.pagination.state.pageIndex + 1;
+  const pageSize = dataViewState.pagination.state.pageSize;
+
+  const { data: sessionsResponse, isLoading } = useListExperimentSessions(
+    workspace,
+    experimentName,
+    { page, page_size: pageSize },
+    { query: { placeholderData: keepPreviousData } }
+  );
+
+  const sessionsData = sessionsResponse?.data;
+  const totalCount = sessionsResponse?.pagination?.total_results ?? sessionsData?.length ?? 0;
+
+  const tableData = useMemo<SessionRow[]>(
+    () =>
+      (sessionsData ?? []).map((session, i) => ({
+        ...session,
+        _rowId: session.session_id ?? String(i),
+      })),
+    [sessionsData]
+  );
+
+  const makeColumns: ComponentProps<typeof DataViewRoot<SessionRow>>['makeColumns'] = ({
+    accessor,
+  }) => [
+    accessor('test_case_id', {
+      header: 'Case',
+      enableSorting: false,
+      size: 200,
+      cell: ({ row }) => {
+        const value = row.original.test_case_id;
+        if (!value) return <Text>-</Text>;
+        return (
+          <Tooltip slotContent={value} className={tooltipClassName} side="bottom">
+            <Text className="cursor-default truncate max-w-[180px] block">{value}</Text>
+          </Tooltip>
+        );
+      },
+    }),
+    accessor('input', {
+      header: 'Input',
+      enableSorting: false,
+      size: 240,
+      cell: ({ row }) => {
+        const value = row.original.input;
+        if (!value) return <Text>-</Text>;
+        return (
+          <Tooltip slotContent={value} className={tooltipClassName} side="bottom">
+            <Text className="cursor-default truncate max-w-[220px] block">{value}</Text>
+          </Tooltip>
+        );
+      },
+    }),
+    accessor('started_at', {
+      header: 'Started at',
+      enableSorting: false,
+      cell: ({ row }) =>
+        row.original.started_at ? (
+          <RelativeTime datetime={row.original.started_at} />
+        ) : (
+          <Text>-</Text>
+        ),
+    }),
+    accessor('ended_at', {
+      header: 'Ended at',
+      enableSorting: false,
+      cell: ({ row }) =>
+        row.original.ended_at ? <RelativeTime datetime={row.original.ended_at} /> : <Text>-</Text>,
+    }),
+    accessor('latency_ms', {
+      header: 'Latency',
+      enableSorting: false,
+      cell: ({ row }) => {
+        const ms = row.original.latency_ms;
+        return <Text>{ms != null ? `${Math.round(ms)} ms` : '-'}</Text>;
+      },
+    }),
+    accessor('status', {
+      header: 'Status',
+      enableSorting: false,
+      cell: ({ row }) => <StatusBadge status={mapStatusForBadge(row.original.status)} />,
+    }),
+    accessor(
+      (original) =>
+        original.input_tokens != null || original.output_tokens != null
+          ? (original.input_tokens ?? 0) + (original.output_tokens ?? 0)
+          : undefined,
+      {
+        id: 'tokens',
+        header: 'Tokens',
+        enableSorting: false,
+        cell: ({ row }) => {
+          const { input_tokens, output_tokens } = row.original;
+          if (input_tokens == null && output_tokens == null) return <Text>-</Text>;
+          return <Text>{String((input_tokens ?? 0) + (output_tokens ?? 0))}</Text>;
+        },
+      }
+    ),
+    accessor('cost_total_usd', {
+      header: 'Cost',
+      enableSorting: false,
+      cell: ({ row }) => {
+        const cost = row.original.cost_total_usd;
+        return <Text>{cost != null ? `$${cost.toFixed(3)}` : '-'}</Text>;
+      },
+    }),
+    accessor((original) => formatEvaluatorScores(original.evaluator_scores), {
+      id: 'evaluator_scores',
+      header: 'Evaluator scores',
+      enableSorting: false,
+      cell: ({ row }) => {
+        const formatted = formatEvaluatorScores(row.original.evaluator_scores);
+        if (formatted === '-') return <Text>-</Text>;
+        return (
+          <Tooltip slotContent={formatted} className={tooltipClassName} side="bottom">
+            <Text className="cursor-default truncate max-w-[200px] block">{formatted}</Text>
+          </Tooltip>
+        );
+      },
+    }),
+  ];
+
+  return (
+    <StudioDataView
+      dataViewState={dataViewState}
+      makeColumns={makeColumns}
+      attributes={{
+        DataViewRoot: {
+          data: tableData,
+          totalCount,
+          requestStatus: isLoading && !sessionsData ? 'loading' : undefined,
+        },
+        DataViewTableContent: {
+          renderEmptyState: () => (
+            <TableEmptyState
+              icon={<FlaskConical className="size-12" />}
+              header="No test cases"
+              emptyMessage="No test case sessions recorded for this experiment yet."
+            />
+          ),
+        },
+      }}
+    />
+  );
+};

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -5,25 +5,14 @@ import { Root as DataViewRoot } from '@nemo/common/src/components/DataView/inter
 import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
-import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
 import { useGetExperiment, useListExperimentSessions } from '@nemo/sdk/generated/platform/api';
 import type { ExperimentSessionResponse } from '@nemo/sdk/generated/platform/schema';
-import {
-  Button,
-  CodeSnippet,
-  TabsContent,
-  TabsList,
-  TabsRoot,
-  TabsTrigger,
-  Text,
-  Tooltip,
-} from '@nvidia/foundations-react-core';
-import { LINK_DOCS_EXPERIMENTS_CLI } from '@studio/constants/links';
+import { Text, Tooltip } from '@nvidia/foundations-react-core';
+import { Empty } from '@studio/components/dataViews/ExperimentSessionsDataView/Empty';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { tooltipClassName } from '@studio/styles/common';
 import { keepPreviousData } from '@tanstack/react-query';
-import { Bot, ChevronRight, File, FlaskConical, Terminal } from 'lucide-react';
 import { type ComponentProps, type FC, useMemo } from 'react';
 
 type SessionRow = ExperimentSessionResponse & { _rowId: string };
@@ -184,68 +173,12 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
           requestStatus: isLoading && !sessionsData ? 'loading' : undefined,
         },
         DataViewTableContent: {
-          renderEmptyState: () => {
-            const dataset = experiment?.dataset_name ?? '<dataset>';
-            const cliCommand =
-              `nemo exp run \\\n` +
-              `  --group "${experimentGroupName}" \\\n` +
-              `  --dataset "${dataset}" \\\n` +
-              `  --evaluators correctness,helpfulness,groundedness,tool-error`;
-            return (
-              <TableEmptyState
-                icon={<FlaskConical className="size-12" />}
-                header="No test cases"
-                emptyMessage="Run an experiment to see test case results."
-                actions={
-                  <div className="w-[560px] border border-base rounded-lg overflow-hidden">
-                    <TabsRoot defaultValue="cli">
-                      <TabsList className="px-density-md">
-                        <TabsTrigger value="coding-agent">
-                          <Bot className="size-4" />
-                          Coding agent
-                        </TabsTrigger>
-                        <TabsTrigger value="cli">
-                          <Terminal className="size-4" />
-                          CLI command
-                        </TabsTrigger>
-                      </TabsList>
-                      <div className="px-density-md pb-density-md flex flex-col gap-density-sm">
-                        <TabsContent value="coding-agent" className="px-0 pb-0 w-full">
-                          <CodeSnippet
-                            value="To be determined"
-                            language="text"
-                            kind="block"
-                            className="w-full whitespace-pre-line"
-                          />
-                        </TabsContent>
-                        <TabsContent value="cli" className="px-0 pb-0">
-                          <CodeSnippet
-                            value={cliCommand}
-                            language="bash"
-                            kind="block"
-                            className="w-full"
-                          />
-                        </TabsContent>
-                        <Button
-                          asChild
-                          color="neutral"
-                          kind="tertiary"
-                          size="small"
-                          className="w-full justify-start"
-                        >
-                          <a href={LINK_DOCS_EXPERIMENTS_CLI} target="_blank" rel="noreferrer">
-                            <File className="!text-brand" />
-                            <Text className="flex-1">CLI docs — learn more</Text>
-                            <ChevronRight />
-                          </a>
-                        </Button>
-                      </div>
-                    </TabsRoot>
-                  </div>
-                }
-              />
-            );
-          },
+          renderEmptyState: () => (
+            <Empty
+              experimentGroupName={experimentGroupName}
+              datasetName={experiment?.dataset_name ?? '<dataset>'}
+            />
+          ),
         },
       }}
     />

--- a/web/packages/studio/src/constants/links.ts
+++ b/web/packages/studio/src/constants/links.ts
@@ -58,6 +58,9 @@ export const LINK_EVAL_DOCS_BENCHMARKS =
 export const LINK_EVAL_DOCS_BENCHMARKS_INDUSTRY =
   'https://docs.nvidia.com/nemo/microservices/latest/evaluator/benchmarks/industry.html';
 
+// Experiments documentation links
+export const LINK_DOCS_EXPERIMENTS_CLI = `${DOCS_BASE_URL}experiments/cli/`;
+
 // Jobs documentation links
 export const LINK_DOCS_JOBS = `${DOCS_BASE_URL}studio/?#jobs`;
 

--- a/web/packages/studio/src/constants/links.ts
+++ b/web/packages/studio/src/constants/links.ts
@@ -58,11 +58,11 @@ export const LINK_EVAL_DOCS_BENCHMARKS =
 export const LINK_EVAL_DOCS_BENCHMARKS_INDUSTRY =
   'https://docs.nvidia.com/nemo/microservices/latest/evaluator/benchmarks/industry.html';
 
-// Experiments documentation links
-export const LINK_DOCS_EXPERIMENTS_CLI = `${DOCS_BASE_URL}experiments/cli/`;
-
 // Jobs documentation links
 export const LINK_DOCS_JOBS = `${DOCS_BASE_URL}studio/?#jobs`;
 
 // Secrets documentation links
 export const LINK_DOCS_SECRETS = `${DOCS_BASE_URL}get-started/concepts/manage-secrets/`;
+
+// Experiments
+export const LINK_DOCS_EXPERIMENTS_CLI = `${DOCS_BASE_URL}experiments/cli/`;

--- a/web/packages/studio/src/constants/routes.ts
+++ b/web/packages/studio/src/constants/routes.ts
@@ -39,6 +39,7 @@ export const ROUTE_PARAMS = {
   /** Benchmark entity name segment under evaluation/benchmarks/:name */
   benchmarkName: 'benchmarkName',
   experimentGroupName: 'experimentGroupName',
+  experimentName: 'experimentName',
 } as const;
 
 // Just an alias to make the routes more readable
@@ -72,6 +73,7 @@ export const ROUTES = {
     /** Empty landing page for the EXPERIMENT feature (gated by VITE_FF_EXPERIMENT). */
     experiment: `/workspaces/:${P.workspace}/experiment`,
     experimentGroupDetail: `/workspaces/:${P.workspace}/experiment/:${P.experimentGroupName}`,
+    experimentDetail: `/workspaces/:${P.workspace}/experiment/:${P.experimentGroupName}/:${P.experimentName}`,
     customizationJobList: `/workspaces/:${P.workspace}/customizations`,
     customizationJobDetails: `/workspaces/:${P.workspace}/customizations/:${P.customizationJobName}`,
     newCustomizationJob: `/workspaces/:${P.workspace}/customizations/fine-tuned/new`,

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/ExperimentDetailMetrics.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/ExperimentDetailMetrics.tsx
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { KVPair } from '@nemo/common/src/components/KVPair';
+import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
+import { useGetExperiment } from '@nemo/sdk/generated/platform/api';
+import { Divider } from '@nvidia/foundations-react-core';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { type FC } from 'react';
+
+interface ExperimentDetailMetricsProps {
+  experimentName: string;
+}
+
+export const ExperimentDetailMetrics: FC<ExperimentDetailMetricsProps> = ({ experimentName }) => {
+  const workspace = useWorkspaceFromPath();
+  const { data: experiment, isLoading } = useGetExperiment(workspace, experimentName);
+
+  const avgCost =
+    experiment?.cost_usd?.mean != null ? `$${experiment.cost_usd.mean.toFixed(3)}` : undefined;
+
+  const avgLatency =
+    experiment?.latency_ms?.mean != null
+      ? `${Math.round(experiment.latency_ms.mean)} ms`
+      : undefined;
+
+  return (
+    <div className="flex gap-8">
+      <KVPair
+        label="Agent Name"
+        value={experiment?.agent_name || undefined}
+        loading={isLoading}
+        orientation="vertical"
+      />
+      <Divider orientation="vertical" className="grow-0 self-stretch" />
+      <KVPair
+        label="Created"
+        value={
+          experiment?.created_at ? <RelativeTime datetime={experiment.created_at} /> : undefined
+        }
+        orientation="vertical"
+      />
+      <Divider orientation="vertical" className="grow-0 self-stretch" />
+      <KVPair
+        label="Updated"
+        value={
+          experiment?.updated_at ? <RelativeTime datetime={experiment.updated_at} /> : undefined
+        }
+        orientation="vertical"
+      />
+      <Divider orientation="vertical" className="grow-0 self-stretch" />
+      <KVPair label="Avg Cost" value={avgCost} loading={isLoading} orientation="vertical" />
+      <Divider orientation="vertical" className="grow-0 self-stretch" />
+      <KVPair label="Avg Latency" value={avgLatency} loading={isLoading} orientation="vertical" />
+    </div>
+  );
+};

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/ExperimentDetailMetrics.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/ExperimentDetailMetrics.tsx
@@ -38,6 +38,7 @@ export const ExperimentDetailMetrics: FC<ExperimentDetailMetricsProps> = ({ expe
         value={
           experiment?.created_at ? <RelativeTime datetime={experiment.created_at} /> : undefined
         }
+        loading={isLoading}
         orientation="vertical"
       />
       <Divider orientation="vertical" className="grow-0 self-stretch" />
@@ -46,6 +47,7 @@ export const ExperimentDetailMetrics: FC<ExperimentDetailMetricsProps> = ({ expe
         value={
           experiment?.updated_at ? <RelativeTime datetime={experiment.updated_at} /> : undefined
         }
+        loading={isLoading}
         orientation="vertical"
       />
       <Divider orientation="vertical" className="grow-0 self-stretch" />

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PageHeader, Stack } from '@nvidia/foundations-react-core';
+import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { ExperimentSessionsDataView } from '@studio/components/dataViews/ExperimentSessionsDataView';
+import { ROUTE_PARAMS } from '@studio/constants/routes';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { ExperimentDetailMetrics } from '@studio/routes/ExperimentDetailRoute/ExperimentDetailMetrics';
+import { getExperimentRoute, getExperimentGroupDetailRoute } from '@studio/routes/utils';
+import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
+import { type FC } from 'react';
+
+export const ExperimentDetailRoute: FC = () => {
+  const workspace = useWorkspaceFromPath();
+  const { experimentGroupName, experimentName } = useRequiredPathParams([
+    ROUTE_PARAMS.experimentGroupName,
+    ROUTE_PARAMS.experimentName,
+  ]);
+
+  useBreadcrumbs({
+    items: [
+      { href: getExperimentRoute(workspace), slotLabel: 'Experiments' },
+      {
+        href: getExperimentGroupDetailRoute(workspace, experimentGroupName),
+        slotLabel: experimentGroupName,
+      },
+      { slotLabel: experimentName },
+    ],
+  });
+
+  return (
+    <AccessibleTitle title={experimentName}>
+      <Stack className="h-full overflow-auto" gap="density-2xl" padding="density-2xl">
+        <PageHeader className="p-0" slotHeading={experimentName} />
+        <ExperimentDetailMetrics experimentName={experimentName} />
+        <ExperimentSessionsDataView experimentName={experimentName} />
+      </Stack>
+    </AccessibleTitle>
+  );
+};

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -35,7 +35,10 @@ export const ExperimentDetailRoute: FC = () => {
       <Stack className="h-full overflow-auto" gap="density-2xl" padding="density-2xl">
         <PageHeader className="p-0" slotHeading={experimentName} />
         <ExperimentDetailMetrics experimentName={experimentName} />
-        <ExperimentSessionsDataView experimentName={experimentName} />
+        <ExperimentSessionsDataView
+          experimentName={experimentName}
+          experimentGroupName={experimentGroupName}
+        />
       </Stack>
     </AccessibleTitle>
   );

--- a/web/packages/studio/src/routes/index.tsx
+++ b/web/packages/studio/src/routes/index.tsx
@@ -155,6 +155,11 @@ const ExperimentGroupDetailRoute = lazy(() =>
     default: module.ExperimentGroupDetailRoute,
   }))
 );
+const ExperimentDetailRoute = lazy(() =>
+  import('@studio/routes/ExperimentDetailRoute').then((module) => ({
+    default: module.ExperimentDetailRoute,
+  }))
+);
 const NoMatchRoute = lazy(() =>
   import('@studio/routes/NoMatchRoute').then((module) => ({ default: module.NoMatchRoute }))
 );
@@ -560,6 +565,11 @@ export const routes: RouteObject[] = [
                   path: ROUTES.workspace.experimentGroupDetail,
                   element: <ExperimentGroupDetailRoute />,
                   errorElement: <ErrorPanel title="Experiment Group" />,
+                },
+                {
+                  path: ROUTES.workspace.experimentDetail,
+                  element: <ExperimentDetailRoute />,
+                  errorElement: <ErrorPanel title="Experiment" />,
                 },
               ]),
               ...gateCustomizationRoutes([

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -321,6 +321,18 @@ export const getExperimentGroupDetailRoute = (workspace: string, experimentGroup
   });
 };
 
+export const getExperimentDetailRoute = (
+  workspace: string,
+  experimentGroupName: string,
+  experimentName: string
+) => {
+  return generatePath(ROUTES.workspace.experimentDetail, {
+    workspace,
+    experimentGroupName: encodeURIComponent(experimentGroupName),
+    experimentName: encodeURIComponent(experimentName),
+  });
+};
+
 export const getPromptTuningFormRoute = (workspace: string, options?: { model?: string }) => {
   const basePath = generatePath(ROUTES.workspace.promptTuningForm, { workspace });
   if (options?.model) {

--- a/web/packages/studio/src/tests/title-change.spec.tsx
+++ b/web/packages/studio/src/tests/title-change.spec.tsx
@@ -35,6 +35,7 @@ const pathParams = {
   [RP.jobName]: 'test-job',
   [RP.benchmarkName]: 'test-benchmark',
   [RP.experimentGroupName]: 'test-experiment-group',
+  [RP.experimentName]: 'test-experiment',
 };
 
 describe('AccessibleTitleE2E', () => {


### PR DESCRIPTION
Closes FP-184

https://github.com/user-attachments/assets/04f0f534-9112-4400-8524-cbd59114377e

# Summary

Studio had no detail view for individual experiments — clicking an experiment row in the group detail table had no destination. This adds the v0 \`ExperimentDetailRoute\` at \`/workspaces/:workspace/experiment/:experimentGroupName/:experimentName\`, along with the route constant, utility function, and lazy-loaded registration.

The detail page shows a metadata bar (Agent Name, Created, Updated, Avg Cost, Avg Latency) sourced from \`useGetExperiment\`, and a paginated test cases table via \`useListExperimentSessions\` with columns: Case, Input, Started at, Ended at, Latency, Status, Tokens, Cost, and Evaluator scores. Long Case, Input, and Evaluator score values truncate with a tooltip. The \`success\` span status is mapped to the \`completed\` badge style. Row clicks in \`ExperimentGroupDataView\` now navigate to the new route.

# Test plan
- [ ] Navigate to Experiments → open any experiment group → click an experiment row → confirm you land on the detail page with the correct breadcrumb trail (Experiments > group name > experiment name)
- [ ] Confirm the metadata bar shows Agent Name, Created, Updated, Avg Cost, and Avg Latency populated from the experiment
- [ ] Confirm the test cases table renders rows with Case, Input, Started at, Ended at, Latency, Status, Tokens, Cost, and Evaluator scores columns
- [ ] Hover a truncated Case or Input cell → confirm the full value appears in a tooltip
- [ ] Navigate to an experiment with no sessions → confirm the flask icon empty state renders with "No test cases" heading and subtext

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experiment detail page with metrics (avg cost, avg latency, agent, created/updated) and breadcrumbed route.
  * Paginated experiment sessions view showing inputs, timestamps, latency, status, token usage, costs, and evaluator scores.
  * Clickable experiment rows navigate to experiment detail pages.
  * Empty sessions view with CLI command and code snippet tab.

* **Documentation**
  * Added CLI docs link for Experiments.

* **Tests**
  * Updated test routing to include experiment name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->