### PR TITLE
ASTD-257: Guard null firstRow and fix expand button a11y

### DIFF
--- a/web/packages/studio/src/components/ModelComparePrompts/ExpandableCell.tsx
+++ b/web/packages/studio/src/components/ModelComparePrompts/ExpandableCell.tsx
@@ -18,7 +18,7 @@ export const ExpandableCell: FC<{
     <div className="group relative flex h-full flex-col">
       <button
         onClick={() => onExpand({ title, content })}
-        className="absolute right-1 top-1 z-10 cursor-pointer rounded bg-surface-base/80 p-1 opacity-0 hover:bg-surface-sunken group-hover:opacity-100"
+        className="absolute right-1 top-1 z-10 cursor-pointer rounded bg-surface-base/80 p-1 opacity-0 hover:bg-surface-sunken group-hover:opacity-100 focus-visible:opacity-100"
         aria-label="Expand cell"
       >
         <Maximize2 size={12} />

--- a/web/packages/studio/src/components/ModelComparePrompts/helpers.ts
+++ b/web/packages/studio/src/components/ModelComparePrompts/helpers.ts
@@ -81,7 +81,7 @@ export async function parseUploadedFile(
   } else if (detection?.schemaType === InputFileSchemaType.CHAT_COMPLETION) {
     promptKey = detection.detectedMessages.user?.selector ?? null;
   }
-  if (!promptKey) {
+  if (!promptKey && firstRow && typeof firstRow === 'object') {
     const candidates = ['prompt', 'question', 'input', 'text'];
     promptKey = candidates.find((k) => typeof firstRow[k] === 'string') ?? null;
   }


### PR DESCRIPTION
## Summary

Fixes **ASTD-257**: Two pre-existing issues in ModelComparePrompts.

## Changes

1. **Null firstRow crash**: Guarded non-object firstRow before probing for prompt keys, preventing crashes when firstRow is null.
2. **Expand button a11y**: Added focus-visible:opacity-100 so keyboard users can see the expand button when focused.

## Testing

- Verified null firstRow no longer crashes the parser
- Verified expand button is visible on focus for keyboard users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The expand-to-modal button now appears on hover and focus states instead of being always visible, providing a cleaner interface.

* **Bug Fixes**
  * Enhanced file upload processing to prevent errors by properly validating data structure before attempting to parse uploaded files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->