### PR TITLE
fix(studio): use singular agent_name/agent_version in experiments views

### DIFF
--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -124,17 +124,15 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
           );
         },
       }),
-      accessor((original) => original.agent_names?.join(', '), {
-        id: 'agent_names',
-        header: 'Agent Names',
+      accessor('agent_name', {
+        header: 'Agent Name',
         enableSorting: false,
-        cell: ({ getValue }) => <Text>{getValue<string>() || '-'}</Text>,
+        cell: ({ row }) => <Text>{row.original.agent_name || '-'}</Text>,
       }),
-      accessor((original) => original.agent_versions?.join(', '), {
-        id: 'agent_versions',
-        header: 'Agent Versions',
+      accessor('agent_version', {
+        header: 'Agent Version',
         enableSorting: false,
-        cell: ({ getValue }) => <Text>{getValue<string>() || '-'}</Text>,
+        cell: ({ row }) => <Text>{row.original.agent_version || '-'}</Text>,
       }),
       accessor('dataset_name', {
         header: 'Dataset Name',

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/ExperimentDetailMetrics.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/ExperimentDetailMetrics.tsx
@@ -27,8 +27,8 @@ export const ExperimentDetailMetrics: FC<ExperimentDetailMetricsProps> = ({ expe
   return (
     <div className="flex gap-8">
       <KVPair
-        label="Agent Names"
-        value={experiment?.agent_names?.join(', ') || undefined}
+        label="Agent Name"
+        value={experiment?.agent_name || undefined}
         loading={isLoading}
         orientation="vertical"
       />


### PR DESCRIPTION
## Summary

Fixes the 3 `TS2551` errors that have made the Studio `typecheck` check red on `main`:

- `ExperimentGroupDataView/index.tsx:127,133` — `agent_names` / `agent_versions` not on `ExperimentRow`
- `ExperimentDetailRoute/ExperimentDetailMetrics.tsx:31` — `agent_names` not on `ExperimentResponse`

**Root cause:** #294 (`d5165414bd`, "Roll up agent_names/agent_versions") left these views reading **plural** `agent_names`/`agent_versions` as arrays (`.join(', ')`), but the generated SDK type `ExperimentResponse` exposes **singular** `agent_name: string` / `agent_version: string` (one agent per experiment). The plural fields never existed in the TS SDK, so typecheck has been broken since that commit.

## Changes

- `ExperimentGroupDataView`: `agent_names`/`agent_versions` columns → singular `agent_name`/`agent_version` accessors; headers "Agent Name"/"Agent Version".
- `ExperimentDetailMetrics`: `agent_names?.join(', ')` → `agent_name`; label "Agent Name".

## Testing

- Full studio `typecheck`: **0 errors** (was 3)
- `eslint` clean; no remaining `agent_names`/`agent_versions` references in studio; no specs cover these files

Resolves ASTD-244.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified agent information display in experiment tables and detail views to show a single agent name and version instead of multiple joined values.
  * Updated metric labels to reflect the single-value format.
  * Added "-" placeholder for missing agent information.
  * Disabled sorting on agent information columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->