### PR TITLE
feat(studio): Skill management for Code Agent

### DIFF
--- a/services/studio/src/nmp/studio/coding_agent_skills.py
+++ b/services/studio/src/nmp/studio/coding_agent_skills.py
@@ -9,10 +9,10 @@ from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Any
 
+import yaml
 from nemo_platform_ext.cli.commands.skills.base import Scope, Skill
 from nemo_platform_ext.cli.commands.skills.registry import (
     DuplicateSkillError,
-    _load_skills_from_root,
     get_installer,
     load_skills,
 )
@@ -101,6 +101,55 @@ def _resolve_skills_entry_point_root(entry_point: Any) -> Path | None:
     return skills_root
 
 
+def _parse_skill_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    metadata = yaml.safe_load(text[4:end]) or {}
+    body = text[end + 5 :]
+    if not isinstance(metadata, dict):
+        raise ValueError(f"Invalid frontmatter: expected a mapping, got {type(metadata).__name__}")
+    return metadata, body
+
+
+def _load_skill_from_dir(entry: Path, source_plugin: str | None = None, source_dist: str | None = None) -> Skill:
+    skill_file = entry / "SKILL.md"
+    raw = skill_file.read_text(encoding="utf-8")
+    try:
+        metadata, body = _parse_skill_frontmatter(raw)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid frontmatter in {skill_file}: {exc}") from exc
+    return Skill(
+        name=metadata.get("name", entry.name),
+        description=metadata.get("description", ""),
+        version=str(metadata.get("version", "0.1")),
+        content=body,
+        raw=raw,
+        source_dir=entry,
+        source_plugin=source_plugin,
+        source_dist=source_dist,
+    )
+
+
+def load_skills_from_root(
+    root: Path,
+    source_plugin: str | None = None,
+    source_dist: str | None = None,
+) -> dict[str, Skill]:
+    """Load skills from one selected root without depending on registry internals."""
+    skills: dict[str, Skill] = {}
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        if not (entry / "SKILL.md").exists():
+            continue
+        skill = _load_skill_from_dir(entry, source_plugin=source_plugin, source_dist=source_dist)
+        skills[skill.name] = skill
+    return skills
+
+
 def _load_skills_from_preferred_entry_points() -> dict[str, Skill]:
     """Load skills for Studio while preferring editable source providers over vendored mirrors."""
     allowed_names = _allowed_skill_provider_names()
@@ -120,7 +169,9 @@ def _load_skills_from_preferred_entry_points() -> dict[str, Skill]:
             key=lambda candidate: _skill_entry_point_preference(candidate[0]),
         )
         source_dist = _skill_entry_point_dist_name(entry_point)
