### PR TITLE
fix: docs platform-all install instructions, remove compose/helm ref

### DIFF
--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -30,14 +30,16 @@ pip uninstall nemo-microservices
 
 ### Install in a Virtual Environment
 
+Install the PyPI `nemo-platform` wrapper package. If you are working from a source checkout, run `make bootstrap` from the repository root instead; the generated SDK package under `sdk/python/nemo-platform/pyproject.toml` does not define the wrapper extras.
+
 ```bash
-pip install nemo-platform[all]
+pip install "nemo-platform[all]"
 ```
 
 Or with uv:
 
 ```bash
-uv pip install nemo-platform[all]
+uv pip install "nemo-platform[all]"
 ```
 
 <Warning>

--- a/docs/contributing/skills-spec.mdx
+++ b/docs/contributing/skills-spec.mdx
@@ -103,7 +103,7 @@ Every skill ships with the following YAML frontmatter at the top of `SKILL.md`. 
 
 Library-prefix naming (`nemo-*`) is required for user-invocable skills (skills install into shared agent catalogs alongside skills from other plugins; the prefix prevents collisions). It's optional for internal helpers.
 
-**Canonical location:** `packages/nemo_platform_ext/src/nemo_platform_ext/skills/<name>/`. Skills there ship with `pip install nemo-platform[all]`.
+**Canonical location:** `packages/nemo_platform_ext/src/nemo_platform_ext/skills/<name>/`. Skills there ship with `pip install "nemo-platform[all]"`.
 
 ---
 

--- a/docs/customizer/tutorials/distillation-customization-job.ipynb
+++ b/docs/customizer/tutorials/distillation-customization-job.ipynb
@@ -67,7 +67,7 @@
         "Before starting this tutorial, ensure you have:\n",
         "\n",
         "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-        "2. **Installed the Python SDK** (included with `pip install nemo-platform[all]`)\n",
+        "2. **Installed the Python SDK** (PyPI wrapper: `pip install \"nemo-platform[all]\"`; source checkout: run `make bootstrap` from the repository root)\n",
         "3. **Installed evaluation dependencies:**\n",
         "\n",
         "```sh\n",

--- a/docs/customizer/tutorials/dpo-customization-job.ipynb
+++ b/docs/customizer/tutorials/dpo-customization-job.ipynb
@@ -59,7 +59,7 @@
         "Before starting this tutorial, ensure you have:\n",
         "\n",
         "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-        "2. **Installed the Python SDK** (included with `pip install nemo-platform[all]`)"
+        "2. **Installed the Python SDK** (PyPI wrapper: `pip install \"nemo-platform[all]\"`; source checkout: run `make bootstrap` from the repository root)"
       ]
     },
     {

--- a/docs/customizer/tutorials/embedding-customization-job.ipynb
+++ b/docs/customizer/tutorials/embedding-customization-job.ipynb
@@ -49,7 +49,7 @@
     "Before starting this tutorial, ensure you have:\n",
     "\n",
     "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-    "2. **Installed the Python SDK** (included with `pip install nemo-platform[all]`)\n",
+    "2. **Installed the Python SDK** (PyPI wrapper: `pip install \"nemo-platform[all]\"`; source checkout: run `make bootstrap` from the repository root)\n",
     "3. **HuggingFace token** with read access to download the SPECTER dataset (get one at [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens))\n",
     "4. **NGC API key** to pull NIM container images from nvcr.io (get one at [ngc.nvidia.com](https://ngc.nvidia.com/) → Setup → Generate API Key)"
    ]

--- a/docs/customizer/tutorials/lora-customization-job.ipynb
+++ b/docs/customizer/tutorials/lora-customization-job.ipynb
@@ -25,7 +25,7 @@
     "Before starting this tutorial, ensure you have:\n",
     "\n",
     "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-    "2. **Installed the Python SDK** (included with `pip install nemo-platform[all]`)\n",
+    "2. **Installed the Python SDK** (PyPI wrapper: `pip install \"nemo-platform[all]\"`; source checkout: run `make bootstrap` from the repository root)\n",
     "3. **Installed the `datasets` package** for loading SQuAD: `pip install datasets`\n",
     "4. **At least one GPU with CUDA 12.8+**\n"
    ]

--- a/docs/customizer/tutorials/optimize-throughput.ipynb
+++ b/docs/customizer/tutorials/optimize-throughput.ipynb
@@ -29,7 +29,7 @@
         "Before starting this tutorial, ensure you have:\n",
         "\n",
         "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-        "2. **Installed the Python SDK** (included with `pip install nemo-platform[all]`)"
