### PR TITLE
ci: pin all versions for third party actions

### DIFF
--- a/.github/actions/build-nemo-platform-wheel/action.yaml
+++ b/.github/actions/build-nemo-platform-wheel/action.yaml
@@ -115,7 +115,7 @@ runs:
     # find them. Other packages (nemo-platform-plugin, ...) skip these.
     - name: Set up pnpm
       if: inputs.package == 'nemo-platform'
-      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      uses: pnpm/action-setup@v4
       with:
         package_json_file: ${{ inputs.source-root }}/web/package.json
 

--- a/.github/actions/build-nemo-platform-wheel/action.yaml
+++ b/.github/actions/build-nemo-platform-wheel/action.yaml
@@ -124,8 +124,6 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "22"
-        cache: pnpm
-        cache-dependency-path: ${{ inputs.source-root }}/${{ inputs.studio-web-root }}/pnpm-lock.yaml
 
     - name: Install pnpm via Corepack
       if: inputs.package == 'nemo-platform'
@@ -162,6 +160,14 @@ runs:
         corepack enable pnpm
         corepack prepare "${package_manager}" --activate
         pnpm --dir "${studio_web_root}" --version
+
+    - name: Restore pnpm cache
+      if: inputs.package == 'nemo-platform'
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: "22"
+        cache: pnpm
+        cache-dependency-path: ${{ inputs.source-root }}/${{ inputs.studio-web-root }}/pnpm-lock.yaml
 
     - name: Build wheel
       id: build

--- a/.github/actions/build-nemo-platform-wheel/action.yaml
+++ b/.github/actions/build-nemo-platform-wheel/action.yaml
@@ -65,7 +65,7 @@ runs:
   using: composite
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         python-version: ${{ inputs.python-version }}
         enable-cache: true
@@ -115,13 +115,13 @@ runs:
     # find them. Other packages (nemo-platform-plugin, ...) skip these.
     - name: Set up pnpm
       if: inputs.package == 'nemo-platform'
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       with:
         package_json_file: ${{ inputs.source-root }}/web/package.json
 
     - name: Set up Node.js
       if: inputs.package == 'nemo-platform'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "22"
         cache: pnpm

--- a/.github/actions/build-nemo-platform-wheel/action.yaml
+++ b/.github/actions/build-nemo-platform-wheel/action.yaml
@@ -1,6 +1,6 @@
 name: Build nemo-platform wheel
 description: >
-  Set up the build toolchain (uv, plus pnpm/node when building nemo-platform
+  Set up the build toolchain (uv, plus node/pnpm when building nemo-platform
   so the hatch hook can compile Studio assets), stamp the SDK version, and
   run `uv build --wheel --package <pkg>`. The build itself — including
   Studio asset compilation and wheel content force-includes — lives in the
@@ -52,6 +52,12 @@ inputs:
       the ci.yaml test job uses `.`.
     required: false
     default: "."
+  studio-web-root:
+    description: >
+      Path to the Studio pnpm workspace, relative to source-root. This is the
+      directory containing package.json and pnpm-lock.yaml.
+    required: false
+    default: web
 
 outputs:
   wheel-path:
@@ -110,22 +116,52 @@ runs:
         echo "wheel-version=${wheel_version}" >>"${GITHUB_OUTPUT}"
 
     # Studio assets are only force-included by the nemo-platform wrapper.
-    # The hatch hook in packages/nemo-platform/hatch_build.py compiles them
-    # via pnpm during `uv build`; we set up pnpm/node here so the hook can
+    # The hatch hook in packages/nemo_platform/hatch_build.py compiles them
+    # via pnpm during `uv build`; we set up node/pnpm here so the hook can
     # find them. Other packages (nemo-platform-plugin, ...) skip these.
-    - name: Set up pnpm
-      if: inputs.package == 'nemo-platform'
-      uses: pnpm/action-setup@v4
-      with:
-        package_json_file: ${{ inputs.source-root }}/web/package.json
-
     - name: Set up Node.js
       if: inputs.package == 'nemo-platform'
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "22"
         cache: pnpm
-        cache-dependency-path: ${{ inputs.source-root }}/web/pnpm-lock.yaml
+        cache-dependency-path: ${{ inputs.source-root }}/${{ inputs.studio-web-root }}/pnpm-lock.yaml
+
+    - name: Install pnpm via Corepack
+      if: inputs.package == 'nemo-platform'
+      shell: bash
+      env:
+        STUDIO_WEB_ROOT: ${{ inputs.source-root }}/${{ inputs.studio-web-root }}
+      run: |
+        set -euo pipefail
+
+        if [[ ! -d "${STUDIO_WEB_ROOT}" ]]; then
+          echo "::error::Studio web root not found at ${STUDIO_WEB_ROOT}" >&2
+          exit 1
+        fi
+
+        studio_web_root="$(cd "${STUDIO_WEB_ROOT}" && pwd -P)"
+        package_json="${studio_web_root}/package.json"
+        lockfile="${studio_web_root}/pnpm-lock.yaml"
+        if [[ ! -f "${package_json}" ]]; then
+          echo "::error::Studio package.json not found at ${package_json}" >&2
+          exit 1
+        fi
+        if [[ ! -f "${lockfile}" ]]; then
+          echo "::error::Studio pnpm lockfile not found at ${lockfile}" >&2
+          exit 1
+        fi
+
+        package_manager="$(PACKAGE_JSON="${package_json}" node -p "JSON.parse(require('fs').readFileSync(process.env.PACKAGE_JSON, 'utf8')).packageManager || ''")"
+        if [[ "${package_manager}" != pnpm@* ]]; then
+          echo "::error::Expected ${package_json} to declare packageManager: pnpm@..., got '${package_manager}'" >&2
+          exit 1
+        fi
+
+        npm i -g corepack@0.31.0
+        corepack enable pnpm
+        corepack prepare "${package_manager}" --activate
+        pnpm --dir "${studio_web_root}" --version
 
     - name: Build wheel
       id: build

--- a/.github/workflows/release-bundle.yaml
+++ b/.github/workflows/release-bundle.yaml
@@ -64,7 +64,7 @@ jobs:
     steps:
       # Fetch tags so RC auto-increment can use plain local Git.
       - name: Checkout workflow code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -225,7 +225,7 @@ jobs:
           } >>"${GITHUB_OUTPUT}"
 
       - name: Checkout selected source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.repository }}
           ref: ${{ inputs.cadence == 'nightly' && steps.resolve-nightly-source.outputs.source_sha || inputs.source_sha }}
