### PR TITLE
fix: show why modal disabled in studio

### DIFF
--- a/web/packages/common/src/components/UploadModal/SimpleFilesTable.test.tsx
+++ b/web/packages/common/src/components/UploadModal/SimpleFilesTable.test.tsx
@@ -301,6 +301,63 @@ describe('SimpleFilesTable', () => {
       // Existing files show path
       expect(screen.getByText('dataset/file1.jsonl')).toBeInTheDocument();
     });
+
+    it('explains why unsupported files are disabled', () => {
+      const files: UploadFile[] = [
+        {
+          id: 'config',
+          type: 'existing',
+          file: {
+            path: 'eval/config.yaml',
+            file_ref: 'ref-config',
+            size: 100,
+            file_url: 'https://example.com/config.yaml',
+          },
+        },
+        {
+          id: 'notes',
+          type: 'existing',
+          file: {
+            path: 'eval/notes.txt',
+            file_ref: 'ref-notes',
+            size: 100,
+            file_url: 'https://example.com/notes.txt',
+          },
+        },
+      ];
+
+      render(<SimpleFilesTable />, {
+        wrapper: createWrapper({
+          files,
+          acceptableFileTypes: ['.yml', '.yaml'],
+          invalidFileMode: 'disable',
+        }),
+      });
+
+      expect(screen.getByRole('radio', { name: 'eval/config.yaml' })).not.toBeDisabled();
+      expect(screen.getByRole('radio', { name: 'eval/notes.txt' })).toBeDisabled();
+      expect(
+        screen.getByText(
+          'Only .yml, .yaml files can be selected. Upload a supported file or choose a different fileset.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('does not show disabled-file guidance when all visible files are selectable', () => {
+      render(<SimpleFilesTable />, {
+        wrapper: createWrapper({
+          files: mockExistingFiles,
+          acceptableFileTypes: ['.jsonl'],
+          invalidFileMode: 'disable',
+        }),
+      });
+
+      expect(
+        screen.queryByText(/Upload a supported file or choose a different fileset/)
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'dataset/file1.jsonl' })).not.toBeDisabled();
+      expect(screen.getByRole('radio', { name: 'dataset/file2.jsonl' })).not.toBeDisabled();
+    });
   });
 
   describe('upload more files', () => {

--- a/web/packages/common/src/components/UploadModal/SimpleFilesTable.tsx
+++ b/web/packages/common/src/components/UploadModal/SimpleFilesTable.tsx
@@ -92,6 +92,13 @@ export const SimpleFilesTable = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [files, allowedExtensions, invalidFileMode]);
 
+  const disabledFilesMessage =
+    invalidFileMode === 'disable' &&
+    allowedExtensions.size > 0 &&
+    visibleFiles.some((file) => !isFileAllowed(file))
+      ? `Only ${acceptableFileTypes.join(', ')} files can be selected. Upload a supported file or choose a different fileset.`
+      : null;
+
   const rows = useMemo<TableRowDefinition[]>(
     () =>
       visibleFiles.map((uploadFile) => {
@@ -156,6 +163,14 @@ export const SimpleFilesTable = () => {
           />
         </RadioGroupRoot>
       )}
+      {disabledFilesMessage ? (
+        <Flex gap="density-sm" align="center">
+          <CircleAlert className="text-feedback-warning shrink-0" />
+          <Text kind="label/regular/sm" className="text-feedback-warning">
+            {disabledFilesMessage}
+          </Text>
+        </Flex>
+      ) : null}
       {errors.file && (
         <Flex gap="density-md" align="center">
           <CircleAlert className="text-feedback-danger" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload modal now displays a helpful guidance message explaining why certain files cannot be selected when file type restrictions are applied in single-select mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->