### PR TITLE
chore: add a job to clear the PR cache on merge/close

### DIFF
--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -1,16 +1,47 @@
-name: Cleanup Cache on PR Close
+name: Cleanup GitHub Actions Caches
+
 on:
   pull_request:
     types: [closed]
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
 
 jobs:
-  cleanup:
+  cleanup-pr:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       actions: write
     steps:
       - name: Delete PR Caches
-        run: |
-          gh cache delete --all --ref refs/pull/${{ github.event.pull_request.number }}/merge
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh cache delete --repo "${GITHUB_REPOSITORY}" --all --succeed-on-no-caches --ref refs/pull/${{ github.event.pull_request.number }}/merge
+
+  cleanup-merge-queue:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete stale merge queue caches
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cutoff="$(date -u -d '4 days ago' '+%Y-%m-%dT%H:%M:%SZ')"
+          echo "Deleting merge queue caches last accessed before ${cutoff}"
+
+          gh api --paginate 'repos/{owner}/{repo}/actions/caches?per_page=100' \
+            --jq '.actions_caches[] | select(.ref | startswith("refs/heads/gh-readonly-queue/")) | select(.last_accessed_at != null and .last_accessed_at < "'"${cutoff}"'") | .id' \
+            | while read -r cache_id; do
+                if [ -n "${cache_id}" ]; then
+                  echo "Deleting cache ${cache_id}"
+                  gh api -X DELETE "repos/{owner}/{repo}/actions/caches/${cache_id}" >/dev/null
+                fi
+              done

--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -1,0 +1,16 @@
+name: Cleanup Cache on PR Close
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete PR Caches
+        run: |
+          gh cache delete --all --ref refs/pull/${{ github.event.pull_request.number }}/merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -66,6 +66,7 @@ jobs:
         with:
             languages: ${{matrix.language}}
             config-file: ./.github/codeql/codeql-config.yml
+            dependency-caching: false
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2


### PR DESCRIPTION
We have a cache problem. See https://github.com/NVIDIA-NeMo/nemo-platform/actions/caches

I'll do a manual cleanup, but this seems easy enough to fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated GitHub Actions cache cleanup workflow that removes stale caches after pull requests are closed.
  * Supports scheduled and manual runs to keep caches tidy, including cleanup of older merge-queue related caches outside pull request events.
  * Updated CodeQL runs to disable dependency caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->