### PR TITLE
feat(studio): link trace detail to test case row click (FP-185)

### DIFF
--- a/web/packages/studio/src/components/IntakeTraceDetailBody/index.tsx
+++ b/web/packages/studio/src/components/IntakeTraceDetailBody/index.tsx
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { KVPair } from '@nemo/common/src/components/KVPair';
+import { formatAbsoluteTimestamp } from '@nemo/common/src/components/RelativeTime/util';
+import { useGetTrace } from '@nemo/sdk/generated/platform/api';
+import { Grid, Panel, Stack, StatusMessage, Text } from '@nvidia/foundations-react-core';
+import { IntakeSpansTable } from '@studio/components/IntakeSpansTable';
+import { IntakeTelemetryStatusBadge } from '@studio/components/IntakeTelemetryStatusBadge';
+import { Loading } from '@studio/components/Layouts/Loading';
+import { NotFound } from '@studio/components/Layouts/NotFound';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { getIntakeSpanRoute } from '@studio/routes/utils';
+import {
+  EMPTY_VALUE,
+  formatCost,
+  formatDurationMs,
+  formatInteger,
+  formatMaybe,
+} from '@studio/util/intakeTelemetry';
+import { Activity, CircleAlert, Hash } from 'lucide-react';
+import { type FC } from 'react';
+import { Link } from 'react-router-dom';
+
+const TRACE_SPANS_PAGE_SIZE = 1000;
+
+export interface IntakeTraceDetailBodyProps {
+  traceId: string;
+  filterTogglePortalTargetId?: string;
+  showSpans?: boolean;
+}
+
+export const IntakeTraceDetailBody: FC<IntakeTraceDetailBodyProps> = ({
+  traceId,
+  filterTogglePortalTargetId,
+  showSpans = true,
+}) => {
+  const workspace = useWorkspaceFromPath();
+
+  const {
+    data: trace,
+    error,
+    isLoading,
+  } = useGetTrace(workspace, traceId, {
+    mode: 'detailed',
+  });
+
+  if (error?.response?.status === 404) {
+    return (
+      <NotFound
+        subheader="Trace Not Found"
+        message="The trace does not exist or you do not have permission to view it."
+      />
+    );
+  }
+
+  if (isLoading) {
+    return <Loading description="Loading trace..." />;
+  }
+
+  if (error) {
+    return (
+      <StatusMessage
+        className="mx-auto mt-density-2xl"
+        size="medium"
+        slotMedia={<CircleAlert width={65} height={65} />}
+        slotHeading="Error loading trace"
+        slotSubheading={error.message}
+      />
+    );
+  }
+
+  if (!trace) {
+    return null;
+  }
+
+  const showExperimentContext = Boolean(
+    trace.experiment_context?.experiment_id || trace.experiment_context?.test_case_id
+  );
+  const showSpanLimitMessage =
+    trace.span_count !== undefined && trace.span_count > TRACE_SPANS_PAGE_SIZE;
+  const wrappingValueAttributes = {
+    value: {
+      className: 'block min-w-0 max-w-full break-all',
+    },
+  };
+
+  const summaryPanels = (
+    <Stack gap="density-2xl" className="min-w-0">
+      <Panel
+        elevation="high"
+        slotIcon={<Activity />}
+        slotHeading="Trace Summary"
+        className="min-w-0 overflow-hidden"
+      >
+        <Stack gap="density-xl">
+          <Grid className="grid-cols-2 gap-density-lg">
+            <KVPair
+              label="Started"
+              value={formatAbsoluteTimestamp(trace.started_at)}
+              orientation="vertical"
+            />
+            <KVPair
+              label="Ended"
+              value={trace.ended_at ? formatAbsoluteTimestamp(trace.ended_at) : EMPTY_VALUE}
+              orientation="vertical"
+            />
+            <KVPair
+              label="Duration"
+              value={formatDurationMs(trace.duration_ms)}
+              orientation="vertical"
+            />
+            <KVPair label="Spans" value={formatInteger(trace.span_count)} orientation="vertical" />
+            <KVPair
+              label="Errors"
+              value={formatInteger(trace.error_count)}
+              orientation="vertical"
+            />
+            <KVPair label="Total Cost" value={formatCost(trace.cost_usd)} orientation="vertical" />
+          </Grid>
+          <Grid className="grid-cols-1 gap-density-lg min-w-0">
+            <KVPair
+              label="Trace ID"
+              value={trace.id}
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+            <KVPair
+              label="Root Span"
+              value={
+                trace.root_span_id ? (
+                  <Link
+                    to={getIntakeSpanRoute(workspace, trace.root_span_id)}
+                    className="break-all"
+                  >
+                    {trace.root_span_id}
+                  </Link>
+                ) : (
+                  EMPTY_VALUE
+                )
+              }
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+            <KVPair
+              label="Status"
+              value={<IntakeTelemetryStatusBadge status={trace.status} />}
+              orientation="vertical"
+            />
+            <KVPair
+              label="Session ID"
+              value={trace.session_id}
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+          </Grid>
+        </Stack>
+      </Panel>
+      {showExperimentContext && (
+        <Panel
+          elevation="high"
+          slotIcon={<Hash />}
+          slotHeading="Experiment Context"
+          className="min-w-0 overflow-hidden"
+        >
+          <Stack gap="density-lg" className="min-w-0">
+            <KVPair
+              label="Summary"
+              value={formatMaybe(
+                trace.experiment_context?.experiment_id || trace.experiment_context?.test_case_id
+              )}
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+            <KVPair
+              label="Experiment ID"
+              value={formatMaybe(trace.experiment_context?.experiment_id)}
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+            <KVPair
+              label="Test Case ID"
+              value={formatMaybe(trace.experiment_context?.test_case_id)}
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+          </Stack>
+        </Panel>
+      )}
+    </Stack>
+  );
+
+  if (!showSpans) {
+    return summaryPanels;
+  }
+
+  return (
+    <Grid className="grid-cols-1 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)] gap-density-2xl items-start">
+      <Stack gap="density-md" className="min-w-0 min-h-[420px]">
+        {showSpanLimitMessage && (
+          <Text kind="body/regular/sm" className="text-secondary">
+            Showing first {TRACE_SPANS_PAGE_SIZE.toLocaleString()} of{' '}
+            {trace.span_count?.toLocaleString()} spans. Parent spans outside this page are marked in
+            the hierarchy.
+          </Text>
+        )}
+        <IntakeSpansTable
+          workspace={workspace}
+          filterTogglePortalTargetId={filterTogglePortalTargetId}
+          fixedFilter={{ trace_id: trace.id }}
+          defaultPageSize={TRACE_SPANS_PAGE_SIZE}
+          mode="summary"
+          showTraceColumn={false}
+          showHierarchy
+          emptyHeader="No Spans"
+          emptyMessage="No spans were found for this trace."
+        />
+      </Stack>
+      {summaryPanels}
+    </Grid>
+  );
+};

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -18,8 +18,8 @@ import type {
 } from '@nemo/sdk/generated/platform/schema';
 import { Button, Stack, Text, Tooltip } from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/dataViews/ExperimentSessionsDataView/Empty';
