### PR TITLE
fix(docker): add fastembed-cache-empty placeholder so default bake builds

### DIFF
--- a/docker/fastembed-cache-empty/.gitkeep
+++ b/docker/fastembed-cache-empty/.gitkeep
@@ -1,0 +1,4 @@
+# Placeholder so the empty fastembed cache build context exists on checkout.
+# Git cannot track empty directories; docker-bake.hcl's FASTEMBED_CACHE_CONTEXT
+# default (docker/fastembed-cache-empty) is COPYed by Dockerfile.nmp-api, so a
+# missing dir breaks default/local 'make docker-build'. CI overrides the var.


### PR DESCRIPTION
## Summary

A clean checkout cannot run the default Docker build. `docker-bake.hcl` defaults `FASTEMBED_CACHE_CONTEXT` to `docker/fastembed-cache-empty` (added in #384), and `Dockerfile.nmp-api` consumes it via `COPY --from=fastembed-cache .`. That directory was never committed — git can't track empty dirs and there was no placeholder file — so the documented local build fails before it starts:

```
ERROR: failed to get build context fastembed-cache: stat docker/fastembed-cache-empty: no such file or directory
make: *** [docker-load] Error 1
```

CI's "Build CPU smoke images" job never hits this because `ci.yaml` overrides `FASTEMBED_CACHE_CONTEXT` to a `${RUNNER_TEMP}/fastembed-cache` dir it `mkdir`s — so only the committed default path (local dev, `make docker-build` / `docker-load`) is broken.

## Fix

Commit a tracked placeholder (`docker/fastembed-cache-empty/.gitkeep`) so the default context exists on checkout. The empty context just means the image downloads the embed model at build time — the existing else-branch in `Dockerfile.nmp-api` already handles that.

## Testing

- Reproduced on a clean `main` checkout: `make docker-load TARGET=docker-cpu` failed immediately with the context error above.
- With the directory present, the same command proceeds past context resolution into the image builds.

## Notes

Found while doing RCA on an unrelated `docker-build` status failure. This is a **separate, pre-existing bug** (default/local builds only); the external CI `docker-build` gate is unaffected because it overrides the cache context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to ensure proper directory structure tracking during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->