### PR TITLE
feat(studio): surface experiment metadata as dynamic columns

### DIFF
--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -113,6 +113,12 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
     [tableData]
   );
 
+  // One column per metadata key: the union across loaded rows, sorted for stable ordering.
+  const metadataKeys = useMemo(
+    () => [...new Set(tableData.flatMap((e) => Object.keys(e.metadata ?? {})))].sort(),
+    [tableData]
+  );
+
   const makeColumns = useCallback<
     ComponentProps<typeof DataViewRoot<ExperimentRow>>['makeColumns']
   >(
@@ -181,6 +187,29 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
         enableSorting: false,
         cell: ({ getValue }) => <Text>{getValue<string>() || '-'}</Text>,
       }),
+      ...metadataKeys.map((key) =>
+        accessor((original) => original.metadata?.[key], {
+          id: `metadata-${key}`,
+          header: snakeCaseToTitleCase(key),
+          enableSorting: false,
+          cell: ({ getValue }) => {
+            const raw = getValue<unknown>();
+            if (raw == null) return <Text>-</Text>;
+            const str =
+              typeof raw === 'object' ? JSON.stringify(raw) : String(raw);
+            if (str.length <= 50) return <Text>{str}</Text>;
+            return (
+              <Tooltip
+                slotContent={<Text kind="body/regular/sm">{str}</Text>}
+                className={tooltipClassName}
+                side="bottom"
+              >
+                <Text className="cursor-default">{str.slice(0, 50)}…</Text>
+              </Tooltip>
+            );
+          },
+        })
+      ),
       ...evaluatorNames.map((name, index) =>
         accessor((original) => original.aggregate_scores?.[name]?.mean, {
           id: `score-${index}`,
@@ -239,7 +268,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
         },
       }),
     ],
-    [evaluatorNames]
+    [evaluatorNames, metadataKeys]
   );
 
   if (groupError) {

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -113,9 +113,15 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
     [tableData]
   );
 
-  // One column per metadata key: the union across loaded rows, sorted for stable ordering.
+  // One column per metadata key: keys are lowercased so case variants (e.g. "status"
+  // and "Status") collapse into one column rather than producing duplicate headers.
   const metadataKeys = useMemo(
-    () => [...new Set(tableData.flatMap((e) => Object.keys(e.metadata ?? {})))].sort(),
+    () =>
+      [
+        ...new Set(
+          tableData.flatMap((e) => Object.keys(e.metadata ?? {}).map((k) => k.toLowerCase()))
+        ),
+      ].sort(),
     [tableData]
   );
 
@@ -188,7 +194,12 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
         cell: ({ getValue }) => <Text>{getValue<string>() || '-'}</Text>,
       }),
       ...metadataKeys.map((key) =>
-        accessor((original) => original.metadata?.[key], {
+        accessor((original) => {
+          const meta = original.metadata ?? {};
+          // Match the first key that lowercases to this column's key.
+          const match = Object.keys(meta).find((k) => k.toLowerCase() === key);
+          return match ? meta[match] : undefined;
+        }, {
           id: `metadata-${key}`,
           header: snakeCaseToTitleCase(key),
           enableSorting: false,

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -194,32 +194,34 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
         cell: ({ getValue }) => <Text>{getValue<string>() || '-'}</Text>,
       }),
       ...metadataKeys.map((key) =>
-        accessor((original) => {
-          const meta = original.metadata ?? {};
-          // Match the first key that lowercases to this column's key.
-          const match = Object.keys(meta).find((k) => k.toLowerCase() === key);
-          return match ? meta[match] : undefined;
-        }, {
-          id: `metadata-${key}`,
-          header: snakeCaseToTitleCase(key),
-          enableSorting: false,
-          cell: ({ getValue }) => {
-            const raw = getValue<unknown>();
-            if (raw == null) return <Text>-</Text>;
-            const str =
-              typeof raw === 'object' ? JSON.stringify(raw) : String(raw);
-            if (str.length <= 50) return <Text>{str}</Text>;
-            return (
-              <Tooltip
-                slotContent={<Text kind="body/regular/sm">{str}</Text>}
-                className={tooltipClassName}
-                side="bottom"
-              >
-                <Text className="cursor-default">{str.slice(0, 50)}…</Text>
-              </Tooltip>
-            );
+        accessor(
+          (original) => {
+            const meta = original.metadata ?? {};
+            // Match the first key that lowercases to this column's key.
+            const match = Object.keys(meta).find((k) => k.toLowerCase() === key);
+            return match ? meta[match] : undefined;
           },
-        })
+          {
+            id: `metadata-${key}`,
+            header: snakeCaseToTitleCase(key),
+            enableSorting: false,
+            cell: ({ getValue }) => {
+              const raw = getValue<unknown>();
+              if (raw == null) return <Text>-</Text>;
+              const str = typeof raw === 'object' ? JSON.stringify(raw) : String(raw);
+              if (str.length <= 50) return <Text>{str}</Text>;
+              return (
+                <Tooltip
+                  slotContent={<Text kind="body/regular/sm">{str}</Text>}
+                  className={tooltipClassName}
+                  side="bottom"
+                >
+                  <Text className="cursor-default">{str.slice(0, 50)}…</Text>
+                </Tooltip>
+              );
+            },
+          }
+        )
       ),
       ...evaluatorNames.map((name, index) =>
         accessor((original) => original.aggregate_scores?.[name]?.mean, {


### PR DESCRIPTION
Closes #ASE-286

https://github.com/user-attachments/assets/7c70b5a4-3145-45bb-8994-252f0d0d5e99

# Summary

Experiments carry free-form `metadata` (producer-supplied key/value pairs) but there was no way to compare them side-by-side in the experiments table. This adds dynamic metadata columns that mirror the existing evaluator-score column pattern: a `useMemo` computes the union of metadata keys across the loaded page, sorts them alphabetically, and maps each into a column accessor inserted after the Models column.

Keys are normalized to lowercase when building the union so case variants (e.g. `status` and `Status` from different producers) collapse into one column instead of producing duplicate headers. The accessor finds the first key that lowercases to a match, so values are still retrieved correctly regardless of producer casing. All metadata columns flow through the existing `EditColumnsMenu` so users can hide noisy keys. Cell rendering handles every value type: `null`/`undefined` → `-`, objects/arrays → `JSON.stringify`, primitives → `String()`. Values over 50 characters truncate with a tooltip showing the full string.

# Test plan
- [ ] Open `test-group-experiment-medadata` in Studio
- [ ] Confirm metadata columns appear between Models and Avg Cost, sorted alphabetically
- [ ] `missing-key-b` row shows `-` in the Environment column (key absent)
- [ ] `object-value` row shows stringified JSON in the Config column
- [ ] `long-value` row truncates Job Name at 50 chars with a tooltip containing the full string
- [ ] `primitives` row shows `3` and `false` for Retries and Cached (not `-`)
- [ ] `no-metadata` row renders without crashing; no extra columns from that row
- [ ] `case-variant-lower` and `case-variant-upper` share a single Status column showing `passing` and `FAILING`
- [ ] Metadata columns are hideable via the Columns menu
- [ ] Navigating to page 2 recomputes the column set to match that page's rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Experiment metadata is now shown as dynamic table columns in the data view, generated from the loaded rows’ keys
  * Missing or null metadata values display as `-`
  * Long metadata values are truncated with hover tooltips to reveal the full content
<!-- end of auto-generated comment: release notes by coderabbit.ai -->