### PR TITLE
feat(evaluator): persist metrics as entities with CRUD, SDK, and job refs

### DIFF
--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -419,6 +419,189 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/workspaces/{workspace}/metrics:
+    get:
+      tags:
+      - Evaluator Plugin Metrics Routes
+      summary: List Metrics By Workspace
+      description: List stored metrics for a specific workspace.
+      operationId: list_metrics_apis_evaluator_v2_workspaces__workspace__metrics_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          description: Page number.
+          default: 1
+          title: Page
+        description: Page number.
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 1000
+          minimum: 1
+          description: Page size.
+          default: 100
+          title: Page Size
+        description: Page size.
+      - name: sort
+        in: query
+        required: false
+        schema:
+          allOf:
+          - $ref: '#/components/schemas/MetricSort'
+          description: The field to sort by. To sort in decreasing order, use `-`
+            in front of the field name.
+          default: created_at
+        description: The field to sort by. To sort in decreasing order, use `-` in
+          front of the field name.
+      - in: query
+        name: filter
+        style: deepObject
+        required: false
+        explode: true
+        schema:
+          $ref: '#/components/schemas/MetricFilter'
+        description: Filter metrics by workspace, name, metric_type, description,
+          created_at, and updated_at.
+      responses:
+        '200':
+          description: Return stored metrics for a workspace
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/workspaces/{workspace}/metrics/{name}:
+    post:
+      tags:
+      - Evaluator Plugin Metrics Routes
+      summary: Create Metric
+      description: Store a new metric, addressed by workspace/name.
+      operationId: create_metric_apis_evaluator_v2_workspaces__workspace__metrics__name__post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          maxLength: 255
+          pattern: ^[\w\-\.]+$
+          title: Name
+      - name: project
+        in: query
+        required: false
+        schema:
+          description: Optional project to associate with the metric.
+          title: Project
+          type: string
+        description: Optional project to associate with the metric.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetricInline'
+      responses:
+        '201':
+          description: Store a new metric
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metric'
+        '409':
+          description: Metric already exists
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Evaluator Plugin Metrics Routes
+      summary: Get Metric
+      description: Get a stored metric by workspace and name.
+      operationId: get_metric_apis_evaluator_v2_workspaces__workspace__metrics__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Return stored metric details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metric'
+        '404':
+          description: Metric not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Evaluator Plugin Metrics Routes
+      summary: Delete Metric
+      description: Delete a stored metric by workspace and name.
+      operationId: delete_metric_apis_evaluator_v2_workspaces__workspace__metrics__name__delete
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '204':
+          description: Delete a stored metric
+        '404':
+          description: Metric not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
     Agent:
@@ -491,6 +674,54 @@ components:
       - value_json_schema
       title: BundledMetricOutputSpec
       description: JSON-safe projection of a runtime metric output spec.
+    CloudpickleMetricPayload:
+      properties:
+        kind:
+          type: string
+          const: cloudpickle
+          title: Kind
+          description: Payload format discriminator.
+        python_version:
+          type: string
+          title: Python Version
+          description: Python version the metric was pickled with (must match at execution).
+        cloudpickle_version:
+          type: string
+          title: Cloudpickle Version
+          description: cloudpickle version used to serialize the metric.
+        pickle_protocol:
+          type: integer
+          title: Pickle Protocol
+          description: Pickle protocol used.
+        blob:
+          type: string
+          format: base64url
+          title: Blob
+          description: Base64-encoded cloudpickled metric object.
+        digest:
+          title: Digest
+          description: SHA-256 digest of the payload bytes. Informational; recomputed
+            server-side.
+          type: string
+      additionalProperties: false
+      type: object
+      required:
+      - kind
+      - python_version
+      - cloudpickle_version
+      - pickle_protocol
+      - blob
+      title: CloudpickleMetricPayload
+      description: 'Wire schema for a cloudpickle-serialized metric payload.
+
+
+        Mirrors the runtime ``CloudpickleMetricPayload`` so the API contract is
+
+        explicit in the OpenAPI spec. The runtime bundle model serializes payloads
+
+        polymorphically (typed as an abstract base), which renders as an opaque
+
+        object in the spec; this concrete DTO documents the actual fields.'
     DatetimeFilter:
       additionalProperties: false
       properties:
@@ -508,13 +739,6 @@ components:
       type: object
     EvaluateInputSpec:
       properties:
-        metrics:
-          items:
-            $ref: '#/components/schemas/MetricBundleInput'
-          type: array
-          minItems: 1
-          title: Metrics
-          description: Bundled metric entities to evaluate.
         dataset:
           anyOf:
           - items:
@@ -551,11 +775,21 @@ components:
           - $ref: '#/components/schemas/FieldMapping'
           description: Optional mapping from canonical evaluator fields to dataset
             columns.
+        metrics:
+          items:
+            anyOf:
+            - $ref: '#/components/schemas/MetricInline'
+            - $ref: '#/components/schemas/MetricRef'
+          type: array
+          minItems: 1
+          title: Metrics
+          description: Metrics to evaluate, given as inline metrics and/or references
+            to stored metrics.
       additionalProperties: false
       type: object
       required:
-      - metrics
       - dataset
+      - metrics
       title: EvaluateInputSpec
       description: Submitter-facing SDK evaluation input for the evaluator plugin
         job.
@@ -699,13 +933,6 @@ components:
       title: EvaluateJobsSortField
     EvaluateSpec:
       properties:
-        metrics:
-          items:
-            $ref: '#/components/schemas/MetricBundleOutput'
-          type: array
-          minItems: 1
-          title: Metrics
-          description: Bundled metric entities to evaluate.
         dataset:
           anyOf:
           - items:
@@ -742,13 +969,21 @@ components:
           - $ref: '#/components/schemas/FieldMapping'
           description: Optional mapping from canonical evaluator fields to dataset
             columns.
+        metrics:
+          items:
+            $ref: '#/components/schemas/MetricInline'
+          type: array
+          minItems: 1
+          title: Metrics
+          description: Inline metrics with all references resolved.
       additionalProperties: false
       type: object
       required:
-      - metrics
       - dataset
+      - metrics
       title: EvaluateSpec
-      description: Canonical SDK evaluation spec with platform model references resolved.
+      description: Canonical SDK evaluation spec with platform model and metric references
+        resolved.
     FieldMapping:
       properties:
         input:
@@ -882,7 +1117,124 @@ components:
       description: Parameters for model inference. Extra fields can be supplied for
         additional options applied to the inference request directly. Fields not supported
         by the model may cause inference errors during evaluation.
-    MetricBundleInput:
+    Metric:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Unique identifier for the stored metric.
+        name:
+          type: string
+          title: Name
+          description: Name of the metric, unique within its workspace.
+        workspace:
+          type: string
+          title: Workspace
+          description: Workspace the metric belongs to.
+        project:
+          title: Project
+          description: The project associated with this metric.
+          type: string
+        metric_type:
+          type: string
+          title: Metric Type
+          description: Runtime metric type name.
+        description:
+          title: Description
+          description: Description captured from the metric's metadata.
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          type: object
+          title: Labels
+          description: Labels captured from the metric's metadata.
+        outputs:
+          items:
+            $ref: '#/components/schemas/BundledMetricOutputSpec'
+          type: array
+          title: Outputs
+          description: The metric's output contracts.
+        secrets:
+          additionalProperties:
+            $ref: '#/components/schemas/SecretRef'
+          type: object
+          title: Secrets
+          description: Secret references required to execute the metric.
+        payload_kind:
+          type: string
+          title: Payload Kind
+          description: Payload discriminator of the stored bundle.
+        payload_digest:
+          type: string
+          title: Payload Digest
+          description: Digest of the stored payload.
+        bundle_ref:
+          type: string
+          title: Bundle Ref
+          description: Files reference to the canonical serialized bundle.
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+          description: Timestamp the metric was created.
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+          description: Timestamp the metric was last updated.
+      type: object
+      required:
+      - id
+      - name
+      - workspace
+      - metric_type
+      - outputs
+      - secrets
+      - payload_kind
+      - payload_digest
+      - bundle_ref
+      - created_at
+      - updated_at
+      title: Metric
+      description: 'API representation of a stored metric.
+
+
+        The canonical executable bundle lives in the Files service; the fields here
+
+        are the queryable projection plus the reference and digest needed to load
+        it.'
+    MetricFilter:
+      additionalProperties: false
+      description: Filter for metric queries.
+      properties:
+        workspace:
+          description: Filter by workspace.
+          title: Workspace
+          type: string
+        name:
+          description: Filter by name.
+          title: Name
+          type: string
+        metric_type:
+          description: Filter by metric type.
+          title: Metric Type
+          type: string
+        description:
+          description: Filter by description.
+          title: Description
+          type: string
+        created_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Filter by creation date.
+        updated_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Filter by update date.
+      title: MetricFilter
+      type: object
+    MetricInline:
       properties:
         bundle_kind:
           type: string
@@ -898,74 +1250,44 @@ components:
           type: string
           minLength: 1
           title: Metric Type
+          description: Runtime metric type name.
         metadata:
-          $ref: '#/components/schemas/MetricMetadata'
+          allOf:
+          - $ref: '#/components/schemas/MetricMetadata'
+          description: User-facing metric metadata.
         outputs:
           items:
             $ref: '#/components/schemas/BundledMetricOutputSpec'
           type: array
           minItems: 1
           title: Outputs
+          description: The metric's output contracts.
         secrets:
           additionalProperties:
             $ref: '#/components/schemas/SecretRef'
           type: object
           title: Secrets
+          description: Secret references required to execute the metric.
         payload:
-          $ref: '#/components/schemas/MetricBundlePayload'
+          oneOf:
+          - $ref: '#/components/schemas/CloudpickleMetricPayload'
+          title: Payload
+          description: Format-specific serialized metric.
+          discriminator:
+            propertyName: kind
+            mapping:
+              cloudpickle: '#/components/schemas/CloudpickleMetricPayload'
       additionalProperties: false
       type: object
       required:
       - metric_type
       - outputs
       - payload
-      title: MetricBundleInput
-      description: Standalone executable metric bundle entity used by backend execution.
-    MetricBundleOutput:
-      properties:
-        bundle_kind:
-          type: string
-          const: metric-bundle
-          title: Bundle Kind
-          default: metric-bundle
-        bundle_format_version:
-          type: string
-          const: v1
-          title: Bundle Format Version
-          default: v1
-        metric_type:
-          type: string
-          minLength: 1
-          title: Metric Type
-        metadata:
-          $ref: '#/components/schemas/MetricMetadata'
-        outputs:
-          items:
-            $ref: '#/components/schemas/BundledMetricOutputSpec'
-          type: array
-          minItems: 1
-          title: Outputs
-        secrets:
-          additionalProperties:
-            $ref: '#/components/schemas/SecretRef'
-          type: object
-          title: Secrets
-        payload:
-          additionalProperties: true
-          type: object
-      additionalProperties: false
-      type: object
-      required:
-      - metric_type
-      - outputs
-      - payload
-      title: MetricBundleOutput
-      description: Standalone executable metric bundle entity used by backend execution.
-    MetricBundlePayload:
-      properties: {}
-      type: object
-      title: MetricBundlePayload
-      description: Base class for concrete Pydantic metric bundle payloads.
+      title: MetricInline
+      description: "An executable metric submitted to the platform.\n\nCarries the\
+        \ bundled metric \u2014 type, metadata, output contracts, secret\nreferences,\
+        \ and a format-specific payload \u2014 used both as the create-request\nbody\
+        \ and as an inline metric in an evaluation job."
     MetricMetadata:
       properties:
         description:
@@ -980,6 +1302,47 @@ components:
       type: object
       title: MetricMetadata
       description: User-facing metadata captured with a bundled metric.
