### PR TITLE
feat(evaluator): add agent-eval SDK domain model value types

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/results.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/results.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Aggregated summary, coverage, and the root result for a completed agent evaluation."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
+from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalTask, SemanticReducer, ViewSignal
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
+from nemo_evaluator_sdk.metrics.protocol import MetricOutput
+from nemo_evaluator_sdk.metrics.utils import metric_type_name
+from nemo_evaluator_sdk.values.results import AggregatedMetricResult, AggregateRangeScore, AggregateScore
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AgentEvalMetricOutputCoverage(BaseModel):
+    """Coverage counts for one metric output across scored trials."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total: int = Field(default=0, description="Total scores considered for this metric output.")
+    scored: int = Field(default=0, description="Scores that produced this output successfully.")
+    failed: int = Field(default=0, description="Scores where the metric failed to run.")
+    missing: int = Field(default=0, description="Scores where the output was expected but absent.")
+
+
+class AgentEvalSummary(BaseModel):
+    """Aggregated metric and semantic-view scores, coverage, and run counts for an agent-eval run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scores: AggregatedMetricResult = Field(
+        default_factory=lambda: AggregatedMetricResult(scores=[]),
+        description=(
+            "Aggregated statistics (mean/min/max/std_dev/nan_count) per metric output, named "
+            "'<metric_type>.<output>', plus per-semantic-view rollups named 'view.<name>'. "
+            "Failed or missing scores are surfaced as nan_count."
+        ),
+    )
+    metric_coverage: dict[str, dict[str, AgentEvalMetricOutputCoverage]] = Field(
+        default_factory=dict,
+        description="Per-metric, per-output coverage counts (total/scored/failed/missing).",
+    )
+    task_count: int = Field(default=0, description="Number of tasks represented in the run.")
+    trial_count: int = Field(default=0, description="Number of distinct trials scored.")
+    score_count: int = Field(default=0, description="Total number of metric scores.")
+
+    @staticmethod
+    def from_scores(
+        scores: Sequence[AgentEvalTaskScore],
+        *,
+        tasks: Sequence[AgentEvalTask] | None = None,
+    ) -> AgentEvalSummary:
+        """Build aggregated scores and coverage for a set of metric scores."""
+        task_list = list(tasks) if tasks is not None else None
+        return AgentEvalSummary(
+            scores=_aggregate_scores(scores, task_list),
+            metric_coverage=_metric_coverage(scores, task_list),
+            task_count=len(task_list) if task_list is not None else len({score.task_id for score in scores}),
+            trial_count=len({score.trial_id for score in scores}),
+            score_count=len(scores),
+        )
+
+
+class AgentEvalResult(BaseModel):
+    """Root result for a completed agent evaluation: tasks, trials, scores, summary, and bundle metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(description="Identifier of this run.")
+    tasks: list[AgentEvalTask] = Field(description="Immutable task definitions evaluated in this run.")
+    trials: list[AgentEvalTrial] = Field(description="Trials produced or imported for the run.")
+    scores: list[AgentEvalTaskScore] = Field(description="Metric scores computed for the trials.")
+    summary: AgentEvalSummary = Field(description="Derived rollups and coverage computed for the run.")
+    benchmark: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Benchmark metadata recorded for the run.",
+    )
+    output_dir: Path | None = Field(default=None, description="Directory the run bundle was written to, if any.")
+    dashboard_path: Path | None = Field(default=None, description="Path to the rendered dashboard, if written.")
+
+
+def _aggregate_scores(
+    scores: Sequence[AgentEvalTaskScore],
+    tasks: Sequence[AgentEvalTask] | None,
+) -> AggregatedMetricResult:
+    """Aggregate per-metric-output and per-semantic-view values into range scores.
+
+    Each metric output becomes a score named ``<metric_type>.<output>`` and each
+    semantic view a score named ``view.<name>``. Failed and missing scores are
+    surfaced as ``nan_count`` so coverage is visible alongside the statistics.
+    """
+    aggregated: list[AggregateScore] = []
+
+    output_names = _metric_output_names(scores, tasks)
+    for metric_type, names in sorted(output_names.items()):
+        metric_records = [score for score in scores if score.metric_type == metric_type]
+        total = len(metric_records)
+        for output_name in names:
+            values: list[float] = []
+            for score in metric_records:
+                value = None
+                # PARTIAL scores can still emit valid per-output values; include them so
+                # stats agree with coverage (which counts non-FAILED outputs as scored).
+                # Outputs actually missing on a PARTIAL score stay None -> counted as nan.
+                if score.status in (AgentEvalScoreStatus.COMPLETED, AgentEvalScoreStatus.PARTIAL):
+                    output = _score_output(score, output_name)
+                    value = _numeric_value(output) if output is not None else None
+                if value is not None:
+                    values.append(value)
+            aggregated.append(_aggregate_range_score(f"{metric_type}.{output_name}", values, total))
+
+    for view_name, (values, total) in sorted(_semantic_view_values(scores, tasks).items()):
+        aggregated.append(_aggregate_range_score(f"view.{view_name}", values, total))
+
+    return AggregatedMetricResult(scores=aggregated)
+
+
+def _aggregate_range_score(name: str, values: list[float], total: int) -> AggregateRangeScore:
+    finite = [value for value in values if math.isfinite(value)]
+    count = len(finite)
+    nan_count = max(total - count, 0)
+    if not finite:
+        return AggregateRangeScore(name=name, count=0, nan_count=nan_count)
+    total_sum = sum(finite)
+    mean = total_sum / count
+    variance = sum((value - mean) ** 2 for value in finite) / count
+    return AggregateRangeScore(
+        name=name,
+        count=count,
+        nan_count=nan_count,
+        sum=total_sum,
+        mean=mean,
+        min=min(finite),
+        max=max(finite),
+        variance=variance,
+        std_dev=math.sqrt(variance),
+    )
+
+
+def _metric_coverage(
+    scores: Sequence[AgentEvalTaskScore],
+    tasks: Sequence[AgentEvalTask] | None,
+) -> dict[str, dict[str, AgentEvalMetricOutputCoverage]]:
+    output_names = _metric_output_names(scores, tasks)
+    coverage: dict[str, dict[str, AgentEvalMetricOutputCoverage]] = {}
+    for metric_type, names in sorted(output_names.items()):
+        metric_records = [score for score in scores if score.metric_type == metric_type]
+        metric_coverage: dict[str, AgentEvalMetricOutputCoverage] = {}
+        for output_name in names:
+            total = len(metric_records)
+            failed = sum(1 for score in metric_records if score.status == AgentEvalScoreStatus.FAILED)
+            scored = sum(
+                1
+                for score in metric_records
+                if score.status != AgentEvalScoreStatus.FAILED
+                and any(output.name == output_name for output in score.outputs)
+            )
+            metric_coverage[output_name] = AgentEvalMetricOutputCoverage(
+                total=total,
+                scored=scored,
+                failed=failed,
+                missing=max(total - scored - failed, 0),
+            )
+        coverage[metric_type] = metric_coverage
+    return coverage
+
+
+def _metric_output_names(
+    scores: Sequence[AgentEvalTaskScore],
+    tasks: Sequence[AgentEvalTask] | None,
+) -> dict[str, list[str]]:
+    names: dict[str, set[str]] = {}
+    if tasks is not None:
+        for task in tasks:
+            for metric in task.metrics:
+                metric_type = metric_type_name(metric)
+                for output in metric.output_spec():
+                    names.setdefault(metric_type, set()).add(output.name)
+
+    for score in scores:
+        for output in score.outputs:
+            names.setdefault(score.metric_type, set()).add(output.name)
+    return {metric_type: sorted(output_names) for metric_type, output_names in names.items()}
+
+
+def _semantic_view_values(
+    scores: Sequence[AgentEvalTaskScore],
+    tasks: Sequence[AgentEvalTask] | None,
+) -> dict[str, tuple[list[float], int]]:
+    """Return reduced view values and the number of attempted reductions per view.
+
+    The integer in each tuple is the total number of trial/view reductions
+    attempted (the denominator for nan_count); the list holds the values that
+    reduced successfully.
+    """
+    if tasks is None:
+        return {}
+
+    tasks_by_id = {task.id: task for task in tasks}
+    # Match the stats path: PARTIAL scores may carry usable signal outputs. Missing
+    # signals still skip the view reduction below, so admitting PARTIAL is safe.
+    score_by_key = {
+        (score.task_id, score.trial_id, score.metric_type): score
+        for score in scores
+        if score.status in (AgentEvalScoreStatus.COMPLETED, AgentEvalScoreStatus.PARTIAL)
+    }
+    trials_by_task: dict[str, set[str]] = {}
+    for score in scores:
+        trials_by_task.setdefault(score.task_id, set()).add(score.trial_id)
+
+    values_by_view: dict[str, list[float]] = {}
+    totals_by_view: dict[str, int] = {}
+    for task_id, trial_ids in trials_by_task.items():
+        task = tasks_by_id.get(task_id)
+        if task is None:
+            continue
+        for trial_id in trial_ids:
+            for view_name, view in task.views.items():
+                totals_by_view[view_name] = totals_by_view.get(view_name, 0) + 1
+                signal_values: list[float] = []
+                for signal in view.signals:
+                    score = score_by_key.get((task_id, trial_id, signal.metric))
+                    output = _score_output(score, signal.output) if score is not None else None
+                    value = _semantic_value(output) if output is not None else None
+                    if value is None:
+                        signal_values = []
+                        break
+                    signal_values.append(value)
+                if not signal_values:
+                    continue
+                reduced = _reduce_semantic_view(view.reducer, signal_values, view.signals)
+                if reduced is not None:
+                    values_by_view.setdefault(view_name, []).append(reduced)
+
+    return {view_name: (values_by_view.get(view_name, []), total) for view_name, total in totals_by_view.items()}
+
+
+def _score_output(score: AgentEvalTaskScore | None, output_name: str) -> MetricOutput | None:
+    if score is None:
+        return None
+    for output in score.outputs:
+        if output.name == output_name:
+            return output
+    return None
+
+
+def _reduce_semantic_view(
+    reducer: SemanticReducer,
+    values: list[float],
+    signals: list[ViewSignal],
+) -> float | None:
+    if reducer == SemanticReducer.SINGLE:
+        return values[0]
+    if reducer == SemanticReducer.ALL:
+        return min(values)
+    if reducer == SemanticReducer.ANY:
+        return max(values)
+    if reducer == SemanticReducer.MEAN:
+        return mean_numeric(values)
+    weights = [signal.weight if signal.weight is not None else 1.0 for signal in signals]
+    denominator = sum(weights)
+    if denominator == 0:
+        return None
+    return sum(value * weight for value, weight in zip(values, weights, strict=True)) / denominator
+
+
+def _numeric_value(output: MetricOutput) -> float | None:
+    value = output.value
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, BaseModel):
+        root = getattr(value, "root", None)
+        if isinstance(root, bool):
+            return None
+        if isinstance(root, int | float):
+            return float(root)
+    return None
+
+
+def _semantic_value(output: MetricOutput) -> float | None:
+    value = output.value
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, BaseModel):
+        root = getattr(value, "root", None)
+        if isinstance(root, bool):
+            return 1.0 if root else 0.0
+    return _numeric_value(output)
+
+
+def mean_numeric(values: list[float]) -> float | None:
+    """Return the mean of finite numeric values, ignoring missing and NaN."""
+    finite = [value for value in values if math.isfinite(value)]
+    if not finite:
+        return None
+    return sum(finite) / len(finite)

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/scores.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/scores.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-trial metric scoring records and scoring diagnostics."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from nemo_evaluator_sdk.metrics.protocol import MetricOutput
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AgentEvalScoreStatus(str, Enum):
+    """Status of metric scoring for one trial."""
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+class AgentEvalDiagnosticSeverity(str, Enum):
+    """Severity level for a scoring diagnostic."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class AgentEvalDiagnostic(BaseModel):
+    """Diagnostic emitted while scoring one trial with one metric."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    severity: AgentEvalDiagnosticSeverity = Field(description="Severity of the diagnostic.")
+    message: str = Field(description="Human-readable diagnostic message.")
+    source: str | None = Field(
+        default=None,
+        description="Component or stage that produced the diagnostic, if known.",
+    )
+    details: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured supporting details for the diagnostic.",
+    )
+
+
+class AgentEvalTaskScore(BaseModel):
+    """Per-task, per-trial, per-metric scoring record: metric outputs, diagnostics, status, and metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(description="Stable identifier for this score record.")
+    run_id: str = Field(description="Identifier of the run this score belongs to.")
+    task_id: str = Field(description="Identifier of the task that was scored.")
+    trial_id: str = Field(description="Identifier of the trial that was scored.")
+    metric_type: str = Field(description="Task-local metric type (metric.type) that produced this score.")
+    status: AgentEvalScoreStatus = Field(description="Status of this metric score.")
+    outputs: list[MetricOutput] = Field(
+        default_factory=list,
+        description="Named metric outputs emitted for this trial/metric pair.",
+    )
+    diagnostics: list[AgentEvalDiagnostic] = Field(
+        default_factory=list,
+        description="Diagnostics emitted while scoring this trial with this metric.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the score.",
+    )

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task definitions, semantic views, and run configuration for agent evaluation."""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from nemo_evaluator_sdk.metrics.protocol import Metric
+from nemo_evaluator_sdk.metrics.utils import metric_type_name
+from nemo_evaluator_sdk.values import RunConfig, RunConfigOnline, RunConfigOnlineModel
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
+
+
+class SemanticReducer(str, Enum):
+    """Reduction strategy used to combine task-scoped view signals into one score."""
+
+    SINGLE = "single"
+    ALL = "all"
+    ANY = "any"
+    MEAN = "mean"
+    WEIGHTED_MEAN = "weighted_mean"
+
+
+class ViewSignal(BaseModel):
+    """Task-scoped metric output that contributes to a semantic view."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    metric: str = Field(description="Task-local metric type (metric.type) whose output feeds this signal.")
+    output: str = Field(description="Name of the metric output, as declared by the metric's output_spec().")
+    weight: float | None = Field(
+        default=None,
+        description="Relative weight for this signal when the view reducer is 'weighted_mean'; unused otherwise.",
+    )
+
+    @field_validator("metric", "output")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("view signal metric and output must not be empty")
+        return value
+
+
+class SemanticView(BaseModel):
+    """Task-scoped reporting view that maps a task's own metric outputs into a named score."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reducer: SemanticReducer = Field(
+        description="Strategy used to reduce this view's signals into a single task-level score.",
+    )
+    signals: list[ViewSignal] = Field(
+        min_length=1,
+        description="Ordered metric outputs contributing to this view; at least one is required.",
+    )
+
+
+class AgentEvalTask(BaseModel):
+    """Standalone agent-eval task: the unit of work being evaluated."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    id: str = Field(description="Stable task identifier, unique within the supplied task collection.")
+    intent: str = Field(description="Human-readable description of the desired agent behavior.")
+    inputs: dict[str, Any] = Field(
+        description="What the agent receives or starts from, e.g. instruction, filesystem seed, or state refs.",
+    )
+    metrics: list[Metric] = Field(
+        default_factory=list,
+        description="Ordered concrete SDK metric instances that score this task; metric types must be unique.",
+    )
+    views: dict[str, SemanticView] = Field(
+        default_factory=dict,
+        description="Optional reporting views mapping this task's metric outputs into named semantic scores.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the task.",
+    )
+
+    @field_validator("id")
+    @classmethod
+    def _id_must_not_be_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("task id must not be empty")
+        return value
+
+    @field_serializer("metrics", when_used="json")
+    def _serialize_metrics(self, metrics: list[Metric]) -> list[dict[str, Any]]:
+        """Serialize local metric instances as descriptors for run bundles."""
+        serialized: list[dict[str, Any]] = []
+        for metric in metrics:
+            outputs = [
+                {
+                    "name": output.name,
+                    "description": output.description,
+                    "value_schema": output.value_schema.__name__,
+                }
+                for output in metric.output_spec()
+            ]
+            serialized.append({"type": metric_type_name(metric), "outputs": outputs})
+        return serialized
+
+    @model_validator(mode="after")
+    def _validate_metric_references(self) -> AgentEvalTask:
+        metric_types = [metric_type_name(metric) for metric in self.metrics]
+        duplicate_metric_types = sorted(
+            {metric_type for metric_type in metric_types if metric_types.count(metric_type) > 1}
+        )
+        if duplicate_metric_types:
+            raise ValueError(f"duplicate task metric types: {duplicate_metric_types}")
+
+        outputs_by_metric = {
+            metric_type_name(metric): {output.name for output in metric.output_spec()} for metric in self.metrics
+        }
+        for view_name, view in self.views.items():
+            for signal in view.signals:
+                if signal.metric not in outputs_by_metric:
+                    raise ValueError(f"view {view_name!r} references unknown metric {signal.metric!r}")
+                if signal.output not in outputs_by_metric[signal.metric]:
+                    raise ValueError(
+                        f"view {view_name!r} references unknown output {signal.output!r} for metric {signal.metric!r}"
+                    )
+        return self
+
+
+class AgentEvalRunConfig(BaseModel):
+    """Configuration for a standalone agent-eval run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    output_dir: Path | None = Field(
+        default=None,
+        description="Directory where the run bundle is written; in-memory only when omitted.",
+    )
+    run_id: str | None = Field(default=None, description="Explicit run identifier; generated when omitted.")
+    prompt_template: str | dict[str, Any] | None = Field(
+        default=None,
+        description="Optional prompt template applied when generating trials online.",
+    )
+    params: RunConfig | RunConfigOnline | RunConfigOnlineModel | None = Field(
+        default=None,
+        description="Inference/run parameters used when producing trials online.",
+    )
+    parallelism: int = Field(default=4, ge=1, description="Maximum number of tasks scored concurrently.")
+    write_dashboard: bool = Field(default=True, description="Whether to render an HTML dashboard for the run.")
+    benchmark: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Benchmark metadata recorded alongside the run.",
+    )
+    fail_fast: bool = Field(default=False, description="Stop the run on the first scoring failure when True.")

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trial artifacts and the runtime interface that produces them."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+from nemo_evaluator_sdk.values import Agent, Model
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class AgentEvalTrialStatus(str, Enum):
+    """Lifecycle status for a trial: completed, failed, or partial."""
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+class AgentOutput(BaseModel):
+    """Captured final output from the evaluated agent, model, or imported baseline for a trial."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    output_text: str | None = Field(
+        default=None,
+        description="User-visible final text produced by the agent, if any.",
+    )
+    response: Any | None = Field(
+        default=None,
+        description="Structured final response payload produced by the agent, if any.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the agent output.",
+    )
+
+
+class AgentEvalTrial(BaseModel):
+    """Durable trial artifact for one task: output, evidence, status, and metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(description="Stable identifier for this trial.")
+    task_id: str = Field(description="Identifier of the AgentEvalTask this trial was produced for.")
+    status: AgentEvalTrialStatus = Field(description="Lifecycle status of the trial.")
+    output: AgentOutput | None = Field(
+        default=None,
+        description="Final agent output captured for the trial; required when status is completed.",
+    )
+    evidence: CandidateEvidence | None = Field(
+        default=None,
+        description="Named evidence descriptors (final state, traces, logs, ...) captured for the trial.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the trial.",
+    )
+
+    @field_validator("id", "task_id")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("trial id and task_id must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def _completed_trial_requires_output(self) -> AgentEvalTrial:
+        if self.status == AgentEvalTrialStatus.COMPLETED and self.output is None:
+            raise ValueError("completed trial requires output")
+        return self
+
+
+@runtime_checkable
+class AgentTaskRunner(Protocol):
+    """Online execution interface that runs tasks and produces trials."""
+
+    async def run_tasks(
+        self,
+        tasks: Sequence[AgentEvalTask],
+        config: AgentEvalRunConfig | None = None,
+    ) -> Sequence[AgentEvalTrial]: ...
+
+
+AgentEvalTarget = Model | Agent | AgentTaskRunner

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/__init__.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/__init__.py
@@ -10,6 +10,7 @@ from nemo_evaluator_sdk.values.dataset_schemas import (
     InputSchema,
 )
 from nemo_evaluator_sdk.values.datasets import DatasetInput, DatasetRows
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor, LocalFilesystemEvidence
 from nemo_evaluator_sdk.values.metrics import (
     BLEU,
     F1,
@@ -95,6 +96,7 @@ __all__ = [
     "AggregateScore",
     "AggregateScoreBase",
     "BooleanValue",
+    "CandidateEvidence",
     "CandidateOutput",
     "ContinuousScore",
     "DatasetRow",
@@ -110,6 +112,7 @@ __all__ = [
     "InferenceParams",
     "JSONScoreParser",
     "Label",
+    "LocalFilesystemEvidence",
     "MetricDescriptor",
     "MetricInput",
     "MetricOutput",
@@ -121,6 +124,7 @@ __all__ = [
     "ModelRef",
     "DatasetInput",
     "EvaluationResult",
+    "EvidenceDescriptor",
     "Percentiles",
     "RangeScore",
     "ReasoningParams",

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evidence value types shared by protocol metrics and agent evaluations."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+
+
+class LocalFilesystemEvidence:
+    """Constrained local filesystem handle for metric evidence access."""
+
+    def __init__(self, root: str | Path) -> None:
+        self._root = Path(root).expanduser().resolve()
+
+    @property
+    def root(self) -> Path:
+        """Resolved root path for this local evidence handle."""
+        return self._root
+
+    def path(self, relative_path: str | Path = ".") -> Path:
+        """Return a path under the evidence root, rejecting traversal outside it."""
+        relative = Path(relative_path)
+        candidate = relative.resolve() if relative.is_absolute() else (self._root / relative).resolve()
+        if candidate != self._root and self._root not in candidate.parents:
+            raise ValueError(f"evidence path {relative_path!r} resolves outside evidence root")
+        return candidate
+
+    async def exists(self, relative_path: str | Path = ".") -> bool:
+        """Return whether a path exists under the evidence root."""
+        path = self.path(relative_path)
+        return await asyncio.to_thread(path.exists)
+
+    async def read_text(self, relative_path: str | Path, *, encoding: str = "utf-8") -> str:
+        """Read a text file under the evidence root."""
+        path = self.path(relative_path)
+        return await asyncio.to_thread(path.read_text, encoding=encoding)
+
+    async def iter_paths(self, relative_path: str | Path = ".", *, recursive: bool = False) -> list[str]:
+        """Return stable relative path names under the evidence root."""
+        base = self.path(relative_path)
+        return await asyncio.to_thread(self._iter_paths_sync, base, recursive)
+
+    def _iter_paths_sync(self, base: Path, recursive: bool) -> list[str]:
+        if base.is_file():
+            return [base.relative_to(self._root).as_posix()]
+        iterator = base.rglob("*") if recursive else base.iterdir()
+        return sorted(path.relative_to(self._root).as_posix() for path in iterator)
+
+
+class EvidenceDescriptor(BaseModel):
+    """Descriptor for a candidate trace, source, or artifact."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str = Field(description="Evidence type, e.g. 'filesystem', 'trace', 'log_bundle', or 'review'.")
+    ref: str | None = Field(
+        default=None,
+        description="Reference to externally stored evidence (e.g. a local path or storage ref).",
+    )
+    format: str | None = Field(
+        default=None,
+        description="Parser hint for the evidence payload, e.g. 'atif' for normalized traces.",
+    )
+    data: Any | None = Field(
+        default=None,
+        description="Small inline evidence payload; at least one of ref or data must be set.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the evidence descriptor.",
+    )
+
+    @model_validator(mode="after")
+    def _requires_ref_or_data(self) -> EvidenceDescriptor:
+        if self.ref is None and self.data is None:
+            raise ValueError("evidence descriptor requires ref or data")
+        return self
+
+
+class CandidateEvidence(BaseModel):
+    """Named evidence descriptors attached to an AgentEvalAttempt."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    descriptors: dict[str, EvidenceDescriptor] = Field(
+        default_factory=dict,
+        description="Evidence descriptors keyed by name (e.g. 'final_state', 'trace', 'logs').",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the evidence collection.",
+    )
+    _filesystem_cache: dict[str, LocalFilesystemEvidence] = PrivateAttr(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_descriptor_mapping(cls, value: Any) -> Any:
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, dict) and "descriptors" not in value and "metadata" not in value:
+            return {"descriptors": value}
+        return value
+
+    def names(self, *, kind: str | None = None) -> list[str]:
+        """Return evidence names, optionally filtered by descriptor kind."""
+        if kind is None:
+            return list(self.descriptors)
+        return [name for name, descriptor in self.descriptors.items() if descriptor.kind == kind]
+
+    def get(self, name: str) -> EvidenceDescriptor | None:
+        """Return a descriptor by name without materializing evidence."""
+        return self.descriptors.get(name)
+
+    def require(self, name: str, *, kind: str | None = None) -> EvidenceDescriptor:
+        """Return a descriptor by name, raising when it is missing or has the wrong kind."""
+        descriptor = self.get(name)
+        if descriptor is None:
+            raise KeyError(f"missing evidence descriptor {name!r}")
+        if kind is not None and descriptor.kind != kind:
+            raise ValueError(f"evidence descriptor {name!r} has kind {descriptor.kind!r}, expected {kind!r}")
+        return descriptor
+
+    async def filesystem(self, name: str) -> LocalFilesystemEvidence:
+        """Return a cached local filesystem handle for a named filesystem descriptor."""
+        cached = self._filesystem_cache.get(name)
+        if cached is not None:
+            return cached
+
+        descriptor = self.require(name, kind="filesystem")
+        if descriptor.ref is None:
+            raise ValueError(f"filesystem evidence descriptor {name!r} requires a local ref")
+
+        root = _local_filesystem_ref(descriptor.ref)
+        handle = LocalFilesystemEvidence(root)
+        self._filesystem_cache[name] = handle
+        return handle
+
+
+def _local_filesystem_ref(ref: str) -> Path:
+    """Resolve a local filesystem ref to a Path.
+
+    Accepts POSIX paths, ``file://`` URIs, and Windows drive paths (e.g. ``C:\\dir``).
+    Network and cloud URI schemes (http, https, s3, gs, ...) are rejected.
+    """
+    parsed = urlparse(ref)
+    # A single-letter scheme is a Windows drive letter (e.g. "C:\\dir"), not a URI scheme.
+    if len(parsed.scheme) == 1 and parsed.scheme.isalpha():
+        return Path(ref)
+    if parsed.scheme in {"http", "https", "s3", "gs"}:
+        raise ValueError("CandidateEvidence.filesystem only supports local filesystem refs")
+    if parsed.scheme == "file":
+        return Path(parsed.path)
+    if parsed.scheme:
+        raise ValueError(f"CandidateEvidence.filesystem does not support {parsed.scheme!r} refs")
+    return Path(ref)

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/protocol.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/protocol.py
@@ -10,6 +10,8 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel, StringConstraints, field_serializer, field_validator
 
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence
+
 MetricTypeName = Annotated[str, StringConstraints(min_length=1)]
 
 
@@ -30,6 +32,10 @@ class CandidateOutput(BaseModel):
     output_text: str | None = None
     response: Any | None = None
     trajectory: Any | None = None
+    evidence: CandidateEvidence | None = Field(
+        default=None,
+        description="Named evidence captured for the candidate (final state, traces, logs, ...) for agent eval.",
+    )
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     def as_sample(self) -> dict[str, Any]:
@@ -41,6 +47,8 @@ class CandidateOutput(BaseModel):
             sample["response"] = self.response
         if self.trajectory is not None:
             sample["trajectory"] = self.trajectory
+        if self.evidence is not None:
+            sample["evidence"] = self.evidence
         return sample
 
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/results.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/results.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Aggregated summary, coverage, and the root result for a completed agent evaluation."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from nemo_platform.beta.evaluator.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
+from nemo_platform.beta.evaluator.agent_eval.tasks import AgentEvalTask, SemanticReducer, ViewSignal
+from nemo_platform.beta.evaluator.agent_eval.trials import AgentEvalTrial
+from nemo_platform.beta.evaluator.metrics.protocol import MetricOutput
+from nemo_platform.beta.evaluator.metrics.utils import metric_type_name
+from nemo_platform.beta.evaluator.values.results import AggregatedMetricResult, AggregateRangeScore, AggregateScore
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AgentEvalMetricOutputCoverage(BaseModel):
+    """Coverage counts for one metric output across scored trials."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total: int = Field(default=0, description="Total scores considered for this metric output.")
+    scored: int = Field(default=0, description="Scores that produced this output successfully.")
+    failed: int = Field(default=0, description="Scores where the metric failed to run.")
+    missing: int = Field(default=0, description="Scores where the output was expected but absent.")
+
+
+class AgentEvalSummary(BaseModel):
+    """Aggregated metric and semantic-view scores, coverage, and run counts for an agent-eval run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scores: AggregatedMetricResult = Field(
+        default_factory=lambda: AggregatedMetricResult(scores=[]),
+        description=(
+            "Aggregated statistics (mean/min/max/std_dev/nan_count) per metric output, named "
+            "'<metric_type>.<output>', plus per-semantic-view rollups named 'view.<name>'. "
+            "Failed or missing scores are surfaced as nan_count."
+        ),
+    )
+    metric_coverage: dict[str, dict[str, AgentEvalMetricOutputCoverage]] = Field(
+        default_factory=dict,
+        description="Per-metric, per-output coverage counts (total/scored/failed/missing).",
+    )
+    task_count: int = Field(default=0, description="Number of tasks represented in the run.")
+    trial_count: int = Field(default=0, description="Number of distinct trials scored.")
+    score_count: int = Field(default=0, description="Total number of metric scores.")
+
+    @staticmethod
+    def from_scores(
+        scores: Sequence[AgentEvalTaskScore],
+        *,
+        tasks: Sequence[AgentEvalTask] | None = None,
+    ) -> AgentEvalSummary:
+        """Build aggregated scores and coverage for a set of metric scores."""
+        task_list = list(tasks) if tasks is not None else None
+        return AgentEvalSummary(
+            scores=_aggregate_scores(scores, task_list),
+            metric_coverage=_metric_coverage(scores, task_list),
+            task_count=len(task_list) if task_list is not None else len({score.task_id for score in scores}),
+            trial_count=len({score.trial_id for score in scores}),
+            score_count=len(scores),
+        )
+
+
+class AgentEvalResult(BaseModel):
+    """Root result for a completed agent evaluation: tasks, trials, scores, summary, and bundle metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(description="Identifier of this run.")
+    tasks: list[AgentEvalTask] = Field(description="Immutable task definitions evaluated in this run.")
+    trials: list[AgentEvalTrial] = Field(description="Trials produced or imported for the run.")
+    scores: list[AgentEvalTaskScore] = Field(description="Metric scores computed for the trials.")
+    summary: AgentEvalSummary = Field(description="Derived rollups and coverage computed for the run.")
+    benchmark: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Benchmark metadata recorded for the run.",
+    )
+    output_dir: Path | None = Field(default=None, description="Directory the run bundle was written to, if any.")
+    dashboard_path: Path | None = Field(default=None, description="Path to the rendered dashboard, if written.")
+
+
+def _aggregate_scores(
+    scores: Sequence[AgentEvalTaskScore],
+    tasks: Sequence[AgentEvalTask] | None,
+) -> AggregatedMetricResult:
+    """Aggregate per-metric-output and per-semantic-view values into range scores.
+
+    Each metric output becomes a score named ``<metric_type>.<output>`` and each
+    semantic view a score named ``view.<name>``. Failed and missing scores are
+    surfaced as ``nan_count`` so coverage is visible alongside the statistics.
+    """
+    aggregated: list[AggregateScore] = []
+
+    output_names = _metric_output_names(scores, tasks)
+    for metric_type, names in sorted(output_names.items()):
+        metric_records = [score for score in scores if score.metric_type == metric_type]
+        total = len(metric_records)
+        for output_name in names:
+            values: list[float] = []
+            for score in metric_records:
+                value = None
+                # PARTIAL scores can still emit valid per-output values; include them so
+                # stats agree with coverage (which counts non-FAILED outputs as scored).
+                # Outputs actually missing on a PARTIAL score stay None -> counted as nan.
+                if score.status in (AgentEvalScoreStatus.COMPLETED, AgentEvalScoreStatus.PARTIAL):
+                    output = _score_output(score, output_name)
+                    value = _numeric_value(output) if output is not None else None
+                if value is not None:
+                    values.append(value)
+            aggregated.append(_aggregate_range_score(f"{metric_type}.{output_name}", values, total))
+
+    for view_name, (values, total) in sorted(_semantic_view_values(scores, tasks).items()):
+        aggregated.append(_aggregate_range_score(f"view.{view_name}", values, total))
+
+    return AggregatedMetricResult(scores=aggregated)
+
+
+def _aggregate_range_score(name: str, values: list[float], total: int) -> AggregateRangeScore:
+    finite = [value for value in values if math.isfinite(value)]
+    count = len(finite)
+    nan_count = max(total - count, 0)
+    if not finite:
+        return AggregateRangeScore(name=name, count=0, nan_count=nan_count)
+    total_sum = sum(finite)
+    mean = total_sum / count
+    variance = sum((value - mean) ** 2 for value in finite) / count
+    return AggregateRangeScore(
+        name=name,
+        count=count,
+        nan_count=nan_count,
+        sum=total_sum,
+        mean=mean,
+        min=min(finite),
+        max=max(finite),
+        variance=variance,
+        std_dev=math.sqrt(variance),
+    )
+
+
+def _metric_coverage(
+    scores: Sequence[AgentEvalTaskScore],
+    tasks: Sequence[AgentEvalTask] | None,
+) -> dict[str, dict[str, AgentEvalMetricOutputCoverage]]:
+    output_names = _metric_output_names(scores, tasks)
+    coverage: dict[str, dict[str, AgentEvalMetricOutputCoverage]] = {}
+    for metric_type, names in sorted(output_names.items()):
+        metric_records = [score for score in scores if score.metric_type == metric_type]
+        metric_coverage: dict[str, AgentEvalMetricOutputCoverage] = {}
+        for output_name in names:
+            total = len(metric_records)
+            failed = sum(1 for score in metric_records if score.status == AgentEvalScoreStatus.FAILED)
+            scored = sum(
+                1
+                for score in metric_records
+                if score.status != AgentEvalScoreStatus.FAILED
+                and any(output.name == output_name for output in score.outputs)
+            )
+            metric_coverage[output_name] = AgentEvalMetricOutputCoverage(
+                total=total,
+                scored=scored,
+                failed=failed,
+                missing=max(total - scored - failed, 0),
+            )
+        coverage[metric_type] = metric_coverage
+    return coverage
+
+
+def _metric_output_names(
+    scores: Sequence[AgentEvalTaskScore],
+    tasks: Sequence[AgentEvalTask] | None,
+) -> dict[str, list[str]]:
+    names: dict[str, set[str]] = {}
+    if tasks is not None:
+        for task in tasks:
+            for metric in task.metrics:
+                metric_type = metric_type_name(metric)
+                for output in metric.output_spec():
+                    names.setdefault(metric_type, set()).add(output.name)
+
+    for score in scores:
+        for output in score.outputs:
+            names.setdefault(score.metric_type, set()).add(output.name)
+    return {metric_type: sorted(output_names) for metric_type, output_names in names.items()}
+
+
+def _semantic_view_values(
+    scores: Sequence[AgentEvalTaskScore],
+    tasks: Sequence[AgentEvalTask] | None,
+) -> dict[str, tuple[list[float], int]]:
+    """Return reduced view values and the number of attempted reductions per view.
+
+    The integer in each tuple is the total number of trial/view reductions
+    attempted (the denominator for nan_count); the list holds the values that
+    reduced successfully.
+    """
+    if tasks is None:
+        return {}
+
+    tasks_by_id = {task.id: task for task in tasks}
+    # Match the stats path: PARTIAL scores may carry usable signal outputs. Missing
+    # signals still skip the view reduction below, so admitting PARTIAL is safe.
+    score_by_key = {
+        (score.task_id, score.trial_id, score.metric_type): score
+        for score in scores
+        if score.status in (AgentEvalScoreStatus.COMPLETED, AgentEvalScoreStatus.PARTIAL)
+    }
+    trials_by_task: dict[str, set[str]] = {}
+    for score in scores:
+        trials_by_task.setdefault(score.task_id, set()).add(score.trial_id)
+
+    values_by_view: dict[str, list[float]] = {}
+    totals_by_view: dict[str, int] = {}
+    for task_id, trial_ids in trials_by_task.items():
+        task = tasks_by_id.get(task_id)
+        if task is None:
+            continue
+        for trial_id in trial_ids:
+            for view_name, view in task.views.items():
+                totals_by_view[view_name] = totals_by_view.get(view_name, 0) + 1
+                signal_values: list[float] = []
+                for signal in view.signals:
+                    score = score_by_key.get((task_id, trial_id, signal.metric))
+                    output = _score_output(score, signal.output) if score is not None else None
+                    value = _semantic_value(output) if output is not None else None
+                    if value is None:
+                        signal_values = []
+                        break
+                    signal_values.append(value)
+                if not signal_values:
+                    continue
+                reduced = _reduce_semantic_view(view.reducer, signal_values, view.signals)
+                if reduced is not None:
+                    values_by_view.setdefault(view_name, []).append(reduced)
+
+    return {view_name: (values_by_view.get(view_name, []), total) for view_name, total in totals_by_view.items()}
+
+
+def _score_output(score: AgentEvalTaskScore | None, output_name: str) -> MetricOutput | None:
+    if score is None:
+        return None
+    for output in score.outputs:
+        if output.name == output_name:
+            return output
+    return None
+
+
+def _reduce_semantic_view(
+    reducer: SemanticReducer,
+    values: list[float],
+    signals: list[ViewSignal],
+) -> float | None:
+    if reducer == SemanticReducer.SINGLE:
+        return values[0]
+    if reducer == SemanticReducer.ALL:
+        return min(values)
+    if reducer == SemanticReducer.ANY:
+        return max(values)
+    if reducer == SemanticReducer.MEAN:
+        return mean_numeric(values)
+    weights = [signal.weight if signal.weight is not None else 1.0 for signal in signals]
+    denominator = sum(weights)
+    if denominator == 0:
+        return None
+    return sum(value * weight for value, weight in zip(values, weights, strict=True)) / denominator
+
+
+def _numeric_value(output: MetricOutput) -> float | None:
+    value = output.value
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, BaseModel):
+        root = getattr(value, "root", None)
+        if isinstance(root, bool):
+            return None
+        if isinstance(root, int | float):
+            return float(root)
+    return None
+
+
+def _semantic_value(output: MetricOutput) -> float | None:
+    value = output.value
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, BaseModel):
+        root = getattr(value, "root", None)
+        if isinstance(root, bool):
+            return 1.0 if root else 0.0
+    return _numeric_value(output)
+
+
+def mean_numeric(values: list[float]) -> float | None:
+    """Return the mean of finite numeric values, ignoring missing and NaN."""
+    finite = [value for value in values if math.isfinite(value)]
+    if not finite:
+        return None
+    return sum(finite) / len(finite)

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/scores.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/scores.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-trial metric scoring records and scoring diagnostics."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from nemo_platform.beta.evaluator.metrics.protocol import MetricOutput
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AgentEvalScoreStatus(str, Enum):
+    """Status of metric scoring for one trial."""
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+class AgentEvalDiagnosticSeverity(str, Enum):
+    """Severity level for a scoring diagnostic."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class AgentEvalDiagnostic(BaseModel):
+    """Diagnostic emitted while scoring one trial with one metric."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    severity: AgentEvalDiagnosticSeverity = Field(description="Severity of the diagnostic.")
+    message: str = Field(description="Human-readable diagnostic message.")
+    source: str | None = Field(
+        default=None,
+        description="Component or stage that produced the diagnostic, if known.",
+    )
+    details: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured supporting details for the diagnostic.",
+    )
+
+
+class AgentEvalTaskScore(BaseModel):
+    """Per-task, per-trial, per-metric scoring record: metric outputs, diagnostics, status, and metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(description="Stable identifier for this score record.")
+    run_id: str = Field(description="Identifier of the run this score belongs to.")
+    task_id: str = Field(description="Identifier of the task that was scored.")
+    trial_id: str = Field(description="Identifier of the trial that was scored.")
+    metric_type: str = Field(description="Task-local metric type (metric.type) that produced this score.")
+    status: AgentEvalScoreStatus = Field(description="Status of this metric score.")
+    outputs: list[MetricOutput] = Field(
+        default_factory=list,
+        description="Named metric outputs emitted for this trial/metric pair.",
+    )
+    diagnostics: list[AgentEvalDiagnostic] = Field(
+        default_factory=list,
+        description="Diagnostics emitted while scoring this trial with this metric.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the score.",
+    )

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/tasks.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/tasks.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task definitions, semantic views, and run configuration for agent evaluation."""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from nemo_platform.beta.evaluator.metrics.protocol import Metric
+from nemo_platform.beta.evaluator.metrics.utils import metric_type_name
+from nemo_platform.beta.evaluator.values import RunConfig, RunConfigOnline, RunConfigOnlineModel
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
+
+
+class SemanticReducer(str, Enum):
+    """Reduction strategy used to combine task-scoped view signals into one score."""
+
+    SINGLE = "single"
+    ALL = "all"
+    ANY = "any"
+    MEAN = "mean"
+    WEIGHTED_MEAN = "weighted_mean"
+
+
+class ViewSignal(BaseModel):
+    """Task-scoped metric output that contributes to a semantic view."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    metric: str = Field(description="Task-local metric type (metric.type) whose output feeds this signal.")
+    output: str = Field(description="Name of the metric output, as declared by the metric's output_spec().")
+    weight: float | None = Field(
+        default=None,
+        description="Relative weight for this signal when the view reducer is 'weighted_mean'; unused otherwise.",
+    )
+
+    @field_validator("metric", "output")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("view signal metric and output must not be empty")
+        return value
+
+
+class SemanticView(BaseModel):
+    """Task-scoped reporting view that maps a task's own metric outputs into a named score."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reducer: SemanticReducer = Field(
+        description="Strategy used to reduce this view's signals into a single task-level score.",
+    )
+    signals: list[ViewSignal] = Field(
+        min_length=1,
+        description="Ordered metric outputs contributing to this view; at least one is required.",
+    )
+
+
+class AgentEvalTask(BaseModel):
+    """Standalone agent-eval task: the unit of work being evaluated."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    id: str = Field(description="Stable task identifier, unique within the supplied task collection.")
+    intent: str = Field(description="Human-readable description of the desired agent behavior.")
+    inputs: dict[str, Any] = Field(
+        description="What the agent receives or starts from, e.g. instruction, filesystem seed, or state refs.",
+    )
+    metrics: list[Metric] = Field(
+        default_factory=list,
+        description="Ordered concrete SDK metric instances that score this task; metric types must be unique.",
+    )
+    views: dict[str, SemanticView] = Field(
+        default_factory=dict,
+        description="Optional reporting views mapping this task's metric outputs into named semantic scores.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the task.",
+    )
+
+    @field_validator("id")
+    @classmethod
+    def _id_must_not_be_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("task id must not be empty")
+        return value
+
+    @field_serializer("metrics", when_used="json")
+    def _serialize_metrics(self, metrics: list[Metric]) -> list[dict[str, Any]]:
+        """Serialize local metric instances as descriptors for run bundles."""
+        serialized: list[dict[str, Any]] = []
+        for metric in metrics:
+            outputs = [
+                {
+                    "name": output.name,
+                    "description": output.description,
+                    "value_schema": output.value_schema.__name__,
+                }
+                for output in metric.output_spec()
+            ]
+            serialized.append({"type": metric_type_name(metric), "outputs": outputs})
+        return serialized
+
+    @model_validator(mode="after")
+    def _validate_metric_references(self) -> AgentEvalTask:
+        metric_types = [metric_type_name(metric) for metric in self.metrics]
+        duplicate_metric_types = sorted(
+            {metric_type for metric_type in metric_types if metric_types.count(metric_type) > 1}
+        )
+        if duplicate_metric_types:
+            raise ValueError(f"duplicate task metric types: {duplicate_metric_types}")
+
+        outputs_by_metric = {
+            metric_type_name(metric): {output.name for output in metric.output_spec()} for metric in self.metrics
+        }
+        for view_name, view in self.views.items():
+            for signal in view.signals:
+                if signal.metric not in outputs_by_metric:
+                    raise ValueError(f"view {view_name!r} references unknown metric {signal.metric!r}")
+                if signal.output not in outputs_by_metric[signal.metric]:
+                    raise ValueError(
+                        f"view {view_name!r} references unknown output {signal.output!r} for metric {signal.metric!r}"
+                    )
+        return self
+
+
+class AgentEvalRunConfig(BaseModel):
+    """Configuration for a standalone agent-eval run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    output_dir: Path | None = Field(
+        default=None,
+        description="Directory where the run bundle is written; in-memory only when omitted.",
+    )
+    run_id: str | None = Field(default=None, description="Explicit run identifier; generated when omitted.")
+    prompt_template: str | dict[str, Any] | None = Field(
+        default=None,
+        description="Optional prompt template applied when generating trials online.",
+    )
+    params: RunConfig | RunConfigOnline | RunConfigOnlineModel | None = Field(
+        default=None,
+        description="Inference/run parameters used when producing trials online.",
+    )
+    parallelism: int = Field(default=4, ge=1, description="Maximum number of tasks scored concurrently.")
+    write_dashboard: bool = Field(default=True, description="Whether to render an HTML dashboard for the run.")
+    benchmark: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Benchmark metadata recorded alongside the run.",
+    )
+    fail_fast: bool = Field(default=False, description="Stop the run on the first scoring failure when True.")

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/trials.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/trials.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trial artifacts and the runtime interface that produces them."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+from nemo_platform.beta.evaluator.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+from nemo_platform.beta.evaluator.values import Agent, Model
+from nemo_platform.beta.evaluator.values.evidence import CandidateEvidence
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class AgentEvalTrialStatus(str, Enum):
+    """Lifecycle status for a trial: completed, failed, or partial."""
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+class AgentOutput(BaseModel):
+    """Captured final output from the evaluated agent, model, or imported baseline for a trial."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    output_text: str | None = Field(
+        default=None,
+        description="User-visible final text produced by the agent, if any.",
+    )
+    response: Any | None = Field(
+        default=None,
+        description="Structured final response payload produced by the agent, if any.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the agent output.",
+    )
+
+
+class AgentEvalTrial(BaseModel):
+    """Durable trial artifact for one task: output, evidence, status, and metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(description="Stable identifier for this trial.")
+    task_id: str = Field(description="Identifier of the AgentEvalTask this trial was produced for.")
+    status: AgentEvalTrialStatus = Field(description="Lifecycle status of the trial.")
+    output: AgentOutput | None = Field(
+        default=None,
+        description="Final agent output captured for the trial; required when status is completed.",
+    )
+    evidence: CandidateEvidence | None = Field(
+        default=None,
+        description="Named evidence descriptors (final state, traces, logs, ...) captured for the trial.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the trial.",
+    )
+
+    @field_validator("id", "task_id")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("trial id and task_id must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def _completed_trial_requires_output(self) -> AgentEvalTrial:
+        if self.status == AgentEvalTrialStatus.COMPLETED and self.output is None:
+            raise ValueError("completed trial requires output")
+        return self
+
+
+@runtime_checkable
+class AgentTaskRunner(Protocol):
+    """Online execution interface that runs tasks and produces trials."""
+
+    async def run_tasks(
+        self,
+        tasks: Sequence[AgentEvalTask],
+        config: AgentEvalRunConfig | None = None,
+    ) -> Sequence[AgentEvalTrial]: ...
+
+
+AgentEvalTarget = Model | Agent | AgentTaskRunner

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/__init__.py
@@ -10,6 +10,7 @@ from nemo_platform.beta.evaluator.values.dataset_schemas import (
     InputSchema,
 )
 from nemo_platform.beta.evaluator.values.datasets import DatasetInput, DatasetRows
+from nemo_platform.beta.evaluator.values.evidence import CandidateEvidence, EvidenceDescriptor, LocalFilesystemEvidence
 from nemo_platform.beta.evaluator.values.metrics import (
     BLEU,
     F1,
@@ -95,6 +96,7 @@ __all__ = [
     "AggregateScore",
     "AggregateScoreBase",
     "BooleanValue",
+    "CandidateEvidence",
     "CandidateOutput",
     "ContinuousScore",
     "DatasetRow",
@@ -110,6 +112,7 @@ __all__ = [
     "InferenceParams",
     "JSONScoreParser",
     "Label",
+    "LocalFilesystemEvidence",
     "MetricDescriptor",
     "MetricInput",
     "MetricOutput",
@@ -121,6 +124,7 @@ __all__ = [
     "ModelRef",
     "DatasetInput",
     "EvaluationResult",
+    "EvidenceDescriptor",
     "Percentiles",
     "RangeScore",
     "ReasoningParams",

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evidence value types shared by protocol metrics and agent evaluations."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+
+
+class LocalFilesystemEvidence:
+    """Constrained local filesystem handle for metric evidence access."""
+
+    def __init__(self, root: str | Path) -> None:
+        self._root = Path(root).expanduser().resolve()
+
+    @property
+    def root(self) -> Path:
+        """Resolved root path for this local evidence handle."""
+        return self._root
+
+    def path(self, relative_path: str | Path = ".") -> Path:
+        """Return a path under the evidence root, rejecting traversal outside it."""
+        relative = Path(relative_path)
+        candidate = relative.resolve() if relative.is_absolute() else (self._root / relative).resolve()
+        if candidate != self._root and self._root not in candidate.parents:
+            raise ValueError(f"evidence path {relative_path!r} resolves outside evidence root")
+        return candidate
+
+    async def exists(self, relative_path: str | Path = ".") -> bool:
+        """Return whether a path exists under the evidence root."""
+        path = self.path(relative_path)
+        return await asyncio.to_thread(path.exists)
+
+    async def read_text(self, relative_path: str | Path, *, encoding: str = "utf-8") -> str:
+        """Read a text file under the evidence root."""
+        path = self.path(relative_path)
+        return await asyncio.to_thread(path.read_text, encoding=encoding)
+
+    async def iter_paths(self, relative_path: str | Path = ".", *, recursive: bool = False) -> list[str]:
+        """Return stable relative path names under the evidence root."""
+        base = self.path(relative_path)
+        return await asyncio.to_thread(self._iter_paths_sync, base, recursive)
+
+    def _iter_paths_sync(self, base: Path, recursive: bool) -> list[str]:
+        if base.is_file():
+            return [base.relative_to(self._root).as_posix()]
+        iterator = base.rglob("*") if recursive else base.iterdir()
+        return sorted(path.relative_to(self._root).as_posix() for path in iterator)
+
+
+class EvidenceDescriptor(BaseModel):
+    """Descriptor for a candidate trace, source, or artifact."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str = Field(description="Evidence type, e.g. 'filesystem', 'trace', 'log_bundle', or 'review'.")
+    ref: str | None = Field(
+        default=None,
+        description="Reference to externally stored evidence (e.g. a local path or storage ref).",
+    )
+    format: str | None = Field(
+        default=None,
+        description="Parser hint for the evidence payload, e.g. 'atif' for normalized traces.",
+    )
+    data: Any | None = Field(
+        default=None,
+        description="Small inline evidence payload; at least one of ref or data must be set.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the evidence descriptor.",
+    )
+
+    @model_validator(mode="after")
+    def _requires_ref_or_data(self) -> EvidenceDescriptor:
+        if self.ref is None and self.data is None:
+            raise ValueError("evidence descriptor requires ref or data")
+        return self
+
+
+class CandidateEvidence(BaseModel):
+    """Named evidence descriptors attached to an AgentEvalAttempt."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    descriptors: dict[str, EvidenceDescriptor] = Field(
+        default_factory=dict,
+        description="Evidence descriptors keyed by name (e.g. 'final_state', 'trace', 'logs').",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form metadata associated with the evidence collection.",
+    )
+    _filesystem_cache: dict[str, LocalFilesystemEvidence] = PrivateAttr(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_descriptor_mapping(cls, value: Any) -> Any:
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, dict) and "descriptors" not in value and "metadata" not in value:
+            return {"descriptors": value}
+        return value
+
+    def names(self, *, kind: str | None = None) -> list[str]:
+        """Return evidence names, optionally filtered by descriptor kind."""
+        if kind is None:
+            return list(self.descriptors)
+        return [name for name, descriptor in self.descriptors.items() if descriptor.kind == kind]
+
+    def get(self, name: str) -> EvidenceDescriptor | None:
+        """Return a descriptor by name without materializing evidence."""
+        return self.descriptors.get(name)
+
+    def require(self, name: str, *, kind: str | None = None) -> EvidenceDescriptor:
+        """Return a descriptor by name, raising when it is missing or has the wrong kind."""
+        descriptor = self.get(name)
+        if descriptor is None:
+            raise KeyError(f"missing evidence descriptor {name!r}")
+        if kind is not None and descriptor.kind != kind:
+            raise ValueError(f"evidence descriptor {name!r} has kind {descriptor.kind!r}, expected {kind!r}")
+        return descriptor
+
+    async def filesystem(self, name: str) -> LocalFilesystemEvidence:
+        """Return a cached local filesystem handle for a named filesystem descriptor."""
+        cached = self._filesystem_cache.get(name)
+        if cached is not None:
+            return cached
+
+        descriptor = self.require(name, kind="filesystem")
+        if descriptor.ref is None:
+            raise ValueError(f"filesystem evidence descriptor {name!r} requires a local ref")
+
+        root = _local_filesystem_ref(descriptor.ref)
+        handle = LocalFilesystemEvidence(root)
+        self._filesystem_cache[name] = handle
+        return handle
+
+
+def _local_filesystem_ref(ref: str) -> Path:
+    """Resolve a local filesystem ref to a Path.
+
+    Accepts POSIX paths, ``file://`` URIs, and Windows drive paths (e.g. ``C:\\dir``).
+    Network and cloud URI schemes (http, https, s3, gs, ...) are rejected.
+    """
+    parsed = urlparse(ref)
+    # A single-letter scheme is a Windows drive letter (e.g. "C:\\dir"), not a URI scheme.
+    if len(parsed.scheme) == 1 and parsed.scheme.isalpha():
+        return Path(ref)
+    if parsed.scheme in {"http", "https", "s3", "gs"}:
+        raise ValueError("CandidateEvidence.filesystem only supports local filesystem refs")
+    if parsed.scheme == "file":
+        return Path(parsed.path)
+    if parsed.scheme:
+        raise ValueError(f"CandidateEvidence.filesystem does not support {parsed.scheme!r} refs")
+    return Path(ref)

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/protocol.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/protocol.py
@@ -10,6 +10,8 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel, StringConstraints, field_serializer, field_validator
 
+from nemo_platform.beta.evaluator.values.evidence import CandidateEvidence
+
 MetricTypeName = Annotated[str, StringConstraints(min_length=1)]
 
 
@@ -30,6 +32,10 @@ class CandidateOutput(BaseModel):
     output_text: str | None = None
     response: Any | None = None
     trajectory: Any | None = None
+    evidence: CandidateEvidence | None = Field(
+        default=None,
+        description="Named evidence captured for the candidate (final state, traces, logs, ...) for agent eval.",
+    )
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     def as_sample(self) -> dict[str, Any]:
@@ -41,6 +47,8 @@ class CandidateOutput(BaseModel):
             sample["response"] = self.response
         if self.trajectory is not None:
             sample["trajectory"] = self.trajectory
+        if self.evidence is not None:
+            sample["evidence"] = self.evidence
         return sample
 
 


### PR DESCRIPTION
Introduce the standalone agent-eval domain model described in the NeMo Evaluator Agent Evaluation design: 

- AgentEvalTask, 
- SemanticView, 
- ViewSignal, 
- AgentOutput, 
- AgentEvalAttempt (trial),
-  AgentEvalTaskResult, and summary/coverage value types, plus the shared EvidenceDescriptor, 

CandidateEvidence, and LocalFilesystemEvidence types. Extend CandidateOutput with a candidate.evidence field and the metric protocol to carry evidence. Mirrored into the vendored nemo_platform beta SDK.



```mermaid
erDiagram
    AgentEvalRunResult ||--o{ AgentEvalTask        : "tasks"
    AgentEvalRunResult ||--o{ AgentEvalAttempt     : "attempts"
    AgentEvalRunResult ||--o{ AgentEvalTaskResult  : "results"
    AgentEvalRunResult ||--|| AgentEvalSummary     : "summary"

    AgentEvalTask      ||--o{ Metric               : "metrics (ordered)"
    AgentEvalTask      ||--o{ SemanticView         : "views"
    SemanticView       ||--|{ ViewSignal           : "signals (>=1)"
    ViewSignal         }o--|| Metric               : "metric+output ref"

    AgentEvalAttempt   }o--|| AgentEvalTask        : "task_id (FK)"
    AgentEvalAttempt   ||--o| AgentOutput          : "output"
    AgentEvalAttempt   ||--o| CandidateEvidence    : "evidence"

    CandidateEvidence  ||--o{ EvidenceDescriptor   : "descriptors"
    CandidateEvidence  ||--o{ LocalFilesystemEvidence : "fs cache (lazy)"
    CandidateOutput    ||--o| CandidateEvidence    : "evidence (extension)"

    AgentEvalTaskResult }o--|| AgentEvalRunResult  : "run_id (FK)"
    AgentEvalTaskResult }o--|| AgentEvalTask       : "task_id (FK)"
    AgentEvalTaskResult }o--|| AgentEvalAttempt    : "attempt_id (FK)"
    AgentEvalTaskResult }o--|| Metric              : "metric_type (FK)"
    AgentEvalTaskResult ||--o{ MetricOutput        : "outputs"
    AgentEvalTaskResult ||--o{ AgentEvalDiagnostic : "diagnostics"

    AgentEvalSummary   ||--o{ AgentEvalMetricOutputCoverage : "metric_coverage"

    MetricInput        ||--|| DatasetRow           : "row"
    MetricInput        ||--|| CandidateOutput      : "candidate"

    AgentEvalTask {
        string id PK
        string intent
        dict inputs
        list metrics
        dict views
        dict metadata
    }
    SemanticView {
        enum reducer "single|all|any|mean|weighted_mean"
        list signals
    }
    ViewSignal {
        string metric
        string output
        float weight
    }
    AgentOutput {
        string text
        any response
        dict metadata
    }
    AgentEvalAttempt {
        string id PK
        string task_id FK
        enum status "completed|failed|partial"
        AgentOutput output
        CandidateEvidence evidence
        dict metadata
    }
    EvidenceDescriptor {
        string kind
        string ref "ref or data required"
        string format "parser hint e.g. atif"
        any data
        dict metadata
    }
    CandidateEvidence {
        dict descriptors
        dict metadata
    }
    LocalFilesystemEvidence {
        Path root
    }
    AgentEvalTaskResult {
        string id PK
        string run_id FK
        string task_id FK
        string attempt_id FK
        string metric_type FK
        enum status
        list outputs
        list diagnostics
        dict metadata
    }
    MetricOutput {
        string name
        any value
    }
    AgentEvalDiagnostic {
        enum severity "error|warning|info"
        string message
        string source
        dict details
    }
    AgentEvalMetricOutputCoverage {
        int total
        int scored
        int failed
        int missing
    }
    AgentEvalSummary {
        float overall_score
        dict metric_scores
        dict metric_coverage
        dict semantic_view_scores
        int task_count
        int attempt_count
        int result_count
    }
    AgentEvalRunResult {
        string run_id PK
        list tasks
        list attempts
        list results
        AgentEvalSummary summary
        dict benchmark
        Path output_dir
        Path dashboard_path
    }
    CandidateOutput {
        string output_text
        any response
        any trajectory "deprecated"
        CandidateEvidence evidence
        dict metadata
    }
    MetricInput {
        DatasetRow row
        CandidateOutput candidate
    }
    DatasetRow {
        int row_index
        dict data
    }
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added evidence support for candidate outputs, including filesystem and metadata handling.
  * Introduced comprehensive agent evaluation framework with task configuration, trial execution, metric scoring, and result aggregation.
  * Added diagnostic tracking and semantic view support for multi-signal evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->