### PR TITLE
fix: ASTD-254: only upload files for local storage filesets

### DIFF
--- a/web/packages/studio/src/routes/FilesetNewRoute/useCreateFileset.ts
+++ b/web/packages/studio/src/routes/FilesetNewRoute/useCreateFileset.ts
@@ -122,8 +122,8 @@ export function useCreateFileset({
 
       setIsSubmitPending(true);
 
-      // Step 1 (sample only): fetch sample files via lazy query
-      let files: File[];
+      // Step 1 (sample/local only): fetch sample files or read local file selection
+      let files: File[] = [];
       if (activeTab === DATASET_TYPE_SAMPLE) {
         if (!sampleFilesRef.current) {
           toast.error('No sample files could be loaded.');
@@ -142,7 +142,7 @@ export function useCreateFileset({
           return;
         }
         files = result.data;
-      } else {
+      } else if (storageTab === 'local') {
         files = toFileList(getValues('files'));
       }
 


### PR DESCRIPTION
## Summary

Fixes **ASTD-254**: Submit handler always pulled files from form state and uploaded them, even when the user switched to the External storage tab. Local files selected before switching tabs could be uploaded unintentionally.

## Changes

- Only read local files when 
- External storage filesets skip the file upload step entirely

## Testing

- Manual verification: selecting local files then switching to External tab no longer uploads those files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where files could be unintentionally uploaded when external storage options were selected during fileset creation. File uploads now correctly occur only with local and sample storage options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->