### PR TITLE
feat(studio): bulk delete agents from the table

### DIFF
--- a/web/packages/studio/src/components/dataViews/AgentsDataView/index.spec.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentsDataView/index.spec.tsx
@@ -530,4 +530,164 @@ describe('CombinedAgentsTable', () => {
       expect(agentDeleteCalled).toBe(false);
     });
   });
+
+  describe('bulk delete', () => {
+    it('deletes every selected agent and its deployments, then shows a summary toast', async () => {
+      const deletedAgents: string[] = [];
+      const deletedDeployments: string[] = [];
+      server.use(
+        http.get(`${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/:workspace/agents`, () =>
+          HttpResponse.json({
+            data: [
+              { name: 'react-agent', description: '', config: {} },
+              { name: 'react-agent2', description: '', config: {} },
+            ],
+            pagination: {
+              page: 1,
+              page_size: 50,
+              current_page_size: 2,
+              total_pages: 1,
+              total_results: 2,
+            },
+          })
+        ),
+        http.get(`${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/:workspace/deployments`, () =>
+          HttpResponse.json({
+            data: [
+              {
+                name: 'react-agent-dep',
+                agent: 'react-agent',
+                status: 'running',
+                workspace: WORKSPACE,
+              },
+            ],
+            pagination: {
+              page: 1,
+              page_size: 100,
+              current_page_size: 1,
+              total_pages: 1,
+              total_results: 1,
+            },
+          })
+        ),
+        http.delete(
+          `${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/:workspace/deployments/:name`,
+          ({ params }) => {
+            deletedDeployments.push(String(params.name));
+            return new HttpResponse(null, { status: 204 });
+          }
+        ),
+        http.delete(
+          `${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/:workspace/agents/:name`,
+          ({ params }) => {
+            deletedAgents.push(String(params.name));
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      const user = userEvent.setup();
+      renderTable();
+      await screen.findByText('react-agent');
+      await screen.findByText('react-agent2');
+
+      // KUI disables checkboxes while loading and swaps nodes on re-render, so wait
+      // for each to be enabled, click, and confirm it registered before continuing.
+      const rowCheckboxAt = (index: number) =>
+        screen.getAllByRole('checkbox', { name: /(De)?select row/i })[index];
+      const selectRow = async (index: number) => {
+        await waitFor(() => expect(rowCheckboxAt(index)).toBeEnabled());
+        if (!(rowCheckboxAt(index) as HTMLInputElement).checked) {
+          await user.click(rowCheckboxAt(index));
+        }
+        await waitFor(() => expect(rowCheckboxAt(index)).toBeChecked());
+      };
+      await selectRow(0);
+      await selectRow(1);
+
+      // The selection bar's Delete button opens the confirmation.
+      await user.click(await screen.findByRole('button', { name: 'Delete selected agents' }));
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText('Delete 2 Agents')).toBeInTheDocument();
+      await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+      await waitFor(() =>
+        expect([...deletedAgents].sort()).toEqual(['react-agent', 'react-agent2'])
+      );
+      expect(deletedDeployments).toContain('react-agent-dep');
+      expect(await screen.findByTestId('mock-toast-success')).toHaveTextContent(
+        '2 agents deleted.'
+      );
+    });
+
+    it('reports a partial failure when one selected agent fails to delete', async () => {
+      const deletedAgents: string[] = [];
+      server.use(
+        http.get(`${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/:workspace/agents`, () =>
+          HttpResponse.json({
+            data: [
+              { name: 'react-agent', description: '', config: {} },
+              { name: 'react-agent2', description: '', config: {} },
+            ],
+            pagination: {
+              page: 1,
+              page_size: 50,
+              current_page_size: 2,
+              total_pages: 1,
+              total_results: 2,
+            },
+          })
+        ),
+        http.get(`${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/:workspace/deployments`, () =>
+          HttpResponse.json({
+            data: [],
+            pagination: {
+              page: 1,
+              page_size: 100,
+              current_page_size: 0,
+              total_pages: 1,
+              total_results: 0,
+            },
+          })
+        ),
+        http.delete(
+          `${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/:workspace/agents/:name`,
+          ({ params }) => {
+            if (params.name === 'react-agent2') {
+              return HttpResponse.json({ detail: 'boom' }, { status: 500 });
+            }
+            deletedAgents.push(String(params.name));
+            return new HttpResponse(null, { status: 204 });
+          }
+        )
+      );
+
+      const user = userEvent.setup();
+      renderTable();
+      await screen.findByText('react-agent');
+      await screen.findByText('react-agent2');
+
+      const rowCheckboxAt = (index: number) =>
+        screen.getAllByRole('checkbox', { name: /(De)?select row/i })[index];
+      const selectRow = async (index: number) => {
+        await waitFor(() => expect(rowCheckboxAt(index)).toBeEnabled());
+        if (!(rowCheckboxAt(index) as HTMLInputElement).checked) {
+          await user.click(rowCheckboxAt(index));
+        }
+        await waitFor(() => expect(rowCheckboxAt(index)).toBeChecked());
+      };
+      await selectRow(0);
+      await selectRow(1);
+
+      await user.click(await screen.findByRole('button', { name: 'Delete selected agents' }));
+      const dialog = await screen.findByRole('dialog');
+      await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+      // The succeeded agent is still deleted; the failure is surfaced as a summary toast.
+      await waitFor(() => expect(deletedAgents).toEqual(['react-agent']));
+      expect(await screen.findByTestId('mock-toast-error')).toHaveTextContent(
+        'Failed to delete 1 of 2 agents.'
+      );
+    });
+  });
 });

