### PR TITLE
feat(models): use nmp-api image as the model-weights puller

### DIFF
--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -430,8 +430,8 @@ Consolidated configuration for the Models service.
 
 ```yaml
 models:
-  # HuggingFace model puller image for weights in data store or huggingface | default: 'nvcr.io/nvidia/nemo-microservices/nds-v2-huggingface-cli:25.10'
-  huggingface_model_puller: nvcr.io/nvidia/nemo-microservices/nds-v2-huggingface-cli:25.10
+  # Image used to pull model weights. Its entrypoint is overridden to the Hugging Face CLI ('hf download ...'), so any image with the 'hf' CLI on PATH works. Defaults to the platform's nmp-api image (registry/tag from platform config); override to use a different puller image.
+  huggingface_model_puller: my-registry/nmp-api:local
   # Controller service configuration
   controller:
     # Interval in seconds for the Models Controller to run its control loop | default: 5
@@ -469,8 +469,8 @@ models:
         models_docker_port_range_start: 49152
         # End of port range for port forwarding (inclusive). Defaults to 500-port range within IANA dynamic/ephemeral range. | default: 49652
         models_docker_port_range_end: 49652
-        # HuggingFace model puller image for downloading SFT model weights from Files service | default: 'nvcr.io/nvidia/nemo-microservices/nds-v2-huggingface-cli:25.10'
-        huggingface_model_puller: nvcr.io/nvidia/nemo-microservices/nds-v2-huggingface-cli:25.10
+        # Image used to pull model weights. Its entrypoint is overridden to the Hugging Face CLI ('hf download ...'), so any image with the 'hf' CLI on PATH works. Defaults to the platform's nmp-api image (registry/tag from platform config); override to use a different puller image.
+        huggingface_model_puller: my-registry/nmp-api:local
         # Timeout in seconds for the model puller container to complete (default: 30 minutes) | default: 1800
         model_puller_timeout: 1800
         # Per-file HTTP download timeout in seconds for the model puller (HF_HUB_DOWNLOAD_TIMEOUT). Increase if large model files fail with IncompleteRead/ChunkedEncodingError (default: 2 hours). | default: 7200

--- a/services/core/models/src/nmp/core/models/config.py
+++ b/services/core/models/src/nmp/core/models/config.py
@@ -4,6 +4,7 @@
 import logging
 from typing import Any, Literal
 
+from nemo_platform_plugin.jobs.image import get_qualified_image
 from nmp.common.config import Runtime, create_service_config_class, get_platform_config, get_service_config
 from nmp.core.models.controllers.backends.registry import (
     BackendConfig,
@@ -434,8 +435,11 @@ class ModelsConfig(create_service_config_class("models")):  # type: ignore
     """
 
     huggingface_model_puller: str = Field(
-        default="nvcr.io/nvidia/nemo-microservices/nds-v2-huggingface-cli:25.10",
-        description="HuggingFace model puller image for weights in data store or huggingface",
+        default_factory=lambda: get_qualified_image("nmp-api"),
+        description="Image used to pull model weights. Its entrypoint is overridden to the "
+        "Hugging Face CLI ('hf download ...'), so any image with the 'hf' CLI on PATH works. "
+        "Defaults to the platform's nmp-api image (registry/tag from platform config); override "
+        "to use a different puller image.",
     )
     controller: ControllerConfig = Field(
         default_factory=ControllerConfig, description="Controller service configuration"

--- a/services/core/models/src/nmp/core/models/controllers/backends/docker/config.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/docker/config.py
@@ -7,6 +7,7 @@ import os
 from enum import Enum
 from typing import Literal
 
+from nemo_platform_plugin.jobs.image import get_qualified_image
 from pydantic import BaseModel, Field
 
 MODELS_DOCKER_NETWORKING_MODE = os.getenv("MODELS_DOCKER_NETWORKING_MODE", "local")
@@ -132,8 +133,11 @@ class DockerBackendConfig(BaseModel):
     )
 
     huggingface_model_puller: str = Field(
-        default="nvcr.io/nvidia/nemo-microservices/nds-v2-huggingface-cli:25.10",
-        description="HuggingFace model puller image for downloading SFT model weights from Files service",
+        default_factory=lambda: get_qualified_image("nmp-api"),
+        description="Image used to pull model weights. Its entrypoint is overridden to the "
+        "Hugging Face CLI ('hf download ...'), so any image with the 'hf' CLI on PATH works. "
+        "Defaults to the platform's nmp-api image (registry/tag from platform config); override "
+        "to use a different puller image.",
     )
 
     model_puller_timeout: int = Field(

--- a/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
@@ -1262,6 +1262,11 @@ class DockerDeploymentCreationReconciler:
         run_kwargs: dict = {
             "image": puller_image,
             "name": puller_container_name,
+            # The puller image is the platform nmp-api image, whose entrypoint is
+            # `nemo services run`. Override it to the Hugging Face CLI so `command`
+            # (["download", <repo>, "--local-dir", "/model-store", ...]) runs as
+            # `hf download ...`.
+            "entrypoint": ["hf"],
             "command": command,
             "environment": env_vars,
             "user": "1000:1000",

--- a/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
@@ -1357,6 +1357,11 @@ class DockerDeploymentCreationReconciler:
             run_kwargs: dict = {
                 "image": puller_image,
                 "name": container_name,
+                # The puller image is the platform nmp-api image, whose entrypoint
+                # is `nemo services run`. Override it to the Hugging Face CLI so
+                # `command` (["download", <fileset>, "--local-dir", ...]) runs as
+                # `hf download ...`.
+                "entrypoint": ["hf"],
                 "command": command,
                 "environment": env_vars,
                 "user": "1000:1000",

--- a/services/core/models/tests/unit/controllers/test_docker_backend.py
+++ b/services/core/models/tests/unit/controllers/test_docker_backend.py
@@ -3383,6 +3383,17 @@ async def test_plugin_puller_success(docker_backend, sample_deployment, mock_doc
     assert error is None
     assert plugin_path == "/model-store/tool_call_plugin/my_plugin.py"
 
+    # The plugin puller runs against the nmp-api image (entrypoint `nemo services
+    # run`), so the download command must run via the `hf` entrypoint override.
+    plugin_puller_calls = [
+        c
+        for c in mock_docker_client.containers.run.call_args_list
+        if c.kwargs.get("labels", {}).get("nmp.nvidia.com/container-type") == "plugin-puller"
+    ]
+    assert len(plugin_puller_calls) == 1
+    assert plugin_puller_calls[0].kwargs["entrypoint"] == ["hf"]
+    assert plugin_puller_calls[0].kwargs["command"][0] == "download"
+
 
 @pytest.mark.asyncio
 async def test_plugin_puller_no_py_files(docker_backend, sample_deployment, mock_docker_client):

