### PR TITLE
feat(customizer): expose all hyperparams supported in backend lib

### DIFF
--- a/plugins/nemo-automodel/src/nemo_automodel_plugin/schema.py
+++ b/plugins/nemo-automodel/src/nemo_automodel_plugin/schema.py
@@ -38,6 +38,10 @@ class LoRAParams(BaseModel):
     dropout: float = Field(default=0.0, ge=0.0, le=1.0, description="LoRA dropout probability for regularization.")
     merge: bool = False
     target_modules: list[str] | None = None
+    exclude_modules: list[str] | None = Field(
+        default=None, description="Module name patterns to exclude from LoRA (e.g. ['*.out_proj'])."
+    )
+    use_triton: bool = Field(default=True, description="Use the optimized Triton LoRA kernel.")
 
 
 class DatasetSpec(BaseModel):
@@ -58,6 +62,10 @@ class TrainingSpec(BaseModel):
     precision: Literal["bf16", "fp16", "fp32", "fp8"] | None = Field(
         default=None,
         description="Model precision for training. Auto-detected from the checkpoint when unset.",
+    )
+    attn_implementation: Literal["sdpa", "flash_attention_2", "eager"] = Field(
+        default="sdpa",
+        description="Attention backend: 'sdpa' (PyTorch native), 'flash_attention_2', or 'eager'.",
     )
     execution_profile: str | None = Field(default=None, min_length=1)
     teacher_model: str | None = None
@@ -90,6 +98,9 @@ class BatchSpec(BaseModel):
     global_batch_size: int = Field(default=8, gt=0)
     micro_batch_size: int = Field(default=1, gt=0)
     sequence_packing: bool = False
+    sequence_packing_max_samples: int = Field(
+        default=1000, gt=0, description="Samples analyzed to estimate the optimal pack size when packing is enabled."
+    )
 
 
 class OptimizerSpec(BaseModel):
@@ -103,6 +114,11 @@ class OptimizerSpec(BaseModel):
     adam_beta1: float = Field(default=0.9, ge=0.0, lt=1.0, description="Adam optimizer beta1.")
     adam_beta2: float = Field(default=0.999, ge=0.0, lt=1.0, description="Adam optimizer beta2.")
     warmup_steps: int = Field(default=0, ge=0)
+    adam_eps: float = Field(default=1e-8, gt=0.0, description="Adam/AdamW epsilon for numerical stability.")
+    optimizer: Literal["Adam", "AdamW"] = Field(default="Adam", description="Optimizer algorithm.")
+    lr_decay_style: Literal["cosine", "linear", "constant"] = Field(
+        default="cosine", description="Learning-rate decay schedule."
+    )
 
 
 class ParallelismSpec(BaseModel):

--- a/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/references/hyperparameters.md
+++ b/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/references/hyperparameters.md
@@ -117,10 +117,13 @@ Full template:
       "alpha": 32,
       "dropout": 0.0,
       "merge": false,
-      "target_modules": null
+      "target_modules": null,
+      "exclude_modules": null,
+      "use_triton": true
     },
     "max_seq_length": 2048,
     "precision": null,