+    MetricRef:
+      type: string
+      pattern: ^[\w\-.]+(/[\w\-.]+)?$
+      title: MetricRef
+      description: 'Reference to a persisted metric (format: ``workspace/name`` or
+        ``name``).'
+    MetricSort:
+      type: string
+      enum:
+      - name
+      - -name
+      - created_at
+      - -created_at
+      - updated_at
+      - -updated_at
+      title: MetricSort
+      description: Sort fields for metric queries.
+    MetricsPage:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/Metric'
+          type: array
+          title: Data
+        pagination:
+          allOf:
+          - $ref: '#/components/schemas/PaginationData'
+          description: Pagination information.
+        sort:
+          title: Sort
+          description: The field on which the results are sorted.
+          type: string
+        filter:
+          title: Filter
+          description: Filtering information.
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - data
+      title: MetricsPage
     Model:
       properties:
         url:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/dependencies.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/dependencies.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FastAPI dependencies for the evaluator metrics API."""
+
+from __future__ import annotations
+
+from fastapi import Depends
+from nemo_evaluator.api.service.metric_service import MetricService
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.dependencies import get_entity_client, get_sdk_client
+from nemo_platform_plugin.entities import EntityClient
+
+
+def get_metric_service(
+    entity_client: EntityClient = Depends(get_entity_client),
+    sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
+) -> MetricService:
+    """Provide a MetricService wired to the Entity Store and Files service."""
+    return MetricService(entity_client, sdk)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/schemas.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/schemas.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Request/response schemas for the evaluator metrics API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from nemo_evaluator.shared.metric_bundles.bundles import (
+    BundledMetricOutputSpec,
+    MetricMetadata,
+)
+from nemo_evaluator_sdk.values.common import SecretRef
+from nemo_platform_plugin.schema import DatetimeFilter, Filter
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CloudpickleMetricPayload(BaseModel):
+    """Wire schema for a cloudpickle-serialized metric payload.
+
+    Mirrors the runtime ``CloudpickleMetricPayload`` so the API contract is
+    explicit in the OpenAPI spec. The runtime bundle model serializes payloads
+    polymorphically (typed as an abstract base), which renders as an opaque
+    object in the spec; this concrete DTO documents the actual fields.
+    """
+
+    model_config = ConfigDict(extra="forbid", ser_json_bytes="base64", val_json_bytes="base64")
+
+    kind: Literal["cloudpickle"] = Field(description="Payload format discriminator.")
+    python_version: str = Field(description="Python version the metric was pickled with (must match at execution).")
+    cloudpickle_version: str = Field(description="cloudpickle version used to serialize the metric.")
+    pickle_protocol: int = Field(description="Pickle protocol used.")
+    blob: bytes = Field(description="Base64-encoded cloudpickled metric object.")
+    digest: str | None = Field(
+        default=None,
+        description="SHA-256 digest of the payload bytes. Informational; recomputed server-side.",
+    )
+
+
+# Discriminated on ``kind`` so additional payload formats can join the union
+# without changing the field type. Cloudpickle is the only kind today.
+MetricPayload = Annotated[CloudpickleMetricPayload, Field(discriminator="kind")]
+
+
+class MetricInline(BaseModel):
+    """An executable metric submitted to the platform.
+
+    Carries the bundled metric — type, metadata, output contracts, secret
+    references, and a format-specific payload — used both as the create-request
+    body and as an inline metric in an evaluation job.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    bundle_kind: Literal["metric-bundle"] = "metric-bundle"
+    bundle_format_version: Literal["v1"] = "v1"
+    metric_type: str = Field(min_length=1, description="Runtime metric type name.")
+    metadata: MetricMetadata = Field(default_factory=MetricMetadata, description="User-facing metric metadata.")
+    outputs: list[BundledMetricOutputSpec] = Field(min_length=1, description="The metric's output contracts.")
+    secrets: dict[str, SecretRef] = Field(
+        default_factory=dict, description="Secret references required to execute the metric."
+    )
+    payload: MetricPayload = Field(description="Format-specific serialized metric.")
+
+
+class Metric(BaseModel):
+    """API representation of a stored metric.
+
+    The canonical executable bundle lives in the Files service; the fields here
+    are the queryable projection plus the reference and digest needed to load it.
+    """
+
+    id: str = Field(description="Unique identifier for the stored metric.")
+    name: str = Field(description="Name of the metric, unique within its workspace.")
+    workspace: str = Field(description="Workspace the metric belongs to.")
+    project: str | None = Field(default=None, description="The project associated with this metric.")
+    metric_type: str = Field(description="Runtime metric type name.")
+    description: str | None = Field(default=None, description="Description captured from the metric's metadata.")
+    labels: dict[str, str] = Field(default_factory=dict, description="Labels captured from the metric's metadata.")
+    outputs: list[BundledMetricOutputSpec] = Field(description="The metric's output contracts.")
+    secrets: dict[str, SecretRef] = Field(description="Secret references required to execute the metric.")
+    payload_kind: str = Field(description="Payload discriminator of the stored bundle.")
+    payload_digest: str = Field(description="Digest of the stored payload.")
+    bundle_ref: str = Field(description="Files reference to the canonical serialized bundle.")
+    created_at: datetime = Field(description="Timestamp the metric was created.")
+    updated_at: datetime = Field(description="Timestamp the metric was last updated.")
+
+
+class MetricSort(StrEnum):
+    """Sort fields for metric queries."""
+
+    NAME_ASC = "name"
+    NAME_DESC = "-name"
+    CREATED_AT_ASC = "created_at"
+    CREATED_AT_DESC = "-created_at"
+    UPDATED_AT_ASC = "updated_at"
+    UPDATED_AT_DESC = "-updated_at"
+
+
+class MetricFilter(Filter):
+    """Filter for metric queries."""
+
+    workspace: str | None = Field(None, description="Filter by workspace.")
+    name: str | None = Field(None, description="Filter by name.")
+    metric_type: str | None = Field(None, description="Filter by metric type.")
+    description: str | None = Field(None, description="Filter by description.")
+    created_at: DatetimeFilter | None = Field(None, description="Filter by creation date.")
+    updated_at: DatetimeFilter | None = Field(None, description="Filter by update date.")

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/service/metric_service.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/service/metric_service.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Service layer for stored metric operations.
+
+Combines the Entity Store (the queryable index) with the Files service (the
+canonical serialized bundle). The service owns the bundle's storage lifecycle.
+
+Stored metrics are immutable: they can be created, read, listed, and deleted,
+but not updated in place. Each bundle upload lands in its own uniquely-named
+fileset, which makes every write/rollback target exactly one metric's bytes. As
+a result no failure mode leaves a metric pointing at the wrong or missing data —
+the worst case is an orphaned fileset (a storage leak), never a corrupted metric:
+
+- create: upload first, then create the entity. On a name conflict (or any
+  index failure) we delete the fileset we just created — never another
+  metric's. The entity is only created once its bundle exists.
+- delete: delete the entity first, then its fileset.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from nemo_evaluator.api.schemas import (
+    Metric,
+    MetricInline,
+)
+from nemo_evaluator.entities import MetricBundleEntity
+from nemo_evaluator.metric_storage import delete_bundle_by_ref, store_bundle
+from nemo_evaluator.shared.metric_bundles.bundles import MetricBundle as RuntimeMetricBundle
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.entities import (
+    EntityClient,
+    EntityConflictError,
+    EntityNotFoundError,
+)
+from nemo_platform_plugin.filter_ops import FilterOperation
+from nemo_platform_plugin.schema import Page, PaginationData
+
+logger = logging.getLogger(__name__)
+
+
+def _sanitize_for_log(value: object) -> str:
+    """Strip line-break/control characters to prevent log injection."""
+    return str(value).replace("\r", "").replace("\n", "")
+
+
+def _entity_to_schema(entity: MetricBundleEntity) -> Metric:
+    """Convert a stored metric entity to its API representation."""
+    created_at = entity.created_at
+    updated_at = entity.updated_at
+    if created_at is None or updated_at is None:
+        raise ValueError(f"Stored metric '{entity.workspace}/{entity.name}' is missing persistence timestamps")
+    return Metric(
+        id=entity.id,
+        name=entity.name,
+        workspace=entity.workspace,
+        project=entity.project,
+        metric_type=entity.metric_type,
+        description=entity.description,
+        labels=entity.labels,
+        outputs=entity.outputs,
+        secrets=entity.secrets,
+        payload_kind=entity.payload_kind,
+        payload_digest=entity.payload_digest,
+        bundle_ref=entity.bundle_ref,
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+
+
+def _entity_from_bundle(
+    *,
+    name: str,
+    workspace: str,
+    bundle: RuntimeMetricBundle,
+    bundle_ref: str,
+    project: str | None,
+) -> MetricBundleEntity:
+    """Build a stored-metric entity from a bundle and its Files reference."""
+    return MetricBundleEntity(
+        name=name,
+        workspace=workspace,
+        project=project,
+        metric_type=bundle.metric_type,
+        description=bundle.metadata.description,
+        labels=bundle.metadata.labels,
+        outputs=bundle.outputs,
+        secrets=bundle.secrets,
+        payload_kind=bundle.payload.kind,
+        payload_digest=bundle.payload.digest,
+        bundle_ref=bundle_ref,
+    )
+
+
+class MetricService:
+    """Service layer for stored metric CRUD."""
+
+    def __init__(self, entity_client: EntityClient, sdk: AsyncNeMoPlatform):
+        self.entity_client = entity_client
+        self.sdk = sdk
+
+    async def create_metric(
+        self,
+        name: str,
+        metric: MetricInline,
+        *,
+        workspace: str,
+        project: str | None = None,
+    ) -> Metric:
+        """Store a new metric (addressed by workspace/name): upload its bundle, then index it."""
+        logger.debug(
+            "Creating metric", extra={"workspace": _sanitize_for_log(workspace), "metric_name": _sanitize_for_log(name)}
+        )
+
+        # Cheap pre-check to avoid uploading a (potentially large) bundle we would
+        # only discard. The entity create below remains the authoritative,
+        # race-safe uniqueness guard.
+        try:
+            await self.entity_client.get(MetricBundleEntity, name=name, workspace=workspace)
+            raise ValueError(f"Metric with name '{name}' already exists in workspace '{workspace}'")
+        except EntityNotFoundError:
+            pass
+
+        # Convert the wire DTO into the runtime bundle (JSON round-trip keeps the
+        # base64 payload handling consistent), then store/index it.
+        runtime_bundle = RuntimeMetricBundle.model_validate_json(metric.model_dump_json())
+        bundle_ref = await store_bundle(self.sdk, workspace, name, runtime_bundle)
+        entity = _entity_from_bundle(
+            name=name,
+            workspace=workspace,
+            bundle=runtime_bundle,
+            bundle_ref=bundle_ref,
+            project=project,
+        )
+
+        try:
+            created = await self.entity_client.create(entity)
+        except EntityConflictError as e:
+            # We own this uniquely-named fileset and the entity was not created;
+            # deleting it cannot affect the existing metric's data.
+            await self._discard_bundle(bundle_ref)
+            raise ValueError(f"Metric with name '{name}' already exists in workspace '{workspace}'") from e
+        except Exception:
+            await self._discard_bundle(bundle_ref)
+            raise
+
+        logger.info(
+            "Metric created",
+            extra={"workspace": _sanitize_for_log(created.workspace), "metric_name": _sanitize_for_log(created.name)},
+        )
+        return _entity_to_schema(created)
+
+    async def get_metric(self, workspace: str, name: str) -> Metric | None:
+        """Get a stored metric by workspace and name."""
+        try:
+            entity = await self.entity_client.get(MetricBundleEntity, workspace=workspace, name=name)
+            return _entity_to_schema(entity)
+        except EntityNotFoundError:
+            return None
+
+    async def list_metrics(
+        self,
+        workspace: str,
+        page: int = 1,
+        page_size: int = 100,
+        sort: str | None = None,
+        filter_operation: FilterOperation | None = None,
+    ) -> Page[Metric]:
+        """List stored metrics with filtering and pagination."""
+        result = await self.entity_client.list(
+            MetricBundleEntity,
+            workspace=workspace,
+            filter_operation=filter_operation,
+            sort=sort,
+            page=page,
+            page_size=page_size,
+        )
+        metrics = [_entity_to_schema(entity) for entity in result.data]
+        return Page(
+            data=metrics,
+            pagination=PaginationData(
+                page=result.pagination.page,
+                page_size=result.pagination.page_size,
+                current_page_size=len(metrics),
+                total_pages=result.pagination.total_pages,
+                total_results=result.pagination.total_results,
+            ),
+            sort=sort,
+            filter=None,
+        )
+
+    async def delete_metric(self, workspace: str, name: str) -> bool:
+        """Delete a stored metric and its backing bundle. Returns False if not found."""
+        try:
+            entity = await self.entity_client.get(MetricBundleEntity, workspace=workspace, name=name)
+        except EntityNotFoundError:
+            return False
+
+        try:
+            await self.entity_client.delete(MetricBundleEntity, name, workspace=workspace)
+        except EntityNotFoundError:
+            # Lost a delete race: another request already removed it.
+            return False
+        await self._discard_bundle(entity.bundle_ref)
+        logger.info(
+            "Metric deleted", extra={"workspace": _sanitize_for_log(workspace), "metric_name": _sanitize_for_log(name)}
+        )
+        return True
+
+    async def _discard_bundle(self, bundle_ref: str) -> None:
+        """Delete an unreferenced bundle fileset.
+
+        Safe by construction: every reference names a fileset created for a
+        single metric version, so deleting it can only remove bytes nothing
+        else points at. A failure here leaks that one fileset (logged) but never
+        affects a live metric.
+        """
+        try:
+            await delete_bundle_by_ref(self.sdk, bundle_ref)
+        except Exception:
+            logger.warning(
+                "Failed to delete unreferenced metric bundle fileset; storage may be leaked",
+                extra={"bundle_ref": _sanitize_for_log(bundle_ref)},
+                exc_info=True,
+            )

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/metrics.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/metrics.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CRUD routes for stored metrics under /apis/evaluator/v2/workspaces/{workspace}/metrics."""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from nemo_evaluator.api.dependencies import get_metric_service
+from nemo_evaluator.api.schemas import (
+    Metric,
+    MetricFilter,
+    MetricInline,
+    MetricSort,
+)
+from nemo_evaluator.api.service.metric_service import MetricService
+from nemo_evaluator.entities import MAX_NAME_LENGTH, NAME_PATTERN
+from nemo_platform_plugin.api.parsed_filter import ParsedFilter, make_filter_dep
+from nemo_platform_plugin.entities import EntityValidationError
+from nemo_platform_plugin.jobs.openapi_utils import generate_openapi_extra_params
+from nemo_platform_plugin.schema import Page
+
+logger = logging.getLogger(__name__)
+
+
+def _sanitize_for_log(value: object) -> str:
+    """Prevent log injection by removing line-break/control characters."""
+    return str(value).replace("\r", "").replace("\n", "")
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/metrics",
+    summary="List Metrics By Workspace",
+    response_description="Return stored metrics for a workspace",
+    status_code=status.HTTP_200_OK,
+    response_model=Page[Metric],
+    response_model_exclude_none=True,
+    openapi_extra=generate_openapi_extra_params(
+        filter_schema=MetricFilter,
+        filter_description="Filter metrics by workspace, name, metric_type, description, created_at, and updated_at.",
+    ),
+)
+async def list_metrics(
+    workspace: str,
+    page: int = Query(default=1, ge=1, description="Page number."),
+    page_size: int = Query(default=100, ge=1, le=1000, description="Page size."),
+    sort: MetricSort = Query(
+        default=MetricSort.CREATED_AT_ASC,
+        description="The field to sort by. To sort in decreasing order, use `-` in front of the field name.",
+    ),
+    parsed_filter: ParsedFilter = Depends(make_filter_dep(MetricFilter)),
+    service: MetricService = Depends(get_metric_service),
+) -> Page[Metric]:
+    """List stored metrics for a specific workspace."""
+    # Discard any workspace override in the filter — always scope to the path workspace.
+    parsed_filter.remove("workspace")
+    try:
+        return await service.list_metrics(
+            workspace=workspace,
+            page=page,
+            page_size=page_size,
+            sort=sort,
+            filter_operation=parsed_filter.operation,
+        )
+    except Exception:
+        logger.exception(f"Failed to list metrics for workspace {_sanitize_for_log(workspace)}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")
+
+
+@router.post(
+    "/metrics/{name}",
+    summary="Create Metric",
+    response_description="Store a new metric",
+    status_code=status.HTTP_201_CREATED,
+    responses={status.HTTP_409_CONFLICT: {"description": "Metric already exists"}},
+)
+async def create_metric(
+    workspace: str,
+    name: Annotated[str, Path(max_length=MAX_NAME_LENGTH, pattern=NAME_PATTERN)],
+    metric: MetricInline,
+    project: str | None = Query(default=None, description="Optional project to associate with the metric."),
+    service: MetricService = Depends(get_metric_service),
+) -> Metric:
+    """Store a new metric, addressed by workspace/name."""
+    safe_workspace = _sanitize_for_log(workspace)
+    safe_name = _sanitize_for_log(name)
+    logger.info(f"Creating metric: {safe_workspace}/{safe_name}")
+    try:
+        return await service.create_metric(name, metric, workspace=workspace, project=project)
+    except EntityValidationError as e:
+        logger.warning(f"Entity store validation error during metric creation: {e}")
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+    except ValueError as e:
+        if "already exists" in str(e).lower():
+            logger.warning(f"Metric already exists: {safe_workspace}/{safe_name}")
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Metric with workspace '{workspace}' and name '{name}' already exists",
+            )
+        logger.warning(f"Metric creation validation error: {e}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid metric data")
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Failed to create metric")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")
+
+
+@router.get(
+    "/metrics/{name}",
+    summary="Get Metric",
+    response_description="Return stored metric details",
+    status_code=status.HTTP_200_OK,
+    responses={status.HTTP_404_NOT_FOUND: {"description": "Metric not found"}},
+)
+async def get_metric(
+    workspace: str,
+    name: str,
+    service: MetricService = Depends(get_metric_service),
+) -> Metric:
+    """Get a stored metric by workspace and name."""
+    logger.debug(f"Getting metric: {_sanitize_for_log(workspace)}/{_sanitize_for_log(name)}")
+    try:
+        metric = await service.get_metric(workspace, name)
+        if not metric:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Metric not found: {workspace}/{name}",
+            )
+        return metric
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception(f"Failed to get metric {_sanitize_for_log(workspace)}/{_sanitize_for_log(name)}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")
+
+
+@router.delete(
+    "/metrics/{name}",
+    summary="Delete Metric",
+    response_description="Delete a stored metric",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={status.HTTP_404_NOT_FOUND: {"description": "Metric not found"}},
+)
+async def delete_metric(
+    workspace: str,
+    name: str,
+    service: MetricService = Depends(get_metric_service),
+):
+    """Delete a stored metric by workspace and name."""
+    logger.info(f"Deleting metric: {_sanitize_for_log(workspace)}/{_sanitize_for_log(name)}")
+    try:
+        deleted = await service.delete_metric(workspace, name)
+        if not deleted:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Metric not found: {workspace}/{name}",
+            )
+        return None
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception(f"Failed to delete metric {_sanitize_for_log(workspace)}/{_sanitize_for_log(name)}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")

--- a/plugins/nemo-evaluator/src/nemo_evaluator/entities.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/entities.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stored metric entity for the evaluator plugin.
+
+A :class:`MetricBundleEntity` is the persisted, queryable index for a metric.
+The full executable :class:`~nemo_evaluator.shared.metric_bundles.bundles.MetricBundle`
+(including its potentially multi-MiB serialized payload) lives in the Files
+service; the entity stores only the lightweight, searchable projection plus a
+reference (``bundle_ref``) and integrity digest (``payload_digest``) that point
+back at the canonical copy.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from nemo_evaluator.shared.metric_bundles.bundles import BundledMetricOutputSpec
+from nemo_evaluator_sdk.values.common import SecretRef
+from nemo_platform_plugin.entities import EntityBase
+from pydantic import Field
+
+# Constants are intentionally local: nmp_common's entity constants are not
+# re-exported to plugins. Keep these aligned with
+# ``nmp.common.entities.constants``.
+MAX_NAME_LENGTH = 255
+MAX_DESCRIPTION_LENGTH = 1000
+NAME_PATTERN = r"^[\w\-\.]+$"
+
+
+class MetricBundleEntity(EntityBase):
+    """Persisted index for a stored metric, addressed by workspace/name.
+
+    The canonical, executable bundle is stored in the Files service and
+    referenced by ``bundle_ref``; the fields here are a denormalized projection
+    kept for display and filtering without downloading the payload.
+    """
+
+    __entity_type__: ClassVar[str] = "metric_bundle"
+
+    metric_type: str = Field(
+        description="Runtime metric type name captured from the bundled metric.",
+        max_length=MAX_NAME_LENGTH,
+    )
+    labels: dict[str, str] = Field(
+        default_factory=dict,
+        description="Labels captured from the bundled metric's metadata.",
+    )
+    outputs: list[BundledMetricOutputSpec] = Field(
+        default_factory=list,
+        description="JSON-safe projection of the metric's output contracts.",
+    )
+    secrets: dict[str, SecretRef] = Field(
+        default_factory=dict,
+        description="Secret environment-variable references required to execute the metric.",
+    )
+    payload_kind: str = Field(
+        description="Payload discriminator of the stored bundle (e.g. 'cloudpickle').",
+        max_length=MAX_NAME_LENGTH,
+    )
+    payload_digest: str = Field(
+        description="Format-specific digest of the stored payload, used to verify integrity on load.",
+        max_length=MAX_NAME_LENGTH,
+    )
+    bundle_ref: str = Field(
+        description="Files reference to the canonical serialized MetricBundle (format: workspace/fileset#path).",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Description captured from the bundled metric's metadata.",
+        max_length=MAX_DESCRIPTION_LENGTH,
+    )

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
@@ -11,7 +11,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, Self, TypeAlias
 
+from nemo_evaluator.api.schemas import MetricInline
 from nemo_evaluator.filesets import FilesetRef, download_dataset, download_dataset_sync
+from nemo_evaluator.metric_refs import MetricRef, resolve_metric_specs
 from nemo_evaluator.resolvers import PlatformModelResolver
 from nemo_evaluator.shared.metric_bundles.bundles import (
     MetricBundle,
@@ -41,7 +43,10 @@ from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 TargetSpec = Model | Agent
-MetricSpec: TypeAlias = Annotated[list[MetricBundle], Field(min_length=1)]
+MetricSpec: TypeAlias = Annotated[list[MetricInline | MetricRef], Field(min_length=1)]
+# Canonical spec carries inline metrics only (refs resolved) — still the wire DTO,
+# so the runtime MetricBundle never surfaces as a public schema.
+ResolvedMetricSpec: TypeAlias = Annotated[list[MetricInline], Field(min_length=1)]
 EvaluationArtifactResult: TypeAlias = EvaluationResult | BenchmarkEvaluationResult
 InlineDataset: TypeAlias = Annotated[list[dict[str, object]], Field(min_length=1)]
 DatasetSpec: TypeAlias = InlineDataset | FilesetRef
@@ -82,6 +87,16 @@ def _bundle_resolved_metric(metric: Metric, source_bundle: MetricBundle) -> Metr
     return resolved_bundle.model_copy(update={"metadata": source_bundle.metadata})
 
 
+def _to_inline(bundle: MetricBundle) -> MetricInline:
+    """Project a runtime bundle onto the wire DTO (JSON round-trip keeps base64 consistent)."""
+    return MetricInline.model_validate_json(bundle.model_dump_json())
+
+
+def _to_runtime_bundle(metric: MetricInline) -> MetricBundle:
+    """Reconstruct the runtime bundle from a wire DTO for execution."""
+    return MetricBundle.model_validate_json(metric.model_dump_json())
+
+
 def _resolve_run_dataset(
     dataset: DatasetSpec,
     *,
@@ -111,12 +126,17 @@ def _resolve_run_dataset(
     raise ValueError("FilesetRef datasets require an SDK client for local evaluator job execution.")
 
 
-class EvaluateInputSpec(BaseModel):
-    """Submitter-facing SDK evaluation input for the evaluator plugin job."""
+class _EvaluateSpecCommon(BaseModel):
+    """Fields shared by the submitter input and the canonical (resolved) spec.
+
+    ``EvaluateInputSpec`` and ``EvaluateSpec`` are siblings rather than a
+    subtype pair: they differ only in their ``metrics`` field (refs allowed vs.
+    fully resolved), and a mutable field can't be narrowed across inheritance
+    without violating invariance.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
-    metrics: MetricSpec = Field(description="Bundled metric entities to evaluate.")
     dataset: DatasetSpec = Field(
         description="Inline dataset rows or a persisted FilesetRef dataset source to evaluate.",
     )
@@ -137,12 +157,24 @@ class EvaluateInputSpec(BaseModel):
         return self
 
 
-class EvaluateSpec(EvaluateInputSpec):
-    """Canonical SDK evaluation spec with platform model references resolved."""
+class EvaluateInputSpec(_EvaluateSpecCommon):
+    """Submitter-facing SDK evaluation input for the evaluator plugin job."""
+
+    metrics: MetricSpec = Field(
+        description="Metrics to evaluate, given as inline metrics and/or references to stored metrics.",
+    )
+
+
+class EvaluateSpec(_EvaluateSpecCommon):
+    """Canonical SDK evaluation spec with platform model and metric references resolved."""
+
+    metrics: ResolvedMetricSpec = Field(description="Inline metrics with all references resolved.")
 
     @model_validator(mode="after")
     def reject_unresolved_metric_model_refs(self) -> Self:
-        unresolved_refs = _unresolved_model_refs([unbundle_metric(bundle) for bundle in self.metrics])
+        unresolved_refs = _unresolved_model_refs(
+            [unbundle_metric(_to_runtime_bundle(metric)) for metric in self.metrics]
+        )
         if unresolved_refs:
             raise ValueError(
                 "EvaluateSpec metric models must be resolved before compile/run: " + ", ".join(unresolved_refs)
@@ -213,15 +245,23 @@ class EvaluateJob(NemoJob):
         async_sdk: AsyncNeMoPlatform | NeMoPlatform | None,
         is_local: bool,
     ) -> BaseModel:
-        """Resolve submitter-facing model references into the canonical evaluation spec."""
-        del workspace, entity_client, is_local
+        """Resolve submitter-facing model and metric references into the canonical evaluation spec."""
+        del is_local
         submit_spec = (
             input_spec.model_copy(deep=True)
             if isinstance(input_spec, EvaluateInputSpec)
-            else EvaluateInputSpec.model_validate(input_spec.model_dump())
+            else EvaluateInputSpec.model_validate_json(input_spec.model_dump_json())
         )
-        metrics = [unbundle_metric(bundle) for bundle in submit_spec.metrics]
-        submit_spec.params = resolve_params(submit_spec.params, submit_spec.target)
+        resolved_async_sdk = async_sdk if isinstance(async_sdk, AsyncNeMoPlatform) else None
+        resolved_metrics = await resolve_metric_specs(
+            submit_spec.metrics,
+            workspace=workspace,
+            entity_client=entity_client,
+            async_sdk=resolved_async_sdk,
+        )
+        metrics = [unbundle_metric(bundle) for bundle in resolved_metrics]
+        params = resolve_params(submit_spec.params, submit_spec.target)
+        final_bundles = resolved_metrics
         unresolved_refs = _unresolved_model_refs(metrics)
         if unresolved_refs:
             if async_sdk is None:
@@ -232,12 +272,18 @@ class EvaluateJob(NemoJob):
             await asyncio.gather(
                 *(metric.resolve_models(resolver) for metric in metrics if isinstance(metric, MetricWithModels))
             )
-        if unresolved_refs:
-            submit_spec.metrics = [
+            final_bundles = [
                 _bundle_resolved_metric(metric, bundle)
-                for metric, bundle in zip(metrics, submit_spec.metrics, strict=True)
+                for metric, bundle in zip(metrics, resolved_metrics, strict=True)
             ]
-        return EvaluateSpec.model_validate(submit_spec.model_dump(mode="python"))
+        return EvaluateSpec(
+            metrics=[_to_inline(bundle) for bundle in final_bundles],
+            dataset=submit_spec.dataset,
+            params=params,
+            target=submit_spec.target,
+            prompt_template=submit_spec.prompt_template,
+            field_mapping=submit_spec.field_mapping,
+        )
 
     def run(
         self,
@@ -251,7 +297,7 @@ class EvaluateJob(NemoJob):
         spec = EvaluateSpec.model_validate(config)
         evaluator = Evaluator()
         params = resolve_params(spec.params, spec.target)
-        metrics = [unbundle_metric(bundle) for bundle in spec.metrics]
+        metrics = [unbundle_metric(_to_runtime_bundle(metric)) for metric in spec.metrics]
         dataset = _resolve_run_dataset(
             spec.dataset,
             ctx=ctx,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/metric_refs.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/metric_refs.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""References to persisted metrics and their resolution into executable bundles.
+
+A :class:`MetricRef` lets an evaluation job point at a stored metric by
+``workspace/name`` instead of inlining it. During spec resolution (``to_spec``),
+references are loaded from storage and inline :class:`MetricInline` DTOs are
+converted, so the canonical job spec and execution path only ever see runtime
+:class:`MetricBundle` objects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.entities import MetricBundleEntity
+from nemo_evaluator.metric_storage import load_bundle
+from nemo_evaluator.shared.metric_bundles.bundles import MetricBundle
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.entities import EntityNotFoundError
+from pydantic import Field, RootModel
+
+# A reference is ``name`` or ``workspace/name``, each segment using the platform
+# name charset. Enforced on the field so empty/malformed refs are rejected at
+# validation time rather than during parsing.
+_METRIC_REF_PATTERN = r"^[\w\-.]+(/[\w\-.]+)?$"
+
+
+class MetricRef(RootModel[str]):
+    """Reference to a persisted metric (format: ``workspace/name`` or ``name``)."""
+
+    root: str = Field(
+        pattern=_METRIC_REF_PATTERN,
+        description="Reference to a stored metric (format: workspace/metric-name, or metric-name in the job workspace).",
+    )
+
+
+def parse_metric_ref(root: str, default_workspace: str) -> tuple[str, str]:
+    """Split a validated metric reference into ``(workspace, name)``.
+
+    The ``workspace/name`` vs bare-``name`` shape is guaranteed by
+    :class:`MetricRef`'s field pattern, so this only needs to split.
+    """
+    workspace, separator, name = root.partition("/")
+    if separator:
+        return workspace, name
+    return default_workspace, root
+
+
+async def resolve_metric_ref(
+    ref: MetricRef,
+    *,
+    workspace: str,
+    entity_client: Any,
+    async_sdk: AsyncNeMoPlatform | None,
+) -> MetricBundle:
+    """Load and reconstruct the stored metric a reference points at."""
+    if entity_client is None or async_sdk is None:
+        raise ValueError(
+            "MetricRef metrics require a platform connection (entity store and async SDK) to resolve; "
+            "they cannot be used in local execution. Pass an inline metric instead."
+        )
+    ref_workspace, name = parse_metric_ref(ref.root, workspace)
+    try:
+        entity = await entity_client.get(MetricBundleEntity, name=name, workspace=ref_workspace)
+    except EntityNotFoundError as exc:
+        raise ValueError(
+            f"Metric reference '{ref.root}' not found. "
+            f"Ensure a stored metric named '{name}' exists in workspace '{ref_workspace}', "
+            "or pass an inline metric instead."
+        ) from exc
+    return await load_bundle(async_sdk, entity.bundle_ref, expected_digest=entity.payload_digest)
+
+
+async def resolve_metric_specs(
+    metrics: list[MetricInline | MetricRef],
+    *,
+    workspace: str,
+    entity_client: Any,
+    async_sdk: AsyncNeMoPlatform | None,
+) -> list[MetricBundle]:
+    """Resolve a wire metric list into runtime bundles.
+
+    References are loaded from storage; inline :class:`MetricInline` DTOs are
+    converted to runtime bundles by JSON round-trip (which keeps the base64
+    payload encoding consistent).
+    """
+    resolved: list[MetricBundle] = []
+    for item in metrics:
+        if isinstance(item, MetricRef):
+            resolved.append(
+                await resolve_metric_ref(
+                    item,
+                    workspace=workspace,
+                    entity_client=entity_client,
+                    async_sdk=async_sdk,
+                )
+            )
+        else:
+            resolved.append(MetricBundle.model_validate_json(item.model_dump_json()))
+    return resolved

--- a/plugins/nemo-evaluator/src/nemo_evaluator/metric_storage.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/metric_storage.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Files-service storage for the canonical serialized MetricBundle.
+
+The evaluator service owns the lifecycle of a stored metric's payload. Each
+upload lands in its own uniquely-named fileset, so an upload never overwrites an
+existing metric's bytes and a failed/abandoned upload can always be cleaned up
+by deleting exactly the fileset it created. The
+:class:`~nemo_evaluator.entities.MetricBundleEntity` holds only the resulting
+reference, never the bytes.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+# Importing the cloudpickle module registers the "cloudpickle" payload kind in
+# the bundle registry so MetricBundle payloads round-trip through validation.
+import nemo_evaluator.shared.metric_bundles.cloudpickle  # noqa: F401
+from nemo_evaluator.shared.metric_bundles.bundles import MetricBundle
+from nemo_platform import AsyncNeMoPlatform
+from pydantic import ValidationError
+
+#: Filename of the serialized bundle stored within each metric's fileset.
+BUNDLE_FILENAME = "bundle.json"
+
+#: Prefix for the per-upload filesets backing stored metrics.
+FILESET_PREFIX = "metric-bundle"
+
+logger = logging.getLogger(__name__)
+
+
+class MetricBundleStorageError(RuntimeError):
+    """Raised when a stored metric bundle cannot be written, read, or verified."""
+
+
+def _new_fileset_name() -> str:
+    """Return a unique fileset name for a single metric-bundle upload.
+
+    Intentionally independent of the metric name: the uuid alone guarantees
+    uniqueness and keeps the name well within the fileset name length limit
+    regardless of how long the (up to 255-char) metric name is. The
+    metric/workspace association is recorded on the entity's ``bundle_ref`` and
+    in the fileset description.
+    """
+    return f"{FILESET_PREFIX}.{uuid.uuid4().hex}"
+
+
+def parse_bundle_ref(bundle_ref: str) -> tuple[str, str, str]:
+    """Split a ``workspace/fileset#path`` reference into its parts."""
+    if "#" not in bundle_ref:
+        raise MetricBundleStorageError(f"invalid metric bundle reference (missing fragment): {bundle_ref!r}")
+    location, path = bundle_ref.split("#", 1)
+    if "/" not in location:
+        raise MetricBundleStorageError(f"invalid metric bundle reference (missing workspace): {bundle_ref!r}")
+    workspace, fileset = location.split("/", 1)
+    if not workspace or not fileset or not path:
+        raise MetricBundleStorageError(f"invalid metric bundle reference: {bundle_ref!r}")
+    return workspace, fileset, path
+
+
+async def store_bundle(sdk: AsyncNeMoPlatform, workspace: str, name: str, bundle: MetricBundle) -> str:
+    """Serialize and upload a metric bundle to a fresh fileset, returning its reference.
+
+    Each call creates a new, uniquely-named fileset, so callers can safely roll
+    back by deleting exactly the reference returned here without risking another
+    metric's data.
+    """
+    fileset = _new_fileset_name()
+    body = bundle.model_dump_json().encode("utf-8")
+    try:
+        await sdk.files.filesets.create(
+            name=fileset,
+            workspace=workspace,
+            description=f"Stored metric bundle for {workspace}/{name}.",
+        )
+    except Exception as exc:
+        raise MetricBundleStorageError(f"failed to create fileset for metric bundle {workspace}/{name}") from exc
+    try:
+        await sdk.files._upload_file(
+            path=BUNDLE_FILENAME,
+            body=body,
+            workspace=workspace,
+            name=fileset,
+        )
+    except Exception as exc:
+        # Roll back the just-created (now-empty) fileset so a failed upload
+        # doesn't leak it, then surface a typed storage error.
+        try:
+            await sdk.files.filesets.delete(name=fileset, workspace=workspace)
+        except Exception:
+            logger.warning(
+                "Failed to clean up fileset after a failed metric bundle upload; storage may be leaked",
+                extra={"fileset": fileset},
+                exc_info=True,
+            )
+        raise MetricBundleStorageError(f"failed to upload metric bundle to {workspace}/{fileset}") from exc
+    # Construct the reference ourselves so storage/retrieval stay self-consistent
+    # regardless of the service's file_ref string format.
+    return f"{workspace}/{fileset}#{BUNDLE_FILENAME}"
+
+
+async def load_bundle(sdk: AsyncNeMoPlatform, bundle_ref: str, *, expected_digest: str | None = None) -> MetricBundle:
+    """Download and reconstruct a stored metric bundle from its Files reference.
+
+    When ``expected_digest`` is provided, the reconstructed payload digest is
+    verified against it to detect drift or corruption.
+    """
+    workspace, fileset, path = parse_bundle_ref(bundle_ref)
+    response = await sdk.files._download_file(path, workspace=workspace, name=fileset)
+    data = await response.read()
+    try:
+        bundle = MetricBundle.model_validate_json(data)
+    except (ValidationError, ValueError) as exc:
+        # ValueError also covers MetricBundlingError (unsupported/invalid payload kind).
+        raise MetricBundleStorageError(f"stored metric bundle at {bundle_ref!r} is corrupt or unreadable") from exc
+    if expected_digest is not None and bundle.payload.digest != expected_digest:
+        raise MetricBundleStorageError(
+            f"metric bundle digest mismatch for {bundle_ref!r}: "
+            f"expected {expected_digest}, found {bundle.payload.digest}"
+        )
+    return bundle
+
+
+async def delete_bundle_by_ref(sdk: AsyncNeMoPlatform, bundle_ref: str) -> None:
+    """Delete the specific fileset a bundle reference points at."""
+    workspace, fileset, _ = parse_bundle_ref(bundle_ref)
+    await sdk.files.filesets.delete(name=fileset, workspace=workspace)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/_executor.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/_executor.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 from typing import Any, TypeAlias, cast
 
 import httpx
+from nemo_evaluator.api.schemas import MetricInline
 from nemo_evaluator.filesets import FilesetRef
 from nemo_evaluator.jobs.evaluate import EvaluateInputSpec, EvaluateJob, EvaluateSpec, TargetSpec
 from nemo_evaluator.resolvers import PlatformModelResolver
@@ -119,8 +120,10 @@ def _build_evaluate_spec(
 ) -> EvaluateInputSpec:
     """Build the evaluator plugin input spec shared by local and remote execution."""
     effective_packager = _require_metric_bundle_packager(metric_bundle_packager)
+    runtime_bundles = bundle_metrics_for_spec(metrics, metric_bundle_packager=effective_packager)
     spec = {
-        "metrics": bundle_metrics_for_spec(metrics, metric_bundle_packager=effective_packager),
+        # Carry inline metrics as the wire DTO (matches EvaluateInputSpec.metrics).
+        "metrics": [MetricInline.model_validate_json(bundle.model_dump_json()) for bundle in runtime_bundles],
         "dataset": _dataset_config(dataset, params),
         "params": params.model_dump(mode="json"),
     }

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/metric_resources.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/metric_resources.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDK resources for managing stored metrics (``client.evaluator.metrics``).
+
+These resources package a runtime metric into a :class:`MetricInline` wire DTO and
+call the evaluator service's ``/metrics`` create/get/list/delete API (metrics are
+immutable). The service owns the payload's Files storage, so the SDK only ever
+sends/receives the metric and its metadata.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from nemo_evaluator.api.schemas import Metric, MetricInline
+from nemo_evaluator.sdk import http_utils
+from nemo_evaluator.shared.metric_bundles.bundles import (
+    MetricBundle,
+    MetricBundlePackager,
+    bundle_metric,
+)
+from nemo_evaluator_sdk.metrics.protocol import Metric as RuntimeMetric
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.schema import Page
+
+
+def _metric_inline(
+    metric: RuntimeMetric | MetricBundle,
+    metric_bundle_packager: MetricBundlePackager | None,
+) -> MetricInline:
+    """Package a runtime metric (or accept a pre-built bundle) as the wire DTO."""
+    if isinstance(metric, MetricBundle):
+        bundle = metric
+    elif metric_bundle_packager is None:
+        raise ValueError(
+            "metric_bundle_packager is required when storing a runtime metric; "
+            "pass CloudpickleMetricBundlePackager(), or pass a pre-built MetricBundle."
+        )
+    else:
+        bundle = bundle_metric(metric, metric_bundle_packager)
+    # JSON round-trip keeps the base64 payload encoding consistent with the runtime model.
+    return MetricInline.model_validate_json(bundle.model_dump_json())
+
+
+class EvaluatorMetricsResource:
+    """Sync resource mounted as ``client.evaluator.metrics``."""
+
+    def __init__(self, platform: NeMoPlatform) -> None:
+        self._platform = platform
+        self._http_client = platform._client
+
+    def _headers(self) -> dict[str, str]:
+        return http_utils.platform_default_headers(self._platform)
+
+    def _collection_url(self, workspace: str | None) -> str:
+        return http_utils.url(self._platform, "/v2/workspaces/{workspace}/metrics", workspace)
+
+    def _item_url(self, name: str, workspace: str | None) -> str:
+        return http_utils.url(
+            self._platform,
+            f"/v2/workspaces/{{workspace}}/metrics/{quote(name, safe='')}",
+            workspace,
+        )
+
+    def create(
+        self,
+        name: str,
+        *,
+        metric: RuntimeMetric | MetricBundle,
+        metric_bundle_packager: MetricBundlePackager | None = None,
+        project: str | None = None,
+        workspace: str | None = None,
+    ) -> Metric:
+        """Store a new metric (addressed by workspace/name), packaging a runtime metric when needed."""
+        body = _metric_inline(metric, metric_bundle_packager)
+        response = self._http_client.post(
+            self._item_url(name, workspace),
+            json=body.model_dump(mode="json"),
+            params={"project": project} if project is not None else None,
+            headers=self._headers(),
+            timeout=self._platform.timeout,
+        )
+        response.raise_for_status()
+        return Metric.model_validate(response.json())
+
+    def retrieve(self, name: str, *, workspace: str | None = None) -> Metric:
+        """Get a stored metric by name."""
+        response = self._http_client.get(
+            self._item_url(name, workspace), headers=self._headers(), timeout=self._platform.timeout
+        )
+        response.raise_for_status()
+        return Metric.model_validate(response.json())
+
+    def list(self, *, workspace: str | None = None, page: int = 1, page_size: int = 100) -> Page[Metric]:
+        """List stored metrics in a workspace."""
+        response = self._http_client.get(
+            self._collection_url(workspace),
+            params={"page": page, "page_size": page_size},
+            headers=self._headers(),
+            timeout=self._platform.timeout,
+        )
+        response.raise_for_status()
+        return Page[Metric].model_validate(response.json())
+
+    def delete(self, name: str, *, workspace: str | None = None) -> None:
+        """Delete a stored metric and its backing bundle."""
+        response = self._http_client.delete(
+            self._item_url(name, workspace), headers=self._headers(), timeout=self._platform.timeout
+        )
+        response.raise_for_status()
+
+
+class AsyncEvaluatorMetricsResource:
+    """Async resource mounted as ``client.evaluator.metrics``."""
+
+    def __init__(self, platform: AsyncNeMoPlatform) -> None:
+        self._platform = platform
+        self._http_client = platform._client
+
+    def _headers(self) -> dict[str, str]:
+        return http_utils.platform_default_headers(self._platform)
+
+    def _collection_url(self, workspace: str | None) -> str:
+        return http_utils.url(self._platform, "/v2/workspaces/{workspace}/metrics", workspace)
+
+    def _item_url(self, name: str, workspace: str | None) -> str:
+        return http_utils.url(
+            self._platform,
+            f"/v2/workspaces/{{workspace}}/metrics/{quote(name, safe='')}",
+            workspace,
+        )
+
+    async def create(
+        self,
+        name: str,
+        *,
+        metric: RuntimeMetric | MetricBundle,
+        metric_bundle_packager: MetricBundlePackager | None = None,
+        project: str | None = None,
+        workspace: str | None = None,
+    ) -> Metric:
+        """Store a new metric (addressed by workspace/name), packaging a runtime metric when needed."""
+        body = _metric_inline(metric, metric_bundle_packager)
+        response = await self._http_client.post(
+            self._item_url(name, workspace),
+            json=body.model_dump(mode="json"),
+            params={"project": project} if project is not None else None,
+            headers=self._headers(),
+            timeout=self._platform.timeout,
+        )
+        response.raise_for_status()
+        return Metric.model_validate(response.json())
+
+    async def retrieve(self, name: str, *, workspace: str | None = None) -> Metric:
+        """Get a stored metric by name."""
+        response = await self._http_client.get(
+            self._item_url(name, workspace), headers=self._headers(), timeout=self._platform.timeout
+        )
+        response.raise_for_status()
+        return Metric.model_validate(response.json())
+
+    async def list(self, *, workspace: str | None = None, page: int = 1, page_size: int = 100) -> Page[Metric]:
+        """List stored metrics in a workspace."""
+        response = await self._http_client.get(
+            self._collection_url(workspace),
+            params={"page": page, "page_size": page_size},
+            headers=self._headers(),
+            timeout=self._platform.timeout,
+        )
+        response.raise_for_status()
+        return Page[Metric].model_validate(response.json())
+
+    async def delete(self, name: str, *, workspace: str | None = None) -> None:
+        """Delete a stored metric and its backing bundle."""
+        response = await self._http_client.delete(
+            self._item_url(name, workspace), headers=self._headers(), timeout=self._platform.timeout
+        )
+        response.raise_for_status()

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/resources.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/resources.py
@@ -19,6 +19,10 @@ from nemo_evaluator.sdk.job_resources import (
     EvaluatorJob,
     EvaluatorJobResource,
 )
+from nemo_evaluator.sdk.metric_resources import (
+    AsyncEvaluatorMetricsResource,
+    EvaluatorMetricsResource,
+)
 from nemo_evaluator.sdk.types import (
     PluginDatasetInput,
     RunConfig,
@@ -47,6 +51,7 @@ class Evaluator:
         self._platform = platform
         self._http_client = platform._client
         self._executor = _SyncEvaluatorPluginExecutor(platform=platform)
+        self.metrics = EvaluatorMetricsResource(platform)
 
     def plugin_status(self) -> dict[str, object]:
         """Return evaluator plugin health information from the service."""
@@ -215,6 +220,7 @@ class AsyncEvaluator:
         self._platform = platform
         self._http_client = platform._client
         self._executor = _AsyncEvaluatorPluginExecutor(platform=platform)
+        self.metrics = AsyncEvaluatorMetricsResource(platform)
 
     async def plugin_status(self) -> dict[str, object]:
         """Return evaluator plugin health information from the service."""

--- a/plugins/nemo-evaluator/src/nemo_evaluator/service.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from fastapi import APIRouter
+from nemo_evaluator.api.v2 import metrics as metrics_routes
 from nemo_evaluator.core import say_hello
 from nemo_evaluator.jobs.evaluate import EvaluateJob
 from nemo_evaluator.schema import HelloResponse
@@ -21,11 +22,36 @@ from nemo_platform_plugin.jobs.routes import add_job_routes
 from nemo_platform_plugin.service import NemoService, RouterSpec
 
 
+def _authz_for_metrics_collection(api_area: str, permission_prefix: str) -> AuthzContribution:
+    """Authz for the stored-metrics CRUD collection (full path includes PUT)."""
+    base = f"/apis/{api_area}/v2/workspaces/{{workspace}}/metrics"
+    read_scopes = [f"{api_area}:read", "platform:read"]
+    write_scopes = [f"{api_area}:write", "platform:write"]
+    return AuthzContribution(
+        permissions={
+            f"{permission_prefix}.create": f"Create {permission_prefix}",
+            f"{permission_prefix}.list": f"List {permission_prefix}",
+            f"{permission_prefix}.read": f"Read {permission_prefix}",
+            f"{permission_prefix}.delete": f"Delete {permission_prefix}",
+        },
+        endpoints={
+            base: {
+                "get": AuthzEndpointMethod(permissions=[f"{permission_prefix}.list"], scopes=read_scopes),
+            },
+            f"{base}/{{name}}": {
+                "post": AuthzEndpointMethod(permissions=[f"{permission_prefix}.create"], scopes=write_scopes),
+                "get": AuthzEndpointMethod(permissions=[f"{permission_prefix}.read"], scopes=read_scopes),
+                "delete": AuthzEndpointMethod(permissions=[f"{permission_prefix}.delete"], scopes=write_scopes),
+            },
+        },
+    )
+
+
 class EvaluatorPluginService(NemoService):
     """Minimal service surface for evaluator pluginification work."""
 
     name: ClassVar[str] = "evaluator"
-    dependencies: ClassVar[list[str]] = ["nemo-evaluator-sdk"]
+    dependencies: ClassVar[list[str]] = ["nemo-evaluator-sdk", "entities", "files"]
 
     @classmethod
     def get_authz_contribution(cls) -> AuthzContribution:
@@ -44,6 +70,10 @@ class EvaluatorPluginService(NemoService):
                 api_area=cls.name,
                 collection_suffix="/evaluate/jobs",
                 permission_prefix=f"{cls.name}.jobs",
+            ),
+            _authz_for_metrics_collection(
+                api_area=cls.name,
+                permission_prefix=f"{cls.name}.metrics",
             ),
         )
 
@@ -79,6 +109,13 @@ class EvaluatorPluginService(NemoService):
                 router=jobs_router,
                 tag="Evaluator Plugin Jobs Routes",
                 description="Evaluator plugin jobs routes.",
+                prefix="/v2/workspaces/{workspace}",
+            ),
+            RouterSpec(
+                # CRUD /apis/evaluator/v2/workspaces/{workspace}/metrics.
+                router=metrics_routes.router,
+                tag="Evaluator Plugin Metrics Routes",
+                description="Stored metric (metric bundle) CRUD routes.",
                 prefix="/v2/workspaces/{workspace}",
             ),
         ]

