### PR TITLE
fix: Data Designer UX improvements

### DIFF
--- a/packages/data_designer_nemo/src/data_designer_nemo/model_provider.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/model_provider.py
@@ -10,7 +10,14 @@ from data_designer.engine.model_provider import ModelProvider as NDDModelProvide
 from data_designer.engine.model_provider import ModelProviderRegistry, resolve_model_provider_registry
 from data_designer_nemo.errors import NDDInternalError, NDDInvalidConfigError
 from data_designer_nemo.sdk_translation import sync_to_async_sdk
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform, NotFoundError, PermissionDeniedError
+from nemo_platform import (
+    APIConnectionError,
+    APITimeoutError,
+    AsyncNeMoPlatform,
+    NeMoPlatform,
+    NotFoundError,
+    PermissionDeniedError,
+)
 from nemo_platform.types.inference import ModelProvider as NMPModelProvider
 
 logger = logging.getLogger(__name__)
@@ -203,6 +210,17 @@ class ModelProviderCollection:
         except (NotFoundError, PermissionDeniedError):
             self.config_errors.append(
                 f"Cannot access provider {user_supplied_provider_name!r}. Check that it exists and you have access to it."
+            )
+            self.inaccessible_providers.add(user_supplied_provider_name)
+        except (APIConnectionError, APITimeoutError) as e:
+            logger.debug(
+                "Error connecting while retrieving model provider",
+                extra={"provider_name": provider_name, "workspace": workspace},
+                exc_info=True,
+            )
+            self.internal_errors.append(
+                "Could not connect to Models or Inference Gateway while resolving "
+                f"provider {user_supplied_provider_name!r}: {e}"
             )
             self.inaccessible_providers.add(user_supplied_provider_name)
         except Exception as e:

--- a/packages/nmp_testing/src/nmp/testing/__init__.py
+++ b/packages/nmp_testing/src/nmp/testing/__init__.py
@@ -15,6 +15,7 @@ API testing:
 - create_test_client: Helper for creating FastAPI test clients with in-memory storage
 - ClientContext: Container for all client types returned by create_test_client
 - TEST_USER_EMAIL, TEST_ADMIN_EMAIL: Constants for test principals
+- subprocess_job_executor_patch: Opt into cpu/default to subprocess/default translation
 
 Utilities:
 - short_unique_name: Helper for generating unique names with length constraints
@@ -59,6 +60,7 @@ from .docker import (
     ensure_mock_sidecar_image,
     get_worker_port_range,
 )
