### PR TITLE
feat(studio): Add Column toggling to GroupExperimentDataView

### DIFF
--- a/web/packages/common/src/components/DataView/StudioDataViewToolbar.tsx
+++ b/web/packages/common/src/components/DataView/StudioDataViewToolbar.tsx
@@ -17,9 +17,8 @@ export interface StudioDataViewToolbarProps<DataType = unknown> {
   }) => ReactNode;
   searchBarProps?: ComponentProps<typeof DataView.SearchBar>;
   /**
-   * Additional content rendered inside the toolbar row, between the search bar and
-   * the filter toggle button. Use this to inject view-specific controls such as a
-   * sort dropdown.
+   * Additional content rendered inside the toolbar row, after the filter toggle button.
+   * Use this to inject view-specific controls such as a sort dropdown.
    */
   slotEnd?: ReactNode;
 }
@@ -66,8 +65,8 @@ export function StudioDataViewToolbar<DataType = unknown>({
             {...searchBarProps}
           />
         )}
-        {slotEnd}
         <FilterPanelToggle showFilters={showFilters} onToggle={onToggleFilters} />
+        {slotEnd}
       </DataView.Toolbar>
       <StudioAppliedFilters />
     </>

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -240,7 +240,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
           slotContent={<div aria-hidden className="h-0 w-[230px]" />}
         >
           <>
-            <Columns3 variant="fill" />
+            <Columns3 />
             <span className="hide-mobile">Columns</span>
           </>
         </EditColumnsMenu>

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { dateTimeFilter } from '@nemo/common/src/components/DataView/dateTimeFilter';
-import { Root as DataViewRoot } from '@nemo/common/src/components/DataView/internal';
+import {
+  Root as DataViewRoot,
+  EditColumnsMenu,
+} from '@nemo/common/src/components/DataView/internal';
 import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
@@ -19,6 +22,7 @@ import { Text, Tooltip } from '@nvidia/foundations-react-core';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { tooltipClassName } from '@studio/styles/common';
 import { keepPreviousData } from '@tanstack/react-query';
+import { Columns3 } from 'lucide-react';
 import { type ComponentProps, type FC, useCallback, useMemo } from 'react';
 
 export type ExperimentRow = ExperimentResponse & { id: string };
@@ -105,6 +109,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
       accessor('name', {
         header: 'Name',
         enableSorting: true,
+        enableHiding: false,
         size: 300,
         cell: ({ row }) => {
           const { name, summary } = row.original;
@@ -226,6 +231,20 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
       dataViewState={dataViewState}
       makeColumns={makeColumns}
       searchField="name"
+      toolbarSlotEnd={
+        <EditColumnsMenu
+          kind="secondary"
+          showChevron={false}
+          // EditColumnsMenu exposes no width control for its dropdown, so this zero-height
+          // spacer sets a min width on the menu (which sizes to its widest child).
+          slotContent={<div aria-hidden className="h-0 w-[230px]" />}
+        >
+          <>
+            <Columns3 variant="fill" />
+            <span className="hide-mobile">Columns</span>
+          </>
+        </EditColumnsMenu>
+      }
       attributes={{
         DataViewRoot: {
           data: tableData,


### PR DESCRIPTION

https://github.com/user-attachments/assets/76cebd93-f1b6-47a7-b7f9-4e2a84ffd56d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Columns" control to the experiment group data view toolbar, letting users open a column visibility menu and adjust which columns are shown.
  * The Name column is now permanently visible and cannot be hidden, ensuring consistent identification across views.

* **Bug Fixes**
  * Adjusted toolbar content ordering so injected controls appear after the filter toggle, ensuring predictable placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->