--- a/services/core/models/tests/unit/controllers/test_docker_backend.py
+++ b/services/core/models/tests/unit/controllers/test_docker_backend.py
@@ -621,6 +621,9 @@ async def test_docker_backend_create_sft_model_success(
     ]
     assert len(puller_calls) == 1
     assert puller_calls[0][1]["command"][0] == "download"
+    # Entrypoint overridden to the HF CLI (puller image is nmp-api, whose
+    # entrypoint is `nemo services run`); command runs as `hf download ...`.
+    assert puller_calls[0][1]["entrypoint"] == ["hf"]
 
     # Verify NIM and sidecar containers were created with managed-by label
     assert mock_docker_client.containers.create.call_count == 2


### PR DESCRIPTION
Default the model-weights puller image to the platform `nmp-api` image (resolved via get_qualified_image("nmp-api"), so registry/tag follow platform config and remain overridable), replacing the bespoke nds-v2-huggingface-cli image. The nmp-api image already ships the huggingface_hub CLI, so the docker backend overrides the puller container entrypoint to `hf` and runs `hf download <repo> --local-dir /model-store [...]`.

Validated end-to-end: the nmp-api image pulls weights from both HF Hub and the Files service through the docker backend.

Regenerate the config reference doc for the new default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated the Hugging Face model puller to use a default image derived from platform configuration (instead of a fixed version).
  * Ensured the puller runs Hugging Face CLI downloads by overriding the puller container entrypoint for both model weights and plugin/tools.

* **Documentation**
  * Refreshed the configuration reference to document the new default behavior and Hugging Face CLI expectations.

* **Tests**
  * Expanded unit tests to verify the puller container entrypoint override and download command structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->