### PR TITLE
fix(docs): update IGW target to be consistent with other docs

### DIFF
--- a/docs/auditor/sdk-resources.mdx
+++ b/docs/auditor/sdk-resources.mdx
@@ -119,7 +119,7 @@ target = auditor.targets.create(
     options={
         "nim": {
             "nmp_uri_spec": {
-                "inference_gateway": {"workspace": "default", "provider": "build"},
+                "inference_gateway": {"workspace": "default", "provider": "nvidia-build"},
             },
         },
     },

--- a/docs/auditor/targets/index.mdx
+++ b/docs/auditor/targets/index.mdx
@@ -35,7 +35,7 @@ target = client.auditor.targets.create(
             "nmp_uri_spec": {
                 "inference_gateway": {
                     "workspace": "default",
-                    "provider": "build",
+                    "provider": "nvidia-build",
                 },
             },
         },
@@ -115,7 +115,7 @@ updated = client.auditor.targets.update(
         "nim": {
             "max_tokens": 2048,
             "nmp_uri_spec": {
-                "inference_gateway": {"workspace": "default", "provider": "build"},
+                "inference_gateway": {"workspace": "default", "provider": "nvidia-build"},
             },
         },
     },

--- a/docs/auditor/targets/inference-gateway.mdx
+++ b/docs/auditor/targets/inference-gateway.mdx
@@ -35,7 +35,7 @@ Both `workspace` and `provider` are required. Other keys inside `nmp_uri_spec` a
 
 ## Worked Example
 
-Audit a NIM endpoint registered as the `build` provider in the `default` workspace:
+Audit a NIM endpoint registered as the `nvidia-build` provider in the `default` workspace:
 
 ```python
 target = client.auditor.targets.create(
@@ -49,7 +49,7 @@ target = client.auditor.targets.create(
             "nmp_uri_spec": {
                 "inference_gateway": {
                     "workspace": "default",
-                    "provider": "build",
+                    "provider": "nvidia-build",
                 },
             },
         },

--- a/docs/auditor/tutorials/run-audit-locally.mdx
+++ b/docs/auditor/tutorials/run-audit-locally.mdx
@@ -23,7 +23,7 @@ This tutorial takes approximately **10 minutes** to complete, plus however long 
 
 - Install and start NeMo Platform using the [Setup guide](/documentation/get-started).
 - Install garak in a Python virtual environment so the plugin can shell out to it. By default the plugin invokes `~/.auditor/.venv/bin/python -m garak`. Override the interpreter path with `NEMO_AUDITOR_GARAK_PYTHON` if your install lives elsewhere.
-- Configure at least one Inference Gateway provider — this tutorial uses a `build` provider named `build` that routes to NVIDIA-build models, but any chat-completion-compatible provider works. See [Inference Gateway](/documentation/vulnerability-scanning/targets/inference-gateway) for details on the `nmp_uri_spec` block used below.
+- Configure at least one Inference Gateway provider — this tutorial uses a provider named `nvidia-build` that routes to NVIDIA Build models, but any chat-completion-compatible provider works. See [Inference Gateway](/documentation/vulnerability-scanning/targets/inference-gateway) for details on the `nmp_uri_spec` block used below.
 
 ---
 
@@ -104,7 +104,7 @@ target = auditor.targets.create(
             "nmp_uri_spec": {
                 "inference_gateway": {
                     "workspace": "default",
-                    "provider": "build",
+                    "provider": "nvidia-build",
                 },
             },
         },

--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -403,6 +403,7 @@ platform-seed-service = [
   "nmp-common",
   "nmp-auth",
   "nmp-guardrails",
+  "nemo-auditor-plugin",
 ]
 
 # Generated from [tool.bundle-package]; do not edit by hand.

--- a/services/platform-seed/pyproject.toml
+++ b/services/platform-seed/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "nmp-platform-seed"
 version = "0.0.1"
-description = "Platform seed service and task - runs centralized seeding (guardrails, evaluator, data designer) after dependencies are ready"
+description = "Platform seed service and task - runs centralized seeding (auth, guardrails, auditor, and plugin seed jobs) after dependencies are ready"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"
 
@@ -9,6 +9,7 @@ dependencies = [
   "nmp-common",
   "nmp-auth",
   "nmp-guardrails",
+  "nemo-auditor-plugin",
 ]
 
 [project.scripts]
@@ -18,6 +19,7 @@ platform-seed = "nmp.platform_seed.__main__:main"
 nmp-common = { workspace = true }
 nmp-auth = { workspace = true }
 nmp-guardrails = { workspace = true }
+nemo-auditor-plugin = { workspace = true }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -4577,6 +4577,7 @@ all = [
     { name = "lark", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-agents-example-calculator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-anonymizer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-auditor-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-evaluator-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4941,6 +4942,7 @@ nmp-common = [
     { name = "structlog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 platform-seed-service = [
+    { name = "nemo-auditor-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-guardrails", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -5027,6 +5029,7 @@ services = [
     { name = "lark", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-agents-example-calculator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-anonymizer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-auditor-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-evaluator-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -5318,6 +5321,9 @@ requires-dist = [
     { name = "nemo-anonymizer", marker = "extra == 'nemo-anonymizer-plugin'", specifier = ">=0.2.1" },
     { name = "nemo-anonymizer", marker = "extra == 'plugins'", specifier = ">=0.2.1" },
     { name = "nemo-anonymizer", marker = "extra == 'services'", specifier = ">=0.2.1" },
+    { name = "nemo-auditor-plugin", marker = "extra == 'all'", editable = "plugins/nemo-auditor" },
+    { name = "nemo-auditor-plugin", marker = "extra == 'platform-seed-service'", editable = "plugins/nemo-auditor" },
+    { name = "nemo-auditor-plugin", marker = "extra == 'services'", editable = "plugins/nemo-auditor" },
     { name = "nemo-evaluator-sdk", marker = "extra == 'all'", editable = "packages/nemo_evaluator_sdk" },
     { name = "nemo-evaluator-sdk", marker = "extra == 'nemo-evaluator-plugin'", editable = "packages/nemo_evaluator_sdk" },
     { name = "nemo-evaluator-sdk", marker = "extra == 'plugins'", editable = "packages/nemo_evaluator_sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -7416,6 +7416,7 @@ name = "nmp-platform-seed"
 version = "0.0.1"
 source = { editable = "services/platform-seed" }
 dependencies = [
+    { name = "nemo-auditor-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-guardrails", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -7430,6 +7431,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "nemo-auditor-plugin", editable = "plugins/nemo-auditor" },
     { name = "nmp-auth", editable = "services/core/auth" },
     { name = "nmp-common", editable = "packages/nmp_common" },
     { name = "nmp-guardrails", editable = "services/guardrails" },


### PR DESCRIPTION
* Update docs to point at IGW provider that is created by setup scripts.
* Add auditor seed job to necessary workspaces so that it works according to docs.

Note that running the platform in local mode will not automatically run the seed jobs. To test, I manually ran the full platform seed task as ```nemo-platform run task --task nmp.platform_seed``` , which now correctly discovers `AuditorSeedJob`. This isolates that particular problem. If `nmp.platform_seed` is not executed on startup where expected, that would be a separate bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated auditor examples, target creation/update, the inference gateway worked example, and the local audit tutorial to use the `nvidia-build` inference gateway provider name instead of `build`.
* **Chores**
  * Updated platform seed service package metadata and added `nemo-auditor-plugin` as a new runtime dependency, including the matching workspace source entry.
  * Extended the platform seed service description to include “auth, guardrails, auditor, and plugin seed jobs.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->