--- a/web/packages/studio/src/components/dataViews/AgentsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentsDataView/index.tsx
@@ -4,6 +4,7 @@
 import { Root as DataViewRoot } from '@nemo/common/src/components/DataView/internal';
 import {
   ROW_ACTIONS_COLUMN_SIZE,
+  ROW_SELECTION_COLUMN_SIZE,
   StudioDataView,
 } from '@nemo/common/src/components/DataView/StudioDataView';
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
@@ -24,15 +25,14 @@ import {
 } from '@nemo/sdk/generated/agents/api';
 import type { Agent } from '@nemo/sdk/generated/agents/schema/Agent';
 import type { AgentDeployment } from '@nemo/sdk/generated/agents/schema/AgentDeployment';
-import { Text } from '@nvidia/foundations-react-core';
-import { getErrorMessage } from '@studio/api/common/utils';
+import { Button, Divider, Flex, Text } from '@nvidia/foundations-react-core';
 import { getAgentModelNames } from '@studio/components/dataViews/AgentsDataView/utils';
 import { DeleteConfirmationModal } from '@studio/components/DeleteConfirmationModal';
 import { DocumentationButton } from '@studio/components/DocumentationButton';
 import { LINK_DOCS_STUDIO } from '@studio/constants/links';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { keepPreviousData, useQueryClient } from '@tanstack/react-query';
-import { HatGlasses } from 'lucide-react';
+import { HatGlasses, Trash, X } from 'lucide-react';
 import { ComponentProps, FC, useEffect, useMemo, useState } from 'react';
 
 export type { Agent, AgentDeployment };
@@ -79,7 +79,10 @@ export type AgentTableRow = {
 const SORTABLE_FIELDS = ['name', 'created_at'] as const;
 const DEFAULT_SORT = '-created_at';
 
-type DeleteState = { kind: 'agent'; item: AgentTableRow } | null;
+type DeleteState =
+  | { kind: 'agent'; item: AgentTableRow }
+  | { kind: 'bulk'; items: AgentTableRow[] }
+  | null;
 
 export interface CombinedAgentsTableProps {
   onAgentRowClick?: (agent: AgentTableRow) => void;
@@ -166,24 +169,19 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
     });
   }, [agentsData, deploymentsData]);
 
-  const deleteAgentMutation = useAgentsDeleteAgent({
-    mutation: {
-      onSuccess: () => {
-        toast.success('Agent deleted.');
-        void queryClient.refetchQueries({
-          queryKey: getAgentsListAgentsQueryKey(workspace),
-        });
-        void queryClient.invalidateQueries({
-          queryKey: getAgentsListDeploymentsQueryKey(workspace),
-        });
-      },
-      onError: (error) => {
-        toast.error(getErrorMessage(error, 'Failed to delete agent.'));
-      },
-    },
-  });
+  const rowSelection = dataViewState.rowSelection.state;
+  const selectedAgents = useMemo(
+    () => tableData.filter((row) => rowSelection[row.id]),
+    [tableData, rowSelection]
+  );
 
+  const deleteAgentMutation = useAgentsDeleteAgent();
   const deleteDeploymentMutation = useAgentsDeleteDeployment();
+
+  const refreshAfterDelete = () => {
+    void queryClient.refetchQueries({ queryKey: getAgentsListAgentsQueryKey(workspace) });
+    void queryClient.invalidateQueries({ queryKey: getAgentsListDeploymentsQueryKey(workspace) });
+  };
 
   const fetchAgentDeploymentNames = async (agentName: string): Promise<string[]> => {
     const PAGE_SIZE = 100;
@@ -199,32 +197,46 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
     return names;
   };
 
