### PR TITLE
ci: cache the embed model for the k8s smoke tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,10 +243,7 @@ jobs:
         run: make docker-push TARGET=docker-cpu
 
       - name: Save fastembed model cache
-        if: >
-          steps.fastembed-cache.outputs.cache-hit != 'true' &&
-          github.ref == 'refs/heads/main' &&
-          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: steps.fastembed-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         continue-on-error: true
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Restore fastembed model cache
         id: fastembed-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.temp }}/fastembed-cache
           key: fastembed-qdrant-all-MiniLM-L6-v2-onnx-main-v1
@@ -211,17 +211,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          uv run --no-project --with 'huggingface-hub>=1.0.1,<2.0.0' python - <<'PY'
-          import os
-
-          from huggingface_hub import snapshot_download
-
-          snapshot_download(
-              repo_id=os.environ["FASTEMBED_MODEL_REPO"],
-              revision=os.environ["FASTEMBED_MODEL_REVISION"],
-              cache_dir=os.environ["FASTEMBED_CACHE_DIR"],
-          )
-          PY
+          HF_HUB_DISABLE_UPDATE_CHECK=1 uv run --no-project --with 'huggingface-hub>=1.0.1,<2.0.0' hf download \
+            "${FASTEMBED_MODEL_REPO}" \
+            --revision "${FASTEMBED_MODEL_REVISION}" \
+            --cache-dir "${FASTEMBED_CACHE_DIR}" \
+            --format quiet
           find "${FASTEMBED_CACHE_DIR}/models--qdrant--all-MiniLM-L6-v2-onnx/snapshots" \
             -mindepth 1 -maxdepth 1 -type d -print -quit | grep -q .
 
@@ -253,7 +247,7 @@ jobs:
           steps.fastembed-cache.outputs.cache-hit != 'true' &&
           github.ref == 'refs/heads/main' &&
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         continue-on-error: true
         with:
           path: ${{ runner.temp }}/fastembed-cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,6 +149,7 @@ jobs:
           image_registry="ghcr.io/${GITHUB_REPOSITORY,,}"
           source_sha="${SOURCE_SHA:-$GITHUB_SHA}"
           bake_tag="${INPUT_IMAGE_TAG:-$source_sha}"
+          fastembed_cache_dir="${RUNNER_TEMP}/fastembed-cache"
           publish_images="false"
 
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
@@ -173,6 +174,10 @@ jobs:
             printf 'CACHE_REGISTRY=%s\n' "$image_registry"
             printf 'BAKE_TAG=%s\n' "$bake_tag"
             printf 'CI_COMMIT_SHA=%s\n' "$source_sha"
+            printf 'FASTEMBED_CACHE_CONTEXT=%s\n' "$fastembed_cache_dir"
+            printf 'FASTEMBED_CACHE_DIR=%s\n' "$fastembed_cache_dir"
+            printf 'FASTEMBED_MODEL_REPO=%s\n' "qdrant/all-MiniLM-L6-v2-onnx"
+            printf 'FASTEMBED_MODEL_REVISION=%s\n' "main"
             printf 'PUBLISH_IMAGES=%s\n' "$publish_images"
           } >> "$GITHUB_ENV"
           {
@@ -180,6 +185,45 @@ jobs:
             printf 'image_tag=%s\n' "$bake_tag"
             printf 'publish_images=%s\n' "$publish_images"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare fastembed model cache directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${FASTEMBED_CACHE_DIR}"
+          touch "${FASTEMBED_CACHE_DIR}/.cache-context"
+
+      - name: Restore fastembed model cache
+        id: fastembed-cache
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ runner.temp }}/fastembed-cache
+          key: fastembed-qdrant-all-MiniLM-L6-v2-onnx-main-v1
+
+      - name: Install uv for fastembed model cache
+        if: steps.fastembed-cache.outputs.cache-hit != 'true'
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version-file: pyproject.toml
+
+      - name: Populate fastembed model cache
+        if: steps.fastembed-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --no-project --with 'huggingface-hub>=1.0.1,<2.0.0' python - <<'PY'
+          import os
+
+          from huggingface_hub import snapshot_download
+
+          snapshot_download(
+              repo_id=os.environ["FASTEMBED_MODEL_REPO"],
+              revision=os.environ["FASTEMBED_MODEL_REVISION"],
+              cache_dir=os.environ["FASTEMBED_CACHE_DIR"],
+          )
+          PY
+          find "${FASTEMBED_CACHE_DIR}/models--qdrant--all-MiniLM-L6-v2-onnx/snapshots" \
+            -mindepth 1 -maxdepth 1 -type d -print -quit | grep -q .
 
       - name: Log in to GHCR
         if: env.PUBLISH_IMAGES == 'true'
