### PR TITLE
docs(studio): fix agents.mdx Agent List actions table

### DIFF
--- a/docs/studio/agents.mdx
+++ b/docs/studio/agents.mdx
@@ -12,16 +12,19 @@ The Agents table shows the agents in the selected workspace, including their dep
 |--------|-------|--------|
 | Review details | Select an agent row | Opens the agent side panel with name, workspace, description, and config format. |
 | Deploy an agent | Row actions > **Deploy** | Creates a deployment for the selected agent. |
-| Chat with a deployment | Agent side panel > **Deployments** > **Chat** | Opens the chat playground for a running deployment. |
-| Delete a deployment | Agent side panel > **Deployments** > **Delete** | Removes that deployment. |
+| Test models | Row actions > **Test models** | Opens the model playground for the agent's configured model. |
+| Clone an agent | Row actions > **Clone** | Creates a copy of the agent definition with a new name. |
+| Chat with a deployment | Agent side panel > **Chat Playground** tab | Opens the chat playground for a running deployment. |
+| Delete a deployment | Agent side panel > **Details** > **Deployments** > **Delete** | Removes that deployment. |
 | Delete an agent | Row actions > **Delete** | Removes the stored agent definition from the workspace. |
 
 ## Agent Details
 
-The agent side panel has two primary areas:
+The agent side panel has three tabs:
 
-- **Agent Details** shows the stored agent metadata and config format.
-- **Deployments** lists active and historical deployments for the agent, including endpoint and status.
+- **Details** shows the stored agent metadata and config format. It includes a **Deployments** section listing active and historical deployments for the agent (endpoint and status), plus recent evaluations.
+- **Chat Playground** opens an interactive chat with a running deployment.
+- **Logs** shows deployment logs.
 
 Agents are created and updated through the `nemo agents` CLI or Agents API. NeMo Studio reflects the current workspace state after the platform services refresh.
 


### PR DESCRIPTION
## Summary

Fixes inaccuracies in the **Agent List** actions table in `docs/studio/agents.mdx`, reported in nvbugs 6337039.

- Add missing **Test models** row action (`Row actions > Test models` → opens the model playground for the agent's configured model).
- Add missing **Clone** row action (`Row actions > Clone` → copies the agent definition with a new name).
- Fix **Chat with a deployment**: now points at the **Chat Playground** tab atop the agent side panel, instead of the stale `Deployments > Chat` location.
- Fix **Delete a deployment** path: `Deployments` is now a section under the **Details** tab.
- Update the **Agent Details** section to describe the three side-panel tabs (Details, Chat Playground, Logs).

## Verification

UI labels and structure confirmed against Studio source:
- Row actions: `web/packages/studio/src/components/dataViews/AgentsDataView/index.tsx`
- Side-panel tabs: `web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/index.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Agents UI documentation to reflect new row actions (test models, clone) and revised action labels
  * Documented three Agent Details side-panel tabs (Details, Chat Playground, Logs) and their respective functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->