-import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { IntakeTraceDetailBody } from '@studio/components/IntakeTraceDetailBody';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { tooltipClassName } from '@studio/styles/common';
 import { keepPreviousData } from '@tanstack/react-query';
 import { Columns3, X } from 'lucide-react';

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -16,13 +16,14 @@ import type {
   ExperimentSessionFilter,
   ExperimentSessionResponse,
 } from '@nemo/sdk/generated/platform/schema';
-import { Text, Tooltip } from '@nvidia/foundations-react-core';
+import { Button, Stack, Text, Tooltip } from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/dataViews/ExperimentSessionsDataView/Empty';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { IntakeTraceDetailBody } from '@studio/routes/IntakeTraceDetailRoute';
 import { tooltipClassName } from '@studio/styles/common';
 import { keepPreviousData } from '@tanstack/react-query';
-import { Columns3 } from 'lucide-react';
-import { type ComponentProps, type FC, useMemo } from 'react';
+import { Columns3, X } from 'lucide-react';
+import { type ComponentProps, type FC, useMemo, useState } from 'react';
 
 type SessionRow = ExperimentSessionResponse & { _rowId: string };
 
@@ -41,6 +42,7 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
   experimentGroupName,
 }) => {
   const workspace = useWorkspaceFromPath();
+  const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
   const dataViewState = useStudioDataViewState<ExperimentSessionFilter>({ columnVisibility: {} });
   const { data: experiment } = useGetExperiment(workspace, experimentName);
 
@@ -210,62 +212,91 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
     ),
   ];
 
