### PR TITLE
fix(studio): Add eval helper text

### DIFF
--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal.test.tsx
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SubmitEvaluationModal } from '@studio/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal';
+import { EVAL_CONFIG_FILESET_HELP_TEXT } from '@studio/routes/agents/AgentSuggestionsRoute/constants';
+import { renderRoute, screen } from '@studio/tests/util/render';
+import userEvent from '@testing-library/user-event';
+
+describe('SubmitEvaluationModal', () => {
+  it('explains the required config format when fileset mode is selected', async () => {
+    const user = userEvent.setup();
+
+    renderRoute(
+      <SubmitEvaluationModal open onClose={vi.fn()} workspace="default" agent="react-agent" />
+    );
+
+    expect(screen.queryByText(EVAL_CONFIG_FILESET_HELP_TEXT)).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('radio', { name: 'Select or upload a config file from a fileset' })
+    );
+
+    expect(screen.getByText(EVAL_CONFIG_FILESET_HELP_TEXT)).toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal.tsx
@@ -12,7 +12,10 @@ import { Block, RadioGroup, Stack, Text } from '@nvidia/foundations-react-core';
 import { type Agent } from '@studio/components/dataViews/AgentsDataView';
 import { PLATFORM_BASE_URL } from '@studio/constants/environment';
 import { ensureEvalConfigFileset } from '@studio/routes/agents/AgentSuggestionsRoute/api';
-import { SAMPLE_EVAL_CONFIG_PATH } from '@studio/routes/agents/AgentSuggestionsRoute/constants';
+import {
+  EVAL_CONFIG_FILESET_HELP_TEXT,
+  SAMPLE_EVAL_CONFIG_PATH,
+} from '@studio/routes/agents/AgentSuggestionsRoute/constants';
 import {
   evalFilesetForAgent,
   evalOutputFilesetFor,
@@ -275,23 +278,28 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
           />
         </Block>
         {mode === MODE_FILESET ? (
-          <ControlledDatasetFileSelect
-            useControllerProps={{
-              control,
-              name: 'datasetFile',
-              rules: { required: 'Pick an eval YAML inside an existing fileset' },
-            }}
-            acceptedFileTypes={['.yml', '.yaml']}
-            invalidFileMode="disable"
-            setError={(error) => setError('datasetFile', error)}
-            clearError={() => clearErrors('datasetFile')}
-            workspace={workspace}
-            inline
-            autoCommit
-            formFieldProps={{
-              slotError: errors.datasetFile?.message,
-            }}
-          />
+          <Stack gap="density-md">
+            <Text kind="body/regular/sm" color="secondary">
+              {EVAL_CONFIG_FILESET_HELP_TEXT}
+            </Text>
+            <ControlledDatasetFileSelect
+              useControllerProps={{
+                control,
+                name: 'datasetFile',
+                rules: { required: 'Pick an eval YAML inside an existing fileset' },
+              }}
+              acceptedFileTypes={['.yml', '.yaml']}
+              invalidFileMode="disable"
+              setError={(error) => setError('datasetFile', error)}
+              clearError={() => clearErrors('datasetFile')}
+              workspace={workspace}
+              inline
+              autoCommit
+              formFieldProps={{
+                slotError: errors.datasetFile?.message,
+              }}
+            />
+          </Stack>
         ) : null}
       </Stack>
     </FormModal>

--- a/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/components/ApplyEvalConfigModal.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/components/ApplyEvalConfigModal.test.tsx
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ApplyEvalConfigModal } from '@studio/routes/agents/AgentSuggestionsRoute/components/ApplyEvalConfigModal';
+import { EVAL_CONFIG_FILESET_HELP_TEXT } from '@studio/routes/agents/AgentSuggestionsRoute/constants';
+import { renderRoute, screen } from '@studio/tests/util/render';
+import userEvent from '@testing-library/user-event';
+
+describe('ApplyEvalConfigModal', () => {
+  it('explains the required config format when fileset mode is selected', async () => {
+    const user = userEvent.setup();
+
+    renderRoute(
+      <ApplyEvalConfigModal
+        open
+        onClose={vi.fn()}
+        workspace="default"
+        suggestionTitle="Validate smaller model"
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText(EVAL_CONFIG_FILESET_HELP_TEXT)).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('radio', { name: 'Select or upload a config file from a fileset' })
+    );
+
+    expect(screen.getByText(EVAL_CONFIG_FILESET_HELP_TEXT)).toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/components/ApplyEvalConfigModal.tsx
+++ b/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/components/ApplyEvalConfigModal.tsx
@@ -6,6 +6,7 @@ import { ControlledDatasetFileSelect } from '@nemo/common/src/components/Dataset
 import { parseFilesetLocation } from '@nemo/common/src/components/DatasetFileSelect/parseFilesetLocation';
 import { FormModal, type FormModalProps } from '@nemo/common/src/components/FormModal';
 import { Block, RadioGroup, Stack, Text } from '@nvidia/foundations-react-core';
+import { EVAL_CONFIG_FILESET_HELP_TEXT } from '@studio/routes/agents/AgentSuggestionsRoute/constants';
 import type { EvalConfigChoice } from '@studio/routes/agents/AgentSuggestionsRoute/types';
 import { type FC, useEffect } from 'react';
 import { useForm, useWatch, type SubmitHandler } from 'react-hook-form';
@@ -124,23 +125,28 @@ export const ApplyEvalConfigModal: FC<ApplyEvalConfigModalProps> = ({
           />
         </Block>
         {mode === MODE_FILESET ? (
-          <ControlledDatasetFileSelect
-            useControllerProps={{
-              control,
-              name: 'datasetFile',
-              rules: { required: 'Pick an eval YAML inside an existing fileset' },
-            }}
-            acceptedFileTypes={['.yml', '.yaml']}
-            invalidFileMode="disable"
-            setError={(error) => setError('datasetFile', error)}
-            clearError={() => clearErrors('datasetFile')}
-            workspace={workspace}
-            inline
-            autoCommit
-            formFieldProps={{
-              slotError: errors.datasetFile?.message,
-            }}
-          />
+          <Stack gap="density-md">
+            <Text kind="body/regular/sm" color="secondary">
+              {EVAL_CONFIG_FILESET_HELP_TEXT}
+            </Text>
+            <ControlledDatasetFileSelect
+              useControllerProps={{
+                control,
+                name: 'datasetFile',
+                rules: { required: 'Pick an eval YAML inside an existing fileset' },
+              }}
+              acceptedFileTypes={['.yml', '.yaml']}
+              invalidFileMode="disable"
+              setError={(error) => setError('datasetFile', error)}
+              clearError={() => clearErrors('datasetFile')}
+              workspace={workspace}
+              inline
+              autoCommit
+              formFieldProps={{
+                slotError: errors.datasetFile?.message,
+              }}
+            />
+          </Stack>
         ) : null}
       </Stack>
     </FormModal>

--- a/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/constants.ts
+++ b/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/constants.ts
@@ -50,6 +50,9 @@ export const STALE_SUGGESTION_MS = 7 * 24 * 60 * 60 * 1000;
 export const SAMPLE_EVAL_CONFIG_PATH = 'react-eval.yml';
 export const SAMPLE_EVAL_DATA_PATH = 'react-eval-data.json';
 
+export const EVAL_CONFIG_FILESET_HELP_TEXT =
+  'A valid evaluation config is a NAT evaluation YAML file with a .yml or .yaml extension. Upload one to a fileset, then select that file here.';
+
 export const SAMPLE_EVAL_YAML = `# react-eval.yml — bundled sample seeded by the optimizer apply flow.
 #
 # Evaluates against the deployed agent endpoint. The judge LLM scores answers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual help text that displays when selecting fileset mode in evaluation configuration modals, providing guidance on expected file formats.

* **Tests**
  * Added test coverage for fileset mode help text visibility in evaluation modals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->