### PR TITLE
feat(studio): Add a pop out window for the Studio Code Agent

### DIFF
--- a/web/packages/studio/src/components/Layouts/GlobalNav/index.test.tsx
+++ b/web/packages/studio/src/components/Layouts/GlobalNav/index.test.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { ROUTES } from '@studio/constants/routes';
 import { mockUseParams } from '@studio/tests/util/mockUseParams';
 import { SIDE_NAV_OPEN_KEY } from '@studio/util/localStorage';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { generatePath, MemoryRouter } from 'react-router-dom';
 
 vi.mock('@studio/components/Breadcrumbs', () => ({
   Breadcrumbs: () => <div data-testid="breadcrumbs" />,
@@ -17,6 +18,10 @@ vi.mock('@studio/components/UserPopover', () => ({
 
 vi.mock('@studio/routes/PageLayout/ThemeSwitch', () => ({
   ThemeSwitch: () => <div data-testid="theme-switch" />,
+}));
+
+vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeTopBarChat', () => ({
+  ClaudeCodeTopBarChat: () => <div data-testid="code-agent-top-bar-chat" />,
 }));
 
 vi.mock('@studio/constants/environment', async (importOriginal) => {
@@ -57,15 +62,15 @@ const createMatchMediaMock = (initialMatches: boolean) => {
   return { mql, matchMediaFn, fireChange };
 };
 
-const renderGlobalNav = async () => {
+const renderGlobalNav = async (initialPath = '/workspaces/test-workspace/jobs') => {
   const { GlobalNav } = await import('@studio/components/Layouts/GlobalNav/index');
   render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[initialPath]}>
       <GlobalNav sideNav={() => <div data-testid="side-nav">Side Nav Content</div>} />
     </MemoryRouter>
   );
   // Wait for Suspense / lazy components to settle before the test proceeds
-  await screen.findByRole('button', { name: /(Collapse|Expand) sidebar/i });
+  await screen.findAllByRole('button', { name: /(Collapse|Expand) sidebar/i });
 };
 
 describe('GlobalNav', () => {
@@ -170,6 +175,36 @@ describe('GlobalNav', () => {
       );
 
       expect(sideNavSpy).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('Code Agent top bar chat', () => {
+    it('mounts outside the dashboard and full Code Agent routes', async () => {
+      createMatchMediaMock(true);
+
+      await renderGlobalNav('/workspaces/test-workspace/jobs');
+
+      expect(screen.getByTestId('code-agent-top-bar-chat')).toBeInTheDocument();
+    });
+
+    it('does not mount on the dashboard route', async () => {
+      createMatchMediaMock(true);
+
+      await renderGlobalNav(
+        generatePath(ROUTES.workspace.dashboard, { workspace: 'test-workspace' })
+      );
+
+      expect(screen.queryByTestId('code-agent-top-bar-chat')).not.toBeInTheDocument();
+    });
+
+    it('does not mount on the full Code Agent route', async () => {
+      createMatchMediaMock(true);
+
+      await renderGlobalNav(
+        generatePath(ROUTES.workspace.claudeCodeChat, { workspace: 'test-workspace' })
+      );
+
+      expect(screen.queryByTestId('code-agent-top-bar-chat')).not.toBeInTheDocument();
     });
   });
 });

--- a/web/packages/studio/src/components/Layouts/GlobalNav/index.tsx
+++ b/web/packages/studio/src/components/Layouts/GlobalNav/index.tsx
@@ -5,13 +5,15 @@ import { AppBar, Button, Flex, Stack, Text, Tooltip } from '@nvidia/foundations-
 import { Breadcrumbs } from '@studio/components/Breadcrumbs';
 import { UserPopover } from '@studio/components/UserPopover';
 import { TOUR_ENABLED } from '@studio/constants/environment';
+import { ROUTES } from '@studio/constants/routes';
 import { useWorkspaceFromPathIfExists } from '@studio/hooks/useWorkspaceFromPath';
+import { ClaudeCodeTopBarChat } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeTopBarChat';
 import { ThemeSwitch } from '@studio/routes/PageLayout/ThemeSwitch';
 import { getWorkspaceDetailsDefaultRoute } from '@studio/routes/utils';
 import { useSidebarState } from '@studio/util/hooks/useSidebarState';
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import { lazy, Suspense, type FC, type ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, matchPath, useLocation } from 'react-router-dom';
 
 const WelcomeTour = lazy(() =>
   import('@studio/components/WelcomeTour').then((m) => ({ default: m.WelcomeTour }))
@@ -24,6 +26,12 @@ interface Props {
 export const GlobalNav: FC<Props> = ({ sideNav }) => {
   const { expanded, toggle } = useSidebarState();
   const workspace = useWorkspaceFromPathIfExists();
+  const location = useLocation();
+  const isDashboardRoute =
+    matchPath({ path: ROUTES.workspace.dashboard, end: true }, location.pathname) !== null;
+  const isClaudeCodeChatRoute =
+    matchPath({ path: ROUTES.workspace.claudeCodeChat, end: true }, location.pathname) !== null;
+  const shouldMountClaudeCodeTopBarChat = !isDashboardRoute && !isClaudeCodeChatRoute;
 
   const toggleLabel = expanded ? 'Collapse sidebar' : 'Expand sidebar';
   const ToggleSidebarButton = (
@@ -71,6 +79,7 @@ export const GlobalNav: FC<Props> = ({ sideNav }) => {
                 <WelcomeTour />
               </Suspense>
             )}
+            {shouldMountClaudeCodeTopBarChat && <ClaudeCodeTopBarChat />}
             <ThemeSwitch />
             <span data-tour="nav-user">
               <UserPopover />

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ROUTES } from '@studio/constants/routes';
+import { getClaudeCodeActiveSessionStorageKey } from '@studio/routes/agents/ClaudeCodeChatRoute/activeSessionStorage';
 import { DashboardLandingRoute } from '@studio/routes/DashboardLandingRoute';
 import { mockFeatureFlags } from '@studio/tests/util/mockFeatureFlags';
 import { TestProviders } from '@studio/tests/util/TestProviders';
@@ -59,6 +60,7 @@ const renderRoute = () => {
 
 describe('DashboardLandingRoute', () => {
   beforeEach(() => {
+    localStorage.clear();
     vi.clearAllMocks();
     mockFeatureFlags({
       agentsEnabled: true,
@@ -330,6 +332,17 @@ describe('DashboardLandingRoute', () => {
     expect(await screen.findByTestId(CHAT_ROUTE_TEST_ID)).toHaveTextContent(
       `${generatePath(ROUTES.workspace.claudeCodeChat, { workspace })}|Check repo`
     );
+  });
+
+  it('clears the active Claude Code session before starting from the landing composer', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(getClaudeCodeActiveSessionStorageKey(workspace), 'session-existing');
+    renderRoute();
+
+    await user.type(await screen.findByRole('textbox', { name: 'Message Claude' }), 'Check repo');
+    await user.click(screen.getByRole('button', { name: 'Send message' }));
+
+    expect(localStorage.getItem(getClaudeCodeActiveSessionStorageKey(workspace))).toBeNull();
   });
 
   it('submits the landing composer when Enter is pressed', async () => {

--- a/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
+++ b/web/packages/studio/src/routes/DashboardLandingRoute/index.tsx
@@ -6,6 +6,7 @@ import { Button, Flex, Text, TextArea, Tooltip } from '@nvidia/foundations-react
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { writeStoredActiveSessionId } from '@studio/routes/agents/ClaudeCodeChatRoute/activeSessionStorage';
 import {
   CLAUDE_CODE_SKILLS_QUERY_KEY,
   listClaudeCodeSkills,
@@ -153,6 +154,7 @@ export const DashboardLandingRoute: FC = () => {
 
   const handleSubmit = useCallback(
     (prompt: string) => {
+      writeStoredActiveSessionId(workspace, null);
       const state: ClaudeCodeChatRouteState = { initialPrompt: prompt };
       navigate(getClaudeCodeChatRoute(workspace), { state });
     },

--- a/web/packages/studio/src/routes/PageLayout/index.tsx
+++ b/web/packages/studio/src/routes/PageLayout/index.tsx
@@ -48,7 +48,9 @@ export const PageLayout = ({ sideNav }: { sideNav?: (collapsed: boolean) => Reac
       className={`min-h-screen relative grid size-full text-primary grid-cols-[auto_minmax(0,1fr)] grid-rows-[auto_1fr] ${gridAreas}`}
     >
       {CODING_AGENT_STUDIO_ENABLED && workspace ? (
-        <ClaudeCodeChatProvider workspace={workspace}>{layout}</ClaudeCodeChatProvider>
+        <ClaudeCodeChatProvider key={workspace} workspace={workspace}>
+          {layout}
+        </ClaudeCodeChatProvider>
       ) : (
         layout
       )}

--- a/web/packages/studio/src/routes/PageLayout/index.tsx
+++ b/web/packages/studio/src/routes/PageLayout/index.tsx
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { GlobalNav } from '@studio/components/Layouts/GlobalNav';
+import { CODING_AGENT_STUDIO_ENABLED } from '@studio/constants/environment';
+import { useWorkspaceFromPathIfExists } from '@studio/hooks/useWorkspaceFromPath';
 import { useAuthAutoLogin } from '@studio/providers/auth';
 import { useAuthTokenStatus } from '@studio/providers/auth/useAuthTokenStatus';
 import { useSelectedWorkspace } from '@studio/providers/workspace';
+import { ClaudeCodeChatProvider } from '@studio/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider';
 import { WorkspaceGuard } from '@studio/routes/RootLayout/WorkspaceGuard';
 import { ReactNode } from 'react';
 import { Outlet } from 'react-router-dom';
@@ -13,6 +16,7 @@ export const PageLayout = ({ sideNav }: { sideNav?: (collapsed: boolean) => Reac
   const { isAuthPending } = useAuthAutoLogin();
   const { isTokenActive } = useAuthTokenStatus();
   const { selectedWorkspace, isWorkspaceUnauthorized, isWorkspaceLoading } = useSelectedWorkspace();
+  const workspace = useWorkspaceFromPathIfExists();
 
   if (isAuthPending) {
     return null;
@@ -25,16 +29,29 @@ export const PageLayout = ({ sideNav }: { sideNav?: (collapsed: boolean) => Reac
     ? "[grid-template-areas:'logobar_navbar''content_content']"
     : "[grid-template-areas:'logobar_navbar''sidebar_content']";
 
-  return (
-    <div
-      className={`min-h-screen relative grid size-full text-primary grid-cols-[auto_minmax(0,1fr)] grid-rows-[auto_1fr] ${gridAreas}`}
-    >
+  // Rendered as direct grid children; the provider adds no DOM of its own, so
+  // it can wrap both the nav (pop-out chat) and the outlet (full chat) while
+  // keeping a single shared chat runtime alive across workspace navigation.
+  const layout = (
+    <>
       <GlobalNav sideNav={hideSideNav ? undefined : sideNav} />
       <div className="bg-surface-sunken transition-colors relative h-full max-h-[calc(100vh-var(--nv-app-bar-height))] overflow-y-auto [grid-area:content]">
         <WorkspaceGuard>
           <Outlet />
         </WorkspaceGuard>
       </div>
+    </>
+  );
+
+  return (
+    <div
+      className={`min-h-screen relative grid size-full text-primary grid-cols-[auto_minmax(0,1fr)] grid-rows-[auto_1fr] ${gridAreas}`}
+    >
+      {CODING_AGENT_STUDIO_ENABLED && workspace ? (
+        <ClaudeCodeChatProvider workspace={workspace}>{layout}</ClaudeCodeChatProvider>
+      ) : (
+        layout
+      )}
     </div>
   );
 };

--- a/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/components/ScorePanels/DataPrivacyPanel.test.tsx
+++ b/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/components/ScorePanels/DataPrivacyPanel.test.tsx
@@ -31,8 +31,11 @@ vi.mock('@nemo/common/src/components/Dial', () => ({
   ),
 }));
 
-// Mock lucide-react icons (React 19: ref is a plain prop, no forwardRef needed)
-vi.mock('lucide-react', () => ({
+// Mock lucide-react icons (React 19: ref is a plain prop, no forwardRef needed).
+// Spread the real module so other icons used by rendered children (e.g. the
+// DataView SearchBar's `Search`) keep working, and only stub the asserted ones.
+vi.mock('lucide-react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('lucide-react')>()),
   CircleCheck: ({ className, ref }: { className?: string; ref?: React.Ref<SVGSVGElement> }) => (
     <svg ref={ref} data-testid="check-circle-icon" className={className} />
   ),

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeChatThread.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeChatThread.tsx
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AssistantRuntimeProvider } from '@assistant-ui/react';
+import { AssistantChatThread } from '@nemo/common/src/components/AssistantChat/AssistantChatThread';
+import { type AgentBlockingInputSubmission } from '@studio/components/agents/AgentBlockingInput';
+import { AgentDecisionInput } from '@studio/components/agents/AgentDecisionInput';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { BlockingInputComposer } from '@studio/routes/agents/ClaudeCodeChatRoute/BlockingInputComposer';
+import { ClaudeCodeStudioLink } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeStudioLink';
+import { ClaudeCodeToolCallPart } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeToolCallPart';
+import type { ClaudeCodeChatRuntime } from '@studio/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime';
+import { type FC, useCallback, useLayoutEffect, useRef } from 'react';
+
+const CHAT_VIEWPORT_SCROLLBAR_CLASS = [
+  '[scrollbar-width:thin]',
+  '[scrollbar-color:var(--border-color-interaction-base)_transparent]',
+  '[&::-webkit-scrollbar]:w-2',
+  '[&::-webkit-scrollbar-corner]:bg-transparent',
+  '[&::-webkit-scrollbar-track]:bg-transparent',
+  '[&::-webkit-scrollbar-thumb]:rounded-full',
+  '[&::-webkit-scrollbar-thumb]:bg-[var(--border-color-interaction-base)]',
+  '[&::-webkit-scrollbar-thumb:hover]:bg-[var(--border-color-interaction-strong)]',
+].join(' ');
+
+interface ClaudeCodeChatThreadProps {
+  chat: ClaudeCodeChatRuntime;
+  mode?: 'full' | 'compact';
+  onReset?: () => void;
+  scrollToBottomSignal?: number;
+}
+
+export const ClaudeCodeChatThread: FC<ClaudeCodeChatThreadProps> = ({
+  chat,
+  mode = 'full',
+  onReset,
+  scrollToBottomSignal,
+}) => {
+  const workspace = useWorkspaceFromPath();
+  const chatViewportRef = useRef<HTMLDivElement>(null);
+  const {
+    decisionChoices,
+    decisionRequest,
+    decisionStatus,
+    handleReset,
+    inputRequest,
+    inputStatus,
+    resolveInputRequest,
+    resolveDecisionRequest,
+    runtime,
+    skipInputRequest,
+    skipDecisionRequest,
+  } = chat;
+
+  const scrollViewportToBottom = useCallback(() => {
+    const viewport = chatViewportRef.current;
+    if (!viewport) return undefined;
+
+    let secondFrame = 0;
+    const firstFrame = window.requestAnimationFrame(() => {
+      viewport.scrollTop = viewport.scrollHeight;
+      secondFrame = window.requestAnimationFrame(() => {
+        viewport.scrollTop = viewport.scrollHeight;
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      if (secondFrame) window.cancelAnimationFrame(secondFrame);
+    };
+  }, []);
+
+  const handleChatReset = useCallback(() => {
+    handleReset();
+    onReset?.();
+  }, [handleReset, onReset]);
+
+  const handleInputSubmit = useCallback(
+    async (submission: AgentBlockingInputSubmission) => {
+      await resolveInputRequest({
+        decision: { value: submission.value },
+        displayText: submission.displayText,
+      });
+    },
+    [resolveInputRequest]
+  );
+
+  useLayoutEffect(() => {
+    if (!decisionRequest && !inputRequest) return undefined;
+    return scrollViewportToBottom();
+  }, [decisionRequest, inputRequest, scrollViewportToBottom]);
+
+  useLayoutEffect(() => {
+    if (scrollToBottomSignal === undefined) return undefined;
+    return scrollViewportToBottom();
+  }, [scrollToBottomSignal, scrollViewportToBottom]);
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <AssistantChatThread
+        contentClassName={
+          mode === 'compact' ? 'w-full px-density-lg' : 'mx-auto w-full max-w-180 px-density-2xl'
+        }
+        composerContainerClassName={
+          mode === 'compact' ? 'w-full px-density-lg' : 'mx-auto w-full max-w-180 px-density-2xl'
+        }
+        viewportClassName={CHAT_VIEWPORT_SCROLLBAR_CLASS}
+        hideAssistantMessageActions
+        toolCallPartComponent={ClaudeCodeToolCallPart}
+        attributes={{
+          ThreadViewport: {
+            ref: chatViewportRef,
+          },
+        }}
+        placeholder="Ask Claude Code to work in this workspace"
+        onReset={handleChatReset}
+        showRunningIndicator={!decisionRequest && !inputRequest}
+        messageContentProps={{ markdownLinkComponent: ClaudeCodeStudioLink }}
+        emptyState={{
+          slotHeading: 'Start a Claude Code session',
+          slotSubheading: 'Ask Claude Code to work in this workspace.',
+        }}
+        composerOverride={
+          decisionRequest ? (
+            <AgentDecisionInput
+              request={decisionRequest}
+              choices={decisionChoices}
+              defaultChoiceId={decisionChoices[0]?.id}
+              status={decisionStatus}
+              onSubmit={resolveDecisionRequest}
+              onSkip={skipDecisionRequest}
+            />
+          ) : inputRequest ? (
+            <BlockingInputComposer
+              inputRequest={inputRequest}
+              inputStatus={inputStatus}
+              workspace={workspace}
+              onSubmit={handleInputSubmit}
+              onSkip={skipInputRequest}
+            />
+          ) : undefined
+        }
+      />
+    </AssistantRuntimeProvider>
+  );
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeLayout.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeLayout.tsx
@@ -14,22 +14,27 @@ interface ClaudeCodeLayoutProps {
   activeSessionId?: string;
   artifacts?: ClaudeCodeChatArtifacts;
   children: ReactNode;
+  onNewChat?: () => void;
 }
 
 export const ClaudeCodeLayout: FC<ClaudeCodeLayoutProps> = ({
   activeSessionId,
   artifacts,
   children,
+  onNewChat,
 }) => {
   const workspace = useWorkspaceFromPath();
   const navigate = useNavigate();
 
   const handleNewChat = useCallback(() => {
+    onNewChat?.();
     navigate(getWorkspaceDashboardRoute(workspace));
-  }, [navigate, workspace]);
+  }, [navigate, onNewChat, workspace]);
 
   const handleSelectSession = useCallback(
     (sessionId: string) => {
+      // Navigating to the session URL drives the shared runtime to load it
+      // (which also persists it as the active session via onSessionIdChange).
       navigate(getClaudeCodeChatRouteForSession(workspace, sessionId));
     },
     [navigate, workspace]

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeTopBarChat.test.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeTopBarChat.test.tsx
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ClaudeCodeTopBarChat } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeTopBarChat';
+import { mockUseParams } from '@studio/tests/util/mockUseParams';
+import { TestProviders } from '@studio/tests/util/TestProviders';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+const mocks = vi.hoisted(() => ({
+  chat: {
+    decisionRequest: null,
+    inputRequest: null,
+    isRunning: false,
+  } as { decisionRequest: unknown; inputRequest: unknown; isRunning: boolean },
+  startNewChat: vi.fn(),
+}));
+
+vi.mock('@studio/constants/environment', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@studio/constants/environment')>();
+  return {
+    ...actual,
+    CODING_AGENT_STUDIO_ENABLED: true,
+  };
+});
+
+vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/context/useClaudeCodeChatContext', () => ({
+  useClaudeCodeChatContext: () => ({
+    chat: mocks.chat,
+    loadStatus: 'idle',
+    loadSession: vi.fn(),
+    startNewChat: mocks.startNewChat,
+  }),
+}));
+
+vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeChatThread', () => ({
+  ClaudeCodeChatThread: () => (
+    <div data-testid="compact-chat-thread">
+      <a href="/workspaces/default/jobs/job-1" onClick={(event) => event.preventDefault()}>
+        Job details
+      </a>
+    </div>
+  ),
+}));
+
+const WORKSPACE = 'default';
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="pathname">{location.pathname}</div>;
+};
+
+const getTopBarChatElement = (initialPath = `/workspaces/${WORKSPACE}/jobs`) => (
+  <TestProviders>
+    <MemoryRouter initialEntries={[initialPath]}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/workspaces/:workspace/*" element={<ClaudeCodeTopBarChat />} />
+      </Routes>
+    </MemoryRouter>
+  </TestProviders>
+);
+
+const renderTopBarChat = (initialPath = `/workspaces/${WORKSPACE}/jobs`) =>
+  render(getTopBarChatElement(initialPath));
+
+describe('ClaudeCodeTopBarChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseParams({ workspace: WORKSPACE });
+    mocks.chat.isRunning = false;
+    mocks.chat.decisionRequest = null;
+    mocks.chat.inputRequest = null;
+  });
+
+  it('opens and closes the compact chat from the top bar icon', async () => {
+    renderTopBarChat();
+    const user = userEvent.setup();
+    const trigger = screen.getByRole('button', { name: 'Open Code Agent chat' });
+
+    await user.click(trigger);
+    expect(await screen.findByTestId('compact-chat-thread')).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Close Code Agent chat' }));
+    await waitFor(() => expect(screen.getByTestId('compact-chat-thread')).not.toBeVisible());
+  });
+
+  it('darkens the screen with a backdrop and closes the chat when it is clicked', async () => {
+    renderTopBarChat();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'Open Code Agent chat' }));
+    const backdrop = await screen.findByTestId('code-agent-chat-backdrop');
+    expect(backdrop).toBeVisible();
+
+    await user.click(backdrop);
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('code-agent-chat-backdrop')).not.toBeInTheDocument()
+    );
+  });
+
+  it('navigates to the main chat from the popout header', async () => {
+    renderTopBarChat();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'Open Code Agent chat' }));
+    await user.click(await screen.findByRole('button', { name: 'Open in main chat' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pathname').textContent).toContain('code-agent')
+    );
+  });
+
+  it('starts a new compact chat from the popout header', async () => {
+    renderTopBarChat();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'Open Code Agent chat' }));
+    await user.click(await screen.findByRole('button', { name: /New/i }));
+
+    expect(mocks.startNewChat).toHaveBeenCalledOnce();
+  });
+
+  it('closes the compact chat when a chat link is clicked', async () => {
+    renderTopBarChat();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'Open Code Agent chat' }));
+    expect(await screen.findByTestId('compact-chat-thread')).toBeVisible();
+
+    await user.click(screen.getByRole('link', { name: 'Job details' }));
+    await waitFor(() => expect(screen.getByTestId('compact-chat-thread')).not.toBeVisible());
+  });
+
+  it('shows a thinking indicator while the agent is running', () => {
+    mocks.chat.isRunning = true;
+
+    renderTopBarChat();
+
+    expect(screen.getAllByTestId('code-agent-thinking-dot')).toHaveLength(3);
+    expect(screen.queryByTestId('code-agent-unread-indicator')).not.toBeInTheDocument();
+  });
+
+  it('surfaces an unread badge after a response finishes while closed', () => {
+    const view = renderTopBarChat();
+
+    expect(screen.queryByTestId('code-agent-unread-indicator')).not.toBeInTheDocument();
+
+    mocks.chat.isRunning = true;
+    view.rerender(getTopBarChatElement());
+    mocks.chat.isRunning = false;
+    view.rerender(getTopBarChatElement());
+
+    expect(screen.getByTestId('code-agent-unread-indicator')).toBeInTheDocument();
+  });
+
+  it('shows the attention badge instead of the thinking dots while awaiting user input', () => {
+    mocks.chat.isRunning = true;
+    mocks.chat.inputRequest = { requestId: 'request-1', kind: 'dataset_file', input: {} };
+
+    renderTopBarChat();
+
+    expect(screen.getByTestId('code-agent-unread-indicator')).toBeInTheDocument();
+    expect(screen.queryByTestId('code-agent-thinking-indicator')).not.toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeTopBarChat.test.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeTopBarChat.test.tsx
@@ -108,9 +108,7 @@ describe('ClaudeCodeTopBarChat', () => {
     await user.click(screen.getByRole('button', { name: 'Open Code Agent chat' }));
     await user.click(await screen.findByRole('button', { name: 'Open in main chat' }));
 
-    await waitFor(() =>
-      expect(screen.getByTestId('pathname').textContent).toContain('code-agent')
-    );
+    await waitFor(() => expect(screen.getByTestId('pathname').textContent).toContain('code-agent'));
   });
 
   it('starts a new compact chat from the popout header', async () => {

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeTopBarChat.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeTopBarChat.tsx
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Button, Flex, Popover, Stack, Tooltip } from '@nvidia/foundations-react-core';
+import { CODING_AGENT_STUDIO_ENABLED } from '@studio/constants/environment';
+import { useWorkspaceFromPathIfExists } from '@studio/hooks/useWorkspaceFromPath';
+import { ClaudeCodeChatThread } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeChatThread';
+import { useClaudeCodeChatContext } from '@studio/routes/agents/ClaudeCodeChatRoute/context/useClaudeCodeChatContext';
+import { getClaudeCodeChatRouteForSession } from '@studio/routes/agents/ClaudeCodeChatRoute/util';
+import { getClaudeCodeChatRoute } from '@studio/routes/utils';
+import { Maximize2, Plus, Terminal, X } from 'lucide-react';
+import { type FC, type MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useNavigate } from 'react-router-dom';
+
+const OPEN_LABEL = 'Open Code Agent chat';
+const CLOSE_LABEL = 'Close Code Agent chat';
+
+const TopBarChatIcon = () => <Terminal size={16} />;
+
+/**
+ * The top-bar pop-out is a thin view of the shared chat runtime (owned by
+ * ClaudeCodeChatProvider). Because the runtime lives above the routes, opening
+ * the pop-out mid-run shows the live stream and thinking/awaiting-input state.
+ */
+const ClaudeCodeTopBarChatPopout: FC<{ workspace: string }> = ({ workspace }) => {
+  const navigate = useNavigate();
+  const { chat, startNewChat } = useClaudeCodeChatContext();
+  const { decisionRequest, inputRequest, isRunning, sessionId } = chat;
+  const [isOpen, setIsOpen] = useState(false);
+  const [hasUnreadResponse, setHasUnreadResponse] = useState(false);
+  const [scrollToBottomSignal, setScrollToBottomSignal] = useState(0);
+
+  // While the agent is blocked on a permission/input request the stream stays
+  // open (isRunning is still true), but it is waiting on the user rather than
+  // thinking — surface the attention badge instead of the loading dots.
+  const isAwaitingUserInput = !!decisionRequest || !!inputRequest;
+
+  // Surface an unread badge when the agent finishes responding while the
+  // pop-out is closed, and clear it the moment the user opens the chat.
+  const wasRunningRef = useRef(false);
+  useEffect(() => {
+    if (isOpen) {
+      setHasUnreadResponse(false);
+    } else if (wasRunningRef.current && !isRunning) {
+      setHasUnreadResponse(true);
+    }
+    wasRunningRef.current = isRunning;
+  }, [isOpen, isRunning]);
+
+  // The popover dismisses on Esc / outside click; just mirror that here.
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (!open) setIsOpen(false);
+  }, []);
+
+  // The controlled popover treats this trigger as "outside" its content, so a
+  // pointer-down would dismiss it right before the click re-opens it. Stop that
+  // dismissal while open and let the click own the toggle.
+  const handleTriggerPointerDown = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      if (isOpen) event.stopPropagation();
+    },
+    [isOpen]
+  );
+
+  const handleTriggerClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      if (isOpen) {
+        setIsOpen(false);
+        return;
+      }
+      setIsOpen(true);
+      setScrollToBottomSignal((signal) => signal + 1);
+    },
+    [isOpen]
+  );
+
+  // Close the pop-out when the user follows an in-chat link to another route.
+  // This runs on the bubble phase (not capture) so the link's own react-router
+  // navigation happens first — closing the popover out from under the anchor
+  // mid-click breaks client-side navigation and triggers a full reload.
+  const handlePopoverLinkClick = useCallback((event: MouseEvent<HTMLElement>) => {
+    if (event.target instanceof Element && event.target.closest('a[href]')) {
+      setIsOpen(false);
+    }
+  }, []);
+
+  // The full chat route shares this runtime, so it opens on the same live
+  // session (continuing any in-flight run).
+  const handleOpenFullChat = useCallback(() => {
+    setIsOpen(false);
+    navigate(
+      sessionId
+        ? getClaudeCodeChatRouteForSession(workspace, sessionId)
+        : getClaudeCodeChatRoute(workspace)
+    );
+  }, [navigate, sessionId, workspace]);
+
+  return (
+    <>
+      {isOpen &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            data-testid="code-agent-chat-backdrop"
+            aria-hidden="true"
+            className="fixed inset-0 z-[1000] bg-black/40 backdrop-blur-[1px]"
+            onClick={() => setIsOpen(false)}
+          />,
+          document.body
+        )}
+      <Popover
+        align="end"
+        open={isOpen}
+        side="bottom"
+        className="z-[1001] !max-h-[calc(100vh-var(--nv-app-bar-height)-48px)] max-w-[calc(100vw-48px)] !overflow-hidden !rounded-xl !bg-surface-sunken !p-0 translate-y-1 dark:!bg-surface-raised"
+        onOpenChange={handleOpenChange}
+        slotContent={
+          <Stack
+            className="min-h-0 h-[min(820px,calc(100vh-var(--nv-app-bar-height)-48px))] w-[min(920px,calc(100vw-192px))] overflow-hidden bg-surface-sunken p-density-md text-primary dark:bg-surface-raised"
+            gap="density-md"
+            onClick={handlePopoverLinkClick}
+          >
+            <Flex align="center" justify="between" gap="density-md">
+              <Button kind="tertiary" size="small" onClick={startNewChat}>
+                <Plus size={14} />
+                New
+              </Button>
+              <Flex align="center" gap="density-xs">
+                <Tooltip slotContent="Open in main chat" side="bottom">
+                  <Button
+                    kind="tertiary"
+                    size="small"
+                    aria-label="Open in main chat"
+                    onClick={handleOpenFullChat}
+                  >
+                    <Maximize2 size={16} />
+                  </Button>
+                </Tooltip>
+                <Button
+                  kind="tertiary"
+                  size="small"
+                  aria-label="Close chat window"
+                  onClick={() => setIsOpen(false)}
+                >
+                  <X size={16} />
+                </Button>
+              </Flex>
+            </Flex>
+            <Stack className="min-h-0 flex-1 overflow-hidden">
+              <ClaudeCodeChatThread
+                chat={chat}
+                mode="compact"
+                scrollToBottomSignal={scrollToBottomSignal}
+              />
+            </Stack>
+          </Stack>
+        }
+      >
+        <Button
+          kind="tertiary"
+          size="small"
+          aria-label={isOpen ? CLOSE_LABEL : OPEN_LABEL}
+          className="relative"
+          title={isOpen ? CLOSE_LABEL : OPEN_LABEL}
+          onPointerDown={handleTriggerPointerDown}
+          onClick={handleTriggerClick}
+        >
+          <TopBarChatIcon />
+          {isRunning && !isAwaitingUserInput ? (
+            <span
+              className="pointer-events-none absolute right-0 top-0 flex h-3 w-5 items-center justify-center gap-0.5 rounded-full border border-base bg-surface-sunken/90 dark:bg-surface-raised/90"
+              data-testid="code-agent-thinking-indicator"
+            >
+              <span
+                className="size-1 animate-pulse rounded-full bg-brand"
+                data-testid="code-agent-thinking-dot"
+              />
+              <span
+                className="size-1 animate-pulse rounded-full bg-brand [animation-delay:150ms]"
+                data-testid="code-agent-thinking-dot"
+              />
+              <span
+                className="size-1 animate-pulse rounded-full bg-brand [animation-delay:300ms]"
+                data-testid="code-agent-thinking-dot"
+              />
+            </span>
+          ) : isAwaitingUserInput || hasUnreadResponse ? (
+            <span
+              className="pointer-events-none absolute right-1 top-1 size-2 rounded-full bg-brand ring-2 ring-surface-sunken dark:ring-surface-raised"
+              data-testid="code-agent-unread-indicator"
+            />
+          ) : null}
+        </Button>
+      </Popover>
+    </>
+  );
+};
+
+export const ClaudeCodeTopBarChat: FC = () => {
+  const workspace = useWorkspaceFromPathIfExists();
+
+  if (!CODING_AGENT_STUDIO_ENABLED || !workspace) return null;
+
+  return <ClaudeCodeTopBarChatPopout workspace={workspace} />;
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/activeSessionStorage.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/activeSessionStorage.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CLAUDE_CODE_ACTIVE_SESSION_KEY_PREFIX } from '@studio/util/localStorage';
+
+export const getClaudeCodeActiveSessionStorageKey = (workspace: string): string =>
+  `${CLAUDE_CODE_ACTIVE_SESSION_KEY_PREFIX}:${workspace}`;
+
+export const readStoredActiveSessionId = (workspace: string | undefined): string | undefined => {
+  if (!workspace || typeof window === 'undefined') return undefined;
+
+  try {
+    const storedSessionId = window.localStorage
+      .getItem(getClaudeCodeActiveSessionStorageKey(workspace))
+      ?.trim();
+    return storedSessionId || undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const writeStoredActiveSessionId = (
+  workspace: string | undefined,
+  sessionId: string | null
+): void => {
+  if (!workspace || typeof window === 'undefined') return;
+
+  try {
+    const storageKey = getClaudeCodeActiveSessionStorageKey(workspace);
+    if (sessionId) {
+      window.localStorage.setItem(storageKey, sessionId);
+    } else {
+      window.localStorage.removeItem(storageKey);
+    }
+  } catch {
+    // localStorage can be unavailable in restricted browser modes.
+  }
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider.test.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider.test.tsx
@@ -39,11 +39,16 @@ vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime', ()
 const WORKSPACE = 'default';
 
 const LoadButton = () => {
-  const { loadSession } = useClaudeCodeChatContext();
+  const { loadSession, startNewChat } = useClaudeCodeChatContext();
   return (
-    <button type="button" onClick={() => loadSession('session-2')}>
-      load
-    </button>
+    <>
+      <button type="button" onClick={() => loadSession('session-2')}>
+        load
+      </button>
+      <button type="button" onClick={startNewChat}>
+        new
+      </button>
+    </>
   );
 };
 
@@ -76,6 +81,31 @@ describe('ClaudeCodeChatProvider', () => {
         expect.objectContaining({ sessionId: 'session-2' })
       )
     );
+  });
+
+  it('cancels a pending session load when a new chat is started', async () => {
+    let resolveHistory: ((value: unknown) => void) | undefined;
+    mocks.getClaudeCodeSessionHistory.mockReturnValue(
+      new Promise((resolve) => {
+        resolveHistory = resolve;
+      })
+    );
+
+    renderProvider();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByText('load'));
+    await user.click(screen.getByText('new'));
+
+    // The load resolves after the reset; it must not rehydrate the old session.
+    resolveHistory?.({
+      session_id: 'session-2',
+      items: [],
+      chat_artifacts: { selections: [], files: [], links: [], tools: [] },
+    });
+
+    await waitFor(() => expect(mocks.handleReset).toHaveBeenCalled());
+    expect(mocks.applySession).not.toHaveBeenCalled();
   });
 
   it('hydrates the stored active session on mount', async () => {

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider.test.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider.test.tsx
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getClaudeCodeActiveSessionStorageKey } from '@studio/routes/agents/ClaudeCodeChatRoute/activeSessionStorage';
+import { ClaudeCodeChatProvider } from '@studio/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider';
+import { useClaudeCodeChatContext } from '@studio/routes/agents/ClaudeCodeChatRoute/context/useClaudeCodeChatContext';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mocks = vi.hoisted(() => ({
+  applySession: vi.fn(),
+  handleReset: vi.fn(),
+  getClaudeCodeSessionHistory: vi.fn(),
+  sessionId: null as string | null,
+}));
+
+vi.mock('@nemo/common/src/providers/toast/useToast', () => ({
+  useToast: () => ({ error: vi.fn() }),
+}));
+
+vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/api', () => ({
+  getClaudeCodeSessionHistory: mocks.getClaudeCodeSessionHistory,
+}));
+
+vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/util', () => ({
+  getClaudeCodeHistoryMessages: () => [],
+}));
+
+vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime', () => ({
+  useClaudeCodeChatRuntime: () => ({
+    loadSession: mocks.applySession,
+    handleReset: mocks.handleReset,
+    sessionId: mocks.sessionId,
+  }),
+}));
+
+const WORKSPACE = 'default';
+
+const LoadButton = () => {
+  const { loadSession } = useClaudeCodeChatContext();
+  return (
+    <button type="button" onClick={() => loadSession('session-2')}>
+      load
+    </button>
+  );
+};
+
+const renderProvider = (children: ReactNode = <LoadButton />) =>
+  render(
+    <MemoryRouter initialEntries={[`/workspaces/${WORKSPACE}/jobs`]}>
+      <ClaudeCodeChatProvider workspace={WORKSPACE}>{children}</ClaudeCodeChatProvider>
+    </MemoryRouter>
+  );
+
+describe('ClaudeCodeChatProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mocks.sessionId = null;
+  });
+
+  it('fetches history and loads it into the runtime on loadSession', async () => {
+    mocks.getClaudeCodeSessionHistory.mockResolvedValue({
+      session_id: 'session-2',
+      items: [],
+      chat_artifacts: { selections: [], files: [], links: [], tools: [] },
+    });
+
+    renderProvider();
+    await userEvent.click(screen.getByText('load'));
+
+    await waitFor(() =>
+      expect(mocks.applySession).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'session-2' })
+      )
+    );
+  });
+
+  it('hydrates the stored active session on mount', async () => {
+    localStorage.setItem(getClaudeCodeActiveSessionStorageKey(WORKSPACE), 'session-1');
+    mocks.getClaudeCodeSessionHistory.mockResolvedValue({
+      session_id: 'session-1',
+      items: [],
+      chat_artifacts: { selections: [], files: [], links: [], tools: [] },
+    });
+
+    renderProvider(<div />);
+
+    await waitFor(() =>
+      expect(mocks.applySession).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'session-1' })
+      )
+    );
+  });
+});

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider.tsx
@@ -80,6 +80,13 @@ export const ClaudeCodeChatProvider: FC<ClaudeCodeChatProviderProps> = ({
     [applySession, sessionId, toast]
   );
 
+  // Starting a new chat must cancel any in-flight session load, otherwise a
+  // late history response would rehydrate the previous session over the reset.
+  const startNewChat = useCallback(() => {
+    requestedSessionIdRef.current = null;
+    handleReset();
+  }, [handleReset]);
+
   // Cold start: restore the last active session once on mount so the pop-out
   // (and full chat) reflect it after a hard refresh on any workspace page.
   const hasHydratedRef = useRef(false);
@@ -92,8 +99,8 @@ export const ClaudeCodeChatProvider: FC<ClaudeCodeChatProviderProps> = ({
   }, [loadSession, workspace]);
 
   const value = useMemo(
-    () => ({ chat, loadStatus, loadSession, startNewChat: handleReset }),
-    [chat, handleReset, loadSession, loadStatus]
+    () => ({ chat, loadStatus, loadSession, startNewChat }),
+    [chat, loadSession, loadStatus, startNewChat]
   );
 
   return <ClaudeCodeChatContext.Provider value={value}>{children}</ClaudeCodeChatContext.Provider>;

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider.tsx
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import {
+  readStoredActiveSessionId,
+  writeStoredActiveSessionId,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/activeSessionStorage';
+import { getClaudeCodeSessionHistory } from '@studio/routes/agents/ClaudeCodeChatRoute/api';
+import {
+  ClaudeCodeChatContext,
+  type ClaudeCodeChatLoadStatus,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/context/useClaudeCodeChatContext';
+import { useClaudeCodeChatRuntime } from '@studio/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime';
+import { getClaudeCodeHistoryMessages } from '@studio/routes/agents/ClaudeCodeChatRoute/util';
+import { type FC, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+interface ClaudeCodeChatProviderProps {
+  children: ReactNode;
+  workspace: string;
+}
+
+/**
+ * Owns the single Code Agent chat runtime for a workspace. Mounted above both
+ * the full chat route and the top-bar pop-out so an in-flight run (and its
+ * thinking / awaiting-input state) survives navigating between them.
+ */
+export const ClaudeCodeChatProvider: FC<ClaudeCodeChatProviderProps> = ({
+  children,
+  workspace,
+}) => {
+  const location = useLocation();
+  const toast = useToast();
+  const [loadStatus, setLoadStatus] = useState<ClaudeCodeChatLoadStatus>('idle');
+  const requestedSessionIdRef = useRef<string | null>(null);
+
+  const handleSessionIdChange = useCallback(
+    (nextSessionId: string | null) => {
+      writeStoredActiveSessionId(workspace, nextSessionId?.trim() || null);
+    },
+    [workspace]
+  );
+
+  const chat = useClaudeCodeChatRuntime({
+    onError: (error) => toast.error(error.message),
+    onSessionIdChange: handleSessionIdChange,
+    studioPathname: `${location.pathname}${location.search}`,
+    workspace,
+  });
+  const { handleReset, loadSession: applySession, sessionId } = chat;
+
+  const loadSession = useCallback(
+    async (nextSessionId: string) => {
+      const trimmedSessionId = nextSessionId.trim();
+      if (!trimmedSessionId || trimmedSessionId === sessionId) return;
+
+      requestedSessionIdRef.current = trimmedSessionId;
+      setLoadStatus('loading');
+
+      try {
+        const history = await getClaudeCodeSessionHistory(trimmedSessionId);
+        // Ignore a stale fetch if a newer session was requested meanwhile.
+        if (requestedSessionIdRef.current !== trimmedSessionId) return;
+
+        applySession({
+          artifacts: history.chat_artifacts,
+          messages: getClaudeCodeHistoryMessages(history),
+          sessionId: history.session_id,
+        });
+        setLoadStatus('idle');
+      } catch (error: unknown) {
+        if (requestedSessionIdRef.current !== trimmedSessionId) return;
+        setLoadStatus('error');
+        toast.error(
+          error instanceof Error ? error.message : 'Could not load Claude Code session.'
+        );
+      }
+    },
+    [applySession, sessionId, toast]
+  );
+
+  // Cold start: restore the last active session once on mount so the pop-out
+  // (and full chat) reflect it after a hard refresh on any workspace page.
+  const hasHydratedRef = useRef(false);
+  useEffect(() => {
+    if (hasHydratedRef.current) return;
+    hasHydratedRef.current = true;
+
+    const storedSessionId = readStoredActiveSessionId(workspace);
+    if (storedSessionId) void loadSession(storedSessionId);
+  }, [loadSession, workspace]);
+
+  const value = useMemo(
+    () => ({ chat, loadStatus, loadSession, startNewChat: handleReset }),
+    [chat, handleReset, loadSession, loadStatus]
+  );
+
+  return <ClaudeCodeChatContext.Provider value={value}>{children}</ClaudeCodeChatContext.Provider>;
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/ClaudeCodeChatProvider.tsx
@@ -72,9 +72,7 @@ export const ClaudeCodeChatProvider: FC<ClaudeCodeChatProviderProps> = ({
       } catch (error: unknown) {
         if (requestedSessionIdRef.current !== trimmedSessionId) return;
         setLoadStatus('error');
-        toast.error(
-          error instanceof Error ? error.message : 'Could not load Claude Code session.'
-        );
+        toast.error(error instanceof Error ? error.message : 'Could not load Claude Code session.');
       }
     },
     [applySession, sessionId, toast]

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/useClaudeCodeChatContext.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/context/useClaudeCodeChatContext.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ClaudeCodeChatRuntime } from '@studio/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime';
+import { createContext, useContext } from 'react';
+
+export type ClaudeCodeChatLoadStatus = 'idle' | 'loading' | 'error';
+
+export interface ClaudeCodeChatContextValue {
+  /** The single chat runtime shared by the full chat route and the pop-out. */
+  chat: ClaudeCodeChatRuntime;
+  /** Status of the most recent `loadSession` fetch. */
+  loadStatus: ClaudeCodeChatLoadStatus;
+  /** Fetch a session's history and load it into the shared runtime. */
+  loadSession: (sessionId: string) => void;
+  /** Reset the shared runtime to a fresh, empty chat. */
+  startNewChat: () => void;
+}
+
+export const ClaudeCodeChatContext = createContext<ClaudeCodeChatContextValue | null>(null);
+
+export const useClaudeCodeChatContext = (): ClaudeCodeChatContextValue => {
+  const context = useContext(ClaudeCodeChatContext);
+  if (!context) {
+    throw new Error('useClaudeCodeChatContext must be used within a ClaudeCodeChatProvider');
+  }
+  return context;
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.test.tsx
@@ -6,6 +6,7 @@ import { ClaudeCodeChatRoute } from '@studio/routes/agents/ClaudeCodeChatRoute';
 import type { ClaudeCodeChatLoadStatus } from '@studio/routes/agents/ClaudeCodeChatRoute/context/useClaudeCodeChatContext';
 import type { ClaudeCodeChatRouteState } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { generatePath, MemoryRouter, Route, Routes } from 'react-router-dom';
 
@@ -45,11 +46,16 @@ vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeLayout', () => ({
   ClaudeCodeLayout: ({
     activeSessionId,
     children,
+    onNewChat,
   }: {
     activeSessionId?: string;
     children: ReactNode;
+    onNewChat?: () => void;
   }) => (
     <div data-active-session-id={activeSessionId ?? ''} data-testid="chat-layout">
+      <button type="button" onClick={onNewChat}>
+        new chat
+      </button>
       {children}
     </div>
   ),
@@ -102,6 +108,15 @@ describe('ClaudeCodeChatRoute', () => {
     renderClaudeCodeChatRoute({ search: '?session=session-existing' });
 
     expect(screen.getByText('Loading chat...')).toBeInTheDocument();
+  });
+
+  it('resets the shared runtime when New Chat is used from the history panel', async () => {
+    mocks.chat.sessionId = 'session-existing';
+
+    renderClaudeCodeChatRoute({ search: '?session=session-existing' });
+    await userEvent.setup().click(screen.getByRole('button', { name: 'new chat' }));
+
+    expect(mocks.startNewChat).toHaveBeenCalledOnce();
   });
 
   it('renders the chat for the active session once loaded', () => {

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.test.tsx
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ROUTES } from '@studio/constants/routes';
+import { ClaudeCodeChatRoute } from '@studio/routes/agents/ClaudeCodeChatRoute';
+import type { ClaudeCodeChatLoadStatus } from '@studio/routes/agents/ClaudeCodeChatRoute/context/useClaudeCodeChatContext';
+import type { ClaudeCodeChatRouteState } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { generatePath, MemoryRouter, Route, Routes } from 'react-router-dom';
+
+const mocks = vi.hoisted(() => ({
+  chat: {
+    artifacts: { selections: [], files: [], links: [], tools: [] },
+    sessionId: null as string | null,
+    submitPrompt: vi.fn(),
+  },
+  loadStatus: 'idle' as ClaudeCodeChatLoadStatus,
+  loadSession: vi.fn(),
+  startNewChat: vi.fn(),
+}));
+
+vi.mock('@studio/hooks/useWorkspaceFromPath', () => ({
+  useWorkspaceFromPath: () => 'default',
+}));
+
+vi.mock('@studio/providers/breadcrumbs/useBreadcrumbs', () => ({
+  useBreadcrumbs: vi.fn(),
+}));
+
+vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/context/useClaudeCodeChatContext', () => ({
+  useClaudeCodeChatContext: () => ({
+    chat: mocks.chat,
+    loadStatus: mocks.loadStatus,
+    loadSession: mocks.loadSession,
+    startNewChat: mocks.startNewChat,
+  }),
+}));
+
+vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeChatThread', () => ({
+  ClaudeCodeChatThread: () => <div data-testid="chat-thread" />,
+}));
+
+vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeLayout', () => ({
+  ClaudeCodeLayout: ({
+    activeSessionId,
+    children,
+  }: {
+    activeSessionId?: string;
+    children: ReactNode;
+  }) => (
+    <div data-active-session-id={activeSessionId ?? ''} data-testid="chat-layout">
+      {children}
+    </div>
+  ),
+}));
+
+const WORKSPACE = 'default';
+const CHAT_PATH = generatePath(ROUTES.workspace.claudeCodeChat, { workspace: WORKSPACE });
+
+const renderClaudeCodeChatRoute = (options?: {
+  search?: string;
+  state?: ClaudeCodeChatRouteState;
+}) =>
+  render(
+    <MemoryRouter
+      initialEntries={[{ pathname: CHAT_PATH, search: options?.search, state: options?.state }]}
+    >
+      <Routes>
+        <Route path={ROUTES.workspace.claudeCodeChat} element={<ClaudeCodeChatRoute />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('ClaudeCodeChatRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.chat.sessionId = null;
+    mocks.chat.submitPrompt = vi.fn();
+    mocks.loadStatus = 'idle';
+  });
+
+  it('starts a dashboard prompt in a fresh session without loading a session', async () => {
+    renderClaudeCodeChatRoute({ state: { initialPrompt: ' Check repo ' } });
+
+    await waitFor(() => expect(mocks.startNewChat).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.chat.submitPrompt).toHaveBeenCalledWith('Check repo'));
+    expect(mocks.loadSession).not.toHaveBeenCalled();
+  });
+
+  it('loads the session selected via the session query param', async () => {
+    renderClaudeCodeChatRoute({ search: '?session=session-existing' });
+
+    await waitFor(() => expect(mocks.loadSession).toHaveBeenCalledWith('session-existing'));
+    expect(mocks.chat.submitPrompt).not.toHaveBeenCalled();
+  });
+
+  it('shows the loading state while the selected session is still loading', () => {
+    mocks.loadStatus = 'loading';
+    mocks.chat.sessionId = null;
+
+    renderClaudeCodeChatRoute({ search: '?session=session-existing' });
+
+    expect(screen.getByText('Loading chat...')).toBeInTheDocument();
+  });
+
+  it('renders the chat for the active session once loaded', () => {
+    mocks.chat.sessionId = 'session-existing';
+
+    renderClaudeCodeChatRoute({ search: '?session=session-existing' });
+
+    expect(screen.getByTestId('chat-thread')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-layout')).toHaveAttribute(
+      'data-active-session-id',
+      'session-existing'
+    );
+  });
+});

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.tsx
@@ -100,7 +100,11 @@ export const ClaudeCodeChatRoute: FC = () => {
   }
 
   return (
-    <ClaudeCodeLayout activeSessionId={sessionId ?? undefined} artifacts={artifacts}>
+    <ClaudeCodeLayout
+      activeSessionId={sessionId ?? undefined}
+      artifacts={artifacts}
+      onNewChat={startNewChat}
+    >
       <AccessibleTitle title={`Code Agent chat for ${workspace}`}>
         <Stack className="h-full w-full py-density-lg">
           <Stack className="min-h-0 w-full flex-1">

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.tsx
@@ -89,7 +89,8 @@ export const ClaudeCodeChatRoute: FC = () => {
     }
   }, [navigate, selectedSessionId, workspace]);
 
