### PR TITLE
fix(studio): stabilize query cache key for telemetry fetch

### DIFF
--- a/web/packages/studio/src/routes/agents/AgentMonitorRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentMonitorRoute/index.tsx
@@ -74,9 +74,10 @@ export const AgentMonitorRoute: FC = () => {
   const filesError = isNotFoundError(filesListQuery.error) ? null : filesListQuery.error;
   const files = useMemo(() => filesListQuery.data?.data ?? [], [filesListQuery.data?.data]);
   const hasFiles = files.length > 0;
+  const filePaths = useMemo(() => files.map((f) => f.path), [files]);
 
   const runsQuery = useQuery({
-    queryKey: ['agent-monitor', 'telemetry-runs', workspace, files.map((f) => f.path)],
+    queryKey: ['agent-monitor', 'telemetry-runs', workspace, filePaths],
     queryFn: ({ signal }) => fetchTelemetryRuns(workspace, files, signal),
     enabled: !!workspace && hasFiles,
     retry: false,


### PR DESCRIPTION
## Summary
- Memoize `filePaths` derived from `files` and use it in the `runsQuery` queryKey in `AgentMonitorRoute/index.tsx` so TanStack Query doesn't see a new array reference on every render and trigger unnecessary refetches.

Fixes ASTD-234.

## Test plan
- [ ] Open the agent monitor route and confirm telemetry runs are not refetched on unrelated re-renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized dependency tracking in agent monitoring to improve performance efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->