### PR TITLE
fix(studio): Remove title for group experiments dataview

### DIFF
--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -121,6 +121,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
         header: 'Name',
         enableSorting: true,
         enableHiding: false,
+        meta: { title: false },
         size: 300,
         cell: ({ row }) => {
           const { name, summary } = row.original;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the display behavior of the "Name" column in the experiment group table view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->