-  const isLoadingSelectedSession = selectedSessionId !== undefined && selectedSessionId !== sessionId;
+  const isLoadingSelectedSession =
+    selectedSessionId !== undefined && selectedSessionId !== sessionId;
 
   if (isLoadingSelectedSession && loadStatus === 'loading') {
     return <ClaudeCodeChatLoadingState selectedSessionId={selectedSessionId} />;

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/index.tsx
@@ -1,35 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AssistantRuntimeProvider } from '@assistant-ui/react';
-import { AssistantChatThread } from '@nemo/common/src/components/AssistantChat/AssistantChatThread';
-import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { Banner, Stack, Text } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
-import { type AgentBlockingInputSubmission } from '@studio/components/agents/AgentBlockingInput';
-import { AgentDecisionInput } from '@studio/components/agents/AgentDecisionInput';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
-import {
-  getClaudeCodeSessionHistory,
-  getClaudeCodeSessionHistoryQueryKey,
-} from '@studio/routes/agents/ClaudeCodeChatRoute/api';
-import { BlockingInputComposer } from '@studio/routes/agents/ClaudeCodeChatRoute/BlockingInputComposer';
+import { ClaudeCodeChatThread } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeChatThread';
 import { ClaudeCodeLayout } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeLayout';
-import { ClaudeCodeStudioLink } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeStudioLink';
-import { ClaudeCodeToolCallPart } from '@studio/routes/agents/ClaudeCodeChatRoute/ClaudeCodeToolCallPart';
-import type {
-  ClaudeCodeChatArtifacts,
-  ClaudeCodeChatRouteState,
-} from '@studio/routes/agents/ClaudeCodeChatRoute/types';
-import { useClaudeCodeChatRuntime } from '@studio/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime';
-import {
-  getClaudeCodeHistoryMessages,
-  getSelectedClaudeCodeSessionId,
-} from '@studio/routes/agents/ClaudeCodeChatRoute/util';
+import { useClaudeCodeChatContext } from '@studio/routes/agents/ClaudeCodeChatRoute/context/useClaudeCodeChatContext';
+import type { ClaudeCodeChatRouteState } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+import { getSelectedClaudeCodeSessionId } from '@studio/routes/agents/ClaudeCodeChatRoute/util';
 import { getClaudeCodeChatRoute, getWorkspaceDashboardRoute } from '@studio/routes/utils';
