### PR TITLE
feat(evaluator): add agent-eval engine (AgentEvaluator)

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/dashboard.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/dashboard.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small HTML dashboard for standalone agent-eval result bundles."""
+
+from __future__ import annotations
+
+import html
+import json
+from pathlib import Path
+from typing import Any
+
+from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
+from nemo_evaluator_sdk.agent_eval.scores import AgentEvalTaskScore
+from pydantic import BaseModel
+
+
+def write_dashboard(result: AgentEvalResult, output_path: str | Path) -> Path:
+    """Write an HTML dashboard and return its path."""
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_dashboard(result), encoding="utf-8")
+    return path
+
+
+def render_dashboard(result: AgentEvalResult) -> str:
+    """Render a compact generic report for metric outputs."""
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agent Eval Report</title>
+  <style>
+    :root {{ color-scheme: light dark; --bg:#f7f8fa; --fg:#172033; --muted:#64748b; --line:#d8dee9; --panel:#fff; --soft:#f8fafc; }}
+    @media (prefers-color-scheme: dark) {{ :root {{ --bg:#111827; --fg:#f8fafc; --muted:#a4aebc; --line:#374151; --panel:#1f2937; --soft:#111827; }} }}
+    * {{ box-sizing: border-box; }}
+    body {{ background: var(--bg); color: var(--fg); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; }}
+    header {{ background: var(--panel); border-bottom: 1px solid var(--line); padding: 28px 32px 20px; }}
+    main {{ max-width: 1320px; margin: 0 auto; padding: 24px 32px 48px; }}
+    h1 {{ margin: 0 0 4px; }}
+    h2 {{ margin-top: 28px; }}
+    .muted {{ color: var(--muted); }}
+    .cards {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin: 24px 0; }}
+    .card {{ background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; min-width: 160px; }}
+    .card strong {{ display: block; font-size: 24px; margin-top: 6px; }}
+    table {{ background: var(--panel); border: 1px solid var(--line); border-collapse: collapse; width: 100%; margin-top: 16px; }}
+    th, td {{ border-bottom: 1px solid var(--line); padding: 9px 10px; text-align: left; vertical-align: top; }}
+    th {{ background: var(--soft); color: var(--muted); font-size: 12px; text-transform: uppercase; }}
+    code {{ background: var(--soft); border-radius: 4px; padding: 1px 4px; }}
+    pre {{ background: var(--soft); border-radius: 6px; max-height: 320px; overflow: auto; padding: 10px; white-space: pre-wrap; }}
+    .output-list {{ display: grid; gap: 8px; }}
+    .output-row strong {{ display: block; margin-bottom: 4px; }}
+  </style>
+</head>
+<body>
+<header>
+  <h1>Agent Eval Report</h1>
+  <div class="muted">Run {_e(result.run_id)} · {_e(result.summary.task_count)} tasks · {_e(result.summary.trial_count)} trials</div>
+</header>
+<main>
+  <div class="cards">
+    <div class="card"><span class="muted">Tasks</span><strong>{_e(result.summary.task_count)}</strong></div>
+    <div class="card"><span class="muted">Trials</span><strong>{_e(result.summary.trial_count)}</strong></div>
+    <div class="card"><span class="muted">Metric Scores</span><strong>{_e(result.summary.score_count)}</strong></div>
+  </div>
+  <h2>Metric Rollups</h2>
+  {_metric_rollups(result)}
+  <h2>Scores</h2>
+  {_score_table(result.scores)}
+</main>
+</body>
+</html>
+"""
+
+
+def _metric_rollups(result: AgentEvalResult) -> str:
+    aggregated = result.summary.scores.scores
+    if not aggregated:
+        return '<p class="muted">No numeric metric outputs to summarize.</p>'
+    rows: list[str] = []
+    for score in sorted(aggregated, key=lambda item: item.name):
+        rows.append(
+            "<tr>"
+            f"<td><code>{_e(score.name)}</code></td>"
+            f"<td>{_format_score(score.mean)}</td>"
+            f"<td>{_e(score.count)}</td>"
+            f"<td>{_e(score.nan_count)}</td>"
+            "</tr>"
+        )
+    return (
+        "<table><thead><tr><th>Name</th><th>Mean</th><th>Count</th><th>NaN</th></tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table>"
+    )
+
+
+def _score_table(scores: list[AgentEvalTaskScore]) -> str:
+    if not scores:
+        return '<p class="muted">No metric scores.</p>'
+    rows = [
+        "<tr>"
+        f"<td><code>{_e(score.task_id)}</code></td>"
+        f"<td><code>{_e(score.trial_id)}</code></td>"
+        f"<td><code>{_e(score.metric_type)}</code></td>"
+        f"<td>{_outputs(score)}</td>"
+        "</tr>"
+        for score in scores
+    ]
+    return (
+        "<table><thead><tr><th>Task</th><th>Trial</th><th>Metric</th><th>Outputs</th></tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table>"
+    )
+
+
+def _outputs(score: AgentEvalTaskScore) -> str:
+    chunks = []
+    for output in score.outputs:
+        chunks.append(
+            f'<div class="output-row"><strong>{_e(output.name)}</strong><pre>{_e(_jsonish(output.value))}</pre></div>'
+        )
+    return '<div class="output-list">' + "".join(chunks) + "</div>"
+
+
+def _jsonish(value: Any) -> str:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    try:
+        return json.dumps(value, indent=2, sort_keys=True)
+    except (TypeError, ValueError):
+        # ValueError covers circular references; fall back to a plain string rather than crash rendering.
+        return str(value)
+
+
+def _format_score(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.3f}"
+
+
+def _e(value: object) -> str:
+    return html.escape(str(value), quote=True)

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
@@ -1,0 +1,542 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone agent evaluation orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import UTC, datetime
+from logging import getLogger
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import urlparse
+
+import httpx
+import nemo_evaluator_sdk.inference as inference
+from nemo_evaluator_sdk.agent_eval.dashboard import write_dashboard
+from nemo_evaluator_sdk.agent_eval.persistence import persist_run
+from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSummary
+from nemo_evaluator_sdk.agent_eval.scores import (
+    AgentEvalDiagnostic,
+    AgentEvalDiagnosticSeverity,
+    AgentEvalScoreStatus,
+    AgentEvalTaskScore,
+)
+from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+from nemo_evaluator_sdk.agent_eval.trials import (
+    AgentEvalTarget,
+    AgentEvalTrial,
+    AgentEvalTrialStatus,
+    AgentOutput,
+    AgentTaskRunner,
+)
+from nemo_evaluator_sdk.agent_inference import (
+    AgentInferenceFn,
+    make_agent_inference_request,
+    new_agent_inference_client,
+)
+from nemo_evaluator_sdk.execution.metric_execution import generate_online_sample, run_sync
+from nemo_evaluator_sdk.execution.samples import build_metric_input
+from nemo_evaluator_sdk.inference import InferenceFn
+from nemo_evaluator_sdk.metrics.protocol import Metric, validate_metric_result
+from nemo_evaluator_sdk.metrics.utils import metric_type_name
+from nemo_evaluator_sdk.values import Agent, Model, RunConfig, RunConfigOnline, RunConfigOnlineModel
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+from openai import AsyncOpenAI
+
+log = getLogger(__name__)
+
+
+class AgentEvaluator:
+    """Run stored-trial or live-target agent evaluations.
+
+    The online inference seam (an optional ``inference_fn``, transport ``client``, and
+    ``default_headers``) is injected on the evaluator instance rather than the run config,
+    because these are runtime transport concerns rather than declarative run settings. A
+    single ``inference_fn``/``client`` pair serves both model and agent targets; leave them
+    unset to let the evaluator build a default client for the resolved target type.
+    """
+
+    def __init__(
+        self,
+        *,
+        inference_fn: InferenceFn | AgentInferenceFn | None = None,
+        client: AsyncOpenAI | httpx.AsyncClient | None = None,
+        default_headers: dict[str, str] | None = None,
+    ) -> None:
+        self.inference_fn = inference_fn
+        self.client = client
+        self.default_headers = default_headers
+
+    async def run(
+        self,
+        *,
+        tasks: Sequence[AgentEvalTask],
+        trials: Sequence[AgentEvalTrial] | None = None,
+        target: AgentEvalTarget | None = None,
+        config: AgentEvalRunConfig | None = None,
+    ) -> AgentEvalResult:
+        """Evaluate imported trials or generate live trials before scoring.
+
+        Exactly one of ``trials`` or ``target`` must be provided.
+        """
+        resolved_config = config or AgentEvalRunConfig()
+        task_list = list(tasks)
+        if not task_list:
+            raise ValueError("at least one task is required")
+
+        run_id = resolved_config.run_id or _new_run_id()
+        runtime_config = resolved_config.model_copy(update={"run_id": run_id})
+
+        # Branch on which seam was supplied so the type checker can narrow ``target`` to a
+        # concrete ``AgentEvalTarget`` without a cast.
+        if trials is not None:
+            if target is not None:
+                raise ValueError("provide exactly one of trials or target")
+            trial_list = list(trials)
+        elif target is not None:
+            trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
+        else:
+            raise ValueError("provide exactly one of trials or target")
+        scores = await self._score_trials(
+            tasks=task_list,
+            trials=trial_list,
+            config=runtime_config,
+            run_id=run_id,
+        )
+        benchmark = {**_benchmark_metadata(task_list), **runtime_config.benchmark}
+        result = AgentEvalResult(
+            run_id=run_id,
+            tasks=task_list,
+            trials=trial_list,
+            scores=scores,
+            summary=AgentEvalSummary.from_scores(scores, tasks=task_list),
+            benchmark=benchmark,
+        )
+
+        if runtime_config.output_dir is not None:
+            result = _persist_with_optional_dashboard(result, runtime_config.output_dir, runtime_config.write_dashboard)
+        return result
+
+    def run_sync(
+        self,
+        *,
+        tasks: Sequence[AgentEvalTask],
+        trials: Sequence[AgentEvalTrial] | None = None,
+        target: AgentEvalTarget | None = None,
+        config: AgentEvalRunConfig | None = None,
+    ) -> AgentEvalResult:
+        """Synchronous bridge for :meth:`run`."""
+        return run_sync(lambda: self.run(tasks=tasks, trials=trials, target=target, config=config))
+
+    async def _score_trials(
+        self,
+        *,
+        tasks: list[AgentEvalTask],
+        trials: list[AgentEvalTrial],
+        config: AgentEvalRunConfig,
+        run_id: str,
+    ) -> list[AgentEvalTaskScore]:
+        tasks_by_id = {task.id: task for task in tasks}
+        task_index_by_id = {task.id: index for index, task in enumerate(tasks)}
+        trials_by_task: dict[str, list[AgentEvalTrial]] = defaultdict(list)
+        for trial in trials:
+            if trial.task_id not in tasks_by_id:
+                raise ValueError(f"trial {trial.id!r} references unknown task {trial.task_id!r}")
+            trials_by_task[trial.task_id].append(trial)
+
+        # Fail loudly when a task produced no trial. Imported trials or an AgentTaskRunner may omit a
+        # task entirely; without this an incomplete run would look successful aside from lower summary
+        # counts. (A richer alternative is to emit a "missing trial" failed score per metric.)
+        tasks_without_trials = [task.id for task in tasks if not trials_by_task.get(task.id)]
+        if tasks_without_trials:
+            raise ValueError(f"no trials produced for tasks: {sorted(tasks_without_trials)}")
+
+        for task in tasks:
+            if not task.metrics:
+                raise ValueError(f"task {task.id!r} does not declare any metrics")
+
+        semaphore = asyncio.Semaphore(config.parallelism)
+
+        async def guarded_score(task: AgentEvalTask, trial: AgentEvalTrial, metric: Metric) -> AgentEvalTaskScore:
+            async with semaphore:
+                row_index = task_index_by_id[task.id]
+                if trial.status == AgentEvalTrialStatus.FAILED:
+                    return _failed_metric_score(
+                        run_id=run_id,
+                        task=task,
+                        trial=trial,
+                        metric=metric,
+                        row_index=row_index,
+                        diagnostic=AgentEvalDiagnostic(
+                            severity=AgentEvalDiagnosticSeverity.ERROR,
+                            message=f"trial {trial.id!r} is failed",
+                            source=metric_type_name(metric),
+                            details={"trial_status": trial.status.value},
+                        ),
+                    )
+                try:
+                    return await _score_metric(
+                        run_id=run_id,
+                        task=task,
+                        trial=trial,
+                        metric=metric,
+                        row_index=row_index,
+                    )
+                except Exception as exc:
+                    if config.fail_fast:
+                        raise
+                    log.warning(
+                        "metric %s failed for trial %r (task %r): %s",
+                        metric_type_name(metric),
+                        trial.id,
+                        task.id,
+                        exc,
+                    )
+                    return _failed_metric_score(
+                        run_id=run_id,
+                        task=task,
+                        trial=trial,
+                        metric=metric,
+                        row_index=row_index,
+                        diagnostic=_exception_diagnostic(exc, metric_type_name(metric)),
+                    )
+
+        return await asyncio.gather(
+            *[
+                guarded_score(task, trial, metric)
+                for task in tasks
+                for trial in trials_by_task.get(task.id, [])
+                for metric in task.metrics
+            ]
+        )
+
+    async def _generate_trials(
+        self,
+        *,
+        tasks: list[AgentEvalTask],
+        target: AgentEvalTarget,
+        config: AgentEvalRunConfig,
+    ) -> list[AgentEvalTrial]:
+        if isinstance(target, AgentTaskRunner):
+            return list(await target.run_tasks(tasks, config=config))
+        if not isinstance(target, (Model, Agent)):
+            raise NotImplementedError(f"unsupported agent-eval target type: {type(target).__name__}")
+
+        params = _resolve_live_params(config, target)
+        prompt_template = config.prompt_template or _default_prompt_template(target)
+        semaphore = asyncio.Semaphore(params.parallelism)
+
+        # Use the injected transport client when provided; otherwise build a default for the
+        # resolved target type and close it when generation finishes.
+        client = self.client
+        close_client: Callable[[], Awaitable[Any]] | None = None
+        if client is None and self.inference_fn is None:
+            if isinstance(target, Model):
+                client = inference.new_inference_client(target)
+                close_client = client.close
+            else:
+                client = new_agent_inference_client()
+                close_client = client.aclose
+
+        try:
+            # When config.params.ignore_request_failure is set, convert a failed generation request
+            # into a FAILED trial (which the scorer turns into failed metric scores) instead of
+            # aborting the whole run. This matches the existing online-evaluator contract.
+            async def generate_one(index: int, task: AgentEvalTask) -> AgentEvalTrial:
+                async with semaphore:
+                    try:
+                        sample = await _generate_sample(
+                            target=target,
+                            row=_task_row(task),
+                            index=index,
+                            prompt_template=prompt_template,
+                            params=params,
+                            inference_fn=self.inference_fn,
+                            client=client,
+                            default_headers=self.default_headers,
+                        )
+                    except Exception as exc:
+                        if params.ignore_request_failure:
+                            return _failed_generation_trial(task, target, exc)
+                        raise
+                    return _trial_from_sample(task, target, sample)
+
+            return await asyncio.gather(*(generate_one(index, task) for index, task in enumerate(tasks)))
+        finally:
+            if close_client is not None:
+                await close_client()
+
+
+async def _generate_sample(
+    *,
+    target: Model | Agent,
+    row: dict[str, Any],
+    index: int,
+    prompt_template: str | dict[str, Any],
+    params: RunConfigOnline | RunConfigOnlineModel,
+    inference_fn: InferenceFn | AgentInferenceFn | None,
+    client: AsyncOpenAI | httpx.AsyncClient | None,
+    default_headers: dict[str, str] | None,
+) -> dict[str, Any]:
+    # InferenceFn and AgentInferenceFn are callable protocols, so isinstance cannot discriminate
+    # the injected fn; narrow it per target type with a cast (matching execution/benchmark_execution).
+    # The transport client is a real class union, so isinstance narrowing is enough there.
+    if isinstance(target, Model):
+        model_params = cast(RunConfigOnlineModel, params)
+        preprocess_hooks, postprocess_hooks = inference.new_hooks(model_params, model_format=target.format)
+        model_inference_fn = (
+            cast(InferenceFn, inference_fn) if inference_fn is not None else inference.make_inference_request
+        )
+        return await generate_online_sample(
+            target=target,
+            row=row,
+            index=index,
+            prompt_template=prompt_template,
+            params=model_params,
+            inference_fn=model_inference_fn,
+            client=client if isinstance(client, AsyncOpenAI) else None,
+            preprocess_hooks=preprocess_hooks,
+            postprocess_hooks=postprocess_hooks,
+            default_headers=default_headers,
+        )
+
+    agent_inference_fn = (
+        cast(AgentInferenceFn, inference_fn) if inference_fn is not None else make_agent_inference_request
+    )
+    return await generate_online_sample(
+        target=target,
+        row=row,
+        index=index,
+        prompt_template=prompt_template,
+        params=params,
+        inference_fn=agent_inference_fn,
+        client=client if isinstance(client, httpx.AsyncClient) else None,
+        default_headers=default_headers,
+    )
+
+
+def _trial_from_sample(task: AgentEvalTask, target: Model | Agent, sample: dict[str, Any]) -> AgentEvalTrial:
+    output_text = sample.get("output_text")
+    if "trajectory" in sample:
+        trace = EvidenceDescriptor(kind="trace", format="json", data=sample["trajectory"])
+    else:
+        trace = EvidenceDescriptor(kind="sdk_online_generation", data={"task_id": task.id, "target": target.name})
+
+    return AgentEvalTrial(
+        id=f"{task.id}:{target.name}",
+        task_id=task.id,
+        status=AgentEvalTrialStatus.COMPLETED,
+        output=AgentOutput(
+            output_text=output_text if isinstance(output_text, str) else None,
+            response=sample.get("response"),
+            metadata={
+                key: value for key, value in sample.items() if key not in {"output_text", "response", "trajectory"}
+            },
+        ),
+        evidence=CandidateEvidence(descriptors={"trace": trace}),
+        metadata={
+            "model_id": target.name,
+            "target_name": target.name,
+            "generated": True,
+        },
+    )
+
+
+def _failed_generation_trial(task: AgentEvalTask, target: Model | Agent, exc: Exception) -> AgentEvalTrial:
+    return AgentEvalTrial(
+        id=f"{task.id}:{target.name}",
+        task_id=task.id,
+        status=AgentEvalTrialStatus.FAILED,
+        output=None,
+        evidence=CandidateEvidence(
+            descriptors={
+                "error": EvidenceDescriptor(
+                    kind="error",
+                    data={"error_type": exc.__class__.__name__, "error": str(exc)},
+                )
+            }
+        ),
+        metadata={
+            "model_id": target.name,
+            "target_name": target.name,
+            "generated": True,
+            "error_type": exc.__class__.__name__,
+            "error": str(exc),
+        },
+    )
+
+
+async def _score_metric(
+    *,
+    run_id: str,
+    task: AgentEvalTask,
+    trial: AgentEvalTrial,
+    metric: Metric,
+    row_index: int,
+) -> AgentEvalTaskScore:
+    output_spec = metric.output_spec()
+    metric_result = validate_metric_result(
+        await metric.compute_scores(build_metric_input(_metric_row(task, trial), _trial_sample(trial), row_index)),
+        output_spec,
+    )
+    metric_type = metric_type_name(metric)
+    return AgentEvalTaskScore(
+        id=_score_id(run_id, task.id, trial.id, metric_type),
+        run_id=run_id,
+        task_id=task.id,
+        trial_id=trial.id,
+        metric_type=metric_type,
+        status=AgentEvalScoreStatus.COMPLETED,
+        outputs=metric_result.outputs,
+        metadata={
+            "row_index": row_index,
+            "trial_metadata": trial.metadata,
+        },
+    )
+
+
+def _failed_metric_score(
+    *,
+    run_id: str,
+    task: AgentEvalTask,
+    trial: AgentEvalTrial,
+    metric: Metric,
+    row_index: int,
+    diagnostic: AgentEvalDiagnostic,
+) -> AgentEvalTaskScore:
+    metric_type = metric_type_name(metric)
+    return AgentEvalTaskScore(
+        id=_score_id(run_id, task.id, trial.id, metric_type),
+        run_id=run_id,
+        task_id=task.id,
+        trial_id=trial.id,
+        metric_type=metric_type,
+        status=AgentEvalScoreStatus.FAILED,
+        outputs=[],
+        diagnostics=[diagnostic],
+        metadata={
+            "row_index": row_index,
+            "trial_metadata": trial.metadata,
+        },
+    )
+
+
+def _exception_diagnostic(exc: Exception, metric_type: str) -> AgentEvalDiagnostic:
+    return AgentEvalDiagnostic(
+        severity=AgentEvalDiagnosticSeverity.ERROR,
+        message=str(exc) or exc.__class__.__name__,
+        source=metric_type,
+        details={"exception_type": exc.__class__.__name__},
+    )
+
+
+def _score_id(run_id: str, task_id: str, trial_id: str, metric_type: str) -> str:
+    return f"{run_id}:{task_id}:{trial_id}:{metric_type}"
+
+
+def _trial_sample(trial: AgentEvalTrial) -> dict[str, Any]:
+    if trial.output is None:
+        return {}
+    sample: dict[str, Any] = {
+        **trial.metadata,
+        **trial.output.metadata,
+    }
+    if trial.output.output_text is not None:
+        sample["output_text"] = trial.output.output_text
+    if trial.output.response is not None:
+        sample["response"] = trial.output.response
+    if trial.evidence is not None:
+        sample["evidence"] = trial.evidence
+    return sample
+
+
+def _resolve_live_params(
+    config: AgentEvalRunConfig,
+    target: Model | Agent,
+) -> RunConfigOnline | RunConfigOnlineModel:
+    params = config.params
+    if isinstance(target, Model):
+        if params is None:
+            return RunConfigOnlineModel(parallelism=config.parallelism)
+        if isinstance(params, RunConfigOnlineModel):
+            return params
+        if isinstance(params, RunConfigOnline):
+            return RunConfigOnlineModel(**params.model_dump(mode="python"))
+        if isinstance(params, RunConfig):
+            return RunConfigOnlineModel(**params.model_dump(mode="python"))
+
+    if params is None:
+        return RunConfigOnline(parallelism=config.parallelism)
+    if isinstance(params, RunConfigOnlineModel):
+        return RunConfigOnline(
+            **params.model_dump(
+                mode="python",
+                exclude={"inference", "system_prompt", "reasoning", "structured_output"},
+            )
+        )
+    if isinstance(params, RunConfigOnline):
+        return params
+    return RunConfigOnline(**params.model_dump(mode="python"))
+
+
+def _default_prompt_template(target: Model | Agent) -> dict[str, Any]:
+    if isinstance(target, Model) and _is_completions_endpoint(target.url):
+        return {"prompt": "{{item.prompt}}"}
+    return {"messages": [{"role": "user", "content": "{{item.prompt}}"}]}
+
+
+def _task_row(task: AgentEvalTask) -> dict[str, Any]:
+    return {
+        **task.inputs,
+        "task_id": task.id,
+        "prompt": task.inputs.get("prompt") or task.inputs.get("instruction") or task.intent,
+    }
+
+
+def _metric_row(task: AgentEvalTask, trial: AgentEvalTrial) -> dict[str, Any]:
+    return {
+        "task": {
+            "id": task.id,
+            "intent": task.intent,
+            "metadata": task.metadata,
+        },
+        "inputs": task.inputs,
+        "trial": {
+            "id": trial.id,
+            "task_id": trial.task_id,
+            "status": trial.status.value,
+            "metadata": trial.metadata,
+        },
+    }
+
+
+def _is_completions_endpoint(url: str) -> bool:
+    path = urlparse(url).path.rstrip("/")
+    return path.endswith("/completions") and not path.endswith("/chat/completions")
+
+
+def _benchmark_metadata(tasks: list[AgentEvalTask]) -> dict[str, Any]:
+    benchmarks = sorted({str(task.metadata.get("benchmark")) for task in tasks if task.metadata.get("benchmark")})
+    if not benchmarks:
+        return {}
+    return {"benchmark": benchmarks[0] if len(benchmarks) == 1 else benchmarks}
+
+
+def _persist_with_optional_dashboard(
+    result: AgentEvalResult,
+    output_dir: Path,
+    write_html: bool,
+) -> AgentEvalResult:
+    path = Path(output_dir)
+    dashboard_path = None
+    if write_html:
+        dashboard_path = write_dashboard(result.model_copy(update={"output_dir": path}), path / "report.html")
+    return persist_run(result.model_copy(update={"output_dir": path, "dashboard_path": dashboard_path}), path)
+
+
+def _new_run_id() -> str:
+    return f"agent-eval-{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}"

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/persistence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/persistence.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persistence helpers for standalone agent-eval result bundles."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
+from pydantic import BaseModel
+
+
+def persist_run(result: AgentEvalResult, output_dir: str | Path) -> AgentEvalResult:
+    """Persist a completed run bundle to ``output_dir``."""
+    path = Path(output_dir)
+    path.mkdir(parents=True, exist_ok=True)
+
+    _write_json(path / "benchmark.json", result.benchmark)
+    _write_jsonl(path / "tasks.jsonl", result.tasks)
+    _write_jsonl(path / "trials.jsonl", result.trials)
+    _write_jsonl(path / "scores.jsonl", result.scores)
+    _write_json(path / "summary.json", result.summary)
+
+    updated = result.model_copy(update={"output_dir": path})
+    _write_json(path / "run.json", _run_manifest(updated))
+    return updated
+
+
+def _run_manifest(result: AgentEvalResult) -> dict[str, Any]:
+    return {
+        "run_id": result.run_id,
+        "output_dir": str(result.output_dir) if result.output_dir is not None else None,
+        "dashboard_path": str(result.dashboard_path) if result.dashboard_path is not None else None,
+        "artifacts": {
+            "benchmark": "benchmark.json",
+            "tasks": "tasks.jsonl",
+            "trials": "trials.jsonl",
+            "scores": "scores.jsonl",
+            "summary": "summary.json",
+        },
+    }
+
+
+def _write_json(path: Path, value: BaseModel | dict[str, Any]) -> None:
+    if isinstance(value, BaseModel):
+        payload = value.model_dump(mode="json")
+    else:
+        payload = value
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: Sequence[BaseModel]) -> None:
+    # Stream row-by-row instead of joining the whole payload in memory first.
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row.model_dump(mode="json"), sort_keys=True))
+            handle.write("\n")

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
@@ -62,6 +62,8 @@ class SemanticView(BaseModel):
 class AgentEvalTask(BaseModel):
     """Standalone agent-eval task: the unit of work being evaluated."""
 