--- a/plugins/nemo-evaluator/tests/api/service/test_metric_service.py
+++ b/plugins/nemo-evaluator/tests/api/service/test_metric_service.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.api.service.metric_service import MetricService
+from nemo_evaluator.entities import MetricBundleEntity
+from nemo_evaluator.metric_storage import parse_bundle_ref
+from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
+from nemo_platform_plugin.entities import (
+    EntityConflictError,
+    EntityNotFoundError,
+    ListResponse,
+    PaginationInfo,
+)
+
+# ---- in-memory fakes -------------------------------------------------------
+
+
+class _FakeFile:
+    def __init__(self, file_ref: str) -> None:
+        self.file_ref = file_ref
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+class _FakeFilesets:
+    def __init__(self, store: dict[tuple[str, str], dict[str, bytes]]) -> None:
+        self._store = store
+
+    async def create(self, *, name, workspace, description=None, exist_ok=False):
+        self._store.setdefault((workspace, name), {})
+        return object()
+
+    async def delete(self, name, *, workspace=None):
+        self._store.pop((workspace, name), None)
+        return object()
+
+
+class _FakeFiles:
+    def __init__(self, store: dict[tuple[str, str], dict[str, bytes]]) -> None:
+        self._store = store
+        self.filesets = _FakeFilesets(store)
+
+    async def _upload_file(self, *, path, body, workspace, name):
+        self._store.setdefault((workspace, name), {})[path] = bytes(body)
+        return _FakeFile(f"{workspace}/{name}#{path}")
+
+    async def _download_file(self, path, *, workspace, name):
+        return _FakeResponse(self._store[(workspace, name)][path])
+
+
+class _FakeSDK:
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], dict[str, bytes]] = {}
+        self.files = _FakeFiles(self._store)
+
+
+class _FakeEntityClient:
+    def __init__(self) -> None:
+        self.entities: dict[tuple[str, str], MetricBundleEntity] = {}
+
+    async def get(self, entity_cls, *, workspace, name):
+        key = (workspace, name)
+        if key not in self.entities:
+            raise EntityNotFoundError(f"{workspace}/{name} not found")
+        return self.entities[key]
+
+    async def create(self, entity):
+        key = (entity.workspace, entity.name)
+        if key in self.entities:
+            raise EntityConflictError(f"{key} exists")
+        now = datetime.now(timezone.utc)
+        entity._id = f"metric_bundle-{entity.name}"
+        entity._created_at = now
+        entity._updated_at = now
+        self.entities[key] = entity
+        return entity
+
+    async def delete(self, entity_cls, name, *, workspace):
+        self.entities.pop((workspace, name), None)
+
+    async def list(self, entity_cls, *, workspace, filter_operation=None, sort=None, page=1, page_size=100):
+        items = [e for (ws, _), e in self.entities.items() if ws == workspace]
+        return ListResponse(
+            data=items,
+            pagination=PaginationInfo(
+                page=page,
+                page_size=page_size,
+                current_page_size=len(items),
+                total_pages=1,
+                total_results=len(items),
+            ),
+        )
+
+
+@pytest.fixture
+def service() -> MetricService:
+    return MetricService(_FakeEntityClient(), _FakeSDK())
+
+
+def _bundle(metric=None) -> MetricInline:
+    """Build a runtime bundle and return it as the API wire DTO (what requests carry)."""
+    metric = metric or ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.output}}")
+    runtime_bundle = bundle_metric(metric, CloudpickleMetricBundlePackager())
+    return MetricInline.model_validate_json(runtime_bundle.model_dump_json())
+
+
+def _fileset_of(service: MetricService, bundle_ref: str) -> tuple[str, str]:
+    workspace, fileset, _ = parse_bundle_ref(bundle_ref)
+    return (workspace, fileset)
+
+
+# ---- tests -----------------------------------------------------------------
+
+
+async def test_create_stores_bundle_and_indexes_entity(service: MetricService) -> None:
+    bundle = _bundle()
+    created = await service.create_metric("exact", bundle, workspace="default")
+
+    assert created.name == "exact"
+    assert created.metric_type == bundle.metric_type
+    assert created.payload_kind == "cloudpickle"
+    assert created.payload_digest == bundle.payload.digest
+    assert created.bundle_ref.startswith("default/metric-bundle.")
+    # Description/labels are sourced from the bundle's metadata.
+    assert created.description == bundle.metadata.description
+    assert created.labels == bundle.metadata.labels
+    # Bundle bytes live in Files, not in the entity index.
+    assert _fileset_of(service, created.bundle_ref) in service.sdk._store
+
+
+async def test_create_rejects_duplicate_without_clobbering_existing(service: MetricService) -> None:
+    first = await service.create_metric("exact", _bundle(), workspace="default")
+
+    with pytest.raises(ValueError, match="already exists"):
+        await service.create_metric("exact", _bundle(), workspace="default")
+
+    # The original metric's bundle must survive the rejected create's rollback.
+    assert _fileset_of(service, first.bundle_ref) in service.sdk._store
+
+
+async def test_get_returns_none_when_missing(service: MetricService) -> None:
+    assert await service.get_metric("default", "nope") is None
+
+
+async def test_delete_removes_entity_and_bundle(service: MetricService) -> None:
+    created = await service.create_metric("m", _bundle(), workspace="default")
+
+    assert await service.delete_metric("default", "m") is True
+    assert await service.get_metric("default", "m") is None
+    assert _fileset_of(service, created.bundle_ref) not in service.sdk._store
+
+
+async def test_delete_returns_false_when_missing(service: MetricService) -> None:
+    assert await service.delete_metric("default", "nope") is False
+
+
+async def test_delete_handles_concurrent_delete_race(service: MetricService) -> None:
+    await service.create_metric("m", _bundle(), workspace="default")
+
+    async def _already_deleted(*_args, **_kwargs):
+        raise EntityNotFoundError("deleted concurrently")
+
+    # Simulate another request removing the entity between get and delete.
+    service.entity_client.delete = _already_deleted
+    assert await service.delete_metric("default", "m") is False
+
+
+async def test_list_returns_workspace_metrics(service: MetricService) -> None:
+    await service.create_metric("a", _bundle(), workspace="default")
+    await service.create_metric("b", _bundle(), workspace="default")
+
+    page = await service.list_metrics("default")
+
+    assert {m.name for m in page.data} == {"a", "b"}
+    assert page.pagination is not None
+    assert page.pagination.total_results == 2