-  const handleDelete = async () => {
-    try {
-      if (deleteState?.kind === 'agent') {
-        const agentName = deleteState.item.name;
-        const deploymentNames = await fetchAgentDeploymentNames(agentName);
-        await Promise.all(
-          deploymentNames.map((name) =>
-            deleteDeploymentMutation.mutateAsync({ workspace, name }).catch((err) => {
-              if ((err as { response?: { status?: number } })?.response?.status === 404) return;
-              toast.error(getErrorMessage(err as Error, `Failed to delete deployment "${name}".`));
-              throw err;
-            })
-          )
-        );
-        await deleteAgentMutation.mutateAsync({ workspace, name: agentName });
-      }
-      return true;
-    } catch {
+  const deleteAgentWithDeployments = async (agentName: string): Promise<void> => {
+    const deploymentNames = await fetchAgentDeploymentNames(agentName);
+    await Promise.all(
+      deploymentNames.map((name) =>
+        deleteDeploymentMutation.mutateAsync({ workspace, name }).catch((err) => {
+          // A deployment already gone (404) is fine; anything else aborts this agent.
+          if ((err as { response?: { status?: number } })?.response?.status === 404) return;
+          throw err;
+        })
+      )
+    );
+    await deleteAgentMutation.mutateAsync({ workspace, name: agentName });
+  };
+
+  const handleDelete = async (): Promise<boolean> => {
+    if (!deleteState) return false;
+    const agents = deleteState.kind === 'agent' ? [deleteState.item] : deleteState.items;
+    const results = await Promise.allSettled(agents.map((a) => deleteAgentWithDeployments(a.name)));
+    const failed = results.filter((r) => r.status === 'rejected').length;
+
+    refreshAfterDelete();
+    if (failed < agents.length) dataViewState.rowSelection.set({});
+
+    if (failed > 0) {
+      toast.error(
+        agents.length === 1
+          ? 'Failed to delete agent.'
+          : `Failed to delete ${failed} of ${agents.length} agents.`
+      );
       return false;
     }
+    toast.success(agents.length === 1 ? 'Agent deleted.' : `${agents.length} agents deleted.`);
+    return true;
   };
 
   const makeColumns: ComponentProps<typeof DataViewRoot<AgentTableRow>>['makeColumns'] = (
     { accessor },
-    { rowActionsColumn }
+    { rowActionsColumn, rowSelectionColumn }
   ) => [
+    rowSelectionColumn({ size: ROW_SELECTION_COLUMN_SIZE }),
     accessor('name', {
       header: 'Name',
       enableSorting: true,
@@ -284,6 +296,29 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
 
   return (
     <>
+      {selectedAgents.length > 0 && (
+        <Flex align="center" gap="2">
+          <Text kind="label/regular/md">
+            {selectedAgents.length} {selectedAgents.length === 1 ? 'row' : 'rows'} selected
+          </Text>
+          <Flex align="center" gap="1">
+            <Button
+              kind="tertiary"
+              aria-label="Delete selected agents"
+              onClick={() => setDeleteState({ kind: 'bulk', items: selectedAgents })}
+            >
+              <Trash /> Delete
+            </Button>
+            <Divider orientation="vertical" />
+            <Button kind="tertiary" onClick={() => dataViewState.rowSelection.set({})}>
+              <span className="only-mobile">
+                <X variant="line" />
+              </span>
+              <span className="hide-mobile">Cancel</span>
+            </Button>
+          </Flex>
+        </Flex>
+      )}
       <StudioDataView
         dataViewState={dataViewState}
         makeColumns={makeColumns}
@@ -311,8 +346,16 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
       {deleteState && (
         <DeleteConfirmationModal
           open
-          title="Delete Agent"
-          description="Are you sure you want to delete this agent and all its deployments?"
+          title={
+            deleteState.kind === 'bulk'
+              ? `Delete ${deleteState.items.length} Agent${deleteState.items.length === 1 ? '' : 's'}`
+              : 'Delete Agent'
+          }
+          description={
+            deleteState.kind === 'bulk'
+              ? `Are you sure you want to delete ${deleteState.items.length} agent${deleteState.items.length === 1 ? '' : 's'} and all their deployments?`
+              : 'Are you sure you want to delete this agent and all its deployments?'
+          }
           onDelete={handleDelete}
           onClose={() => setDeleteState(null)}
           simpleConfirm


### PR DESCRIPTION
## Summary

Adds **bulk delete** of agents from the agents table.

- Row-selection checkboxes (+ select-all) on the agents table.
- A selection bar appears when rows are selected: **"N rows selected"** + a tertiary **Delete** button + a **Cancel** (matching the shared `BulkActions` UX).
- **Delete** opens the existing `DeleteConfirmationModal` ("Delete N Agents"), then tears down each selected agent the same way single-delete does — delete the agent's deployments first, then the agent — running all selected agents via `Promise.allSettled`. One summary toast (`"N agents deleted."` or `"Failed to delete X of N agents."`), selection cleared, list refetched once. Single-row delete uses the same unified path.

## Why a custom selection bar (not the DataView toolbar slot)

The DataView's built-in `renderBulkActions` only renders inside `StudioDataViewToolbar`, which returns `null` unless the table has a search field or a filterable column. `AgentsListAgentsParams` supports **neither** (no filter/search on the agents list API), so that toolbar can't appear for agents. The selection bar is therefore rendered directly in `AgentsDataView` (the checkboxes are columns, so they're unaffected), styled to match the canonical `BulkActions` component.

## Testing

- `AgentsDataView` spec: existing 17 + new bulk-delete test (select all → Delete → both agents' deployments + agents deleted, summary toast) → **18 pass**.
- Typecheck / eslint clean.

Resolves ASTD-246.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents table: multi-row selection with checkbox toolbar showing count, Delete and Cancel actions.
  * Bulk delete: deletes agents and their associated deployments in parallel, refreshes views, and shows aggregated success/error toasts with correct pluralized messaging.
* **Tests**
  * Added tests for bulk-delete happy path and partial-failure scenarios verifying selection, confirmation, deletion outcomes, and success/error toasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->