### PR TITLE
ci(release): declare publishable container images for release

### DIFF
--- a/.github/scripts/write_release_bundle_metadata.py
+++ b/.github/scripts/write_release_bundle_metadata.py
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Write release bundle metadata for downloaded SDK wheel artifacts."""
+"""Write release bundle metadata for downloaded SDK wheel artifacts.
+
+Container artifacts are metadata-only manifest entries: the image bits are
+built and staged by Platform-Deploy from its dev registry at the bundle's
+source SHA, so container entries carry no path or checksum.
+"""
 
 import argparse
 import hashlib
@@ -22,10 +27,12 @@ class BundleMetadataError(Exception):
     """Raised when the release bundle metadata cannot be written safely."""
 
 
-def safe_sdk_id(sdk_id: str) -> str:
-    if not re.fullmatch(r"[A-Za-z0-9._-]+", sdk_id) or sdk_id in {".", ".."}:
-        raise BundleMetadataError(f"selected SDK id must be a safe single path segment: {sdk_id}")
-    return sdk_id
+def safe_artifact_id(artifact_type: str, artifact_id: str) -> str:
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", artifact_id) or artifact_id in {".", ".."}:
+        raise BundleMetadataError(
+            f"selected {artifact_type} id must be a safe single path segment: {artifact_id}"
+        )
+    return artifact_id
 
 
 def parse_release_date_json(value: str) -> str | None:
@@ -43,7 +50,8 @@ def artifact_ref(artifact_type: object, artifact_id: object) -> str:
     return f"{artifact_type}:{artifact_id}"
 
 
-def parse_selected_sdk_ids(value: str) -> list[str]:
+def parse_selected_artifact_ids(value: str) -> dict[str, list[str]]:
+    """Parse selected_artifacts_json into ids grouped by artifact type."""
     try:
         parsed = json.loads(value)
     except json.JSONDecodeError as error:
@@ -52,29 +60,34 @@ def parse_selected_sdk_ids(value: str) -> list[str]:
     if not isinstance(parsed, list) or not parsed:
         raise BundleMetadataError("selected_artifacts_json must be a non-empty list")
 
-    sdk_ids: list[str] = []
-    seen: set[str] = set()
+    ids_by_type: dict[str, list[str]] = {"sdk": [], "container": []}
+    seen: dict[str, set[str]] = {artifact_type: set() for artifact_type in ids_by_type}
     for artifact in parsed:
         if not isinstance(artifact, dict):
             raise BundleMetadataError("selected_artifacts_json entries must be objects")
 
         artifact_type = artifact.get("type")
         artifact_id = artifact.get("id")
-        if artifact_type != "sdk":
+        if artifact_type not in ids_by_type:
             raise BundleMetadataError(
-                f"only SDK artifacts are supported in V1 bundles: {artifact_ref(artifact_type, artifact_id)}"
+                f"unsupported artifact type in bundle selection: {artifact_ref(artifact_type, artifact_id)}"
             )
         if not isinstance(artifact_id, str) or not artifact_id:
-            raise BundleMetadataError("selected SDK artifact id must be a non-empty string")
+            raise BundleMetadataError(f"selected {artifact_type} artifact id must be a non-empty string")
 
-        sdk_id = safe_sdk_id(artifact_id)
-        if sdk_id in seen:
-            raise BundleMetadataError(f"selected_artifacts_json contains duplicate SDK id: {sdk_id}")
+        checked_id = safe_artifact_id(artifact_type, artifact_id)
+        if checked_id in seen[artifact_type]:
+            raise BundleMetadataError(
+                f"selected_artifacts_json contains duplicate {artifact_type} id: {checked_id}"
+            )
 
-        seen.add(sdk_id)
-        sdk_ids.append(sdk_id)
+        seen[artifact_type].add(checked_id)
+        ids_by_type[artifact_type].append(checked_id)
 
-    return sdk_ids
+    if not ids_by_type["sdk"]:
+        raise BundleMetadataError("selected_artifacts_json must include at least one SDK artifact")
+
+    return ids_by_type
 
 
 def find_sdk_wheel(sdk_artifacts_dir: Path, sdk_id: str, *, single_sdk_artifact: bool) -> Path:
@@ -167,7 +180,8 @@ def write_release_bundle_metadata(
     if not source_sha:
         raise BundleMetadataError("source_sha is required")
 
-    sdk_ids = parse_selected_sdk_ids(selected_artifacts_json)
+    ids_by_type = parse_selected_artifact_ids(selected_artifacts_json)
+    sdk_ids = ids_by_type["sdk"]
     release_date = parse_release_date_json(release_date_json)
     wheels_dir = prepare_bundle_dir(bundle_dir)
 
@@ -186,6 +200,17 @@ def write_release_bundle_metadata(
                 "id": sdk_id,
                 "version": wheel_version,
                 "path": bundle_relative_path(bundle_dir, wheel_path),
+            }
+        )
+
+    # Container artifacts are metadata-only: the consumer stages the images
+    # from its dev registry by source_sha and tags them with release_label.
+    for container_id in ids_by_type["container"]:
+        artifacts.append(
+            {
+                "type": "container",
+                "id": container_id,
+                "version": release_label,
             }
         )
 

--- a/.github/scripts/write_release_bundle_metadata.py
+++ b/.github/scripts/write_release_bundle_metadata.py
@@ -4,7 +4,7 @@
 """Write release bundle metadata for downloaded SDK wheel artifacts.
 
 Container artifacts are metadata-only manifest entries: the image bits are
