### PR TITLE
fix(customizer): set correct flag for full-sft using Unsloth backend

### DIFF
--- a/services/unsloth/src/nmp/unsloth/tasks/training/backends/unsloth_sft.py
+++ b/services/unsloth/src/nmp/unsloth/tasks/training/backends/unsloth_sft.py
@@ -54,9 +54,32 @@ def compute_default_eval_steps(
     return max(1, effective_steps - 1)
 
 
+def build_model_load_kwargs(spec: UnslothJobOutput, resolved_model: str) -> dict[str, Any]:
+    """Assemble ``FastLanguageModel.from_pretrained`` kwargs (sans torch dtype).
+
+    Kept torch-free so it can be unit-tested without the heavy ML stack; the
+    ``dtype`` literal → torch dtype mapping stays in :func:`train_sft`.
+
+    For ``finetuning_type='all_weights'`` we pass ``full_finetuning=True``.
+    Unsloth only routes through ``FastModel.from_pretrained`` (which marks every
+    parameter trainable and sets up the optimizer/precision state for full FT)
+    when this flag is set. Without it — even with 4-/8-bit disabled — Unsloth
+    takes its default LoRA-optimized load path and warns that full finetuning
+    was not requested, leaving the all-weights run mis-configured.
+    """
+    return {
+        "model_name": resolved_model,
+        "max_seq_length": spec.model.max_seq_length,
+        "load_in_4bit": spec.model.load_in_4bit,
+        "load_in_8bit": spec.model.load_in_8bit,
+        "full_finetuning": spec.training.finetuning_type == "all_weights",
+        "trust_remote_code": spec.model.trust_remote_code,
+    }
+
+
 def train_sft(
-    spec: "UnslothJobOutput",
-    ctx: "JobContext",
+    spec: UnslothJobOutput,
+    ctx: JobContext,
     *,
     model_path: str | None = None,
     dataset_path: str | None = None,
@@ -130,13 +153,7 @@ def train_sft(
 
     # ── Model loading ──────────────────────────────────────────────────
     resolved_model = model_path or spec.model.name
-    model_kwargs: dict[str, Any] = {
-        "model_name": resolved_model,
-        "max_seq_length": spec.model.max_seq_length,
-        "load_in_4bit": spec.model.load_in_4bit,
-        "load_in_8bit": spec.model.load_in_8bit,
-        "trust_remote_code": spec.model.trust_remote_code,
-    }
+    model_kwargs = build_model_load_kwargs(spec, resolved_model)
     # Unsloth's `dtype` kwarg accepts `None` (auto) or a torch dtype. Map
     # the JSON-friendly literal to a torch dtype lazily.
     if spec.model.dtype != "auto":
@@ -175,9 +192,11 @@ def train_sft(
             use_gradient_checkpointing=gc_value,
             max_seq_length=spec.model.max_seq_length,
         )
-    # All-weights FT: leave `model` as-is. `from_pretrained` already returned the
-    # un-wrapped HF model since `load_in_4bit`/`load_in_8bit` were both
-    # rejected by the spec validator for `finetuning_type='all_weights'`.
+    # All-weights FT: leave `model` as-is. `build_model_load_kwargs` passed
+    # `full_finetuning=True`, so `from_pretrained` routed through Unsloth's
+    # `FastModel.from_pretrained` and returned an un-wrapped HF model with every
+    # parameter trainable (4-/8-bit were already rejected by the spec validator
+    # for `finetuning_type='all_weights'`).
 
     # ── Dataset ────────────────────────────────────────────────────────
     resolved_train_path = dataset_path or spec.dataset.path
@@ -402,7 +421,7 @@ def _load_training_dataset(
     return raw.map(_render)
 
 
-def _save_model(model: Any, tokenizer: Any, output_dir: Any, spec: "UnslothJobOutput") -> Any:
+def _save_model(model: Any, tokenizer: Any, output_dir: Any, spec: UnslothJobOutput) -> Any:
     """Dispatch on save_method; returns the path actually written to.
 
     Unsloth's recipes use three methods:

--- a/services/unsloth/tests/test_model_load_kwargs.py
+++ b/services/unsloth/tests/test_model_load_kwargs.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``build_model_load_kwargs`` in the unsloth SFT driver.
+
+These exercise the torch-free kwargs assembly only, so the module imports
+fine on a CPU box without ``unsloth``/``torch`` installed.
+"""
+
+from __future__ import annotations
+
+from nmp.unsloth.schemas import (
+    DatasetSpec,
+    ModelLoadSpec,
+    OutputResponse,
+    TrainingSpec,
+    UnslothJobOutput,
+)
+from nmp.unsloth.tasks.training.backends.unsloth_sft import build_model_load_kwargs
+
+
+def _spec(*, finetuning_type: str, load_in_4bit: bool) -> UnslothJobOutput:
+    return UnslothJobOutput(
+        model=ModelLoadSpec(name="meta/llama-3.1-8b", load_in_4bit=load_in_4bit),
+        dataset=DatasetSpec(path="ws/train"),
+        training=TrainingSpec(finetuning_type=finetuning_type),
+        output=OutputResponse(name="out", type="model", save_method="lora", fileset="out"),
+    )
+
+
+def test_all_weights_sets_full_finetuning() -> None:
+    # all-weights FT loads in 16-bit (validator forbids 4/8-bit upstream) and
+    # MUST request full_finetuning so Unsloth uses the full-FT load path.
+    kwargs = build_model_load_kwargs(_spec(finetuning_type="all_weights", load_in_4bit=False), "/local/model")
+    assert kwargs["full_finetuning"] is True
+    assert kwargs["load_in_4bit"] is False
+    assert kwargs["model_name"] == "/local/model"
+
+
+def test_lora_does_not_set_full_finetuning() -> None:
+    kwargs = build_model_load_kwargs(_spec(finetuning_type="lora", load_in_4bit=True), "/local/model")
+    assert kwargs["full_finetuning"] is False
+    assert kwargs["load_in_4bit"] is True
+
+
+def test_dtype_not_included() -> None:
+    # dtype mapping needs torch and stays in train_sft; the helper must not emit it.
+    kwargs = build_model_load_kwargs(_spec(finetuning_type="lora", load_in_4bit=True), "/local/model")
+    assert "dtype" not in kwargs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized model-loading argument construction to consistently apply quantization options and correctly set the full-weight fine-tuning behavior (while leaving dtype handling to later in the training flow).

* **Tests**
  * Added CPU-import-safe unit tests verifying full-weight vs LoRA flag behavior, preservation of quantization settings, and that dtype is not included in the assembled model-loading kwargs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->