### PR TITLE
fix(studio): eliminate per-render scans and mutation in data views

### DIFF
--- a/web/packages/studio/src/components/dataViews/CustomModelsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/CustomModelsDataView/index.tsx
@@ -144,22 +144,16 @@ export const CustomModelsDataView: FC<CustomModelsDataViewProps> = ({
     expansion: true,
   });
 
-  const filterQuery = useMemo(
-    () =>
-      buildCustomModelsFilter({
-        name: dataViewState.debouncedSearchBar || undefined,
-        base_model: dataViewState.debouncedColumnFilters.find((f) => f.id === 'base_model')
-          ?.value as string | undefined,
-        finetuning_type: dataViewState.debouncedColumnFilters.find(
-          (f) => f.id === 'finetuning_type'
-        )?.value as FinetuningType | undefined,
-        created_at: dataViewState.debouncedColumnFilters.find((f) => f.id === 'created_at')
-          ?.value as DatetimeFilter | undefined,
-        updated_at: dataViewState.debouncedColumnFilters.find((f) => f.id === 'updated_at')
-          ?.value as DatetimeFilter | undefined,
-      }),
-    [dataViewState.debouncedSearchBar, dataViewState.debouncedColumnFilters]
-  );
+  const filterQuery = useMemo(() => {
+    const filterMap = new Map(dataViewState.debouncedColumnFilters.map((f) => [f.id, f.value]));
+    return buildCustomModelsFilter({
+      name: dataViewState.debouncedSearchBar || undefined,
+      base_model: filterMap.get('base_model') as string | undefined,
+      finetuning_type: filterMap.get('finetuning_type') as FinetuningType | undefined,
+      created_at: filterMap.get('created_at') as DatetimeFilter | undefined,
+      updated_at: filterMap.get('updated_at') as DatetimeFilter | undefined,
+    });
+  }, [dataViewState.debouncedSearchBar, dataViewState.debouncedColumnFilters]);
 
   const {
     data: modelsResponse,
@@ -200,6 +194,16 @@ export const CustomModelsDataView: FC<CustomModelsDataViewProps> = ({
           }))
         : undefined,
     }));
+  }, [modelsResponse?.data]);
+
+  const adapterMap = useMemo(() => {
+    const map = new Map<string, Map<string, Adapter>>();
+    for (const model of modelsResponse?.data ?? []) {
+      if (model.adapters?.length) {
+        map.set(model.id, new Map(model.adapters.map((a) => [a.name, a])));
+      }
+    }
+    return map;
   }, [modelsResponse?.data]);
 
   const resetFilters = useCallback(() => {
@@ -338,7 +342,7 @@ export const CustomModelsDataView: FC<CustomModelsDataViewProps> = ({
             {
               children: 'Model details',
               onSelect: () => {
-                const adapter = parentModel.adapters?.find((a) => a.name === row.name);
+                const adapter = adapterMap.get(parentModel.id)?.get(row.name);
                 onRowClick?.(parentModel, 'model-details', adapter);
               },
             },
@@ -404,7 +408,7 @@ export const CustomModelsDataView: FC<CustomModelsDataViewProps> = ({
         )}
         onRowClick={(row: ModelTableRow) => {
           if (row._parentModel) {
-            const adapter = row._parentModel.adapters?.find((a) => a.name === row.name);
+            const adapter = adapterMap.get(row._parentModel.id)?.get(row.name);
             onRowClick?.(row._parentModel, 'model-details', adapter);
           } else {
             onRowClick?.(row, 'model-details');

--- a/web/packages/studio/src/routes/InferenceProvidersListRoute/InferenceProviderDetailsSidePanel/index.tsx
+++ b/web/packages/studio/src/routes/InferenceProvidersListRoute/InferenceProviderDetailsSidePanel/index.tsx
@@ -44,6 +44,7 @@ export const InferenceProviderDetailsSidePanel: FC<InferenceProviderDetailsSideP
   provider,
 }) => {
   const models = useMemo(() => (provider ? servedModelLabels(provider) : []), [provider]);
+  const sortedModels = useMemo(() => [...models].sort(), [models]);
   const statusMessage = provider?.status_message?.trim();
 
   const statusMessageContent = isStatusMessageError(provider.status) ? (
@@ -120,7 +121,7 @@ export const InferenceProviderDetailsSidePanel: FC<InferenceProviderDetailsSideP
           <KVPair
             attributes={{ value: { className: 'whitespace-pre-wrap' } }}
             label="Served models"
-            value={models.length > 0 ? models.sort().join('\n') : '—'}
+            value={sortedModels.length > 0 ? sortedModels.join('\n') : '—'}
           />
         </Stack>
       </Stack>


### PR DESCRIPTION
- Replace four sequential `.find()` passes in `buildCustomModelsFilter` with a single `Map` built in `useMemo` for O(1) lookups
- Pre-build `Map<modelId, Map<adapterName, Adapter>>` so adapter lookups in `rowActions` and `onRowClick` are O(1) instead of scanning adapters on every row render
- Replace in-place `models.sort()` in `InferenceProviderDetailsSidePanel` with `useMemo(() => [...models].sort(), [models])` to avoid mutating the memoized array and re-sorting on every render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed array mutation issue in model list display to ensure stable rendering.

* **Refactor**
  * Optimized filter query construction and adapter mapping logic for improved performance in the custom models view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->