### PR TITLE
fix: correct customizer values in the helm chart

### DIFF
--- a/k8s/helm/templates/api/api-deployment.yaml
+++ b/k8s/helm/templates/api/api-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.api.enabled }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}
+{{- $platformConfig := include "nemo-platform.calculatedConfig" . | fromYaml }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -74,6 +75,10 @@ spec:
               {{- else }}
               value: {{ include "nemo-platform.internalBaseUrl" . | quote }}
               {{- end }}
+            - name: NMP_AUTOMODEL_DEFAULT_TRAINING_EXECUTION_PROFILE
+              value: {{ dig "automodel" "default_training_execution_profile" "default" $platformConfig | quote }}
+            - name: NMP_UNSLOTH_DEFAULT_TRAINING_EXECUTION_PROFILE
+              value: {{ dig "unsloth" "default_training_execution_profile" "default" $platformConfig | quote }}
             {{- if include "nemo-platform.embeddedPdpEnabled" . }}
             - name: NMP_AUTH_POLICY_DECISION_POINT_BASE_URL
               value: {{ include "nemo-platform.apiLoopbackBaseUrl" . | quote }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -371,6 +371,19 @@ basePlatformConfig: |
   # -- customizer is the configuration specific to the Customizer service
   customizer: {}
 
+  # -- automodel is the configuration specific to Automodel customization jobs
+  automodel:
+    default_training_execution_profile: default
+
+  # -- unsloth is the configuration specific to Unsloth customization jobs
+  unsloth:
+    default_training_execution_profile: default
+
+  # -- safe_synthesizer is the configuration specific to the Safe Synthesizer service
+  safe_synthesizer:
+    job_mode: container
+    container_image: safe-synthesizer-tasks
+
   # -- evaluator is the configuration specific to the Evaluator service
   evaluator: {}
 


### PR DESCRIPTION
Changes to the structure of customizer require changes in the helm chart to keep it functioning. This seems to fix things in terms of the e2e tests, i think.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training execution profiles now configurable for AutoModel and Unsloth services with default settings.
  * Safe synthesizer container configuration added with default job execution mode and image specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->