--- a/plugins/nemo-evaluator/tests/api/v2/test_metrics_routes.py
+++ b/plugins/nemo-evaluator/tests/api/v2/test_metrics_routes.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""HTTP route-level tests for the /metrics CRUD endpoints.
+
+Drives the real FastAPI router + MetricService through a TestClient, with the
+entity store and Files service replaced by in-memory fakes. Covers route wiring,
+the get_metric_service dependency, and status-code mapping (201/204/404/409).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from nemo_evaluator.api.dependencies import get_metric_service
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.api.service.metric_service import MetricService
+from nemo_evaluator.api.v2 import metrics as metrics_routes
+from nemo_evaluator.entities import MetricBundleEntity
+from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
+from nemo_platform_plugin.entities import (
+    EntityConflictError,
+    EntityNotFoundError,
+    ListResponse,
+    PaginationInfo,
+)
+
+# ---- in-memory fakes -------------------------------------------------------
+
+
+class _FakeFile:
+    def __init__(self, file_ref: str) -> None:
+        self.file_ref = file_ref
+
+
+class _FakeFilesets:
+    def __init__(self, store: dict[tuple[str, str], dict[str, bytes]]) -> None:
+        self._store = store
+
+    async def create(self, *, name, workspace, description=None, exist_ok=False):
+        self._store.setdefault((workspace, name), {})
+        return object()
+
+    async def delete(self, name, *, workspace=None):
+        self._store.pop((workspace, name), None)
+        return object()
+
+
+class _FakeFiles:
+    def __init__(self, store: dict[tuple[str, str], dict[str, bytes]]) -> None:
+        self._store = store
+        self.filesets = _FakeFilesets(store)
+
+    async def _upload_file(self, *, path, body, workspace, name):
+        self._store.setdefault((workspace, name), {})[path] = bytes(body)
+        return _FakeFile(f"{workspace}/{name}#{path}")
+
+
+class _FakeSDK:
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], dict[str, bytes]] = {}
+        self.files = _FakeFiles(self._store)
+
+
+class _FakeEntityClient:
+    def __init__(self) -> None:
+        self.entities: dict[tuple[str, str], MetricBundleEntity] = {}
+
+    async def get(self, entity_cls, *, workspace, name):
+        key = (workspace, name)
+        if key not in self.entities:
+            raise EntityNotFoundError(f"{workspace}/{name} not found")
+        return self.entities[key]
+
+    async def create(self, entity):
+        key = (entity.workspace, entity.name)
+        if key in self.entities:
+            raise EntityConflictError(f"{key} exists")
+        now = datetime.now(timezone.utc)
+        entity._id = f"metric_bundle-{entity.name}"
+        entity._created_at = now
+        entity._updated_at = now
+        self.entities[key] = entity
+        return entity
+
+    async def delete(self, entity_cls, name, *, workspace):
+        self.entities.pop((workspace, name), None)
+
+    async def list(self, entity_cls, *, workspace, filter_operation=None, sort=None, page=1, page_size=100):
+        items = [e for (ws, _), e in self.entities.items() if ws == workspace]
+        return ListResponse(
+            data=items,
+            pagination=PaginationInfo(
+                page=page,
+                page_size=page_size,
+                current_page_size=len(items),
+                total_pages=1,
+                total_results=len(items),
+            ),
+        )
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    # Mirror production mounting: the router's paths are relative; the
+    # workspace-scoped prefix is applied via RouterSpec in the plugin service.
+    app.include_router(metrics_routes.router, prefix="/v2/workspaces/{workspace}")
+    service = MetricService(_FakeEntityClient(), _FakeSDK())
+    app.dependency_overrides[get_metric_service] = lambda: service
+    return TestClient(app)
+
+
+def _create_body() -> dict:
+    """The create request body is a bare MetricInline (name comes from the path)."""
+    metric = ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.output}}")
+    runtime_bundle = bundle_metric(metric, CloudpickleMetricBundlePackager())
+    return MetricInline.model_validate_json(runtime_bundle.model_dump_json()).model_dump(mode="json")
+
+
+_BASE = "/v2/workspaces/default/metrics"
+
+
+def test_create_then_get(client: TestClient) -> None:
+    resp = client.post(f"{_BASE}/exact", json=_create_body())
+    assert resp.status_code == 201
+    assert resp.json()["name"] == "exact"
+
+    got = client.get(f"{_BASE}/exact")
+    assert got.status_code == 200
+    assert got.json()["payload_kind"] == "cloudpickle"
+
+
+def test_create_duplicate_returns_409(client: TestClient) -> None:
+    assert client.post(f"{_BASE}/exact", json=_create_body()).status_code == 201
+    assert client.post(f"{_BASE}/exact", json=_create_body()).status_code == 409
+
+
+def test_get_missing_returns_404(client: TestClient) -> None:
+    assert client.get(f"{_BASE}/nope").status_code == 404
+
+
+def test_list_returns_created_metrics(client: TestClient) -> None:
+    client.post(f"{_BASE}/a", json=_create_body())
+    client.post(f"{_BASE}/b", json=_create_body())
+
+    resp = client.get(_BASE)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert {m["name"] for m in body["data"]} == {"a", "b"}
+    assert body["pagination"]["total_results"] == 2
+
+
+def test_create_then_delete(client: TestClient) -> None:
+    client.post(f"{_BASE}/exact", json=_create_body())
+
+    deleted = client.delete(f"{_BASE}/exact")
+    assert deleted.status_code == 204
+    assert client.get(f"{_BASE}/exact").status_code == 404
+
+
+def test_delete_missing_returns_404(client: TestClient) -> None:
+    assert client.delete(f"{_BASE}/nope").status_code == 404

