### PR TITLE
ci: use action-semantic-pull-requests directly to update as needed

### DIFF
--- a/.github/workflows/semantic-pull-requests.yaml
+++ b/.github/workflows/semantic-pull-requests.yaml
@@ -17,4 +17,16 @@ permissions:
 
 jobs:
   semantic-pull-request:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_semantic_pull_request.yml@d48ee21a4986f7281abf746b7d500880c0e91f41 # v1.5.1
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Semantic PR Title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+
+      - name: PR Title length
+        if: always()
+        run: |
+          title_length="$(jq -er '.pull_request.title | strings | length' "${GITHUB_EVENT_PATH}")"
+
+          test "${title_length}" -le 100


### PR DESCRIPTION
The version used in the shared template uses node 16, which will be shut down this week on github runners. Beyond that, there are some simplifications over the upstream template that seem helpful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow for pull request validation with stricter title requirements, including a maximum character limit of 100 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->