### PR TITLE
fix(intake): Do not read unneeded trace input/output for list view

### DIFF
--- a/services/intake/src/nmp/intake/spans/trace_repository.py
+++ b/services/intake/src/nmp/intake/spans/trace_repository.py
@@ -35,8 +35,6 @@ TRACE_COLUMNS = [
     "source_format",
     "root_span_id",
     "name",
-    "input",
-    "output",
     "project",
     "experiment_id",
     "test_case_id",
@@ -69,8 +67,6 @@ _CURRENT_SPAN_VALUE_COLUMNS = (
     "attributes_string",
     "attributes_number",
     "attributes_bool",
-    "input",
-    "output",
     "event_ts",
     "is_deleted",
 )
@@ -199,8 +195,6 @@ def _trace_select_columns(*, include_aggregates: bool) -> str:
         "traces.source_format AS source_format",
         "traces.root_span_id AS root_span_id",
         "traces.name AS name",
-        "traces.input AS input",
-        "traces.output AS output",
         "traces.project AS project",
         "traces.experiment_id AS experiment_id",
         "traces.test_case_id AS test_case_id",
@@ -215,6 +209,8 @@ def _trace_select_columns(*, include_aggregates: bool) -> str:
 
 def _trace_index_sql(table: str, filters: TraceListFilter) -> tuple[str, dict[str, Any]]:
     where_sql, parameters = _trace_index_where(filters, qualifier="trace_roots")
+    # Trace responses do not expose root payloads; including those wide text
+    # columns here forces ClickHouse to scan them before pagination.
     query = f"""
         SELECT
             trace_roots.trace_id AS id,
@@ -223,8 +219,6 @@ def _trace_index_sql(table: str, filters: TraceListFilter) -> tuple[str, dict[st
             trace_roots.source_format AS source_format,
             nullIf(trace_roots.root_span_id, '') AS root_span_id,
             nullIf(trace_roots.root_name, '') AS name,
-            nullIf(trace_roots.root_input, '') AS input,
-            nullIf(trace_roots.root_output, '') AS output,
             nullIf(trace_roots.project, '') AS project,
             nullIf(trace_roots.experiment_id, '') AS experiment_id,
             nullIf(trace_roots.test_case_id, '') AS test_case_id,
@@ -232,7 +226,7 @@ def _trace_index_sql(table: str, filters: TraceListFilter) -> tuple[str, dict[st
             trace_roots.root_ended_at AS ended_at,
             trace_roots.root_status AS status,
             trace_roots.event_ts AS ingested_at
-        FROM (SELECT * FROM {table} FINAL) AS trace_roots
+        FROM {table} AS trace_roots FINAL
         WHERE {where_sql}
         ORDER BY trace_roots.root_started_at ASC, trace_roots.root_span_id ASC
         LIMIT 1 BY trace_roots.workspace, trace_roots.source_format, trace_roots.trace_id
@@ -325,7 +319,11 @@ def _trace_index_where(filters: TraceListFilter, *, qualifier: str) -> tuple[str
     return " AND ".join(clauses), parameters
 
 
-def current_spans_sql(table: str, *, extra_where_sql: str | None = None) -> str:
+def current_spans_sql(
+    table: str,
+    *,
+    extra_where_sql: str | None = None,
+) -> str:
     source_alias = "span_versions"
     columns = [
         *[f"{source_alias}.{column} AS {column}" for column in _CURRENT_SPAN_IDENTITY_COLUMNS],

--- a/services/intake/tests/test_traces_clickhouse_repository.py
+++ b/services/intake/tests/test_traces_clickhouse_repository.py
@@ -65,8 +65,10 @@ async def test_summary_mode_reads_root_spans_without_metric_aggregates():
     )
 
     assert client.queries[0].lstrip().startswith("SELECT count()")
-    assert "FROM (SELECT * FROM trace_index FINAL) AS trace_roots" in client.queries[0]
+    assert "FROM trace_index AS trace_roots FINAL" in client.queries[0]
     assert "trace_roots.root_status AS status" in client.queries[0]
+    assert "trace_roots.root_input" not in client.queries[0]
+    assert "trace_roots.root_output" not in client.queries[0]
     assert "LIMIT 1 BY trace_roots.workspace, trace_roots.source_format, trace_roots.trace_id" in client.queries[0]
     assert "span_versions" not in client.queries[0]
     assert "sumIf" not in client.queries[1]
@@ -87,12 +89,16 @@ async def test_detailed_mode_adds_trace_aggregate_block():
         mode="detailed",
     )
 
-    assert "FROM (SELECT * FROM trace_index FINAL) AS trace_roots" in client.queries[0]
+    assert "FROM trace_index AS trace_roots FINAL" in client.queries[0]
     assert "span_versions" not in client.queries[0]
     assert "page_traces AS" in client.queries[1]
     assert "AS trace_spans" in client.queries[1]
     assert "(span_versions.workspace, span_versions.source_format, span_versions.trace_id) IN" in client.queries[1]
     assert "SELECT workspace, source_format, id FROM page_traces" in client.queries[1]
+    assert "argMax(span_versions.input," not in client.queries[1]
+    assert "argMax(span_versions.output," not in client.queries[1]
+    assert "argMax(span_versions.attributes_string," in client.queries[1]
+    assert "argMax(span_versions.attributes_number," in client.queries[1]
     assert "sumIf" in client.queries[1]
     assert "groupUniqArrayIf" in client.queries[1]
     assert "count() AS span_count" in client.queries[1]
@@ -120,8 +126,8 @@ async def test_list_traces_maps_detailed_row():
     assert trace.session_id == "session-a"
     assert trace.root_span_id == "span-root"
     assert trace.name == "root"
-    assert trace.input == "root input"
-    assert trace.output == "root output"
+    assert trace.input is None
+    assert trace.output is None
     assert trace.duration_ms == 2500
     assert trace.project == "project-a"
     assert trace.experiment_id == "experiment-a"
@@ -218,8 +224,6 @@ def _trace_row(
         "source_format": "otel",
         "root_span_id": "span-root",
         "name": "root",
-        "input": "root input",
-        "output": "root output",
         "project": "project-a",
         "experiment_id": "experiment-a",
         "test_case_id": "case-a",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated trace read/list responses to no longer expose root-level `input`/`output` payload fields.
  * Removed span `input`/`output` from trace rollup/value aggregation so only the supported aggregate fields are returned.
  * Kept root identity details (such as source format, root span ID, and name) in responses.
* **Tests**
  * Adjusted ClickHouse SQL expectation tests and updated row-mapping assertions to reflect the new query projections and `None` values for omitted payload fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->