-built and staged by Platform-Deploy from its dev registry at the bundle's
+built and staged by the release consumer from its dev registry at the bundle's
 source SHA, so container entries carry no path or checksum.
 """
 

--- a/.github/scripts/write_release_bundle_metadata.py
+++ b/.github/scripts/write_release_bundle_metadata.py
@@ -29,9 +29,7 @@ class BundleMetadataError(Exception):
 
 def safe_artifact_id(artifact_type: str, artifact_id: str) -> str:
     if not re.fullmatch(r"[A-Za-z0-9._-]+", artifact_id) or artifact_id in {".", ".."}:
-        raise BundleMetadataError(
-            f"selected {artifact_type} id must be a safe single path segment: {artifact_id}"
-        )
+        raise BundleMetadataError(f"selected {artifact_type} id must be a safe single path segment: {artifact_id}")
     return artifact_id
 
 
@@ -77,16 +75,13 @@ def parse_selected_artifact_ids(value: str) -> dict[str, list[str]]:
 
         checked_id = safe_artifact_id(artifact_type, artifact_id)
         if checked_id in seen[artifact_type]:
-            raise BundleMetadataError(
-                f"selected_artifacts_json contains duplicate {artifact_type} id: {checked_id}"
-            )
+            raise BundleMetadataError(f"selected_artifacts_json contains duplicate {artifact_type} id: {checked_id}")
 
         seen[artifact_type].add(checked_id)
         ids_by_type[artifact_type].append(checked_id)
 
-    if not ids_by_type["sdk"]:
-        raise BundleMetadataError("selected_artifacts_json must include at least one SDK artifact")
-
+    # A bundle may be SDK-only, container-only, or mixed; the non-empty-list
+    # check above already guarantees at least one artifact of some type.
     return ids_by_type
 
 

--- a/.github/workflows/release-bundle.yaml
+++ b/.github/workflows/release-bundle.yaml
@@ -302,8 +302,24 @@ jobs:
             exit 1
           fi
 
+          # Containers ride along on every release regardless of release_scope
+          # (scope governs SDK selection only): the container catalog is the
+          # eligibility list, and image bits are not built here. Entries are
+          # recorded in the manifest as typed artifacts; Platform-Deploy stages
+          # the images from its dev registry by this release's source SHA.
+          container_catalog="$(yq -o=json '.container // []' "${catalog}" | jq -c 'map(.id)')"
+          if ! jq -e 'type == "array" and all(.[]; type == "string" and length > 0)' <<<"${container_catalog}" >/dev/null; then
+            echo "::error::release/assets.yaml container must contain non-empty string id values"
+            exit 1
+          fi
+          if ! jq -e 'length == (unique | length)' <<<"${container_catalog}" >/dev/null; then
+            echo "::error::release/assets.yaml container contains duplicate ids"
+            exit 1
+          fi
+
           sdk_artifacts_json="$(jq -nc --argjson ids "${selected_sdk_ids}" '$ids | map({type: "sdk", id: .})')"
-          selected_artifacts_json="${sdk_artifacts_json}"
+          container_artifacts_json="$(jq -nc --argjson ids "${container_catalog}" '$ids | map({type: "container", id: .})')"
+          selected_artifacts_json="$(jq -nc --argjson sdks "${sdk_artifacts_json}" --argjson containers "${container_artifacts_json}" '$sdks + $containers')"
           sdk_matrix="$(jq -nc --argjson artifacts "${sdk_artifacts_json}" '{include: $artifacts}')"
           sdk_count="$(jq -r 'length' <<<"${selected_sdk_ids}")"
 
@@ -314,6 +330,7 @@ jobs:
           } >>"${GITHUB_OUTPUT}"
 
           echo "Planned SDK release artifacts: $(jq -r 'join(", ")' <<<"${selected_sdk_ids}")"
+          echo "Planned container release artifacts: $(jq -r 'join(", ")' <<<"${container_catalog}")"
 
   reserve-release-tag:
     name: Reserve release tag

--- a/.github/workflows/release-bundle.yaml
+++ b/.github/workflows/release-bundle.yaml
@@ -243,8 +243,8 @@ jobs:
       #   containers -> every catalog container, no SDKs
       #   custom     -> exactly sdk_ids + container_ids (either may be empty)
       # Container image bits are not built here; container entries are recorded
-      # in the manifest as typed artifacts and Platform-Deploy stages them from
-      # its dev registry by this release's source SHA.
+      # in the manifest as typed artifacts and the release consumer stages them
+      # from the dev registry by this release's source SHA.
       - name: Plan release assets
         id: plan-assets
         shell: bash
@@ -278,7 +278,11 @@ jobs:
           # catalog: no empty entries, no duplicates, no unknown ids.
           parse_custom_ids() {
             local raw="$1" kind="$2" catalog_json="$3" parsed unknown
-            parsed="$(jq -Rnc --arg value "${raw}" '$value | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))')"
+            parsed="$(jq -Rnc --arg value "${raw}" '$value | split(",") | map(gsub("^\\s+|\\s+$"; ""))')"
+            if jq -e 'any(.[]; length == 0)' <<<"${parsed}" >/dev/null; then
+              echo "::error::${kind}_ids contains an empty entry"
+              exit 1
+            fi
             if ! jq -e 'length == (unique | length)' <<<"${parsed}" >/dev/null; then
               echo "::error::${kind}_ids contains duplicate entries"
               exit 1

--- a/.github/workflows/release-bundle.yaml
+++ b/.github/workflows/release-bundle.yaml
@@ -23,12 +23,17 @@ on:
         type: string
         default: ""
       release_scope:
-        description: "Release artifact scope: sdks or custom."
+        description: "Release artifact scope: all, sdks, containers, or custom."
         required: false
         type: string
-        default: "sdks"
+        default: "all"
       sdk_ids:
         description: "Comma-separated SDK IDs for custom releases."
+        required: false
+        type: string
+        default: ""
+      container_ids:
+        description: "Comma-separated container IDs for custom releases."
         required: false
         type: string
         default: ""
@@ -55,6 +60,7 @@ jobs:
       nightly_timestamp: ${{ steps.resolve-nightly-source.outputs.nightly_timestamp }}
       selected_artifacts_json: ${{ steps.plan-assets.outputs.selected_artifacts_json }}
       sdk_count: ${{ steps.plan-assets.outputs.sdk_count }}
+      container_count: ${{ steps.plan-assets.outputs.container_count }}
       sdk_matrix: ${{ steps.plan-assets.outputs.sdk_matrix }}
       release_tag: ${{ inputs.cadence == 'nightly' && steps.resolve-nightly-source.outputs.release_tag || steps.resolve-release-metadata.outputs.release_tag }}
       release_date_json: ${{ inputs.cadence == 'nightly' && steps.resolve-nightly-source.outputs.release_date_json || steps.resolve-release-metadata.outputs.release_date_json }}
@@ -231,106 +237,120 @@ jobs:
           ref: ${{ inputs.cadence == 'nightly' && steps.resolve-nightly-source.outputs.source_sha || inputs.source_sha }}
           path: source
 
-      # Plan SDK-only V1 artifacts before any release side effects:
-      # sdks selects every catalog SDK; custom selects listed sdk_ids.
+      # Plan release artifacts before any release side effects. release_scope:
+      #   all        -> every catalog SDK + every catalog container (default)
+      #   sdks       -> every catalog SDK, no containers
+      #   containers -> every catalog container, no SDKs
+      #   custom     -> exactly sdk_ids + container_ids (either may be empty)
+      # Container image bits are not built here; container entries are recorded
+      # in the manifest as typed artifacts and Platform-Deploy stages them from
+      # its dev registry by this release's source SHA.
       - name: Plan release assets
         id: plan-assets
         shell: bash
         env:
           RELEASE_SCOPE: ${{ inputs.release_scope }}
           SDK_IDS: ${{ inputs.sdk_ids }}
+          CONTAINER_IDS: ${{ inputs.container_ids }}
         run: |
           set -euo pipefail
 
           catalog="source/release/assets.yaml"
           [[ -f "${catalog}" ]] || { echo "::error::release asset catalog is missing: ${catalog}"; exit 1; }
 
-          sdk_catalog="$(yq -o=json '.sdk' "${catalog}" | jq -c 'if type == "array" then map(.id) else . end')"
-          if ! jq -e 'type == "array" and all(.[]; type == "string" and length > 0)' <<<"${sdk_catalog}" >/dev/null; then
-            echo "::error::release/assets.yaml sdk must contain non-empty string id values"
-            exit 1
-          fi
+          # Read and validate a catalog section ('.sdk' / '.container') into a
+          # JSON id array: non-empty string ids, no duplicates.
+          read_catalog() {
+            local section="$1" kind="$2" ids
+            ids="$(yq -o=json "${section} // []" "${catalog}" | jq -c 'map(.id)')"
+            if ! jq -e 'type == "array" and all(.[]; type == "string" and length > 0)' <<<"${ids}" >/dev/null; then
+              echo "::error::release/assets.yaml ${kind} must contain non-empty string id values"
+              exit 1
+            fi
+            if ! jq -e 'length == (unique | length)' <<<"${ids}" >/dev/null; then
+              echo "::error::release/assets.yaml ${kind} contains duplicate ids"
+              exit 1
+            fi
+            printf '%s' "${ids}"
+          }
 
-          if ! jq -e 'length == (unique | length)' <<<"${sdk_catalog}" >/dev/null; then
-            echo "::error::release/assets.yaml sdk contains duplicate ids"
-            exit 1
-          fi
+          # Parse a comma-separated custom id list and validate it against its
+          # catalog: no empty entries, no duplicates, no unknown ids.
+          parse_custom_ids() {
+            local raw="$1" kind="$2" catalog_json="$3" parsed unknown
+            parsed="$(jq -Rnc --arg value "${raw}" '$value | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))')"
+            if ! jq -e 'length == (unique | length)' <<<"${parsed}" >/dev/null; then
+              echo "::error::${kind}_ids contains duplicate entries"
+              exit 1
+            fi
+            unknown="$(jq -nc --argjson selected "${parsed}" --argjson catalog "${catalog_json}" '$selected - $catalog')"
+            if [[ "${unknown}" != "[]" ]]; then
+              echo "::error::unknown ${kind} id(s): $(jq -r 'join(", ")' <<<"${unknown}")"
+              exit 1
+            fi
+            printf '%s' "${parsed}"
+          }
+
+          sdk_catalog="$(read_catalog '.sdk' sdk)"
+          container_catalog="$(read_catalog '.container' container)"
 
           case "${RELEASE_SCOPE}" in
-            sdks | custom)
+            all | sdks | containers | custom)
               ;;
             *)
-              echo "::error::Unknown release_scope: ${RELEASE_SCOPE}"
+              echo "::error::Unknown release_scope: ${RELEASE_SCOPE} (expected all, sdks, containers, or custom)"
               exit 1
               ;;
           esac
 
-          if [[ "${RELEASE_SCOPE}" != "custom" && -n "${SDK_IDS}" ]]; then
-            echo "::error::sdk_ids can only be used when release_scope is custom"
+          if [[ "${RELEASE_SCOPE}" != "custom" && ( -n "${SDK_IDS}" || -n "${CONTAINER_IDS}" ) ]]; then
+            echo "::error::sdk_ids/container_ids can only be used when release_scope is custom"
             exit 1
           fi
 
           case "${RELEASE_SCOPE}" in
+            all)
+              selected_sdk_ids="${sdk_catalog}"
+              selected_container_ids="${container_catalog}"
+              ;;
             sdks)
               selected_sdk_ids="${sdk_catalog}"
+              selected_container_ids='[]'
+              ;;
+            containers)
+              selected_sdk_ids='[]'
+              selected_container_ids="${container_catalog}"
               ;;
             custom)
-              if [[ -z "${SDK_IDS}" ]]; then
-                echo "::error::custom release_scope requires sdk_ids"
-                exit 1
-              fi
-              custom_sdk_ids="$(jq -Rnc --arg value "${SDK_IDS}" '$value | split(",") | map(gsub("^\\s+|\\s+$"; ""))')"
-              if jq -e 'any(.[]; length == 0)' <<<"${custom_sdk_ids}" >/dev/null; then
-                echo "::error::sdk_ids contains an empty entry"
-                exit 1
-              fi
-              if ! jq -e 'length == (unique | length)' <<<"${custom_sdk_ids}" >/dev/null; then
-                echo "::error::sdk_ids contains duplicate entries"
-                exit 1
-              fi
-              unknown="$(jq -nc --argjson selected "${custom_sdk_ids}" --argjson catalog "${sdk_catalog}" '$selected - $catalog')"
-              if [[ "${unknown}" != "[]" ]]; then
-                echo "::error::unknown sdk id(s): $(jq -r 'join(", ")' <<<"${unknown}")"
-                exit 1
-              fi
-              selected_sdk_ids="${custom_sdk_ids}"
+              selected_sdk_ids='[]'
+              selected_container_ids='[]'
+              [[ -n "${SDK_IDS}" ]] && selected_sdk_ids="$(parse_custom_ids "${SDK_IDS}" sdk "${sdk_catalog}")"
+              [[ -n "${CONTAINER_IDS}" ]] && selected_container_ids="$(parse_custom_ids "${CONTAINER_IDS}" container "${container_catalog}")"
               ;;
           esac
 
-          if [[ "$(jq 'length' <<<"${selected_sdk_ids}")" == "0" ]]; then
-            echo "::error::release selection must include at least one supported SDK artifact"
-            exit 1
-          fi
-
-          # Containers ride along on every release regardless of release_scope
-          # (scope governs SDK selection only): the container catalog is the
-          # eligibility list, and image bits are not built here. Entries are
-          # recorded in the manifest as typed artifacts; Platform-Deploy stages
-          # the images from its dev registry by this release's source SHA.
-          container_catalog="$(yq -o=json '.container // []' "${catalog}" | jq -c 'map(.id)')"
-          if ! jq -e 'type == "array" and all(.[]; type == "string" and length > 0)' <<<"${container_catalog}" >/dev/null; then
-            echo "::error::release/assets.yaml container must contain non-empty string id values"
-            exit 1
-          fi
-          if ! jq -e 'length == (unique | length)' <<<"${container_catalog}" >/dev/null; then
-            echo "::error::release/assets.yaml container contains duplicate ids"
+          total="$(jq -n --argjson s "${selected_sdk_ids}" --argjson c "${selected_container_ids}" '($s | length) + ($c | length)')"
+          if [[ "${total}" == "0" ]]; then
+            echo "::error::release selection is empty; choose a non-empty release_scope or provide sdk_ids/container_ids"
             exit 1
           fi
 
           sdk_artifacts_json="$(jq -nc --argjson ids "${selected_sdk_ids}" '$ids | map({type: "sdk", id: .})')"
-          container_artifacts_json="$(jq -nc --argjson ids "${container_catalog}" '$ids | map({type: "container", id: .})')"
+          container_artifacts_json="$(jq -nc --argjson ids "${selected_container_ids}" '$ids | map({type: "container", id: .})')"
           selected_artifacts_json="$(jq -nc --argjson sdks "${sdk_artifacts_json}" --argjson containers "${container_artifacts_json}" '$sdks + $containers')"
           sdk_matrix="$(jq -nc --argjson artifacts "${sdk_artifacts_json}" '{include: $artifacts}')"
           sdk_count="$(jq -r 'length' <<<"${selected_sdk_ids}")"
+          container_count="$(jq -r 'length' <<<"${selected_container_ids}")"
 
           {
             printf 'selected_artifacts_json=%s\n' "${selected_artifacts_json}"
             printf 'sdk_count=%s\n' "${sdk_count}"
+            printf 'container_count=%s\n' "${container_count}"
             printf 'sdk_matrix=%s\n' "${sdk_matrix}"
           } >>"${GITHUB_OUTPUT}"
 
-          echo "Planned SDK release artifacts: $(jq -r 'join(", ")' <<<"${selected_sdk_ids}")"
-          echo "Planned container release artifacts: $(jq -r 'join(", ")' <<<"${container_catalog}")"
+          echo "Planned SDK release artifacts: $(jq -r 'if length == 0 then "(none)" else join(", ") end' <<<"${selected_sdk_ids}")"
+          echo "Planned container release artifacts: $(jq -r 'if length == 0 then "(none)" else join(", ") end' <<<"${selected_container_ids}")"
 
   reserve-release-tag:
     name: Reserve release tag
@@ -381,6 +401,8 @@ jobs:
   build-sdks:
     name: Build SDK (${{ matrix.id }})
     needs: [plan-release, reserve-release-tag]
+    # Skip cleanly for container-only releases (sdk_matrix would be empty).
+    if: ${{ needs.plan-release.outputs.sdk_count != '0' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -428,6 +450,9 @@ jobs:
   assemble-release-bundle:
     name: Assemble release bundle
     needs: [plan-release, build-sdks]
+    # build-sdks is skipped for container-only releases; still assemble as long
+    # as planning succeeded and the SDK builds did not fail.
+    if: ${{ !cancelled() && needs.plan-release.result == 'success' && (needs.build-sdks.result == 'success' || needs.build-sdks.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -443,7 +468,10 @@ jobs:
       - name: Checkout workflow code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # No SDK wheels exist for container-only releases; skip the download
+      # (the metadata writer handles an empty/absent artifacts dir).
       - name: Download SDK wheels
+        if: ${{ needs.plan-release.outputs.sdk_count != '0' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: release-sdk-*
@@ -524,6 +552,12 @@ jobs:
             notes_range=(--notes-start-tag "${NOTES_START_TAG}")
           fi
 
+          # Wheels are absent for container-only releases; nullglob keeps the
+          # unmatched glob from being passed to gh literally.
+          shopt -s nullglob
+          wheels=(release-bundle/wheels/*.whl)
+          shopt -u nullglob
+
           # Upload each artifact as its own asset. GitHub flattens asset names to basenames; the
           # consumer restores wheels/ from the manifest paths. Re-run model: if a release already
           # exists for this tag the command fails ("a release with the same tag name already
@@ -533,7 +567,7 @@ jobs:
           gh release create "${RELEASE_TAG}" \
             release-bundle/release-manifest.json \
             release-bundle/checksums.txt \
-            release-bundle/wheels/*.whl \
+            "${wheels[@]}" \
             --title "${RELEASE_TAG}" \
             --generate-notes \
             "${notes_range[@]}"

--- a/.github/workflows/release-bundle.yaml
+++ b/.github/workflows/release-bundle.yaml
@@ -453,10 +453,13 @@ jobs:
 
   assemble-release-bundle:
     name: Assemble release bundle
-    needs: [plan-release, build-sdks]
-    # build-sdks is skipped for container-only releases; still assemble as long
-    # as planning succeeded and the SDK builds did not fail.
-    if: ${{ !cancelled() && needs.plan-release.result == 'success' && (needs.build-sdks.result == 'success' || needs.build-sdks.result == 'skipped') }}
+    needs: [plan-release, reserve-release-tag, build-sdks]
+    # build-sdks is skipped for container-only releases; still assemble as long as
+    # planning and tag reservation succeeded and the SDK builds did not fail. The
+    # reserve-release-tag gate is required because build-sdks is also skipped when
+    # tag creation fails (its dependency failed), so its result alone would let a
+    # failed tag reservation still build and dispatch the bundle.
+    if: ${{ !cancelled() && needs.plan-release.result == 'success' && needs.reserve-release-tag.result == 'success' && (needs.build-sdks.result == 'success' || needs.build-sdks.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -16,12 +16,19 @@ on:
         description: "Release artifact scope."
         required: false
         type: choice
-        default: sdks
+        default: all
         options:
+          - all
           - sdks
+          - containers
           - custom
       sdk_ids:
         description: "Comma-separated SDK IDs for custom releases."
+        required: false
+        type: string
+        default: ""
+      container_ids:
+        description: "Comma-separated container IDs for custom releases."
         required: false
         type: string
         default: ""
@@ -38,8 +45,9 @@ jobs:
     with:
       cadence: nightly
       source_sha: ${{ github.event_name == 'workflow_dispatch' && inputs.source_sha || '' }}
-      release_scope: ${{ github.event_name == 'workflow_dispatch' && inputs.release_scope || 'sdks' }}
+      release_scope: ${{ github.event_name == 'workflow_dispatch' && inputs.release_scope || 'all' }}
       sdk_ids: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk_ids || '' }}
+      container_ids: ${{ github.event_name == 'workflow_dispatch' && inputs.container_ids || '' }}
     secrets:
       CI_DISPATCH_TOKEN: ${{ secrets.CI_DISPATCH_TOKEN }}
       CI_DISPATCH_REPO: ${{ secrets.CI_DISPATCH_REPO }}

--- a/.github/workflows/release-rc.yaml
+++ b/.github/workflows/release-rc.yaml
@@ -20,12 +20,19 @@ on:
         description: "Release artifact scope."
         required: false
         type: choice
-        default: sdks
+        default: all
         options:
+          - all
           - sdks
+          - containers
           - custom
       sdk_ids:
         description: "Comma-separated SDK IDs for custom releases."
+        required: false
+        type: string
+        default: ""
+      container_ids:
+        description: "Comma-separated container IDs for custom releases."
         required: false
         type: string
         default: ""
@@ -46,6 +53,7 @@ jobs:
       release_date: ${{ inputs.release_date }}
       release_scope: ${{ inputs.release_scope }}
       sdk_ids: ${{ inputs.sdk_ids }}
+      container_ids: ${{ inputs.container_ids }}
     secrets:
       CI_DISPATCH_TOKEN: ${{ secrets.CI_DISPATCH_TOKEN }}
       CI_DISPATCH_REPO: ${{ secrets.CI_DISPATCH_REPO }}

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -21,12 +21,19 @@ on:
         description: "Release artifact scope."
         required: false
         type: choice
-        default: sdks
+        default: all
         options:
+          - all
           - sdks
+          - containers
           - custom
       sdk_ids:
         description: "Comma-separated SDK IDs for custom releases."
+        required: false
+        type: string
+        default: ""
+      container_ids:
+        description: "Comma-separated container IDs for custom releases."
         required: false
         type: string
         default: ""
@@ -51,6 +58,7 @@ jobs:
           RELEASE_DATE: ${{ inputs.release_date }}
           RELEASE_SCOPE: ${{ inputs.release_scope }}
           SDK_IDS: ${{ inputs.sdk_ids }}
+          CONTAINER_IDS: ${{ inputs.container_ids }}
         run: |
           set -euo pipefail
 
@@ -69,6 +77,7 @@ jobs:
             echo "| Release scope | ${RELEASE_SCOPE} |"
             if [[ "${RELEASE_SCOPE}" == "custom" ]]; then
               echo "| SDK IDs | ${SDK_IDS:-not provided} |"
+              echo "| Container IDs | ${CONTAINER_IDS:-not provided} |"
             fi
             echo "| Destination | Stable git tag, release bundle artifact, downstream \`release-bundle-produced\` dispatch |"
             echo
@@ -101,6 +110,7 @@ jobs:
       release_date: ${{ inputs.release_date }}
       release_scope: ${{ inputs.release_scope }}
       sdk_ids: ${{ inputs.sdk_ids }}
+      container_ids: ${{ inputs.container_ids }}
     secrets:
       CI_DISPATCH_TOKEN: ${{ secrets.CI_DISPATCH_TOKEN }}
       CI_DISPATCH_REPO: ${{ secrets.CI_DISPATCH_REPO }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -89,6 +89,21 @@ Also check:
 
 ---
 
+## Container image eligibility
+
+The `container:` list in `release/assets.yaml` declares which container
+images are eligible for release publishing. Platform-Deploy's
+`Release Deploy Artifacts` (staging) and `Release Promote Public` (public
+NGC) workflows read this list from this repository at the release ref, so
+eligibility is version-pinned: re-staging an old tag publishes the container
+set that was declared at that commit. Adding an image here also requires a
+catalog metadata entry (overview, labels) in Platform-Deploy
+`release/nemo-assets-config.yaml`, and the image must be pushed to the dev
+registry tagged with this repository's commit SHA (the Automodel images are
+built by Platform-Deploy's `docker-automodel.yaml`).
+
+---
+
 ## Nightly builds
 
 Nightly builds run automatically at 20:00 PT and publish to `pypi.nvidia.com`. They use the HEAD of `main` and version strings like `0.1.3.dev20260101120000`. No action required from the team.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -92,15 +92,27 @@ Also check:
 ## Container image eligibility
 
 The `container:` list in `release/assets.yaml` declares which container
-images are eligible for release publishing. Containers ride along on every
-release regardless of `release_scope` (scope governs SDK selection only):
-the bundle workflow records them as `container`-typed entries in
-`release-manifest.json`, and Platform-Deploy's `Release Deploy Artifacts`
-workflow stages the images automatically after the SDK publish, reading
-this list from this repository at the release ref. Eligibility is therefore
-version-pinned: re-staging an old tag publishes the container set that was
-declared at that commit. `Release Promote Public` (public NGC) reads the
-same list at the release tag and stays a manual step.
+images are eligible for release publishing. The bundle workflow records the
+selected containers as `container`-typed entries in `release-manifest.json`,
+and Platform-Deploy's `Release Deploy Artifacts` workflow stages those images
+after the SDK publish, reading this list from this repository at the release
+ref. Eligibility is therefore version-pinned: re-staging an old tag publishes
+the container set declared at that commit. `Release Promote Public` (public
+NGC) reads the same list at the release tag and stays a manual step.
+
+`release_scope` controls what a release includes (default `all`):
+
+| Scope | Includes |
+| --- | --- |
+| `all` | every catalog SDK + every catalog container (default) |
+| `sdks` | every catalog SDK, no containers |
+| `containers` | every catalog container, no SDKs |
+| `custom` | exactly the comma-separated `sdk_ids` + `container_ids` (either may be empty) |
+
+`custom` enables single-artifact or arbitrary-subset releases (for example a
+patch release of one container via `release_scope: custom`,
+`container_ids: nmp-automodel-tasks`); `containers` releases the whole
+container set with no SDK wheels.
 
 Adding an image here also requires a catalog metadata entry (overview,
 labels) in Platform-Deploy `release/nemo-assets-config.yaml`. Images are

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -92,15 +92,22 @@ Also check:
 ## Container image eligibility
 
 The `container:` list in `release/assets.yaml` declares which container
-images are eligible for release publishing. Platform-Deploy's
-`Release Deploy Artifacts` (staging) and `Release Promote Public` (public
-NGC) workflows read this list from this repository at the release ref, so
-eligibility is version-pinned: re-staging an old tag publishes the container
-set that was declared at that commit. Adding an image here also requires a
-catalog metadata entry (overview, labels) in Platform-Deploy
-`release/nemo-assets-config.yaml`, and the image must be pushed to the dev
-registry tagged with this repository's commit SHA (the Automodel images are
-built by Platform-Deploy's `docker-automodel.yaml`).
+images are eligible for release publishing. Containers ride along on every
+release regardless of `release_scope` (scope governs SDK selection only):
+the bundle workflow records them as `container`-typed entries in
+`release-manifest.json`, and Platform-Deploy's `Release Deploy Artifacts`
+workflow stages the images automatically after the SDK publish, reading
+this list from this repository at the release ref. Eligibility is therefore
+version-pinned: re-staging an old tag publishes the container set that was
+declared at that commit. `Release Promote Public` (public NGC) reads the
+same list at the release tag and stays a manual step.
+
+Adding an image here also requires a catalog metadata entry (overview,
+labels) in Platform-Deploy `release/nemo-assets-config.yaml`. Images are
+built into the dev registry tagged with this repository's commit SHA on
+every merge to main (Platform-Deploy's `docker-automodel.yaml` via the
+ci-passed dispatch); release SHAs that predate that trigger need a manual
+`docker-automodel.yaml` dispatch first.
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -94,11 +94,10 @@ Also check:
 The `container:` list in `release/assets.yaml` declares which container
 images are eligible for release publishing. The bundle workflow records the
 selected containers as `container`-typed entries in `release-manifest.json`,
-and Platform-Deploy's `Release Deploy Artifacts` workflow stages those images
-after the SDK publish, reading this list from this repository at the release
-ref. Eligibility is therefore version-pinned: re-staging an old tag publishes
-the container set declared at that commit. `Release Promote Public` (public
-NGC) reads the same list at the release tag and stays a manual step.
+and the release consumer stages those images after the SDK publish, reading
+this list from this repository at the release ref. Eligibility is therefore
+version-pinned: re-staging an old tag publishes the container set declared at
+that commit.
 
 `release_scope` controls what a release includes (default `all`):
 
@@ -114,12 +113,10 @@ patch release of one container via `release_scope: custom`,
 `container_ids: nmp-automodel-tasks`); `containers` releases the whole
 container set with no SDK wheels.
 
-Adding an image here also requires a catalog metadata entry (overview,
-labels) in Platform-Deploy `release/nemo-assets-config.yaml`. Images are
-built into the dev registry tagged with this repository's commit SHA on
-every merge to main (Platform-Deploy's `docker-automodel.yaml` via the
-ci-passed dispatch); release SHAs that predate that trigger need a manual
-`docker-automodel.yaml` dispatch first.
+Adding an image here also requires a catalog metadata entry on the consumer
+side. Images are built into the dev registry tagged with this repository's
+commit SHA on every merge to main; release SHAs that predate that build
+trigger need a manual image build first.
 
 ---
 

--- a/release/assets.yaml
+++ b/release/assets.yaml
@@ -1,3 +1,15 @@
 sdk:
   - id: nemo-platform
   - id: nemo-platform-plugin
+
+# Container images eligible for release publishing. This list is the single
+# source of truth: Platform-Deploy's Release Deploy Artifacts and Release
+# Promote Public workflows read it from this repository at the release ref.
+# Each id must match an image name pushed to the dev registry tagged by this
+# repository's commit SHA, and should have a catalog metadata entry in
+# Platform-Deploy release/nemo-assets-config.yaml.
+container:
+  - id: nmp-automodel-base
+  - id: nmp-automodel-tasks
+  - id: nmp-automodel-training
+  - id: nmp-unsloth-training

--- a/release/assets.yaml
+++ b/release/assets.yaml
@@ -11,3 +11,5 @@ container:
   - id: nmp-automodel-tasks
   - id: nmp-automodel-training
   - id: nmp-unsloth-training
+  - id: auditor-tasks
+  - id: safe-synthesizer-tasks

--- a/release/assets.yaml
+++ b/release/assets.yaml
@@ -3,18 +3,11 @@ sdk:
   - id: nemo-platform-plugin
 
 # Container images eligible for release publishing. This list is the single
-# source of truth: Platform-Deploy's Release Deploy Artifacts and Release
-# Promote Public workflows read it from this repository at the release ref.
-# Each id must match an image name pushed to the dev registry tagged by this
-# repository's commit SHA, and should have a catalog metadata entry in
-# Platform-Deploy release/nemo-assets-config.yaml.
+# source of truth: the release-consumer repository reads it at the release ref
+# to decide which images to stage. Each id must match an image name pushed to
+# the dev registry tagged by this repository's commit SHA, and should have a
+# catalog metadata entry on the consumer side.
 container:
-  - id: nmp-automodel-base
   - id: nmp-automodel-tasks
   - id: nmp-automodel-training
   - id: nmp-unsloth-training
-  # Core deployable services: the bare minimum the Helm chart and customizer
-  # need for a working platform (built by Platform-Deploy docker.yaml docker-cpu).
-  - id: nmp-api
-  - id: nmp-core
-  - id: nmp-cpu-tasks

--- a/release/assets.yaml
+++ b/release/assets.yaml
@@ -13,3 +13,8 @@ container:
   - id: nmp-automodel-tasks
   - id: nmp-automodel-training
   - id: nmp-unsloth-training
+  # Core deployable services: the bare minimum the Helm chart and customizer
+  # need for a working platform (built by Platform-Deploy docker.yaml docker-cpu).
+  - id: nmp-api
+  - id: nmp-core
+  - id: nmp-cpu-tasks

--- a/tests/unit/release/test_write_release_bundle_metadata.py
+++ b/tests/unit/release/test_write_release_bundle_metadata.py
@@ -281,8 +281,8 @@ def test_multiple_directly_downloaded_wheels_fail_clearly(tmp_path: Path):
         )
 
 
-def test_non_sdk_artifact_type_fails_clearly(tmp_path: Path):
-    with pytest.raises(BundleMetadataError, match="only SDK artifacts are supported"):
+def test_unsupported_artifact_type_fails_clearly(tmp_path: Path):
+    with pytest.raises(BundleMetadataError, match="unsupported artifact type"):
         bundle_metadata.write_release_bundle_metadata(
             sdk_artifacts_dir=tmp_path / "downloaded-artifacts",
             bundle_dir=tmp_path / "release-bundle",
@@ -294,8 +294,85 @@ def test_non_sdk_artifact_type_fails_clearly(tmp_path: Path):
         )
 
 
+def test_container_artifacts_become_metadata_only_entries(tmp_path: Path):
+    sdk_artifacts_dir = tmp_path / "downloaded-artifacts"
+    bundle_dir = tmp_path / "release-bundle"
+    write_wheel(sdk_artifacts_dir, "nemo-platform")
+
+    bundle_metadata.write_release_bundle_metadata(
+        sdk_artifacts_dir=sdk_artifacts_dir,
+        bundle_dir=bundle_dir,
+        selected_artifacts_json=selected_artifacts(
+            {"type": "sdk", "id": "nemo-platform"},
+            {"type": "container", "id": "nmp-automodel-tasks"},
+            {"type": "container", "id": "nmp-unsloth-training"},
+        ),
+        cadence="rc",
+        release_label="1.0.0-rc1",
+        release_date_json="null",
+        source_sha="c" * 40,
+    )
+
+    artifacts = read_manifest(bundle_dir)["artifacts"]
+    assert artifacts[1:] == [  # type: ignore[index]
+        {"type": "container", "id": "nmp-automodel-tasks", "version": "1.0.0-rc1"},
+        {"type": "container", "id": "nmp-unsloth-training", "version": "1.0.0-rc1"},
+    ]
+    # Container entries are metadata-only: no path, and nothing extra in checksums.
+    assert set(parse_checksums(bundle_dir)) == {
+        "release-manifest.json",
+        "wheels/nemo_platform-1.0.0-py3-none-any.whl",
+    }
+
+
+def test_container_only_selection_fails_clearly(tmp_path: Path):
+    with pytest.raises(BundleMetadataError, match="at least one SDK artifact"):
+        bundle_metadata.write_release_bundle_metadata(
+            sdk_artifacts_dir=tmp_path / "downloaded-artifacts",
+            bundle_dir=tmp_path / "release-bundle",
+            selected_artifacts_json=selected_artifacts({"type": "container", "id": "nmp-automodel-tasks"}),
+            cadence="release",
+            release_label="1.0.0",
+            release_date_json="null",
+            source_sha="a" * 40,
+        )
+
+
+def test_duplicate_container_ids_fail_clearly(tmp_path: Path):
+    with pytest.raises(BundleMetadataError, match="duplicate container id: nmp-automodel-tasks"):
+        bundle_metadata.write_release_bundle_metadata(
+            sdk_artifacts_dir=tmp_path / "downloaded-artifacts",
+            bundle_dir=tmp_path / "release-bundle",
+            selected_artifacts_json=selected_artifacts(
+                {"type": "sdk", "id": "nemo-platform"},
+                {"type": "container", "id": "nmp-automodel-tasks"},
+                {"type": "container", "id": "nmp-automodel-tasks"},
+            ),
+            cadence="release",
+            release_label="1.0.0",
+            release_date_json="null",
+            source_sha="a" * 40,
+        )
+
+
+def test_unsafe_container_id_fails_clearly(tmp_path: Path):
+    with pytest.raises(BundleMetadataError, match="container id must be a safe single path segment"):
+        bundle_metadata.write_release_bundle_metadata(
+            sdk_artifacts_dir=tmp_path / "downloaded-artifacts",
+            bundle_dir=tmp_path / "release-bundle",
+            selected_artifacts_json=selected_artifacts(
+                {"type": "sdk", "id": "nemo-platform"},
+                {"type": "container", "id": "../evil"},
+            ),
+            cadence="release",
+            release_label="1.0.0",
+            release_date_json="null",
+            source_sha="a" * 40,
+        )
+
+
 def test_duplicate_selected_sdk_ids_fail_clearly(tmp_path: Path):
-    with pytest.raises(BundleMetadataError, match="duplicate SDK id: nemo-platform"):
+    with pytest.raises(BundleMetadataError, match="duplicate sdk id: nemo-platform"):
         bundle_metadata.write_release_bundle_metadata(
             sdk_artifacts_dir=tmp_path / "downloaded-artifacts",
             bundle_dir=tmp_path / "release-bundle",

--- a/tests/unit/release/test_write_release_bundle_metadata.py
+++ b/tests/unit/release/test_write_release_bundle_metadata.py
@@ -325,12 +325,35 @@ def test_container_artifacts_become_metadata_only_entries(tmp_path: Path):
     }
 
 
-def test_container_only_selection_fails_clearly(tmp_path: Path):
-    with pytest.raises(BundleMetadataError, match="at least one SDK artifact"):
+def test_container_only_selection_is_valid(tmp_path: Path):
+    bundle_dir = tmp_path / "release-bundle"
+    bundle_metadata.write_release_bundle_metadata(
+        sdk_artifacts_dir=tmp_path / "downloaded-artifacts",
+        bundle_dir=bundle_dir,
+        selected_artifacts_json=selected_artifacts(
+            {"type": "container", "id": "nmp-automodel-tasks"},
+            {"type": "container", "id": "nmp-unsloth-training"},
+        ),
+        cadence="release",
+        release_label="1.0.0",
+        release_date_json="null",
+        source_sha="a" * 40,
+    )
+
+    # Container-only bundle: only container entries, no wheels, checksums = manifest only.
+    assert read_manifest(bundle_dir)["artifacts"] == [
+        {"type": "container", "id": "nmp-automodel-tasks", "version": "1.0.0"},
+        {"type": "container", "id": "nmp-unsloth-training", "version": "1.0.0"},
+    ]
+    assert set(parse_checksums(bundle_dir)) == {"release-manifest.json"}
+
+
+def test_empty_selection_fails_clearly(tmp_path: Path):
+    with pytest.raises(BundleMetadataError, match="non-empty list"):
         bundle_metadata.write_release_bundle_metadata(
             sdk_artifacts_dir=tmp_path / "downloaded-artifacts",
             bundle_dir=tmp_path / "release-bundle",
-            selected_artifacts_json=selected_artifacts({"type": "container", "id": "nmp-automodel-tasks"}),
+            selected_artifacts_json="[]",
             cadence="release",
             release_label="1.0.0",
             release_date_json="null",


### PR DESCRIPTION
## Summary

Makes `release/assets.yaml` the **single source of truth** for which container images are eligible for release publishing, and records the selected images as typed entries in the release bundle manifest -- converging containers onto the existing release flow.

- New `container:` list in `release/assets.yaml` (mirrors the `sdk:` list) declaring the publishable images: `nmp-automodel-tasks`, `nmp-automodel-training`, `nmp-unsloth-training`, `auditor-tasks`, `safe-synthesizer-tasks`.
- `release-bundle.yaml` `plan-assets` validates the catalog (non-empty, unique ids) and selects SDKs **and** containers per `release_scope`, appending `{"type": "container", "id": ...}` entries to the selected artifacts.
- `write_release_bundle_metadata.py` records them in `release-manifest.json` as metadata-only entries (type, id, version = release label; no path or checksum -- image bits are built and staged by the release consumer from its dev registry at the bundle's source SHA). Unit tests extended (19 passing).
- `RELEASING.md` documents the eligibility contract and the `release_scope` table.

`release_scope` (default `all`): `all` = every SDK + every container; `sdks` = SDKs only; `containers` = containers only; `custom` = exactly the comma-separated `sdk_ids` + `container_ids` (either may be empty). Eligibility is version-pinned -- re-staging an old tag publishes the container set declared at that commit.

Consumer side (NVIDIA-NeMo/Platform-Deploy#95): `release-bundle-received` automatically stages the selected containers after the SDK publish, reading this list at the release ref. Public NGC publishing is out of band via the NGC catalog process (`ngc-publishing-configs`); this repo only declares eligibility.

## Merge order

Either order is safe: without the consumer PR, the manifest's container entries are recorded but unconsumed (the existing SDK publish plan filters `type == "sdk"`); without this PR, the consumer's staging step no-ops with "no containers declared". The full flow activates when both land.

Refs: [AIREINF-216](https://linear.app/nvidia/issue/AIREINF-216)