+        "2. **Installed the Python SDK** (PyPI wrapper: `pip install \"nemo-platform[all]\"`; source checkout: run `make bootstrap` from the repository root)"
       ]
     },
     {

--- a/docs/customizer/tutorials/sft-customization-job.ipynb
+++ b/docs/customizer/tutorials/sft-customization-job.ipynb
@@ -58,7 +58,7 @@
         "Before starting this tutorial, ensure you have:\n",
         "\n",
         "1. **Completed the [Quickstart](../../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
-        "2. **Installed the Python SDK** (included with `pip install nemo-platform[all]`)"
+        "2. **Installed the Python SDK** (PyPI wrapper: `pip install \"nemo-platform[all]\"`; source checkout: run `make bootstrap` from the repository root)"
       ]
     },
     {

--- a/docs/evaluator/tutorials/define-run-custom-python-metrics.mdx
+++ b/docs/evaluator/tutorials/define-run-custom-python-metrics.mdx
@@ -29,7 +29,7 @@ Keep custom metric code dependency-light. Local execution runs your metric in th
 
 ## Prerequisites
 
-Install the Evaluator SDK:
+Install the PyPI `nemo-platform` wrapper package, which includes the Evaluator SDK. The `all` extra is defined by the wrapper package; if you are working from a source checkout, run `make bootstrap` from the repository root instead.
 
 ```bash
 pip install "nemo-platform[all]"

--- a/docs/evaluator/tutorials/run-llm-judge-evaluation.mdx
+++ b/docs/evaluator/tutorials/run-llm-judge-evaluation.mdx
@@ -40,8 +40,10 @@ This tutorial takes approximately **20 minutes** to complete.
 
 1. Install and start NeMo Platform using the [Setup guide](/documentation/get-started).
 
+For PyPI installs, use the `nemo-platform` wrapper package. If you are working from a source checkout, run `make bootstrap` from the repository root instead.
+
 ```bash
-! pip install nemo-platform[all]
+! pip install "nemo-platform[all]"
 ! nemo setup
 ```
 

--- a/docs/example-applications/tool-calling.ipynb
+++ b/docs/example-applications/tool-calling.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "Before starting this tutorial, ensure you have:\n",
     "\n",
-    "1. **Installed the Python SDK with the Data Designer extra** (`uv pip install nemo-platform[all]`)\n",
+    "1. **Installed the Python SDK with Data Designer support** (PyPI wrapper: `uv pip install \"nemo-platform[all]\"`; source checkout: run `make bootstrap` from the repository root)\n",
     "1. **Completed the [Quickstart](../get-started/quickstart.md)** to install and deploy NeMo Platform locally\n",
     "1. (Optional if running outside of Quickstart) **Authenticated with the platform** using the CLI:\n",
     "   ```bash\n",

--- a/docs/fern/snippets/customizer/tutorials/_snippets/customizer-prereqs.mdx
+++ b/docs/fern/snippets/customizer/tutorials/_snippets/customizer-prereqs.mdx
@@ -7,7 +7,7 @@ description: ""
 Before starting, make sure you have:
 
 - NeMo Platform installed and deployed (see [Setup](/documentation/get-started))
-- The `nemo-platform` Python SDK installed (`pip install nemo-platform[all]`)
+- The PyPI `nemo-platform` wrapper package installed (`pip install "nemo-platform[all]"`). If you are working from a source checkout, run `make bootstrap` from the repository root instead.
 - (Optional) Weights & Biases account and API key for enhanced visualization
 
 **Set up environment variables:**

--- a/docs/pysdk/index.mdx
+++ b/docs/pysdk/index.mdx
@@ -8,10 +8,10 @@ The [NeMo Platform Python SDK](https://pypi.org/project/nemo-platform/) is a lib
 
 ## Installation
 
-Install the NeMo Platform Python SDK using `pip`:
+Install the PyPI `nemo-platform` wrapper package using `pip`. The wrapper defines the `all` extra and includes the SDK. If you are working from a source checkout, run `make bootstrap` from the repository root instead; the generated SDK package under `sdk/python/nemo-platform/pyproject.toml` does not define the wrapper extras.
 
 ```bash
-pip install nemo-platform[all]
+pip install "nemo-platform[all]"
 ```
 
 <Note>

--- a/docs/safe-synthesizer/tutorials/differential-privacy.mdx
+++ b/docs/safe-synthesizer/tutorials/differential-privacy.mdx
@@ -60,13 +60,15 @@ By default, NeMo Safe Synthesizer uses **record-level** differential privacy, wh
 
 ## Setup
 
-Install the NeMo Platform SDK with Safe Synthesizer support:
+Install the PyPI `nemo-platform` wrapper package with Safe Synthesizer support. The `all` extra is defined by the wrapper package, not by the generated SDK package under `sdk/python/nemo-platform/pyproject.toml`. If you are working from a source checkout, run `make bootstrap` from the repository root instead, then install the tutorial-only packages (`kagglehub matplotlib`) in that environment.
+
+For a PyPI install:
 
 ```shell
 if command -v uv &> /dev/null; then
- uv pip install nemo-platform[all] kagglehub matplotlib
+ uv pip install "nemo-platform[all]" kagglehub matplotlib
 else
- pip install nemo-platform[all] kagglehub matplotlib
+ pip install "nemo-platform[all]" kagglehub matplotlib
 fi
 ```
 

--- a/docs/safe-synthesizer/tutorials/index.mdx
+++ b/docs/safe-synthesizer/tutorials/index.mdx
@@ -10,10 +10,10 @@ Learn how to run NeMo Safe Synthesizer jobs through hands-on tutorials to genera
 
 Before starting any tutorial, ensure you have:
 
-- [NeMo Safe Synthesizer deployed](/documentation/synthesize-safe-data) using Docker Compose or Helm
-- Python environment with `nemo-platform` SDK installed:
+- [NeMo Safe Synthesizer running](/documentation/synthesize-safe-data)
+- Python environment with the PyPI `nemo-platform` wrapper package installed. The `all` extra is defined by the wrapper package, not by the generated SDK package under `sdk/python/nemo-platform/pyproject.toml`. If you are working from a source checkout, run `make bootstrap` from the repository root instead.
  ```bash
- pip install nemo-platform[all]
+ pip install "nemo-platform[all]"
  ```
 - Jupyter environment for running tutorial notebooks
 

--- a/docs/safe-synthesizer/tutorials/safe-synthesizer-101.mdx
+++ b/docs/safe-synthesizer/tutorials/safe-synthesizer-101.mdx
@@ -30,13 +30,15 @@ By the end of this tutorial, you'll understand how to:
 
 ## Step 1: Install the SDK
 
-Install the NeMo Platform SDK with Safe Synthesizer support. Run the following command in a **terminal (shell)**:
+Install the PyPI `nemo-platform` wrapper package with Safe Synthesizer support. The `all` extra is defined by the wrapper package under `packages/nemo_platform/pyproject.toml`, not by the generated SDK package. If you are working from a source checkout, run `make bootstrap` from the repository root instead, then install the tutorial-only packages (`kagglehub matplotlib`) in that environment.
+
+For a PyPI install, run the following command in a **terminal (shell)**:
 
 ```shell
 if command -v uv &> /dev/null; then
- uv pip install nemo-platform[all] kagglehub matplotlib
+ uv pip install "nemo-platform[all]" kagglehub matplotlib
 else
- pip install nemo-platform[all] kagglehub matplotlib
+ pip install "nemo-platform[all]" kagglehub matplotlib
 fi
 ```
 

--- a/docs/support-matrix.mdx
+++ b/docs/support-matrix.mdx
@@ -21,7 +21,7 @@ Docker Compose, Helm, Kubernetes, and OpenShift deployment paths are not part of
 
 | Area | Supported | Notes |
 |------|-----------|-------|
-| Package installation | `uv` recommended; `pip` supported | The one-line installer sets up `uv` automatically. Published packages can also be installed with `pip install nemo-platform[all]`. |
+| Package installation | `uv` recommended; `pip` supported | The one-line installer sets up `uv` automatically. Published packages can also be installed with `pip install "nemo-platform[all]"`. |
 | Shell | Bash or zsh | Used by the installer, setup commands, and documented examples. |
 | Browser | Current Chrome, Edge, Firefox, or Safari | Required for the Studio UI and generated documentation. |
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation commands across tutorials and guides to use quoted extras for the NeMo Platform CLI/PyPI wrapper (e.g., `pip install "nemo-platform[all]"` / `uv pip install "nemo-platform[all]"`), replacing unquoted examples.
  * Added clearer two-path instructions for source checkouts (run `make bootstrap` from the repository root).
  * Clarified that the `all` extra is provided by the wrapper package (not the generated SDK).
  * Refreshed Safe Synthesizer prerequisites wording (requirements now reference “running”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->