--- a/plugins/nemo-evaluator/tests/sdk/test_metric_sdk_resources.py
+++ b/plugins/nemo-evaluator/tests/sdk/test_metric_sdk_resources.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the client.evaluator.metrics SDK resources."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nemo_evaluator.api.schemas import Metric
+from nemo_evaluator.sdk.metric_resources import (
+    AsyncEvaluatorMetricsResource,
+    EvaluatorMetricsResource,
+)
+from nemo_evaluator.shared.metric_bundles.bundles import MetricBundle, bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
+
+
+def _bundle() -> MetricBundle:
+    metric = ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.output}}")
+    return bundle_metric(metric, CloudpickleMetricBundlePackager())
+
+
+def _metric_response(name: str, bundle: MetricBundle) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    return Metric(
+        id=f"metric_bundle-{name}",
+        name=name,
+        workspace="default",
+        metric_type=bundle.metric_type,
+        description=bundle.metadata.description,
+        labels=bundle.metadata.labels,
+        outputs=bundle.outputs,
+        secrets=bundle.secrets,
+        payload_kind=bundle.payload.kind,
+        payload_digest=bundle.payload.digest,
+        bundle_ref=f"default/metric-bundle.{name}#bundle.json",
+        created_at=now,
+        updated_at=now,
+    ).model_dump(mode="json")
+
+
+def _response(payload: dict[str, Any]) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _platform(http_client: Any) -> MagicMock:
+    platform = MagicMock()
+    platform._client = http_client
+    platform.base_url = "http://localhost:8080"
+    platform.workspace = "default"
+    platform.default_headers = {}
+    platform.timeout = 30
+    return platform
+
+
+# ---- sync ------------------------------------------------------------------
+
+
+def test_sync_create_posts_bundle_and_returns_metric() -> None:
+    bundle = _bundle()
+    http_client = MagicMock()
+    http_client.post.return_value = _response(_metric_response("exact", bundle))
+    resource = EvaluatorMetricsResource(_platform(http_client))
+
+    result = resource.create("exact", metric=bundle)
+
+    assert result.name == "exact"
+    url, kwargs = http_client.post.call_args[0], http_client.post.call_args.kwargs
+    # Name is in the path; the body is the bare MetricInline.
+    assert url[0] == "http://localhost:8080/apis/evaluator/v2/workspaces/default/metrics/exact"
+    body = kwargs["json"]
+    assert body["metric_type"] == bundle.metric_type
+    assert body["payload"]["kind"] == "cloudpickle"
+
+
+def test_sync_create_requires_packager_for_runtime_metric() -> None:
+    resource = EvaluatorMetricsResource(_platform(MagicMock()))
+    metric = ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.output}}")
+
+    with pytest.raises(ValueError, match="metric_bundle_packager is required"):
+        resource.create("exact", metric=metric)
+
+
+def test_sync_retrieve_targets_item_url() -> None:
+    bundle = _bundle()
+    http_client = MagicMock()
+    http_client.get.return_value = _response(_metric_response("exact", bundle))
+    resource = EvaluatorMetricsResource(_platform(http_client))
+
+    resource.retrieve("exact")
+
+    assert http_client.get.call_args[0][0] == "http://localhost:8080/apis/evaluator/v2/workspaces/default/metrics/exact"
+
+
+def test_sync_list_returns_data_items() -> None:
+    bundle = _bundle()
+    http_client = MagicMock()
+    http_client.get.return_value = _response({"data": [_metric_response("a", bundle), _metric_response("b", bundle)]})
+    resource = EvaluatorMetricsResource(_platform(http_client))
+
+    result = resource.list()
+
+    assert {m.name for m in result.data} == {"a", "b"}
+
+
+def test_sync_delete_issues_delete_request() -> None:
+    http_client = MagicMock()
+    http_client.delete.return_value = _response({})
+    resource = EvaluatorMetricsResource(_platform(http_client))
+
+    resource.delete("exact")
+
+    assert (
+        http_client.delete.call_args[0][0] == "http://localhost:8080/apis/evaluator/v2/workspaces/default/metrics/exact"
+    )
+
+
+# ---- async -----------------------------------------------------------------
+
+
+async def test_async_create_posts_bundle_and_returns_metric() -> None:
+    bundle = _bundle()
+    http_client = MagicMock()
+    http_client.post = AsyncMock(return_value=_response(_metric_response("exact", bundle)))
+    resource = AsyncEvaluatorMetricsResource(_platform(http_client))
+
+    result = await resource.create("exact", metric=bundle, workspace="ws1")
+
+    assert result.name == "exact"
+    assert http_client.post.call_args[0][0] == "http://localhost:8080/apis/evaluator/v2/workspaces/ws1/metrics/exact"

