### PR TITLE
fix(studio): Test models context menu option is not behind a FF

### DIFF
--- a/web/packages/studio/src/components/dataViews/AgentsDataView/index.test.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentsDataView/index.test.tsx
@@ -5,12 +5,13 @@ import { AgentsTable } from '@studio/components/dataViews/AgentsDataView';
 import { PLATFORM_BASE_URL } from '@studio/constants/environment';
 import { ROUTES } from '@studio/constants/routes';
 import { server } from '@studio/mocks/node';
-import { getAgentsListRoute } from '@studio/routes/utils';
+import { getAgentsListRoute, getModelCompareRoute } from '@studio/routes/utils';
 import { XL_SELECTOR_TIMEOUT } from '@studio/tests/util/constants';
 import { renderRoute, screen, waitFor } from '@studio/tests/util/render';
 import { within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
+import { useLocation } from 'react-router-dom';
 
 const WORKSPACE = 'default';
 
@@ -30,6 +31,11 @@ const renderTable = (onAgentRowClick = vi.fn(), history = getAgentsListRoute(WOR
       },
     ],
   });
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="model-compare-location">{`${location.pathname}${location.search}`}</div>;
+};
 
 describe('CombinedAgentsTable', () => {
   describe('columns', () => {
@@ -133,7 +139,7 @@ describe('CombinedAgentsTable', () => {
   });
 
   describe('row actions', () => {
-    it('shows Deploy and Delete actions for agent rows', async () => {
+    it('shows Deploy, Test models, Clone, and Delete actions for agent rows', async () => {
       const user = userEvent.setup();
       renderTable();
 
@@ -143,9 +149,63 @@ describe('CombinedAgentsTable', () => {
       await user.click(menuButtons[0]);
 
       const deployItems = await screen.findAllByRole('menuitem', { name: 'Deploy' });
+      const testModelItems = screen.getAllByRole('menuitem', { name: 'Test models' });
+      const cloneItems = screen.getAllByRole('menuitem', { name: 'Clone' });
       const deleteItems = screen.getAllByRole('menuitem', { name: 'Delete' });
       expect(deployItems.length).toBeGreaterThan(0);
+      expect(testModelItems.length).toBeGreaterThan(0);
+      expect(cloneItems.length).toBeGreaterThan(0);
       expect(deleteItems.length).toBeGreaterThan(0);
+    });
+
+    it('opens Playground with the row model selected when Test models is selected', async () => {
+      const user = userEvent.setup();
+      renderRoute(undefined, {
+        history: getAgentsListRoute(WORKSPACE),
+        routes: [
+          {
+            path: ROUTES.workspace.agentsList,
+            element: <AgentsTable />,
+          },
+          {
+            path: ROUTES.workspace.modelCompare,
+            element: <LocationProbe />,
+          },
+        ],
+      });
+
+      await screen.findByText(MOCK_AGENTS[0].name);
+
+      await user.click(screen.getAllByRole('button', { name: /actions/i })[0]);
+      await user.click((await screen.findAllByRole('menuitem', { name: 'Test models' }))[0]);
+
+      expect(await screen.findByTestId('model-compare-location')).toHaveTextContent(
+        `${getModelCompareRoute(WORKSPACE)}?model=${encodeURIComponent(
+          `${WORKSPACE}/meta-llama-3-1-70b-instruct`
+        )}`
+      );
+    });
+
+    it('hides Test models when Playground is disabled', async () => {
+      const user = userEvent.setup();
+      renderRoute(undefined, {
+        history: getAgentsListRoute(WORKSPACE),
+        routes: [
+          {
+            path: ROUTES.workspace.agentsList,
+            element: <AgentsTable canTestModels={false} />,
+          },
+        ],
+      });
+
+      await screen.findByText(MOCK_AGENTS[0].name);
+
+      await user.click(screen.getAllByRole('button', { name: /actions/i })[0]);
+
+      expect((await screen.findAllByRole('menuitem', { name: 'Deploy' })).length).toBeGreaterThan(
+        0
+      );
+      expect(screen.queryByRole('menuitem', { name: 'Test models' })).not.toBeInTheDocument();
     });
 
     it('calls onCloneAgent with the row when Clone is selected', async () => {

--- a/web/packages/studio/src/components/dataViews/AgentsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentsDataView/index.tsx
@@ -29,13 +29,14 @@ import { Button, Divider, Flex, Text } from '@nvidia/foundations-react-core';
 import { getAgentModelNames } from '@studio/components/dataViews/AgentsDataView/utils';
 import { DeleteConfirmationModal } from '@studio/components/DeleteConfirmationModal';
 import { DocumentationButton } from '@studio/components/DocumentationButton';
+import { MODEL_COMPARE_ENABLED } from '@studio/constants/environment';
 import { LINK_DOCS_STUDIO } from '@studio/constants/links';
-import { ROUTES } from '@studio/constants/routes';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { getModelCompareRoute } from '@studio/routes/utils';
 import { keepPreviousData, useQueryClient } from '@tanstack/react-query';
 import { HatGlasses, Trash, X } from 'lucide-react';
 import { ComponentProps, FC, useEffect, useMemo, useState } from 'react';
-import { generatePath, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export type { Agent, AgentDeployment };
 
@@ -91,6 +92,7 @@ export interface CombinedAgentsTableProps {
   onCreateDeployment?: (agentName: string) => void;
   onCloneAgent?: (agent: AgentTableRow) => void;
   onAgentsLoaded?: (agents: Agent[]) => void;
+  canTestModels?: boolean;
 }
 
 export const AgentsTable: FC<CombinedAgentsTableProps> = ({
@@ -98,6 +100,7 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
   onCreateDeployment,
   onCloneAgent,
   onAgentsLoaded,
+  canTestModels = MODEL_COMPARE_ENABLED,
 }) => {
   const workspace = useWorkspaceFromPath();
   const navigate = useNavigate();
@@ -285,15 +288,19 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
           children: 'Deploy',
           onSelect: () => onCreateDeployment?.(row.name),
         },
-        {
-          children: 'Test models',
-          onSelect: () => {
-            const target = generatePath(ROUTES.workspace.modelCompare, { workspace });
-            const model = row.models[0];
-            const urn = model ? `${row.workspace}/${model}` : null;
-            navigate(urn ? `${target}?model=${encodeURIComponent(urn)}` : target);
-          },
-        },
+        ...(canTestModels
+          ? [
+              {
+                children: 'Test models',
+                onSelect: () => {
+                  const target = getModelCompareRoute(workspace);
+                  const model = row.models[0];
+                  const urn = model ? `${row.workspace}/${model}` : null;
+                  navigate(urn ? `${target}?model=${encodeURIComponent(urn)}` : target);
+                },
+              },
+            ]
+          : []),
         {
           children: 'Clone',
           onSelect: () => onCloneAgent?.(row),


### PR DESCRIPTION
https://linear.app/nvidia/issue/ASTD-251/test-models-context-menu-action-on-agents-tab-returns-404
https://nvbugspro.nvidia.com/bug/6336721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Test models" action to the agents table with model comparison integration
  * "Test models" feature availability can be toggled via system configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->