### PR TITLE
fix(studio): agent rule for KUI Select API, CSS patches existing bad usages

### DIFF
--- a/web/packages/common/src/components/form/ControlledSearchableSelect/index.tsx
+++ b/web/packages/common/src/components/form/ControlledSearchableSelect/index.tsx
@@ -263,7 +263,7 @@ export const ControlledSearchableSelect = ({
               />
             </Block>
             {/* eslint-disable-next-line no-restricted-syntax */}
-            <Stack className="overflow-auto w-full" style={{ maxHeight }} role="listbox">
+            <Stack className="overflow-auto w-full" style={{ maxHeight }}>
               {isLoading && filteredOptions.length === 0 ? (
                 <Flex align="center" justify="center" className="py-4">
                   <Spinner aria-label="Loading options" size="small" />

--- a/web/packages/common/src/components/form/ControlledSearchableSelect/index.tsx
+++ b/web/packages/common/src/components/form/ControlledSearchableSelect/index.tsx
@@ -241,7 +241,7 @@ export const ControlledSearchableSelect = ({
           status={status || (error ? 'error' : undefined)}
           {...selectProps}
         />
-        <SelectContent className="w-(--radix-popper-anchor-width) bg-surface-raised border border-base rounded-md shadow-md overflow-hidden">
+        <SelectContent className="w-(--radix-popper-anchor-width)">
           <Block className="p-2 w-full sticky top-0 bg-surface z-10">
             <TextInput
               ref={searchInputRef}

--- a/web/packages/common/src/components/form/ControlledSearchableSelect/index.tsx
+++ b/web/packages/common/src/components/form/ControlledSearchableSelect/index.tsx
@@ -9,6 +9,7 @@ import {
   FormField,
   SelectContent,
   SelectItem,
+  SelectListbox,
   SelectProps,
   SelectRoot,
   SelectTrigger,
@@ -242,116 +243,118 @@ export const ControlledSearchableSelect = ({
           {...selectProps}
         />
         <SelectContent className="w-(--radix-popper-anchor-width)">
-          <Block className="p-2 w-full sticky top-0 bg-surface z-10">
-            <TextInput
-              ref={searchInputRef}
-              name={`${useControllerProps.name}-search`}
-              className="overflow-hidden"
-              slotStart={<Filter />}
-              placeholder={searchPlaceholder}
-              value={localSearch}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                setLocalSearch(e.target.value);
-              }}
-              attributes={{
-                Input: {
-                  ['data-testid' as never]: `${useControllerProps.name}-search`,
-                },
-              }}
-            />
-          </Block>
-          {/* eslint-disable-next-line no-restricted-syntax */}
-          <Stack className="overflow-auto w-full" style={{ maxHeight }} role="listbox">
-            {isLoading && filteredOptions.length === 0 ? (
-              <Flex align="center" justify="center" className="py-4">
-                <Spinner aria-label="Loading options" size="small" />
-              </Flex>
-            ) : filteredOptions.length > 0 ? (
-              <>
-                {isLoading && (
-                  <Flex align="center" justify="center" className="py-2">
-                    <Spinner aria-label="Refreshing options" size="small" />
-                  </Flex>
-                )}
-                {(() => {
-                  const groupKeys = groupLabels ? Object.keys(groupLabels) : [];
-                  if (groupKeys.length === 0) {
-                    return filteredOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.render ?? option.label}
-                      </SelectItem>
-                    ));
-                  }
-                  const buckets = new Map<string | undefined, SelectItemOption[]>();
-                  for (const option of filteredOptions) {
-                    const key = option.group;
-                    const existing = buckets.get(key);
-                    if (existing) existing.push(option);
-                    else buckets.set(key, [option]);
-                  }
-                  const orderedKeys = [
-                    ...groupKeys.filter((k) => buckets.has(k)),
-                    ...Array.from(buckets.keys()).filter(
-                      (k): k is string | undefined => !k || !groupKeys.includes(k)
-                    ),
-                  ];
-                  return orderedKeys.flatMap((key) => {
-                    const items = buckets.get(key) ?? [];
-                    if (items.length === 0) return [];
-                    const heading = key ? groupLabels?.[key] : undefined;
-                    return [
-                      heading ? (
-                        <Block
-                          key={`__heading-${key}`}
-                          className="px-2 pt-2 pb-1 text-xs uppercase tracking-wide text-subtle"
-                        >
-                          {heading}
-                        </Block>
-                      ) : null,
-                      ...items.map((option) => (
-                        <SelectItem key={`${key ?? ''}:${option.value}`} value={option.value}>
+          <SelectListbox>
+            <Block className="p-2 w-full sticky top-0 bg-surface z-10">
+              <TextInput
+                ref={searchInputRef}
+                name={`${useControllerProps.name}-search`}
+                className="overflow-hidden"
+                slotStart={<Filter />}
+                placeholder={searchPlaceholder}
+                value={localSearch}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  setLocalSearch(e.target.value);
+                }}
+                attributes={{
+                  Input: {
+                    ['data-testid' as never]: `${useControllerProps.name}-search`,
+                  },
+                }}
+              />
+            </Block>
+            {/* eslint-disable-next-line no-restricted-syntax */}
+            <Stack className="overflow-auto w-full" style={{ maxHeight }} role="listbox">
+              {isLoading && filteredOptions.length === 0 ? (
+                <Flex align="center" justify="center" className="py-4">
+                  <Spinner aria-label="Loading options" size="small" />
+                </Flex>
+              ) : filteredOptions.length > 0 ? (
+                <>
+                  {isLoading && (
+                    <Flex align="center" justify="center" className="py-2">
+                      <Spinner aria-label="Refreshing options" size="small" />
+                    </Flex>
+                  )}
+                  {(() => {
+                    const groupKeys = groupLabels ? Object.keys(groupLabels) : [];
+                    if (groupKeys.length === 0) {
+                      return filteredOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
                           {option.render ?? option.label}
                         </SelectItem>
-                      )),
-                    ].filter(Boolean);
-                  });
-                })()}
-                {/* Infinite scroll sentinel; collapsed to 1px when idle with more pages (no empty min-height) */}
-                {showLoadMoreFooter ? (
-                  <Flex
-                    ref={loaderRef}
-                    align="center"
-                    justify="center"
-                    className={
-                      loadingMore || showDoneFooter
-                        ? 'min-h-8 py-2'
-                        : 'h-px min-h-px w-full shrink-0 py-0'
+                      ));
                     }
-                  >
-                    {loadingMore ? <Spinner aria-label="Loading more" size="small" /> : null}
-                    {showDoneFooter ? (
-                      <Text kind="body/regular/sm" className="text-subtle">
-                        {doneLoadingMessage}
-                      </Text>
-                    ) : null}
-                  </Flex>
-                ) : null}
-              </>
-            ) : (
-              <Flex align="center" justify="center" className="py-4">
-                <Text kind="body/regular/sm" className="text-subtle">
-                  {emptyMessage}
-                </Text>
-              </Flex>
-            )}
-          </Stack>
-          {listFooter ? (
-            <Block className="shrink-0 border-t-1 border-t-base p-0 w-full">
-              {listFooter({
-                close: () => setSelectOpen(false),
-              })}
-            </Block>
-          ) : null}
+                    const buckets = new Map<string | undefined, SelectItemOption[]>();
+                    for (const option of filteredOptions) {
+                      const key = option.group;
+                      const existing = buckets.get(key);
+                      if (existing) existing.push(option);
+                      else buckets.set(key, [option]);
+                    }
+                    const orderedKeys = [
+                      ...groupKeys.filter((k) => buckets.has(k)),
+                      ...Array.from(buckets.keys()).filter(
+                        (k): k is string | undefined => !k || !groupKeys.includes(k)
+                      ),
+                    ];
+                    return orderedKeys.flatMap((key) => {
+                      const items = buckets.get(key) ?? [];
+                      if (items.length === 0) return [];
+                      const heading = key ? groupLabels?.[key] : undefined;
+                      return [
+                        heading ? (
+                          <Block
+                            key={`__heading-${key}`}
+                            className="px-2 pt-2 pb-1 text-xs uppercase tracking-wide text-subtle"
+                          >
+                            {heading}
+                          </Block>
+                        ) : null,
+                        ...items.map((option) => (
+                          <SelectItem key={`${key ?? ''}:${option.value}`} value={option.value}>
+                            {option.render ?? option.label}
+                          </SelectItem>
+                        )),
+                      ].filter(Boolean);
+                    });
+                  })()}
+                  {/* Infinite scroll sentinel; collapsed to 1px when idle with more pages (no empty min-height) */}
+                  {showLoadMoreFooter ? (
+                    <Flex
+                      ref={loaderRef}
+                      align="center"
+                      justify="center"
+                      className={
+                        loadingMore || showDoneFooter
+                          ? 'min-h-8 py-2'
+                          : 'h-px min-h-px w-full shrink-0 py-0'
+                      }
+                    >
+                      {loadingMore ? <Spinner aria-label="Loading more" size="small" /> : null}
+                      {showDoneFooter ? (
+                        <Text kind="body/regular/sm" className="text-subtle">
+                          {doneLoadingMessage}
+                        </Text>
+                      ) : null}
+                    </Flex>
+                  ) : null}
+                </>
+              ) : (
+                <Flex align="center" justify="center" className="py-4">
+                  <Text kind="body/regular/sm" className="text-subtle">
+                    {emptyMessage}
+                  </Text>
+                </Flex>
+              )}
+            </Stack>
+            {listFooter ? (
+              <Block className="shrink-0 border-t-1 border-t-base p-0 w-full">
+                {listFooter({
+                  close: () => setSelectOpen(false),
+                })}
+              </Block>
+            ) : null}
+          </SelectListbox>
         </SelectContent>
       </SelectRoot>
     </FormField>

--- a/web/packages/studio/AGENTS.md
+++ b/web/packages/studio/AGENTS.md
@@ -28,3 +28,29 @@
   - `@studio/` → `packages/studio/src/`
   - `@e2e-tests/` → `packages/studio/e2e-tests/`
 - Other local packages are imported via pnpm workspaces
+
+### KUI v1 Select: always wrap items in SelectListbox
+
+In KUI v1, `SelectContent` is a transparent popover host — it has no background.
+Background, border, and shadow come from `SelectListbox` → `MenuRoot` internally.
+
+**Required pattern:**
+
+```tsx
+<SelectContent>
+  <SelectListbox>
+    <SelectItem value="a">A</SelectItem>
+  </SelectListbox>
+</SelectContent>
+```
+
+Wrong — transparent dropdown:
+
+```tsx
+<SelectContent>
+  <SelectItem value="a">A</SelectItem> {/* no SelectListbox = no background */}
+</SelectContent>
+```
+
+Exception: call sites that fill SelectContent with custom children containing their
+own background (e.g. a sticky Block with bg-surface) are fine as-is.

--- a/web/packages/studio/src/components/evaluation/EvaluationModelSelect.tsx
+++ b/web/packages/studio/src/components/evaluation/EvaluationModelSelect.tsx
@@ -116,7 +116,7 @@ export const EvaluationModelSelect = <TFieldValues extends FieldValues = FieldVa
           required={required}
           status={fieldError ? 'error' : undefined}
         />
-        <SelectContent className="w-(--radix-popper-anchor-width) bg-surface-raised border border-base rounded-md shadow-md overflow-hidden">
+        <SelectContent className="w-(--radix-popper-anchor-width)">
           <Block className="p-2 w-full sticky top-0 bg-surface z-10">
             <TextInput
               ref={filterInputRef}

--- a/web/packages/studio/src/components/evaluation/EvaluationModelSelect.tsx
+++ b/web/packages/studio/src/components/evaluation/EvaluationModelSelect.tsx
@@ -12,6 +12,7 @@ import {
   FormField,
   SelectContent,
   SelectItem,
+  SelectListbox,
   SelectRoot,
   SelectTrigger,
   Stack,
@@ -117,60 +118,62 @@ export const EvaluationModelSelect = <TFieldValues extends FieldValues = FieldVa
           status={fieldError ? 'error' : undefined}
         />
         <SelectContent className="w-(--radix-popper-anchor-width)">
-          <Block className="p-2 w-full sticky top-0 bg-surface z-10">
-            <TextInput
-              ref={filterInputRef}
-              name="model-filter"
-              className="overflow-hidden"
-              slotStart={<Filter />}
-              placeholder="Search..."
-              value={search}
-              onChange={handleSearchChange}
-              attributes={{
-                Input: {
-                  ['data-testid' as never]: 'model-filter',
-                },
-              }}
-            />
-          </Block>
-          <Stack className="overflow-auto w-full max-h-[300px]">
-            {groupedItems.size > 0 ? (
-              Array.from(groupedItems.entries()).map(([workspace, wsItems]) => (
-                <DropdownSection key={workspace}>
-                  <DropdownHeading>
-                    <Flex gap="density-sm" align="center">
-                      {creatorToIcon(workspace, { className: 'text-base' })}
-                      <Text className="font-bold">{workspace}</Text>
-                    </Flex>
-                  </DropdownHeading>
-                  {wsItems.map((item) => (
-                    <SelectItem key={item.value} className="relative" value={item.value}>
-                      <Flex className="w-full" align="center" justify="between" gap="density-sm">
-                        <Text className="truncate flex-1">
-                          {item.adapter
-                            ? `${item.model.name} / ${item.adapter.name}`
-                            : item.model.name}
-                        </Text>
-                        {item.adapter && (
-                          <Badge kind="solid" color="green" className="shrink-0">
-                            LoRA
-                          </Badge>
-                        )}
+          <SelectListbox>
+            <Block className="p-2 w-full sticky top-0 bg-surface z-10">
+              <TextInput
+                ref={filterInputRef}
+                name="model-filter"
+                className="overflow-hidden"
+                slotStart={<Filter />}
+                placeholder="Search..."
+                value={search}
+                onChange={handleSearchChange}
+                attributes={{
+                  Input: {
+                    ['data-testid' as never]: 'model-filter',
+                  },
+                }}
+              />
+            </Block>
+            <Stack className="overflow-auto w-full max-h-[300px]">
+              {groupedItems.size > 0 ? (
+                Array.from(groupedItems.entries()).map(([workspace, wsItems]) => (
+                  <DropdownSection key={workspace}>
+                    <DropdownHeading>
+                      <Flex gap="density-sm" align="center">
+                        {creatorToIcon(workspace, { className: 'text-base' })}
+                        <Text className="font-bold">{workspace}</Text>
                       </Flex>
-                    </SelectItem>
-                  ))}
+                    </DropdownHeading>
+                    {wsItems.map((item) => (
+                      <SelectItem key={item.value} className="relative" value={item.value}>
+                        <Flex className="w-full" align="center" justify="between" gap="density-sm">
+                          <Text className="truncate flex-1">
+                            {item.adapter
+                              ? `${item.model.name} / ${item.adapter.name}`
+                              : item.model.name}
+                          </Text>
+                          {item.adapter && (
+                            <Badge kind="solid" color="green" className="shrink-0">
+                              LoRA
+                            </Badge>
+                          )}
+                        </Flex>
+                      </SelectItem>
+                    ))}
+                  </DropdownSection>
+                ))
+              ) : (
+                <DropdownSection>
+                  {!isLoading && (
+                    <DropdownHeading>
+                      <Text>No Models Found</Text>
+                    </DropdownHeading>
+                  )}
                 </DropdownSection>
-              ))
-            ) : (
-              <DropdownSection>
-                {!isLoading && (
-                  <DropdownHeading>
-                    <Text>No Models Found</Text>
-                  </DropdownHeading>
-                )}
-              </DropdownSection>
-            )}
-          </Stack>
+              )}
+            </Stack>
+          </SelectListbox>
         </SelectContent>
       </SelectRoot>
     </FormField>

--- a/web/packages/studio/src/index.css
+++ b/web/packages/studio/src/index.css
@@ -57,6 +57,16 @@ body {
   }
 }
 
+/* hack fix: KUI v1 SelectContent uses native popover which resets background to transparent;
+   restore surface styles so all dropdowns render opaque regardless of inner structure. */
+.nv-select-content[popover] {
+  background-color: var(--background-color-surface-raised);
+  border: 1px solid var(--border-color-base);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+}
+
 /* hack fix - Switch component has incorrect outline color */
 .nv-switch-track {
   &[data-state='checked'] {


### PR DESCRIPTION
fixes ASTD-249/bug-dropdowns-have-transparent-options-across-the-site

After the KUI v1 upgrade, some Select dropdowns render with a transparent background. The issue is NOT universal — it only hits call sites that put SelectItems directly inside SelectContent without a SelectListbox wrapper. Playground/ModelCompare selects appear unaffected because their SelectContent children include elements with their own
background (Block with bg-surface, or an explicit bg-surface-raised workaround).

### Root Cause

KUI v0: `SelectContent` rendered via Ariakit → MenuRoot → nv-menu-root class.

`nv-menu-root` carries `background-color: var(--background-color-surface-raised)`

KUI v1: `SelectContent` is now a bare `<div popover="auto" class="nv-select-content">`

`generated/styles.css:6511` explicitly resets the browser popover default:

```css
.nv-select-content[popover] {
  background: 0 0;   /* transparent */
  border: 0;
  ...
}
```

Background now lives on SelectListbox → MenuRoot (nv-menu-root). Sites that skip `SelectListbox` and go straight to `SelectItems` have no background element at all.

Confirmed broken: `SchemaSelectControl` (DatasetSchema right pane).
Confirmed working: `Playground/ModelCompare` selects (inner Block with `bg-surface` covers it).

Affected call sites (no explicit bg, no inner bg fallback)

```
- web/packages/studio/src/routes/FilesetDetailRoute/DatasetSchemaEditor/SchemaSelectControl/index.tsx
- web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.tsx
- web/packages/studio/src/components/filesets/AddToFolderModal/index.tsx
- web/packages/studio/src/components/filesets/FilesetFileExplorer/UploadToFolderModal/index.tsx
- web/packages/studio/src/components/evaluation/Configurations/form/LLMJudgeInput.tsx
- web/packages/studio/src/components/evaluation/Configurations/form/StringCheckInput.tsx
- web/packages/studio/src/components/DatasetFileSelect/index.tsx
- web/packages/studio/src/routes/InferenceProvidersListRoute/CreateInferenceProviderSidePanel/InferenceModelProviderSelect.tsx
```

### Fix

One CSS rule in `web/packages/studio/src/index.css`

Following the pattern of existing KUI hack fixes already in that file (nv-tooltip-content, nv-switch-track, nv-checkbox-input), add:

```
/* hack fix: KUI v1 SelectContent uses native popover which resets background;
   restore surface styles so all dropdowns render opaque. */
.nv-select-content[popover] {
  background-color: var(--background-color-surface-raised);
  border: 1px solid var(--border-color-base);
  border-radius: var(--radius-md);
  box-shadow: var(--shadow-md);
  overflow: hidden;
}
```

Why this wins:
- 1 file, ~7 lines
- Equal specificity to the background: 0 0 rule, placed AFTER `@import './generated/styles.css'` → source order ensures our rule wins
- Global: fixes all current and future SelectContent usages automatically
- No component restructuring, no wrapper, no per-call-site changes
- Existing explicit workarounds (EvaluationModelSelect, ControlledSearchableSelect) become
redundant but harmless

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved dropdown/popover rendering for searchable selects and evaluation model selection, standardizing list rendering for consistent background, borders, rounded corners, shadows, and overflow behavior.
* **Documentation**
  * Added clearer KUI v1 Select guidance, including a required pattern for wrapping dropdown items to ensure correct styling, plus an exception for custom `SelectContent` content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->