+  const showTraceDetail = selectedTraceId !== null;
+
   return (
-    <StudioDataView
-      dataViewState={dataViewState}
-      makeColumns={makeColumns}
-      searchField="test_case_id"
-      toolbarSlotEnd={
-        <EditColumnsMenu
-          kind="secondary"
-          showChevron={false}
-          slotContent={<div aria-hidden className="h-0 w-[230px]" />}
-        >
-          <>
-            <Columns3 />
-            <span className="hide-mobile">Columns</span>
-          </>
-        </EditColumnsMenu>
-      }
-      attributes={{
-        DataViewRoot: {
-          data: visibleTableData,
-          totalCount,
-          requestStatus: isLoading && !sessionsData ? 'loading' : undefined,
-        },
-        DataViewSearchBar: { placeholder: 'Search case...' },
-        DataViewTableContent: {
-          renderEmptyState: () => {
-            const hasActiveFilters =
-              !!dataViewState.searchBar.state || dataViewState.columnFiltering.state.length > 0;
-            if (hasActiveFilters) {
-              return (
-                <TableEmptyState
-                  header="No matching test cases"
-                  emptyMessage={
-                    <>
-                      Change your filters and try again, or{' '}
-                      <button
-                        className="text-content-link hover:underline"
-                        onClick={dataViewState.resetFilters}
-                      >
-                        clear filters
-                      </button>
-                      .
-                    </>
-                  }
-                />
-              );
-            }
-            return (
-              <Empty
-                experimentGroupName={experimentGroupName}
-                datasetName={experiment?.dataset_name ?? '<dataset>'}
-              />
-            );
-          },
-        },
-      }}
-    />
+    <div className="flex gap-density-xl items-start">
+      <div className="min-w-0 flex-1">
+        <StudioDataView
+          dataViewState={dataViewState}
+          makeColumns={makeColumns}
+          searchField="test_case_id"
+          onRowClick={(row) => {
+            if (row.trace_id) setSelectedTraceId(row.trace_id);
+          }}
+          toolbarSlotEnd={
+            <EditColumnsMenu
+              kind="secondary"
+              showChevron={false}
+              slotContent={<div aria-hidden className="h-0 w-[230px]" />}
+            >
+              <>
+                <Columns3 />
+                <span className="hide-mobile">Columns</span>
+              </>
+            </EditColumnsMenu>
+          }
+          attributes={{
+            DataViewRoot: {
+              data: visibleTableData,
+              totalCount,
+              requestStatus: isLoading && !sessionsData ? 'loading' : undefined,
+            },
+            DataViewSearchBar: { placeholder: 'Search case...' },
+            DataViewTableContent: {
+              renderEmptyState: () => {
+                const hasActiveFilters =
+                  !!dataViewState.searchBar.state || dataViewState.columnFiltering.state.length > 0;
+                if (hasActiveFilters) {
+                  return (
+                    <TableEmptyState
+                      header="No matching test cases"
+                      emptyMessage={
+                        <>
+                          Change your filters and try again, or{' '}
+                          <button
+                            className="text-content-link hover:underline"
+                            onClick={dataViewState.resetFilters}
+                          >
+                            clear filters
+                          </button>
+                          .
+                        </>
+                      }
+                    />
+                  );
+                }
+                return (
+                  <Empty
+                    experimentGroupName={experimentGroupName}
+                    datasetName={experiment?.dataset_name ?? '<dataset>'}
+                  />
+                );
+              },
+            },
+          }}
+        />
+      </div>
+      <Stack
+        className={[
+          'gap-density-xl',
+          'transition-[width,opacity] duration-300 ease-out motion-reduce:transition-none shrink-0  overflow-hidden',
+          showTraceDetail ? 'w-[480px] opacity-100' : 'w-0 opacity-0 pointer-events-none',
+        ].join(' ')}
+      >
+        <div className="flex justify-end py-density-xs">
+          <Button
+            kind="tertiary"
+            aria-label="Close trace detail"
+            onClick={() => setSelectedTraceId(null)}
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+        {selectedTraceId !== null && (
+          <IntakeTraceDetailBody traceId={selectedTraceId} showSpans={false} />
+        )}
+      </Stack>
+    </div>
   );
 };

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -19,7 +19,7 @@ import type {
 import { Button, Stack, Text, Tooltip } from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/dataViews/ExperimentSessionsDataView/Empty';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
-import { IntakeTraceDetailBody } from '@studio/routes/IntakeTraceDetailRoute';
+import { IntakeTraceDetailBody } from '@studio/components/IntakeTraceDetailBody';
 import { tooltipClassName } from '@studio/styles/common';
 import { keepPreviousData } from '@tanstack/react-query';
 import { Columns3, X } from 'lucide-react';

--- a/web/packages/studio/src/routes/IntakeTraceDetailRoute/index.spec.tsx
+++ b/web/packages/studio/src/routes/IntakeTraceDetailRoute/index.spec.tsx
@@ -19,8 +19,8 @@ describe('IntakeTraceDetailRoute', () => {
   it('renders experiment context only when present and filters spans to the trace', async () => {
     renderTraceDetail('trace-agent-run-001');
 
-    expect(await screen.findByText('Trace Answer customer policy question')).toBeInTheDocument();
-    expect(screen.getByText('Experiment Context')).toBeInTheDocument();
+    expect(await screen.findByText('Trace trace-agent-run-001')).toBeInTheDocument();
+    expect(await screen.findByText('Experiment Context')).toBeInTheDocument();
     expect(await screen.findByText('Generate final response')).toBeInTheDocument();
     expect(screen.queryByText('Retrieve deployment troubleshooting steps')).not.toBeInTheDocument();
   });
@@ -29,7 +29,7 @@ describe('IntakeTraceDetailRoute', () => {
     renderTraceDetail('trace-agent-run-002');
 
     expect(
-      await screen.findByText('Trace Retrieve deployment troubleshooting steps')
+      await screen.findByText('Trace trace-agent-run-002')
     ).toBeInTheDocument();
     expect(screen.queryByText('Experiment Context')).not.toBeInTheDocument();
   });

--- a/web/packages/studio/src/routes/IntakeTraceDetailRoute/index.spec.tsx
+++ b/web/packages/studio/src/routes/IntakeTraceDetailRoute/index.spec.tsx
@@ -28,9 +28,7 @@ describe('IntakeTraceDetailRoute', () => {
   it('omits experiment context when the trace has none', async () => {
     renderTraceDetail('trace-agent-run-002');
 
-    expect(
-      await screen.findByText('Trace trace-agent-run-002')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Trace trace-agent-run-002')).toBeInTheDocument();
     expect(screen.queryByText('Experiment Context')).not.toBeInTheDocument();
   });
 });

--- a/web/packages/studio/src/routes/IntakeTraceDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/IntakeTraceDetailRoute/index.tsx
@@ -56,15 +56,7 @@ interface IntakeTraceDetailContentProps {
 
 const IntakeTraceDetailContent: FC<IntakeTraceDetailContentProps> = ({ traceId }) => {
   const workspace = useWorkspaceFromPath();
-
-  const {
-    data: trace,
-    error,
-    isLoading,
-  } = useGetTrace(workspace, traceId, {
-    mode: 'detailed',
-  });
-
+  const { data: trace } = useGetTrace(workspace, traceId, { mode: 'detailed' });
   const { setBreadcrumbs } = useBreadcrumbs();
   const traceBreadcrumbLabel = trace ? getTraceDisplayName(trace) : traceId;
 
@@ -79,6 +71,49 @@ const IntakeTraceDetailContent: FC<IntakeTraceDetailContentProps> = ({ traceId }
       },
     ]);
   }, [setBreadcrumbs, traceBreadcrumbLabel, workspace]);
+
+  return (
+    <AccessibleTitle title={`Trace ${traceBreadcrumbLabel}`}>
+      <Stack gap="density-2xl" padding="density-2xl" className="h-full overflow-auto">
+        <PageHeader
+          className="p-0"
+          slotHeading={`Trace ${traceBreadcrumbLabel}`}
+          slotActions={
+            <div
+              id={TRACE_DETAIL_SPANS_FILTER_TARGET_ID}
+              className="flex shrink-0 items-center justify-end"
+            />
+          }
+        />
+        <IntakeTraceDetailBody
+          traceId={traceId}
+          filterTogglePortalTargetId={TRACE_DETAIL_SPANS_FILTER_TARGET_ID}
+        />
+      </Stack>
+    </AccessibleTitle>
+  );
+};
+
+interface IntakeTraceDetailBodyProps {
+  traceId: string;
+  filterTogglePortalTargetId?: string;
+  showSpans?: boolean;
+}
+
+export const IntakeTraceDetailBody: FC<IntakeTraceDetailBodyProps> = ({
+  traceId,
+  filterTogglePortalTargetId,
+  showSpans = true,
+}) => {
+  const workspace = useWorkspaceFromPath();
+
+  const {
+    data: trace,
+    error,
+    isLoading,
+  } = useGetTrace(workspace, traceId, {
+    mode: 'detailed',
+  });
 
   if (error?.response?.status === 404) {
     return (
@@ -109,7 +144,6 @@ const IntakeTraceDetailContent: FC<IntakeTraceDetailContentProps> = ({ traceId }
     return null;
   }
 
-  const title = getTraceDisplayName(trace);
   const showExperimentContext = Boolean(
     trace.experiment_context?.experiment_id || trace.experiment_context?.test_case_id
   );
@@ -121,153 +155,138 @@ const IntakeTraceDetailContent: FC<IntakeTraceDetailContentProps> = ({ traceId }
     },
   };
 
+  const summaryPanels = (
+    <Stack gap="density-2xl" className="min-w-0">
+      <Panel
+        elevation="high"
+        slotIcon={<Activity />}
+        slotHeading="Trace Summary"
+        className="min-w-0 overflow-hidden"
+      >
+        <Stack gap="density-xl">
+          <Grid className="grid-cols-2 gap-density-lg">
+            <KVPair
+              label="Started"
+              value={formatAbsoluteTimestamp(trace.started_at)}
+              orientation="vertical"
+            />
+            <KVPair
+              label="Ended"
+              value={trace.ended_at ? formatAbsoluteTimestamp(trace.ended_at) : EMPTY_VALUE}
+              orientation="vertical"
+            />
+            <KVPair
+              label="Duration"
+              value={formatDurationMs(trace.duration_ms)}
+              orientation="vertical"
+            />
+            <KVPair label="Spans" value={formatInteger(trace.span_count)} orientation="vertical" />
+            <KVPair
+              label="Errors"
+              value={formatInteger(trace.error_count)}
+              orientation="vertical"
+            />
+            <KVPair label="Total Cost" value={formatCost(trace.cost_usd)} orientation="vertical" />
+          </Grid>
+          <Grid className="grid-cols-1 gap-density-lg min-w-0">
+            <KVPair
+              label="Trace ID"
+              value={trace.id}
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+            <KVPair
+              label="Root Span"
+              value={
+                trace.root_span_id ? (
+                  <Link
+                    to={getIntakeSpanRoute(workspace, trace.root_span_id)}
+                    className="break-all"
+                  >
+                    {trace.root_span_id}
+                  </Link>
+                ) : (
+                  EMPTY_VALUE
+                )
+              }
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+            <KVPair
+              label="Status"
+              value={<IntakeTelemetryStatusBadge status={trace.status} />}
+              orientation="vertical"
+            />
+            <KVPair
+              label="Session ID"
+              value={trace.session_id}
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+          </Grid>
+        </Stack>
+      </Panel>
+      {showExperimentContext && (
+        <Panel
+          elevation="high"
+          slotIcon={<Hash />}
+          slotHeading="Experiment Context"
+          className="min-w-0 overflow-hidden"
+        >
+          <Stack gap="density-lg" className="min-w-0">
+            <KVPair
+              label="Summary"
+              value={formatMaybe(
+                trace.experiment_context?.experiment_id || trace.experiment_context?.test_case_id
+              )}
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+            <KVPair
+              label="Experiment ID"
+              value={formatMaybe(trace.experiment_context?.experiment_id)}
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+            <KVPair
+              label="Test Case ID"
+              value={formatMaybe(trace.experiment_context?.test_case_id)}
+              orientation="vertical"
+              attributes={wrappingValueAttributes}
+            />
+          </Stack>
+        </Panel>
+      )}
+    </Stack>
+  );
+
+  if (!showSpans) {
+    return summaryPanels;
+  }
+
   return (
-    <AccessibleTitle title={`Trace ${title}`}>
-      <Stack gap="density-2xl" padding="density-2xl" className="h-full overflow-auto">
-        <PageHeader
-          className="p-0"
-          slotHeading={`Trace ${title}`}
-          slotActions={
-            <div
-              id={TRACE_DETAIL_SPANS_FILTER_TARGET_ID}
-              className="flex shrink-0 items-center justify-end"
-            />
-          }
+    <Grid className="grid-cols-1 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)] gap-density-2xl items-start">
+      <Stack gap="density-md" className="min-w-0 min-h-[420px]">
+        {showSpanLimitMessage && (
+          <Text kind="body/regular/sm" className="text-secondary">
+            Showing first {TRACE_SPANS_PAGE_SIZE.toLocaleString()} of{' '}
+            {trace.span_count?.toLocaleString()} spans. Parent spans outside this page are marked in
+            the hierarchy.
+          </Text>
+        )}
+        <IntakeSpansTable
+          workspace={workspace}
+          filterTogglePortalTargetId={filterTogglePortalTargetId}
+          fixedFilter={{ trace_id: trace.id }}
+          defaultPageSize={TRACE_SPANS_PAGE_SIZE}
+          mode="summary"
+          showTraceColumn={false}
+          showHierarchy
+          emptyHeader="No Spans"
+          emptyMessage="No spans were found for this trace."
         />
-        <Grid className="grid-cols-1 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)] gap-density-2xl items-start">
-          <Stack gap="density-md" className="min-w-0 min-h-[420px]">
-            {showSpanLimitMessage && (
-              <Text kind="body/regular/sm" className="text-secondary">
-                Showing first {TRACE_SPANS_PAGE_SIZE.toLocaleString()} of{' '}
-                {trace.span_count?.toLocaleString()} spans. Parent spans outside this page are
-                marked in the hierarchy.
-              </Text>
-            )}
-            <IntakeSpansTable
-              workspace={workspace}
-              filterTogglePortalTargetId={TRACE_DETAIL_SPANS_FILTER_TARGET_ID}
-              fixedFilter={{ trace_id: trace.id }}
-              defaultPageSize={TRACE_SPANS_PAGE_SIZE}
-              mode="summary"
-              showTraceColumn={false}
-              showHierarchy
-              emptyHeader="No Spans"
-              emptyMessage="No spans were found for this trace."
-            />
-          </Stack>
-          <Stack gap="density-2xl" className="min-w-0">
-            <Panel
-              elevation="high"
-              slotIcon={<Activity />}
-              slotHeading="Trace Summary"
-              className="min-w-0 overflow-hidden"
-            >
-              <Stack gap="density-xl">
-                <Grid className="grid-cols-2 gap-density-lg">
-                  <KVPair
-                    label="Started"
-                    value={formatAbsoluteTimestamp(trace.started_at)}
-                    orientation="vertical"
-                  />
-                  <KVPair
-                    label="Ended"
-                    value={trace.ended_at ? formatAbsoluteTimestamp(trace.ended_at) : EMPTY_VALUE}
-                    orientation="vertical"
-                  />
-                  <KVPair
-                    label="Duration"
-                    value={formatDurationMs(trace.duration_ms)}
-                    orientation="vertical"
-                  />
-                  <KVPair
-                    label="Spans"
-                    value={formatInteger(trace.span_count)}
-                    orientation="vertical"
-                  />
-                  <KVPair
-                    label="Errors"
-                    value={formatInteger(trace.error_count)}
-                    orientation="vertical"
-                  />
-                  <KVPair
-                    label="Total Cost"
-                    value={formatCost(trace.cost_usd)}
-                    orientation="vertical"
-                  />
-                </Grid>
-                <Grid className="grid-cols-1 gap-density-lg min-w-0">
-                  <KVPair
-                    label="Trace ID"
-                    value={trace.id}
-                    orientation="vertical"
-                    attributes={wrappingValueAttributes}
-                  />
-                  <KVPair
-                    label="Root Span"
-                    value={
-                      trace.root_span_id ? (
-                        <Link
-                          to={getIntakeSpanRoute(workspace, trace.root_span_id)}
-                          className="break-all"
-                        >
-                          {trace.root_span_id}
-                        </Link>
-                      ) : (
-                        EMPTY_VALUE
-                      )
-                    }
-                    orientation="vertical"
-                    attributes={wrappingValueAttributes}
-                  />
-                  <KVPair
-                    label="Status"
-                    value={<IntakeTelemetryStatusBadge status={trace.status} />}
-                    orientation="vertical"
-                  />
-                  <KVPair
-                    label="Session ID"
-                    value={trace.session_id}
-                    orientation="vertical"
-                    attributes={wrappingValueAttributes}
-                  />
-                </Grid>
-              </Stack>
-            </Panel>
-            {showExperimentContext && (
-              <Panel
-                elevation="high"
-                slotIcon={<Hash />}
-                slotHeading="Experiment Context"
-                className="min-w-0 overflow-hidden"
-              >
-                <Stack gap="density-lg" className="min-w-0">
-                  <KVPair
-                    label="Summary"
-                    value={formatMaybe(
-                      trace.experiment_context?.experiment_id ||
-                        trace.experiment_context?.test_case_id
-                    )}
-                    orientation="vertical"
-                    attributes={wrappingValueAttributes}
-                  />
-                  <KVPair
-                    label="Experiment ID"
-                    value={formatMaybe(trace.experiment_context?.experiment_id)}
-                    orientation="vertical"
-                    attributes={wrappingValueAttributes}
-                  />
-                  <KVPair
-                    label="Test Case ID"
-                    value={formatMaybe(trace.experiment_context?.test_case_id)}
-                    orientation="vertical"
-                    attributes={wrappingValueAttributes}
-                  />
-                </Stack>
-              </Panel>
-            )}
-          </Stack>
-        </Grid>
       </Stack>
-    </AccessibleTitle>
+      {summaryPanels}
+    </Grid>
   );
 };

--- a/web/packages/studio/src/routes/IntakeTraceDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/IntakeTraceDetailRoute/index.tsx
@@ -1,39 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { KVPair } from '@nemo/common/src/components/KVPair';
-import { formatAbsoluteTimestamp } from '@nemo/common/src/components/RelativeTime/util';
-import { useGetTrace } from '@nemo/sdk/generated/platform/api';
-import {
-  Grid,
-  PageHeader,
-  Panel,
-  Stack,
-  StatusMessage,
-  Text,
-} from '@nvidia/foundations-react-core';
+import { PageHeader, Stack } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
-import { IntakeSpansTable } from '@studio/components/IntakeSpansTable';
-import { IntakeTelemetryStatusBadge } from '@studio/components/IntakeTelemetryStatusBadge';
-import { Loading } from '@studio/components/Layouts/Loading';
+import { IntakeTraceDetailBody } from '@studio/components/IntakeTraceDetailBody';
 import { NotFound } from '@studio/components/Layouts/NotFound';
 import { ROUTE_PARAMS } from '@studio/constants/routes';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
-import { getIntakeSpanRoute, getIntakeTracesRoute } from '@studio/routes/utils';
-import {
-  EMPTY_VALUE,
-  formatCost,
-  formatDurationMs,
-  formatInteger,
-  formatMaybe,
-  getTraceDisplayName,
-} from '@studio/util/intakeTelemetry';
-import { Activity, CircleAlert, Hash } from 'lucide-react';
+import { getIntakeTracesRoute } from '@studio/routes/utils';
 import { type FC, useEffect } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
-const TRACE_SPANS_PAGE_SIZE = 1000;
 const TRACE_DETAIL_SPANS_FILTER_TARGET_ID = 'trace-detail-spans-filter-action-target';
 
 type TraceRouteParams = Record<typeof ROUTE_PARAMS.traceId, string | undefined>;
@@ -56,9 +34,7 @@ interface IntakeTraceDetailContentProps {
 
 const IntakeTraceDetailContent: FC<IntakeTraceDetailContentProps> = ({ traceId }) => {
   const workspace = useWorkspaceFromPath();
-  const { data: trace } = useGetTrace(workspace, traceId, { mode: 'detailed' });
   const { setBreadcrumbs } = useBreadcrumbs();
-  const traceBreadcrumbLabel = trace ? getTraceDisplayName(trace) : traceId;
 
   useEffect(() => {
     setBreadcrumbs([
@@ -67,17 +43,17 @@ const IntakeTraceDetailContent: FC<IntakeTraceDetailContentProps> = ({ traceId }
         href: getIntakeTracesRoute(workspace),
       },
       {
-        slotLabel: `Trace ${traceBreadcrumbLabel}`,
+        slotLabel: `Trace ${traceId}`,
       },
     ]);
-  }, [setBreadcrumbs, traceBreadcrumbLabel, workspace]);
+  }, [setBreadcrumbs, traceId, workspace]);
 
   return (
-    <AccessibleTitle title={`Trace ${traceBreadcrumbLabel}`}>
+    <AccessibleTitle title={`Trace ${traceId}`}>
       <Stack gap="density-2xl" padding="density-2xl" className="h-full overflow-auto">
         <PageHeader
           className="p-0"
-          slotHeading={`Trace ${traceBreadcrumbLabel}`}
+          slotHeading={`Trace ${traceId}`}
           slotActions={
             <div
               id={TRACE_DETAIL_SPANS_FILTER_TARGET_ID}
@@ -91,202 +67,5 @@ const IntakeTraceDetailContent: FC<IntakeTraceDetailContentProps> = ({ traceId }
         />
       </Stack>
     </AccessibleTitle>
-  );
-};
-
-interface IntakeTraceDetailBodyProps {
-  traceId: string;
-  filterTogglePortalTargetId?: string;
-  showSpans?: boolean;
-}
-
-export const IntakeTraceDetailBody: FC<IntakeTraceDetailBodyProps> = ({
-  traceId,
-  filterTogglePortalTargetId,
-  showSpans = true,
-}) => {
-  const workspace = useWorkspaceFromPath();
-
-  const {
-    data: trace,
-    error,
-    isLoading,
-  } = useGetTrace(workspace, traceId, {
-    mode: 'detailed',
-  });
-
-  if (error?.response?.status === 404) {
-    return (
-      <NotFound
-        subheader="Trace Not Found"
-        message="The trace does not exist or you do not have permission to view it."
-      />
-    );
-  }
-
-  if (isLoading) {
-    return <Loading description="Loading trace..." />;
-  }
-
-  if (error) {
-    return (
-      <StatusMessage
-        className="mx-auto mt-density-2xl"
-        size="medium"
-        slotMedia={<CircleAlert width={65} height={65} />}
-        slotHeading="Error loading trace"
-        slotSubheading={error.message}
-      />
-    );
-  }
-
-  if (!trace) {
-    return null;
-  }
-
-  const showExperimentContext = Boolean(
-    trace.experiment_context?.experiment_id || trace.experiment_context?.test_case_id
-  );
-  const showSpanLimitMessage =
-    trace.span_count !== undefined && trace.span_count > TRACE_SPANS_PAGE_SIZE;
-  const wrappingValueAttributes = {
-    value: {
-      className: 'block min-w-0 max-w-full break-all',
-    },
-  };
-
-  const summaryPanels = (
-    <Stack gap="density-2xl" className="min-w-0">
-      <Panel
-        elevation="high"
-        slotIcon={<Activity />}
-        slotHeading="Trace Summary"
-        className="min-w-0 overflow-hidden"
-      >
-        <Stack gap="density-xl">
-          <Grid className="grid-cols-2 gap-density-lg">
-            <KVPair
-              label="Started"
-              value={formatAbsoluteTimestamp(trace.started_at)}
-              orientation="vertical"
-            />
-            <KVPair
-              label="Ended"
-              value={trace.ended_at ? formatAbsoluteTimestamp(trace.ended_at) : EMPTY_VALUE}
-              orientation="vertical"
-            />
-            <KVPair
-              label="Duration"
-              value={formatDurationMs(trace.duration_ms)}
-              orientation="vertical"
-            />
-            <KVPair label="Spans" value={formatInteger(trace.span_count)} orientation="vertical" />
-            <KVPair
-              label="Errors"
-              value={formatInteger(trace.error_count)}
-              orientation="vertical"
-            />
-            <KVPair label="Total Cost" value={formatCost(trace.cost_usd)} orientation="vertical" />
-          </Grid>
-          <Grid className="grid-cols-1 gap-density-lg min-w-0">
-            <KVPair
-              label="Trace ID"
-              value={trace.id}
-              orientation="vertical"
-              attributes={wrappingValueAttributes}
-            />
-            <KVPair
-              label="Root Span"
-              value={
-                trace.root_span_id ? (
-                  <Link
-                    to={getIntakeSpanRoute(workspace, trace.root_span_id)}
-                    className="break-all"
-                  >
-                    {trace.root_span_id}
-                  </Link>
-                ) : (
-                  EMPTY_VALUE
-                )
-              }
-              orientation="vertical"
-              attributes={wrappingValueAttributes}
-            />
-            <KVPair
-              label="Status"
-              value={<IntakeTelemetryStatusBadge status={trace.status} />}
-              orientation="vertical"
-            />
-            <KVPair
-              label="Session ID"
-              value={trace.session_id}
-              orientation="vertical"
-              attributes={wrappingValueAttributes}
-            />
-          </Grid>
-        </Stack>
-      </Panel>
-      {showExperimentContext && (
-        <Panel
-          elevation="high"
-          slotIcon={<Hash />}
-          slotHeading="Experiment Context"
-          className="min-w-0 overflow-hidden"
-        >
-          <Stack gap="density-lg" className="min-w-0">
-            <KVPair
-              label="Summary"
-              value={formatMaybe(
-                trace.experiment_context?.experiment_id || trace.experiment_context?.test_case_id
-              )}
-              orientation="vertical"
-              attributes={wrappingValueAttributes}
-            />
-            <KVPair
-              label="Experiment ID"
-              value={formatMaybe(trace.experiment_context?.experiment_id)}
-              orientation="vertical"
-              attributes={wrappingValueAttributes}
-            />
-            <KVPair
-              label="Test Case ID"
-              value={formatMaybe(trace.experiment_context?.test_case_id)}
-              orientation="vertical"
-              attributes={wrappingValueAttributes}
-            />
-          </Stack>
-        </Panel>
-      )}
-    </Stack>
-  );
-
-  if (!showSpans) {
-    return summaryPanels;
-  }
-
-  return (
-    <Grid className="grid-cols-1 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)] gap-density-2xl items-start">
-      <Stack gap="density-md" className="min-w-0 min-h-[420px]">
-        {showSpanLimitMessage && (
-          <Text kind="body/regular/sm" className="text-secondary">
-            Showing first {TRACE_SPANS_PAGE_SIZE.toLocaleString()} of{' '}
-            {trace.span_count?.toLocaleString()} spans. Parent spans outside this page are marked in
-            the hierarchy.
-          </Text>
-        )}
-        <IntakeSpansTable
-          workspace={workspace}
-          filterTogglePortalTargetId={filterTogglePortalTargetId}
-          fixedFilter={{ trace_id: trace.id }}
-          defaultPageSize={TRACE_SPANS_PAGE_SIZE}
-          mode="summary"
-          showTraceColumn={false}
-          showHierarchy
-          emptyHeader="No Spans"
-          emptyMessage="No spans were found for this trace."
-        />
-      </Stack>
-      {summaryPanels}
-    </Grid>
   );
 };


### PR DESCRIPTION
Closes FP-185

https://github.com/user-attachments/assets/108caf12-633c-4af2-842e-db61ada18935

# Summary

Clicking a session row in the experiment detail page now opens an inline trace detail panel to the right of the table, using the same CSS transition pattern as the filter panel. The panel shows Trace Summary and Experiment Context cards; the spans table is omitted in this narrower context.

To enable reuse, IntakeTraceDetailBody is extracted from IntakeTraceDetailRoute — separating the route-level concerns (breadcrumbs, PageHeader) from the content. A showSpans prop (default true) controls whether the spans table renders, leaving the Intake full-page view unchanged.

# Test plan

- [ ] Open an experiment detail page → click any session row → confirm the trace detail panel slides in from the right showing Trace Summary and Experiment Context
- [ ] Click the × button → confirm the panel closes
- [ ] Navigate to Intake → Traces → open any trace → confirm the full-page view still shows the spans table and renders correctly
- [ ] Click a row with no trace_id (if any) → confirm nothing opens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive side-panel trace detail view in the sessions table; selecting a row opens trace details in a right panel with a close button.
  * Trace detail pages now render via a shared detail view, with experiment context, a span-count “showing first N of M” message when truncated, and optional spans/table content.
* **Bug Fixes / UX Improvements**
  * Improved trace detail loading, not-found, and error feedback; simplified page shell while keeping the missing-trace guard.
* **Tests**
  * Updated route tests to assert trace content asynchronously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->