### PR TITLE
fix(studio): Add base models to Studio docs

### DIFF
--- a/docs/studio/index.mdx
+++ b/docs/studio/index.mdx
@@ -39,6 +39,14 @@ Use **Agents \> Monitor** to inspect agent telemetry stored by the platform, inc
 
 For the full workflow, see [Studio Monitor](/documentation/studio/monitor).
 
+### Models
+
+Use **Models \> Base Models** to browse model entities available in the current workspace. Base models include models registered in the workspace and default platform models.
+
+The Base Models page supports searching by model name, filtering by creation or update date, sorting alphabetically or by creation time, and showing only customizable models. Select a model card to open the model details side panel.
+
+The model details side panel shows model metadata, parameters, and available actions. From the side panel you can open the chat playground for chat-capable models or navigate to model evaluation results.
+
 ### Workspaces
 
 Keep models and data organized in dedicated workspaces.


### PR DESCRIPTION
https://nvbugspro.nvidia.com/bug/6336902
https://linear.app/nvidia/issue/ASTD-252/docsstudioindexmdx-missing-base-models-section-evaluations-section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Models feature, detailing how to browse base models available in your workspace, use search and filtering options by name and timestamps, view customizable model configurations, and access model details including parameters and available actions like launching the chat playground or viewing evaluation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->