### PR TITLE
ci: pin PR labeler to allowlisted 1.3.0 commit

### DIFF
--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Apply conventional-commit label
     runs-on: ubuntu-latest
     steps:
-      - uses: ytanikin/pr-conventional-commits@6ac1cea04190fc076b0e539025501d7e7d241ac1 # 1.4.0
+      - uses: ytanikin/pr-conventional-commits@b628c5a234cc32513014b7bfdd1e47b532124d98 # 1.3.0
         with:
           task_types: '["feat","fix","docs","style","refactor","perf","test","build","ci","chore","revert","cp"]'
           add_label: 'true'


### PR DESCRIPTION
Every "Label PR by type" run fails with `startup_failure` since #252 merged (e.g. [this run](https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/27300024416)). The org's Actions allowlist permits `ytanikin/pr-conventional-commits` only at `b628c5a234cc32513014b7bfdd1e47b532124d98` (1.3.0), but the workflow pins `6ac1cea04190fc076b0e539025501d7e7d241ac1` (1.4.0), so GitHub rejects the workflow before any job starts.

This repins to the allowlisted commit. The only change between 1.3.0 and 1.4.0 is an optional scope-labeling feature we don't use, plus docs — labeling, validation failure on bad titles, and stale-label removal on retitle are identical.

```sh
❯ gh api repos/NVIDIA-NeMo/nemo-platform/actions/permissions/selected-actions --jq '.patterns_allowed[] | select(test("ytanikin"))'
ytanikin/pr-conventional-commits@b628c5a234cc32513014b7bfdd1e47b532124d98
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal PR workflow automation.

This PR contains only infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->