### PR TITLE
fix: set permissions for nat_runner folders

### DIFF
--- a/tests/agentic-use/nat_runner.py
+++ b/tests/agentic-use/nat_runner.py
@@ -73,6 +73,7 @@ import fnmatch
 import json
 import os
 import shlex
+import stat
 import subprocess
 import sys
 import textwrap
@@ -99,6 +100,7 @@ PLATFORM_CONFIG_PATH = "/app/packages/nmp_platform/config/local.yaml"
 DOCKER_SOCKET_HOST_PATH = Path("/var/run/docker.sock")
 DOCKER_SOCKET_CONTAINER_PATH = "/var/run/docker.sock"
 PLACEHOLDER_SECRET_VALUES = {"null", "none"}
+CONTAINER_WRITABLE_DIR_MODE = 0o777
 
 
 def _normalize_secret(value: str | None) -> str:
@@ -111,6 +113,15 @@ def _normalize_secret(value: str | None) -> str:
 
 def _secret_from_env(name: str) -> str:
     return _normalize_secret(os.environ.get(name))
+
+
+def _ensure_container_writable_dir(path: Path) -> None:
+    """Create a bind-mount directory writable by container users with mismatched UID/GID."""
+    path.mkdir(parents=True, exist_ok=True)
+    current_mode = stat.S_IMODE(path.stat().st_mode)
+    desired_mode = current_mode | CONTAINER_WRITABLE_DIR_MODE
+    if desired_mode != current_mode:
+        path.chmod(desired_mode)
 
 
 _CANDIDATE_PARAM_STRING_KEYS = frozenset(
@@ -925,8 +936,9 @@ def run_agent_phase(
 
     instruction = instruction_path.read_text()
     agent_log_dir = output_dir / "agent"
-    agent_log_dir.mkdir(parents=True, exist_ok=True)
-    workspace_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_container_writable_dir(agent_log_dir)
+    _ensure_container_writable_dir(workspace_dir)
+    _ensure_container_writable_dir(state_dir)
 
     # Build the environment passed into the container
     env: dict[str, str] = {
@@ -1514,9 +1526,12 @@ def run_verify_phase(
         print(f"[nat_runner] ERROR: No test_outputs.py in {tests_dir}; verification failed")
         return False, ""
 
+    agent_log_dir = output_dir / "agent"
     verifier_log_dir = output_dir / "verifier"
-    verifier_log_dir.mkdir(parents=True, exist_ok=True)
-    workspace_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_container_writable_dir(agent_log_dir)
+    _ensure_container_writable_dir(verifier_log_dir)
+    _ensure_container_writable_dir(workspace_dir)
+    _ensure_container_writable_dir(state_dir)
 
     smoke_seed_cmd = ""
     smoke_cleanup_cmd = ""
@@ -1570,7 +1585,7 @@ def run_verify_phase(
             (str(workspace_dir), "/app/workspace"),
             (str(SHARED_DIR), "/app/tests/agentic-use/shared:ro"),
             (str(REPO_ROOT / "packages" / "nemo_evaluator_sdk" / "src"), "/app/packages/nemo_evaluator_sdk/src:ro"),
-            (str(output_dir / "agent"), "/logs/agent"),
+            (str(agent_log_dir), "/logs/agent"),
             (str(verifier_log_dir), "/logs/verifier"),
             # Persist service/database state across AGENT and VERIFY containers.
             # This restores Harbor-like state continuity while keeping phase isolation.
@@ -1635,9 +1650,9 @@ def run_task(
     output_dir = jobs_dir / f"{ts}-{task_name}"
     output_dir.mkdir(parents=True, exist_ok=True)
     state_dir = output_dir / "state"
-    state_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_container_writable_dir(state_dir)
     workspace_dir = output_dir / "workspace"
-    workspace_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_container_writable_dir(workspace_dir)
 
     image_tag = f"nmp-nat-{task_name}:latest"
 

--- a/tests/agentic-use/tests/test_nat_runner_config.py
+++ b/tests/agentic-use/tests/test_nat_runner_config.py
@@ -4,6 +4,7 @@
 """Tests for _prepare_aut_config_for_runtime IGW routing logic."""
 
 import json
+import stat
 import subprocess
 import sys
 from importlib import util
@@ -668,6 +669,58 @@ workflow:
         assert (str(codex_auth), "/tmp/codex_host_auth.json:ro") in captured_mounts
         assert (str(workspace_dir), "/app/workspace") in captured_mounts
         assert (str(codex_home), "/tmp/codex_host_home") not in captured_mounts
+
+    def test_run_agent_phase_relaxes_bind_mount_directory_permissions(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        (task_dir / "instruction.md").write_text("Do the thing.")
+        output_dir = tmp_path / "out"
+        state_dir = tmp_path / "state"
+        workspace_dir = tmp_path / "workspace"
+        state_dir.mkdir()
+        workspace_dir.mkdir()
+        state_dir.chmod(0o775)
+        workspace_dir.chmod(0o775)
+
+        monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+        captured_mounts: list[tuple[str, str]] = []
+
+        def fake_docker_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess:
+            mounts = cast(list[tuple[str, str]], kwargs["mounts"])
+            captured_mounts.extend(mounts)
+            return subprocess.CompletedProcess(args=["docker"], returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(nat_runner, "_docker_run", fake_docker_run)
+
+        assert run_agent_phase(
+            task_dir,
+            "task-image",
+            output_dir,
+            nvidia_api_key="",
+            anthropic_api_key="",
+            anthropic_base_url="https://anthropic.example",
+            nmp_base_url="http://localhost:8080",
+            agent_model=None,
+            agent_params={},
+            codex_auth_json=None,
+            timeout=10,
+            agent_backend="codex",
+            aut_agent_name="test-agent",
+            aut_agent_config=None,
+            aut_seed_providers=True,
+            state_dir=state_dir,
+            workspace_dir=workspace_dir,
+        )
+
+        agent_log_dir = output_dir / "agent"
+        assert stat.S_IMODE(agent_log_dir.stat().st_mode) == 0o777
+        assert stat.S_IMODE(state_dir.stat().st_mode) == 0o777
+        assert stat.S_IMODE(workspace_dir.stat().st_mode) == 0o777
+        assert (str(agent_log_dir), "/logs/agent") in captured_mounts
+        assert (str(state_dir), "/data") in captured_mounts
+        assert (str(workspace_dir), "/app/workspace") in captured_mounts
 
     def test_run_verify_phase_mounts_shared_evaluator_harness(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved file permission issues with container directories to ensure proper write access during setup and runtime operations.
  * Improved configuration of logging and workspace directories for container environments.

* **Tests**
  * Added comprehensive tests to validate directory permission handling and container mount configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->