### PR TITLE
ASTD-260: Gate chat playground on valid deployment target

### DIFF
--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/ChatPlaygroundContent.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/ChatPlaygroundContent.tsx
@@ -72,7 +72,7 @@ export const ChatPlaygroundContent: FC<ChatPlaygroundContentProps> = ({
               ? `${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/${workspace}/deployments/${chatDeployment.name}/-/v1`
               : undefined
           }
-          disabled={noHealthyDeployments}
+          disabled={isDeploymentsLoading || noHealthyDeployments || !chatDeployment}
         />
       </Block>
     </div>


### PR DESCRIPTION
## Summary

Fixes **ASTD-260**: Chat playground was enabled while deployments were still loading and when no  was resolved, allowing chat requests with an undefined .

## Changes

- Disable  when  is true
- Disable  when  is undefined (no resolved deployment target)
- Existing  check is preserved for the zero-deployments case

## Testing

- Manual verification: chat is now disabled during deployment loading and when no deployment is selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat interface availability to properly disable when deployments are loading or when no deployment is selected, preventing user interactions during unavailable states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->