### PR TITLE
chore: update readme links to docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://img.shields.io/badge/CI-passing-brightgreen?style=flat-square&logo=githubactions&logoColor=white)](https://github.com/NVIDIA-NeMo/nemo-platform/actions/workflows/ci.yaml)
 [![License](https://img.shields.io/badge/license-Apache_2.0-D22128?style=flat-square)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11--3.14-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
-[![Docs](https://img.shields.io/badge/docs-nvidia--nemo.github.io-76B900?style=flat-square&logo=readthedocs&logoColor=white)](https://nvidia-nemo.github.io/nemo-platform/)
+[![Docs](https://img.shields.io/static/v1?label=docs&message=docs.nvidia.com%2Fnemo-platform&color=76B900&style=flat-square&logo=readthedocs&logoColor=white)](https://docs.nvidia.com/nemo-platform)
 
 Make the agents you ship faster, more accurate, and safer.
 
@@ -164,7 +164,7 @@ The demo agent uses `${NEMO_DEFAULT_MODEL}` for both execution and the judge LLM
 
 ## Documentation
 
-Full documentation: [NeMo Platform docs](https://nvidia-nemo.github.io/nemo-platform/).
+Full documentation: [NeMo Platform docs](https://docs.nvidia.com/nemo-platform)
 
 - [Setup](docs/get-started/setup.md): installation, providers, SDK.
 - [CLI reference](docs/cli/index.md): all commands.

--- a/packages/nemo_platform/README.md
+++ b/packages/nemo_platform/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache_2.0-D22128?style=flat-square)](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11--3.14-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
-[![Docs](https://img.shields.io/badge/docs-nvidia--nemo.github.io-76B900?style=flat-square&logo=readthedocs&logoColor=white)](https://nvidia-nemo.github.io/nemo-platform/)
+[![Docs](https://img.shields.io/static/v1?label=docs&message=docs.nvidia.com%2Fnemo-platform&color=76B900&style=flat-square&logo=readthedocs&logoColor=white)](https://docs.nvidia.com/nemo-platform)
 
 Make the agents you ship faster, more accurate, and safer.
 
@@ -80,7 +80,7 @@ http://localhost:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1/c
 ## Links
 
 - **Source:** https://github.com/NVIDIA-NeMo/nemo-platform
-- **Documentation:** https://nvidia-nemo.github.io/nemo-platform/
+- **Documentation:** https://docs.nvidia.com/nemo-platform/
 - **Setup playbook:** https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/SETUP.md
 - **CLI reference:** https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/docs/cli/index.md
 - **API reference:** https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/docs/api/index.md

--- a/packages/nemo_platform_ext/pyproject.toml
+++ b/packages/nemo_platform_ext/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://nvidia-nemo.github.io/nemo-platform/main/"
+Homepage = "https://docs.nvidia.com/nemo-platform"
 
 [dependency-groups]
 dev = [

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/app.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/app.py
@@ -224,7 +224,7 @@ def main(
     """
     Command-line interface for NeMo Platform.
 
-    :books: Documentation: https://nvidia-nemo.github.io/nemo-platform/main/
+    :books: Documentation: https://docs.nvidia.com/nemo-platform
 
     [green]Getting started:[/]
     - Browse documentation with [cyan]`nemo docs --list`[/]

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -133,7 +133,7 @@ _KNOWN_PROVIDERS_BY_NAME: dict[str, KnownProvider] = {p.name: p for p in KNOWN_P
 # ---------------------------------------------------------------------------
 
 
-_NEMO_DOCS_URL = "https://nvidia-nemo.github.io/nemo-platform/main/"
+_NEMO_DOCS_URL = "https://docs.nvidia.com/nemo-platform"
 
 
 @dataclass(frozen=True)

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -2379,7 +2379,7 @@ class TestRenderOnboardingCard:
         panel = mock_console.print.call_args_list[0].args[0]
         content = panel.renderable
         assert "What can I do with NeMo Platform?" in content
-        assert "nvidia-nemo.github.io/nemo-platform" in content
+        assert "docs.nvidia.com/nemo-platform" in content
 
     def test_unknown_value_is_silently_skipped(self):
         with patch(f"{SETUP_MOD}.console") as mock_console:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/README.md
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache_2.0-D22128?style=flat-square)](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11--3.14-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
-[![Docs](https://img.shields.io/badge/docs-nvidia--nemo.github.io-76B900?style=flat-square&logo=readthedocs&logoColor=white)](https://nvidia-nemo.github.io/nemo-platform/)
+[![Docs](https://img.shields.io/static/v1?label=docs&message=docs.nvidia.com%2Fnemo-platform&color=76B900&style=flat-square&logo=readthedocs&logoColor=white)](https://docs.nvidia.com/nemo-platform)
 
 Build NeMo Platform plugins in Python.
 
@@ -109,7 +109,7 @@ That's a complete plugin. Adding a CLI command, a job, a controller, typed confi
 - **This package source:** https://github.com/NVIDIA-NeMo/nemo-platform/tree/main/packages/nemo_platform_plugin
 - **NeMo Platform on PyPI:** https://pypi.org/project/nemo-platform/
 - **NeMo Platform on GitHub:** https://github.com/NVIDIA-NeMo/nemo-platform
-- **NeMo Platform docs:** https://nvidia-nemo.github.io/nemo-platform/
+- **NeMo Platform docs:** https://docs.nvidia.com/nemo-platform/
 - **Issue tracker:** https://github.com/NVIDIA-NeMo/nemo-platform/issues
 
 ## License

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/app.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/app.py
@@ -224,7 +224,7 @@ def main(
     """
     Command-line interface for NeMo Platform.
 
-    :books: Documentation: https://nvidia-nemo.github.io/nemo-platform/main/
+    :books: Documentation: https://docs.nvidia.com/nemo-platform
 
     [green]Getting started:[/]
     - Browse documentation with [cyan]`nemo docs --list`[/]

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
@@ -133,7 +133,7 @@ _KNOWN_PROVIDERS_BY_NAME: dict[str, KnownProvider] = {p.name: p for p in KNOWN_P
 # ---------------------------------------------------------------------------
 
 
-_NEMO_DOCS_URL = "https://nvidia-nemo.github.io/nemo-platform/main/"
+_NEMO_DOCS_URL = "https://docs.nvidia.com/nemo-platform"
 
 
 @dataclass(frozen=True)

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
@@ -2379,7 +2379,7 @@ class TestRenderOnboardingCard:
         panel = mock_console.print.call_args_list[0].args[0]
         content = panel.renderable
         assert "What can I do with NeMo Platform?" in content
-        assert "nvidia-nemo.github.io/nemo-platform" in content
+        assert "docs.nvidia.com/nemo-platform" in content
 
     def test_unknown_value_is_silently_skipped(self):
         with patch(f"{SETUP_MOD}.console") as mock_console:

--- a/services/core/mcp/README.md
+++ b/services/core/mcp/README.md
@@ -186,4 +186,4 @@ async def my_tool(param: str) -> dict[str, Any]:
 
 - [MCP Specification](https://modelcontextprotocol.io/specification/2025-11-25)
 - [FastMCP Documentation](https://gofastmcp.com/)
-- [NeMo Platform Docs](https://nvidia-nemo.github.io/nemo-platform/main/)
+- [NeMo Platform Docs](https://docs.nvidia.com/nemo-platform)

--- a/services/core/mcp/src/nmp/core/mcp/server.py
+++ b/services/core/mcp/src/nmp/core/mcp/server.py
@@ -48,7 +48,7 @@ def create_server(base_url: str | None = None) -> FastMCP:
     # Initialize platform aggregator
     platform = FastMCP(
         "NeMo Platform",
-        website_url="https://nvidia-nemo.github.io/nemo-platform/main/",
+        website_url="https://docs.nvidia.com/nemo-platform",
     )
 
     # Mount per service MCP servers

--- a/tests/agentic-use/agentic_flows/auth.md
+++ b/tests/agentic-use/agentic_flows/auth.md
@@ -69,7 +69,4 @@ The Auth service provides workspace management and authorization capabilities. W
 
 ## Documentation References
 
-- [Workspaces Concepts](https://docs.nvidia.com/nemo-platform/latest/get-started/concepts/workspaces.html)
-- [Auth Overview](https://docs.nvidia.com/nemo-platform/latest/auth/index.html)
-- [Auth Concepts](https://docs.nvidia.com/nemo-platform/latest/auth/concepts.html)
-- [Managing Access](https://docs.nvidia.com/nemo-platform/latest/auth/managing-access.html)
+- [Workspaces Concepts](https://docs.nvidia.com/nemo/microservices/latest/get-started/concepts/workspaces.html)

--- a/web/packages/studio/src/constants/links.ts
+++ b/web/packages/studio/src/constants/links.ts
@@ -1,68 +1,56 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const BASE_DOCS_URL = 'https://nvidia-nemo.github.io/';
-const PLATFORM_DOCS_REPO_NAME = 'nemo-platform';
-const DOCS_BASE_URL = `${BASE_DOCS_URL}${PLATFORM_DOCS_REPO_NAME}/main/`;
+const DOCS_BASE_URL = 'https://docs.nvidia.com/nemo-platform/latest/documentation/';
+const GITHUB_REPO_URL = 'https://github.com/NVIDIA-NeMo/nemo-platform';
 
 // Studio documentation links
-export const LINK_DOCS_STUDIO = `${DOCS_BASE_URL}studio/`;
-export const LINK_DOCS_STUDIO_CUSTOMIZATION =
-  'https://docs.nvidia.com/nemo/microservices/latest/customizer/index.html';
-export const LINK_DOCS_STUDIO_EVALUATION = `${DOCS_BASE_URL}evaluator/`;
-export const LINK_DOCS_PROJECT = `${DOCS_BASE_URL}studio/projects/`;
-export const LINK_DOCS_DATASETS = `${DOCS_BASE_URL}get-started/concepts/projects/`;
-export const LINK_DOCS_MODELS = `${DOCS_BASE_URL}run-inference/about/`;
-export const LINK_DOCS_DEPLOYMENTS =
-  'https://docs.nvidia.com/nemo/microservices/latest/run-inference/tutorials/deploy-models.html';
+export const LINK_DOCS_STUDIO = `${DOCS_BASE_URL}studio`;
+export const LINK_DOCS_STUDIO_CUSTOMIZATION = `${DOCS_BASE_URL}customizer-reference`;
+export const LINK_DOCS_STUDIO_EVALUATION = `${DOCS_BASE_URL}evaluate-models`;
+export const LINK_DOCS_PROJECT = `${DOCS_BASE_URL}get-started/core-concepts/projects`;
+export const LINK_DOCS_DATASETS = `${DOCS_BASE_URL}get-started/core-concepts/manage-files`;
+export const LINK_DOCS_MODELS = `${DOCS_BASE_URL}models-and-inference`;
+export const LINK_DOCS_DEPLOYMENTS = `${DOCS_BASE_URL}reference/cli-reference#nemo-inference-deployments`;
 
 /** Inference providers, gateway routing, and external endpoints */
-export const LINK_DOCS_INFERENCE_PROVIDERS = `${DOCS_BASE_URL}run-inference/about/`;
-export const LINK_DOCS_SAFE_SYNTHESIZER =
-  'https://docs.nvidia.com/nemo/microservices/latest/safe-synthesizer/about/index.html';
+export const LINK_DOCS_INFERENCE_PROVIDERS = `${DOCS_BASE_URL}models-and-inference#model-providers`;
+export const LINK_DOCS_SAFE_SYNTHESIZER = `${DOCS_BASE_URL}synthesize-safe-data`;
 
 // SDK documentation links
-export const LINK_DOCS_SDK = DOCS_BASE_URL;
+export const LINK_DOCS_SDK = `${DOCS_BASE_URL}reference/python-sdk`;
 
 // Fine Tune documentation links
-export const LINK_DOCS_FINE_TUNE_CONFIGURATION_DECISIONS =
-  'https://docs.nvidia.com/nemo/microservices/latest/fine-tune/tutorials/understand-configurations-and-models.html#making-configuration-decisions';
-export const LINK_DOCS_FINE_TUNE_DATASET_FORMAT_REQUIREMENTS =
-  'https://docs.nvidia.com/nemo/microservices/latest/fine-tune/models/data-format.html';
-export const LINK_DOCS_FINE_TUNE_HYPERPARAMETERS =
-  'https://docs.nvidia.com/nemo/microservices/latest/customizer/about.html#hyperparameters';
-export const LINK_DOCS_FINE_TUNE_MODEL_ENTITIES =
-  'https://docs.nvidia.com/nemo/microservices/latest/customizer/manage-model-entities/index.html#manage-model-entities-for-customization';
+export const LINK_DOCS_FINE_TUNE_CONFIGURATION_DECISIONS = `${DOCS_BASE_URL}customizer-reference/tutorials/understanding-models-and-training#making-configuration-decisions`;
+export const LINK_DOCS_FINE_TUNE_DATASET_FORMAT_REQUIREMENTS = `${DOCS_BASE_URL}customizer-reference/models/dataset-format`;
+export const LINK_DOCS_FINE_TUNE_HYPERPARAMETERS = `${DOCS_BASE_URL}customizer-reference/manage-customization-jobs/training-configuration`;
+export const LINK_DOCS_FINE_TUNE_MODEL_ENTITIES = `${DOCS_BASE_URL}customizer-reference/manage-model-entities/overview`;
 
 // Guardrail documentation links
-export const LINK_DOCS_GUARDRAIL = `${DOCS_BASE_URL}guardrails/`;
+export const LINK_DOCS_GUARDRAIL = `${DOCS_BASE_URL}guardrail-models`;
 
 // Top-level NeMo "Concepts" documentation links
-export const LINK_DOCS_CONCEPTS_CUSTOMIZATION =
-  'https://docs.nvidia.com/nemo/microservices/latest/about/core-concepts/customization.html';
+export const LINK_DOCS_CONCEPTS_CUSTOMIZATION = `${DOCS_BASE_URL}customizer-reference/customization-concepts`;
 
-export const LINK_DOCS_SEQUENCE_PACKING =
-  'https://docs.nvidia.com/nemo/microservices/latest/about/core-concepts/customization.html#sequence-packing';
+export const LINK_DOCS_SEQUENCE_PACKING = `${DOCS_BASE_URL}customizer-reference/customization-concepts#sequence-packing`;
 
 // Third party documentation links
 export const LINK_DOCS_OPENAI_FUNCTION_SCHEMA =
   'https://platform.openai.com/docs/guides/function-calling#defining-functions';
 
 // Support links
-export const LINK_GITHUB_ISSUES = `https://github.com/NVIDIA-NeMo/${PLATFORM_DOCS_REPO_NAME}/issues`;
+export const LINK_GITHUB_ISSUES = `${GITHUB_REPO_URL}/issues`;
 
 // Evaluation documentation links
-export const LINK_EVAL_DOCS_METRICS = `${DOCS_BASE_URL}evaluator/metrics/`;
-export const LINK_EVAL_DOCS_BENCHMARKS =
-  'https://docs.nvidia.com/nemo/microservices/latest/evaluator/benchmarks/index.html';
-export const LINK_EVAL_DOCS_BENCHMARKS_INDUSTRY =
-  'https://docs.nvidia.com/nemo/microservices/latest/evaluator/benchmarks/industry.html';
+export const LINK_EVAL_DOCS_METRICS = `${DOCS_BASE_URL}evaluate-models/metrics`;
+export const LINK_EVAL_DOCS_BENCHMARKS = `${DOCS_BASE_URL}evaluate-models`;
+export const LINK_EVAL_DOCS_BENCHMARKS_INDUSTRY = `${DOCS_BASE_URL}evaluate-models`;
 
 // Jobs documentation links
-export const LINK_DOCS_JOBS = `${DOCS_BASE_URL}studio/?#jobs`;
+export const LINK_DOCS_JOBS = `${DOCS_BASE_URL}studio#jobs`;
 
 // Secrets documentation links
-export const LINK_DOCS_SECRETS = `${DOCS_BASE_URL}get-started/concepts/manage-secrets/`;
+export const LINK_DOCS_SECRETS = `${DOCS_BASE_URL}get-started/core-concepts/manage-secrets`;
 
 // Experiments
-export const LINK_DOCS_EXPERIMENTS_CLI = `${DOCS_BASE_URL}experiments/cli/`;
+export const LINK_DOCS_EXPERIMENTS_CLI = `${DOCS_BASE_URL}reference/cli-reference`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation links across the platform to point to the new documentation site at `docs.nvidia.com/nemo-platform` instead of the previous GitHub Pages location.
  * Documentation references in CLI tools, onboarding flows, and UI components now direct users to the updated documentation URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->