### PR TITLE
fix(studio): only onboard on the first example agent

### DIFF
--- a/web/packages/studio/src/components/dataViews/AgentsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentsDataView/index.tsx
@@ -33,7 +33,7 @@ import { LINK_DOCS_STUDIO } from '@studio/constants/links';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { keepPreviousData, useQueryClient } from '@tanstack/react-query';
 import { HatGlasses } from 'lucide-react';
-import { ComponentProps, FC, useMemo, useState } from 'react';
+import { ComponentProps, FC, useEffect, useMemo, useState } from 'react';
 
 export type { Agent, AgentDeployment };
 
@@ -84,11 +84,13 @@ type DeleteState = { kind: 'agent'; item: AgentTableRow } | null;
 export interface CombinedAgentsTableProps {
   onAgentRowClick?: (agent: AgentTableRow) => void;
   onCreateDeployment?: (agentName: string) => void;
+  onAgentsLoaded?: (agents: Agent[]) => void;
 }
 
 export const AgentsTable: FC<CombinedAgentsTableProps> = ({
   onAgentRowClick,
   onCreateDeployment,
+  onAgentsLoaded,
 }) => {
   const workspace = useWorkspaceFromPath();
   const queryClient = useQueryClient();
@@ -130,6 +132,11 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
   });
 
   const agentsData = agentsResponse?.data;
+
+  useEffect(() => {
+    if (agentsData) onAgentsLoaded?.(agentsData);
+  }, [agentsData, onAgentsLoaded]);
+
   const totalCount = agentsResponse?.pagination?.total_results ?? agentsData?.length ?? 0;
   const deploymentsData = deploymentsResponse?.data;
 

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/walkthroughStorage.spec.ts
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/walkthroughStorage.spec.ts
@@ -3,8 +3,10 @@
 
 import {
   clearAgentWalkthroughPending,
+  hasShownExampleAgentIntro,
   isAgentWalkthroughPending,
   markAgentWalkthroughPending,
+  markExampleAgentIntroShown,
 } from '@studio/components/sidePanels/AgentPanels/AgentPanel/walkthroughStorage';
 
 describe('agent walkthrough storage', () => {
@@ -24,5 +26,15 @@ describe('agent walkthrough storage', () => {
     markAgentWalkthroughPending('calc');
     clearAgentWalkthroughPending('calc');
     expect(isAgentWalkthroughPending('calc')).toBe(false);
+  });
+});
+
+describe('example agent intro flag', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('reports not shown until marked', () => {
+    expect(hasShownExampleAgentIntro()).toBe(false);
+    markExampleAgentIntroShown();
+    expect(hasShownExampleAgentIntro()).toBe(true);
   });
 });

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/walkthroughStorage.ts
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/walkthroughStorage.ts
@@ -30,3 +30,25 @@ export const clearAgentWalkthroughPending = (agentName: string): void => {
     // ignore
   }
 };
+
+// Session-global flag: has the example-agent intro (open sidepanel + deploy→chat
+// walkthrough) already been shown this session? Only the first example agent created
+// per session gets the guided intro; later creations land quietly on the list. Being
+// session-scoped, the first creation also covers the first-ever case.
+const EXAMPLE_AGENT_INTRO_KEY = 'nemo:example-agent-intro-shown';
+
+export const hasShownExampleAgentIntro = (): boolean => {
+  try {
+    return sessionStorage.getItem(EXAMPLE_AGENT_INTRO_KEY) === '1';
+  } catch {
+    return false;
+  }
+};
+
+export const markExampleAgentIntroShown = (): void => {
+  try {
+    sessionStorage.setItem(EXAMPLE_AGENT_INTRO_KEY, '1');
+  } catch {
+    // sessionStorage unavailable (private mode / SSR) — intro just won't be suppressed.
+  }
+};

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/index.spec.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/index.spec.tsx
@@ -3,6 +3,7 @@
 
 import { getAgentsListAgentsQueryKey } from '@nemo/sdk/generated/agents/api';
 import { getModelsListModelsQueryKey } from '@nemo/sdk/generated/platform/api';