+    "attn_implementation": "sdpa",
     "execution_profile": null
   },
   "schedule": {
@@ -132,7 +135,8 @@ Full template:
   "batch": {
     "global_batch_size": 4,
     "micro_batch_size": 1,
-    "sequence_packing": false
+    "sequence_packing": false,
+    "sequence_packing_max_samples": 1000
   },
   "optimizer": {
     "learning_rate": 5e-5,
@@ -140,6 +144,9 @@ Full template:
     "weight_decay": 0.01,
     "adam_beta1": 0.9,
     "adam_beta2": 0.999,
+    "adam_eps": 1e-8,
+    "optimizer": "Adam",
+    "lr_decay_style": "cosine",
     "warmup_steps": 0
   },
   "parallelism": {
@@ -171,8 +178,11 @@ Full template:
 | `lora.dropout` | `0.0` | LoRA dropout (0.0–1.0) for regularization |
 | `lora.merge` | `false` | If true with `lora_merged`, output is full weights not adapter |
 | `lora.target_modules` | `null` | e.g. `["q_proj","v_proj"]`; null = platform default targets |
+| `lora.exclude_modules` | `null` | Patterns to exclude from LoRA, e.g. `["*.out_proj"]` |
+| `lora.use_triton` | `true` | Use the optimized Triton LoRA kernel |
 | `max_seq_length` | `2048` | Truncate/pack to this length; lower if OOM |
 | `precision` | `null` | `bf16` \| `fp16` \| `fp32` \| `fp8`; null auto-detects from the checkpoint |
+| `attn_implementation` | `sdpa` | `sdpa` (PyTorch native) \| `flash_attention_2` \| `eager` |
 | `teacher_model` | — | **Model entity ref** (not HF id). Required for distillation; see below |
 | `distillation_ratio` | `0.5` | KD blend (0–1) |
 | `distillation_temperature` | `1.0` | KD temperature |
@@ -199,6 +209,7 @@ LoRA block is auto-created when `finetuning_type` is `lora` or `lora_merged`.
 | `global_batch_size` | `8` (schema) | Effective batch across all GPUs; **≥48 GB LoRA tables → `SKILL.md`** |
 | `micro_batch_size` | `1` (schema) | **Per GPU**; same SKILL tables for single- and multi-GPU (TP=1) |
 | `sequence_packing` | `false` | Pack short sequences for throughput (needs compatible data) |
+| `sequence_packing_max_samples` | `1000` | Samples analyzed to estimate the optimal pack size (only when packing) |
 
 **Validation:** `global_batch_size` must be divisible by `micro_batch_size × data_parallel_size`, where:
 
@@ -215,6 +226,9 @@ Example: 1 node, 2 GPUs, TP=1 → DP=2 → GBS must be a multiple of `2 × micro
 | `weight_decay` | `0.01` | L2-style regularization |
 | `adam_beta1` | `0.9` | Adam optimizer beta1 |
 | `adam_beta2` | `0.999` | Adam optimizer beta2 |
+| `adam_eps` | `1e-8` | Adam/AdamW epsilon for numerical stability |
+| `optimizer` | `Adam` | `Adam` \| `AdamW` |
+| `lr_decay_style` | `cosine` | `cosine` \| `linear` \| `constant` |
 | `warmup_steps` | `0` | Linear warmup; try ~10% of total steps for long runs |
 
 ### `parallelism`
@@ -403,7 +417,9 @@ Full template (every section, defaults inline):
     "load_in_4bit": true,
     "load_in_8bit": false,
     "dtype": "auto",
-    "trust_remote_code": false
+    "trust_remote_code": false,
+    "device_map": null,
+    "rope_scaling": null
   },
   "dataset": {
     "path": "default/<dataset-fileset>",
@@ -422,7 +438,13 @@ Full template (every section, defaults inline):
       "target_modules": ["q_proj","k_proj","v_proj","o_proj","gate_proj","up_proj","down_proj"],
       "bias": "none",
       "use_rslora": false,
-      "random_state": 3407
+      "random_state": 3407,
+      "use_dora": false,
+      "loftq_config": null,
+      "modules_to_save": null,
+      "layers_to_transform": null,
+      "layer_replication": null,
+      "init_lora_weights": true
     },
     "use_gradient_checkpointing": "unsloth"
   },
@@ -432,6 +454,7 @@ Full template (every section, defaults inline):
     "warmup_steps": 0,
     "warmup_ratio": null,
     "lr_scheduler_type": "linear",
+    "lr_scheduler_kwargs": null,
     "logging_steps": 1,
     "save_steps": null,
     "eval_steps": null,
@@ -444,7 +467,13 @@ Full template (every section, defaults inline):
   "optimizer": {
     "learning_rate": 5e-5,
     "weight_decay": 0.0,
-    "optim": "adamw_8bit"
+    "optim": "adamw_8bit",
+    "adam_beta1": 0.9,
+    "adam_beta2": 0.999,
+    "adam_epsilon": 1e-8,
+    "max_grad_norm": 1.0,
+    "label_smoothing_factor": 0.0,
+    "neftune_noise_alpha": null
   },
   "hardware": {
     "gpus": "0",
@@ -474,6 +503,7 @@ Full template (every section, defaults inline):
 | `dtype` | `"auto"` | One of `"auto"`, `"bfloat16"`, `"float16"`, `"float32"`. |
 | `trust_remote_code` | `false` | HF `trust_remote_code` flag for custom model code (required by some hybrid Mamba/MoE models, e.g. Nemotron-H). |
 | `device_map` | `null` | Placement for `FastLanguageModel.from_pretrained`. `null` pins the whole model to the single visible GPU (`{"": 0}`) — the right default for this single-GPU backend. Leave unset unless experimenting; `"auto"`/`"balanced"`/`"sequential"` can spill layers to CPU on unified-memory hosts (GB10 / DGX Spark) and abort 4-bit loads. |
+| `rope_scaling` | `null` | RoPE scaling for long-context extension, e.g. `{"type": "linear", "factor": 2.0}`. `null` uses the model's native context length. |
 
 **Mutex:** `load_in_4bit` xor `load_in_8bit`. Both quantization flags are also **incompatible with `training.finetuning_type: "all_weights"`** — full SFT must use a non-quantized base.
 
@@ -511,6 +541,12 @@ See `references/dataset-formats.md` § Unsloth for row-shape rules.
 | `bias` | `"none"` | `"none"` / `"all"` / `"lora_only"`. |
 | `use_rslora` | `false` | Rank-stabilized LoRA. |
 | `random_state` | `3407` | Reproducibility seed for the LoRA init. |
+| `use_dora` | `false` | DoRA (weight-decomposed LoRA). Better quality at low ranks; adds overhead. |
+| `loftq_config` | `null` | LoftQ init config for quantized bases. `null` disables. |
+| `modules_to_save` | `null` | Extra non-LoRA modules trained & saved in full, e.g. `["embed_tokens","lm_head"]` (vocab changes / continued pretraining). |
+| `layers_to_transform` | `null` | Restrict LoRA to specific layer index(es). `null` = all layers. |
+| `layer_replication` | `null` | Layer-replication ranges for stacking, e.g. `[[0,16],[8,24]]`. |
+| `init_lora_weights` | `true` | Init scheme. `true` = PEFT default; `"gaussian"`/`"pissa"`/`"olora"`/`"loftq"` for advanced inits. |
 
 `lora` is auto-filled with these defaults when `finetuning_type: "lora"` and the user omits the block. Must be `null` / omitted when `finetuning_type: "all_weights"`.
 
@@ -523,6 +559,7 @@ See `references/dataset-formats.md` § Unsloth for row-shape rules.
 | `warmup_steps` | `0` | Linear warmup. Mutex with `warmup_ratio`. |
 | `warmup_ratio` | `null` | Fractional warmup over total steps. Mutex with `warmup_steps`. |
 | `lr_scheduler_type` | `"linear"` | `"linear"`, `"cosine"`, `"constant"`, `"constant_with_warmup"`, `"cosine_with_restarts"`. |
+| `lr_scheduler_kwargs` | `null` | Extra scheduler kwargs, e.g. `{"num_cycles": 3}` for `cosine_with_restarts`. `null` uses defaults. |
 | `logging_steps` | `1` | Loss-log cadence. |
 | `save_steps` | `null` | If set, save checkpoint every N steps. |
 | `eval_steps` | `null` | If set with `validation_path`, eval every N steps. When `null` and `validation_path` is set, the training driver defaults to **one validation pass per effective epoch** at `max(1, effective_steps - 1)` (same effective-step cap as automodel's default `val_check_interval`). |
@@ -546,6 +583,12 @@ See `references/dataset-formats.md` § Unsloth for row-shape rules.
 | `learning_rate` | `2e-4` (schema default; skill uses `5e-5` for LoRA SFT) | See LR table below. |
 | `weight_decay` | `0.0` | L2-style regularization. |
 | `optim` | `"adamw_8bit"` | `"adamw_torch"`, `"adamw_torch_fused"` (Hopper+), `"adamw_8bit"`, `"paged_adamw_8bit"`, `"sgd"`. `adamw_8bit` has the smallest optimizer state and is Unsloth's notebook default. |
+| `adam_beta1` | `0.9` | Adam/AdamW beta1. |
+| `adam_beta2` | `0.999` | Adam/AdamW beta2. |
+| `adam_epsilon` | `1e-8` | Adam/AdamW epsilon. |
+| `max_grad_norm` | `1.0` | Gradient-clipping max norm (TRL default). |
+| `label_smoothing_factor` | `0.0` | Label smoothing for the CE loss. `0.0` disables. |
+| `neftune_noise_alpha` | `null` | NEFTune embedding-noise alpha (quality boost). `null` disables. |
 
 `warmup_steps` is on `schedule`, not on `optimizer` (different from the automodel schema).
 

--- a/plugins/nemo-unsloth/src/nemo_unsloth_plugin/schema.py
+++ b/plugins/nemo-unsloth/src/nemo_unsloth_plugin/schema.py
@@ -100,18 +100,14 @@ class UnslothJobInput(BaseModel):
         # 4bit / 8bit mutex (bitsandbytes — they really are exclusive)
         if self.model.load_in_4bit and self.model.load_in_8bit:
             raise ValueError("model.load_in_4bit and model.load_in_8bit are mutually exclusive")
-        # all-weights (full) FT cannot quantize
+        # all-weights (full) FT cannot quantize. The lora/finetuning_type invariant
+        # (auto-fill for lora, reject lora for all_weights) is enforced in TrainingSpec.
         if self.training.finetuning_type == "all_weights":
             if self.model.load_in_4bit or self.model.load_in_8bit:
                 raise ValueError(
                     "training.finetuning_type='all_weights' is incompatible with 4-bit/8-bit loading; "
                     "set model.load_in_4bit=false and model.load_in_8bit=false"
                 )
-            if self.training.lora is not None:
-                raise ValueError("training.lora must be unset when training.finetuning_type='all_weights'")
-        # auto-fill LoRA when implied but not provided
-        if self.training.finetuning_type == "lora" and self.training.lora is None:
-            self.training.lora = LoRAParams()
         # warmup_steps and warmup_ratio mutex (transformers also enforces this
         # at runtime; we surface it earlier with a clearer message)
         if self.schedule.warmup_steps and self.schedule.warmup_ratio is not None:

--- a/services/automodel/src/nmp/automodel/adapter.py
+++ b/services/automodel/src/nmp/automodel/adapter.py
@@ -38,6 +38,8 @@ def _build_peft(training: dict[str, Any]) -> LoRAParams | None:
         dropout=lora.get("dropout", 0.0),
         merge=ft == "lora_merged" or lora.get("merge", False),
         target_modules=lora.get("target_modules"),
+        exclude_modules=lora.get("exclude_modules"),
+        use_triton=lora.get("use_triton", True),
     )
 
 
@@ -55,6 +57,9 @@ def _build_training_block(spec: dict[str, Any]) -> SFTTraining | DistillationTra
         "weight_decay": optimizer.get("weight_decay", 0.01),
         "adam_beta1": optimizer.get("adam_beta1", 0.9),
         "adam_beta2": optimizer.get("adam_beta2", 0.999),
+        "adam_eps": optimizer.get("adam_eps", 1e-8),
+        "optimizer": optimizer.get("optimizer", "Adam"),
+        "lr_decay_style": optimizer.get("lr_decay_style", "cosine"),
         "warmup_steps": optimizer.get("warmup_steps", 0),
         "epochs": schedule.get("epochs", 1),
         "max_steps": schedule.get("max_steps"),
@@ -62,8 +67,10 @@ def _build_training_block(spec: dict[str, Any]) -> SFTTraining | DistillationTra
         "batch_size": batch.get("global_batch_size", 8),
         "micro_batch_size": batch.get("micro_batch_size", 1),
         "sequence_packing": batch.get("sequence_packing", False),
+        "sequence_packing_max_samples": batch.get("sequence_packing_max_samples", 1000),
         "max_seq_length": training.get("max_seq_length", 2048),
         "precision": training.get("precision"),
+        "attn_implementation": training.get("attn_implementation", "sdpa"),
         "seed": schedule.get("seed"),
         "parallelism": ParallelismParams(
             num_nodes=parallelism.get("num_nodes", 1),

--- a/services/automodel/src/nmp/automodel/api/v2/jobs/schemas.py
+++ b/services/automodel/src/nmp/automodel/api/v2/jobs/schemas.py
@@ -88,6 +88,14 @@ class LoRAParams(_PEFTParams):
         description="Module name patterns to apply LoRA to (e.g., ['*.q_proj', '*.v_proj']). "
         "If not set, applies to all '*proj' linear layers.",
     )
+    exclude_modules: Optional[list[str]] = Field(
+        default=None,
+        description="Module name patterns to exclude from LoRA (e.g., ['*.out_proj']).",
+    )
+    use_triton: bool = Field(
+        default=True,
+        description="Use the optimized Triton LoRA kernel.",
+    )
     merge: bool = Field(
         default=False,
         description="Merge LoRA weights into base model after training. "
@@ -173,12 +181,20 @@ class _TrainingBase(BaseModel):
         default=0.999,
         description="Adam beta2 parameter. Adjust for optimizer tuning.",
     )
+    adam_eps: float = Field(
+        default=1e-8,
+        gt=0.0,
+        description="Adam/AdamW epsilon for numerical stability.",
+    )
     warmup_steps: int = Field(
         default=0,
         ge=0,
         description="Linear warmup steps. Recommended: 10% of total training steps for stable training.",
     )
-    optimizer: Optional[str] = Field(default=None, description="Optimizer name (e.g., 'adamw').")
+    optimizer: Literal["Adam", "AdamW"] = Field(default="Adam", description="Optimizer algorithm.")
+    lr_decay_style: Literal["cosine", "linear", "constant"] = Field(
+        default="cosine", description="Learning-rate decay schedule."
+    )
 
     # --- Schedule ---
     epochs: int = Field(
@@ -218,6 +234,11 @@ class _TrainingBase(BaseModel):
         default=False,
         description="Enable sequence packing for efficiency. Can improve training speed.",
     )
+    sequence_packing_max_samples: int = Field(
+        default=1000,
+        gt=0,
+        description="Samples analyzed to estimate the optimal pack size when sequence packing is enabled.",
+    )
 
     # --- Model ---
     max_seq_length: int = Field(
@@ -228,6 +249,10 @@ class _TrainingBase(BaseModel):
     precision: Optional[Precision] = Field(
         default=None,
         description="Model precision for training. Auto-detected if unset.",
+    )
+    attn_implementation: Literal["sdpa", "flash_attention_2", "eager"] = Field(
+        default="sdpa",
+        description="Attention backend: 'sdpa' (PyTorch native), 'flash_attention_2', or 'eager'.",
     )
     seed: Optional[int] = Field(
         default=None,

--- a/services/automodel/src/nmp/automodel/app/jobs/training/compiler.py
+++ b/services/automodel/src/nmp/automodel/app/jobs/training/compiler.py
@@ -157,10 +157,14 @@ def compile_training_step(
             global_batch_size=training.batch_size,
             micro_batch_size=training.micro_batch_size,
             sequence_packing=training.sequence_packing,
+            sequence_packing_max_samples=training.sequence_packing_max_samples,
         ),
         optimizer=TrainingStepConfig.OptimizerConfig(
+            optimizer_name=training.optimizer,
+            lr_decay_style=training.lr_decay_style,
             learning_rate=training.learning_rate,
             min_learning_rate=training.min_learning_rate,
+            eps=training.adam_eps,
             weight_decay=training.weight_decay,
             beta1=training.adam_beta1,
             beta2=training.adam_beta2,
@@ -241,6 +245,7 @@ def _translate_model_config(
         name=_extract_model_name(job_spec),
         max_seq_length=training.max_seq_length,
         precision=training.precision,
+        attn_implementation=training.attn_implementation,
         trust_remote_code=trust_remote_code,
         is_embedding_model=is_embedding_model,
         chat_template=chat_template,
@@ -293,7 +298,8 @@ def _translate_lora_config(api_lora: LoRAParams, me: ModelEntity) -> LoRAConfig:
         alpha=api_lora.alpha,
         dropout=api_lora.dropout,
         target_modules=api_lora.target_modules,
-        use_triton=True,
+        exclude_modules=api_lora.exclude_modules,
+        use_triton=api_lora.use_triton,
     )
 
     if not lora.target_modules:

--- a/services/automodel/src/nmp/automodel/app/jobs/training/schemas.py
+++ b/services/automodel/src/nmp/automodel/app/jobs/training/schemas.py
@@ -186,6 +186,8 @@ class TrainingStepConfig(BaseModel):
 
     class OptimizerConfig(BaseModel):
         optimizer_type: Optional[OptimizerType] = Field(default=None)
+        optimizer_name: str = "Adam"
+        lr_decay_style: str = "cosine"
         learning_rate: float = 1e-4
         min_learning_rate: Optional[float] = None
         eps: float = 1e-8

--- a/services/automodel/src/nmp/automodel/tasks/training/backends/config.py
+++ b/services/automodel/src/nmp/automodel/tasks/training/backends/config.py
@@ -233,8 +233,14 @@ def compile_automodel_config(
             )
 
     # === Optimizer ===
+    # Map the optimizer choice to its torch class. Reject unknown names instead of
+    # silently falling back to Adam, which would mask a misconfigured optimizer.
+    optimizer_targets = {"Adam": "torch.optim.Adam", "AdamW": "torch.optim.AdamW"}
+    optimizer_name = customizer_config.optimizer.optimizer_name
+    if optimizer_name not in optimizer_targets:
+        raise ValueError(f"Unsupported optimizer_name {optimizer_name!r}; expected one of {sorted(optimizer_targets)}.")
     cfg["optimizer"] = {
-        "_target_": "torch.optim.Adam",
+        "_target_": optimizer_targets[optimizer_name],
         "lr": customizer_config.optimizer.learning_rate,
         "weight_decay": customizer_config.optimizer.weight_decay,
         "betas": [customizer_config.optimizer.beta1, customizer_config.optimizer.beta2],
@@ -242,7 +248,7 @@ def compile_automodel_config(
     }
 
     cfg["lr_scheduler"] = {
-        "lr_decay_style": "cosine",
+        "lr_decay_style": customizer_config.optimizer.lr_decay_style,
         "lr_warmup_steps": customizer_config.optimizer.warmup_steps,
     }
     if customizer_config.optimizer.min_learning_rate:
@@ -289,7 +295,6 @@ def compile_automodel_config(
 
             cfg["packed_sequence"] = {
                 "packed_sequence_size": optimal_pack_size,
-                "split_across_pack": False,
             }
 
             # Use pack size as the effective sequence length for datasets
@@ -335,9 +340,8 @@ def compile_automodel_config(
             "use_triton": lora.use_triton,
             "target_modules": lora.target_modules,
         }
-        # TODO: Support exclude_modules via the API
-        # if lora.exclude_modules:
-        #     peft_cfg["exclude_modules"] = lora.exclude_modules
+        if lora.exclude_modules:
+            peft_cfg["exclude_modules"] = lora.exclude_modules
         cfg["peft"] = peft_cfg
 
     # === Loss ===

--- a/services/automodel/tests/contract/output_configs/gpt_oss_lora_packing.yaml
+++ b/services/automodel/tests/contract/output_configs/gpt_oss_lora_packing.yaml
@@ -49,7 +49,6 @@ checkpoint:
   v4_compatible: true
 packed_sequence:
   packed_sequence_size: 816
-  split_across_pack: false
 dataset:
   _target_: nemo_automodel.components.datasets.llm.column_mapped_text_instruction_dataset.ColumnMappedTextInstructionDataset
   path_or_dataset_id: ./sample-datasets/prompt_completion/training.jsonl

--- a/services/automodel/tests/contract/output_configs/llama_3_2_1b_lora_packing.yaml
+++ b/services/automodel/tests/contract/output_configs/llama_3_2_1b_lora_packing.yaml
@@ -46,7 +46,6 @@ checkpoint:
   v4_compatible: true
 packed_sequence:
   packed_sequence_size: 832
-  split_across_pack: false
 dataset:
   _target_: nemo_automodel.components.datasets.llm.column_mapped_text_instruction_dataset.ColumnMappedTextInstructionDataset
   path_or_dataset_id: ./sample-datasets/prompt_completion/training.jsonl

--- a/services/automodel/tests/contract/output_configs/nemotron_nano_lora_packing.yaml
+++ b/services/automodel/tests/contract/output_configs/nemotron_nano_lora_packing.yaml
@@ -50,7 +50,6 @@ checkpoint:
   v4_compatible: false
 packed_sequence:
   packed_sequence_size: 212
-  split_across_pack: false
 dataset:
   _target_: nemo_automodel.components.datasets.llm.column_mapped_text_instruction_dataset.ColumnMappedTextInstructionDataset
   path_or_dataset_id: ./sample-datasets/prompt_completion/training.jsonl

--- a/services/automodel/tests/test_adapter.py
+++ b/services/automodel/tests/test_adapter.py
@@ -72,6 +72,55 @@ def test_adapter_new_fields_default_when_omitted() -> None:
     assert spec.training.peft.dropout == 0.0
 
 
+def test_adapter_plumbs_pass2_hyperparameters() -> None:
+    """Pass-2 hyperparameters set on the plugin spec must reach the v2 SFTTraining."""
+    spec = automodel_spec_to_compiler_output(
+        {
+            "model": "meta/llama",
+            "dataset": {"training": "default/train"},
+            "training": {
+                "training_type": "sft",
+                "finetuning_type": "lora",
+                "attn_implementation": "flash_attention_2",
+                "lora": {"rank": 8, "exclude_modules": ["*.out_proj"], "use_triton": False},
+            },
+            "optimizer": {"adam_eps": 1e-6, "optimizer": "AdamW", "lr_decay_style": "linear"},
+            "batch": {"sequence_packing": True, "sequence_packing_max_samples": 256},
+            "output": {"name": "out", "type": "adapter", "fileset": "out-fs"},
+        },
+    )
+    assert isinstance(spec.training, SFTTraining)
+    assert spec.training.adam_eps == 1e-6
+    assert spec.training.optimizer == "AdamW"
+    assert spec.training.lr_decay_style == "linear"
+    assert spec.training.attn_implementation == "flash_attention_2"
+    assert spec.training.sequence_packing_max_samples == 256
+    assert spec.training.peft is not None
+    assert spec.training.peft.exclude_modules == ["*.out_proj"]
+    assert spec.training.peft.use_triton is False
+
+
+def test_adapter_pass2_defaults_when_omitted() -> None:
+    """Omitting pass-2 fields preserves the historical hardcoded defaults."""
+    spec = automodel_spec_to_compiler_output(
+        {
+            "model": "meta/llama",
+            "dataset": {"training": "default/train"},
+            "training": {"training_type": "sft", "finetuning_type": "lora"},
+            "output": {"name": "out", "type": "adapter", "fileset": "out-fs"},
+        },
+    )
+    assert isinstance(spec.training, SFTTraining)
+    assert spec.training.adam_eps == 1e-8
+    assert spec.training.optimizer == "Adam"
+    assert spec.training.lr_decay_style == "cosine"
+    assert spec.training.attn_implementation == "sdpa"
+    assert spec.training.sequence_packing_max_samples == 1000
+    assert spec.training.peft is not None
+    assert spec.training.peft.exclude_modules is None
+    assert spec.training.peft.use_triton is True
+
+
 def test_adapter_distillation() -> None:
     spec = automodel_spec_to_compiler_output(
         {

--- a/services/automodel/tests/test_compiler.py
+++ b/services/automodel/tests/test_compiler.py
@@ -70,6 +70,40 @@ def test_build_file_download_config_rejects_missing_model_fileset() -> None:
         _build_file_download_config(_make_job_output(), _make_mock_model_entity(fileset=None))
 
 
+def test_compile_training_step_carries_pass2_fields() -> None:
+    """Pass-2 hyperparameters on the v2 SFTTraining reach the internal TrainingStepConfig."""
+    from nmp.automodel.app.jobs.training.compiler import compile_training_step
+
+    job_output = CustomizationJobOutput(
+        model="default/test-target",
+        dataset="default/my-dataset",
+        training=SFTTraining(
+            peft=LoRAParams(rank=8, alpha=32, merge=False, exclude_modules=["*.out_proj"], use_triton=False),
+            learning_rate=1e-4,
+            adam_eps=1e-6,
+            optimizer="AdamW",
+            lr_decay_style="linear",
+            attn_implementation="flash_attention_2",
+            batch_size=4,
+            micro_batch_size=1,
+            sequence_packing=True,
+            sequence_packing_max_samples=256,
+            max_seq_length=2048,
+        ),
+        output=OutputResponse(name="out", type="adapter", fileset="out-fs"),
+    )
+    step = compile_training_step(job_output, base_env=[], me=_make_mock_model_entity())
+    cfg = step.config if hasattr(step, "config") else step["config"]
+
+    assert cfg["optimizer"]["optimizer_name"] == "AdamW"
+    assert cfg["optimizer"]["lr_decay_style"] == "linear"
+    assert cfg["optimizer"]["eps"] == 1e-6
+    assert cfg["model"]["attn_implementation"] == "flash_attention_2"
+    assert cfg["batch"]["sequence_packing_max_samples"] == 256
+    assert cfg["training"]["lora"]["exclude_modules"] == ["*.out_proj"]
+    assert cfg["training"]["lora"]["use_triton"] is False
+
+
 @pytest.mark.asyncio
 async def test_platform_job_config_compiler_sft_lora(mock_sdk, monkeypatch):
     monkeypatch.setattr(

--- a/services/unsloth/src/nmp/unsloth/schemas.py
+++ b/services/unsloth/src/nmp/unsloth/schemas.py
@@ -29,10 +29,10 @@ validation errors, not silently-ignored fields.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal, Self
 
 from nemo_platform_plugin.integrations import IntegrationsSpec
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ModelLoadSpec(BaseModel):
@@ -74,6 +74,14 @@ class ModelLoadSpec(BaseModel):
             "multi-device experiments."
         ),
     )
+    rope_scaling: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "RoPE scaling config for long-context extension, passed to "
+            "FastLanguageModel.from_pretrained (e.g. {'type': 'linear', 'factor': 2.0}). "
+            "None uses the model's native context length."
+        ),
+    )
 
 
 class LoRAParams(BaseModel):
@@ -99,6 +107,33 @@ class LoRAParams(BaseModel):
     bias: Literal["none", "all", "lora_only"] = "none"
     use_rslora: bool = False
     random_state: int = 3407
+    use_dora: bool = Field(
+        default=False,
+        description="DoRA (weight-decomposed LoRA). Improves quality at low ranks; adds training overhead.",
+    )
+    loftq_config: dict[str, Any] | None = Field(
+        default=None,
+        description="LoftQ initialization config for quantized bases. None disables LoftQ.",
+    )
+    modules_to_save: list[str] | None = Field(
+        default=None,
+        description=(
+            "Extra non-LoRA modules to train and save in full (e.g. ['embed_tokens', 'lm_head']). "
+            "Needed for vocab changes / continued pretraining."
+        ),
+    )
+    layers_to_transform: int | list[int] | None = Field(
+        default=None,
+        description="Restrict LoRA to specific layer index(es). None applies to all layers.",
+    )
+    layer_replication: list[list[int]] | None = Field(
+        default=None,
+        description="Layer-replication ranges for stacking, e.g. [[0, 16], [8, 24]]. None disables.",
+    )
+    init_lora_weights: bool | Literal["gaussian", "pissa", "olora", "loftq"] = Field(
+        default=True,
+        description="LoRA weight init scheme. True = PEFT default; 'pissa'/'olora'/'loftq' for advanced inits.",
+    )
 
 
 class TrainingSpec(BaseModel):
@@ -113,6 +148,22 @@ class TrainingSpec(BaseModel):
         description="Required when finetuning_type='lora'. Auto-filled with defaults if omitted.",
     )
     use_gradient_checkpointing: Literal["unsloth", "true", "false"] = "unsloth"
+
+    @model_validator(mode="after")
+    def _enforce_lora_invariant(self) -> Self:
+        """Keep ``lora`` consistent with ``finetuning_type`` at the schema level.
+
+        ``build_peft_kwargs`` (and the training driver) assume a LoRA run always
+        carries a populated ``lora`` block. Enforcing it here means every path
+        that builds a ``TrainingSpec`` — the plugin's ``UnslothJobInput``, a
+        directly-constructed ``UnslothJobOutput``, SDK callers, tests — gets the
+        invariant for free, instead of relying on a downstream ``assert``.
+        """
+        if self.finetuning_type == "lora" and self.lora is None:
+            self.lora = LoRAParams()
+        if self.finetuning_type == "all_weights" and self.lora is not None:
+            raise ValueError("training.lora must be unset when finetuning_type='all_weights'")
+        return self
 
 
 class DatasetSpec(BaseModel):
@@ -170,6 +221,13 @@ class ScheduleSpec(BaseModel):
     save_steps: int | None = Field(default=None, gt=0)
     eval_steps: int | None = Field(default=None, gt=0)
     seed: int = 3407
+    lr_scheduler_kwargs: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Extra kwargs for the LR scheduler, e.g. {'num_cycles': 3} for cosine_with_restarts. "
+            "None uses scheduler defaults."
+        ),
+    )
 
 
 class BatchSpec(BaseModel):
@@ -194,6 +252,18 @@ class OptimizerSpec(BaseModel):
         "paged_adamw_8bit",
         "sgd",
     ] = "adamw_8bit"
+    adam_beta1: float = Field(default=0.9, ge=0.0, lt=1.0, description="Adam/AdamW beta1.")
+    adam_beta2: float = Field(default=0.999, ge=0.0, lt=1.0, description="Adam/AdamW beta2.")
+    adam_epsilon: float = Field(default=1e-8, gt=0.0, description="Adam/AdamW epsilon for numerical stability.")
+    max_grad_norm: float = Field(default=1.0, ge=0.0, description="Gradient-clipping max norm (TRL default 1.0).")
+    label_smoothing_factor: float = Field(
+        default=0.0, ge=0.0, lt=1.0, description="Label smoothing for the cross-entropy loss. 0.0 disables."
+    )
+    neftune_noise_alpha: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="NEFTune embedding-noise alpha (quality boost). None disables.",
+    )
 
 
 class HardwareSpec(BaseModel):

--- a/services/unsloth/src/nmp/unsloth/tasks/training/backends/unsloth_sft.py
+++ b/services/unsloth/src/nmp/unsloth/tasks/training/backends/unsloth_sft.py
@@ -67,7 +67,7 @@ def build_model_load_kwargs(spec: UnslothJobOutput, resolved_model: str) -> dict
     takes its default LoRA-optimized load path and warns that full finetuning
     was not requested, leaving the all-weights run mis-configured.
     """
-    return {
+    kwargs: dict[str, Any] = {
         "model_name": resolved_model,
         "max_seq_length": spec.model.max_seq_length,
         "load_in_4bit": spec.model.load_in_4bit,
@@ -76,6 +76,45 @@ def build_model_load_kwargs(spec: UnslothJobOutput, resolved_model: str) -> dict
         "trust_remote_code": spec.model.trust_remote_code,
         "device_map": spec.model.device_map if spec.model.device_map is not None else {"": 0},
     }
+    # Only pass rope_scaling when set — None lets Unsloth use the model's native context length.
+    if spec.model.rope_scaling is not None:
+        kwargs["rope_scaling"] = spec.model.rope_scaling
+    return kwargs
+
+
+def build_peft_kwargs(spec: UnslothJobOutput, *, gradient_checkpointing: bool | str) -> dict[str, Any]:
+    """Assemble ``FastLanguageModel.get_peft_model`` kwargs for a LoRA run.
+
+    Torch-free (unit-testable). Caller resolves ``gradient_checkpointing`` from
+    ``spec.training.use_gradient_checkpointing`` (the JSON literal → ``True`` /
+    ``False`` / ``"unsloth"`` mapping). Optional knobs (``loftq_config``,
+    ``modules_to_save``, ``layers_to_transform``, ``layer_replication``) are only
+    emitted when set so PEFT/Unsloth see absence, not ``None``.
+    """
+    lora = spec.training.lora
+    assert lora is not None  # guaranteed by TrainingSpec._enforce_lora_invariant
+    kwargs: dict[str, Any] = {
+        "r": lora.rank,
+        "lora_alpha": lora.alpha,
+        "lora_dropout": lora.dropout,
+        "target_modules": list(lora.target_modules),
+        "bias": lora.bias,
+        "use_rslora": lora.use_rslora,
+        "random_state": lora.random_state,
+        "use_dora": lora.use_dora,
+        "init_lora_weights": lora.init_lora_weights,
+        "use_gradient_checkpointing": gradient_checkpointing,
+        "max_seq_length": spec.model.max_seq_length,
+    }
+    if lora.loftq_config is not None:
+        kwargs["loftq_config"] = lora.loftq_config
+    if lora.modules_to_save is not None:
+        kwargs["modules_to_save"] = lora.modules_to_save
+    if lora.layers_to_transform is not None:
+        kwargs["layers_to_transform"] = lora.layers_to_transform
+    if lora.layer_replication is not None:
+        kwargs["layer_replication"] = lora.layer_replication
+    return kwargs
 
 
 def train_sft(
@@ -183,15 +222,7 @@ def train_sft(
             gc_value = False
         model = FastLanguageModel.get_peft_model(
             model,
-            r=spec.training.lora.rank,
-            lora_alpha=spec.training.lora.alpha,
-            lora_dropout=spec.training.lora.dropout,
-            target_modules=list(spec.training.lora.target_modules),
-            bias=spec.training.lora.bias,
-            use_rslora=spec.training.lora.use_rslora,
-            random_state=spec.training.lora.random_state,
-            use_gradient_checkpointing=gc_value,
-            max_seq_length=spec.model.max_seq_length,
+            **build_peft_kwargs(spec, gradient_checkpointing=gc_value),
         )
     # All-weights FT: leave `model` as-is. `build_model_load_kwargs` passed
     # `full_finetuning=True`, so `from_pretrained` routed through Unsloth's
@@ -251,6 +282,11 @@ def train_sft(
         "learning_rate": spec.optimizer.learning_rate,
         "weight_decay": spec.optimizer.weight_decay,
         "optim": spec.optimizer.optim,
+        "adam_beta1": spec.optimizer.adam_beta1,
+        "adam_beta2": spec.optimizer.adam_beta2,
+        "adam_epsilon": spec.optimizer.adam_epsilon,
+        "max_grad_norm": spec.optimizer.max_grad_norm,
+        "label_smoothing_factor": spec.optimizer.label_smoothing_factor,
         "lr_scheduler_type": spec.schedule.lr_scheduler_type,
         "warmup_steps": spec.schedule.warmup_steps,
         "logging_steps": spec.schedule.logging_steps,
@@ -263,6 +299,11 @@ def train_sft(
         "max_length": spec.model.max_seq_length,
         "packing": spec.dataset.packing,
     }
+    # Optional knobs: only set when provided so trl/transformers keep their defaults.
+    if spec.optimizer.neftune_noise_alpha is not None:
+        args_kwargs["neftune_noise_alpha"] = spec.optimizer.neftune_noise_alpha
+    if spec.schedule.lr_scheduler_kwargs is not None:
+        args_kwargs["lr_scheduler_kwargs"] = spec.schedule.lr_scheduler_kwargs
     if spec.schedule.warmup_ratio is not None:
         args_kwargs["warmup_ratio"] = spec.schedule.warmup_ratio
     # epochs always set (defaults to 1); max_steps, when present, caps/overrides it (trl semantics).

--- a/services/unsloth/tests/test_model_load_kwargs.py
+++ b/services/unsloth/tests/test_model_load_kwargs.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for ``build_model_load_kwargs`` in the unsloth SFT driver.
+"""Tests for ``build_model_load_kwargs`` / ``build_peft_kwargs`` in the unsloth SFT driver.
 
 These exercise the torch-free kwargs assembly only, so the module imports
 fine on a CPU box without ``unsloth``/``torch`` installed.
@@ -9,21 +9,30 @@ fine on a CPU box without ``unsloth``/``torch`` installed.
 
 from __future__ import annotations
 
+from typing import Any
+
 from nmp.unsloth.schemas import (
     DatasetSpec,
+    LoRAParams,
     ModelLoadSpec,
     OutputResponse,
     TrainingSpec,
     UnslothJobOutput,
 )
-from nmp.unsloth.tasks.training.backends.unsloth_sft import build_model_load_kwargs
+from nmp.unsloth.tasks.training.backends.unsloth_sft import build_model_load_kwargs, build_peft_kwargs
 
 
-def _spec(*, finetuning_type: str, load_in_4bit: bool) -> UnslothJobOutput:
+def _spec(
+    *,
+    finetuning_type: str = "lora",
+    load_in_4bit: bool = True,
+    model_extra: dict[str, Any] | None = None,
+    lora: LoRAParams | None = None,
+) -> UnslothJobOutput:
     return UnslothJobOutput(
-        model=ModelLoadSpec(name="meta/llama-3.1-8b", load_in_4bit=load_in_4bit),
+        model=ModelLoadSpec(name="meta/llama-3.1-8b", load_in_4bit=load_in_4bit, **(model_extra or {})),
         dataset=DatasetSpec(path="ws/train"),
-        training=TrainingSpec(finetuning_type=finetuning_type),
+        training=TrainingSpec(finetuning_type=finetuning_type, lora=lora),
         output=OutputResponse(name="out", type="model", save_method="lora", fileset="out"),
     )
 
@@ -47,3 +56,44 @@ def test_dtype_not_included() -> None:
     # dtype mapping needs torch and stays in train_sft; the helper must not emit it.
     kwargs = build_model_load_kwargs(_spec(finetuning_type="lora", load_in_4bit=True), "/local/model")
     assert "dtype" not in kwargs
+
+
+def test_rope_scaling_omitted_when_none() -> None:
+    kwargs = build_model_load_kwargs(_spec(), "/local/model")
+    assert "rope_scaling" not in kwargs
+
+
+def test_rope_scaling_passed_when_set() -> None:
+    spec = _spec(model_extra={"rope_scaling": {"type": "linear", "factor": 2.0}})
+    kwargs = build_model_load_kwargs(spec, "/local/model")
+    assert kwargs["rope_scaling"] == {"type": "linear", "factor": 2.0}
+
+
+def test_peft_kwargs_defaults_preserve_behavior() -> None:
+    # Default LoRAParams → library-default knobs; optional ones omitted (not None).
+    kwargs = build_peft_kwargs(_spec(lora=LoRAParams()), gradient_checkpointing="unsloth")
+    assert kwargs["r"] == 16
+    assert kwargs["use_dora"] is False
+    assert kwargs["init_lora_weights"] is True
+    assert kwargs["use_gradient_checkpointing"] == "unsloth"
+    for omitted in ("loftq_config", "modules_to_save", "layers_to_transform", "layer_replication"):
+        assert omitted not in kwargs
+
+
+def test_peft_kwargs_emits_optional_fields_when_set() -> None:
+    lora = LoRAParams(
+        use_dora=True,
+        init_lora_weights="pissa",
+        modules_to_save=["embed_tokens", "lm_head"],
+        layers_to_transform=[0, 1, 2],
+        layer_replication=[[0, 16], [8, 24]],
+        loftq_config={"loftq_bits": 4},
+    )
+    kwargs = build_peft_kwargs(_spec(lora=lora), gradient_checkpointing=True)
+    assert kwargs["use_dora"] is True
+    assert kwargs["init_lora_weights"] == "pissa"
+    assert kwargs["modules_to_save"] == ["embed_tokens", "lm_head"]
+    assert kwargs["layers_to_transform"] == [0, 1, 2]
+    assert kwargs["layer_replication"] == [[0, 16], [8, 24]]
+    assert kwargs["loftq_config"] == {"loftq_bits": 4}
+    assert kwargs["use_gradient_checkpointing"] is True

--- a/services/unsloth/tests/test_schemas.py
+++ b/services/unsloth/tests/test_schemas.py
@@ -82,8 +82,21 @@ class TestSubShapesIndependently:
         t = TrainingSpec()
         assert t.training_type == "sft"
         assert t.finetuning_type == "lora"
-        # Canonical shape doesn't auto-fill `lora` (that's the plugin's
-        # input validator's job).
+        # finetuning_type defaults to 'lora', so the schema auto-fills a default
+        # LoRAParams block — downstream (build_peft_kwargs) can rely on it.
+        assert t.lora == LoRAParams()
+
+    def test_lora_finetuning_autofills_lora(self) -> None:
+        # Explicit lora type with no block → default LoRAParams, never None.
+        t = TrainingSpec(finetuning_type="lora", lora=None)
+        assert t.lora == LoRAParams()
+
+    def test_all_weights_rejects_lora_block(self) -> None:
+        with pytest.raises(ValidationError, match="training.lora must be unset"):
+            TrainingSpec(finetuning_type="all_weights", lora=LoRAParams())
+
+    def test_all_weights_allows_no_lora(self) -> None:
+        t = TrainingSpec(finetuning_type="all_weights")
         assert t.lora is None
 
     def test_output_response_extras_forbidden(self) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Expanded training customization for Automodel: optimizer selection (Adam/AdamW), configurable epsilon, learning-rate decay styles, attention backend choice, and sequence packing limits.
- Enhanced LoRA/PEFT controls: module exclusion patterns and improved Triton LoRA support.
- Expanded Unsloth options: optional RoPE scaling plus advanced LoRA/PEFT targeting (DoRA/LoftQ, layer/module selection) and additional optimizer/training hyperparameters.

**Documentation**
- Updated hyperparameter references and copy-paste JSON templates for the new Automodel and Unsloth fields.

**Tests**
- Added/extended tests to verify pass-through behavior and defaulting/validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->