### PR TITLE
fix(cli): Fix startup banner display

### DIFF
--- a/packages/nmp_platform_runner/src/nmp/platform_runner/run.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/run.py
@@ -35,6 +35,23 @@ def _startup_phase(name: str, t0: float) -> None:
     logger.info("[STARTUP] %s: %dms", name, elapsed_ms)
 
 
+def _database_display(db_url: str) -> str:
+    """Format a SQLAlchemy database URL for the startup banner."""
+    try:
+        from sqlalchemy.engine import make_url
+
+        parsed = make_url(db_url)
+    except Exception:
+        logger.debug("Failed to parse database URL for startup banner", exc_info=True)
+        db_type = db_url.split("://")[0].split("+")[0] if "://" in db_url else "unknown"
+        return db_type
+
+    db_type = parsed.drivername.split("+", 1)[0]
+    if db_type == "sqlite":
+        return f"{db_type} ({parsed.database or ''})"
+    return db_type
+
+
 def run_controllers_in_threads(
     controller_run_funcs: dict[str, Callable],
     stop_signal: threading.Event,
@@ -243,12 +260,7 @@ def _display_banner(
 
     entities_config = get_service_config(EntitiesConfig)
     db_url = entities_config.database_config.sqlalchemy_database_url()
-    db_type = db_url.split("://")[0].split("+")[0] if "://" in db_url else "unknown"
-    if db_type == "sqlite":
-        db_path = db_url.replace("sqlite://", "").replace("sqlite+aiosqlite://", "")
-        db_display = f"{db_type} ({db_path})"
-    else:
-        db_display = db_type
+    db_display = _database_display(db_url)
 
     auth_config = get_auth_config()
     auth_status = "enabled" if auth_config.enabled else "disabled"

--- a/packages/nmp_platform_runner/tests/test_run.py
+++ b/packages/nmp_platform_runner/tests/test_run.py
@@ -32,7 +32,7 @@ def test_database_display_formats_non_sqlite_driver() -> None:
     assert _database_display("postgresql+asyncpg://user:pass@localhost:5432/nemo") == "postgresql"
 
 
-def test_database_display_logs_parse_failures(caplog) -> None:
+def test_database_display_logs_parse_failures(caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.DEBUG, logger="nmp.platform_runner.run"):
         assert _database_display("postgresql://localhost:not-a-port/nemo") == "postgresql"
 

--- a/packages/nmp_platform_runner/tests/test_run.py
+++ b/packages/nmp_platform_runner/tests/test_run.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for platform runner startup display helpers."""
+
+import logging
+
+import pytest
+from nmp.platform_runner.run import _database_display
+
+
+@pytest.mark.parametrize(
+    ("db_url", "expected"),
+    [
+        (
+            "sqlite:////var/data/nmp-platform.db",
+            "sqlite (/var/data/nmp-platform.db)",
+        ),
+        (
+            "sqlite+aiosqlite:////var/data/nmp-platform.db",
+            "sqlite (/var/data/nmp-platform.db)",
+        ),
+        ("sqlite:///relative/nmp-platform.db", "sqlite (relative/nmp-platform.db)"),
+        ("sqlite+aiosqlite:///relative/nmp-platform.db", "sqlite (relative/nmp-platform.db)"),
+    ],
+)
+def test_database_display_formats_sqlite_paths(db_url: str, expected: str) -> None:
+    assert _database_display(db_url) == expected
+
+
+def test_database_display_formats_non_sqlite_driver() -> None:
+    assert _database_display("postgresql+asyncpg://user:pass@localhost:5432/nemo") == "postgresql"
+
+
+def test_database_display_logs_parse_failures(caplog) -> None:
+    with caplog.at_level(logging.DEBUG, logger="nmp.platform_runner.run"):
+        assert _database_display("postgresql://localhost:not-a-port/nemo") == "postgresql"
+
+    records = [record for record in caplog.records if record.name == "nmp.platform_runner.run"]
+    assert len(records) == 1
+    assert records[0].message == "Failed to parse database URL for startup banner"
+    assert records[0].exc_info is not None


### PR DESCRIPTION
## Summary

- Fix the platform runner startup banner database display to preserve SQLite database paths.
- Use SQLAlchemy URL parsing inside the banner helper while keeping imports local to the plain-log startup path.
- Add debug logging when database URL parsing fails, then fall back to the existing driver-name behavior.
- Add unit coverage for SQLite, async SQLite, non-SQLite, and parse-failure fallback behavior.

## Testing

- [x] `uv run --frozen pytest packages/nmp_platform_runner/tests/test_run.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the startup banner’s database URL presentation by standardizing formatting across SQLite and non-SQLite drivers, with fallback behavior when URL parsing fails.

* **Tests**
  * Added dedicated test coverage for database URL formatting, including SQLite prefix stripping, preservation of SQLite paths, non-SQLite driver name display, and verification of debug logging on parse errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->