### PR TITLE
ASTD-259: Add missing deps to handleInferFromExisting

### DIFF
--- a/web/packages/studio/src/routes/FilesetDetailRoute/DatasetSchemaEditor/useDatasetSchemaEditor.ts
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/DatasetSchemaEditor/useDatasetSchemaEditor.ts
@@ -229,8 +229,7 @@ export function useDatasetSchemaEditor({
     } finally {
       setIsInferring(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- workspace/datasetName captured inside downloadFileHead's own useCallback
-  }, [supportedExistingFiles, downloadFileHead]);
+  }, [supportedExistingFiles, downloadFileHead, workspace, datasetName]);
 
   const { mutateAsync: updateMetadata, isPending: isSaving } = useFilesUpdateFilesetMetadata();
   const queryClient = useQueryClient();


### PR DESCRIPTION
## Summary

Fixes **ASTD-259**: The handleInferFromExisting useCallback was missing workspace and datasetName from its dependency array, causing stale values after route changes.

## Changes

- Added workspace and datasetName to the useCallback dependency array
- Removed the incorrect eslint-disable comment

## Testing

- Verified the dependency array now includes all referenced values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements made to the dataset schema editor component to enhance code quality, reliability, and maintainability without affecting user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->