-        for skill in _load_skills_from_root(skills_root, source_plugin=provider_name, source_dist=source_dist).values():
+        # Vendored root loading keeps this duplicate-provider fallback independent
+        # from private helpers in the CLI skill registry.
+        for skill in load_skills_from_root(skills_root, source_plugin=provider_name, source_dist=source_dist).values():
             existing = all_skills.get(skill.name)
             if existing is not None:
                 raise DuplicateSkillError(

--- a/services/studio/src/nmp/studio/coding_agent_skills.py
+++ b/services/studio/src/nmp/studio/coding_agent_skills.py
@@ -5,23 +5,36 @@
 
 import logging
 from collections.abc import Iterable
+from dataclasses import dataclass
 from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Any
 
 import yaml
-from nemo_platform_ext.cli.commands.skills.base import Scope, Skill
-from nemo_platform_ext.cli.commands.skills.registry import (
-    DuplicateSkillError,
-    get_installer,
-    load_skills,
-)
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
 _PLATFORM_SKILL_SOURCE_DISTS = frozenset({"nemo-platform-ext", "nemo-platform-sdk"})
 _AGGREGATE_SKILL_SOURCE_DIST = "nemo-platform"
+
+
+@dataclass
+class Skill:
+    """Minimal skill metadata Studio needs from a ``nemo.skills`` provider."""
+
+    name: str
+    description: str
+    version: str
+    content: str
+    raw: str
+    source_dir: Path | None = None
+    source_plugin: str | None = None
+    source_dist: str | None = None
+
+
+class DuplicateSkillError(ValueError):
+    """Raised when multiple skill providers declare the same skill name."""
 
 
 class ClaudeSkillResponse(BaseModel):
@@ -150,6 +163,32 @@ def load_skills_from_root(
     return skills
 
 
+def load_skills() -> dict[str, Skill]:
+    """Load skills from installed ``nemo.skills`` entry points."""
+    allowed_names = _allowed_skill_provider_names()
+    all_skills: dict[str, Skill] = {}
+    for entry_point in _raw_skill_entry_points():
+        if allowed_names is not None and entry_point.name not in allowed_names:
+            continue
+        skills_root = _resolve_skills_entry_point_root(entry_point)
+        if skills_root is None:
+            continue
+        source_dist = _skill_entry_point_dist_name(entry_point)
+        for skill in load_skills_from_root(
+            skills_root,
+            source_plugin=entry_point.name,
+            source_dist=source_dist,
+        ).values():
+            existing = all_skills.get(skill.name)
+            if existing is not None:
+                raise DuplicateSkillError(
+                    f"Duplicate skill '{skill.name}' found in provider {entry_point.name}: "
+                    f"{skill.source_dir}. Already defined in {existing.source_dir}."
+                )
+            all_skills[skill.name] = skill
+    return dict(sorted(all_skills.items()))
+
+
 def _load_skills_from_preferred_entry_points() -> dict[str, Skill]:
     """Load skills for Studio while preferring editable source providers over vendored mirrors."""
     allowed_names = _allowed_skill_provider_names()
@@ -211,9 +250,12 @@ def _skill_source_label(skill: Skill) -> str:
     return "-"
 
 
+def _claude_install_path(project_root: Path, skill_name: str) -> Path:
+    return project_root / ".claude" / "skills" / f"nemo-{skill_name}" / "SKILL.md"
+
+
 def _claude_skill_response(name: str, skill: Skill, server_cwd: Path) -> ClaudeSkillResponse:
-    installer = get_installer("claude")
-    install_path = installer.get_install_path(Scope.PROJECT, server_cwd, name)
+    install_path = _claude_install_path(server_cwd, name)
     source_path = _path_for_response(skill.source_dir, server_cwd) if skill.source_dir is not None else None
     return ClaudeSkillResponse(
         name=name,

--- a/services/studio/src/nmp/studio/coding_agent_skills.py
+++ b/services/studio/src/nmp/studio/coding_agent_skills.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Claude skill discovery helpers for the Studio coding-agent bridge."""
+
+import logging
+from collections.abc import Iterable
+from importlib.metadata import entry_points
+from pathlib import Path
+from typing import Any
+
+from nemo_platform_ext.cli.commands.skills.base import Scope, Skill
+from nemo_platform_ext.cli.commands.skills.registry import (
+    DuplicateSkillError,
+    _load_skills_from_root,
+    get_installer,
+    load_skills,
+)
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+_PLATFORM_SKILL_SOURCE_DISTS = frozenset({"nemo-platform-ext", "nemo-platform-sdk"})
+_AGGREGATE_SKILL_SOURCE_DIST = "nemo-platform"
+
+
+class ClaudeSkillResponse(BaseModel):
+    """A NeMo skill as it is exposed to Claude Code for this repository."""
+
+    name: str
+    claude_name: str
+    description: str
+    source: str
+    source_path: str | None = None
+    install_path: str
+    installed: bool
+
+
+def _skill_entry_point_dist_name(entry_point: Any) -> str | None:
+    dist = getattr(entry_point, "dist", None)
+    name = getattr(dist, "name", None)
+    return name if isinstance(name, str) else None
+
+
+def _skill_entry_point_preference(entry_point: Any) -> tuple[int, str]:
+    """Pick editable plugin providers before the bundled aggregate distribution."""
+    dist_name = _skill_entry_point_dist_name(entry_point)
+    if entry_point.name == "platform":
+        if dist_name == "nemo-platform-ext":
+            return (0, dist_name)
+        if dist_name == _AGGREGATE_SKILL_SOURCE_DIST:
+            return (1, dist_name)
+        if dist_name == "nemo-platform-sdk":
+            return (2, dist_name)
+    if dist_name == _AGGREGATE_SKILL_SOURCE_DIST:
+        return (1, dist_name)
+    return (0, dist_name or "")
+
+
+def _allowed_skill_provider_names() -> set[str] | None:
+    try:
+        from nemo_platform_plugin.discovery import discover_entry_points
+    except ImportError:
+        logger.warning("nemo-platform-plugin is unavailable; using all nemo.skills entry points", exc_info=True)
+        return None
+    return set(discover_entry_points("nemo.skills").keys())
+
+
+def _raw_skill_entry_points() -> Iterable[Any]:
+    return entry_points(group="nemo.skills")
+
+
+def _resolve_skills_entry_point_root(entry_point: Any) -> Path | None:
+    try:
+        skills_dir_factory = entry_point.load()
+    except Exception:
+        logger.warning(
+            "Failed to load 'nemo.skills' entry point %r (%s) - skipping",
+            entry_point.name,
+            entry_point.value,
+            exc_info=True,
+        )
+        return None
+
+    try:
+        skills_root = skills_dir_factory()
+    except Exception:
+        logger.warning("Failed to resolve skills directory for provider %r", entry_point.name, exc_info=True)
+        return None
+
+    if not isinstance(skills_root, Path):
+        logger.warning(
+            "Skipping provider %r skills: expected Path, got %s",
+            entry_point.name,
+            type(skills_root).__name__,
+        )
+        return None
+    if not skills_root.is_dir():
+        logger.warning("Skipping provider %r skills: path is not a directory: %s", entry_point.name, skills_root)
+        return None
+    return skills_root
+
+
+def _load_skills_from_preferred_entry_points() -> dict[str, Skill]:
+    """Load skills for Studio while preferring editable source providers over vendored mirrors."""
+    allowed_names = _allowed_skill_provider_names()
+    candidates_by_name: dict[str, list[tuple[Any, Path]]] = {}
+    for entry_point in _raw_skill_entry_points():
+        if allowed_names is not None and entry_point.name not in allowed_names:
+            continue
+        skills_root = _resolve_skills_entry_point_root(entry_point)
+        if skills_root is None:
+            continue
+        candidates_by_name.setdefault(entry_point.name, []).append((entry_point, skills_root))
+
+    all_skills: dict[str, Skill] = {}
+    for provider_name in sorted(candidates_by_name):
+        entry_point, skills_root = min(
+            candidates_by_name[provider_name],
+            key=lambda candidate: _skill_entry_point_preference(candidate[0]),
+        )
+        source_dist = _skill_entry_point_dist_name(entry_point)
+        for skill in _load_skills_from_root(skills_root, source_plugin=provider_name, source_dist=source_dist).values():
+            existing = all_skills.get(skill.name)
+            if existing is not None:
+                raise DuplicateSkillError(
+                    f"Duplicate skill '{skill.name}' found in provider {provider_name}: "
+                    f"{skill.source_dir}. Already defined in {existing.source_dir}."
+                )
+            all_skills[skill.name] = skill
+    return dict(sorted(all_skills.items()))
+
+
+def _load_claude_skills() -> dict[str, Skill]:
+    try:
+        return load_skills()
+    except DuplicateSkillError as exc:
+        logger.warning(
+            "Skill registry has duplicate provider content; falling back to preferred editable providers: %s",
+            exc,
+        )
+        return _load_skills_from_preferred_entry_points()
+
+
+def _path_for_response(path: Path, server_cwd: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(server_cwd))
+    except ValueError:
+        return str(resolved)
+
+
+def _skill_source_label(skill: Skill) -> str:
+    if skill.source_dist is not None:
+        if skill.source_dist in _PLATFORM_SKILL_SOURCE_DISTS:
+            return "nemo-platform"
+        return skill.source_dist
+    if skill.source_plugin is not None:
+        return skill.source_plugin
+    return "-"
+
+
+def _claude_skill_response(name: str, skill: Skill, server_cwd: Path) -> ClaudeSkillResponse:
+    installer = get_installer("claude")
+    install_path = installer.get_install_path(Scope.PROJECT, server_cwd, name)
+    source_path = _path_for_response(skill.source_dir, server_cwd) if skill.source_dir is not None else None
+    return ClaudeSkillResponse(
+        name=name,
+        claude_name=install_path.parent.name,
+        description=skill.description,
+        source=_skill_source_label(skill),
+        source_path=source_path,
+        install_path=_path_for_response(install_path, server_cwd),
+        installed=install_path.is_file(),
+    )
+
+
+def list_claude_skill_responses(server_cwd: Path) -> list[ClaudeSkillResponse]:
+    """List NeMo skills with Claude Code install metadata for a Studio working directory."""
+    skills = _load_claude_skills()
+    return [_claude_skill_response(name, skill, server_cwd) for name, skill in skills.items()]

--- a/services/studio/src/nmp/studio/coding_agents.py
+++ b/services/studio/src/nmp/studio/coding_agents.py
@@ -19,6 +19,7 @@ from urllib.parse import urlencode, urlparse
 from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from nmp.studio import studio_links
+from nmp.studio.coding_agent_skills import ClaudeSkillResponse, DuplicateSkillError, list_claude_skill_responses
 from pydantic import BaseModel, Field
 from starlette.routing import NoMatchFound
 
@@ -532,6 +533,15 @@ def get_session_history(session_id: str) -> SessionHistoryResponse:
 
     _initialized_sessions.add(sid)
     return SessionHistoryResponse(session_id=sid, items=items)
+
+
+@router.get("/skills", response_model=list[ClaudeSkillResponse])
+def list_claude_skills() -> list[ClaudeSkillResponse]:
+    """List NeMo skills that the repo's Claude Code installer exposes."""
+    try:
+        return list_claude_skill_responses(SERVER_CWD)
+    except DuplicateSkillError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 def _mcp_url(

--- a/services/studio/tests/unit/test_coding_agents.py
+++ b/services/studio/tests/unit/test_coding_agents.py
@@ -5,6 +5,7 @@
 
 import asyncio
 import json
+import logging
 import re
 import uuid
 from pathlib import Path
@@ -13,7 +14,7 @@ from typing import Any
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
-from nmp.studio import coding_agents, studio_links
+from nmp.studio import coding_agent_skills, coding_agents, studio_links
 from nmp.studio.config import StudioConfig
 from nmp.studio.service import StudioService
 
@@ -49,6 +50,37 @@ def service_client_with_feature_flags(
 def supported_destinations_from_description(description: str) -> set[str]:
     _, _, values = description.partition("Supported values: ")
     return set(values.removesuffix(".").split(", "))
+
+
+def _inference_source_dir(root: Path) -> Path:
+    source_dir = root / "packages" / "nemo_platform_ext" / "skills" / "inference"
+    source_dir.mkdir(parents=True)
+    return source_dir
+
+
+def _inference_skill(source_dir: Path) -> coding_agent_skills.Skill:
+    return coding_agent_skills.Skill(
+        name="inference",
+        description="Use NeMo Platform inference.",
+        version="0.1",
+        content="# Inference",
+        raw="# Inference",
+        source_dir=source_dir,
+        source_plugin="platform",
+        source_dist="nemo-platform-ext",
+    )
+
+
+def _expected_inference_skill_response(*, installed: bool) -> dict[str, Any]:
+    return {
+        "name": "inference",
+        "claude_name": "nemo-inference",
+        "description": "Use NeMo Platform inference.",
+        "source": "nemo-platform",
+        "source_path": "packages/nemo_platform_ext/skills/inference",
+        "install_path": ".claude/skills/nemo-inference/SKILL.md",
+        "installed": installed,
+    }
 
 
 def test_create_session_returns_uuid(service_client: TestClient):
@@ -182,6 +214,75 @@ def test_list_and_get_history_sessions(
         ],
     }
     assert session_id in coding_agents._initialized_sessions
+
+
+def test_list_claude_skills_returns_claude_install_metadata(
+    service_client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source_dir = _inference_source_dir(tmp_path)
+    installed_skill = tmp_path / ".claude" / "skills" / "nemo-inference" / "SKILL.md"
+    installed_skill.parent.mkdir(parents=True)
+    installed_skill.write_text("# Installed")
+    skill = _inference_skill(source_dir)
+
+    monkeypatch.setattr(coding_agents, "SERVER_CWD", tmp_path)
+    monkeypatch.setattr(coding_agent_skills, "load_skills", lambda: {"inference": skill})
+
+    response = service_client.get("/v2/coding-agents/skills")
+
+    assert response.status_code == 200
+    assert response.json() == [_expected_inference_skill_response(installed=True)]
+
+
+def test_load_claude_skills_falls_back_on_duplicate_skill_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    skill = _inference_skill(_inference_source_dir(tmp_path))
+    fallback_called = False
+
+    def fallback() -> dict[str, coding_agent_skills.Skill]:
+        nonlocal fallback_called
+        fallback_called = True
+        return {"inference": skill}
+
+    monkeypatch.setattr(
+        coding_agent_skills,
+        "load_skills",
+        lambda: (_ for _ in ()).throw(coding_agent_skills.DuplicateSkillError("vendored drift")),
+    )
+    monkeypatch.setattr(coding_agent_skills, "_load_skills_from_preferred_entry_points", fallback)
+
+    with caplog.at_level(logging.WARNING):
+        loaded = coding_agent_skills._load_claude_skills()
+
+    assert loaded == {"inference": skill}
+    assert fallback_called
+    assert "vendored drift" in caplog.text
+
+
+def test_list_claude_skills_returns_500_when_fallback_also_fails(
+    service_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        coding_agent_skills,
+        "load_skills",
+        lambda: (_ for _ in ()).throw(coding_agent_skills.DuplicateSkillError("registry drift")),
+    )
+    monkeypatch.setattr(
+        coding_agent_skills,
+        "_load_skills_from_preferred_entry_points",
+        lambda: (_ for _ in ()).throw(coding_agent_skills.DuplicateSkillError("fallback drift")),
+    )
+
+    response = service_client.get("/v2/coding-agents/skills")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "fallback drift"
 
 
 def test_invalid_session_id_returns_400(service_client: TestClient):

--- a/services/studio/tests/unit/test_coding_agents.py
+++ b/services/studio/tests/unit/test_coding_agents.py
@@ -83,6 +83,26 @@ def _expected_inference_skill_response(*, installed: bool) -> dict[str, Any]:
     }
 
 
+def test_vendored_load_skills_from_root_loads_selected_root_without_registry_private_helper(tmp_path: Path):
+    source_dir = _inference_source_dir(tmp_path)
+    (source_dir / "SKILL.md").write_text(
+        "---\nname: inference\ndescription: Use NeMo Platform inference.\nversion: 2\n---\n# Inference\n",
+        encoding="utf-8",
+    )
+
+    loaded = coding_agent_skills.load_skills_from_root(
+        tmp_path / "packages" / "nemo_platform_ext" / "skills",
+        source_plugin="platform",
+        source_dist="nemo-platform-ext",
+    )
+
+    assert list(loaded) == ["inference"]
+    assert loaded["inference"].description == "Use NeMo Platform inference."
+    assert loaded["inference"].version == "2"
+    assert loaded["inference"].source_plugin == "platform"
+    assert loaded["inference"].source_dist == "nemo-platform-ext"
+
+
 def test_create_session_returns_uuid(service_client: TestClient):
     response = service_client.post("/v2/coding-agents/sessions")
 

--- a/web/packages/studio/src/routes/DashboardLandingRoute/SkillActionSection.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/SkillActionSection.tsx
@@ -4,21 +4,12 @@
 import { Banner, Button, Card, Flex, Skeleton, Stack, Text } from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/Empty';
 import type { SkillActionSuggestion } from '@studio/routes/DashboardLandingRoute/skillActionSuggestions';
-import { type FC, type WheelEvent } from 'react';
+import { type FC, type WheelEvent, useCallback, useEffect, useRef } from 'react';
 
 const SKILL_ACTION_CARD_CLASS = 'h-40 w-72 flex-none cursor-pointer shadow-none!';
 
-const HORIZONTAL_SCROLLBAR_CLASS = [
-  '[scrollbar-width:thin]',
-  '[scrollbar-color:var(--border-color-interaction-base)_transparent]',
-  '[&::-webkit-scrollbar]:h-2',
-  '[&::-webkit-scrollbar]:w-2',
-  '[&::-webkit-scrollbar-corner]:bg-transparent',
-  '[&::-webkit-scrollbar-track]:bg-transparent',
-  '[&::-webkit-scrollbar-thumb]:rounded-full',
-  '[&::-webkit-scrollbar-thumb]:bg-[var(--border-color-interaction-base)]',
-  '[&::-webkit-scrollbar-thumb:hover]:bg-[var(--border-color-interaction-strong)]',
-].join(' ');
+const HIDDEN_NATIVE_SCROLLBAR_CLASS = '[scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
+const MIN_SCROLLBAR_THUMB_PERCENT = 12;
 
 interface SkillActionListProps {
   actions: SkillActionSuggestion[];
@@ -26,6 +17,34 @@ interface SkillActionListProps {
 }
 
 const SkillActionList: FC<SkillActionListProps> = ({ actions, onSelect }) => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const scrollbarThumbRef = useRef<HTMLDivElement>(null);
+
+  const updateScrollbar = useCallback(() => {
+    const scrollContainer = scrollContainerRef.current;
+    const scrollbarThumb = scrollbarThumbRef.current;
+    if (!scrollContainer) return;
+
+    const { clientWidth, scrollLeft, scrollWidth } = scrollContainer;
+    const maxScrollLeft = scrollWidth - clientWidth;
+    if (maxScrollLeft <= 0 || scrollWidth <= 0) {
+      if (scrollbarThumb) {
+        scrollbarThumb.style.marginLeft = '0%';
+        scrollbarThumb.style.width = '100%';
+      }
+      return;
+    }
+
+    const thumbWidthPercent = Math.max(
+      MIN_SCROLLBAR_THUMB_PERCENT,
+      (clientWidth / scrollWidth) * 100
+    );
+    if (scrollbarThumb) {
+      scrollbarThumb.style.marginLeft = `${(scrollLeft / maxScrollLeft) * (100 - thumbWidthPercent)}%`;
+      scrollbarThumb.style.width = `${thumbWidthPercent}%`;
+    }
+  }, []);
+
   const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
     if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
 
@@ -41,49 +60,91 @@ const SkillActionList: FC<SkillActionListProps> = ({ actions, onSelect }) => {
 
     event.preventDefault();
     scrollContainer.scrollLeft = nextScrollLeft;
+    updateScrollbar();
   };
 
+  const handleScroll = () => {
+    updateScrollbar();
+  };
+
+  useEffect(() => {
+    updateScrollbar();
+
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined' ? undefined : new ResizeObserver(updateScrollbar);
+    resizeObserver?.observe(scrollContainer);
+    window.addEventListener('resize', updateScrollbar);
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', updateScrollbar);
+    };
+  }, [actions.length, updateScrollbar]);
+
   return (
-    <div
-      aria-label="Skill action suggestions"
-      className={`flex w-full items-stretch gap-density-md overflow-x-auto pb-density-sm ${HORIZONTAL_SCROLLBAR_CLASS}`}
-      onWheel={handleWheel}
-    >
-      {actions.map((action) => (
+    <div className="w-full">
+      <div
+        ref={scrollContainerRef}
+        aria-label="Skill action suggestions"
+        className={`w-full overflow-x-auto ${HIDDEN_NATIVE_SCROLLBAR_CLASS}`}
+        onScroll={handleScroll}
+        onWheel={handleWheel}
+      >
         <div
-          key={`${action.skillName}:${action.claudeName}`}
-          className="w-72 flex-none"
-          data-testid={`skill-action-card-${action.skillName}`}
+          className="flex w-max min-w-full items-stretch gap-density-md pb-density-lg"
+          data-testid="skill-action-row"
         >
-          <Card asChild interactive className="h-40 w-full cursor-pointer shadow-none!">
-            <button
-              type="button"
-              className="flex h-full w-full flex-col gap-density-md text-left"
-              onClick={() => onSelect(action.prompt)}
+          {actions.map((action) => (
+            <div
+              key={`${action.skillName}:${action.claudeName}`}
+              className="w-72 flex-none"
+              data-testid={`skill-action-card-${action.skillName}`}
             >
-              <span className="flex size-8 shrink-0 items-center justify-center rounded bg-surface-raised text-accent">
-                {action.icon}
-              </span>
-              <span className="flex min-h-0 flex-1 flex-col gap-density-xxs">
-                <Text kind="label/bold/sm" className="line-clamp-1 block">
-                  {action.title}
-                </Text>
-                <Text
-                  kind="body/regular/xs"
-                  color="secondary"
-                  className="block truncate"
-                  data-testid="skill-action-skill-name"
+              <Card asChild interactive className="h-40 w-full cursor-pointer shadow-none!">
+                <button
+                  type="button"
+                  className="flex h-full w-full flex-col gap-density-md text-left"
+                  onClick={() => onSelect(action.prompt)}
                 >
-                  {action.skillName}
-                </Text>
-                <Text kind="body/regular/sm" color="secondary" className="line-clamp-2 block">
-                  {action.description}
-                </Text>
-              </span>
-            </button>
-          </Card>
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded bg-surface-raised text-accent">
+                    {action.icon}
+                  </span>
+                  <span className="flex min-h-0 flex-1 flex-col gap-density-xxs">
+                    <Text kind="label/bold/sm" className="line-clamp-1 block">
+                      {action.title}
+                    </Text>
+                    <Text
+                      kind="body/regular/xs"
+                      color="secondary"
+                      className="block truncate"
+                      data-testid="skill-action-skill-name"
+                    >
+                      {action.skillName}
+                    </Text>
+                    <Text kind="body/regular/sm" color="secondary" className="line-clamp-2 block">
+                      {action.description}
+                    </Text>
+                  </span>
+                </button>
+              </Card>
+            </div>
+          ))}
         </div>
-      ))}
+      </div>
+      <div
+        aria-hidden="true"
+        className="h-2 w-full rounded-full bg-[var(--background-color-interaction-hover)]"
+        data-testid="skill-action-scrollbar"
+      >
+        <div
+          ref={scrollbarThumbRef}
+          className="h-full rounded-full bg-[var(--border-color-interaction-base)]"
+          data-testid="skill-action-scrollbar-thumb"
+        />
+      </div>
     </div>
   );
 };

--- a/web/packages/studio/src/routes/DashboardLandingRoute/SkillActionSection.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/SkillActionSection.tsx
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Banner, Button, Card, Flex, Skeleton, Stack, Text } from '@nvidia/foundations-react-core';
+import { Card, Flex, Skeleton, Stack, Text } from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/Empty';
-import type { SkillActionSuggestion } from '@studio/routes/DashboardLandingRoute/skillActionSuggestions';
+import type { SkillActionTemplate } from '@studio/routes/DashboardLandingRoute/skillActionSuggestions';
 import type { FC } from 'react';
 
 const SKILL_ACTION_CARD_CLASS = 'h-40 w-72 flex-none cursor-pointer shadow-none!';
@@ -20,8 +20,13 @@ const HORIZONTAL_SCROLLBAR_CLASS = [
   '[&::-webkit-scrollbar-thumb:hover]:bg-[var(--border-color-interaction-strong)]',
 ].join(' ');
 
+export interface SkillActionCard extends SkillActionTemplate {
+  skillName?: string;
+  claudeName?: string;
+}
+
 interface SkillActionListProps {
-  actions: SkillActionSuggestion[];
+  actions: SkillActionCard[];
   onSelect: (prompt: string) => void;
 }
 
@@ -31,15 +36,17 @@ const SkillActionList: FC<SkillActionListProps> = ({ actions, onSelect }) => {
       aria-label="Skill action suggestions"
       className={`w-full overflow-x-auto ${HORIZONTAL_SCROLLBAR_CLASS}`}
     >
-      <div
-        className="flex w-max min-w-full items-stretch gap-density-md pb-density-lg"
+      <Flex
+        align="stretch"
+        gap="density-md"
+        className="w-max min-w-full pb-density-lg"
         data-testid="skill-action-row"
       >
         {actions.map((action) => (
           <div
-            key={`${action.skillName}:${action.claudeName}`}
+            key={`${action.skillName ?? action.title}:${action.claudeName ?? action.prompt}`}
             className="w-72 flex-none"
-            data-testid={`skill-action-card-${action.skillName}`}
+            data-testid={action.skillName ? `skill-action-card-${action.skillName}` : undefined}
           >
             <Card asChild interactive className="h-40 w-full cursor-pointer shadow-none!">
               <button
@@ -50,27 +57,29 @@ const SkillActionList: FC<SkillActionListProps> = ({ actions, onSelect }) => {
                 <span className="flex size-8 shrink-0 items-center justify-center rounded bg-surface-raised text-accent">
                   {action.icon}
                 </span>
-                <span className="flex min-h-0 flex-1 flex-col gap-density-xxs">
+                <Flex direction="col" gap="density-xxs" className="min-h-0 flex-1">
                   <Text kind="label/bold/sm" className="line-clamp-1 block">
                     {action.title}
                   </Text>
-                  <Text
-                    kind="body/regular/xs"
-                    color="secondary"
-                    className="block truncate"
-                    data-testid="skill-action-skill-name"
-                  >
-                    {action.skillName}
-                  </Text>
+                  {action.skillName ? (
+                    <Text
+                      kind="body/regular/xs"
+                      color="secondary"
+                      className="block truncate"
+                      data-testid="skill-action-skill-name"
+                    >
+                      {action.skillName}
+                    </Text>
+                  ) : null}
                   <Text kind="body/regular/sm" color="secondary" className="line-clamp-2 block">
                     {action.description}
                   </Text>
-                </span>
+                </Flex>
               </button>
             </Card>
           </div>
         ))}
-      </div>
+      </Flex>
     </div>
   );
 };
@@ -84,39 +93,20 @@ const SkillActionSkeleton = () => (
 );
 
 export interface SkillActionSectionProps {
-  actions: SkillActionSuggestion[];
-  isError: boolean;
+  actions: SkillActionCard[];
   isLoading: boolean;
-  onRetry: () => void;
   onSelect: (prompt: string) => void;
   totalSkillCount: number;
 }
 
 export const SkillActionSection: FC<SkillActionSectionProps> = ({
   actions,
-  isError,
   isLoading,
-  onRetry,
   onSelect,
   totalSkillCount,
 }) => {
   if (isLoading) {
     return <SkillActionSkeleton />;
-  }
-
-  if (isError) {
-    return (
-      <Stack gap="density-sm" className="w-full" data-testid="skill-actions-error">
-        <Banner kind="inline" status="error">
-          Could not load Claude skills.
-        </Banner>
-        <Flex justify="center">
-          <Button kind="secondary" size="small" type="button" onClick={onRetry}>
-            Retry
-          </Button>
-        </Flex>
-      </Stack>
-    );
   }
 
   if (!totalSkillCount) {

--- a/web/packages/studio/src/routes/DashboardLandingRoute/SkillActionSection.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/SkillActionSection.tsx
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Banner, Button, Card, Flex, Skeleton, Stack, Text } from '@nvidia/foundations-react-core';
+import { Empty } from '@studio/components/Empty';
+import type { SkillActionSuggestion } from '@studio/routes/DashboardLandingRoute/skillActionSuggestions';
+import { type FC, type WheelEvent } from 'react';
+
+const SKILL_ACTION_CARD_CLASS = 'h-40 w-72 flex-none cursor-pointer shadow-none!';
+
+const HORIZONTAL_SCROLLBAR_CLASS = [
+  '[scrollbar-width:thin]',
+  '[scrollbar-color:var(--border-color-interaction-base)_transparent]',
+  '[&::-webkit-scrollbar]:h-2',
+  '[&::-webkit-scrollbar]:w-2',
+  '[&::-webkit-scrollbar-corner]:bg-transparent',
+  '[&::-webkit-scrollbar-track]:bg-transparent',
+  '[&::-webkit-scrollbar-thumb]:rounded-full',
+  '[&::-webkit-scrollbar-thumb]:bg-[var(--border-color-interaction-base)]',
+  '[&::-webkit-scrollbar-thumb:hover]:bg-[var(--border-color-interaction-strong)]',
+].join(' ');
+
+interface SkillActionListProps {
+  actions: SkillActionSuggestion[];
+  onSelect: (prompt: string) => void;
+}
+
+const SkillActionList: FC<SkillActionListProps> = ({ actions, onSelect }) => {
+  const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
+    if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+
+    const scrollContainer = event.currentTarget;
+    const maxScrollLeft = scrollContainer.scrollWidth - scrollContainer.clientWidth;
+    if (maxScrollLeft <= 0) return;
+
+    const nextScrollLeft = Math.min(
+      maxScrollLeft,
+      Math.max(0, scrollContainer.scrollLeft + event.deltaY)
+    );
+    if (nextScrollLeft === scrollContainer.scrollLeft) return;
+
+    event.preventDefault();
+    scrollContainer.scrollLeft = nextScrollLeft;
+  };
+
+  return (
+    <div
+      aria-label="Skill action suggestions"
+      className={`flex w-full items-stretch gap-density-md overflow-x-auto pb-density-sm ${HORIZONTAL_SCROLLBAR_CLASS}`}
+      onWheel={handleWheel}
+    >
+      {actions.map((action) => (
+        <div
+          key={`${action.skillName}:${action.claudeName}`}
+          className="w-72 flex-none"
+          data-testid={`skill-action-card-${action.skillName}`}
+        >
+          <Card asChild interactive className="h-40 w-full cursor-pointer shadow-none!">
+            <button
+              type="button"
+              className="flex h-full w-full flex-col gap-density-md text-left"
+              onClick={() => onSelect(action.prompt)}
+            >
+              <span className="flex size-8 shrink-0 items-center justify-center rounded bg-surface-raised text-accent">
+                {action.icon}
+              </span>
+              <span className="flex min-h-0 flex-1 flex-col gap-density-xxs">
+                <Text kind="label/bold/sm" className="line-clamp-1 block">
+                  {action.title}
+                </Text>
+                <Text
+                  kind="body/regular/xs"
+                  color="secondary"
+                  className="block truncate"
+                  data-testid="skill-action-skill-name"
+                >
+                  {action.skillName}
+                </Text>
+                <Text kind="body/regular/sm" color="secondary" className="line-clamp-2 block">
+                  {action.description}
+                </Text>
+              </span>
+            </button>
+          </Card>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const SkillActionSkeleton = () => (
+  <Flex gap="density-md" className="w-full overflow-hidden" data-testid="skill-actions-loading">
+    {Array.from({ length: 3 }, (_, index) => (
+      <Skeleton key={index} className={SKILL_ACTION_CARD_CLASS} />
+    ))}
+  </Flex>
+);
+
+export interface SkillActionSectionProps {
+  actions: SkillActionSuggestion[];
+  isError: boolean;
+  isLoading: boolean;
+  onRetry: () => void;
+  onSelect: (prompt: string) => void;
+  totalSkillCount: number;
+}
+
+export const SkillActionSection: FC<SkillActionSectionProps> = ({
+  actions,
+  isError,
+  isLoading,
+  onRetry,
+  onSelect,
+  totalSkillCount,
+}) => {
+  if (isLoading) {
+    return <SkillActionSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <Stack gap="density-sm" className="w-full" data-testid="skill-actions-error">
+        <Banner kind="inline" status="error">
+          Could not load Claude skills.
+        </Banner>
+        <Flex justify="center">
+          <Button kind="secondary" size="small" type="button" onClick={onRetry}>
+            Retry
+          </Button>
+        </Flex>
+      </Stack>
+    );
+  }
+
+  if (!totalSkillCount) {
+    return (
+      <div className="w-full" data-testid="skill-actions-empty">
+        <Empty
+          title="No skills found"
+          description="Claude Code skills will appear here once they are available in this workspace."
+        />
+      </div>
+    );
+  }
+
+  if (!actions.length) {
+    return (
+      <Stack gap="density-sm" className="w-full text-center" data-testid="skill-actions-disabled">
+        <Text kind="body/regular/sm" color="secondary">
+          Skills are installed, but none are enabled for this workspace configuration.
+        </Text>
+      </Stack>
+    );
+  }
+
+  return <SkillActionList actions={actions} onSelect={onSelect} />;
+};

--- a/web/packages/studio/src/routes/DashboardLandingRoute/SkillActionSection.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/SkillActionSection.tsx
@@ -4,12 +4,21 @@
 import { Banner, Button, Card, Flex, Skeleton, Stack, Text } from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/Empty';
 import type { SkillActionSuggestion } from '@studio/routes/DashboardLandingRoute/skillActionSuggestions';
-import { type FC, type WheelEvent, useCallback, useEffect, useRef } from 'react';
+import type { FC } from 'react';
 
 const SKILL_ACTION_CARD_CLASS = 'h-40 w-72 flex-none cursor-pointer shadow-none!';
 
-const HIDDEN_NATIVE_SCROLLBAR_CLASS = '[scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
-const MIN_SCROLLBAR_THUMB_PERCENT = 12;
+const HORIZONTAL_SCROLLBAR_CLASS = [
+  '[scrollbar-width:thin]',
+  '[scrollbar-color:var(--border-color-interaction-base)_var(--background-color-interaction-hover)]',
+  '[&::-webkit-scrollbar]:h-2',
+  '[&::-webkit-scrollbar-corner]:bg-transparent',
+  '[&::-webkit-scrollbar-track]:rounded-full',
+  '[&::-webkit-scrollbar-track]:bg-[var(--background-color-interaction-hover)]',
+  '[&::-webkit-scrollbar-thumb]:rounded-full',
+  '[&::-webkit-scrollbar-thumb]:bg-[var(--border-color-interaction-base)]',
+  '[&::-webkit-scrollbar-thumb:hover]:bg-[var(--border-color-interaction-strong)]',
+].join(' ');
 
 interface SkillActionListProps {
   actions: SkillActionSuggestion[];
@@ -17,133 +26,50 @@ interface SkillActionListProps {
 }
 
 const SkillActionList: FC<SkillActionListProps> = ({ actions, onSelect }) => {
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const scrollbarThumbRef = useRef<HTMLDivElement>(null);
-
-  const updateScrollbar = useCallback(() => {
-    const scrollContainer = scrollContainerRef.current;
-    const scrollbarThumb = scrollbarThumbRef.current;
-    if (!scrollContainer) return;
-
-    const { clientWidth, scrollLeft, scrollWidth } = scrollContainer;
-    const maxScrollLeft = scrollWidth - clientWidth;
-    if (maxScrollLeft <= 0 || scrollWidth <= 0) {
-      if (scrollbarThumb) {
-        scrollbarThumb.style.marginLeft = '0%';
-        scrollbarThumb.style.width = '100%';
-      }
-      return;
-    }
-
-    const thumbWidthPercent = Math.max(
-      MIN_SCROLLBAR_THUMB_PERCENT,
-      (clientWidth / scrollWidth) * 100
-    );
-    if (scrollbarThumb) {
-      scrollbarThumb.style.marginLeft = `${(scrollLeft / maxScrollLeft) * (100 - thumbWidthPercent)}%`;
-      scrollbarThumb.style.width = `${thumbWidthPercent}%`;
-    }
-  }, []);
-
-  const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
-    if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
-
-    const scrollContainer = event.currentTarget;
-    const maxScrollLeft = scrollContainer.scrollWidth - scrollContainer.clientWidth;
-    if (maxScrollLeft <= 0) return;
-
-    const nextScrollLeft = Math.min(
-      maxScrollLeft,
-      Math.max(0, scrollContainer.scrollLeft + event.deltaY)
-    );
-    if (nextScrollLeft === scrollContainer.scrollLeft) return;
-
-    event.preventDefault();
-    scrollContainer.scrollLeft = nextScrollLeft;
-    updateScrollbar();
-  };
-
-  const handleScroll = () => {
-    updateScrollbar();
-  };
-
-  useEffect(() => {
-    updateScrollbar();
-
-    const scrollContainer = scrollContainerRef.current;
-    if (!scrollContainer) return;
-
-    const resizeObserver =
-      typeof ResizeObserver === 'undefined' ? undefined : new ResizeObserver(updateScrollbar);
-    resizeObserver?.observe(scrollContainer);
-    window.addEventListener('resize', updateScrollbar);
-
-    return () => {
-      resizeObserver?.disconnect();
-      window.removeEventListener('resize', updateScrollbar);
-    };
-  }, [actions.length, updateScrollbar]);
-
   return (
-    <div className="w-full">
+    <div
+      aria-label="Skill action suggestions"
+      className={`w-full overflow-x-auto ${HORIZONTAL_SCROLLBAR_CLASS}`}
+    >
       <div
-        ref={scrollContainerRef}
-        aria-label="Skill action suggestions"
-        className={`w-full overflow-x-auto ${HIDDEN_NATIVE_SCROLLBAR_CLASS}`}
-        onScroll={handleScroll}
-        onWheel={handleWheel}
+        className="flex w-max min-w-full items-stretch gap-density-md pb-density-lg"
+        data-testid="skill-action-row"
       >
-        <div
-          className="flex w-max min-w-full items-stretch gap-density-md pb-density-lg"
-          data-testid="skill-action-row"
-        >
-          {actions.map((action) => (
-            <div
-              key={`${action.skillName}:${action.claudeName}`}
-              className="w-72 flex-none"
-              data-testid={`skill-action-card-${action.skillName}`}
-            >
-              <Card asChild interactive className="h-40 w-full cursor-pointer shadow-none!">
-                <button
-                  type="button"
-                  className="flex h-full w-full flex-col gap-density-md text-left"
-                  onClick={() => onSelect(action.prompt)}
-                >
-                  <span className="flex size-8 shrink-0 items-center justify-center rounded bg-surface-raised text-accent">
-                    {action.icon}
-                  </span>
-                  <span className="flex min-h-0 flex-1 flex-col gap-density-xxs">
-                    <Text kind="label/bold/sm" className="line-clamp-1 block">
-                      {action.title}
-                    </Text>
-                    <Text
-                      kind="body/regular/xs"
-                      color="secondary"
-                      className="block truncate"
-                      data-testid="skill-action-skill-name"
-                    >
-                      {action.skillName}
-                    </Text>
-                    <Text kind="body/regular/sm" color="secondary" className="line-clamp-2 block">
-                      {action.description}
-                    </Text>
-                  </span>
-                </button>
-              </Card>
-            </div>
-          ))}
-        </div>
-      </div>
-      <div
-        aria-hidden="true"
-        className="h-2 w-full rounded-full bg-[var(--background-color-interaction-hover)]"
-        data-testid="skill-action-scrollbar"
-      >
-        <div
-          ref={scrollbarThumbRef}
-          className="h-full rounded-full bg-[var(--border-color-interaction-base)]"
-          data-testid="skill-action-scrollbar-thumb"
-        />
+        {actions.map((action) => (
+          <div
+            key={`${action.skillName}:${action.claudeName}`}
+            className="w-72 flex-none"
+            data-testid={`skill-action-card-${action.skillName}`}
+          >
+            <Card asChild interactive className="h-40 w-full cursor-pointer shadow-none!">
+              <button
+                type="button"
+                className="flex h-full w-full flex-col gap-density-md text-left"
+                onClick={() => onSelect(action.prompt)}
+              >
+                <span className="flex size-8 shrink-0 items-center justify-center rounded bg-surface-raised text-accent">
+                  {action.icon}
+                </span>
+                <span className="flex min-h-0 flex-1 flex-col gap-density-xxs">
+                  <Text kind="label/bold/sm" className="line-clamp-1 block">
+                    {action.title}
+                  </Text>
+                  <Text
+                    kind="body/regular/xs"
+                    color="secondary"
+                    className="block truncate"
+                    data-testid="skill-action-skill-name"
+                  >
+                    {action.skillName}
+                  </Text>
+                  <Text kind="body/regular/sm" color="secondary" className="line-clamp-2 block">
+                    {action.description}
+                  </Text>
+                </span>
+              </button>
+            </Card>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
@@ -253,13 +253,16 @@ describe('DashboardLandingRoute', () => {
     expect(await screen.findByTestId('skill-actions-disabled')).toBeInTheDocument();
   });
 
-  it('shows an error state when Claude skills fail to load', async () => {
+  it('falls back to default action cards when Claude skills fail to load', async () => {
     mocks.listClaudeCodeSkills.mockRejectedValue(new Error('skills unavailable'));
 
     renderRoute();
 
-    expect(await screen.findByTestId('skill-actions-error')).toBeInTheDocument();
-    expect(screen.getByText('Could not load Claude skills.')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /Explore repo/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Draft a change/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Review recent work/ })).toBeInTheDocument();
+    expect(screen.queryByText('Could not load Claude skills.')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('skill-actions-error')).not.toBeInTheDocument();
   });
 
   it('shows an empty state when no Claude skills are available', async () => {

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
@@ -3,10 +3,15 @@
 
 import { ROUTES } from '@studio/constants/routes';
 import { DashboardLandingRoute } from '@studio/routes/DashboardLandingRoute';
+import { mockFeatureFlags } from '@studio/tests/util/mockFeatureFlags';
 import { TestProviders } from '@studio/tests/util/TestProviders';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMemoryRouter, generatePath, RouterProvider, useLocation } from 'react-router';
+
+const mocks = vi.hoisted(() => ({
+  listClaudeCodeSkills: vi.fn(),
+}));
 
 vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/api', async (importOriginal) => {
   const actual =
@@ -15,6 +20,7 @@ vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/api', async (importOriginal) 
   return {
     ...actual,
     listClaudeCodeHistorySessions: vi.fn(async () => []),
+    listClaudeCodeSkills: mocks.listClaudeCodeSkills,
   };
 });
 
@@ -52,6 +58,70 @@ const renderRoute = () => {
 };
 
 describe('DashboardLandingRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFeatureFlags({
+      agentsEnabled: true,
+      guardrailsEnabled: true,
+      inferenceProviderEnabled: true,
+      safeSynthesizerEnabled: true,
+    });
+    mocks.listClaudeCodeSkills.mockResolvedValue([
+      {
+        name: 'nemo-guardrails',
+        claude_name: 'nemo-nemo-guardrails',
+        description: 'NeMo guardrails CLI reference.',
+        source: 'nemo-platform',
+        install_path: '.claude/skills/nemo-nemo-guardrails/SKILL.md',
+        installed: false,
+      },
+      {
+        name: 'guardrails-plugin',
+        claude_name: 'nemo-guardrails-plugin',
+        description: 'Guardrails plugin reference.',
+        source: 'nemo-guardrails-plugin',
+        install_path: '.claude/skills/nemo-guardrails-plugin/SKILL.md',
+        installed: false,
+      },
+      {
+        name: 'agents-optimize',
+        claude_name: 'nemo-agents-optimize',
+        description: 'Optimize a deployed NeMo agent.',
+        source: 'nemo-agents-plugin',
+        install_path: '.claude/skills/nemo-agents-optimize/SKILL.md',
+        installed: false,
+      },
+      {
+        name: 'inference',
+        claude_name: 'nemo-inference',
+        description: 'Configure inference providers and virtual models.',
+        source: 'nemo-platform',
+        install_path: '.claude/skills/nemo-inference/SKILL.md',
+        installed: false,
+      },
+      {
+        name: 'nemo-build-agent',
+        claude_name: 'nemo-nemo-build-agent',
+        description: 'Build and deploy a NAT workflow from a spec.',
+        source: 'nemo-platform',
+        install_path: '.claude/skills/nemo-nemo-build-agent/SKILL.md',
+        installed: false,
+      },
+      {
+        name: 'safe-synthesizer',
+        claude_name: 'nemo-safe-synthesizer',
+        description: 'Generate safety-focused synthetic data.',
+        source: 'nemo-platform',
+        install_path: '.claude/skills/nemo-safe-synthesizer/SKILL.md',
+        installed: false,
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('renders the dashboard landing page', async () => {
     renderRoute();
 
@@ -66,20 +136,177 @@ describe('DashboardLandingRoute', () => {
       '[&&]:focus-visible:ring-0'
     );
     expect(composer).not.toHaveClass('[&&]:focus-visible:outline-accent');
-    expect(screen.getByRole('button', { name: /Create an agent/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Start an evaluation/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Set up a secret/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Explore repo/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Draft a change/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Review recent work/ })).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /Add guardrails to an agent/ })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('skill-action-card-nemo-guardrails')).toHaveClass(
+      'w-72',
+      'flex-none'
+    );
+    expect(screen.getByRole('button', { name: /Debug guardrails middleware/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Optimize an agent/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Configure inference/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Build an agent/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Generate safety data/ })).toBeInTheDocument();
+    expect(
+      screen.getAllByTestId('skill-action-skill-name').map((node) => node.textContent)
+    ).toEqual(expect.arrayContaining(['nemo-guardrails', 'guardrails-plugin']));
   });
 
-  it('lets prompt suggestions populate the landing composer', async () => {
+  it('uses the Studio thin horizontal scrollbar styling for skill actions', async () => {
+    renderRoute();
+
+    await screen.findByRole('button', { name: /Add guardrails to an agent/ });
+
+    const skillActions = screen.getByLabelText('Skill action suggestions');
+    expect(skillActions).toHaveClass(
+      '[scrollbar-width:thin]',
+      '[scrollbar-color:var(--border-color-interaction-base)_transparent]',
+      '[&::-webkit-scrollbar-thumb]:rounded-full',
+      'pb-density-sm'
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Previous skill actions' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Next skill actions' })).not.toBeInTheDocument();
+  });
+
+  it('maps vertical wheel scrolling to horizontal skill action scrolling', async () => {
+    renderRoute();
+
+    const skillActions = await screen.findByLabelText('Skill action suggestions');
+    Object.defineProperty(skillActions, 'clientWidth', { configurable: true, value: 320 });
+    Object.defineProperty(skillActions, 'scrollWidth', { configurable: true, value: 1200 });
+
+    fireEvent.wheel(skillActions, { deltaY: 180, deltaX: 0 });
+
+    expect(skillActions.scrollLeft).toBe(180);
+  });
+
+  it('requires the skill and related feature flag before showing action cards', async () => {
+    mockFeatureFlags({
+      agentsEnabled: true,
+      evaluatorEnabled: true,
+      guardrailsEnabled: false,
+      inferenceProviderEnabled: true,
+      safeSynthesizerEnabled: false,
+    });
+    mocks.listClaudeCodeSkills.mockResolvedValue([
+      {
+        name: 'nemo-guardrails',
+        claude_name: 'nemo-nemo-guardrails',
+        description: 'NeMo guardrails CLI reference.',
+        source: 'nemo-platform',
+        install_path: '.claude/skills/nemo-nemo-guardrails/SKILL.md',
+        installed: false,
+      },
+      {
+        name: 'inference',
+        claude_name: 'nemo-inference',
+        description: 'Configure inference providers and virtual models.',
+        source: 'nemo-platform',
+        install_path: '.claude/skills/nemo-inference/SKILL.md',
+        installed: false,
+      },
+      {
+        name: 'safe-synthesizer',
+        claude_name: 'nemo-safe-synthesizer',
+        description: 'Generate safety-focused synthetic data.',
+        source: 'nemo-platform',
+        install_path: '.claude/skills/nemo-safe-synthesizer/SKILL.md',
+        installed: false,
+      },
+    ]);
+
+    renderRoute();
+
+    expect(await screen.findByRole('button', { name: /Configure inference/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Add guardrails to an agent/ })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Generate safety data/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Run model evaluations/ })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('skill-actions-disabled')).not.toBeInTheDocument();
+  });
+
+  it('shows a disabled message when every skill is filtered by feature flags', async () => {
+    mockFeatureFlags({
+      guardrailsEnabled: false,
+      inferenceProviderEnabled: false,
+      safeSynthesizerEnabled: false,
+    });
+    mocks.listClaudeCodeSkills.mockResolvedValue([
+      {
+        name: 'nemo-guardrails',
+        claude_name: 'nemo-nemo-guardrails',
+        description: 'NeMo guardrails CLI reference.',
+        source: 'nemo-platform',
+        install_path: '.claude/skills/nemo-nemo-guardrails/SKILL.md',
+        installed: false,
+      },
+      {
+        name: 'inference',
+        claude_name: 'nemo-inference',
+        description: 'Configure inference providers and virtual models.',
+        source: 'nemo-platform',
+        install_path: '.claude/skills/nemo-inference/SKILL.md',
+        installed: false,
+      },
+    ]);
+
+    renderRoute();
+
+    expect(await screen.findByTestId('skill-actions-disabled')).toBeInTheDocument();
+  });
+
+  it('shows an error state when Claude skills fail to load', async () => {
+    mocks.listClaudeCodeSkills.mockRejectedValue(new Error('skills unavailable'));
+
+    renderRoute();
+
+    expect(await screen.findByTestId('skill-actions-error')).toBeInTheDocument();
+    expect(screen.getByText('Could not load Claude skills.')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when no Claude skills are available', async () => {
+    mocks.listClaudeCodeSkills.mockResolvedValue([]);
+
+    renderRoute();
+
+    expect(await screen.findByTestId('skill-actions-empty')).toBeInTheDocument();
+    expect(screen.getByText('No skills found')).toBeInTheDocument();
+  });
+
+  it('shows a fallback action card for skills without curated templates', async () => {
+    mocks.listClaudeCodeSkills.mockResolvedValue([
+      {
+        name: 'custom-plugin-skill',
+        claude_name: 'nemo-custom-plugin-skill',
+        description: 'A plugin-specific workflow.',
+        source: 'custom-plugin',
+        install_path: '.claude/skills/nemo-custom-plugin-skill/SKILL.md',
+        installed: false,
+      },
+    ]);
+
+    renderRoute();
+
+    expect(await screen.findByRole('button', { name: /Custom Plugin Skill/ })).toBeInTheDocument();
+    expect(screen.getByText('custom-plugin-skill')).toBeInTheDocument();
+  });
+
+  it('lets skill action cards populate the landing composer', async () => {
     const user = userEvent.setup();
     renderRoute();
 
-    await user.click(await screen.findByRole('button', { name: /Create an agent/ }));
+    await user.click(await screen.findByRole('button', { name: /Add guardrails to an agent/ }));
 
-    expect(screen.getByRole('textbox', { name: 'Message Claude' })).toHaveValue(
-      'Create a new agent in this workspace and deploy it once it is ready.'
-    );
+    expect(
+      screen.getByRole<HTMLTextAreaElement>('textbox', { name: 'Message Claude' }).value
+    ).toContain('add input and output guardrails');
   });
 
   it('only enables the send affordance once the composer has text', async () => {

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
@@ -156,18 +156,24 @@ describe('DashboardLandingRoute', () => {
     ).toEqual(expect.arrayContaining(['nemo-guardrails', 'guardrails-plugin']));
   });
 
-  it('uses the Studio thin horizontal scrollbar styling for skill actions', async () => {
+  it('uses an always-visible custom horizontal scrollbar for skill actions', async () => {
     renderRoute();
 
     await screen.findByRole('button', { name: /Add guardrails to an agent/ });
 
     const skillActions = screen.getByLabelText('Skill action suggestions');
+    Object.defineProperty(skillActions, 'clientWidth', { configurable: true, value: 320 });
+    Object.defineProperty(skillActions, 'scrollWidth', { configurable: true, value: 1200 });
+    fireEvent.scroll(skillActions);
+
     expect(skillActions).toHaveClass(
-      '[scrollbar-width:thin]',
-      '[scrollbar-color:var(--border-color-interaction-base)_transparent]',
-      '[&::-webkit-scrollbar-thumb]:rounded-full',
-      'pb-density-sm'
+      'overflow-x-auto',
+      '[scrollbar-width:none]',
+      '[&::-webkit-scrollbar]:hidden'
     );
+    expect(screen.getByTestId('skill-action-row')).toHaveClass('pb-density-lg');
+    expect(screen.getByTestId('skill-action-scrollbar')).not.toHaveClass('hidden');
+    expect(screen.getByTestId('skill-action-scrollbar-thumb')).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Previous skill actions' })
     ).not.toBeInTheDocument();

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.spec.tsx
@@ -5,7 +5,7 @@ import { ROUTES } from '@studio/constants/routes';
 import { DashboardLandingRoute } from '@studio/routes/DashboardLandingRoute';
 import { mockFeatureFlags } from '@studio/tests/util/mockFeatureFlags';
 import { TestProviders } from '@studio/tests/util/TestProviders';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMemoryRouter, generatePath, RouterProvider, useLocation } from 'react-router';
 
@@ -156,40 +156,25 @@ describe('DashboardLandingRoute', () => {
     ).toEqual(expect.arrayContaining(['nemo-guardrails', 'guardrails-plugin']));
   });
 
-  it('uses an always-visible custom horizontal scrollbar for skill actions', async () => {
+  it('uses a styled native horizontal scrollbar for skill actions', async () => {
     renderRoute();
 
     await screen.findByRole('button', { name: /Add guardrails to an agent/ });
 
     const skillActions = screen.getByLabelText('Skill action suggestions');
-    Object.defineProperty(skillActions, 'clientWidth', { configurable: true, value: 320 });
-    Object.defineProperty(skillActions, 'scrollWidth', { configurable: true, value: 1200 });
-    fireEvent.scroll(skillActions);
 
     expect(skillActions).toHaveClass(
       'overflow-x-auto',
-      '[scrollbar-width:none]',
-      '[&::-webkit-scrollbar]:hidden'
+      '[scrollbar-width:thin]',
+      '[scrollbar-color:var(--border-color-interaction-base)_var(--background-color-interaction-hover)]',
+      '[&::-webkit-scrollbar-thumb]:rounded-full'
     );
     expect(screen.getByTestId('skill-action-row')).toHaveClass('pb-density-lg');
-    expect(screen.getByTestId('skill-action-scrollbar')).not.toHaveClass('hidden');
-    expect(screen.getByTestId('skill-action-scrollbar-thumb')).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-action-scrollbar')).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Previous skill actions' })
     ).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Next skill actions' })).not.toBeInTheDocument();
-  });
-
-  it('maps vertical wheel scrolling to horizontal skill action scrolling', async () => {
-    renderRoute();
-
-    const skillActions = await screen.findByLabelText('Skill action suggestions');
-    Object.defineProperty(skillActions, 'clientWidth', { configurable: true, value: 320 });
-    Object.defineProperty(skillActions, 'scrollWidth', { configurable: true, value: 1200 });
-
-    fireEvent.wheel(skillActions, { deltaY: 180, deltaX: 0 });
-
-    expect(skillActions.scrollLeft).toBe(180);
   });
 
   it('requires the skill and related feature flag before showing action cards', async () => {

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
@@ -12,11 +12,14 @@ import {
 } from '@studio/routes/agents/ClaudeCodeChatRoute/api';
 import { ClaudeCodeLayout } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeLayout';
 import type { ClaudeCodeChatRouteState } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
-import { SkillActionSection } from '@studio/routes/DashboardLandingRoute/SkillActionSection';
+import {
+  SkillActionSection,
+  type SkillActionCard,
+} from '@studio/routes/DashboardLandingRoute/SkillActionSection';
 import { getSkillActionSuggestions } from '@studio/routes/DashboardLandingRoute/skillActionSuggestions';
 import { getClaudeCodeChatRoute } from '@studio/routes/utils';
 import { useQuery } from '@tanstack/react-query';
-import { Send, Terminal } from 'lucide-react';
+import { GitBranch, Hammer, Search, Send, Terminal } from 'lucide-react';
 import {
   type ChangeEvent,
   type FC,
@@ -99,6 +102,27 @@ const LandingComposer = ({
   );
 };
 
+const DEFAULT_LANDING_ACTIONS = [
+  {
+    title: 'Explore repo',
+    description: 'Give me a concise map of this repo and the main places I should know about.',
+    prompt: 'Give me a concise map of this repo and the main places I should know about.',
+    icon: <Search size={18} />,
+  },
+  {
+    title: 'Draft a change',
+    description: 'Help me plan and implement the next small product improvement in nemo-platform.',
+    prompt: 'Help me plan and implement the next small product improvement in nemo-platform.',
+    icon: <Hammer size={18} />,
+  },
+  {
+    title: 'Review recent work',
+    description: 'Review the current working tree and call out anything risky or unfinished.',
+    prompt: 'Review the current working tree and call out anything risky or unfinished.',
+    icon: <GitBranch size={18} />,
+  },
+] satisfies SkillActionCard[];
+
 export const DashboardLandingRoute: FC = () => {
   const workspace = useWorkspaceFromPath();
   const navigate = useNavigate();
@@ -107,12 +131,17 @@ export const DashboardLandingRoute: FC = () => {
     data: skills,
     isError: isSkillsError,
     isLoading: isSkillsLoading,
-    refetch: refetchSkills,
   } = useQuery({
     queryKey: CLAUDE_CODE_SKILLS_QUERY_KEY,
     queryFn: listClaudeCodeSkills,
   });
-  const skillActionSuggestions = useMemo(() => getSkillActionSuggestions(skills ?? []), [skills]);
+  const skillActionSuggestions = useMemo(
+    () => (isSkillsError ? DEFAULT_LANDING_ACTIONS : getSkillActionSuggestions(skills ?? [])),
+    [isSkillsError, skills]
+  );
+  const totalActionSourceCount = isSkillsError
+    ? DEFAULT_LANDING_ACTIONS.length
+    : (skills?.length ?? 0);
 
   useBreadcrumbs({
     items: [{ slotLabel: 'Dashboard' }],
@@ -146,11 +175,9 @@ export const DashboardLandingRoute: FC = () => {
 
               <SkillActionSection
                 actions={skillActionSuggestions}
-                isError={isSkillsError}
                 isLoading={isSkillsLoading}
-                onRetry={() => void refetchSkills()}
                 onSelect={handlePromptSelect}
-                totalSkillCount={skills?.length ?? 0}
+                totalSkillCount={totalActionSourceCount}
               />
             </Flex>
           </main>

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
@@ -2,70 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { GradientBackground } from '@nemo/common/src/components/GradientBackground';
-import { Button, Card, Flex, Text, TextArea, Tooltip } from '@nvidia/foundations-react-core';
+import { Button, Flex, Text, TextArea, Tooltip } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import {
+  CLAUDE_CODE_SKILLS_QUERY_KEY,
+  listClaudeCodeSkills,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/api';
 import { ClaudeCodeLayout } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeLayout';
 import type { ClaudeCodeChatRouteState } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import { SkillActionSection } from '@studio/routes/DashboardLandingRoute/SkillActionSection';
+import { getSkillActionSuggestions } from '@studio/routes/DashboardLandingRoute/skillActionSuggestions';
 import { getClaudeCodeChatRoute } from '@studio/routes/utils';
-import { FlaskConical, HatGlasses, KeyRound, Send, Terminal } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { Send, Terminal } from 'lucide-react';
 import {
   type ChangeEvent,
   type FC,
   type FormEvent,
   type KeyboardEvent,
-  type ReactNode,
   useCallback,
+  useMemo,
   useState,
 } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-interface PromptSuggestion {
-  title: string;
-  prompt: string;
-  icon: ReactNode;
-}
-
-const PROMPT_SUGGESTIONS: PromptSuggestion[] = [
-  {
-    title: 'Create an agent',
-    prompt: 'Create a new agent in this workspace and deploy it once it is ready.',
-    icon: <HatGlasses size={18} />,
-  },
-  {
-    title: 'Start an evaluation',
-    prompt: 'Start an evaluation for one of my agents using an example evaluation config.',
-    icon: <FlaskConical size={18} />,
-  },
-  {
-    title: 'Set up a secret',
-    prompt: 'Help me create a workspace secret for an API key.',
-    icon: <KeyRound size={18} />,
-  },
-];
-
-const PromptCard = ({
-  suggestion,
-  onSelect,
-}: {
-  suggestion: PromptSuggestion;
-  onSelect: () => void;
-}) => (
-  <Card asChild interactive className="min-h-28 w-full cursor-pointer shadow-none!">
-    <button type="button" onClick={onSelect}>
-      <span className="flex size-8 items-center justify-center rounded bg-surface-raised text-accent">
-        {suggestion.icon}
-      </span>
-      <span className="min-w-0">
-        <Text kind="label/bold/md">{suggestion.title}</Text>
-        <Text kind="body/regular/sm" color="secondary" className="mt-1 line-clamp-2">
-          {suggestion.prompt}
-        </Text>
-      </span>
-    </button>
-  </Card>
-);
 
 const LandingComposer = ({
   input,
@@ -142,6 +103,16 @@ export const DashboardLandingRoute: FC = () => {
   const workspace = useWorkspaceFromPath();
   const navigate = useNavigate();
   const [input, setInput] = useState('');
+  const {
+    data: skills,
+    isError: isSkillsError,
+    isLoading: isSkillsLoading,
+    refetch: refetchSkills,
+  } = useQuery({
+    queryKey: CLAUDE_CODE_SKILLS_QUERY_KEY,
+    queryFn: listClaudeCodeSkills,
+  });
+  const skillActionSuggestions = useMemo(() => getSkillActionSuggestions(skills ?? []), [skills]);
 
   useBreadcrumbs({
     items: [{ slotLabel: 'Dashboard' }],
@@ -173,15 +144,14 @@ export const DashboardLandingRoute: FC = () => {
 
               <LandingComposer input={input} onChange={setInput} onSubmit={handleSubmit} />
 
-              <Flex className="grid w-full grid-cols-1 gap-3 md:grid-cols-3">
-                {PROMPT_SUGGESTIONS.map((suggestion) => (
-                  <PromptCard
-                    key={suggestion.title}
-                    suggestion={suggestion}
-                    onSelect={() => handlePromptSelect(suggestion.prompt)}
-                  />
-                ))}
-              </Flex>
+              <SkillActionSection
+                actions={skillActionSuggestions}
+                isError={isSkillsError}
+                isLoading={isSkillsLoading}
+                onRetry={() => void refetchSkills()}
+                onSelect={handlePromptSelect}
+                totalSkillCount={skills?.length ?? 0}
+              />
             </Flex>
           </main>
         </GradientBackground>

--- a/web/packages/studio/src/routes/DashboardLandingRoute/skillActionSuggestions.ts
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/skillActionSuggestions.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { featureFlags } from '@studio/constants/featureFlags';
+import type { ClaudeCodeSkill } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import {
+  SKILL_ACTION_TEMPLATES,
+  type SkillActionSuggestion,
+  type SkillActionTemplate,
+  type SkillActionTemplateName,
+} from '@studio/routes/DashboardLandingRoute/skillActionTemplateCatalog';
+import {
+  getSkillDisplayName,
+  getSkillLookupKeys,
+} from '@studio/routes/DashboardLandingRoute/skillDisplayName';
+import { Wrench } from 'lucide-react';
+import { createElement } from 'react';
+
+export type {
+  SkillActionSuggestion,
+  SkillActionTemplate,
+} from '@studio/routes/DashboardLandingRoute/skillActionTemplateCatalog';
+
+const isSkillActionTemplateName = (skillName: string): skillName is SkillActionTemplateName =>
+  Object.prototype.hasOwnProperty.call(SKILL_ACTION_TEMPLATES, skillName);
+
+const getSkillActionTemplate = (skill: ClaudeCodeSkill): SkillActionTemplate | undefined => {
+  for (const lookupKey of getSkillLookupKeys(skill)) {
+    if (isSkillActionTemplateName(lookupKey)) {
+      return SKILL_ACTION_TEMPLATES[lookupKey];
+    }
+  }
+
+  return undefined;
+};
+
+const getFallbackSkillActionTemplate = (skill: ClaudeCodeSkill): SkillActionTemplate => ({
+  title: getSkillDisplayName(skill),
+  description: skill.description || 'Use this NeMo Platform skill in Claude Code.',
+  prompt: `Use the ${skill.name} skill for this NeMo Platform task. Inspect the workspace first and ask for anything missing before acting.`,
+  icon: createElement(Wrench, { size: 18 }),
+});
+
+export const isSkillActionEnabled = (template: SkillActionTemplate) =>
+  template.requiredFeatureFlags?.every((flag) => featureFlags[flag] !== false) ?? true;
+
+export const getSkillActionSuggestions = (skills: ClaudeCodeSkill[]): SkillActionSuggestion[] => {
+  const seenSkills = new Set<string>();
+  const suggestions: SkillActionSuggestion[] = [];
+
+  for (const skill of skills) {
+    const skillKey = `${skill.name}:${skill.claude_name}`;
+    if (seenSkills.has(skillKey)) continue;
+
+    const template = getSkillActionTemplate(skill) ?? getFallbackSkillActionTemplate(skill);
+    if (!isSkillActionEnabled(template)) continue;
+
+    seenSkills.add(skillKey);
+    suggestions.push({
+      ...template,
+      skillName: skill.name,
+      claudeName: skill.claude_name,
+    });
+  }
+
+  return suggestions;
+};

--- a/web/packages/studio/src/routes/DashboardLandingRoute/skillActionTemplateCatalog.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/skillActionTemplateCatalog.tsx
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FeatureFlags } from '@studio/constants/featureFlags/featureFlags';
+import {
+  BarChart3,
+  Database,
+  Gauge,
+  GitBranch,
+  Hammer,
+  KeyRound,
+  Search,
+  SearchCheck,
+  ShieldCheck,
+  Sparkles,
+  Terminal,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
+
+export interface SkillActionTemplate {
+  title: string;
+  description: string;
+  prompt: string;
+  icon: ReactNode;
+  requiredFeatureFlags?: readonly FeatureFlagName[];
+}
+
+export interface SkillActionSuggestion extends SkillActionTemplate {
+  skillName: string;
+  claudeName: string;
+}
+
+type FeatureFlagName = keyof FeatureFlags;
+
+export const SKILL_ACTION_TEMPLATES = {
+  'agents-optimize': {
+    title: 'Optimize an agent',
+    description: 'Find routing, prompt, model, and skill changes that improve cost or quality.',
+    prompt:
+      'Use the agents-optimize skill to inspect a deployed NeMo agent and recommend changes that improve cost, latency, or quality.',
+    icon: <Gauge size={18} />,
+    requiredFeatureFlags: ['agentsEnabled'],
+  },
+  'agents-secure': {
+    title: 'Harden an agent',
+    description: 'Audit safety, PII, guardrails, and secret exposure risks.',
+    prompt:
+      'Use the agents-secure skill to audit a deployed NeMo agent for safety, PII exposure, missing guardrails, and leaked secrets.',
+    icon: <SearchCheck size={18} />,
+    requiredFeatureFlags: ['agentsEnabled'],
+  },
+  anonymizer: {
+    title: 'Anonymize a dataset',
+    description: 'Detect and replace PII in CSV or Parquet data.',
+    prompt:
+      'Use the anonymizer skill to detect and anonymize PII in a dataset. Inspect the available files first and recommend a replacement strategy.',
+    icon: <Database size={18} />,
+    requiredFeatureFlags: ['datasetsEnabled'],
+  },
+  auditor: {
+    title: 'Run a security audit',
+    description: 'Scan an agent target for vulnerabilities and risky behavior.',
+    prompt:
+      'Use the auditor skill to configure and run a security audit for a NeMo Platform agent target.',
+    icon: <SearchCheck size={18} />,
+    requiredFeatureFlags: ['agentsEnabled'],
+  },
+  'guardrails-plugin': {
+    title: 'Debug guardrails middleware',
+    description: 'Create, attach, and verify guardrail configs through inference middleware.',
+    prompt:
+      'Use the guardrails-plugin skill to create, attach, or debug guardrail middleware for a NeMo inference path.',
+    icon: <ShieldCheck size={18} />,
+    requiredFeatureFlags: ['guardrailsEnabled'],
+  },
+  inference: {
+    title: 'Configure inference',
+    description: 'Register providers, virtual models, routing, and translation middleware.',
+    prompt:
+      'Use the inference skill to configure a NeMo inference provider, virtual model, or middleware route in this workspace.',
+    icon: <GitBranch size={18} />,
+    requiredFeatureFlags: ['inferenceProviderEnabled'],
+  },
+  'nemo-build-agent': {
+    title: 'Build an agent',
+    description: 'Scaffold and deploy a NAT workflow from an agent spec.',
+    prompt:
+      'Use the nemo-build-agent skill to scaffold and deploy a NeMo agent from an existing spec. Inspect the workspace first and ask for the target spec if needed.',
+    icon: <Hammer size={18} />,
+    requiredFeatureFlags: ['agentsEnabled'],
+  },
+  'nemo-data-designer-plugin': {
+    title: 'Generate synthetic data',
+    description: 'Create a dataset or data generation workflow.',
+    prompt:
+      'Use the nemo-data-designer-plugin skill to create a synthetic dataset for this workspace. Ask for any missing dataset requirements before generating files.',
+    icon: <Sparkles size={18} />,
+    requiredFeatureFlags: ['dataDesignerEnabled'],
+  },
+  'nemo-eval-history': {
+    title: 'Review eval history',
+    description: 'Inspect previous evaluation runs and compare outcomes.',
+    prompt:
+      'Use the nemo-eval-history skill to review previous evaluation runs and summarize the most important changes or failures.',
+    icon: <BarChart3 size={18} />,
+    requiredFeatureFlags: ['evaluatorEnabled'],
+  },
+  'nemo-evaluator': {
+    title: 'Run model evaluations',
+    description: 'Create metrics or benchmarks and inspect results.',
+    prompt:
+      'Use the nemo-evaluator skill to create or run an evaluation, then summarize the metric results and any follow-up recommendations.',
+    icon: <BarChart3 size={18} />,
+    requiredFeatureFlags: ['evaluatorEnabled'],
+  },
+  'nemo-evaluator-plugin': {
+    title: 'Use evaluator plugin',
+    description: 'Work with evaluator jobs, SDK specs, and plugin-owned skills.',
+    prompt:
+      'Use the nemo-evaluator-plugin skill to inspect or update evaluator plugin jobs, SDK specs, or plugin-owned evaluator skills.',
+    icon: <BarChart3 size={18} />,
+    requiredFeatureFlags: ['evaluatorEnabled'],
+  },
+  'nemo-explore': {
+    title: 'Explore an agent idea',
+    description: 'Capture the job, audience, tools, model, and constraints.',
+    prompt:
+      'Use the nemo-explore skill to guide an agent design conversation and capture the important decisions before writing a spec.',
+    icon: <Search size={18} />,
+    requiredFeatureFlags: ['agentsEnabled'],
+  },
+  'nemo-files': {
+    title: 'Manage filesets',
+    description: 'Upload, download, and inspect datasets or JSONL artifacts.',
+    prompt:
+      'Use the nemo-files skill to inspect filesets and help upload, download, or manage dataset artifacts for this workspace.',
+    icon: <Database size={18} />,
+    requiredFeatureFlags: ['datasetsEnabled'],
+  },
+  'nemo-fine-tune': {
+    title: 'Check fine-tuning status',
+    description: 'Confirm what fine-tuning path is currently available.',
+    prompt:
+      'Use the nemo-fine-tune skill to explain the current fine-tuning status for NeMo Platform and avoid unsupported training paths.',
+    icon: <Gauge size={18} />,
+    requiredFeatureFlags: ['customizerEnabled'],
+  },
+  'nemo-guardrails': {
+    title: 'Add guardrails to an agent',
+    description: 'Configure content safety and apply rails to inference.',
+    prompt:
+      'Use the nemo-guardrails skill to add input and output guardrails to an agent in this workspace. Start by inspecting what exists, then propose and implement the safest path.',
+    icon: <ShieldCheck size={18} />,
+    requiredFeatureFlags: ['guardrailsEnabled'],
+  },
+  'nemo-model-selection': {
+    title: 'Choose a model',
+    description: 'Compare model options for an agent or workflow.',
+    prompt:
+      'Use the nemo-model-selection skill to compare model options for a NeMo Platform agent or workflow and recommend a starting point.',
+    icon: <SearchCheck size={18} />,
+    requiredFeatureFlags: ['baseModelsEnabled'],
+  },
+  'nemo-secrets': {
+    title: 'Manage secrets',
+    description: 'Create, list, or update credentials for platform workflows.',
+    prompt:
+      'Use the nemo-secrets skill to help manage credentials for this workspace. Start by checking what secret operation is needed.',
+    icon: <KeyRound size={18} />,
+    requiredFeatureFlags: ['secretsEnabled'],
+  },
+  'nemo-skill-selection': {
+    title: 'Pick the right NeMo skill',
+    description: 'Route a broad task to the right specialized workflow.',
+    prompt:
+      'Use the nemo-skill-selection skill to route this NeMo Platform task to the right specialized skill before taking action.',
+    icon: <GitBranch size={18} />,
+    requiredFeatureFlags: ['agentsEnabled'],
+  },
+  'nemo-spec': {
+    title: 'Write an agent spec',
+    description: 'Turn exploration notes into a durable agent specification.',
+    prompt:
+      'Use the nemo-spec skill to turn the current agent design notes into a durable NeMo Platform agent specification.',
+    icon: <Hammer size={18} />,
+    requiredFeatureFlags: ['agentsEnabled'],
+  },
+  'nemo-status': {
+    title: 'Check platform status',
+    description: 'Summarize health, providers, deployed agents, and available models.',
+    prompt:
+      'Use the nemo-status skill to check NeMo Platform health, deployed agents, providers, and available models.',
+    icon: <Terminal size={18} />,
+    requiredFeatureFlags: ['agentsEnabled'],
+  },
+  'nemo-teardown': {
+    title: 'Shut down platform',
+    description: 'Choose a safe stop or cleanup path for local services.',
+    prompt:
+      'Use the nemo-teardown skill to guide a safe NeMo Platform shutdown or cleanup. Confirm before any destructive action.',
+    icon: <Terminal size={18} />,
+    requiredFeatureFlags: ['agentsEnabled'],
+  },
+  'nemo-try-agent': {
+    title: 'Try a deployed agent',
+    description: 'Send a query to an agent or fall back to model chat.',
+    prompt:
+      'Use the nemo-try-agent skill to send a query to a deployed NeMo Platform agent, announcing the routing decision before sending.',
+    icon: <Terminal size={18} />,
+    requiredFeatureFlags: ['agentsEnabled'],
+  },
+  'safe-synthesizer': {
+    title: 'Generate safety data',
+    description: 'Create safety-focused synthetic data with Safe Synthesizer.',
+    prompt:
+      'Use the safe-synthesizer skill to create safety-focused synthetic data for a NeMo Platform workflow.',
+    icon: <Sparkles size={18} />,
+    requiredFeatureFlags: ['safeSynthesizerEnabled'],
+  },
+  'skills-optimization': {
+    title: 'Optimize agent skills',
+    description: 'Run skill evaluation and improvement loops.',
+    prompt:
+      'Use the skills-optimization skill to evaluate and improve an agent skill suite, then summarize the recommended changes.',
+    icon: <Gauge size={18} />,
+    requiredFeatureFlags: ['agentsEnabled'],
+  },
+} satisfies Record<string, SkillActionTemplate>;
+
+export type SkillActionTemplateName = keyof typeof SKILL_ACTION_TEMPLATES;

--- a/web/packages/studio/src/routes/DashboardLandingRoute/skillActionTemplates.spec.ts
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/skillActionTemplates.spec.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ClaudeCodeSkill } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import { getSkillActionSuggestions } from '@studio/routes/DashboardLandingRoute/skillActionSuggestions';
+import { mockFeatureFlags } from '@studio/tests/util/mockFeatureFlags';
+
+const skill = (overrides: Partial<ClaudeCodeSkill>): ClaudeCodeSkill => ({
+  name: 'inference',
+  claude_name: 'nemo-inference',
+  description: 'Use NeMo Platform inference.',
+  source: 'nemo-platform',
+  install_path: '.claude/skills/nemo-inference/SKILL.md',
+  installed: false,
+  ...overrides,
+});
+
+describe('getSkillActionSuggestions', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves templates from claude install names without alias tables', () => {
+    mockFeatureFlags({ inferenceProviderEnabled: true });
+
+    const [suggestion] = getSkillActionSuggestions([
+      skill({ name: 'inference', claude_name: 'nemo-inference' }),
+    ]);
+
+    expect(suggestion?.title).toBe('Configure inference');
+    expect(suggestion?.skillName).toBe('inference');
+  });
+
+  it('creates a fallback card for skills without curated templates', () => {
+    const [suggestion] = getSkillActionSuggestions([
+      skill({
+        name: 'custom-plugin-skill',
+        claude_name: 'nemo-custom-plugin-skill',
+        description: 'A plugin-specific workflow.',
+      }),
+    ]);
+
+    expect(suggestion?.title).toBe('Custom Plugin Skill');
+    expect(suggestion?.prompt).toContain('custom-plugin-skill');
+  });
+
+  it('filters curated templates when required feature flags are disabled', () => {
+    mockFeatureFlags({ guardrailsEnabled: false });
+
+    expect(
+      getSkillActionSuggestions([
+        skill({ name: 'nemo-guardrails', claude_name: 'nemo-nemo-guardrails' }),
+      ])
+    ).toEqual([]);
+  });
+});

--- a/web/packages/studio/src/routes/DashboardLandingRoute/skillDisplayName.spec.ts
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/skillDisplayName.spec.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ClaudeCodeSkill } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import {
+  getSkillDisplayName,
+  getSkillLookupKeys,
+} from '@studio/routes/DashboardLandingRoute/skillDisplayName';
+
+const skill = (overrides: Partial<ClaudeCodeSkill>): ClaudeCodeSkill => ({
+  name: 'inference',
+  claude_name: 'nemo-inference',
+  description: 'Use NeMo Platform inference.',
+  source: 'nemo-platform',
+  install_path: '.claude/skills/nemo-inference/SKILL.md',
+  installed: false,
+  ...overrides,
+});
+
+describe('getSkillDisplayName', () => {
+  it('title-cases simple skill names', () => {
+    expect(getSkillDisplayName(skill({ name: 'inference' }))).toBe('Inference');
+  });
+
+  it('strips repeated nemo- prefixes before title-casing', () => {
+    expect(getSkillDisplayName(skill({ name: 'nemo-guardrails' }))).toBe('Guardrails');
+    expect(getSkillDisplayName(skill({ name: 'nemo-build-agent' }))).toBe('Build Agent');
+  });
+});
+
+describe('getSkillLookupKeys', () => {
+  it('normalizes claude install names back to template keys', () => {
+    expect(
+      getSkillLookupKeys(skill({ name: 'nemo-guardrails', claude_name: 'nemo-nemo-guardrails' }))
+    ).toEqual(expect.arrayContaining(['nemo-guardrails', 'guardrails', 'nemo-nemo-guardrails']));
+  });
+
+  it('maps nemo-inference to the inference template key', () => {
+    expect(getSkillLookupKeys(skill({ name: 'inference', claude_name: 'nemo-inference' }))).toEqual(
+      expect.arrayContaining(['inference', 'nemo-inference'])
+    );
+  });
+});

--- a/web/packages/studio/src/routes/DashboardLandingRoute/skillDisplayName.ts
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/skillDisplayName.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ClaudeCodeSkill } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+
+const titleCaseSkillSegment = (segment: string): string =>
+  segment ? segment.charAt(0).toUpperCase() + segment.slice(1) : segment;
+
+/** Strip repeated ``nemo-`` prefixes before title-casing skill folder names. */
+export const getSkillLookupKeys = (skill: ClaudeCodeSkill): string[] => {
+  const keys = new Set<string>();
+
+  for (const rawName of [skill.name, skill.claude_name]) {
+    let current = rawName;
+    keys.add(current);
+    while (current.startsWith('nemo-')) {
+      current = current.slice(5);
+      keys.add(current);
+    }
+  }
+
+  return [...keys];
+};
+
+export const getSkillDisplayName = (skill: ClaudeCodeSkill): string => {
+  let name = skill.name;
+  while (name.startsWith('nemo-')) {
+    name = name.slice(5);
+  }
+
+  const displayName = name.split('-').filter(Boolean).map(titleCaseSkillSegment).join(' ');
+
+  return displayName || skill.claude_name;
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeHistoryPanel.spec.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeHistoryPanel.spec.tsx
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ClaudeCodeHistoryPanel } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeHistoryPanel';
+import { render, screen } from '@studio/tests/util/render';
+import userEvent from '@testing-library/user-event';
+
+const mocks = vi.hoisted(() => ({
+  listClaudeCodeHistorySessions: vi.fn(),
+  listClaudeCodeSkills: vi.fn(),
+}));
+
+vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/api', () => ({
+  CLAUDE_CODE_HISTORY_SESSIONS_QUERY_KEY: ['claude-code', 'history', 'sessions'],
+  CLAUDE_CODE_SKILLS_QUERY_KEY: ['claude-code', 'skills'],
+  listClaudeCodeHistorySessions: mocks.listClaudeCodeHistorySessions,
+  listClaudeCodeSkills: mocks.listClaudeCodeSkills,
+}));
+
+describe('ClaudeCodeHistoryPanel', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    mocks.listClaudeCodeHistorySessions.mockResolvedValue([]);
+    mocks.listClaudeCodeSkills.mockResolvedValue([
+      {
+        name: 'inference',
+        claude_name: 'nemo-inference',
+        description: 'Use NeMo Platform inference.',
+        source: 'nemo-platform',
+        source_path: 'packages/nemo_platform_ext/src/nemo_platform_ext/skills/inference',
+        install_path: '.claude/skills/nemo-inference/SKILL.md',
+        installed: false,
+      },
+    ]);
+  });
+
+  it('renders history and skills segmented controls', () => {
+    render(
+      <ClaudeCodeHistoryPanel
+        activeSessionId="session-1"
+        onNewChat={vi.fn()}
+        onSelectSession={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('radio', { name: 'History' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Skills' })).not.toBeChecked();
+    expect(screen.getByRole('button', { name: 'New chat' })).toBeInTheDocument();
+  });
+
+  it('renders history sessions and keeps selection working', async () => {
+    const user = userEvent.setup();
+    const onNewChat = vi.fn();
+    const onSelectSession = vi.fn();
+    mocks.listClaudeCodeHistorySessions.mockResolvedValue([
+      {
+        session_id: 'session-1',
+        mtime: Date.now() / 1000,
+        first_prompt: 'Review the latest agent work',
+        message_count: 2,
+        token_count: 100,
+        tool_call_count: 1,
+        tool_calls: ['Bash'],
+      },
+    ]);
+
+    render(
+      <ClaudeCodeHistoryPanel
+        activeSessionId="session-1"
+        onNewChat={onNewChat}
+        onSelectSession={onSelectSession}
+      />
+    );
+
+    expect(await screen.findByText('Review the latest agent work')).toBeInTheDocument();
+    expect(screen.getByText('Bash')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'New chat' }));
+    expect(onNewChat).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: /Review the latest agent work/ }));
+    expect(onSelectSession).toHaveBeenCalledWith('session-1');
+  });
+
+  it('lists Claude Code skills in the skills tab', async () => {
+    const user = userEvent.setup();
+    render(
+      <ClaudeCodeHistoryPanel
+        activeSessionId="session-1"
+        onNewChat={vi.fn()}
+        onSelectSession={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('radio', { name: 'Skills' }));
+
+    expect(await screen.findByText('Inference')).toBeInTheDocument();
+    expect(screen.getByText('Use NeMo Platform inference.')).toBeInTheDocument();
+    expect(screen.getByText('nemo-inference')).toBeInTheDocument();
+    expect(screen.queryByText('Source: nemo-platform')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Skill file:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Claude file:/)).not.toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeHistoryPanel.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeHistoryPanel.tsx
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  Badge,
   Banner,
   Button,
+  Card,
   Flex,
+  SegmentedControl,
   Skeleton,
   Stack,
   Text,
@@ -13,14 +16,21 @@ import {
 import { Empty } from '@studio/components/Empty';
 import {
   CLAUDE_CODE_HISTORY_SESSIONS_QUERY_KEY,
+  CLAUDE_CODE_SKILLS_QUERY_KEY,
   listClaudeCodeHistorySessions,
+  listClaudeCodeSkills,
 } from '@studio/routes/agents/ClaudeCodeChatRoute/api';
-import type { ClaudeCodeHistorySession } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import type {
+  ClaudeCodeHistorySession,
+  ClaudeCodeSkill,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import { getSkillDisplayName } from '@studio/routes/DashboardLandingRoute/skillDisplayName';
 import { useLocalStorage } from '@studio/util/hooks/useLocalStorage';
-import { CLAUDE_CODE_HISTORY_OPEN_KEY } from '@studio/util/localStorage';
+import { CLAUDE_CODE_HISTORY_OPEN_KEY, CLAUDE_CODE_PANEL_TAB_KEY } from '@studio/util/localStorage';
 import { useQuery } from '@tanstack/react-query';
 import cn from 'classnames';
 import {
+  BookOpen,
   History,
   MessageSquare,
   MessageSquarePlus,
@@ -36,6 +46,32 @@ interface ClaudeCodeHistoryPanelProps {
   onNewChat: () => void;
   onSelectSession: (sessionId: string) => void;
 }
+
+type ClaudeCodePanelTab = 'history' | 'skills';
+
+const isClaudeCodePanelTab = (value: string): value is ClaudeCodePanelTab =>
+  value === 'history' || value === 'skills';
+
+const PANEL_TAB_ITEMS = [
+  {
+    value: 'history',
+    children: (
+      <Flex align="center" gap="density-xs">
+        <History size={16} />
+        History
+      </Flex>
+    ),
+  },
+  {
+    value: 'skills',
+    children: (
+      <Flex align="center" gap="density-xs">
+        <BookOpen size={16} />
+        Skills
+      </Flex>
+    ),
+  },
+];
 
 const getCompactRelativeTime = (mtime: number): string => {
   const elapsedMs = Math.max(Date.now() - mtime * 1000, 0);
@@ -61,6 +97,14 @@ const HistoryPanelSkeleton = () => (
     <Skeleton className="h-16 w-full" />
     <Skeleton className="h-16 w-full" />
     <Skeleton className="h-16 w-full" />
+  </Stack>
+);
+
+const SkillsPanelSkeleton = () => (
+  <Stack gap="density-sm" padding="density-md">
+    <Skeleton className="h-24 w-full" />
+    <Skeleton className="h-24 w-full" />
+    <Skeleton className="h-24 w-full" />
   </Stack>
 );
 
@@ -124,18 +168,44 @@ const HistorySessionButton = ({
   </button>
 );
 
-interface HistoryPanelContentsProps extends ClaudeCodeHistoryPanelProps {
-  collapseLabel: string;
-  onCollapse: () => void;
-}
+const SkillCard = ({ skill }: { skill: ClaudeCodeSkill }) => (
+  <Card
+    className="h-auto shadow-none [&_.nv-card-content]:p-density-md"
+    attributes={{ CardContent: { className: 'min-h-0' } }}
+  >
+    <Stack gap="density-sm" className="min-w-0">
+      <Flex align="start" justify="between" gap="density-sm" className="min-w-0">
+        <Flex align="start" gap="density-sm" className="min-w-0">
+          <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded bg-surface-sunken text-secondary">
+            <BookOpen size={14} />
+          </span>
+          <Stack gap="density-xxs" className="min-w-0">
+            <Text kind="body/semibold/sm" className="truncate" title={skill.name}>
+              {getSkillDisplayName(skill)}
+            </Text>
+            <Text kind="body/regular/xs" color="secondary" className="truncate">
+              {skill.claude_name}
+            </Text>
+          </Stack>
+        </Flex>
+        {skill.installed ? (
+          <Badge kind="solid" color="green" className="shrink-0">
+            Installed
+          </Badge>
+        ) : null}
+      </Flex>
+      <Text kind="body/regular/sm" color="secondary" className="break-words">
+        {skill.description || 'No description'}
+      </Text>
+    </Stack>
+  </Card>
+);
 
 const HistoryPanelContents = ({
   activeSessionId,
-  collapseLabel,
-  onCollapse,
   onNewChat,
   onSelectSession,
-}: HistoryPanelContentsProps) => {
+}: ClaudeCodeHistoryPanelProps) => {
   const {
     data: sessions = [],
     error,
@@ -148,19 +218,19 @@ const HistoryPanelContents = ({
 
   return (
     <>
-      <Flex
-        align="center"
-        justify="between"
-        gap="density-sm"
-        className="border-b border-base px-density-md py-density-sm"
-      >
-        <Flex align="center" gap="density-sm" className="min-w-0">
-          <History size={18} className="shrink-0 text-secondary" />
-          <Text kind="label/bold/md" className="truncate">
-            Claude history
-          </Text>
-        </Flex>
+      <div className="border-b border-base px-density-md py-density-sm">
         <Flex align="center" gap="density-xs">
+          <Button
+            color="neutral"
+            kind="secondary"
+            size="small"
+            type="button"
+            className="min-w-0 flex-1"
+            onClick={onNewChat}
+          >
+            <MessageSquarePlus size={16} />
+            <Text kind="label/bold/md">New chat</Text>
+          </Button>
           <Tooltip slotContent="Refresh history">
             <Button
               aria-label="Refresh history"
@@ -173,31 +243,7 @@ const HistoryPanelContents = ({
               <RefreshCw size={16} />
             </Button>
           </Tooltip>
-          <Tooltip slotContent={collapseLabel} side="left">
-            <Button
-              aria-label={collapseLabel}
-              kind="tertiary"
-              size="small"
-              type="button"
-              onClick={onCollapse}
-            >
-              <PanelRightClose size={18} />
-            </Button>
-          </Tooltip>
         </Flex>
-      </Flex>
-      <div className="border-b border-base px-density-md py-density-sm">
-        <Button
-          color="neutral"
-          kind="secondary"
-          size="small"
-          type="button"
-          className="w-full"
-          onClick={onNewChat}
-        >
-          <MessageSquarePlus size={16} />
-          <Text kind="label/bold/md">New chat</Text>
-        </Button>
       </div>
       {error && (
         <div className="px-density-md py-density-sm">
@@ -228,10 +274,77 @@ const HistoryPanelContents = ({
   );
 };
 
+const SkillsPanelContents = () => {
+  const {
+    data: skills = [],
+    error,
+    isLoading,
+    refetch,
+  } = useQuery({
+    queryKey: CLAUDE_CODE_SKILLS_QUERY_KEY,
+    queryFn: listClaudeCodeSkills,
+  });
+
+  return (
+    <>
+      <Flex
+        align="center"
+        justify="between"
+        gap="density-sm"
+        className="border-b border-base px-density-md py-density-sm"
+      >
+        <Text kind="body/regular/sm" color="secondary">
+          {skills.length} skills
+        </Text>
+        <Tooltip slotContent="Refresh skills">
+          <Button
+            aria-label="Refresh skills"
+            kind="tertiary"
+            size="small"
+            type="button"
+            disabled={isLoading}
+            onClick={() => void refetch()}
+          >
+            <RefreshCw size={16} />
+          </Button>
+        </Tooltip>
+      </Flex>
+      {error && (
+        <div className="px-density-md py-density-sm">
+          <Banner kind="inline" status="error">
+            Could not load Claude skills.
+          </Banner>
+        </div>
+      )}
+      {isLoading ? (
+        <SkillsPanelSkeleton />
+      ) : skills.length ? (
+        <div className="min-h-0 flex-1 overflow-y-auto p-density-sm">
+          <Stack gap="density-md">
+            {skills.map((skill) => (
+              <SkillCard key={skill.claude_name} skill={skill} />
+            ))}
+          </Stack>
+        </div>
+      ) : !error ? (
+        <Flex className="min-h-0 flex-1" align="center" justify="center">
+          <Empty title="No skills found" description="Claude Code skills will appear here." />
+        </Flex>
+      ) : null}
+    </>
+  );
+};
+
 export const ClaudeCodeHistoryPanel: FC<ClaudeCodeHistoryPanelProps> = (props) => {
   const [historyOpen, setHistoryOpen] = useLocalStorage(CLAUDE_CODE_HISTORY_OPEN_KEY, 'true');
+  const [panelTab, setPanelTab] = useLocalStorage(CLAUDE_CODE_PANEL_TAB_KEY, 'history');
   const isOpen = historyOpen !== 'false';
+  const selectedTab =
+    typeof panelTab === 'string' && isClaudeCodePanelTab(panelTab) ? panelTab : 'history';
   const toggleLabel = isOpen ? 'Collapse Claude history' : 'Expand Claude history';
+  const handleTabChange = (value: string) => {
+    if (isClaudeCodePanelTab(value)) setPanelTab(value);
+  };
 
   if (!isOpen) {
     return (
@@ -253,11 +366,34 @@ export const ClaudeCodeHistoryPanel: FC<ClaudeCodeHistoryPanelProps> = (props) =
 
   return (
     <aside className="flex min-h-80 w-full shrink-0 flex-col border-t border-base bg-surface-base lg:w-84 lg:border-l lg:border-t-0">
-      <HistoryPanelContents
-        {...props}
-        collapseLabel={toggleLabel}
-        onCollapse={() => setHistoryOpen('false')}
-      />
+      <Flex
+        align="center"
+        justify="between"
+        gap="density-sm"
+        className="border-b border-base px-density-md py-density-sm"
+      >
+        <SegmentedControl
+          size="tiny"
+          value={selectedTab}
+          onValueChange={handleTabChange}
+          items={PANEL_TAB_ITEMS}
+          className="min-w-0 flex-1"
+        />
+        <Tooltip slotContent={toggleLabel} side="left">
+          <Button
+            aria-label={toggleLabel}
+            kind="tertiary"
+            size="small"
+            type="button"
+            onClick={() => setHistoryOpen('false')}
+          >
+            <PanelRightClose size={18} />
+          </Button>
+        </Tooltip>
+      </Flex>
+      <div className="flex min-h-0 flex-1 flex-col">
+        {selectedTab === 'history' ? <HistoryPanelContents {...props} /> : <SkillsPanelContents />}
+      </div>
     </aside>
   );
 };

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.spec.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.spec.ts
@@ -3,6 +3,7 @@
 
 import { BASE_URL } from '@studio/constants/environment';
 import {
+  listClaudeCodeSkills,
   resolveClaudeCodePermission,
   streamClaudeCodeMessage,
 } from '@studio/routes/agents/ClaudeCodeChatRoute/api';
@@ -186,5 +187,37 @@ describe('Claude Code API helpers', () => {
         method: 'POST',
       })
     );
+  });
+
+  it('loads Claude Code skill metadata', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            name: 'inference',
+            claude_name: 'nemo-inference',
+            description: 'Use NeMo Platform inference.',
+            source: 'nemo-platform',
+            source_path: 'packages/nemo_platform_ext/src/nemo_platform_ext/skills/inference',
+            install_path: '.claude/skills/nemo-inference/SKILL.md',
+            installed: false,
+          },
+        ]),
+        { status: 200 }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(listClaudeCodeSkills()).resolves.toEqual([
+      {
+        name: 'inference',
+        claude_name: 'nemo-inference',
+        description: 'Use NeMo Platform inference.',
+        source: 'nemo-platform',
+        source_path: 'packages/nemo_platform_ext/src/nemo_platform_ext/skills/inference',
+        install_path: '.claude/skills/nemo-inference/SKILL.md',
+        installed: false,
+      },
+    ]);
   });
 });

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/api.ts
@@ -10,6 +10,7 @@ import type {
   ClaudeCodePermissionRequest,
   ClaudeCodeSessionHistory,
   ClaudeCodeSessionHistoryItem,
+  ClaudeCodeSkill,
   ClaudeCodeStreamHandlers,
 } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
 
@@ -39,6 +40,8 @@ export const CLAUDE_CODE_HISTORY_SESSIONS_QUERY_KEY = [
   'history',
   'sessions',
 ] as const;
+
+export const CLAUDE_CODE_SKILLS_QUERY_KEY = ['claude-code', 'skills'] as const;
 
 export const getClaudeCodeSessionHistoryQueryKey = (sessionId: string) =>
   ['claude-code', 'history', 'session', sessionId] as const;
@@ -100,6 +103,24 @@ const parseHistorySession = (value: unknown): ClaudeCodeHistorySession | undefin
   };
 };
 
+const parseClaudeCodeSkill = (value: unknown): ClaudeCodeSkill | undefined => {
+  if (!isRecord(value)) return undefined;
+  const name = getString(value.name);
+  const claudeName = getString(value.claude_name);
+  const installPath = getString(value.install_path);
+  if (!name || !claudeName || !installPath) return undefined;
+
+  return {
+    name,
+    claude_name: claudeName,
+    description: getString(value.description),
+    source: getString(value.source) || '-',
+    source_path: getString(value.source_path) || undefined,
+    install_path: installPath,
+    installed: value.installed === true,
+  };
+};
+
 const parseAssistantPart = (value: unknown): ClaudeCodeAssistantHistoryPart | undefined => {
   if (!isRecord(value)) return undefined;
 
@@ -150,6 +171,21 @@ export const listClaudeCodeHistorySessions = async (): Promise<ClaudeCodeHistory
   return body
     .map(parseHistorySession)
     .filter((session): session is ClaudeCodeHistorySession => session !== undefined);
+};
+
+export const listClaudeCodeSkills = async (): Promise<ClaudeCodeSkill[]> => {
+  const response = await fetch(claudeCodeApiUrl('/skills'));
+
+  if (!response.ok) {
+    throw new Error(await getResponseErrorMessage(response, 'Failed to load Claude Code skills'));
+  }
+
+  const body = (await response.json()) as unknown;
+  if (!Array.isArray(body)) return [];
+
+  return body
+    .map(parseClaudeCodeSkill)
+    .filter((skill): skill is ClaudeCodeSkill => skill !== undefined);
 };
 
 export const getClaudeCodeSessionHistory = async (

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/types.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/types.ts
@@ -35,6 +35,16 @@ export interface ClaudeCodeHistorySession {
   tool_calls: string[];
 }
 
+export interface ClaudeCodeSkill {
+  name: string;
+  claude_name: string;
+  description: string;
+  source: string;
+  source_path?: string | null;
+  install_path: string;
+  installed: boolean;
+}
+
 export interface ClaudeCodeUserHistoryItem {
   kind: 'user';
   text: string;

--- a/web/packages/studio/src/util/localStorage.ts
+++ b/web/packages/studio/src/util/localStorage.ts
@@ -3,6 +3,7 @@
 
 export const SIDE_NAV_OPEN_KEY = 'side-nav-open';
 export const CLAUDE_CODE_HISTORY_OPEN_KEY = 'claude-code-history-open';
+export const CLAUDE_CODE_PANEL_TAB_KEY = 'claude-code-panel-tab';
 export const WORKSPACE_DROPDOWN_RECENT_KEY = 'workspace-dropdown-recent';
 export const UI_THEME = 'ui-theme';
 export const SELECTED_WORKSPACE_KEY = 'selected-workspace';


### PR DESCRIPTION

<img width="1728" height="1002" alt="image" src="https://github.com/user-attachments/assets/9c7c4726-e8df-41a6-978c-4da4fcb59c14" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API endpoint exposing Claude skill metadata and install status for the workspace.
  * Dashboard: new Skill Action section with scrollable action cards (loading/error/empty/disabled states, retry) that populate the composer when clicked.
  * Claude Code panel: added "Skills" tab with persisted tab selection and skill cards; skill name normalization and a frontend skill catalog; client helpers to fetch/validate skills.

* **Tests**
  * Added/expanded tests covering skill listing, fallback/error (500), UI states, display-name logic, and action-card behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->