@@ -323,7 +323,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout source at release SHA
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.plan-release.outputs.source_sha }}
           fetch-tags: true
@@ -372,12 +372,12 @@ jobs:
       matrix: ${{ fromJson(needs.plan-release.outputs.sdk_matrix) }}
     steps:
       - name: Checkout workflow code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: workflow
 
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ needs.plan-release.outputs.source_repo }}
           ref: ${{ needs.plan-release.outputs.source_sha }}
@@ -400,7 +400,7 @@ jobs:
           nightly-timestamp: ${{ needs.plan-release.outputs.nightly_timestamp }}
 
       - name: Upload SDK wheel
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-sdk-${{ matrix.id }}
           path: ${{ steps.build-sdk-wheel.outputs.wheel-path }}
@@ -424,17 +424,17 @@ jobs:
       release_checksums_digest: ${{ steps.upload-release.outputs.checksums_digest }}
     steps:
       - name: Checkout workflow code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download SDK wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: release-sdk-*
           path: downloaded-sdk-artifacts
           merge-multiple: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.11"
 
@@ -470,7 +470,7 @@ jobs:
       - name: Upload release bundle artifact
         id: upload-release-bundle
         if: inputs.cadence == 'nightly'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-bundle-${{ needs.plan-release.outputs.release_label }}
           path: release-bundle/

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -26,7 +26,7 @@ jobs:
         if: ${{ github.event_name == 'merge_group' }}
         run: echo "Skipping secrets scan for merge queue"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: ${{ github.event_name != 'merge_group' }}
         with:
           fetch-depth: 0
@@ -57,15 +57,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
             languages: ${{matrix.language}}
             config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
             category: "/language:${{matrix.language}}"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -30,6 +30,7 @@ jobs:
         if: ${{ github.event_name != 'merge_group' }}
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: TruffleHog OSS
         if: ${{ github.event_name != 'merge_group' }}
         id: trufflehog

--- a/.github/workflows/semantic-pull-requests.yaml
+++ b/.github/workflows/semantic-pull-requests.yaml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   semantic-pull-request:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_semantic_pull_request.yml@v0.65.12
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_semantic_pull_request.yml@d48ee21a4986f7281abf746b7d500880c0e91f41 # v1.5.1


### PR DESCRIPTION
This is a step toward automating actions updates with dependabot and maintaining a better security posture. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable Studio web-root input (defaults to "web") to locate the Studio workspace.

* **Chores**
  * CI workflows and actions pinned to immutable commits for more reproducible, secure runs.
  * Node/pnpm toolchain setup hardened: workspace validation, Corepack/pnpm activation, and scoped lockfile/caching to stabilize installs and caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->