### PR TITLE
test(intake): derive chat-completions fixture `created` from now

### DIFF
--- a/services/intake/tests/integration/spans/test_chat_completions_ingest.py
+++ b/services/intake/tests/integration/spans/test_chat_completions_ingest.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import time
 from decimal import Decimal
 from typing import Any
 
@@ -50,7 +51,9 @@ def _openai_response(**overrides: Any) -> dict[str, Any]:
     response = {
         "id": "chatcmpl-test-abc123",
         "object": "chat.completion",
-        "created": 1778698885,
+        # Now-based: span started_at derives from `created`, and the spans/traces
+        # list endpoints default to a 30-day lookback — a fixed date ages out.
+        "created": int(time.time()),
         "model": "gpt-4o-mini-2024-08-06",
         "choices": [
             {


### PR DESCRIPTION
## What

Replace the fixed `created: 1778698885` (2026-05-13T19:01:25Z) in the chat-completions ingest test factory with `int(time.time())`.

## Why

The ingest endpoint maps `response.created` to span `started_at`, and the spans/traces list endpoints default `started_at_gte` to now−30d. At 2026-06-12T19:01Z the fixture crossed that boundary and every list read-back in the file started returning empty — 8 of 16 tests failing (`IndexError` on `data[0]` or length asserts). The one read-back test without a `created` field kept passing because ingest falls back to `ingested_at`.

Same failure class as #174. That PR pinned reads with an explicit `filter[started_at][gte]` because ATIF step timestamps are part of the payload format under test; here `created` is incidental (no assertion reads it back), so deriving it from now is a one-line fix and keeps the tests exercising the default read path. The OTLP conftest in this suite already derives span times from `now()`.

Dedupe/hash-fallback tests are unaffected: each reuses a single body dict within the test, so both POSTs carry the same `created`.

## Verification

`uv run --frozen pytest services/intake/tests/integration/spans/test_chat_completions_ingest.py -v` — 16 passed (8 failed before).

Swept intake tests for other fixed timestamps exposed to the lookback: `test_evaluator_results_atif.py` reads back via the evaluator-results endpoint (no lookback default); `test_atif_ingest.py` reads were already pinned by #174.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test data generation to ensure test spans remain within expected lookback windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->