+import { markExampleAgentIntroShown } from '@studio/components/sidePanels/AgentPanels/AgentPanel/walkthroughStorage';
 import { PLATFORM_BASE_URL } from '@studio/constants/environment';
 import { ROUTES } from '@studio/constants/routes';
 import { workspace1 } from '@studio/mocks/entity-store/projects';
@@ -53,6 +54,9 @@ const clickCreateOnceReady = async (user: ReturnType<typeof userEvent.setup>) =>
 };
 
 describe('AgentsListRoute', () => {
+  // Opening the sidepanel + intro tour is gated on a per-session flag; isolate it.
+  beforeEach(() => sessionStorage.clear());
+
   it('renders the page shell', async () => {
     renderList();
     expect(await screen.findByText('Agents')).toBeInTheDocument();
@@ -98,6 +102,71 @@ describe('AgentsListRoute', () => {
     expect(config.functions.current_datetime._type).toBe('current_datetime');
     // A concrete workspace model is chosen (service does not resolve ${NEMO_DEFAULT_MODEL}).
     expect(config.llms.llm.model_name).toBe('nvidia-nemotron-nano-9b-v2');
+  });
+
+  it('does not reopen the sidepanel/intro for a later example agent in the same session', async () => {
+    const user = userEvent.setup();
+    mockModels(['nvidia-nemotron-nano-9b-v2']);
+    // An example agent intro was already shown earlier this session.
+    markExampleAgentIntroShown();
+
+    let created = false;
+    server.use(
+      http.post(CREATE_AGENT_URL, async ({ request, params }) => {
+        created = true;
+        const body = (await request.json()) as { name?: string };
+        return HttpResponse.json({ ...body, workspace: params['workspace'] });
+      })
+    );
+
+    renderList();
+    await clickCreateOnceReady(user);
+
+    // Creation still happens, but we stay on the list — no navigation to the detail panel.
+    await waitFor(() => expect(created).toBe(true));
+    expect(screen.queryByText('Agent detail page')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create Example Agent' })).toBeInTheDocument();
+  });
+
+  it('skips onboarding when an example agent already exists in the workspace', async () => {
+    const user = userEvent.setup();
+    mockModels(['nvidia-nemotron-nano-9b-v2']);
+    // Fresh session, but a calculator-demo agent already exists — a returning user.
+    server.use(
+      http.get(CREATE_AGENT_URL, () =>
+        HttpResponse.json({
+          data: [{ name: 'calculator-demo-agent-abc123', workspace }],
+          pagination: {
+            page: 1,
+            page_size: 50,
+            current_page_size: 1,
+            total_pages: 1,
+            total_results: 1,
+          },
+          sort: '-created_at',
+          filter: null,
+        })
+      )
+    );
+
+    let created = false;
+    server.use(
+      http.post(CREATE_AGENT_URL, async ({ request, params }) => {
+        created = true;
+        const body = (await request.json()) as { name?: string };
+        return HttpResponse.json({ ...body, workspace: params['workspace'] });
+      })
+    );
+
+    renderList();
+    // Wait until the existing example agent is visible so the agents query has settled.
+    await screen.findByText('calculator-demo-agent-abc123');
+    await clickCreateOnceReady(user);
+
+    // No onboarding: stays on the list despite the fresh session.
+    await waitFor(() => expect(created).toBe(true));
+    expect(screen.queryByText('Agent detail page')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create Example Agent' })).toBeInTheDocument();
   });
 
   it('prefers a suggested Nemotron model over a non-suggested one', async () => {

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
@@ -4,6 +4,7 @@
 import { LoadingButton } from '@nemo/common/src/components/LoadingButton';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { useAgentsCreateAgent } from '@nemo/sdk/generated/agents/api';
+import type { Agent } from '@nemo/sdk/generated/agents/schema/Agent';
 import { useModelsListModels } from '@nemo/sdk/generated/platform/api';
 import { PageHeader, Stack } from '@nvidia/foundations-react-core';
 import { getErrorMessage } from '@studio/api/common/utils';
@@ -13,7 +14,11 @@ import {
   AgentPanel,
   type AgentPanelTab,
 } from '@studio/components/sidePanels/AgentPanels/AgentPanel';
-import { markAgentWalkthroughPending } from '@studio/components/sidePanels/AgentPanels/AgentPanel/walkthroughStorage';
+import {
+  hasShownExampleAgentIntro,
+  markAgentWalkthroughPending,
+  markExampleAgentIntroShown,
+} from '@studio/components/sidePanels/AgentPanels/AgentPanel/walkthroughStorage';
 import { DEFAULT_LARGE_PAGE_SIZE } from '@studio/constants/constants';
 import { ROUTE_PARAMS } from '@studio/constants/routes';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
@@ -28,8 +33,12 @@ const TAB_SEARCH_PARAM = 'tab';
 
 const EXAMPLE_AGENT_DESCRIPTION = 'A ReAct agent with a calculator and datetime tool.';
 
+const EXAMPLE_AGENT_NAME_PREFIX = 'calculator-demo-agent';
+
 const buildExampleAgentName = (): string =>
-  `calculator-demo-agent-${Math.random().toString(36).slice(2, 8)}`;
+  `${EXAMPLE_AGENT_NAME_PREFIX}-${Math.random().toString(36).slice(2, 8)}`;
+
+const isExampleAgentName = (name: string): boolean => name.startsWith(EXAMPLE_AGENT_NAME_PREFIX);
 
 // model_name is concrete: the service doesn't resolve ${NEMO_DEFAULT_MODEL} (only the CLI does).
 const buildExampleAgentConfig = (modelName: string): Record<string, unknown> => ({
@@ -84,12 +93,18 @@ export const AgentsListRoute: FC = () => {
     { query: { enabled: !!workspace } }
   );
 
+  const [loadedAgents, setLoadedAgents] = useState<Agent[]>([]);
+
   const { mutateAsync: createAgent, isPending } = useAgentsCreateAgent({
     mutation: {
       onSuccess: (agent) => {
         toast.success(`Agent "${agent.name}" created`);
-        if (agent.name) {
-          // Queue the deploy→chat walkthrough for this agent; the panel starts it.
+        const priorExampleAgentExists = loadedAgents.some(
+          (existing) =>
+            !!existing.name && existing.name !== agent.name && isExampleAgentName(existing.name)
+        );
+        if (agent.name && !hasShownExampleAgentIntro() && !priorExampleAgentExists) {
+          markExampleAgentIntroShown();
           markAgentWalkthroughPending(agent.name);
           navigate(getAgentDetailRoute(workspace, agent.name));
         } else {
@@ -165,6 +180,7 @@ export const AgentsListRoute: FC = () => {
         <AgentsTable
           onAgentRowClick={handleOpenPanel}
           onCreateDeployment={(agentName) => setCreateDeploymentAgent(agentName)}
+          onAgentsLoaded={setLoadedAgents}
         />
       </Stack>
       <CreateDeploymentModal


### PR DESCRIPTION
## Summary

Creating an example agent opened the sidepanel and started the deploy→chat intro tour **every time**. This scopes onboarding so it only runs for a genuinely new user.

Onboarding (open sidepanel + intro tour) now runs only when **both**:
- it's the first example agent created **this session** (sessionStorage flag), and
- **no** example agent (`calculator-demo-agent*`) already exists in the workspace.

Returning users (who already have an example agent) and repeat creations land quietly on the agents list.

## Changes

- `AgentPanel/walkthroughStorage.ts`: session-scoped `hasShownExampleAgentIntro()` / `markExampleAgentIntroShown()`.
- `AgentsListRoute/index.tsx`: gate onboarding on the session flag **and** absence of an existing example agent; `EXAMPLE_AGENT_NAME_PREFIX` + `isExampleAgentName`.
- `AgentsDataView`: new optional `onAgentsLoaded(agents)` callback that surfaces the table's loaded page; the route reuses that list for the existing-agent check (no extra query).

The existing-agent check is scoped to the agents table's current page (first page by default) — an accepted tradeoff to reuse the already-loaded, polled list rather than add a second query.

## Testing

- `AgentsListRoute` spec (incl. new cases: skip on later same-session create, skip when an example already exists) — pass
- `AgentsDataView` spec, `walkthroughStorage` spec — pass
- Typecheck / eslint clean