--- a/plugins/nemo-evaluator/tests/test_metric_entity.py
+++ b/plugins/nemo-evaluator/tests/test_metric_entity.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serialization round-trip tests for MetricBundleEntity.
+
+The entity store persists an entity's custom fields with
+``model_dump(exclude=base, mode="json")`` into a JSON column and rebuilds it with
+``model_validate``. These tests exercise that exact round-trip (which the
+in-memory fakes elsewhere bypass) to guard the complex fields — ``secrets``,
+``outputs``, and ``labels`` — that carry non-trivial nested types.
+"""
+
+from __future__ import annotations
+
+import json
+
+from nemo_evaluator.entities import MetricBundleEntity
+from nemo_evaluator.shared.metric_bundles.bundles import MetricBundle, bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator_sdk.enums import ModelFormat
+from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
+from nemo_evaluator_sdk.metrics.llm_judge import LLMJudgeMetric
+from nemo_evaluator_sdk.values import Model, SecretRef
+from nemo_evaluator_sdk.values.scores import JSONScoreParser, RangeScore
+
+
+def _entity(bundle: MetricBundle) -> MetricBundleEntity:
+    return MetricBundleEntity(
+        name="m",
+        workspace="default",
+        metric_type=bundle.metric_type,
+        description=bundle.metadata.description,
+        labels=bundle.metadata.labels,
+        outputs=bundle.outputs,
+        secrets=bundle.secrets,
+        payload_kind=bundle.payload.kind,
+        payload_digest=bundle.payload.digest,
+        bundle_ref="default/metric-bundle.abc#bundle.json",
+    )
+
+
+def _roundtrip(entity: MetricBundleEntity) -> MetricBundleEntity:
+    """Mirror the entity store: dump custom fields to JSON, then rebuild."""
+    data = entity.model_dump(exclude=MetricBundleEntity.__base_fields__, exclude_computed_fields=True, mode="json")
+    # Prove the data is genuinely JSON-serializable (the entity store uses a JSON column).
+    data = json.loads(json.dumps(data))
+    return MetricBundleEntity.model_validate({"name": entity.name, "workspace": entity.workspace, **data})
+
+
+def test_roundtrip_preserves_simple_metric() -> None:
+    bundle = bundle_metric(
+        ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.output}}"),
+        CloudpickleMetricBundlePackager(),
+    )
+    entity = _entity(bundle)
+
+    restored = _roundtrip(entity)
+
+    assert restored.metric_type == entity.metric_type
+    assert restored.outputs == entity.outputs
+    assert restored.labels == entity.labels
+    assert restored.payload_kind == entity.payload_kind
+    assert restored.payload_digest == entity.payload_digest
+    assert restored.bundle_ref == entity.bundle_ref
+
+
+def test_roundtrip_preserves_secrets_and_metadata() -> None:
+    metric = LLMJudgeMetric(
+        model=Model(
+            url="https://judge.example.test/v1/chat/completions",
+            name="judge-model",
+            api_key_secret=SecretRef(root="judge-secret"),
+            format=ModelFormat.OPEN_AI,
+        ),
+        scores=[RangeScore(name="helpfulness", minimum=1, maximum=5, parser=JSONScoreParser(json_path="helpfulness"))],
+    )
+    bundle = bundle_metric(metric, CloudpickleMetricBundlePackager())
+    entity = _entity(bundle)
+    assert entity.secrets  # sanity: this metric captures a secret reference
+
+    restored = _roundtrip(entity)
+
+    # dict[str, SecretRef] and the JSON-schema-bearing outputs must survive the column.
+    assert restored.secrets == entity.secrets
+    assert restored.outputs == entity.outputs

--- a/plugins/nemo-evaluator/tests/test_metric_refs.py
+++ b/plugins/nemo-evaluator/tests/test_metric_refs.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.entities import MetricBundleEntity
+from nemo_evaluator.jobs.evaluate import EvaluateInputSpec, EvaluateSpec
+from nemo_evaluator.metric_refs import (
+    MetricRef,
+    parse_metric_ref,
+    resolve_metric_specs,
+)
+from nemo_evaluator.metric_storage import store_bundle
+from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
+from nemo_platform_plugin.entities import EntityNotFoundError
+from pydantic import ValidationError
+
+# ---- in-memory fakes (mirror the storage round-trip) -----------------------
+
+
+class _FakeFile:
+    def __init__(self, file_ref: str) -> None:
+        self.file_ref = file_ref
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+class _FakeFilesets:
+    def __init__(self, store) -> None:
+        self._store = store
+
+    async def create(self, *, name, workspace, description=None, exist_ok=False):
+        self._store.setdefault((workspace, name), {})
+        return object()
+
+    async def delete(self, name, *, workspace=None):
+        self._store.pop((workspace, name), None)
+        return object()
+
+
+class _FakeFiles:
+    def __init__(self, store) -> None:
+        self._store = store
+        self.filesets = _FakeFilesets(store)
+
+    async def _upload_file(self, *, path, body, workspace, name):
+        self._store.setdefault((workspace, name), {})[path] = bytes(body)
+        return _FakeFile(f"{workspace}/{name}#{path}")
+
+    async def _download_file(self, path, *, workspace, name):
+        return _FakeResponse(self._store[(workspace, name)][path])
+
+
+class _FakeSDK:
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], dict[str, bytes]] = {}
+        self.files = _FakeFiles(self._store)
+
+
+class _FakeEntityClient:
+    def __init__(self) -> None:
+        self.entities: dict[tuple[str, str], MetricBundleEntity] = {}
+
+    async def get(self, entity_cls, *, workspace, name):
+        try:
+            return self.entities[(workspace, name)]
+        except KeyError:
+            raise EntityNotFoundError(f"{workspace}/{name} not found")
+
+
+def _bundle():
+    metric = ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.output}}")
+    return bundle_metric(metric, CloudpickleMetricBundlePackager())
+
+
+def _metric_inline() -> MetricInline:
+    """An inline metric as carried on the wire (MetricInline DTO)."""
+    return MetricInline.model_validate_json(_bundle().model_dump_json())
+
+
+async def _stored(sdk: _FakeSDK, entity_client: _FakeEntityClient, workspace: str, name: str):
+    bundle = _bundle()
+    ref = await store_bundle(sdk, workspace, name, bundle)
+    entity_client.entities[(workspace, name)] = MetricBundleEntity(
+        name=name,
+        workspace=workspace,
+        metric_type=bundle.metric_type,
+        outputs=bundle.outputs,
+        payload_kind=bundle.payload.kind,
+        payload_digest=bundle.payload.digest,
+        bundle_ref=ref,
+    )
+    return bundle
+
+
+# ---- ref parsing -----------------------------------------------------------
+
+
+def test_parse_metric_ref_qualified() -> None:
+    assert parse_metric_ref("ws/my-metric", "default") == ("ws", "my-metric")
+
+
+def test_parse_metric_ref_bare_name_uses_default_workspace() -> None:
+    assert parse_metric_ref("my-metric", "default") == ("default", "my-metric")
+
+
+@pytest.mark.parametrize("ref", ["", "ws/", "/name", "ws/a/b", "bad name"])
+def test_metric_ref_field_rejects_malformed(ref: str) -> None:
+    # Malformed refs are rejected by the MetricRef field pattern at validation time.
+    with pytest.raises(ValidationError):
+        MetricRef(root=ref)
+
+
+# ---- resolution ------------------------------------------------------------
+
+
+async def test_resolve_converts_inline_metric_to_runtime_bundle() -> None:
+    inline = _metric_inline()
+    result = await resolve_metric_specs([inline], workspace="default", entity_client=None, async_sdk=None)
+    assert len(result) == 1
+    assert result[0].metric_type == inline.metric_type
+    assert result[0].payload.digest == inline.payload.digest
+
+
+async def test_resolve_loads_referenced_bundle() -> None:
+    sdk = _FakeSDK()
+    entity_client = _FakeEntityClient()
+    stored = await _stored(sdk, entity_client, "default", "exact")
+
+    result = await resolve_metric_specs(
+        [MetricRef(root="default/exact")],
+        workspace="default",
+        entity_client=entity_client,
+        async_sdk=sdk,
+    )
+
+    assert len(result) == 1
+    assert result[0].payload.digest == stored.payload.digest
+
+
+async def test_resolve_mixes_refs_and_inline_preserving_order() -> None:
+    sdk = _FakeSDK()
+    entity_client = _FakeEntityClient()
+    await _stored(sdk, entity_client, "default", "exact")
+    inline = _metric_inline()
+
+    result = await resolve_metric_specs(
+        [MetricRef(root="exact"), inline],
+        workspace="default",
+        entity_client=entity_client,
+        async_sdk=sdk,
+    )
+
+    assert len(result) == 2
+    assert result[1].payload.digest == inline.payload.digest
+
+
+async def test_resolve_ref_without_sdk_raises() -> None:
+    with pytest.raises(ValueError, match="require a platform connection"):
+        await resolve_metric_specs(
+            [MetricRef(root="default/exact")],
+            workspace="default",
+            entity_client=_FakeEntityClient(),
+            async_sdk=None,
+        )
+
+
+async def test_resolve_missing_metric_raises_clear_error() -> None:
+    with pytest.raises(ValueError, match="not found"):
+        await resolve_metric_specs(
+            [MetricRef(root="default/no-such-metric")],
+            workspace="default",
+            entity_client=_FakeEntityClient(),
+            async_sdk=_FakeSDK(),
+        )
+
+
+async def test_resolve_ref_without_entity_client_raises() -> None:
+    with pytest.raises(ValueError, match="require a platform connection"):
+        await resolve_metric_specs(
+            [MetricRef(root="default/exact")],
+            workspace="default",
+            entity_client=None,
+            async_sdk=_FakeSDK(),
+        )
+
+
+# ---- spec-level union behavior ---------------------------------------------
+
+
+def test_input_spec_accepts_ref_and_inline() -> None:
+    spec = EvaluateInputSpec(
+        metrics=["default/stored-metric", _metric_inline()],
+        dataset=[{"expected": "a", "output": "a"}],
+    )
+    assert isinstance(spec.metrics[0], MetricRef)
+    assert spec.metrics[0].root == "default/stored-metric"
+
+
+def test_canonical_spec_rejects_unresolved_ref() -> None:
+    with pytest.raises(ValidationError):
+        EvaluateSpec(
+            metrics=["default/stored-metric"],
+            dataset=[{"expected": "a", "output": "a"}],
+        )

--- a/plugins/nemo-evaluator/tests/test_metric_storage.py
+++ b/plugins/nemo-evaluator/tests/test_metric_storage.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from nemo_evaluator.metric_storage import (
+    BUNDLE_FILENAME,
+    FILESET_PREFIX,
+    MetricBundleStorageError,
+    delete_bundle_by_ref,
+    load_bundle,
+    parse_bundle_ref,
+    store_bundle,
+)
+from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
+
+
+class _FakeFile:
+    def __init__(self, file_ref: str) -> None:
+        self.file_ref = file_ref
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+class _FakeFilesets:
+    def __init__(self, store: dict[tuple[str, str], dict[str, bytes]]) -> None:
+        self._store = store
+
+    async def create(self, *, name, workspace, description=None, exist_ok=False):
+        self._store.setdefault((workspace, name), {})
+        return object()
+
+    async def delete(self, name, *, workspace=None):
+        self._store.pop((workspace, name), None)
+        return object()
+
+
+class _FakeFiles:
+    def __init__(self, store: dict[tuple[str, str], dict[str, bytes]]) -> None:
+        self._store = store
+        self.filesets = _FakeFilesets(store)
+
+    async def _upload_file(self, *, path, body, workspace, name):
+        self._store.setdefault((workspace, name), {})[path] = bytes(body)
+        return _FakeFile(f"{workspace}/{name}#{path}")
+
+    async def _download_file(self, path, *, workspace, name):
+        return _FakeResponse(self._store[(workspace, name)][path])
+
+
+class _FakeSDK:
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], dict[str, bytes]] = {}
+        self.files = _FakeFiles(self._store)
+
+
+def _sample_bundle():
+    metric = ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.output}}")
+    return bundle_metric(metric, CloudpickleMetricBundlePackager())
+
+
+def test_parse_bundle_ref_splits_parts() -> None:
+    assert parse_bundle_ref("default/metric-bundle.m.abc#bundle.json") == (
+        "default",
+        "metric-bundle.m.abc",
+        "bundle.json",
+    )
+
+
+@pytest.mark.parametrize("ref", ["no-fragment", "missing-workspace#bundle.json", "ws/fs#"])
+def test_parse_bundle_ref_rejects_malformed(ref: str) -> None:
+    with pytest.raises(MetricBundleStorageError):
+        parse_bundle_ref(ref)
+
+
+async def test_store_returns_unique_per_metric_ref() -> None:
+    sdk = _FakeSDK()
+    bundle = _sample_bundle()
+
+    ref1 = await store_bundle(sdk, "default", "my-metric", bundle)
+    ref2 = await store_bundle(sdk, "default", "my-metric", bundle)
+
+    assert ref1.startswith("default/metric-bundle.")
+    assert ref1.endswith(f"#{BUNDLE_FILENAME}")
+    # Each upload lands in its own fileset, so a rollback can't clobber another.
+    assert ref1 != ref2
+
+
+async def test_store_fileset_name_stays_within_limit_for_long_metric_name() -> None:
+    sdk = _FakeSDK()
+    bundle = _sample_bundle()
+    long_name = "m" * 255  # MAX_NAME_LENGTH
+
+    ref = await store_bundle(sdk, "default", long_name, bundle)
+
+    _, fileset, _ = parse_bundle_ref(ref)
+    # The Files service caps fileset names at 255 chars.
+    assert len(fileset) <= 255
+
+
+async def test_store_cleans_up_fileset_on_upload_failure() -> None:
+    sdk = _FakeSDK()
+    bundle = _sample_bundle()
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("network blip during upload")
+
+    sdk.files._upload_file = _boom
+
+    with pytest.raises(MetricBundleStorageError):
+        await store_bundle(sdk, "default", "my-metric", bundle)
+    # The fileset created just before the failed upload must not be left orphaned.
+    assert [key for key in sdk._store if key[1].startswith(FILESET_PREFIX)] == []
+
+
+async def test_store_then_load_round_trips_bundle() -> None:
+    sdk = _FakeSDK()
+    bundle = _sample_bundle()
+
+    ref = await store_bundle(sdk, "default", "my-metric", bundle)
+
+    loaded = await load_bundle(sdk, ref, expected_digest=bundle.payload.digest)
+    assert loaded.metric_type == bundle.metric_type
+    assert loaded.payload.digest == bundle.payload.digest
+
+
+async def test_load_rejects_digest_mismatch() -> None:
+    sdk = _FakeSDK()
+    bundle = _sample_bundle()
+    ref = await store_bundle(sdk, "default", "my-metric", bundle)
+
+    with pytest.raises(MetricBundleStorageError, match="digest mismatch"):
+        await load_bundle(sdk, ref, expected_digest="deadbeef")
+
+
+async def test_load_rejects_corrupt_bundle() -> None:
+    sdk = _FakeSDK()
+    # Stored bytes that aren't a valid serialized MetricBundle.
+    sdk._store[("default", "metric-bundle.deadbeef")] = {"bundle.json": b"not a bundle"}
+
+    with pytest.raises(MetricBundleStorageError, match="corrupt or unreadable"):
+        await load_bundle(sdk, "default/metric-bundle.deadbeef#bundle.json")
+
+
+async def test_delete_by_ref_removes_only_that_fileset() -> None:
+    sdk = _FakeSDK()
+    bundle = _sample_bundle()
+    ref1 = await store_bundle(sdk, "default", "my-metric", bundle)
+    ref2 = await store_bundle(sdk, "default", "my-metric", bundle)
+
+    await delete_bundle_by_ref(sdk, ref1)
+
+    _, fileset1, _ = parse_bundle_ref(ref1)
+    _, fileset2, _ = parse_bundle_ref(ref2)
+    assert ("default", fileset1) not in sdk._store
+    assert ("default", fileset2) in sdk._store


### PR DESCRIPTION
## Summary
Adds metric persistence to the evaluator plugin: store reusable metrics on the platform and reference them from eval jobs. Restores the metrics surface removed in #230, aligned to its `workspace/name` conventions.

## What's included
- **Entity + storage** — `MetricBundleEntity` (`entity_type` `metric_bundle`) in the entity store; the executable cloudpickle bundle is uploaded to the **Files service** (one fileset per metric), with the entity holding only `bundle_ref` + integrity digest.
- **CRUD API** (name-in-path, matching the removed service) — `POST` / `GET` / `DELETE /apis/evaluator/v2/workspaces/{workspace}/metrics/{name}` + workspace list. Metrics are **immutable** (no update).
- **SDK** — `client.evaluator.metrics` (`create` / `retrieve` / `list` / `delete`).
- **Job integration** — `EvaluateInputSpec.metrics` accepts inline `MetricInline` and/or `MetricRef` (`workspace/name`); refs are resolved from the entity store + Files during server-side spec resolution (`to_spec`).
- **OpenAPI** — explicit `CloudpickleMetricPayload` schema (discriminated on `kind`); regenerated `plugins/nemo-evaluator/openapi/openapi.yaml`.

## Testing
- **237 unit tests** (entity JSON round-trip, Files storage, service CRUD, HTTP routes, SDK resource, ref resolution).
- **End-to-end against running services** (entities, files, jobs + controller, evaluator):
  - metric CRUD + bundle round-trip through the real Files service;
  - a **submit-with-ref eval job** — the server resolved the `MetricRef` at submit time (canonical spec inlined the metric), the job ran to completion, and aggregate scores were returned.
- `ruff`, `ty`, and `pyright` clean.

## Notes / follow-ups
- Cleanup failure during create/delete is **leak-only** (an orphaned `metric-bundle.*` fileset, logged) — never a corrupted/broken metric. A GC sweep is tracked as a follow-up.
- cloudpickle payloads are shared executable code within a workspace (workspace-scoped + permission-gated under `evaluator.metrics.*`).
- Not in this PR: the unrelated core `files`-API SDK drift surfaced when regenerating (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stored metrics CRUD APIs for listing, creating, retrieving, and deleting metrics within workspaces.
  * Updated evaluation metric contracts to support inline metrics plus references, with reference resolution for execution.
  * Introduced new metric payload and querying schemas (including typed payload handling) and enhanced list filtering/sorting/pagination.
  * Added synchronous and asynchronous SDK resources for stored metrics.

* **Tests**
  * Added unit and end-to-end coverage for metrics endpoints, SDK resources, metric references, storage persistence, and entity serialization round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->