+from .jobs import subprocess_job_executor_patch
 from .notebooks import (
     cleanup_temp_venv_and_kernel,
     create_temp_venv_with_kernel,
@@ -92,6 +94,7 @@ __all__ = [
     "ClientContext",
     "TEST_USER_EMAIL",
     "TEST_ADMIN_EMAIL",
+    "subprocess_job_executor_patch",
     # Utilities
     "short_unique_name",
     "unique_email",

--- a/packages/nmp_testing/src/nmp/testing/jobs.py
+++ b/packages/nmp_testing/src/nmp/testing/jobs.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Jobs service testing helpers."""
+
+from collections.abc import Iterable, Iterator
+from contextlib import ExitStack, contextmanager
+from unittest.mock import patch
+
+from nmp.core.jobs.app.profiles import ExecutionProfileT
+from nmp.core.jobs.controllers.backends.subprocess import SubprocessJobExecutionProfile
+
+
+@contextmanager
+def subprocess_job_executor_patch(
+    executors: Iterable[ExecutionProfileT] = (),
+    *,
+    profile: str = "default",
+) -> Iterator[list[ExecutionProfileT]]:
+    """Patch Jobs execution profiles for CPU-step translation tests.
+
+    The Jobs API translates ``cpu/<profile>`` container steps to
+    ``subprocess/<profile>`` only when that subprocess profile is explicitly
+    configured in ``jobs.config.executors``. The endpoint also validates against
+    a module-level profile list, so both sources are patched together. Use this
+    around tests that submit plugin-compiled CPU jobs against an in-process Jobs
+    API.
+    """
+    from nmp.core.jobs import config as jobs_config_module
+    from nmp.core.jobs.api.v2.jobs import endpoints as jobs_endpoints
+
+    patched_executors = list(executors)
+    if not any(executor.provider == "subprocess" and executor.profile == profile for executor in patched_executors):
+        patched_executors.insert(0, SubprocessJobExecutionProfile(profile=profile))
+
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(jobs_config_module.config, "executors", patched_executors))
+        stack.enter_context(patch.object(jobs_config_module, "profiles", patched_executors))
+        stack.enter_context(patch.object(jobs_endpoints, "profiles", patched_executors))
+        yield patched_executors

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/inputs.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/inputs.py
@@ -19,7 +19,8 @@ from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import typer
-from data_designer.cli.utils.config_loader import load_config_builder
+from data_designer.cli.ui import print_error
+from data_designer.cli.utils.config_loader import ConfigLoadError, load_config_builder
 from data_designer.config.config_builder import DataDesignerConfigBuilder
 from data_designer.config.utils.constants import DEFAULT_NUM_RECORDS
 
@@ -57,10 +58,17 @@ def get_current_config_builder() -> DataDesignerConfigBuilder | None:
 
 
 @contextlib.contextmanager
-def _stash_builder(builder: DataDesignerConfigBuilder) -> Iterator[None]:
+def _spec_from_builder(config_source: str, num_records: int) -> Iterator[str]:
+    try:
+        builder = load_config_builder(config_source)
+    except ConfigLoadError as e:
+        print_error(f"Could not load config: {e}")
+        raise typer.Exit(code=1) from e
+
+    spec_json = _build_spec_from_builder(builder, num_records)
     token = _current_config_builder.set(builder)
     try:
-        yield
+        yield spec_json
     finally:
         _current_config_builder.reset(token)
 
@@ -110,12 +118,10 @@ def _replace_function_run(group: typer.Typer) -> None:
         save_results: bool = typer.Option(False, "--save-results", help=_SAVE_RESULTS_HELP),
         artifact_path: str | None = typer.Option(None, "--artifact-path", "-o", help=_ARTIFACT_PATH_HELP),
     ) -> None:
-        builder = load_config_builder(config_source)
-        spec_json = _build_spec_from_builder(builder, num_records)
-        with _stash_builder(builder):
+        with _spec_from_builder(config_source, num_records) as spec:
             original(
                 typer_ctx,
-                spec=spec_json,
+                spec=spec,
                 spec_file=None,
                 workspace=workspace,
                 non_interactive=non_interactive,
@@ -140,12 +146,10 @@ def _replace_function_submit(group: typer.Typer) -> None:
         save_results: bool = typer.Option(False, "--save-results", help=_SAVE_RESULTS_HELP),
         artifact_path: str | None = typer.Option(None, "--artifact-path", "-o", help=_ARTIFACT_PATH_HELP),
     ) -> None:
-        builder = load_config_builder(config_source)
-        spec_json = _build_spec_from_builder(builder, num_records)
-        with _stash_builder(builder):
+        with _spec_from_builder(config_source, num_records) as spec:
             original(
                 typer_ctx,
-                spec=spec_json,
+                spec=spec,
                 spec_file=None,
                 cluster=cluster,
                 base_url=base_url,
@@ -168,10 +172,8 @@ def _replace_job_run(group: typer.Typer) -> None:
             DEFAULT_NUM_RECORDS, "--num-records", "-n", help="Number of records to generate.", min=1
         ),
     ) -> None:
-        builder = load_config_builder(config_source)
-        spec_json = _build_spec_from_builder(builder, num_records)
-        with _stash_builder(builder):
-            original(typer_ctx, spec=spec_json, spec_file=None, config=None, config_file=None)
+        with _spec_from_builder(config_source, num_records) as spec:
+            original(typer_ctx, spec=spec, spec_file=None, config=None, config_file=None)
 
 
 def _replace_job_submit(group: typer.Typer) -> None:
@@ -193,12 +195,10 @@ def _replace_job_submit(group: typer.Typer) -> None:
         ),
         options_file: Path | None = typer.Option(None, "--options-file"),
     ) -> None:
-        builder = load_config_builder(config_source)
-        spec_json = _build_spec_from_builder(builder, num_records)
-        with _stash_builder(builder):
+        with _spec_from_builder(config_source, num_records) as spec:
             original(
                 typer_ctx,
-                spec=spec_json,
+                spec=spec,
                 spec_file=None,
                 options=options,
                 options_file=options_file,

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/renderers.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/renderers.py
@@ -27,9 +27,12 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+import typer
 from data_designer.cli.ui import console, print_error, print_header, print_success, wait_for_navigation_key
 from data_designer.cli.utils.sample_records_pager import PAGER_FILENAME, create_sample_records_pager
 from data_designer.config.preview_results import PreviewResults
+from data_designer.errors import DataDesignerError
+from data_designer_nemo.errors import NDDError
 from nemo_data_designer_plugin.cli.inputs import get_current_config_builder
 from nemo_data_designer_plugin.functions._types import (
     AnalysisFrame,
@@ -249,6 +252,7 @@ class PreviewRenderer(CLIRenderer):
 
     def on_error(self, error: BaseException, *, ctx: RendererContext) -> None:
         print_error(f"Preview failed: {error}")
+        _handle_error(error)
 
 
 class CreateRenderer(CLIRenderer):
@@ -279,6 +283,7 @@ class CreateRenderer(CLIRenderer):
 
     def on_error(self, error: BaseException, *, ctx: RendererContext) -> None:
         print_error(f"Create failed: {error}")
+        _handle_error(error)
 
 
 def _print_log(frame: LogFrame) -> None:
@@ -306,3 +311,13 @@ def _can_browse_interactively(ctx: RendererContext, total: int) -> bool:
     if ctx.cli_kwargs.get("non_interactive"):
         return False
     return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _handle_error(error: BaseException) -> None:
+    """Raises a typer.Exit error if the error is a first-class
+    Data Designer (library or platform plugin) error. This ensures
+    the stacktrace doesn't leak out, and instead we only present
+    the custom error message.
+    """
+    if isinstance(error, (DataDesignerError, NDDError)):
+        raise typer.Exit(code=1) from error

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/run.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/run.py
@@ -86,8 +86,11 @@ def _run_step_config(
         dd_ctx=dd_ctx,
     )
     data_designer.set_run_config(dd.RunConfig(buffer_size=BUFFER_SIZE))
-    # TODO: set `on_batch_complete=lambda _: result_manager.save_artifacts()` once it is available here
-    dataset_creation_results = data_designer.create(config_builder, num_records=step_config.job_config.num_records)
+    dataset_creation_results = data_designer.create(
+        config_builder,
+        num_records=step_config.job_config.num_records,
+        on_batch_complete=lambda _: result_manager.save_artifacts(),
+    )
 
     artifacts_result = result_manager.save_artifacts()
     analysis_result = result_manager.save_analysis(dataset_creation_results.load_analysis())

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
@@ -107,6 +107,15 @@ class DataDesignerJobResource(WithRecordSamplerMixin):
         self._workspace = workspace
         self._consecutive_poll_errors = 0
 
+    @property
+    def name(self) -> str:
+        """The unique identifying name of the job.
+
+        Returns:
+            The job name.
+        """
+        return self._job_name
+
     def get_job(self) -> dict[str, object]:
         """Get the current job.
 
@@ -313,6 +322,15 @@ class AsyncDataDesignerJobResource(WithRecordSamplerMixin):
         self._platform = platform
         self._workspace = workspace
         self._consecutive_poll_errors = 0
+
+    @property
+    def name(self) -> str:
+        """The unique identifying name of the job.
+
+        Returns:
+            The job name.
+        """
+        return self._job_name
 
     async def get_job(self) -> dict[str, object]:
         """Get the current job.

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/testing/utils.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/testing/utils.py
@@ -36,13 +36,11 @@ from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
 from nemo_platform_plugin.jobs.result_manager import ResultManager
 from nmp.core.files.service import FilesService
 from nmp.core.inference_gateway.service import InferenceGatewayService
-from nmp.core.jobs.config import config as jobs_config
-from nmp.core.jobs.controllers.backends.subprocess import SubprocessJobExecutionProfile
 from nmp.core.jobs.service import JobsService
 from nmp.core.models.service import ModelsService
 from nmp.core.secrets.service import SecretsService
 from nmp.platform_runner.plugin_adapter import NemoServiceAdapter
-from nmp.testing import ClientContext, TaskResult, add_mock_provider, create_test_client
+from nmp.testing import ClientContext, TaskResult, add_mock_provider, create_test_client, subprocess_job_executor_patch
 
 WORKSPACE_NAME = "my-workspace"
 
@@ -415,9 +413,7 @@ async def task_context(
         persistent.mkdir()
 
         with (
-            # Match Jobs' integration test fixture pattern. Ensures tests can still pass
-            # without requiring Docker running.
-            patch.object(jobs_config, "executors", [SubprocessJobExecutionProfile(profile="default")]),
+            subprocess_job_executor_patch(),
             create_test_client(
                 _TestDataDesignerService,
                 FilesService,

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/testing/utils.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/testing/utils.py
@@ -36,6 +36,8 @@ from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
 from nemo_platform_plugin.jobs.result_manager import ResultManager
 from nmp.core.files.service import FilesService
 from nmp.core.inference_gateway.service import InferenceGatewayService
+from nmp.core.jobs.config import config as jobs_config
+from nmp.core.jobs.controllers.backends.subprocess import SubprocessJobExecutionProfile
 from nmp.core.jobs.service import JobsService
 from nmp.core.models.service import ModelsService
 from nmp.core.secrets.service import SecretsService
@@ -412,14 +414,19 @@ async def task_context(
         ephemeral.mkdir()
         persistent.mkdir()
 
-        with create_test_client(
-            _TestDataDesignerService,
-            FilesService,
-            JobsService,
-            client_type=ClientContext,
-            workspaces=["default"],
-            workspace="default",
-        ) as client_context:
+        with (
+            # Match Jobs' integration test fixture pattern. Ensures tests can still pass
+            # without requiring Docker running.
+            patch.object(jobs_config, "executors", [SubprocessJobExecutionProfile(profile="default")]),
+            create_test_client(
+                _TestDataDesignerService,
+                FilesService,
+                JobsService,
+                client_type=ClientContext,
+                workspaces=["default"],
+                workspace="default",
+            ) as client_context,
+        ):
             job = client_context.sdk.jobs.create(
                 workspace="default",
                 name=job_name,

--- a/plugins/nemo-data-designer/tests/integration/test_job_task.py
+++ b/plugins/nemo-data-designer/tests/integration/test_job_task.py
@@ -101,9 +101,6 @@ async def test_task(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="Batch-completion artifact saves are not yet available through the high-level library interfaces"
-)
 async def test_save_partial_dataset_on_failure(_failing_result_manager: None, tmp_path: Path) -> None:
     test_value = "test-value"
     builder = dd.DataDesignerConfigBuilder(model_configs=[u.make_model_config()])

--- a/plugins/nemo-data-designer/tests/integration/test_preview_local_cli.py
+++ b/plugins/nemo-data-designer/tests/integration/test_preview_local_cli.py
@@ -157,6 +157,31 @@ def load_config_builder() -> dd.DataDesignerConfigBuilder:
     assert "Field required" not in result.output
 
 
+def test_bad_config_source_shows_clear_error_and_no_traceback(tmp_path: Path) -> None:
+    config_path = u.write_config_file(
+        tmp_path,
+        """
+import data_designer.config as dd
+import pandas as pd
+
+
+def wrong_function_name() -> dd.DataDesignerConfigBuilder:
+    return dd.DataDesignerConfigBuilder()
+""",
+        name="dataframe_seed_create_config.py",
+    )
+
+    with u.make_mock_client_context(workspace="default") as client_context:
+        result = u.invoke_cli(
+            ["create", "run", str(config_path), "--num-records", "3"],
+            client_context,
+        )
+
+    assert result.exit_code != 0
+    assert "load_config_builder()" in result.output
+    assert "traceback" not in result.output.lower()
+
+
 def test_create_run_reports_artifacts_and_dataset_path(tmp_path: Path) -> None:
     config_path = _write_sampler_config(tmp_path)
 

--- a/services/core/jobs/tests/conftest.py
+++ b/services/core/jobs/tests/conftest.py
@@ -5,7 +5,7 @@ import datetime
 import tempfile
 from pathlib import Path
 from typing import AsyncGenerator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
@@ -55,7 +55,7 @@ from nmp.core.jobs.entities import (
     PlatformJobAttempt,
     PlatformJobResult,
 )
-from nmp.testing import create_test_client
+from nmp.testing import create_test_client, subprocess_job_executor_patch
 from nmp.testing.blockbuster import blockbuster_fixture
 from pydantic import BaseModel
 from pytest import fixture
@@ -513,12 +513,12 @@ def hello_world_job_config(
 
 @pytest_asyncio.fixture
 async def test_client(mock_dispatcher, mock_store, job_config_with_many_profiles) -> AsyncGenerator[AsyncClient, None]:
-    # Mock the config.executors to have the test execution profiles
+    # Mock the config.executors to have the test execution profiles, including
+    # subprocess/default for cpu/default to subprocess/default translation.
     from nmp.common.auth.middleware import AuthorizationMiddleware
     from nmp.common.service.dependencies import get_sdk_client
-    from nmp.core.jobs.config import config
 
-    with patch.object(config, "executors", job_config_with_many_profiles.executors):
+    with subprocess_job_executor_patch(job_config_with_many_profiles.executors):
         app = FastAPI()
 
         # Add auth middleware with auth disabled - this sets up auth_client_context


### PR DESCRIPTION
### What's here

Some CLI improvements to prevent leaking ugly stack traces when we already are raising a clear custom error message.

Restores the old "save as batches complete" job results logic. This feature was temporarily removed when we switched to use the library's high-level `DataDesigner` interface object server-side—it previously did not expose the hook (we could only access it because we were operating "one level down").

Adds a `name` property to the high-level `[Async]DataDesignerJobResource` objects for easy access to the unique identifier for re-fetching that object later.

Lifts a Jobs integration test helper to a shared location so that Data Designer integration tests can also set it. I noticed that the DD integration tests were failing locally when run _without_ Docker running in the background. This fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages for network connectivity and timeout issues
  * CLI now displays clear error messages without stack traces for configuration errors

* **New Features**
  * Added incremental artifact saving during batch job processing
  * Made job name accessible through public API

* **Tests**
  * Expanded integration test coverage for error handling and partial dataset scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->