### PR TITLE
ci: correct dependencies and logic around dispatch job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -800,7 +800,6 @@ jobs:
 
   notify-ci-consumer:
     name: Notify CI consumer
-    needs: [ci-status]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -798,18 +798,3 @@ jobs:
           printf '%s\n' "${NEEDS_JSON}" \
             | jq -e 'to_entries | map(.value.result) | all(. as $result | ["success", "skipped"] | any($result == .))'
 
-  notify-ci-consumer:
-    name: Notify CI consumer
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Send completion event
-        env:
-          GH_TOKEN: ${{ secrets.CI_DISPATCH_TOKEN }}
-          DISPATCH_REPO: ${{ secrets.CI_DISPATCH_REPO }}
-        run: |
-          jq -n --arg ref "${GITHUB_SHA}" \
-            '{event_type: "ci-passed", client_payload: {ref: $ref}}' \
-          | gh api -X POST "/repos/${DISPATCH_REPO}/dispatches" --input -

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -21,7 +21,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CI_DISPATCH_TOKEN }}
           DISPATCH_REPO: ${{ secrets.CI_DISPATCH_REPO }}
+        shell: bash
         run: |
+          set -euo pipefail
           jq -n --arg ref "${GITHUB_SHA}" \
             '{event_type: "ci-passed", client_payload: {ref: $ref}}' \
           | gh api -X POST "/repos/${DISPATCH_REPO}/dispatches" --input -

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -14,7 +14,6 @@ concurrency:
 jobs:
   notify-ci-consumer:
     name: Notify CI consumer
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Send completion event

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -1,0 +1,27 @@
+name: Dispatch
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  notify-ci-consumer:
+    name: Notify CI consumer
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send completion event
+        env:
+          GH_TOKEN: ${{ secrets.CI_DISPATCH_TOKEN }}
+          DISPATCH_REPO: ${{ secrets.CI_DISPATCH_REPO }}
+        run: |
+          jq -n --arg ref "${GITHUB_SHA}" \
+            '{event_type: "ci-passed", client_payload: {ref: $ref}}' \
+          | gh api -X POST "/repos/${DISPATCH_REPO}/dispatches" --input -


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved CI notification out of the main workflow into a dedicated dispatch workflow that triggers on pushes to main.
  * Added a separate dispatch job that emits a "ci-passed" dispatch event to the external consumer.
  * Removed the previous notification job from the main CI flow.
  * Main CI now ends with an aggregate status summary and a validation step ensuring dependent jobs are success or skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->