### PR TITLE
fix(studio): replace missing MetricBundleInput type

### DIFF
--- a/web/packages/studio/src/components/sidePanels/MetricRunSidePanel/index.tsx
+++ b/web/packages/studio/src/components/sidePanels/MetricRunSidePanel/index.tsx
@@ -13,11 +13,7 @@ import type { VariableDef } from '@nemo/common/src/components/form/VariableTextA
 import { ModelSelectV2 } from '@nemo/common/src/components/ModelSelectV2';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { useEvaluatorCreateEvaluateJob } from '@nemo/sdk/generated/evaluator/api';
-import type {
-  EvaluateJobRequest,
-  MetricBundleInput,
-  Model,
-} from '@nemo/sdk/generated/evaluator/schema';
+import type { EvaluateJobRequest, MetricInline, Model } from '@nemo/sdk/generated/evaluator/schema';
 import {
   Button,
   Flex,
@@ -282,7 +278,7 @@ export const MetricRunSidePanel: FC<MetricRunSidePanelProps> = ({
         formData.jobType === 'online'
           ? {
               spec: {
-                metrics: [metric as unknown as MetricBundleInput],
+                metrics: [metric as unknown as MetricInline],
                 dataset: formData.dataset,
                 target,
                 prompt_template: promptTemplatePayload ?? undefined,
@@ -291,7 +287,7 @@ export const MetricRunSidePanel: FC<MetricRunSidePanelProps> = ({
             }
           : {
               spec: {
-                metrics: [metric as unknown as MetricBundleInput],
+                metrics: [metric as unknown as MetricInline],
                 dataset: formData.dataset,
               },
             };


### PR DESCRIPTION
## Summary

- Replace removed MetricBundleInput import with MetricInline in MetricRunSidePanel

## Context

The evaluator was recently migrated to a plugin format. As part of that migration, EvaluateInputSpec.metrics changed from `MetricBundleInput[]` to `(MetricInline | MetricRef)[]` and `MetricBundleInput`` was removed from the generated SDK schema entirely.

`MetricRunSidePanel` still imported `MetricBundleInput` and cast metric to that type at two call sites, breaking the `packages/studio` typecheck job in CI.

## Fix

Swap the import and both cast sites: `MetricBundleInput` → `MetricInline`. The cast is structural: `MetricItemWithId` (from the evaluator metric entity) aligns with `MetricInline` so this is a rename, not a behavioral change.

## Files changed

`web/packages/studio/src/components/sidePanels/MetricRunSidePanel/index.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metric evaluation job request formatting. Updated how metrics are processed when building evaluation requests for both online and offline jobs to use the correct data structure, ensuring metrics are properly handled during job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->