### PR TITLE
fix(intake): Fix POST /evaluator-results idempotentcy

### DIFF
--- a/services/intake/src/nmp/intake/spans/api/evaluator_results.py
+++ b/services/intake/src/nmp/intake/spans/api/evaluator_results.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from nmp.common.api.common import Page
@@ -32,6 +31,7 @@ from nmp.intake.spans.api.query_filters import (
 from nmp.intake.spans.domain import EvaluatorResult as DomainEvaluatorResult
 from nmp.intake.spans.domain import EvaluatorResultListFilter
 from nmp.intake.spans.service import EvaluatorResultNotFoundError
+from nmp.intake.spans.storage import stable_id
 
 router = APIRouter(dependencies=[Depends(require_workspace_access)])
 API_TAG = "Evaluator Results"
@@ -51,8 +51,18 @@ async def create_evaluator_result(
     auth_client: AuthClient = Depends(get_auth_client),
 ) -> EvaluatorResult:
     now = datetime.now(timezone.utc)
+    # Identity-derived id: one result per (workspace, session, span, evaluator name). Re-POSTing
+    # the same target hashes to the same id, so ReplacingMergeTree upserts (latest write wins)
+    # rather than accumulating duplicate or stale rows.
+    evaluator_result_id = stable_id(
+        workspace,
+        body.session_id,
+        body.span_id,
+        body.name,
+        prefix="eval",
+    )
     domain_result = DomainEvaluatorResult(
-        evaluator_result_id=f"eval-{uuid4().hex}",
+        evaluator_result_id=evaluator_result_id,
         span_id=body.span_id,
         session_id=body.session_id,
         workspace=workspace,

--- a/services/intake/tests/integration/spans/test_evaluator_results_crud.py
+++ b/services/intake/tests/integration/spans/test_evaluator_results_crud.py
@@ -95,3 +95,37 @@ def test_create_evaluator_result_rejects_non_binary_boolean_value(client: TestCl
 def test_get_evaluator_result_returns_404_when_missing(client: TestClient):
     response = client.get(f"{EVAL_BASE}/eval-does-not-exist")
     assert response.status_code == 404, response.text
+
+
+def test_create_evaluator_result_is_idempotent_for_identical_writes(client: TestClient):
+    body = _make_numeric_body()
+
+    first = client.post(EVAL_BASE, json=body)
+    assert first.status_code == 201, first.text
+    second = client.post(EVAL_BASE, json=body)
+    assert second.status_code == 201, second.text
+
+    # An identical re-POST hashes to the same deterministic id...
+    assert first.json()["evaluator_result_id"] == second.json()["evaluator_result_id"]
+
+    # ...and dedupes on read rather than creating a permanent duplicate row.
+    listed = client.get(EVAL_BASE, params={"page_size": 50})
+    assert listed.status_code == 200, listed.text
+    assert listed.json()["pagination"]["total_results"] == 1
+
+
+def test_re_post_same_target_with_different_value_upserts_latest(client: TestClient):
+    first = client.post(EVAL_BASE, json=_make_numeric_body(value=0.85))
+    assert first.status_code == 201, first.text
+    second = client.post(EVAL_BASE, json=_make_numeric_body(value=0.42))
+    assert second.status_code == 201, second.text
+
+    # Same target (workspace, session, span, name) -> same id; a re-score upserts, not appends.
+    assert first.json()["evaluator_result_id"] == second.json()["evaluator_result_id"]
+
+    listed = client.get(EVAL_BASE, params={"page_size": 50})
+    assert listed.status_code == 200, listed.text
+    page = listed.json()
+    assert page["pagination"]["total_results"] == 1
+    # Latest write wins.
+    assert page["data"][0]["value"] == 0.42


### PR DESCRIPTION
Linear issue: [ASE-318](https://linear.app/nvidia/issue/ASE-318/post-evaluator-results-is-not-idempotent-retried-writes-create)

**Problem**
`POST evaluator-results` generates a random `evaluator_result_id`. Since that id is part of the `evaluator_results` ReplacingMergeTree sort key, re-POSTing the same logical evaluator result creates a second row that never dedupes. 

**Fix**
Follow the same pattern as atif_mapping endpoints. Derive `evaluator_result_id` deterministically from the result's identity. There's one result per (workspace, session, span, evaluator name), so re-POSTing the same target hashes to the same id and upserts — ReplacingMergeTree keeps the latest by ingested_at — instead of creating duplicate or stale rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluator results API now uses deterministic IDs instead of random identifiers, enabling idempotent operations and preventing duplicate results on repeated submissions.
  * API now supports upsert behavior: resubmitting the same target with an updated value updates the existing result instead of creating a new entry.

* **Tests**
  * Added integration tests verifying idempotency and upsert behavior for evaluator results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->