### PR TITLE
ci: establish workflow to clean up image artifacts

### DIFF
--- a/.github/scripts/cleanup-ghcr-ci-images.sh
+++ b/.github/scripts/cleanup-ghcr-ci-images.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! [[ "${STALE_HOURS}" =~ ^[0-9]+$ ]]; then
+  echo "stale_hours must be a positive integer, got: ${STALE_HOURS}" >&2
+  exit 1
+fi
+
+if [ "${STALE_HOURS}" -lt 1 ]; then
+  echo "stale_hours must be at least 1, got: ${STALE_HOURS}" >&2
+  exit 1
+fi
+
+owner="${GITHUB_REPOSITORY_OWNER,,}"
+repo="${GITHUB_REPOSITORY#*/}"
+repo="${repo,,}"
+
+date_utc() {
+  if command -v gdate >/dev/null 2>&1; then
+    gdate -u -d "$1" '+%Y-%m-%dT%H:%M:%SZ'
+    return
+  fi
+
+  date -u -d "$1" '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+cutoff="$(date_utc "${STALE_HOURS} hours ago")"
+
+# GitHub's package version API exposes updated_at, not a separate last-pulled timestamp.
+# These are the docker-cpu images published by .github/workflows/ci.yaml.
+images=(
+  "nmp-api"
+  "nmp-core"
+  "nmp-cpu-tasks"
+)
+
+echo "Scanning ghcr.io/${owner}/${repo} image versions last updated before ${cutoff}"
+echo "dry_run=${DRY_RUN}"
+
+total_deleted=0
+total_candidates=0
+
+url_encode() {
+  jq -nr --arg value "$1" '$value|@uri'
+}
+
+find_stale_versions() {
+  local endpoint="$1"
+  local jq_filter
+  jq_filter="
+    .[] |
+    select(.updated_at != null and .updated_at < \"${cutoff}\") |
+    select(((.metadata.container.tags // []) | index(\"latest\")) | not) |
+    [.id, .name, .updated_at, ((.metadata.container.tags // []) | join(\",\"))] |
+    @tsv
+  "
+
+  gh api --paginate "${endpoint}/versions?per_page=100" --jq "${jq_filter}"
+}
+
+for image in "${images[@]}"; do
+  package_name="${repo}/${image}"
+  encoded_package_name="$(url_encode "${package_name}")"
+  endpoint="/orgs/${owner}/packages/container/${encoded_package_name}"
+
+  echo "::group::${package_name}"
+
+  api_error="$(mktemp)"
+  if ! stale_versions="$(find_stale_versions "${endpoint}" 2>"${api_error}")"; then
+    if grep -q "HTTP 404" "${api_error}"; then
+      echo "Package ${package_name} was not found; skipping."
+      echo "::endgroup::"
+      continue
+    fi
+
+    cat "${api_error}" >&2
+    exit 1
+  fi
+
+  if [ -z "${stale_versions}" ]; then
+    echo "No stale package versions found."
+    echo "::endgroup::"
+    continue
+  fi
+
+  while IFS=$'\t' read -r version_id digest updated_at tags; do
+    if [ -z "${version_id}" ]; then
+      continue
+    fi
+
+    total_candidates=$((total_candidates + 1))
+    tag_summary="${tags:-<untagged>}"
+    echo "Candidate ${package_name}@${digest} updated_at=${updated_at} tags=${tag_summary}"
+
+    if [ "${DRY_RUN}" = "true" ]; then
+      continue
+    fi
+
+    gh api -X DELETE "${endpoint}/versions/${version_id}" >/dev/null
+    total_deleted=$((total_deleted + 1))
+    echo "Deleted package version ${version_id}"
+  done <<< "${stale_versions}"
+
+  echo "::endgroup::"
+done
+
+echo "Stale candidates: ${total_candidates}"
+echo "Deleted versions: ${total_deleted}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1159,7 +1159,15 @@ jobs:
   coverage-comment:
     name: Post coverage comment
     needs: [python-unit-test, python-integration-test]
-    if: always() && github.event_name == 'pull_request'
+    if: >
+      always() &&
+      github.event_name == 'pull_request' &&
+      (
+        needs.python-unit-test.result == 'success' ||
+        needs.python-unit-test.result == 'failure' ||
+        needs.python-integration-test.result == 'success' ||
+        needs.python-integration-test.result == 'failure'
+      )
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,6 +176,7 @@ jobs:
             printf 'CI_COMMIT_SHA=%s\n' "$source_sha"
             printf 'FASTEMBED_CACHE_CONTEXT=%s\n' "$fastembed_cache_dir"
             printf 'FASTEMBED_CACHE_DIR=%s\n' "$fastembed_cache_dir"
+            printf 'DOCKER_BAKE_ALLOW_FS_READ=%s\n' "$fastembed_cache_dir"
             printf 'FASTEMBED_MODEL_REPO=%s\n' "qdrant/all-MiniLM-L6-v2-onnx"
             printf 'FASTEMBED_MODEL_REVISION=%s\n' "main"
             printf 'PUBLISH_IMAGES=%s\n' "$publish_images"

--- a/.github/workflows/ghcr-cleanup.yaml
+++ b/.github/workflows/ghcr-cleanup.yaml
@@ -1,8 +1,6 @@
 name: Cleanup GHCR CI Images
 
 on:
-  pull_request:
-    branches: [main]
   schedule:
     - cron: "43 4 * * *"
   workflow_dispatch:
@@ -25,31 +23,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  dry-run-pr:
-    name: Dry run stale GHCR CI image cleanup
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-    env:
-      DRY_RUN: "true"
-      STALE_HOURS: "24"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Dry run stale package version deletion
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: bash .github/scripts/cleanup-ghcr-ci-images.sh
-
   cleanup:
     name: Delete stale GHCR CI image versions
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ghcr-cleanup.yaml
+++ b/.github/workflows/ghcr-cleanup.yaml
@@ -1,0 +1,70 @@
+name: Cleanup GHCR CI Images
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "43 4 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log stale GHCR package versions without deleting them.
+        required: false
+        type: boolean
+        default: false
+      stale_hours:
+        description: Delete versions last updated more than this many hours ago.
+        required: false
+        type: number
+        default: 24
+
+permissions: {}
+
+concurrency:
+  group: ghcr-cleanup-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  dry-run-pr:
+    name: Dry run stale GHCR CI image cleanup
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      DRY_RUN: "true"
+      STALE_HOURS: "24"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Dry run stale package version deletion
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/cleanup-ghcr-ci-images.sh
+
+  cleanup:
+    name: Delete stale GHCR CI image versions
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      STALE_HOURS: ${{ inputs.stale_hours || '24' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Delete stale package versions
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/cleanup-ghcr-ci-images.sh

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ DOCKER_BAKE_FILE ?= docker-bake.hcl
 DOCKER_TARGET ?= $(if $(TARGET),$(TARGET),docker-cpu)
 DOCKER_PLATFORMS ?= $(BUILD_ARCH)
 DOCKER_PLATFORM_SET = $(if $(DOCKER_PLATFORMS),--set "*.platform=$(DOCKER_PLATFORMS)",)
+DOCKER_BAKE_ALLOW_FS_READ ?=
+DOCKER_BAKE_ALLOW_FS_READ_FLAG = $(if $(DOCKER_BAKE_ALLOW_FS_READ), --allow=fs.read=$(DOCKER_BAKE_ALLOW_FS_READ),)
 
 .PHONY: docker-list-targets
 docker-list-targets: ## List Docker bake targets
@@ -44,15 +46,15 @@ docker-print: ## Print Docker bake graph for TARGET, default docker-cpu
 
 .PHONY: docker-build
 docker-build: ## Build Docker bake TARGET without pushing, default docker-cpu
-	docker buildx bake -f $(DOCKER_BAKE_FILE) $(DOCKER_TARGET)
+	docker buildx bake$(DOCKER_BAKE_ALLOW_FS_READ_FLAG) -f $(DOCKER_BAKE_FILE) $(DOCKER_TARGET)
 
 .PHONY: docker-load
 docker-load: ## Build and load single-platform Docker bake TARGET, default docker-cpu
-	docker buildx bake -f $(DOCKER_BAKE_FILE) $(DOCKER_TARGET) $(DOCKER_PLATFORM_SET) --load
+	docker buildx bake$(DOCKER_BAKE_ALLOW_FS_READ_FLAG) -f $(DOCKER_BAKE_FILE) $(DOCKER_TARGET) $(DOCKER_PLATFORM_SET) --load
 
 .PHONY: docker-push
 docker-push: ## Build and push Docker bake TARGET, default docker-cpu
-	docker buildx bake -f $(DOCKER_BAKE_FILE) $(DOCKER_TARGET) --push
+	docker buildx bake$(DOCKER_BAKE_ALLOW_FS_READ_FLAG) -f $(DOCKER_BAKE_FILE) $(DOCKER_TARGET) --push
 
 .PHONY: refresh-openapi
 refresh-openapi:  ## Generate the OpenAPI specification

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ help:
 	@echo "Makefile commands:"
 	@grep -E '^[a-zA-Z_-][a-zA-Z0-9_/-]*:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-
 DOCKER_BAKE_FILE ?= docker-bake.hcl
 DOCKER_TARGET ?= $(if $(TARGET),$(TARGET),docker-cpu)
 DOCKER_PLATFORMS ?= $(BUILD_ARCH)

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ help:
 	@echo "Makefile commands:"
 	@grep -E '^[a-zA-Z_-][a-zA-Z0-9_/-]*:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+
 DOCKER_BAKE_FILE ?= docker-bake.hcl
 DOCKER_TARGET ?= $(if $(TARGET),$(TARGET),docker-cpu)
 DOCKER_PLATFORMS ?= $(BUILD_ARCH)


### PR DESCRIPTION
Initially this is going to do a dry run on the PR, but the goal is to ensure we aren't adding lots of useless images to the ghcr registry, since most of the builds are purely for testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a scheduled and manual workflow to clean up stale container image versions in the registry, with configurable `stale_hours` and a `dry_run` mode to preview deletions.
* **CI**
  * Updated Docker build/push/load behavior to pass through an `allow=fs.read` control via Bake flags.
  * Tightened the coverage comment trigger to run only on pull requests when relevant test jobs complete successfully or with failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->