### PR TITLE
feat(studio): Add CLI/agent instructions to experiment group empty state

### DIFF
--- a/web/packages/common/src/components/DataView/internal/StatusResult.tsx
+++ b/web/packages/common/src/components/DataView/internal/StatusResult.tsx
@@ -25,7 +25,7 @@ export interface StatusResultProps extends Partial<StatusMessageProps> {
       hasFiltersApplied: boolean;
       hasSearchApplied: boolean;
     }
-  ) => JSX.Element;
+  ) => JSX.Element | null;
 }
 
 export function StatusResult({

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/Empty.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/Empty.tsx
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
+import {
+  Button,
+  CodeSnippet,
+  TabsContent,
+  TabsList,
+  TabsRoot,
+  TabsTrigger,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { LINK_DOCS_EXPERIMENTS_CLI } from '@studio/constants/links';
+import { Bot, ChevronRight, File, FlaskConical, Terminal } from 'lucide-react';
+
+interface EmptyProps {
+  experimentGroupName: string;
+}
+
+export const Empty = ({ experimentGroupName }: EmptyProps) => {
+  const cliCommand =
+    `nemo exp run \\\n` +
+    `  --group "${experimentGroupName}" \\\n` +
+    `  --dataset "<dataset-name>" \\\n` +
+    `  --evaluators correctness,helpfulness,groundedness,tool-error`;
+
+  return (
+    <TableEmptyState
+      icon={<FlaskConical className="size-12" />}
+      header="No Experiments"
+      emptyMessage="Run an experiment to see results for this group."
+      actions={
+        <div className="w-[560px] border border-base rounded-lg overflow-hidden">
+          <TabsRoot defaultValue="cli">
+            <TabsList className="px-density-md">
+              <TabsTrigger value="coding-agent">
+                <Bot className="size-4" />
+                Coding agent
+              </TabsTrigger>
+              <TabsTrigger value="cli">
+                <Terminal className="size-4" />
+                CLI command
+              </TabsTrigger>
+            </TabsList>
+            <div className="px-density-md pb-density-md flex flex-col gap-density-sm">
+              <TabsContent value="coding-agent" className="px-0 pb-0 w-full">
+                <CodeSnippet
+                  value="To be determined"
+                  language="text"
+                  kind="block"
+                  className="w-full whitespace-pre-line"
+                />
+              </TabsContent>
+              <TabsContent value="cli" className="px-0 pb-0">
+                <CodeSnippet value={cliCommand} language="bash" kind="block" className="w-full" />
+              </TabsContent>
+              <Button
+                asChild
+                color="neutral"
+                kind="tertiary"
+                size="small"
+                className="w-full justify-start"
+              >
+                <a href={LINK_DOCS_EXPERIMENTS_CLI} target="_blank" rel="noreferrer">
+                  <File className="!text-brand" />
+                  <Text className="flex-1">CLI docs — learn more</Text>
+                  <ChevronRight />
+                </a>
+              </Button>
+            </div>
+          </TabsRoot>
+        </div>
+      }
+    />
+  );
+};

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/Empty.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/Empty.tsx
@@ -31,7 +31,7 @@ export const Empty = ({ experimentGroupName }: EmptyProps) => {
       header="No Experiments"
       emptyMessage="Run an experiment to see results for this group."
       actions={
-        <div className="w-[560px] border border-base rounded-lg overflow-hidden">
+        <div className="w-[560px] border border-base rounded-lg overflow-hidden bg-surface-raised">
           <TabsRoot defaultValue="cli">
             <TabsList className="px-density-md">
               <TabsTrigger value="coding-agent">

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/Empty.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/Empty.tsx
@@ -31,7 +31,7 @@ export const Empty = ({ experimentGroupName }: EmptyProps) => {
       header="No Experiments"
       emptyMessage="Run an experiment to see results for this group."
       actions={
-        <div className="w-[560px] border border-base rounded-lg overflow-hidden bg-surface-raised">
+        <div className="w-[560px] border border-base rounded-lg overflow-hidden bg-surface-overlay">
           <TabsRoot defaultValue="cli">
             <TabsList className="px-density-md">
               <TabsTrigger value="coding-agent">

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/Empty.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/Empty.tsx
@@ -19,9 +19,10 @@ interface EmptyProps {
 }
 
 export const Empty = ({ experimentGroupName }: EmptyProps) => {
+  const escapedGroupName = experimentGroupName.replace(/'/g, "'\\''");
   const cliCommand =
     `nemo exp run \\\n` +
-    `  --group "${experimentGroupName}" \\\n` +
+    `  --group '${escapedGroupName}' \\\n` +
     `  --dataset "<dataset-name>" \\\n` +
     `  --evaluators correctness,helpfulness,groundedness,tool-error`;
 

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -258,7 +258,10 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
           requestStatus: isGroupLoading || (isLoading && !experimentsData) ? 'loading' : undefined,
         },
         DataViewTableContent: {
-          renderEmptyState: () => <Empty experimentGroupName={experimentGroupName} />,
+          renderEmptyState: ({ hasFiltersApplied, hasSearchApplied }) =>
+            hasFiltersApplied || hasSearchApplied ? null : (
+              <Empty experimentGroupName={experimentGroupName} />
+            ),
         },
       }}
     />

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -9,7 +9,6 @@ import {
 import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
-import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
 import { getSortParamWithWhitelist } from '@nemo/common/src/utils/query';
 import { useGetExperimentGroup, useListExperiments } from '@nemo/sdk/generated/platform/api';
@@ -19,6 +18,7 @@ import type {
   ListExperimentsSort,
 } from '@nemo/sdk/generated/platform/schema';
 import { Text, Tooltip } from '@nvidia/foundations-react-core';
+import { Empty } from '@studio/components/dataViews/ExperimentGroupDataView/Empty';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { getExperimentDetailRoute } from '@studio/routes/utils';
 import { tooltipClassName } from '@studio/styles/common';
@@ -258,12 +258,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
           requestStatus: isGroupLoading || (isLoading && !experimentsData) ? 'loading' : undefined,
         },
         DataViewTableContent: {
-          renderEmptyState: () => (
-            <TableEmptyState
-              header="No Experiments"
-              emptyMessage="This group has no experiments yet."
-            />
-          ),
+          renderEmptyState: () => <Empty experimentGroupName={experimentGroupName} />,
         },
       }}
     />

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/Empty.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/Empty.tsx
@@ -32,7 +32,7 @@ export const Empty = ({ experimentGroupName, datasetName }: EmptyProps) => {
       header="No test cases"
       emptyMessage="Run an experiment to see test case results."
       actions={
-        <div className="w-[560px] border border-base rounded-lg overflow-hidden">
+        <div className="w-[560px] border border-base rounded-lg overflow-hidden bg-surface-overlay">
           <TabsRoot defaultValue="cli">
             <TabsList className="px-density-md">
               <TabsTrigger value="coding-agent">


### PR DESCRIPTION
https://github.com/user-attachments/assets/3754afbd-2f87-459a-9ff9-21372799cb40

The experiment group detail page showed a bare "No Experiments" message when a group had no runs, giving users no guidance on next steps. This replaces it with the same tabbed CLI command / coding agent panel already used by ExperimentSessionsDataView, pre-filling the group name in the nemo exp run command so users can copy and run it immediately.

The ExperimentGroupResponse doesn't carry dataset info, so --dataset uses a <dataset-name> placeholder — consistent with how the sessions view handles unknown values.

Test plan
- [ ] Navigate to an experiment group with no experiments — confirm the tabbed panel appears with "CLI command" selected by default
- [ ] Verify the CLI snippet contains the correct group name
- [ ] Switch to the "Coding agent" tab — confirm it renders without errors
- [ ] Click "CLI docs — learn more" — confirm it opens the docs link in a new tab
- [ ] Add an experiment to the group — confirm the empty state disappears



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced empty state for experiment groups. Users now see a CLI command example and direct access to documentation when no experiments are present, streamlining the workflow for creating and managing experiments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->