-import { useQuery } from '@tanstack/react-query';
-import { type FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { type FC, useCallback, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const getInitialPrompt = (state: unknown): string | undefined => {
@@ -41,24 +23,6 @@ const getInitialPrompt = (state: unknown): string | undefined => {
   const trimmedPrompt = initialPrompt.trim();
   return trimmedPrompt || undefined;
 };
-
-interface ClaudeCodeChatSurfaceProps {
-  initialArtifacts?: ClaudeCodeChatArtifacts;
-  initialMessages?: ReturnType<typeof getClaudeCodeHistoryMessages>;
-  initialPrompt?: string;
-  initialSessionId?: string;
-}
-
-const CHAT_VIEWPORT_SCROLLBAR_CLASS = [
-  '[scrollbar-width:thin]',
-  '[scrollbar-color:var(--border-color-interaction-base)_transparent]',
-  '[&::-webkit-scrollbar]:w-2',
-  '[&::-webkit-scrollbar-corner]:bg-transparent',
-  '[&::-webkit-scrollbar-track]:bg-transparent',
-  '[&::-webkit-scrollbar-thumb]:rounded-full',
-  '[&::-webkit-scrollbar-thumb]:bg-[var(--border-color-interaction-base)]',
-  '[&::-webkit-scrollbar-thumb:hover]:bg-[var(--border-color-interaction-strong)]',
-].join(' ');
 
 const ClaudeCodeChatLoadingState = ({ selectedSessionId }: { selectedSessionId?: string }) => (
   <ClaudeCodeLayout activeSessionId={selectedSessionId}>
@@ -84,58 +48,14 @@ const ClaudeCodeChatErrorState = ({ selectedSessionId }: { selectedSessionId?: s
   </ClaudeCodeLayout>
 );
 
-const ClaudeCodeChatSurface: FC<ClaudeCodeChatSurfaceProps> = ({
-  initialArtifacts,
-  initialMessages = [],
-  initialPrompt,
-  initialSessionId,
-}) => {
+export const ClaudeCodeChatRoute: FC = () => {
   const workspace = useWorkspaceFromPath();
   const location = useLocation();
   const navigate = useNavigate();
-  const toast = useToast();
-  const consumedInitialPromptRef = useRef<string | undefined>(undefined);
-  const chatViewportRef = useRef<HTMLDivElement>(null);
-  const {
-    artifacts,
-    decisionChoices,
-    decisionRequest,
-    decisionStatus,
-    handleReset,
-    inputRequest,
-    inputStatus,
-    resolveInputRequest,
-    resolveDecisionRequest,
-    runtime,
-    sessionId,
-    skipInputRequest,
-    skipDecisionRequest,
-    submitPrompt,
-  } = useClaudeCodeChatRuntime({
-    initialArtifacts,
-    initialMessages,
-    initialSessionId,
-    onError: (error) => toast.error(error.message),
-    workspace,
-  });
-  const activeSessionId = initialSessionId ?? sessionId ?? undefined;
-
-  const handleChatReset = useCallback(() => {
-    handleReset();
-    if (initialSessionId) {
-      navigate(getClaudeCodeChatRoute(workspace), { replace: true });
-    }
-  }, [handleReset, initialSessionId, navigate, workspace]);
-
-  const handleInputSubmit = useCallback(
-    async (submission: AgentBlockingInputSubmission) => {
-      await resolveInputRequest({
-        decision: { value: submission.value },
-        displayText: submission.displayText,
-      });
-    },
-    [resolveInputRequest]
-  );
+  const { chat, loadStatus, loadSession, startNewChat } = useClaudeCodeChatContext();
+  const { artifacts, sessionId, submitPrompt } = chat;
+  const selectedSessionId = getSelectedClaudeCodeSessionId(location.search);
+  const initialPrompt = getInitialPrompt(location.state);
 
   useBreadcrumbs({
     items: [
@@ -144,111 +64,50 @@ const ClaudeCodeChatSurface: FC<ClaudeCodeChatSurfaceProps> = ({
     ],
   });
 
+  // Point the shared runtime at the session selected via the URL.
+  useEffect(() => {
+    if (selectedSessionId && selectedSessionId !== sessionId) {
+      loadSession(selectedSessionId);
+    }
+  }, [loadSession, selectedSessionId, sessionId]);
+
+  // Consume a dashboard-provided prompt exactly once: start fresh, fire it, and
+  // clear the navigation state immediately so a refresh does not resubmit.
+  const consumedInitialPromptRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (!initialPrompt || consumedInitialPromptRef.current === initialPrompt) return;
 
     consumedInitialPromptRef.current = initialPrompt;
     navigate(`${location.pathname}${location.search}`, { replace: true, state: null });
+    startNewChat();
     void submitPrompt(initialPrompt);
-  }, [initialPrompt, location.pathname, location.search, navigate, submitPrompt]);
+  }, [initialPrompt, location.pathname, location.search, navigate, startNewChat, submitPrompt]);
 
-  useLayoutEffect(() => {
-    if (!decisionRequest && !inputRequest) return undefined;
+  const handleChatReset = useCallback(() => {
+    if (selectedSessionId) {
+      navigate(getClaudeCodeChatRoute(workspace), { replace: true });
+    }
+  }, [navigate, selectedSessionId, workspace]);
 
-    const viewport = chatViewportRef.current;
-    if (!viewport) return undefined;
+  const isLoadingSelectedSession = selectedSessionId !== undefined && selectedSessionId !== sessionId;
 
-    const frame = window.requestAnimationFrame(() => {
-      viewport.scrollTop = viewport.scrollHeight;
-    });
-
-    return () => window.cancelAnimationFrame(frame);
-  }, [decisionRequest, inputRequest]);
-
-  return (
-    <ClaudeCodeLayout activeSessionId={activeSessionId} artifacts={artifacts}>
-      <AccessibleTitle title={`Code Agent chat for ${workspace}`}>
-        <Stack className="h-full w-full py-density-lg">
-          <Stack className="min-h-0 w-full flex-1">
-            <AssistantRuntimeProvider runtime={runtime}>
-              <AssistantChatThread
-                contentClassName="mx-auto w-full max-w-180 px-density-2xl"
-                composerContainerClassName="mx-auto w-full max-w-180 px-density-2xl"
-                viewportClassName={CHAT_VIEWPORT_SCROLLBAR_CLASS}
-                hideAssistantMessageActions
-                toolCallPartComponent={ClaudeCodeToolCallPart}
-                attributes={{
-                  ThreadViewport: {
-                    ref: chatViewportRef,
-                  },
-                }}
-                placeholder="Ask Claude Code to work in this workspace"
-                onReset={handleChatReset}
-                showRunningIndicator={!decisionRequest && !inputRequest}
-                messageContentProps={{ markdownLinkComponent: ClaudeCodeStudioLink }}
-                emptyState={{
-                  slotHeading: 'Start a Claude Code session',
-                  slotSubheading: 'Ask Claude Code to work in this workspace.',
-                }}
-                composerOverride={
-                  decisionRequest ? (
-                    <AgentDecisionInput
-                      request={decisionRequest}
-                      choices={decisionChoices}
-                      defaultChoiceId={decisionChoices[0]?.id}
-                      status={decisionStatus}
-                      onSubmit={resolveDecisionRequest}
-                      onSkip={skipDecisionRequest}
-                    />
-                  ) : inputRequest ? (
-                    <BlockingInputComposer
-                      inputRequest={inputRequest}
-                      inputStatus={inputStatus}
-                      workspace={workspace}
-                      onSubmit={handleInputSubmit}
-                      onSkip={skipInputRequest}
-                    />
-                  ) : undefined
-                }
-              />
-            </AssistantRuntimeProvider>
-          </Stack>
-        </Stack>
-      </AccessibleTitle>
-    </ClaudeCodeLayout>
-  );
-};
-
-export const ClaudeCodeChatRoute: FC = () => {
-  const location = useLocation();
-  const selectedSessionId = getSelectedClaudeCodeSessionId(location.search);
-  const initialPrompt = getInitialPrompt(location.state);
-  const sessionHistoryQuery = useQuery({
-    queryKey: getClaudeCodeSessionHistoryQueryKey(selectedSessionId ?? ''),
-    queryFn: () => getClaudeCodeSessionHistory(selectedSessionId ?? ''),
-    enabled: !!selectedSessionId,
-    refetchOnMount: 'always',
-  });
-  const initialMessages = useMemo(
-    () => getClaudeCodeHistoryMessages(sessionHistoryQuery.data),
-    [sessionHistoryQuery.data]
-  );
-
-  if (selectedSessionId && sessionHistoryQuery.isLoading) {
+  if (isLoadingSelectedSession && loadStatus === 'loading') {
     return <ClaudeCodeChatLoadingState selectedSessionId={selectedSessionId} />;
   }
 
-  if (selectedSessionId && sessionHistoryQuery.isError) {
+  if (isLoadingSelectedSession && loadStatus === 'error') {
     return <ClaudeCodeChatErrorState selectedSessionId={selectedSessionId} />;
   }
 
   return (
-    <ClaudeCodeChatSurface
-      key={selectedSessionId ?? 'new'}
-      initialArtifacts={sessionHistoryQuery.data?.chat_artifacts}
-      initialMessages={initialMessages}
-      initialPrompt={selectedSessionId ? undefined : initialPrompt}
-      initialSessionId={selectedSessionId}
-    />
+    <ClaudeCodeLayout activeSessionId={sessionId ?? undefined} artifacts={artifacts}>
+      <AccessibleTitle title={`Code Agent chat for ${workspace}`}>
+        <Stack className="h-full w-full py-density-lg">
+          <Stack className="min-h-0 w-full flex-1">
+            <ClaudeCodeChatThread chat={chat} onReset={handleChatReset} />
+          </Stack>
+        </Stack>
+      </AccessibleTitle>
+    </ClaudeCodeLayout>
   );
 };

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.test.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.test.ts
@@ -31,6 +31,8 @@ vi.mock('@studio/routes/agents/ClaudeCodeChatRoute/useCustomAssistantChatRuntime
     appendUserMessage: mocks.appendUserMessage,
     handleReset: vi.fn(),
     isRunning: false,
+    messages: [],
+    replaceMessages: vi.fn(),
     runtime: {},
     submitPrompt: async (prompt: string) => {
       await onRun({
@@ -94,6 +96,29 @@ describe('useClaudeCodeChatRuntime', () => {
     );
     expect(result.current.artifacts.model).toBeUndefined();
     expect(result.current.artifacts.model_source).toBeUndefined();
+  });
+
+  it('passes Studio route context to streamed messages', async () => {
+    mocks.createClaudeCodeSession.mockResolvedValue('session-1');
+    mocks.streamClaudeCodeMessage.mockResolvedValue(undefined);
+
+    const { result } = renderUseClaudeCodeChatRuntime({
+      studioPathname: '/workspaces/default/jobs?status=running',
+      workspace: 'default',
+    });
+
+    await act(async () => {
+      await result.current.submitPrompt('Show running jobs');
+    });
+
+    expect(mocks.streamClaudeCodeMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Show running jobs',
+        sessionId: 'session-1',
+        studioPathname: '/workspaces/default/jobs?status=running',
+        workspace: 'default',
+      })
+    );
   });
 
   it('syncs artifacts when historical session metadata arrives after mount', async () => {

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.ts
@@ -563,7 +563,11 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
   }, [clearInputRequest, clearPermissionRequest, onSessionIdChange, resetThread, workspace]);
 
   const loadSession = useCallback(
-    ({ artifacts: nextArtifacts, messages, sessionId: nextSessionId }: LoadClaudeCodeSessionOptions) => {
+    ({
+      artifacts: nextArtifacts,
+      messages,
+      sessionId: nextSessionId,
+    }: LoadClaudeCodeSessionOptions) => {
       sessionIdRef.current = nextSessionId;
       setSessionId(nextSessionId);
       onSessionIdChange?.(nextSessionId);

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.ts
@@ -214,7 +214,15 @@ interface UseClaudeCodeChatRuntimeOptions {
   initialMessages?: readonly ThreadMessageLike[];
   initialSessionId?: string;
   onError?: (error: Error) => void;
+  onSessionIdChange?: (sessionId: string | null) => void;
+  studioPathname?: string;
   workspace?: string;
+}
+
+interface LoadClaudeCodeSessionOptions {
+  artifacts?: ClaudeCodeChatArtifacts;
+  messages: readonly ThreadMessageLike[];
+  sessionId: string;
 }
 
 export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptions) => {
@@ -238,6 +246,8 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
   );
   const initialArtifactsSignature = getArtifactsSignature(options?.initialArtifacts);
   const onError = options?.onError;
+  const onSessionIdChange = options?.onSessionIdChange;
+  const studioPathname = options?.studioPathname;
 
   initialArtifactsRef.current = options?.initialArtifacts;
 
@@ -251,8 +261,9 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
     const nextSessionId = await createClaudeCodeSession();
     sessionIdRef.current = nextSessionId;
     setSessionId(nextSessionId);
+    onSessionIdChange?.(nextSessionId);
     return nextSessionId;
-  }, []);
+  }, [onSessionIdChange]);
 
   const clearPermissionRequest = useCallback((requestId?: string) => {
     if (requestId && permissionRequestRef.current?.requestId !== requestId) return;
@@ -337,6 +348,7 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
     appendUserMessage,
     handleReset: resetThread,
     isRunning,
+    replaceMessages,
     runtime,
     submitPrompt,
   } = useCustomAssistantChatRuntime({
@@ -352,6 +364,7 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
         await streamClaudeCodeMessage({
           sessionId: activeSessionId,
           message: prompt,
+          studioPathname,
           workspace: options?.workspace,
           signal,
           handlers: {
@@ -542,11 +555,25 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
   const handleReset = useCallback(() => {
     sessionIdRef.current = null;
     setSessionId(null);
+    onSessionIdChange?.(null);
     setArtifacts(createWorkspaceArtifacts(undefined, workspace));
     clearPermissionRequest();
     clearInputRequest();
     resetThread();
-  }, [clearInputRequest, clearPermissionRequest, resetThread, workspace]);
+  }, [clearInputRequest, clearPermissionRequest, onSessionIdChange, resetThread, workspace]);
+
+  const loadSession = useCallback(
+    ({ artifacts: nextArtifacts, messages, sessionId: nextSessionId }: LoadClaudeCodeSessionOptions) => {
+      sessionIdRef.current = nextSessionId;
+      setSessionId(nextSessionId);
+      onSessionIdChange?.(nextSessionId);
+      setArtifacts(createWorkspaceArtifacts(nextArtifacts, workspace));
+      clearPermissionRequest();
+      clearInputRequest();
+      replaceMessages(messages);
+    },
+    [clearInputRequest, clearPermissionRequest, onSessionIdChange, replaceMessages, workspace]
+  );
 
   return {
     artifacts,
@@ -557,6 +584,7 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
     inputRequest,
     inputStatus,
     isRunning,
+    loadSession,
     resolveInputRequest,
     resolveDecisionRequest,
     runtime,
@@ -566,3 +594,5 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
     submitPrompt,
   };
 };
+
+export type ClaudeCodeChatRuntime = ReturnType<typeof useClaudeCodeChatRuntime>;

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useCustomAssistantChatRuntime.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useCustomAssistantChatRuntime.ts
@@ -353,6 +353,15 @@ export const useCustomAssistantChatRuntime = ({
     setThreadMessages([]);
   }, [setThreadMessages]);
 
+  const replaceMessages = useCallback(
+    (nextMessages: readonly ThreadMessageLike[]) => {
+      abortControllerRef.current?.abort();
+      setIsRunning(false);
+      setThreadMessages(nextMessages);
+    },
+    [setThreadMessages]
+  );
+
   const runtime = useExternalStoreRuntime<ThreadMessageLike>({
     messages,
     setMessages: setThreadMessages,
@@ -369,6 +378,8 @@ export const useCustomAssistantChatRuntime = ({
     appendUserMessage,
     handleReset,
     isRunning,
+    messages,
+    replaceMessages,
     runtime,
     submitPrompt,
   };

--- a/web/packages/studio/src/util/localStorage.ts
+++ b/web/packages/studio/src/util/localStorage.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const SIDE_NAV_OPEN_KEY = 'side-nav-open';
+export const CLAUDE_CODE_ACTIVE_SESSION_KEY_PREFIX = 'claude-code-active-session';
 export const CLAUDE_CODE_HISTORY_OPEN_KEY = 'claude-code-history-open';
 export const CLAUDE_CODE_PANEL_TAB_KEY = 'claude-code-panel-tab';
 export const WORKSPACE_DROPDOWN_RECENT_KEY = 'workspace-dropdown-recent';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a compact Code Agent chat pop-out in the top bar, with live “thinking”/unread indicators and quick navigation to the full chat.
  * Introduced a shared Code Agent chat experience across a dedicated workspace chat route, including session persistence/restoration.
* **Bug Fixes**
  * Improved session handling to prevent stale session history reloading and to clear any previously active session when starting a new chat from the landing page.
* **Tests**
  * Expanded route-aware and top-bar chat coverage to validate conditional rendering and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->