+    # TODO: Tasks may need to define a set of required_capabilities or something that allow the
+    # runtime to skip trying to complete a task that isn't possible.
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     id: str = Field(description="Stable task identifier, unique within the supplied task collection.")

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/samples.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/samples.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from nemo_evaluator_sdk.metrics.protocol import CandidateOutput, DatasetRow, MetricInput
 
-_CANDIDATE_SAMPLE_FIELDS = frozenset({"output_text", "response", "trajectory"})
+_CANDIDATE_SAMPLE_FIELDS = frozenset({"output_text", "response", "trajectory", "evidence"})
 
 
 def build_offline_sample(row: dict[str, Any]) -> dict[str, Any]:
@@ -37,6 +37,7 @@ def build_metric_input(row: dict[str, Any], sample: dict[str, Any], index: int |
             output_text=output_text if isinstance(output_text, str) else None,
             response=sample.get("response"),
             trajectory=sample.get("trajectory"),
+            evidence=sample.get("evidence"),
             metadata=metadata,
         ),
     )

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_dashboard.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_dashboard.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from nemo_evaluator_sdk.agent_eval.dashboard import render_dashboard
+from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSummary
+from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
+from nemo_evaluator_sdk.metrics.protocol import MetricOutput
+from nemo_evaluator_sdk.values.results import AggregatedMetricResult, AggregateRangeScore
+
+
+def test_dashboard_contains_metric_rollups_and_outputs() -> None:
+    result = AgentEvalResult(
+        run_id="run-1",
+        tasks=[],
+        trials=[],
+        scores=[
+            AgentEvalTaskScore(
+                id="run-1:task-1:trial-1:example_metric",
+                run_id="run-1",
+                task_id="task-1",
+                trial_id="trial-1",
+                metric_type="example_metric",
+                status=AgentEvalScoreStatus.COMPLETED,
+                outputs=[
+                    MetricOutput(name="score", value=0.5),
+                    MetricOutput(name="label", value="partial"),
+                ],
+            )
+        ],
+        summary=AgentEvalSummary(
+            scores=AggregatedMetricResult(
+                scores=[AggregateRangeScore(name="example_metric.score", count=1, nan_count=0, mean=0.5)]
+            ),
+            task_count=1,
+            trial_count=1,
+            score_count=1,
+        ),
+    )
+
+    html = render_dashboard(result)
+
+    assert "0.500" in html
+    assert "example_metric" in html
+    assert "trial-1" in html
+    assert "partial" in html
+    assert "Scores" in html

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
@@ -1,0 +1,431 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
+from nemo_evaluator_sdk.agent_eval.results import AgentEvalSummary
+from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
+from nemo_evaluator_sdk.agent_eval.tasks import (
+    AgentEvalRunConfig,
+    AgentEvalTask,
+    SemanticReducer,
+    SemanticView,
+    ViewSignal,
+)
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
+from nemo_evaluator_sdk.enums import AgentFormat, ModelFormat
+from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
+from nemo_evaluator_sdk.values import Agent, Model, RunConfigOnline, RunConfigOnlineModel
+from nemo_evaluator_sdk.values.results import AggregateScore
+
+
+def _score(summary: AgentEvalSummary, name: str) -> AggregateScore:
+    for aggregate in summary.scores.scores:
+        if aggregate.name == name:
+            return aggregate
+    raise KeyError(name)
+
+
+class _ConstantMetric:
+    @property
+    def type(self) -> str:
+        return "constant_metric"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.continuous_score("score")]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        return MetricResult(outputs=[MetricOutput(name="score", value=0.75)])
+
+
+class _EvidenceMetric:
+    def __init__(self) -> None:
+        self.inputs: list[MetricInput] = []
+
+    @property
+    def type(self) -> str:
+        return "evidence_metric"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.continuous_score("score")]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        self.inputs.append(input)
+        return MetricResult(outputs=[MetricOutput(name="score", value=1.0)])
+
+
+class _OtherMetric:
+    @property
+    def type(self) -> str:
+        return "other_metric"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.continuous_score("quality")]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        return MetricResult(outputs=[MetricOutput(name="quality", value=0.25)])
+
+
+class _FailingMetric:
+    @property
+    def type(self) -> str:
+        return "failing_metric"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.continuous_score("score")]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        raise RuntimeError("missing final_state evidence")
+
+
+def _task(metric: Any | None = None) -> AgentEvalTask:
+    return AgentEvalTask(
+        id="task-1",
+        intent="Answer a professional benchmark prompt.",
+        inputs={"prompt": "What is the answer?", "domain": "Finance MBA"},
+        metrics=[metric or _ConstantMetric()],
+        metadata={"benchmark": "Example", "domain": "Finance MBA"},
+    )
+
+
+def _candidate_trial() -> AgentEvalTrial:
+    return AgentEvalTrial(
+        id="trial-1",
+        task_id="task-1",
+        status=AgentEvalTrialStatus.COMPLETED,
+        output=AgentOutput(output_text="Candidate answer"),
+        metadata={"model_id": "candidate"},
+    )
+
+
+def _task_score(
+    run_id: str,
+    task_id: str,
+    trial_id: str,
+    metric_type: str,
+    output_name: str,
+    output_value: float,
+) -> AgentEvalTaskScore:
+    return AgentEvalTaskScore(
+        id=f"{run_id}:{task_id}:{trial_id}:{metric_type}",
+        run_id=run_id,
+        task_id=task_id,
+        trial_id=trial_id,
+        metric_type=metric_type,
+        status=AgentEvalScoreStatus.COMPLETED,
+        outputs=[MetricOutput(name=output_name, value=output_value)],
+    )
+
+
+class _TaskRunner:
+    def __init__(self) -> None:
+        self.config: AgentEvalRunConfig | None = None
+
+    async def run_tasks(
+        self,
+        tasks: Sequence[AgentEvalTask],
+        config: AgentEvalRunConfig | None = None,
+    ) -> list[AgentEvalTrial]:
+        self.config = config
+        return [
+            AgentEvalTrial(
+                id=f"{task.id}:runtime",
+                task_id=task.id,
+                status=AgentEvalTrialStatus.COMPLETED,
+                output=AgentOutput(output_text="Runtime answer"),
+                metadata={"model_id": "runtime"},
+            )
+            for task in tasks
+        ]
+
+
+def test_run_rejects_trials_and_target_together() -> None:
+    model = Model(url="https://model.test/v1/chat/completions", name="target", format=ModelFormat.OPEN_AI)
+
+    with pytest.raises(ValueError, match="provide exactly one"):
+        AgentEvaluator().run_sync(
+            tasks=[_task()],
+            trials=[_candidate_trial()],
+            target=model,
+        )
+
+
+@pytest.mark.asyncio
+async def test_scores_imported_trials_with_metric_and_persists_bundle(tmp_path: Path) -> None:
+    result = await AgentEvaluator().run(
+        tasks=[_task()],
+        trials=[_candidate_trial()],
+        config=AgentEvalRunConfig(output_dir=tmp_path, parallelism=1),
+    )
+
+    assert _score(result.summary, "constant_metric.score").mean == 0.75
+    assert result.dashboard_path == tmp_path / "report.html"
+    assert (tmp_path / "run.json").exists()
+    assert (tmp_path / "scores.jsonl").exists()
+    assert "run_id" not in json.loads((tmp_path / "benchmark.json").read_text(encoding="utf-8"))
+
+    score_payload = json.loads((tmp_path / "scores.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    assert score_payload["id"] == f"{result.run_id}:task-1:trial-1:constant_metric"
+    assert score_payload["run_id"] == result.run_id
+    assert score_payload["status"] == "completed"
+    assert score_payload["diagnostics"] == []
+
+    run_payload = json.loads((tmp_path / "run.json").read_text(encoding="utf-8"))
+    assert run_payload == {
+        "artifacts": {
+            "benchmark": "benchmark.json",
+            "scores": "scores.jsonl",
+            "summary": "summary.json",
+            "tasks": "tasks.jsonl",
+            "trials": "trials.jsonl",
+        },
+        "dashboard_path": str(tmp_path / "report.html"),
+        "output_dir": str(tmp_path),
+        "run_id": result.run_id,
+    }
+    assert result.scores[0].metric_type == "constant_metric"
+    assert result.scores[0].outputs[0].value == 0.75
+
+
+@pytest.mark.asyncio
+async def test_scores_partial_trials() -> None:
+    result = await AgentEvaluator().run(
+        tasks=[_task()],
+        trials=[
+            AgentEvalTrial(
+                id="trial-1",
+                task_id="task-1",
+                status=AgentEvalTrialStatus.PARTIAL,
+                output=AgentOutput(output_text="Partial answer"),
+            )
+        ],
+    )
+
+    assert _score(result.summary, "constant_metric.score").mean == 0.75
+
+
+@pytest.mark.asyncio
+async def test_target_runtime_produces_trials_before_scoring() -> None:
+    runtime = _TaskRunner()
+    result = await AgentEvaluator().run(
+        tasks=[_task()],
+        target=runtime,
+    )
+
+    assert result.trials[0].id == "task-1:runtime"
+    assert runtime.config is not None
+    assert runtime.config.run_id == result.run_id
+    assert _score(result.summary, "constant_metric.score").mean == 0.75
+
+
+@pytest.mark.asyncio
+async def test_live_model_generation_with_mocked_inference() -> None:
+    async def fake_model_inference(
+        model: Model,
+        request: dict[str, Any],
+        max_retries: int | None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        del model, max_retries, kwargs
+        assert request["messages"][0]["content"] == "What is the answer?"
+        assert "prompt" not in request
+        return {"choices": [{"message": {"role": "assistant", "content": "Generated model answer"}}]}
+
+    model = Model(url="https://model.test/v1/chat/completions", name="target-model", format=ModelFormat.OPEN_AI)
+    result = await AgentEvaluator(inference_fn=fake_model_inference).run(
+        tasks=[_task()],
+        target=model,
+        config=AgentEvalRunConfig(params=RunConfigOnlineModel(parallelism=1)),
+    )
+
+    assert result.trials[0].metadata["model_id"] == "target-model"
+    assert result.trials[0].output is not None
+    assert result.trials[0].output.output_text == "Generated model answer"
+    assert _score(result.summary, "constant_metric.score").mean == 0.75
+
+
+@pytest.mark.asyncio
+async def test_live_model_generation_uses_instruction_when_prompt_is_absent() -> None:
+    async def fake_model_inference(
+        model: Model,
+        request: dict[str, Any],
+        max_retries: int | None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        del model, max_retries, kwargs
+        assert request["messages"][0]["content"] == "Use the task instruction."
+        return {"choices": [{"message": {"role": "assistant", "content": "Generated model answer"}}]}
+
+    task = AgentEvalTask(
+        id="task-1",
+        intent="Fallback intent.",
+        inputs={"instruction": "Use the task instruction."},
+        metrics=[_ConstantMetric()],
+    )
+    model = Model(url="https://model.test/v1/chat/completions", name="target-model", format=ModelFormat.OPEN_AI)
+
+    await AgentEvaluator(inference_fn=fake_model_inference).run(
+        tasks=[task],
+        target=model,
+        config=AgentEvalRunConfig(params=RunConfigOnlineModel(parallelism=1)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_metric_failure_records_failed_score_and_does_not_stop_other_metrics() -> None:
+    task = _task(metric=_FailingMetric())
+    other_task = AgentEvalTask(
+        id="task-2",
+        intent="Answer another prompt.",
+        inputs={"prompt": "Another question?"},
+        metrics=[_OtherMetric()],
+    )
+    trials = [
+        _candidate_trial(),
+        AgentEvalTrial(
+            id="trial-2",
+            task_id="task-2",
+            status=AgentEvalTrialStatus.COMPLETED,
+            output=AgentOutput(output_text="Other answer"),
+        ),
+    ]
+
+    result = await AgentEvaluator().run(tasks=[task, other_task], trials=trials)
+
+    failed = next(item for item in result.scores if item.metric_type == "failing_metric")
+    completed = next(item for item in result.scores if item.metric_type == "other_metric")
+    assert failed.status.value == "failed"
+    assert failed.outputs == []
+    assert failed.diagnostics[0].message == "missing final_state evidence"
+    assert completed.status.value == "completed"
+    assert completed.outputs[0].value == 0.25
+    assert result.summary.metric_coverage["failing_metric"]["score"].failed == 1
+    assert result.summary.metric_coverage["other_metric"]["quality"].scored == 1
+
+
+@pytest.mark.asyncio
+async def test_metric_failure_can_fail_fast_for_development() -> None:
+    with pytest.raises(RuntimeError, match="missing final_state evidence"):
+        await AgentEvaluator().run(
+            tasks=[_task(metric=_FailingMetric())],
+            trials=[_candidate_trial()],
+            config=AgentEvalRunConfig(fail_fast=True),
+        )
+
+
+def test_summary_reports_coverage_and_merges_views_into_scores() -> None:
+    task = AgentEvalTask(
+        id="task-1",
+        intent="Answer a prompt.",
+        inputs={"prompt": "Question?"},
+        metrics=[_ConstantMetric(), _OtherMetric()],
+        views={
+            "outcome_correctness": SemanticView(
+                reducer=SemanticReducer.MEAN,
+                signals=[
+                    ViewSignal(metric="constant_metric", output="score"),
+                    ViewSignal(metric="other_metric", output="quality"),
+                ],
+            )
+        },
+    )
+    scores = [
+        _task_score("run-1", "task-1", "trial-1", "constant_metric", "score", 1.0),
+        _task_score("run-1", "task-1", "trial-1", "other_metric", "quality", 0.0),
+    ]
+
+    summary = AgentEvalSummary.from_scores(scores, tasks=[task])
+
+    assert _score(summary, "constant_metric.score").mean == 1.0
+    assert _score(summary, "other_metric.quality").mean == 0.0
+    assert _score(summary, "view.outcome_correctness").mean == 0.5
+    assert summary.metric_coverage["constant_metric"]["score"].total == 1
+    assert summary.metric_coverage["constant_metric"]["score"].scored == 1
+
+
+@pytest.mark.asyncio
+async def test_live_agent_generation_preserves_trace_evidence_for_metrics() -> None:
+    metric = _EvidenceMetric()
+
+    async def fake_agent_inference(
+        agent: Agent,
+        request: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        del agent, kwargs
+        assert request["messages"][0]["content"] == "What is the answer?"
+        return {
+            "choices": [{"message": {"role": "assistant", "content": "Generated agent answer"}}],
+            "trajectory": [{"tool": "search", "line": 3}],
+        }
+
+    agent = Agent(
+        url="https://agent.test",
+        name="target-agent",
+        format=AgentFormat.GENERIC,
+        body={"input": "{{ messages[-1].content }}"},
+        response_path="$.answer",
+    )
+    result = await AgentEvaluator(inference_fn=fake_agent_inference).run(
+        tasks=[_task(metric)],
+        target=agent,
+        config=AgentEvalRunConfig(params=RunConfigOnline(parallelism=1)),
+    )
+
+    assert result.trials[0].evidence is not None
+    assert result.trials[0].evidence.require("trace").kind == "trace"
+    assert result.trials[0].output is not None
+    assert result.trials[0].output.output_text == "Generated agent answer"
+    assert metric.inputs[0].candidate.evidence == result.trials[0].evidence
+
+
+@pytest.mark.asyncio
+async def test_live_generation_ignore_request_failure_records_failed_trial() -> None:
+    async def failing_model_inference(
+        model: Model,
+        request: dict[str, Any],
+        max_retries: int | None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        del model, request, max_retries, kwargs
+        raise RuntimeError("inference boom")
+
+    model = Model(url="https://model.test/v1/chat/completions", name="target-model", format=ModelFormat.OPEN_AI)
+
+    result = await AgentEvaluator(inference_fn=failing_model_inference).run(
+        tasks=[_task()],
+        target=model,
+        config=AgentEvalRunConfig(params=RunConfigOnlineModel(parallelism=1, ignore_request_failure=True)),
+    )
+
+    assert result.trials[0].status is AgentEvalTrialStatus.FAILED
+    assert result.trials[0].output is None
+    assert result.trials[0].metadata["error"] == "inference boom"
+    assert result.scores[0].status is AgentEvalScoreStatus.FAILED
+    assert result.summary.metric_coverage["constant_metric"]["score"].failed == 1
+
+    # Without ignore_request_failure the run aborts on the first failed request.
+    with pytest.raises(RuntimeError, match="inference boom"):
+        await AgentEvaluator(inference_fn=failing_model_inference).run(
+            tasks=[_task()],
+            target=model,
+            config=AgentEvalRunConfig(params=RunConfigOnlineModel(parallelism=1)),
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_tasks_without_trials() -> None:
+    other_task = AgentEvalTask(
+        id="task-2",
+        intent="Answer another prompt.",
+        inputs={"prompt": "Another question?"},
+        metrics=[_OtherMetric()],
+    )
+
+    with pytest.raises(ValueError, match=r"no trials produced for tasks: \['task-2'\]"):
+        await AgentEvaluator().run(tasks=[_task(), other_task], trials=[_candidate_trial()])

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/dashboard.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/dashboard.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small HTML dashboard for standalone agent-eval result bundles."""
+
+from __future__ import annotations
+
+import html
+import json
+from pathlib import Path
+from typing import Any
+
+from nemo_platform.beta.evaluator.agent_eval.results import AgentEvalResult
+from nemo_platform.beta.evaluator.agent_eval.scores import AgentEvalTaskScore
+from pydantic import BaseModel
+
+
+def write_dashboard(result: AgentEvalResult, output_path: str | Path) -> Path:
+    """Write an HTML dashboard and return its path."""
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_dashboard(result), encoding="utf-8")
+    return path
+
+
+def render_dashboard(result: AgentEvalResult) -> str:
+    """Render a compact generic report for metric outputs."""
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agent Eval Report</title>
+  <style>
+    :root {{ color-scheme: light dark; --bg:#f7f8fa; --fg:#172033; --muted:#64748b; --line:#d8dee9; --panel:#fff; --soft:#f8fafc; }}
+    @media (prefers-color-scheme: dark) {{ :root {{ --bg:#111827; --fg:#f8fafc; --muted:#a4aebc; --line:#374151; --panel:#1f2937; --soft:#111827; }} }}
+    * {{ box-sizing: border-box; }}
+    body {{ background: var(--bg); color: var(--fg); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; }}
+    header {{ background: var(--panel); border-bottom: 1px solid var(--line); padding: 28px 32px 20px; }}
+    main {{ max-width: 1320px; margin: 0 auto; padding: 24px 32px 48px; }}
+    h1 {{ margin: 0 0 4px; }}
+    h2 {{ margin-top: 28px; }}
+    .muted {{ color: var(--muted); }}
+    .cards {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin: 24px 0; }}
+    .card {{ background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; min-width: 160px; }}
+    .card strong {{ display: block; font-size: 24px; margin-top: 6px; }}
+    table {{ background: var(--panel); border: 1px solid var(--line); border-collapse: collapse; width: 100%; margin-top: 16px; }}
+    th, td {{ border-bottom: 1px solid var(--line); padding: 9px 10px; text-align: left; vertical-align: top; }}
+    th {{ background: var(--soft); color: var(--muted); font-size: 12px; text-transform: uppercase; }}
+    code {{ background: var(--soft); border-radius: 4px; padding: 1px 4px; }}
+    pre {{ background: var(--soft); border-radius: 6px; max-height: 320px; overflow: auto; padding: 10px; white-space: pre-wrap; }}
+    .output-list {{ display: grid; gap: 8px; }}
+    .output-row strong {{ display: block; margin-bottom: 4px; }}
+  </style>
+</head>
+<body>
+<header>
+  <h1>Agent Eval Report</h1>
+  <div class="muted">Run {_e(result.run_id)} · {_e(result.summary.task_count)} tasks · {_e(result.summary.trial_count)} trials</div>
+</header>
+<main>
+  <div class="cards">
+    <div class="card"><span class="muted">Tasks</span><strong>{_e(result.summary.task_count)}</strong></div>
+    <div class="card"><span class="muted">Trials</span><strong>{_e(result.summary.trial_count)}</strong></div>
+    <div class="card"><span class="muted">Metric Scores</span><strong>{_e(result.summary.score_count)}</strong></div>
+  </div>
+  <h2>Metric Rollups</h2>
+  {_metric_rollups(result)}
+  <h2>Scores</h2>
+  {_score_table(result.scores)}
+</main>
+</body>
+</html>
+"""
+
+
+def _metric_rollups(result: AgentEvalResult) -> str:
+    aggregated = result.summary.scores.scores
+    if not aggregated:
+        return '<p class="muted">No numeric metric outputs to summarize.</p>'
+    rows: list[str] = []
+    for score in sorted(aggregated, key=lambda item: item.name):
+        rows.append(
+            "<tr>"
+            f"<td><code>{_e(score.name)}</code></td>"
+            f"<td>{_format_score(score.mean)}</td>"
+            f"<td>{_e(score.count)}</td>"
+            f"<td>{_e(score.nan_count)}</td>"
+            "</tr>"
+        )
+    return (
+        "<table><thead><tr><th>Name</th><th>Mean</th><th>Count</th><th>NaN</th></tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table>"
+    )
+
+
+def _score_table(scores: list[AgentEvalTaskScore]) -> str:
+    if not scores:
+        return '<p class="muted">No metric scores.</p>'
+    rows = [
+        "<tr>"
+        f"<td><code>{_e(score.task_id)}</code></td>"
+        f"<td><code>{_e(score.trial_id)}</code></td>"
+        f"<td><code>{_e(score.metric_type)}</code></td>"
+        f"<td>{_outputs(score)}</td>"
+        "</tr>"
+        for score in scores
+    ]
+    return (
+        "<table><thead><tr><th>Task</th><th>Trial</th><th>Metric</th><th>Outputs</th></tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table>"
+    )
+
+
+def _outputs(score: AgentEvalTaskScore) -> str:
+    chunks = []
+    for output in score.outputs:
+        chunks.append(
+            f'<div class="output-row"><strong>{_e(output.name)}</strong><pre>{_e(_jsonish(output.value))}</pre></div>'
+        )
+    return '<div class="output-list">' + "".join(chunks) + "</div>"
+
+
+def _jsonish(value: Any) -> str:
+    if isinstance(value, BaseModel):
+        value = value.model_dump(mode="json")
+    try:
+        return json.dumps(value, indent=2, sort_keys=True)
+    except (TypeError, ValueError):
+        # ValueError covers circular references; fall back to a plain string rather than crash rendering.
+        return str(value)
+
+
+def _format_score(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.3f}"
+
+
+def _e(value: object) -> str:
+    return html.escape(str(value), quote=True)

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
@@ -1,0 +1,542 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone agent evaluation orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import UTC, datetime
+from logging import getLogger
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import urlparse
+
+import httpx
+import nemo_platform.beta.evaluator.inference as inference
+from nemo_platform.beta.evaluator.agent_eval.dashboard import write_dashboard
+from nemo_platform.beta.evaluator.agent_eval.persistence import persist_run
+from nemo_platform.beta.evaluator.agent_eval.results import AgentEvalResult, AgentEvalSummary
+from nemo_platform.beta.evaluator.agent_eval.scores import (
+    AgentEvalDiagnostic,
+    AgentEvalDiagnosticSeverity,
+    AgentEvalScoreStatus,
+    AgentEvalTaskScore,
+)
+from nemo_platform.beta.evaluator.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+from nemo_platform.beta.evaluator.agent_eval.trials import (
+    AgentEvalTarget,
+    AgentEvalTrial,
+    AgentEvalTrialStatus,
+    AgentOutput,
+    AgentTaskRunner,
+)
+from nemo_platform.beta.evaluator.agent_inference import (
+    AgentInferenceFn,
+    make_agent_inference_request,
+    new_agent_inference_client,
+)
+from nemo_platform.beta.evaluator.execution.metric_execution import generate_online_sample, run_sync
+from nemo_platform.beta.evaluator.execution.samples import build_metric_input
+from nemo_platform.beta.evaluator.inference import InferenceFn
+from nemo_platform.beta.evaluator.metrics.protocol import Metric, validate_metric_result
+from nemo_platform.beta.evaluator.metrics.utils import metric_type_name
+from nemo_platform.beta.evaluator.values import Agent, Model, RunConfig, RunConfigOnline, RunConfigOnlineModel
+from nemo_platform.beta.evaluator.values.evidence import CandidateEvidence, EvidenceDescriptor
+from openai import AsyncOpenAI
+
+log = getLogger(__name__)
+
+
+class AgentEvaluator:
+    """Run stored-trial or live-target agent evaluations.
+
+    The online inference seam (an optional ``inference_fn``, transport ``client``, and
+    ``default_headers``) is injected on the evaluator instance rather than the run config,
+    because these are runtime transport concerns rather than declarative run settings. A
+    single ``inference_fn``/``client`` pair serves both model and agent targets; leave them
+    unset to let the evaluator build a default client for the resolved target type.
+    """
+
+    def __init__(
+        self,
+        *,
+        inference_fn: InferenceFn | AgentInferenceFn | None = None,
+        client: AsyncOpenAI | httpx.AsyncClient | None = None,
+        default_headers: dict[str, str] | None = None,
+    ) -> None:
+        self.inference_fn = inference_fn
+        self.client = client
+        self.default_headers = default_headers
+
+    async def run(
+        self,
+        *,
+        tasks: Sequence[AgentEvalTask],
+        trials: Sequence[AgentEvalTrial] | None = None,
+        target: AgentEvalTarget | None = None,
+        config: AgentEvalRunConfig | None = None,
+    ) -> AgentEvalResult:
+        """Evaluate imported trials or generate live trials before scoring.
+
+        Exactly one of ``trials`` or ``target`` must be provided.
+        """
+        resolved_config = config or AgentEvalRunConfig()
+        task_list = list(tasks)
+        if not task_list:
+            raise ValueError("at least one task is required")
+
+        run_id = resolved_config.run_id or _new_run_id()
+        runtime_config = resolved_config.model_copy(update={"run_id": run_id})
+
+        # Branch on which seam was supplied so the type checker can narrow ``target`` to a
+        # concrete ``AgentEvalTarget`` without a cast.
+        if trials is not None:
+            if target is not None:
+                raise ValueError("provide exactly one of trials or target")
+            trial_list = list(trials)
+        elif target is not None:
+            trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
+        else:
+            raise ValueError("provide exactly one of trials or target")
+        scores = await self._score_trials(
+            tasks=task_list,
+            trials=trial_list,
+            config=runtime_config,
+            run_id=run_id,
+        )
+        benchmark = {**_benchmark_metadata(task_list), **runtime_config.benchmark}
+        result = AgentEvalResult(
+            run_id=run_id,
+            tasks=task_list,
+            trials=trial_list,
+            scores=scores,
+            summary=AgentEvalSummary.from_scores(scores, tasks=task_list),
+            benchmark=benchmark,
+        )
+
+        if runtime_config.output_dir is not None:
+            result = _persist_with_optional_dashboard(result, runtime_config.output_dir, runtime_config.write_dashboard)
+        return result
+
+    def run_sync(
+        self,
+        *,
+        tasks: Sequence[AgentEvalTask],
+        trials: Sequence[AgentEvalTrial] | None = None,
+        target: AgentEvalTarget | None = None,
+        config: AgentEvalRunConfig | None = None,
+    ) -> AgentEvalResult:
+        """Synchronous bridge for :meth:`run`."""
+        return run_sync(lambda: self.run(tasks=tasks, trials=trials, target=target, config=config))
+
+    async def _score_trials(
+        self,
+        *,
+        tasks: list[AgentEvalTask],
+        trials: list[AgentEvalTrial],
+        config: AgentEvalRunConfig,
+        run_id: str,
+    ) -> list[AgentEvalTaskScore]:
+        tasks_by_id = {task.id: task for task in tasks}
+        task_index_by_id = {task.id: index for index, task in enumerate(tasks)}
+        trials_by_task: dict[str, list[AgentEvalTrial]] = defaultdict(list)
+        for trial in trials:
+            if trial.task_id not in tasks_by_id:
+                raise ValueError(f"trial {trial.id!r} references unknown task {trial.task_id!r}")
+            trials_by_task[trial.task_id].append(trial)
+
+        # Fail loudly when a task produced no trial. Imported trials or an AgentTaskRunner may omit a
+        # task entirely; without this an incomplete run would look successful aside from lower summary
+        # counts. (A richer alternative is to emit a "missing trial" failed score per metric.)
+        tasks_without_trials = [task.id for task in tasks if not trials_by_task.get(task.id)]
+        if tasks_without_trials:
+            raise ValueError(f"no trials produced for tasks: {sorted(tasks_without_trials)}")
+
+        for task in tasks:
+            if not task.metrics:
+                raise ValueError(f"task {task.id!r} does not declare any metrics")
+
+        semaphore = asyncio.Semaphore(config.parallelism)
+
+        async def guarded_score(task: AgentEvalTask, trial: AgentEvalTrial, metric: Metric) -> AgentEvalTaskScore:
+            async with semaphore:
+                row_index = task_index_by_id[task.id]
+                if trial.status == AgentEvalTrialStatus.FAILED:
+                    return _failed_metric_score(
+                        run_id=run_id,
+                        task=task,
+                        trial=trial,
+                        metric=metric,
+                        row_index=row_index,
+                        diagnostic=AgentEvalDiagnostic(
+                            severity=AgentEvalDiagnosticSeverity.ERROR,
+                            message=f"trial {trial.id!r} is failed",
+                            source=metric_type_name(metric),
+                            details={"trial_status": trial.status.value},
+                        ),
+                    )
+                try:
+                    return await _score_metric(
+                        run_id=run_id,
+                        task=task,
+                        trial=trial,
+                        metric=metric,
+                        row_index=row_index,
+                    )
+                except Exception as exc:
+                    if config.fail_fast:
+                        raise
+                    log.warning(
+                        "metric %s failed for trial %r (task %r): %s",
+                        metric_type_name(metric),
+                        trial.id,
+                        task.id,
+                        exc,
+                    )
+                    return _failed_metric_score(
+                        run_id=run_id,
+                        task=task,
+                        trial=trial,
+                        metric=metric,
+                        row_index=row_index,
+                        diagnostic=_exception_diagnostic(exc, metric_type_name(metric)),
+                    )
+
+        return await asyncio.gather(
+            *[
+                guarded_score(task, trial, metric)
+                for task in tasks
+                for trial in trials_by_task.get(task.id, [])
+                for metric in task.metrics
+            ]
+        )
+
+    async def _generate_trials(
+        self,
+        *,
+        tasks: list[AgentEvalTask],
+        target: AgentEvalTarget,
+        config: AgentEvalRunConfig,
+    ) -> list[AgentEvalTrial]:
+        if isinstance(target, AgentTaskRunner):
+            return list(await target.run_tasks(tasks, config=config))
+        if not isinstance(target, (Model, Agent)):
+            raise NotImplementedError(f"unsupported agent-eval target type: {type(target).__name__}")
+
+        params = _resolve_live_params(config, target)
+        prompt_template = config.prompt_template or _default_prompt_template(target)
+        semaphore = asyncio.Semaphore(params.parallelism)
+
+        # Use the injected transport client when provided; otherwise build a default for the
+        # resolved target type and close it when generation finishes.
+        client = self.client
+        close_client: Callable[[], Awaitable[Any]] | None = None
+        if client is None and self.inference_fn is None:
+            if isinstance(target, Model):
+                client = inference.new_inference_client(target)
+                close_client = client.close
+            else:
+                client = new_agent_inference_client()
+                close_client = client.aclose
+
+        try:
+            # When config.params.ignore_request_failure is set, convert a failed generation request
+            # into a FAILED trial (which the scorer turns into failed metric scores) instead of
+            # aborting the whole run. This matches the existing online-evaluator contract.
+            async def generate_one(index: int, task: AgentEvalTask) -> AgentEvalTrial:
+                async with semaphore:
+                    try:
+                        sample = await _generate_sample(
+                            target=target,
+                            row=_task_row(task),
+                            index=index,
+                            prompt_template=prompt_template,
+                            params=params,
+                            inference_fn=self.inference_fn,
+                            client=client,
+                            default_headers=self.default_headers,
+                        )
+                    except Exception as exc:
+                        if params.ignore_request_failure:
+                            return _failed_generation_trial(task, target, exc)
+                        raise
+                    return _trial_from_sample(task, target, sample)
+
+            return await asyncio.gather(*(generate_one(index, task) for index, task in enumerate(tasks)))
+        finally:
+            if close_client is not None:
+                await close_client()
+
+
+async def _generate_sample(
+    *,
+    target: Model | Agent,
+    row: dict[str, Any],
+    index: int,
+    prompt_template: str | dict[str, Any],
+    params: RunConfigOnline | RunConfigOnlineModel,
+    inference_fn: InferenceFn | AgentInferenceFn | None,
+    client: AsyncOpenAI | httpx.AsyncClient | None,
+    default_headers: dict[str, str] | None,
+) -> dict[str, Any]:
+    # InferenceFn and AgentInferenceFn are callable protocols, so isinstance cannot discriminate
+    # the injected fn; narrow it per target type with a cast (matching execution/benchmark_execution).
+    # The transport client is a real class union, so isinstance narrowing is enough there.
+    if isinstance(target, Model):
+        model_params = cast(RunConfigOnlineModel, params)
+        preprocess_hooks, postprocess_hooks = inference.new_hooks(model_params, model_format=target.format)
+        model_inference_fn = (
+            cast(InferenceFn, inference_fn) if inference_fn is not None else inference.make_inference_request
+        )
+        return await generate_online_sample(
+            target=target,
+            row=row,
+            index=index,
+            prompt_template=prompt_template,
+            params=model_params,
+            inference_fn=model_inference_fn,
+            client=client if isinstance(client, AsyncOpenAI) else None,
+            preprocess_hooks=preprocess_hooks,
+            postprocess_hooks=postprocess_hooks,
+            default_headers=default_headers,
+        )
+
+    agent_inference_fn = (
+        cast(AgentInferenceFn, inference_fn) if inference_fn is not None else make_agent_inference_request
+    )
+    return await generate_online_sample(
+        target=target,
+        row=row,
+        index=index,
+        prompt_template=prompt_template,
+        params=params,
+        inference_fn=agent_inference_fn,
+        client=client if isinstance(client, httpx.AsyncClient) else None,
+        default_headers=default_headers,
+    )
+
+
+def _trial_from_sample(task: AgentEvalTask, target: Model | Agent, sample: dict[str, Any]) -> AgentEvalTrial:
+    output_text = sample.get("output_text")
+    if "trajectory" in sample:
+        trace = EvidenceDescriptor(kind="trace", format="json", data=sample["trajectory"])
+    else:
+        trace = EvidenceDescriptor(kind="sdk_online_generation", data={"task_id": task.id, "target": target.name})
+
+    return AgentEvalTrial(
+        id=f"{task.id}:{target.name}",
+        task_id=task.id,
+        status=AgentEvalTrialStatus.COMPLETED,
+        output=AgentOutput(
+            output_text=output_text if isinstance(output_text, str) else None,
+            response=sample.get("response"),
+            metadata={
+                key: value for key, value in sample.items() if key not in {"output_text", "response", "trajectory"}
+            },
+        ),
+        evidence=CandidateEvidence(descriptors={"trace": trace}),
+        metadata={
+            "model_id": target.name,
+            "target_name": target.name,
+            "generated": True,
+        },
+    )
+
+
+def _failed_generation_trial(task: AgentEvalTask, target: Model | Agent, exc: Exception) -> AgentEvalTrial:
+    return AgentEvalTrial(
+        id=f"{task.id}:{target.name}",
+        task_id=task.id,
+        status=AgentEvalTrialStatus.FAILED,
+        output=None,
+        evidence=CandidateEvidence(
+            descriptors={
+                "error": EvidenceDescriptor(
+                    kind="error",
+                    data={"error_type": exc.__class__.__name__, "error": str(exc)},
+                )
+            }
+        ),
+        metadata={
+            "model_id": target.name,
+            "target_name": target.name,
+            "generated": True,
+            "error_type": exc.__class__.__name__,
+            "error": str(exc),
+        },
+    )
+
+
+async def _score_metric(
+    *,
+    run_id: str,
+    task: AgentEvalTask,
+    trial: AgentEvalTrial,
+    metric: Metric,
+    row_index: int,
+) -> AgentEvalTaskScore:
+    output_spec = metric.output_spec()
+    metric_result = validate_metric_result(
+        await metric.compute_scores(build_metric_input(_metric_row(task, trial), _trial_sample(trial), row_index)),
+        output_spec,
+    )
+    metric_type = metric_type_name(metric)
+    return AgentEvalTaskScore(
+        id=_score_id(run_id, task.id, trial.id, metric_type),
+        run_id=run_id,
+        task_id=task.id,
+        trial_id=trial.id,
+        metric_type=metric_type,
+        status=AgentEvalScoreStatus.COMPLETED,
+        outputs=metric_result.outputs,
+        metadata={
+            "row_index": row_index,
+            "trial_metadata": trial.metadata,
+        },
+    )
+
+
+def _failed_metric_score(
+    *,
+    run_id: str,
+    task: AgentEvalTask,
+    trial: AgentEvalTrial,
+    metric: Metric,
+    row_index: int,
+    diagnostic: AgentEvalDiagnostic,
+) -> AgentEvalTaskScore:
+    metric_type = metric_type_name(metric)
+    return AgentEvalTaskScore(
+        id=_score_id(run_id, task.id, trial.id, metric_type),
+        run_id=run_id,
+        task_id=task.id,
+        trial_id=trial.id,
+        metric_type=metric_type,
+        status=AgentEvalScoreStatus.FAILED,
+        outputs=[],
+        diagnostics=[diagnostic],
+        metadata={
+            "row_index": row_index,
+            "trial_metadata": trial.metadata,
+        },
+    )
+
+
+def _exception_diagnostic(exc: Exception, metric_type: str) -> AgentEvalDiagnostic:
+    return AgentEvalDiagnostic(
+        severity=AgentEvalDiagnosticSeverity.ERROR,
+        message=str(exc) or exc.__class__.__name__,
+        source=metric_type,
+        details={"exception_type": exc.__class__.__name__},
+    )
+
+
+def _score_id(run_id: str, task_id: str, trial_id: str, metric_type: str) -> str:
+    return f"{run_id}:{task_id}:{trial_id}:{metric_type}"
+
+
+def _trial_sample(trial: AgentEvalTrial) -> dict[str, Any]:
+    if trial.output is None:
+        return {}
+    sample: dict[str, Any] = {
+        **trial.metadata,
+        **trial.output.metadata,
+    }
+    if trial.output.output_text is not None:
+        sample["output_text"] = trial.output.output_text
+    if trial.output.response is not None:
+        sample["response"] = trial.output.response
+    if trial.evidence is not None:
+        sample["evidence"] = trial.evidence
+    return sample
+
+
+def _resolve_live_params(
+    config: AgentEvalRunConfig,
+    target: Model | Agent,
+) -> RunConfigOnline | RunConfigOnlineModel:
+    params = config.params
+    if isinstance(target, Model):
+        if params is None:
+            return RunConfigOnlineModel(parallelism=config.parallelism)
+        if isinstance(params, RunConfigOnlineModel):
+            return params
+        if isinstance(params, RunConfigOnline):
+            return RunConfigOnlineModel(**params.model_dump(mode="python"))
+        if isinstance(params, RunConfig):
+            return RunConfigOnlineModel(**params.model_dump(mode="python"))
+
+    if params is None:
+        return RunConfigOnline(parallelism=config.parallelism)
+    if isinstance(params, RunConfigOnlineModel):
+        return RunConfigOnline(
+            **params.model_dump(
+                mode="python",
+                exclude={"inference", "system_prompt", "reasoning", "structured_output"},
+            )
+        )
+    if isinstance(params, RunConfigOnline):
+        return params
+    return RunConfigOnline(**params.model_dump(mode="python"))
+
+
+def _default_prompt_template(target: Model | Agent) -> dict[str, Any]:
+    if isinstance(target, Model) and _is_completions_endpoint(target.url):
+        return {"prompt": "{{item.prompt}}"}
+    return {"messages": [{"role": "user", "content": "{{item.prompt}}"}]}
+
+
+def _task_row(task: AgentEvalTask) -> dict[str, Any]:
+    return {
+        **task.inputs,
+        "task_id": task.id,
+        "prompt": task.inputs.get("prompt") or task.inputs.get("instruction") or task.intent,
+    }
+
+
+def _metric_row(task: AgentEvalTask, trial: AgentEvalTrial) -> dict[str, Any]:
+    return {
+        "task": {
+            "id": task.id,
+            "intent": task.intent,
+            "metadata": task.metadata,
+        },
+        "inputs": task.inputs,
+        "trial": {
+            "id": trial.id,
+            "task_id": trial.task_id,
+            "status": trial.status.value,
+            "metadata": trial.metadata,
+        },
+    }
+
+
+def _is_completions_endpoint(url: str) -> bool:
+    path = urlparse(url).path.rstrip("/")
+    return path.endswith("/completions") and not path.endswith("/chat/completions")
+
+
+def _benchmark_metadata(tasks: list[AgentEvalTask]) -> dict[str, Any]:
+    benchmarks = sorted({str(task.metadata.get("benchmark")) for task in tasks if task.metadata.get("benchmark")})
+    if not benchmarks:
+        return {}
+    return {"benchmark": benchmarks[0] if len(benchmarks) == 1 else benchmarks}
+
+
+def _persist_with_optional_dashboard(
+    result: AgentEvalResult,
+    output_dir: Path,
+    write_html: bool,
+) -> AgentEvalResult:
+    path = Path(output_dir)
+    dashboard_path = None
+    if write_html:
+        dashboard_path = write_dashboard(result.model_copy(update={"output_dir": path}), path / "report.html")
+    return persist_run(result.model_copy(update={"output_dir": path, "dashboard_path": dashboard_path}), path)
+
+
+def _new_run_id() -> str:
+    return f"agent-eval-{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}"

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/persistence.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/persistence.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persistence helpers for standalone agent-eval result bundles."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from nemo_platform.beta.evaluator.agent_eval.results import AgentEvalResult
+from pydantic import BaseModel
+
+
+def persist_run(result: AgentEvalResult, output_dir: str | Path) -> AgentEvalResult:
+    """Persist a completed run bundle to ``output_dir``."""
+    path = Path(output_dir)
+    path.mkdir(parents=True, exist_ok=True)
+
+    _write_json(path / "benchmark.json", result.benchmark)
+    _write_jsonl(path / "tasks.jsonl", result.tasks)
+    _write_jsonl(path / "trials.jsonl", result.trials)
+    _write_jsonl(path / "scores.jsonl", result.scores)
+    _write_json(path / "summary.json", result.summary)
+
+    updated = result.model_copy(update={"output_dir": path})
+    _write_json(path / "run.json", _run_manifest(updated))
+    return updated
+
+
+def _run_manifest(result: AgentEvalResult) -> dict[str, Any]:
+    return {
+        "run_id": result.run_id,
+        "output_dir": str(result.output_dir) if result.output_dir is not None else None,
+        "dashboard_path": str(result.dashboard_path) if result.dashboard_path is not None else None,
+        "artifacts": {
+            "benchmark": "benchmark.json",
+            "tasks": "tasks.jsonl",
+            "trials": "trials.jsonl",
+            "scores": "scores.jsonl",
+            "summary": "summary.json",
+        },
+    }
+
+
+def _write_json(path: Path, value: BaseModel | dict[str, Any]) -> None:
+    if isinstance(value, BaseModel):
+        payload = value.model_dump(mode="json")
+    else:
+        payload = value
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: Sequence[BaseModel]) -> None:
+    # Stream row-by-row instead of joining the whole payload in memory first.
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row.model_dump(mode="json"), sort_keys=True))
+            handle.write("\n")

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/tasks.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/tasks.py
@@ -62,6 +62,8 @@ class SemanticView(BaseModel):
 class AgentEvalTask(BaseModel):
     """Standalone agent-eval task: the unit of work being evaluated."""
 
+    # TODO: Tasks may need to define a set of required_capabilities or something that allow the
+    # runtime to skip trying to complete a task that isn't possible.
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     id: str = Field(description="Stable task identifier, unique within the supplied task collection.")

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/execution/samples.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/execution/samples.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from nemo_platform.beta.evaluator.metrics.protocol import CandidateOutput, DatasetRow, MetricInput
 
-_CANDIDATE_SAMPLE_FIELDS = frozenset({"output_text", "response", "trajectory"})
+_CANDIDATE_SAMPLE_FIELDS = frozenset({"output_text", "response", "trajectory", "evidence"})
 
 
 def build_offline_sample(row: dict[str, Any]) -> dict[str, Any]:
@@ -37,6 +37,7 @@ def build_metric_input(row: dict[str, Any], sample: dict[str, Any], index: int |
             output_text=output_text if isinstance(output_text, str) else None,
             response=sample.get("response"),
             trajectory=sample.get("trajectory"),
+            evidence=sample.get("evidence"),
             metadata=metadata,
         ),
     )


### PR DESCRIPTION
Add the standalone agent-eval orchestration engine on top of the domain model: AgentEvaluator (generation + scoring), run-bundle persistence, and an HTML dashboard.

Adapted to the refactored domain model: trial/score naming, status enums, AggregatedMetricResult-based summary, and from_scores aggregation. Online inference seams (inference fns, clients, default headers) are injected on the AgentEvaluator instance rather than AgentEvalRunConfig. Also maps candidate evidence through build_metric_input so metrics can consume trial evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an agent evaluation orchestrator to validate inputs, run scoring concurrently, and return a complete evaluation result bundle.
  * Added HTML dashboard rendering and file writing for compact evaluation summaries, metric rollups, and per-trial score tables.
  * Added run persistence to save benchmark/summary JSON, JSONL task/trial/score data, and a run manifest to disk.
  * Extended evaluation sample handling to include `evidence` in candidate payloads.
* **Tests**
  * Added dashboard and evaluator test suites covering scoring flows, failure modes, persistence, and live trial generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->