### PR TITLE
fix(auth): Remove `has_role: false` to stop 403s in tot

### DIFF
--- a/docs/auth/authorization/permissions-reference.mdx
+++ b/docs/auth/authorization/permissions-reference.mdx
@@ -18,7 +18,8 @@ PlatformAdmin is omitted — it bypasses permission checks entirely at the polic
 
 | Permission | Description | Viewer | Editor | Admin |
 |------------|-------------|:------:|:------:|:-----:|
-| `entities.(read \\| create \\| update \\| delete)` | Read, create, update, delete entities |  |  |  |
+| `entities.read` | Read entities | ✓ | ✓ | ✓ |
+| `entities.(create \\| update \\| delete)` | Create, update, delete entities |  | ✓ | ✓ |
 
 ## Files API
 

--- a/services/core/auth/src/nmp/core/auth/assets/static-authz.yaml
+++ b/services/core/auth/src/nmp/core/auth/assets/static-authz.yaml
@@ -10,16 +10,12 @@ authz:
     entities:
       create:
         description: "Create entities"
-        has_role: false
       delete:
         description: "Delete entities"
-        has_role: false
       read:
         description: "Read entities"
-        has_role: false
       update:
         description: "Update entities"
-        has_role: false
     filesets:
       create:
         description: "Create filesets"
@@ -269,6 +265,7 @@ authz:
     Viewer:
       description: "Read-only access to workspace resources"
       permissions:
+      - entities.read
       - filesets.list
       - filesets.read
       - guardrails.configs.list
@@ -309,6 +306,9 @@ authz:
       description: "Read and write access to workspace resources"
       includes: ["Viewer"]
       permissions:
+      - entities.create
+      - entities.delete
+      - entities.update
       - filesets.create
       - filesets.delete
       - filesets.update


### PR DESCRIPTION
Signed-off-by: Matthew Grossman <mgrossman@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Entities API permissions reference by splitting combined permission into separate read-only and write/delete access entries

* **Permissions Updates**
  * Adjusted entity-related role permissions: Viewer role now includes read access to entities; Editor role now includes create, update, and delete capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->