### PR TITLE
ci: adjust the behavior of the dependency caching for uv

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -533,31 +533,93 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Install chart-verifier
+        id: install-chart-verifier
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
           mkdir -p "${RUNNER_TEMP}/chart-verifier"
           chart_verifier_archive="chart-verifier-${CHART_VERIFIER_VERSION}.tgz"
-          curl -fsSL \
-            -o "${RUNNER_TEMP}/chart-verifier.tar.gz" \
-            "https://github.com/redhat-certification/chart-verifier/releases/download/${CHART_VERIFIER_VERSION}/${chart_verifier_archive}"
-          chart_verifier_sha256="$(
-            curl -fsSL "https://api.github.com/repos/redhat-certification/chart-verifier/releases/tags/${CHART_VERIFIER_VERSION}" \
-              | python3 -c 'import json, sys; target = sys.argv[1]; digests = [asset.get("digest", "") for asset in json.load(sys.stdin).get("assets", []) if asset.get("name") == target]; digest = digests[0] if digests else ""; print(digest.removeprefix("sha256:")) if digest.startswith("sha256:") else sys.exit(1)' "${chart_verifier_archive}"
-          )"
+          chart_verifier_archive_path="${RUNNER_TEMP}/chart-verifier.tar.gz"
+          release_metadata_path="${RUNNER_TEMP}/chart-verifier-release.json"
+          release_url="https://github.com/redhat-certification/chart-verifier/releases/download/${CHART_VERIFIER_VERSION}/${chart_verifier_archive}"
+          release_api_url="https://api.github.com/repos/redhat-certification/chart-verifier/releases/tags/${CHART_VERIFIER_VERSION}"
+
+          curl_args=(
+            --fail
+            --show-error
+            --silent
+            --location
+            --retry 5
+            --retry-delay 2
+            --retry-all-errors
+          )
+          github_api_args=(
+            "${curl_args[@]}"
+            --header "Accept: application/vnd.github+json"
+            --header "X-GitHub-Api-Version: 2022-11-28"
+          )
+          if [ -n "${GITHUB_TOKEN:-}" ]; then
+            github_api_args+=(--header "Authorization: Bearer ${GITHUB_TOKEN}")
+          fi
+
+          if ! curl "${curl_args[@]}" -o "${chart_verifier_archive_path}" "${release_url}"; then
+            echo "::warning::Unable to download chart-verifier ${CHART_VERIFIER_VERSION}; skipping chart verifier."
+            echo "installed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if ! curl "${github_api_args[@]}" -o "${release_metadata_path}" "${release_api_url}"; then
+            echo "::warning::Unable to fetch chart-verifier release metadata; skipping chart verifier."
+            echo "installed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if ! chart_verifier_sha256="$(
+            python3 - "${release_metadata_path}" "${chart_verifier_archive}" <<'PY'
+          import json
+          import sys
+
+          metadata_path = sys.argv[1]
+          target = sys.argv[2]
+
+          with open(metadata_path, encoding="utf-8") as metadata_file:
+              release = json.load(metadata_file)
+
+          for asset in release.get("assets", []):
+              if asset.get("name") != target:
+                  continue
+              digest = asset.get("digest", "")
+              if digest.startswith("sha256:"):
+                  print(digest.removeprefix("sha256:"))
+                  sys.exit(0)
+
+          print(f"sha256 digest not found for release asset {target}", file=sys.stderr)
+          sys.exit(1)
+          PY
+          )"; then
+            echo "::warning::Unable to read chart-verifier release digest; skipping chart verifier."
+            echo "installed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
           printf '%s  %s\n' "${chart_verifier_sha256}" "${RUNNER_TEMP}/chart-verifier.tar.gz" \
             | sha256sum -c -
           tar -xzf "${RUNNER_TEMP}/chart-verifier.tar.gz" -C "${RUNNER_TEMP}/chart-verifier" chart-verifier
           chmod +x "${RUNNER_TEMP}/chart-verifier/chart-verifier"
           echo "${RUNNER_TEMP}/chart-verifier" >> "${GITHUB_PATH}"