@@ -197,16 +241,23 @@ jobs:
       - name: Build CPU images
         if: env.PUBLISH_IMAGES != 'true'
         shell: bash
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: make docker-load TARGET=docker-cpu
 
       - name: Build and publish CPU images
         if: env.PUBLISH_IMAGES == 'true'
         shell: bash
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: make docker-push TARGET=docker-cpu
+
+      - name: Save fastembed model cache
+        if: >
+          steps.fastembed-cache.outputs.cache-hit != 'true' &&
+          github.ref == 'refs/heads/main' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/fastembed-cache
+          key: fastembed-qdrant-all-MiniLM-L6-v2-onnx-main-v1
 
   kind-cpu-smoke:
     name: Kind CPU smoke test
@@ -308,7 +359,6 @@ jobs:
       - name: Start kind cluster
         shell: bash
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           NGC_API_KEY: not-used-for-ghcr-cpu-smoke
         run: bash "${K8S_E2E_SCRIPTS}/setup_local_kind_cpu.sh"
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -103,8 +103,8 @@ variable "BUILD_ARCH" {
   default = ""
 }
 
-variable "HF_TOKEN" {
-  default = ""
+variable "FASTEMBED_CACHE_CONTEXT" {
+  default = "docker/fastembed-cache-empty"
 }
 
 variable "CUDA_VERSION" {
@@ -201,16 +201,6 @@ function "maybe_registry_cache_to" {
 function "image_output" {
   params = []
   result = ["type=image,compression=zstd,force-compression=true"]
-}
-
-function "maybe_hf_token_secret" {
-  params = []
-  result = notequal(HF_TOKEN, "") ? [
-    {
-      type = "env"
-      id   = "HF_TOKEN"
-    }
-  ] : []
 }
 
 function "maybe_registry_cache_from" {
@@ -463,6 +453,7 @@ target "nmp-api-docker" {
     nmp-jobs-launcher         = "target:nmp-jobs-launcher"
     nmp-studio-ui             = "target:nmp-studio-ui"
     policy-wasm-artifacts     = "target:root-policy-wasm-artifacts"
+    fastembed-cache           = FASTEMBED_CACHE_CONTEXT
   }
   args = {
     NMP_PLATFORM_VERSION = notequal(BAKE_TAG, "") ? BAKE_TAG : "dev"
@@ -472,7 +463,6 @@ target "nmp-api-docker" {
   cache-from = maybe_registry_cache_from("nmp-api")
   tags       = sha_and_maybe_latest_tags("nmp-api")
   output     = image_output()
-  secret     = maybe_hf_token_secret()
   platforms  = get_platforms()
 }
 

--- a/docker/Dockerfile.nmp-api
+++ b/docker/Dockerfile.nmp-api
@@ -30,9 +30,12 @@ RUN sh /app/script/install_duckdb_extensions.sh
 # Download embedding model used by `nemoguardrails` library.
 # Uses snapshot_download directly to avoid importing onnxruntime, which crashes under QEMU (ARM64 cross-compilation).
 # Stored in /tmp/fastembed_cache (fastembed's default cache location) and copied to the runtime image below.
-RUN --mount=type=secret,id=HF_TOKEN,required=false \
-    if [ -s /run/secrets/HF_TOKEN ]; then export HF_TOKEN="$(cat /run/secrets/HF_TOKEN)"; fi; \
-    uv run --no-sync python -c 'import os, tempfile; from huggingface_hub import snapshot_download; snapshot_download(repo_id="qdrant/all-MiniLM-L6-v2-onnx", cache_dir=os.path.join(tempfile.gettempdir(), "fastembed_cache"))'
+COPY --from=fastembed-cache . /tmp/fastembed_cache/
+RUN if find /tmp/fastembed_cache/models--qdrant--all-MiniLM-L6-v2-onnx/snapshots -mindepth 1 -maxdepth 1 -type d -print -quit 2>/dev/null | grep -q .; then \
+        echo "Using cached qdrant/all-MiniLM-L6-v2-onnx fastembed model"; \
+    else \
+        uv run --no-sync python -c 'import os, tempfile; from huggingface_hub import snapshot_download; snapshot_download(repo_id="qdrant/all-MiniLM-L6-v2-onnx", cache_dir=os.path.join(tempfile.gettempdir(), "fastembed_cache"))'; \
+    fi
 
 FROM ${NMP_PYTHON_BASE} AS runtime
 ARG USERNAME=nvs


### PR DESCRIPTION
Down loading the qdrant/all-MiniLM model for every PR is causing 429s. Using the cache makes sense for this, and it likely needs exactly one cache, period, not something that is keyed to a particular PR or commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the Docker CPU smoke build pipeline by introducing FastEmbed model snapshot caching with automatic restore on cache hit and save on cache miss.
  * Reduced build times by preloading a shared cache and only downloading the ONNX model when it’s not already present.
  * Simplified the build/publish flow by separating image loading vs pushing based on the publish setting, and avoiding token wiring in those steps.
  * Removed the Hugging Face token from the local kind CPU smoke setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->