### PR TITLE
fix: helm chart KEK secret management must accept ready-made secret

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,11 +197,15 @@ jobs:
       - name: Build CPU images
         if: env.PUBLISH_IMAGES != 'true'
         shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: make docker-load TARGET=docker-cpu
 
       - name: Build and publish CPU images
         if: env.PUBLISH_IMAGES == 'true'
         shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: make docker-push TARGET=docker-cpu
 
   kind-cpu-smoke:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -103,6 +103,10 @@ variable "BUILD_ARCH" {
   default = ""
 }
 
+variable "HF_TOKEN" {
+  default = ""
+}
+
 variable "CUDA_VERSION" {
   default = "12.8.1"
 }
@@ -197,6 +201,16 @@ function "maybe_registry_cache_to" {
 function "image_output" {
   params = []
   result = ["type=image,compression=zstd,force-compression=true"]
+}
+
+function "maybe_hf_token_secret" {
+  params = []
+  result = notequal(HF_TOKEN, "") ? [
+    {
+      type = "env"
+      id   = "HF_TOKEN"
+    }
+  ] : []
 }
 
 function "maybe_registry_cache_from" {
@@ -458,6 +472,7 @@ target "nmp-api-docker" {
   cache-from = maybe_registry_cache_from("nmp-api")
   tags       = sha_and_maybe_latest_tags("nmp-api")
   output     = image_output()
+  secret     = maybe_hf_token_secret()
   platforms  = get_platforms()
 }
 

--- a/docker/Dockerfile.nmp-api
+++ b/docker/Dockerfile.nmp-api
@@ -30,7 +30,9 @@ RUN sh /app/script/install_duckdb_extensions.sh
 # Download embedding model used by `nemoguardrails` library.
 # Uses snapshot_download directly to avoid importing onnxruntime, which crashes under QEMU (ARM64 cross-compilation).
 # Stored in /tmp/fastembed_cache (fastembed's default cache location) and copied to the runtime image below.
-RUN uv run --no-sync python -c 'import os, tempfile; from huggingface_hub import snapshot_download; snapshot_download(repo_id="qdrant/all-MiniLM-L6-v2-onnx", cache_dir=os.path.join(tempfile.gettempdir(), "fastembed_cache"))'
+RUN --mount=type=secret,id=HF_TOKEN,required=false \
+    if [ -s /run/secrets/HF_TOKEN ]; then export HF_TOKEN="$(cat /run/secrets/HF_TOKEN)"; fi; \
+    uv run --no-sync python -c 'import os, tempfile; from huggingface_hub import snapshot_download; snapshot_download(repo_id="qdrant/all-MiniLM-L6-v2-onnx", cache_dir=os.path.join(tempfile.gettempdir(), "fastembed_cache"))'
 
 FROM ${NMP_PYTHON_BASE} AS runtime
 ARG USERNAME=nvs

--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -10,9 +10,15 @@ The platform secrets service reads `NMP_SECRETS_DEFAULT_ENCRYPTION_KEY` from the
 API env Secret. The value must be base64-encoded and decode to at least 32 bytes.
 
 Set `secrets.defaultEncryptionKey.value` to provide your own key. When that value
-is empty and `envFromSecret` is not set, the chart runs a pre-install hook that
-creates `<fullname>-api-env` with a per-install random key. The hook is
-install-only and refuses to patch or rotate an existing Secret.
+is empty and neither `envFromSecret` nor
+`secrets.defaultEncryptionKey.existingSecret.name` is set, the chart runs a
+pre-install hook that creates `<fullname>-api-env` with a per-install random key.
+The hook is install-only and refuses to patch or rotate an existing Secret.
+
+Set `secrets.defaultEncryptionKey.existingSecret.name` to use an existing Secret
+for only the secrets service encryption key. After Kubernetes decodes the Secret
+data, the value loaded from `secrets.defaultEncryptionKey.existingSecret.key`
+must be a base64-encoded key that decodes to at least 32 bytes.
 
 Set `envFromSecret` to use a fully user-managed API env Secret. In that mode the
 chart does not create or generate the API env Secret.
@@ -293,7 +299,10 @@ secrets will not decrypt with a new key.
 | rbac | object | `{"k8sNimOperatorEnabled":true,"volcanoEnabled":true}` | RBAC configuration settings for optional dependencies |
 | rbac.k8sNimOperatorEnabled | bool | `true` | Specifies whether to enable the core Controller to have RBAC permissions to k8s-nim-operator's NIMService for scheduling NIMs. |
 | rbac.volcanoEnabled | bool | `true` | Specifies whether to enable the core Controller to have RBAC permissions to Volcano for scheduling distributed jobs. |
-| secrets | object | `{"defaultEncryptionKey":{"generated":{"activeDeadlineSeconds":120,"affinity":{},"backoffLimit":3,"enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"docker.io/library/python","tag":"3.12-slim"},"nodeSelector":{},"podSecurityContext":{},"resources":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"tolerations":[],"ttlSecondsAfterFinished":300},"value":""}}` | Secrets service configuration. |
+| secrets | object | `{"defaultEncryptionKey":{"existingSecret":{"key":"NMP_SECRETS_DEFAULT_ENCRYPTION_KEY","name":""},"generated":{"activeDeadlineSeconds":120,"affinity":{},"backoffLimit":3,"enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"docker.io/library/python","tag":"3.12-slim"},"nodeSelector":{},"podSecurityContext":{},"resources":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"tolerations":[],"ttlSecondsAfterFinished":300},"value":""}}` | Secrets service configuration. |
+| secrets.defaultEncryptionKey.existingSecret | object | `{"key":"NMP_SECRETS_DEFAULT_ENCRYPTION_KEY","name":""}` | Existing Kubernetes Secret containing the key for encrypting platform secrets. If name is set, the chart does not create or generate the default api-env Secret. |
+| secrets.defaultEncryptionKey.existingSecret.key | string | `"NMP_SECRETS_DEFAULT_ENCRYPTION_KEY"` | Key in the existing Secret. After Kubernetes decodes the Secret data, the loaded value must be the base64-encoded NMP_SECRETS_DEFAULT_ENCRYPTION_KEY string. |
+| secrets.defaultEncryptionKey.existingSecret.name | string | `""` | Name of an existing Kubernetes Secret containing the encryption key. |
 | secrets.defaultEncryptionKey.generated | object | `{"activeDeadlineSeconds":120,"affinity":{},"backoffLimit":3,"enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"docker.io/library/python","tag":"3.12-slim"},"nodeSelector":{},"podSecurityContext":{},"resources":{},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"tolerations":[],"ttlSecondsAfterFinished":300}` | Generated key configuration used only when value and envFromSecret are empty. The generated key is not rotated or recreated on upgrade. |
 | secrets.defaultEncryptionKey.generated.activeDeadlineSeconds | int | `120` | Maximum seconds for the key generation hook to run. |
 | secrets.defaultEncryptionKey.generated.affinity | object | `{}` | Affinity for the key generation hook. |

--- a/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
+++ b/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
@@ -10,9 +10,15 @@ The platform secrets service reads `NMP_SECRETS_DEFAULT_ENCRYPTION_KEY` from the
 API env Secret. The value must be base64-encoded and decode to at least 32 bytes.
 
 Set `secrets.defaultEncryptionKey.value` to provide your own key. When that value
-is empty and `envFromSecret` is not set, the chart runs a pre-install hook that
-creates `<fullname>-api-env` with a per-install random key. The hook is
-install-only and refuses to patch or rotate an existing Secret.
+is empty and neither `envFromSecret` nor
+`secrets.defaultEncryptionKey.existingSecret.name` is set, the chart runs a
+pre-install hook that creates `<fullname>-api-env` with a per-install random key.
+The hook is install-only and refuses to patch or rotate an existing Secret.
+
+Set `secrets.defaultEncryptionKey.existingSecret.name` to use an existing Secret
+for only the secrets service encryption key. After Kubernetes decodes the Secret
+data, the value loaded from `secrets.defaultEncryptionKey.existingSecret.key`
+must be a base64-encoded key that decodes to at least 32 bytes.
 
 Set `envFromSecret` to use a fully user-managed API env Secret. In that mode the
 chart does not create or generate the API env Secret.

--- a/k8s/helm/templates/NOTES.txt
+++ b/k8s/helm/templates/NOTES.txt
@@ -1,7 +1,7 @@
 {{- $apiServiceName := include "nmp-api.api-servicename" . -}}
 {{- $apiServicePort := .Values.api.service.port -}}
 {{- $apiEnvSecretName := include "nemo-platform.apiEnvSecretName" . -}}
-{{- $defaultEncryptionKeyName := include "nemo-platform.defaultEncryptionKeyEnvName" . -}}
+{{- $defaultEncryptionKeySecretKey := include "nemo-platform.defaultEncryptionKeySecretKey" . -}}
 {{- $namespace := .Release.Namespace -}}
 ================================================================================
 🚀 NVIDIA NeMo Microservices Platform
@@ -72,10 +72,10 @@ Successfully installed {{ .Chart.Name }}-{{ .Chart.Version }}, named {{ .Release
   Documentation: https://docs.nvidia.com/nemo-platform
 
   Back up the {{ $apiEnvSecretName }} Secret. If it is lost, existing encrypted
-  platform secrets become unrecoverable. To print {{ $defaultEncryptionKeyName }}
-  for secure backup:
+  platform secrets become unrecoverable. To print the stored Secret data value
+  for key {{ $defaultEncryptionKeySecretKey }} for secure backup:
 
-    kubectl get secret -n {{ $namespace }} {{ $apiEnvSecretName }} -o go-template='{{ "{{" }} index .data {{ $defaultEncryptionKeyName | quote }} | base64decode {{ "}}" }}{{ "{{" }} "\n" {{ "}}" }}'
+    kubectl get secret -n {{ $namespace }} {{ $apiEnvSecretName }} -o go-template='{{ "{{" }} index .data {{ $defaultEncryptionKeySecretKey | quote }} {{ "}}" }}{{ "{{" }} "\n" {{ "}}" }}'
 
 {{- if .Values.postgresql.enabled }}
 

--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -149,12 +149,12 @@ checksum/config: {{ include (print $.Template.BasePath "/platform-configmap.yaml
 {{- end -}}
 
 {{/*
-Name of the API environment Secret. This Secret provides environment variables
-loaded via envFrom, including the secrets service default encryption key when the
-chart manages it.
+Name of the Secret containing API environment values or the secrets service
+default encryption key. Existing default-encryption-key Secrets are mounted with
+secretKeyRef instead of envFrom.
 */}}
 {{- define "nemo-platform.apiEnvSecretName" -}}
-{{- .Values.envFromSecret | default (printf "%s-api-env" (include "nemo-platform.fullname" .)) -}}
+{{- .Values.envFromSecret | default (include "nemo-platform.defaultEncryptionKeyExistingSecretName" .) | default (printf "%s-api-env" (include "nemo-platform.fullname" .)) -}}
 {{- end -}}
 
 {{/*
@@ -165,13 +165,27 @@ NMP_SECRETS_DEFAULT_ENCRYPTION_KEY
 {{- end -}}
 
 {{/*
+Existing Secret name for the secrets service default encryption key.
+*/}}
+{{- define "nemo-platform.defaultEncryptionKeyExistingSecretName" -}}
+{{- .Values.secrets.defaultEncryptionKey.existingSecret.name | default "" -}}
+{{- end -}}
+
+{{/*
+Secret key that contains the secrets service default encryption key.
+*/}}
+{{- define "nemo-platform.defaultEncryptionKeySecretKey" -}}
+{{- .Values.secrets.defaultEncryptionKey.existingSecret.key | default (include "nemo-platform.defaultEncryptionKeyEnvName" .) -}}
+{{- end -}}
+
+{{/*
 Whether the chart should generate the API env Secret through a pre-install hook.
 Generation is install-only. On upgrade, a missing generated key is unrecoverable
 without restoring the original key or rotating/re-encrypting secrets through the
 supported admin flow, so the chart must not generate a replacement.
 */}}
 {{- define "nemo-platform.generateDefaultEncryptionKey" -}}
-{{- if and .Release.IsInstall (not .Values.envFromSecret) (not .Values.secrets.defaultEncryptionKey.value) .Values.secrets.defaultEncryptionKey.generated.enabled -}}
+{{- if and .Release.IsInstall (not .Values.envFromSecret) (not (include "nemo-platform.defaultEncryptionKeyExistingSecretName" .)) (not .Values.secrets.defaultEncryptionKey.value) .Values.secrets.defaultEncryptionKey.generated.enabled -}}
 true
 {{- end -}}
 {{- end -}}
@@ -180,7 +194,7 @@ true
 Whether an upgrade should require the generated API env Secret to already exist.
 */}}
 {{- define "nemo-platform.requireExistingGeneratedDefaultEncryptionKey" -}}
-{{- if and .Release.IsUpgrade (not .Values.envFromSecret) (not .Values.secrets.defaultEncryptionKey.value) .Values.secrets.defaultEncryptionKey.generated.enabled -}}
+{{- if and .Release.IsUpgrade (not .Values.envFromSecret) (not (include "nemo-platform.defaultEncryptionKeyExistingSecretName" .)) (not .Values.secrets.defaultEncryptionKey.value) .Values.secrets.defaultEncryptionKey.generated.enabled -}}
 true
 {{- end -}}
 {{- end -}}

--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -175,7 +175,11 @@ Existing Secret name for the secrets service default encryption key.
 Secret key that contains the secrets service default encryption key.
 */}}
 {{- define "nemo-platform.defaultEncryptionKeySecretKey" -}}
+{{- if include "nemo-platform.defaultEncryptionKeyExistingSecretName" . -}}
 {{- .Values.secrets.defaultEncryptionKey.existingSecret.key | default (include "nemo-platform.defaultEncryptionKeyEnvName" .) -}}
+{{- else -}}
+{{- include "nemo-platform.defaultEncryptionKeyEnvName" . -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/k8s/helm/templates/api-env-secret-validation.yaml
+++ b/k8s/helm/templates/api-env-secret-validation.yaml
@@ -1,0 +1,7 @@
+{{- $existingSecretName := include "nemo-platform.defaultEncryptionKeyExistingSecretName" . -}}
+{{- if and .Values.envFromSecret $existingSecretName -}}
+{{- fail "set only one of envFromSecret or secrets.defaultEncryptionKey.existingSecret.name" -}}
+{{- end -}}
+{{- if and .Values.secrets.defaultEncryptionKey.value $existingSecretName -}}
+{{- fail "set only one of secrets.defaultEncryptionKey.value or secrets.defaultEncryptionKey.existingSecret.name" -}}
+{{- end -}}

--- a/k8s/helm/templates/api-env-secret.yaml
+++ b/k8s/helm/templates/api-env-secret.yaml
@@ -1,5 +1,7 @@
 {{- if not .Values.envFromSecret }}
-{{- if .Values.secrets.defaultEncryptionKey.value }}
+{{- if include "nemo-platform.defaultEncryptionKeyExistingSecretName" . }}
+{{- /* User provided the default-encryption-key Secret. */ -}}
+{{- else if .Values.secrets.defaultEncryptionKey.value }}
 {{- $secretName := include "nemo-platform.apiEnvSecretName" . -}}
 {{- $keyName := include "nemo-platform.defaultEncryptionKeyEnvName" . -}}
 {{- $keyValue := required (printf "secrets.defaultEncryptionKey.value is required to populate Secret %s key %s" $secretName $keyName) (.Values.secrets.defaultEncryptionKey.value | toString) -}}
@@ -28,6 +30,6 @@ stringData:
 {{- else if and (not .Release.IsInstall) (not .Release.IsUpgrade) }}
 {{- /* helm lint evaluates templates without install or upgrade mode. */ -}}
 {{- else }}
-{{- fail "set envFromSecret, secrets.defaultEncryptionKey.value, or enable secrets.defaultEncryptionKey.generated.enabled" }}
+{{- fail "set envFromSecret, secrets.defaultEncryptionKey.existingSecret.name, secrets.defaultEncryptionKey.value, or enable secrets.defaultEncryptionKey.generated.enabled" }}
 {{- end }}
 {{- end }}

--- a/k8s/helm/templates/api/api-deployment.yaml
+++ b/k8s/helm/templates/api/api-deployment.yaml
@@ -53,10 +53,19 @@ spec:
             {{- range .Values.api.extraArgs }}
             - {{ . | quote }}
             {{- end }}
+          {{- if not (include "nemo-platform.defaultEncryptionKeyExistingSecretName" .) }}
           envFrom:
             - secretRef:
                 name: {{ include "nemo-platform.apiEnvSecretName" . }}
+          {{- end }}
           env:
+            {{- if include "nemo-platform.defaultEncryptionKeyExistingSecretName" . }}
+            - name: {{ include "nemo-platform.defaultEncryptionKeyEnvName" . }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nemo-platform.defaultEncryptionKeyExistingSecretName" . | quote }}
+                  key: {{ include "nemo-platform.defaultEncryptionKeySecretKey" . | quote }}
+            {{- end }}
             - name: NMP_CONFIG_FILE_PATH
               value: /etc/nmp/config.yaml
             - name: NMP_BASE_URL

--- a/k8s/helm/templates/platform-seed-job.yaml
+++ b/k8s/helm/templates/platform-seed-job.yaml
@@ -47,10 +47,19 @@ spec:
             - task
             - --task
             - nmp.platform_seed
+          {{- if not (include "nemo-platform.defaultEncryptionKeyExistingSecretName" .) }}
           envFrom:
             - secretRef:
                 name: {{ include "nemo-platform.apiEnvSecretName" . }}
+          {{- end }}
           env:
+            {{- if include "nemo-platform.defaultEncryptionKeyExistingSecretName" . }}
+            - name: {{ include "nemo-platform.defaultEncryptionKeyEnvName" . }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nemo-platform.defaultEncryptionKeyExistingSecretName" . | quote }}
+                  key: {{ include "nemo-platform.defaultEncryptionKeySecretKey" . | quote }}
+            {{- end }}
             - name: NMP_CONFIG_FILE_PATH
               value: /etc/nmp/config.yaml
             - name: OTEL_SERVICE_NAME

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -21,6 +21,12 @@ secrets:
   defaultEncryptionKey:
     # -- Optional base64-encoded key for encrypting platform secrets. The decoded key must be at least 32 bytes. If empty and envFromSecret is not set, a pre-install hook generates a per-install key.
     value: ""
+    # -- Existing Kubernetes Secret containing the key for encrypting platform secrets. If name is set, the chart does not create or generate the default api-env Secret.
+    existingSecret:
+      # -- Name of an existing Kubernetes Secret containing the encryption key.
+      name: ""
+      # -- Key in the existing Secret. After Kubernetes decodes the Secret data, the loaded value must be the base64-encoded NMP_SECRETS_DEFAULT_ENCRYPTION_KEY string.
+      key: NMP_SECRETS_DEFAULT_ENCRYPTION_KEY
     # -- Generated key configuration used only when value and envFromSecret are empty. The generated key is not rotated or recreated on upgrade.
     generated:
       enabled: true


### PR DESCRIPTION
When switching to the auto-generated secret, we also need to allow for a presented secret to work. Otherwise, you cannot restore your backup easily. `envFromSecret` might work and all, but that's a very different use case and practice than creating a secret from a vault and presenting it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for referencing an externally managed Kubernetes Secret for the default secrets encryption key via Helm values (`existingSecret` name/key).
  * Added optional Hugging Face token support for Docker builds and embedding model downloads when configured.
* **Documentation**
  * Expanded Helm README/values and install notes to document encryption-key selection rules, including mutual exclusivity.
* **Bug Fixes**
  * Improved render-time validation and conditional wiring to prevent conflicting environment/encryption-key configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->