### PR TITLE
fix(studio): replace ScrollTable with KUI table, fix scrolling

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -56,5 +56,10 @@
     "node": ">=22.18.0 <23",
     "pnpm": ">=10.32.1"
   },
+  "pnpm": {
+    "overrides": {
+      "@codemirror/view": "6.43.1"
+    }
+  },
   "packageManager": "pnpm@10.32.1"
 }

--- a/web/packages/common/src/components/UploadModal/SimpleFilesTable.test.tsx
+++ b/web/packages/common/src/components/UploadModal/SimpleFilesTable.test.tsx
@@ -44,6 +44,22 @@ const createWrapper = (
 describe('SimpleFilesTable', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // @tanstack/react-virtual measures elements via getBoundingClientRect to determine
+    // the visible row range. JSDOM returns 0 for all dimensions, causing the virtualizer
+    // to compute an empty visible range and render no rows. Return a fixed 56px height
+    // (matching VirtualizedTableContent's default rowHeight) so the virtualizer renders
+    // all rows within the overscan window.
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      height: 56,
+      width: 560,
+      top: 0,
+      left: 0,
+      bottom: 56,
+      right: 560,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
   });
 
   const mockNewFiles: UploadFile[] = [

--- a/web/packages/common/src/components/UploadModal/SimpleFilesTable.tsx
+++ b/web/packages/common/src/components/UploadModal/SimpleFilesTable.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import * as DataView from '@nemo/common/src/components/DataView/internal';
 import { useUploadModalContext } from '@nemo/common/src/components/UploadModal/Context/useUploadModalContext';
 import { useInlinePickerSlot } from '@nemo/common/src/components/UploadModal/InlinePickerSlot';
 import { UploadFile } from '@nemo/common/src/components/UploadModal/types';
@@ -8,21 +9,23 @@ import { formatFileSize } from '@nemo/common/src/components/UploadModal/utils';
 import {
   Button,
   Checkbox,
-  Text,
   Flex,
-  Stack,
-  RadioGroupRoot,
-  RadioGroupItem,
   RadioGroupInput,
-  TableBody,
-  TableDataCell,
-  TableHead,
-  TableHeaderCell,
-  TableRoot,
-  TableRow,
+  RadioGroupItem,
+  RadioGroupRoot,
+  Stack,
+  Text,
 } from '@nvidia/foundations-react-core';
 import { CircleAlert } from 'lucide-react';
-import { useCallback, useMemo, useRef } from 'react';
+import { type ComponentProps, useCallback, useMemo, useRef } from 'react';
+
+type FileRow = {
+  id: string;
+  name: string;
+  size: number;
+  isDisabled: boolean;
+  uploadFile: UploadFile;
+};
 
 export const SimpleFilesTable = () => {
   const [state, dispatch] = useUploadModalContext();
@@ -52,38 +55,7 @@ export const SimpleFilesTable = () => {
     if (allowedExtensions.size === 0) return true;
     return allowedExtensions.has(fileExtension(uploadFile));
   };
-  const toggleFileSelection = useCallback(
-    (file: UploadFile) => {
-      dispatch({
-        type: 'TOGGLE_FILE_SELECTION',
-        payload: file,
-      });
-    },
-    [dispatch]
-  );
-  const handleSingleSelect = useCallback(
-    (id: string) => {
-      const file = files.find((f) => f.id === id);
-      if (!file) return;
-      dispatch({ type: 'TOGGLE_FILE_SELECTION', payload: file });
-    },
-    [dispatch, files]
-  );
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const files = event.target.files;
-    if (files) {
-      dispatch({
-        type: 'SET_FILES',
-        payload: Array.from(files).map((file) => ({ id: file.name, type: 'new', file })),
-      });
-    }
-  };
 
-  // ``invalidFileMode`` controls how files whose extension isn't in
-  // ``acceptableFileTypes`` are rendered. ``'hide'`` filters them out so the
-  // user only sees pickable files; ``'disable'`` keeps them visible but
-  // marks the radio/checkbox as ``disabled``; ``'show'`` (default) keeps
-  // the prior behaviour and lets the parent validate after submit.
   const visibleFiles = useMemo(() => {
     if (invalidFileMode !== 'hide' || allowedExtensions.size === 0) return files;
     return files.filter(isFileAllowed);
@@ -97,12 +69,9 @@ export const SimpleFilesTable = () => {
       ? `Only ${acceptableFileTypes.join(', ')} files can be selected. Upload a supported file or choose a different fileset.`
       : null;
 
-  const fileRows = useMemo(
+  const fileRows = useMemo<FileRow[]>(
     () =>
       visibleFiles.map((uploadFile) => {
-        // In ``'disable'`` mode, mismatched-extension rows render but their
-        // selector control is ``disabled``. ``'hide'`` already filtered
-        // them; ``'show'`` keeps everything pickable.
         const isDisabled = invalidFileMode === 'disable' && !isFileAllowed(uploadFile);
         const name = uploadFile.type === 'existing' ? uploadFile.file.path : uploadFile.file.name;
         const size = uploadFile.type === 'existing' ? uploadFile.file.size : uploadFile.file.size;
@@ -112,59 +81,73 @@ export const SimpleFilesTable = () => {
     [visibleFiles, invalidFileMode, allowedExtensions]
   );
 
-  const table = (
-    <div className="overflow-y-auto max-h-[45dvh] border border-base rounded-md">
-      <TableRoot layout="auto" align="left" className="w-full bg-inherit">
-        <TableHead className="sticky top-0 z-[1] bg-surface-overlay border-b-0 sticky-table-header">
-          <TableRow className="border-b-0">
-            <TableHeaderCell />
-            <TableHeaderCell>Name</TableHeaderCell>
-            <TableHeaderCell>Size</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {fileRows.map(({ id, name, size, isDisabled, uploadFile }) => (
-            <TableRow key={id}>
-              <TableDataCell>
-                {allowMultipleFileSelection ? (
-                  <Checkbox
-                    name={name}
-                    attributes={{ CheckboxInput: { 'aria-label': name } }}
-                    checked={selectedFiles.some((f) => f.id === id)}
-                    onCheckedChange={() => toggleFileSelection(uploadFile)}
-                    disabled={isDisabled}
-                  />
-                ) : (
-                  <RadioGroupItem aria-label={name}>
-                    <RadioGroupInput value={id} disabled={isDisabled} />
-                  </RadioGroupItem>
-                )}
-              </TableDataCell>
-              <TableDataCell>{name}</TableDataCell>
-              <TableDataCell>{formatFileSize(size)}</TableDataCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </TableRoot>
-    </div>
+  const dataViewState = DataView.useDataViewState();
+
+  const makeColumns = useCallback<ComponentProps<typeof DataView.Root<FileRow>>['makeColumns']>(
+    (col) => [
+      col.display({
+        id: 'select',
+        header: () => null,
+        size: 40,
+        maxSize: 40,
+        minSize: 40,
+        meta: { alignment: 'center' as const },
+        cell: ({ row }) =>
+          allowMultipleFileSelection ? (
+            <Checkbox
+              checked={selectedFiles.some((f) => f.id === row.original.id)}
+              onCheckedChange={() =>
+                dispatch({ type: 'TOGGLE_FILE_SELECTION', payload: row.original.uploadFile })
+              }
+              disabled={row.original.isDisabled}
+              attributes={{ CheckboxInput: { 'aria-label': row.original.name } }}
+            />
+          ) : (
+            <RadioGroupItem aria-label={row.original.name}>
+              <RadioGroupInput value={row.original.id} disabled={row.original.isDisabled} />
+            </RadioGroupItem>
+          ),
+      }),
+      col.accessor('name', { header: 'Name' }),
+      col.accessor('size', {
+        header: 'Size',
+        cell: (ctx) => formatFileSize(ctx.getValue()),
+      }),
+    ],
+    [allowMultipleFileSelection, selectedFiles, dispatch]
   );
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newFiles = event.target.files;
+    if (newFiles) {
+      dispatch({
+        type: 'SET_FILES',
+        payload: Array.from(newFiles).map((file) => ({ id: file.name, type: 'new', file })),
+      });
+    }
+  };
 
   return (
     <Stack className="min-h-0 flex-1 w-full" gap="density-md">
-      {allowMultipleFileSelection ? (
-        table
-      ) : (
-        // ``RadioGroupRoot`` defaults to its content's natural width — force
-        // ``w-full`` so the inner table fills the modal's width.
+      <div className="border border-base rounded-md overflow-hidden">
         <RadioGroupRoot
           name="simple-files-table"
           value={selectedFiles[0]?.id ?? ''}
-          onValueChange={handleSingleSelect}
-          className="w-full"
+          onValueChange={(id) => {
+            const file = fileRows.find((r) => r.id === id);
+            if (file) dispatch({ type: 'TOGGLE_FILE_SELECTION', payload: file.uploadFile });
+          }}
         >
-          {table}
+          <DataView.Root
+            data={fileRows}
+            state={dataViewState}
+            makeColumns={makeColumns}
+            reactTableOptions={{ getRowId: (row) => row.id }}
+          >
+            <DataView.VirtualizedTableContent maxHeight="45dvh" />
+          </DataView.Root>
         </RadioGroupRoot>
-      )}
+      </div>
       {disabledFilesMessage ? (
         <Flex gap="density-sm" align="center">
           <CircleAlert className="text-feedback-warning shrink-0" />

--- a/web/packages/common/src/components/UploadModal/SimpleFilesTable.tsx
+++ b/web/packages/common/src/components/UploadModal/SimpleFilesTable.tsx
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ScrollTable } from '@nemo/common/src/components/ScrollTable';
 import { useUploadModalContext } from '@nemo/common/src/components/UploadModal/Context/useUploadModalContext';
 import { useInlinePickerSlot } from '@nemo/common/src/components/UploadModal/InlinePickerSlot';
 import { UploadFile } from '@nemo/common/src/components/UploadModal/types';
@@ -10,13 +9,17 @@ import {
   Button,
   Checkbox,
   Text,
-  TableColumnDefinition,
-  TableRowDefinition,
   Flex,
   Stack,
   RadioGroupRoot,
   RadioGroupItem,
   RadioGroupInput,
+  TableBody,
+  TableDataCell,
+  TableHead,
+  TableHeaderCell,
+  TableRoot,
+  TableRow,
 } from '@nvidia/foundations-react-core';
 import { CircleAlert } from 'lucide-react';
 import { useCallback, useMemo, useRef } from 'react';
@@ -76,12 +79,6 @@ export const SimpleFilesTable = () => {
     }
   };
 
-  const columns: TableColumnDefinition[] = [
-    { children: '' },
-    { children: 'Name' },
-    { children: 'Size' },
-  ];
-
   // ``invalidFileMode`` controls how files whose extension isn't in
   // ``acceptableFileTypes`` are rendered. ``'hide'`` filters them out so the
   // user only sees pickable files; ``'disable'`` keeps them visible but
@@ -100,7 +97,7 @@ export const SimpleFilesTable = () => {
       ? `Only ${acceptableFileTypes.join(', ')} files can be selected. Upload a supported file or choose a different fileset.`
       : null;
 
-  const rows = useMemo<TableRowDefinition[]>(
+  const fileRows = useMemo(
     () =>
       visibleFiles.map((uploadFile) => {
         // In ``'disable'`` mode, mismatched-extension rows render but their
@@ -109,59 +106,63 @@ export const SimpleFilesTable = () => {
         const isDisabled = invalidFileMode === 'disable' && !isFileAllowed(uploadFile);
         const name = uploadFile.type === 'existing' ? uploadFile.file.path : uploadFile.file.name;
         const size = uploadFile.type === 'existing' ? uploadFile.file.size : uploadFile.file.size;
-        return {
-          id: uploadFile.id,
-          cells: [
-            {
-              children: allowMultipleFileSelection ? (
-                <Checkbox
-                  name={name}
-                  attributes={{ CheckboxInput: { 'aria-label': name } }}
-                  checked={selectedFiles.some((file) => file.id === uploadFile.id)}
-                  onCheckedChange={() => toggleFileSelection(uploadFile)}
-                  disabled={isDisabled}
-                />
-              ) : (
-                <RadioGroupItem aria-label={name}>
-                  <RadioGroupInput value={uploadFile.id} disabled={isDisabled} />
-                </RadioGroupItem>
-              ),
-            },
-            { children: name },
-            { children: formatFileSize(size) },
-          ],
-        };
+        return { id: uploadFile.id, name, size, isDisabled, uploadFile };
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [visibleFiles, selectedFiles, toggleFileSelection, allowMultipleFileSelection, invalidFileMode]
+    [visibleFiles, invalidFileMode, allowedExtensions]
+  );
+
+  const table = (
+    <div className="overflow-y-auto max-h-[45dvh] border border-base rounded-md">
+      <TableRoot layout="auto" align="left" className="w-full bg-inherit">
+        <TableHead className="sticky top-0 z-[1] bg-surface-overlay border-b-0 sticky-table-header">
+          <TableRow className="border-b-0">
+            <TableHeaderCell />
+            <TableHeaderCell>Name</TableHeaderCell>
+            <TableHeaderCell>Size</TableHeaderCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {fileRows.map(({ id, name, size, isDisabled, uploadFile }) => (
+            <TableRow key={id}>
+              <TableDataCell>
+                {allowMultipleFileSelection ? (
+                  <Checkbox
+                    name={name}
+                    attributes={{ CheckboxInput: { 'aria-label': name } }}
+                    checked={selectedFiles.some((f) => f.id === id)}
+                    onCheckedChange={() => toggleFileSelection(uploadFile)}
+                    disabled={isDisabled}
+                  />
+                ) : (
+                  <RadioGroupItem aria-label={name}>
+                    <RadioGroupInput value={id} disabled={isDisabled} />
+                  </RadioGroupItem>
+                )}
+              </TableDataCell>
+              <TableDataCell>{name}</TableDataCell>
+              <TableDataCell>{formatFileSize(size)}</TableDataCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </TableRoot>
+    </div>
   );
 
   return (
     <Stack className="min-h-0 flex-1 w-full" gap="density-md">
       {allowMultipleFileSelection ? (
-        <ScrollTable
-          pagination={false}
-          columns={columns}
-          rows={rows}
-          allowHorizontalScroll
-          className="pb-0 w-full"
-        />
+        table
       ) : (
         // ``RadioGroupRoot`` defaults to its content's natural width — force
-        // ``w-full`` so the inner ScrollTable fills the modal's width.
+        // ``w-full`` so the inner table fills the modal's width.
         <RadioGroupRoot
           name="simple-files-table"
           value={selectedFiles[0]?.id ?? ''}
           onValueChange={handleSingleSelect}
           className="w-full"
         >
-          <ScrollTable
-            pagination={false}
-            columns={columns}
-            rows={rows}
-            allowHorizontalScroll
-            className="pb-0 w-full"
-          />
+          {table}
         </RadioGroupRoot>
       )}
       {disabledFilesMessage ? (

--- a/web/packages/common/src/components/UploadModal/index.tsx
+++ b/web/packages/common/src/components/UploadModal/index.tsx
@@ -68,10 +68,7 @@ const UploadModalContent: FC<UploadModalProps> = ({
   return (
     <ModalRoot id={modalId} open={open} onOpenChange={handleUserClose} {...attributes?.ModalRoot}>
       <ModalDialog>
-        <ModalContent
-          className={`w-[560px] overflow-hidden ${className || ''}`}
-          {...attributes?.ModalContent}
-        >
+        <ModalContent className={`w-[560px] ${className || ''}`} {...attributes?.ModalContent}>
           <ModalHeading {...attributes?.ModalHeading}>{title}</ModalHeading>
           <ModalMain {...attributes?.ModalMain}>
             <UploadPickerBody

--- a/web/packages/common/src/components/UploadModal/index.tsx
+++ b/web/packages/common/src/components/UploadModal/index.tsx
@@ -24,7 +24,6 @@ import {
   ModalHeading,
   ModalMain,
   ModalRoot,
-  Stack,
 } from '@nvidia/foundations-react-core';
 import { FC, MouseEvent, useId, useMemo } from 'react';
 
@@ -70,34 +69,30 @@ const UploadModalContent: FC<UploadModalProps> = ({
     <ModalRoot id={modalId} open={open} onOpenChange={handleUserClose} {...attributes?.ModalRoot}>
       <ModalDialog>
         <ModalContent
-          className={`max-h-[90vh] overflow-y-auto ${className || ''}`}
+          className={`w-[560px] overflow-hidden ${className || ''}`}
           {...attributes?.ModalContent}
         >
-          <Stack gap="density-2xl" className="max-h-full overflow-y-hidden">
-            <ModalHeading {...attributes?.ModalHeading}>{title}</ModalHeading>
-            <ModalMain {...attributes?.ModalMain} asChild>
-              <Stack gap="density-md" className="shrink overflow-y-auto">
-                <UploadPickerBody
-                  workspace={workspace}
-                  includeDataset={includeDataset}
-                  includeTabs={includeTabs}
-                />
-              </Stack>
-            </ModalMain>
-            <ModalFooter className="flex w-full justify-end gap-2" {...attributes?.ModalFooter}>
-              <Button kind="tertiary" onClick={handleUserClose} type="button">
-                {cancelButtonText}
-              </Button>
-              <LoadingButton
-                type="button"
-                color="brand"
-                loading={isSubmitting}
-                onClick={handleSubmit}
-              >
-                {submitButtonText}
-              </LoadingButton>
-            </ModalFooter>
-          </Stack>
+          <ModalHeading {...attributes?.ModalHeading}>{title}</ModalHeading>
+          <ModalMain {...attributes?.ModalMain}>
+            <UploadPickerBody
+              workspace={workspace}
+              includeDataset={includeDataset}
+              includeTabs={includeTabs}
+            />
+          </ModalMain>
+          <ModalFooter className="flex w-full justify-end gap-2" {...attributes?.ModalFooter}>
+            <Button kind="tertiary" onClick={handleUserClose} type="button">
+              {cancelButtonText}
+            </Button>
+            <LoadingButton
+              type="button"
+              color="brand"
+              loading={isSubmitting}
+              onClick={handleSubmit}
+            >
+              {submitButtonText}
+            </LoadingButton>
+          </ModalFooter>
         </ModalContent>
       </ModalDialog>
     </ModalRoot>

--- a/web/packages/studio/src/index.css
+++ b/web/packages/studio/src/index.css
@@ -77,6 +77,12 @@ body {
   }
 }
 
+/* hack fix: sticky table header separator — box-shadow is the only reliable way to
+   paint a bottom border that stays with a position:sticky thead across browsers */
+.sticky-table-header {
+  box-shadow: 0 2px 0 var(--border-color-base);
+}
+
 /* hack fix: KUI ships Checkbox and RadioGroupItem without a pointer cursor */
 .nv-checkbox-input,
 .nv-radio-group-item {

--- a/web/packages/studio/src/index.css
+++ b/web/packages/studio/src/index.css
@@ -77,12 +77,6 @@ body {
   }
 }
 
-/* hack fix: sticky table header separator — box-shadow is the only reliable way to
-   paint a bottom border that stays with a position:sticky thead across browsers */
-.sticky-table-header {
-  box-shadow: 0 2px 0 var(--border-color-base);
-}
-
 /* hack fix: KUI ships Checkbox and RadioGroupItem without a pointer cursor */
 .nv-checkbox-input,
 .nv-radio-group-item {

--- a/web/packages/studio/src/routes/FilesetDetailRoute/FilesetCard/index.tsx
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/FilesetCard/index.tsx
@@ -7,6 +7,7 @@ import {
   FilesetPurpose,
   type FilesetFileOutput,
   type FilesetOutput,
+  type ModelEntityFilter,
 } from '@nemo/sdk/generated/platform/schema';
 import { Stack } from '@nvidia/foundations-react-core';
 import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
@@ -42,7 +43,12 @@ export const FilesetCard: FC<FilesetCardProps> = ({
 
   const { data: modelEntitiesResponse } = useModelsListModels(
     workspace,
-    { filter: { fileset: getEntityReference({ workspace, name: filesetName }) } },
+    // fileset filter is valid on the backend but missing from the generated SDK type (stale SDK)
+    {
+      filter: {
+        fileset: getEntityReference({ workspace, name: filesetName }),
+      } as ModelEntityFilter,
+    },
     { query: { enabled: isModel } }
   );
   const modelEntities = modelEntitiesResponse?.data ?? [];

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -184,6 +184,9 @@ catalogs:
       specifier: ^3.25.76
       version: 3.25.76
 
+overrides:
+  '@codemirror/view': 6.43.1
+
 importers:
 
   .:
@@ -288,8 +291,8 @@ importers:
         specifier: ^6.5.2
         version: 6.6.0
       '@codemirror/view':
-        specifier: ^6.39.4
-        version: 6.40.0
+        specifier: 6.43.1
+        version: 6.43.1
       '@nemo/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -310,10 +313,10 @@ importers:
         version: 3.13.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@uiw/codemirror-theme-github':
         specifier: ^4.25.2
-        version: 4.25.8(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)
+        version: 4.25.8(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)
       '@uiw/react-codemirror':
         specifier: ^4.25.4
-        version: 4.25.8(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.40.0)(codemirror@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 4.25.8(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.1)(codemirror@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -1112,9 +1115,6 @@ packages:
 
   '@codemirror/theme-one-dark@6.1.3':
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
-
-  '@codemirror/view@6.40.0':
-    resolution: {integrity: sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==}
 
   '@codemirror/view@6.43.1':
     resolution: {integrity: sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==}
@@ -4043,7 +4043,7 @@ packages:
       '@codemirror/lint': '>=6.0.0'
       '@codemirror/search': '>=6.0.0'
       '@codemirror/state': '>=6.0.0'
-      '@codemirror/view': '>=6.0.0'
+      '@codemirror/view': 6.43.1
 
   '@uiw/codemirror-theme-github@4.25.8':
     resolution: {integrity: sha512-kTZsf2PmOCHBuudB50BX1kAODmErzks6lxxhbHj76KQ+p4eizu0giowV1LoyY/FCLLqRjIe77tE31hvo8agasg==}
@@ -4053,7 +4053,7 @@ packages:
     peerDependencies:
       '@codemirror/language': '>=6.0.0'
       '@codemirror/state': '>=6.0.0'
-      '@codemirror/view': '>=6.0.0'
+      '@codemirror/view': 6.43.1
 
   '@uiw/react-codemirror@4.25.8':
     resolution: {integrity: sha512-A0aLOuJZm2yJ+U9GlMFwxwFciztjd5LhcAG4SMqFxdD58wH+sCQXuY4UU5J2hqgS390qAlShtUgREvJPUonbuQ==}
@@ -4061,7 +4061,7 @@ packages:
       '@babel/runtime': '>=7.11.0'
       '@codemirror/state': '>=6.0.0'
       '@codemirror/theme-one-dark': '>=6.0.0'
-      '@codemirror/view': '>=6.0.0'
+      '@codemirror/view': 6.43.1
       codemirror: '>=6.0.0'
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
@@ -7830,7 +7830,7 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.12.2
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.40.0
+      '@codemirror/view': 6.43.1
       '@lezer/common': 1.5.1
 
   '@codemirror/autocomplete@6.20.3':
@@ -7844,7 +7844,7 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.12.2
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.40.0
+      '@codemirror/view': 6.43.1
       '@lezer/common': 1.5.1
 
   '@codemirror/lang-javascript@6.2.5':
@@ -7853,7 +7853,7 @@ snapshots:
       '@codemirror/language': 6.12.2
       '@codemirror/lint': 6.9.5
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.40.0
+      '@codemirror/view': 6.43.1
       '@lezer/common': 1.5.1
       '@lezer/javascript': 1.5.4
 
@@ -7883,7 +7883,7 @@ snapshots:
   '@codemirror/language@6.12.2':
     dependencies:
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.40.0
+      '@codemirror/view': 6.43.1
       '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.8
@@ -7901,7 +7901,7 @@ snapshots:
   '@codemirror/lint@6.9.5':
     dependencies:
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.40.0
+      '@codemirror/view': 6.43.1
       crelt: 1.0.6
 
   '@codemirror/lint@6.9.7':
@@ -7926,13 +7926,6 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
       '@lezer/highlight': 1.2.3
-
-  '@codemirror/view@6.40.0':
-    dependencies:
-      '@codemirror/state': 6.6.0
-      crelt: 1.0.6
-      style-mod: 4.1.3
-      w3c-keyname: 2.2.8
 
   '@codemirror/view@6.43.1':
     dependencies:
@@ -10890,7 +10883,7 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20251124.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20251124.1
 
-  '@uiw/codemirror-extensions-basic-setup@4.25.8(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)':
+  '@uiw/codemirror-extensions-basic-setup@4.25.8(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)':
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/commands': 6.10.3
@@ -10898,30 +10891,30 @@ snapshots:
       '@codemirror/lint': 6.9.5
       '@codemirror/search': 6.6.0
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.40.0
+      '@codemirror/view': 6.43.1
 
-  '@uiw/codemirror-theme-github@4.25.8(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)':
+  '@uiw/codemirror-theme-github@4.25.8(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)':
     dependencies:
-      '@uiw/codemirror-themes': 4.25.8(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)
+      '@uiw/codemirror-themes': 4.25.8(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
 
-  '@uiw/codemirror-themes@4.25.8(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)':
+  '@uiw/codemirror-themes@4.25.8(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)':
     dependencies:
       '@codemirror/language': 6.12.2
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.40.0
+      '@codemirror/view': 6.43.1
 
-  '@uiw/react-codemirror@4.25.8(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.40.0)(codemirror@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@uiw/react-codemirror@4.25.8(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.1)(codemirror@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@codemirror/commands': 6.10.3
       '@codemirror/state': 6.6.0
       '@codemirror/theme-one-dark': 6.1.3
-      '@codemirror/view': 6.40.0
-      '@uiw/codemirror-extensions-basic-setup': 4.25.8(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)
+      '@codemirror/view': 6.43.1
+      '@uiw/codemirror-extensions-basic-setup': 4.25.8(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)
       codemirror: 6.0.2
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)


### PR DESCRIPTION
`ScrollTable` wasn't the best fit for the files list in the Dataset file picker modal.  One reason is that it didn't bring sticky table headers with it, leaving us to either use DataView (overkill) or roll our own. So we roll our own basic implementation of KUI table here, which is a fairly simple use case and appropriate.

As a bonus, the styling looks better since the rows do not have padding beyond their separators. We also gain sticky table headers.

To fix sticky table header bottom row from scrolling out of view, we needed to apply a known CSS hack involving `box-shadow`:


> border-bottom on a table element (tr, th, thead) is laid out by the browser's table algorithm, not the element's own paint layer — sticky doesn't take it with the element. box-shadow bypasses the table layout model and is always painted with the sticky element. This is standard practice; MDN and CSS Working Group guidance both recommend box-shadow for sticky table header separators.



<img width="608" height="791" alt="Screenshot 2026-06-22 at 12 52 07 PM" src="https://github.com/user-attachments/assets/29daf072-ab91-44df-995c-de76b55ec7a8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved file selection in the upload list, supporting both single-select (radio) and multi-select (checkbox) modes with clearer per-row controls.
* **Style**
  * Redesigned the file upload modal layout for a simpler, cleaner presentation.
  * Enhanced the file table presentation with sticky headers and clearer visual separators.
* **Bug Fixes**
  * Improved upload table rendering reliability in automated tests by stabilizing layout measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->