### PR TITLE
chore: improve reliablity of container build by increasing timeout

### DIFF
--- a/docker/Dockerfile.safe-synthesizer-tasks
+++ b/docker/Dockerfile.safe-synthesizer-tasks
@@ -35,6 +35,8 @@ ARG USERNAME=nemo
 ARG USER_UID=1000
 ARG USER_GID=1000
 
+ENV UV_HTTP_TIMEOUT=120
+
 COPY --from=uv /uv /uvx /usr/local/bin/
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
The safe-synthesizer container used in e2e tests and such often gets a timeout around cuda installation stuff. Extending the UV timeout generally makes that much more reliable (and has in other places this was necessary).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->