### PR TITLE
fix: disable auth by default for local env

### DIFF
--- a/packages/nmp_platform/config/local.yaml
+++ b/packages/nmp_platform/config/local.yaml
@@ -20,7 +20,7 @@ platform:
 service: {}
 
 auth:
-  enabled: true
+  enabled: false
   allow_unsigned_jwt: true  # local CLI: nemo auth login --unsigned-token
   policy_decision_point_provider: embedded
   policy_decision_point_base_url: "http://localhost:8080"

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml
@@ -7,7 +7,7 @@ platform:
 service: {}
 
 auth:
-  enabled: true
+  enabled: false
   allow_unsigned_jwt: true
   policy_decision_point_provider: embedded
   policy_decision_point_base_url: "http://127.0.0.1:8080"


### PR DESCRIPTION
## Summary

Adding the customizer plugin (`36efeb985`, side change `d6613e3ba`) flipped `auth.enabled` to `true` in both local configs. With the embedded PDP that requires a built `policy.wasm` — which `make bootstrap` / `nemo setup --start-services` do **not** build — local startup hit `PolicyEngineError` (`embedded_pdp/engine.py`).

This reverts the local default back to `auth.enabled: false`.

## Changes

- `packages/nmp_platform/config/local.yaml`: `auth.enabled: true` → `false`
- `packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml`: `auth.enabled: true` → `false`

## Why no customizer change is needed

The customizer was originally cited as the reason to enable auth ("auth required for local seed"), but it does **not** functionally require auth:

- Secrets CRUD is **unauthenticated** (behind the global middleware, which allows all requests when auth is off) — exactly how inference-gateway uses secrets with auth disabled.
- The customizer never calls the secrets API directly; the W&B key is pulled from Secrets at **job runtime**.
- It registers **no seed job**.
- "Auth required for local seed" referred to **authz role bindings**, which only matter once auth is enabled in the first place.

So with auth off the customizer behaves like every other service in local dev (unprotected, by design) — no special handling required.