+          echo "installed=true" >> "${GITHUB_OUTPUT}"
       - name: Prepare Helm dependencies
+        if: steps.install-chart-verifier.outputs.installed == 'true'
         shell: bash
         run: |
           helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
           helm repo update
           helm dep update "${HELM_FOLDER}"
       - name: Run chart verifier
+        if: steps.install-chart-verifier.outputs.installed == 'true'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -206,6 +206,7 @@ jobs:
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version-file: pyproject.toml
+          cache-dependency-glob: uv.lock
 
       - name: Populate fastembed model cache
         if: steps.fastembed-cache.outputs.cache-hit != 'true'
@@ -592,6 +593,7 @@ jobs:
         with:
           enable-cache: true
           python-version: "3.11"
+          cache-dependency-glob: uv.lock
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
@@ -657,6 +659,7 @@ jobs:
         with:
           python-version: "3.11"
           enable-cache: true
+          cache-dependency-glob: uv.lock
       - name: Run tools unit tests
         run: uv run pytest tools -v --junit-xml=report.xml
       - name: Upload test artifacts
@@ -686,6 +689,7 @@ jobs:
         with:
           python-version: "3.11"
           enable-cache: true
+          cache-dependency-glob: uv.lock
       - name: Run unit tests
         run: make test-unit-ci
         env:
@@ -724,6 +728,7 @@ jobs:
         with:
           python-version: "3.11"
           enable-cache: true
+          cache-dependency-glob: uv.lock
       - name: Log in to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -817,6 +822,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          cache-dependency-glob: uv.lock
       - name: Download wheel
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -894,6 +900,7 @@ jobs:
         with:
           python-version: "3.13"
           enable-cache: true
+          cache-dependency-glob: uv.lock
       - name: Run e2e tests
         run: make test-e2e
         env:
@@ -1137,6 +1144,7 @@ jobs:
           working-directory: nemo-platform
           python-version: "3.11"
           enable-cache: true
+          cache-dependency-glob: uv.lock
       - name: Bootstrap Python environment
         working-directory: nemo-platform
         run: make bootstrap-python

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -568,13 +568,13 @@ jobs:
           if ! curl "${curl_args[@]}" -o "${chart_verifier_archive_path}" "${release_url}"; then
             echo "::warning::Unable to download chart-verifier ${CHART_VERIFIER_VERSION}; skipping chart verifier."
             echo "installed=false" >> "${GITHUB_OUTPUT}"
-            exit 0
+            exit 1
           fi
 
           if ! curl "${github_api_args[@]}" -o "${release_metadata_path}" "${release_api_url}"; then
             echo "::warning::Unable to fetch chart-verifier release metadata; skipping chart verifier."
             echo "installed=false" >> "${GITHUB_OUTPUT}"
-            exit 0
+            exit 1
           fi
 
           if ! chart_verifier_sha256="$(
@@ -602,7 +602,7 @@ jobs:
           )"; then
             echo "::warning::Unable to read chart-verifier release digest; skipping chart verifier."
             echo "installed=false" >> "${GITHUB_OUTPUT}"
-            exit 0
+            exit 1
           fi
 
           printf '%s  %s\n' "${chart_verifier_sha256}" "${RUNNER_TEMP}/chart-verifier.tar.gz" \


### PR DESCRIPTION
uv-setup will create new caches for a lot of differences. This makes it so the cache only changes if the uv.lock file does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/build efficiency by tying the dependency cache to the lockfile, ensuring caches refresh correctly and reducing stale-cache issues across linting, tests, wheels, and benchmarks.
  * Refined the Helm chart verifier workflow to download with retry-friendly metadata lookup, verify archives with SHA256 checksums, and expose explicit success/failure output to gate “prepare dependencies” and “run verification” steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->