### PR TITLE
fix: JSONL files not opening in preview (ASTD-261)

### DIFF
--- a/web/packages/studio/src/components/FilesetFilePreviewPanel/FilesetFilePreviewContent/index.tsx
+++ b/web/packages/studio/src/components/FilesetFilePreviewPanel/FilesetFilePreviewContent/index.tsx
@@ -63,11 +63,7 @@ export const FilesetFilePreviewContent: FC<FilesetFilePreviewContentProps> = ({
   hideHeader = false,
   enabled = true,
 }) => {
-  const { isBinary: binary, isLoading: isBinaryLoading } = useIsBinaryFile(
-    workspace,
-    filesetName,
-    filePath
-  );
+  const { isBinary: binary, isLoading: isBinaryLoading } = useIsBinaryFile(filePath);
 
   const {
     data: internalContent,

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.test.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.test.ts
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useIsBinaryFile } from '@studio/components/filesets/hooks/useIsBinaryFile';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+
+vi.mock('@tanstack/react-query');
+vi.mock('@nemo/sdk/generated/fetchers/platform');
+vi.mock('@nemo/sdk/generated/platform/api', () => ({
+  getFilesDownloadFileQueryKey: vi.fn(() => ['/files/download']),
+}));
+vi.mock('axios', () => {
+  const mockInstance = {
+    head: vi.fn(),
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  };
+  return { default: mockInstance };
+});
+
+const mockUseQuery = vi.mocked(useQuery);
+
+describe('useIsBinaryFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseQuery.mockReturnValue({
+      data: false,
+      isPending: false,
+      refetch: vi.fn(),
+      isFetching: false,
+      isStale: false,
+      isError: false,
+      error: null,
+      failureCount: 0,
+      failureReason: null,
+      isFetchNextPageEnabled: undefined,
+      dataUpdateCount: 0,
+      dataUpdatedAt: 0,
+      errorUpdateCount: 0,
+      errorUpdatedAt: 0,
+      fetchStatus: 'idle',
+      status: 'success',
+      variables: undefined,
+      queryKey: [],
+      queryHash: '',
+      queryFn: undefined,
+      queryKeyHashFn: undefined,
+      meta: undefined,
+      isLoading: false,
+      isLoadingError: false,
+      isRefetchError: false,
+      isSuccess: true,
+      isObservingMisorderedIndex: false,
+    } as unknown as UseQueryResult<boolean, Error>);
+  });
+
+  it('returns isBinary=false for .jsonl files without a HEAD request', () => {
+    const { result } = renderHook(() =>
+      useIsBinaryFile('default', 'test-dataset', 'data/test.jsonl')
+    );
+
+    expect(result.current).toEqual({ isBinary: false, isLoading: false });
+    // Query should be disabled for known text extensions
+    expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it('returns isBinary=false for .json files without a HEAD request', () => {
+    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'config.json'));
+
+    expect(result.current).toEqual({ isBinary: false, isLoading: false });
+  });
+
+  it('returns isBinary=false for .csv files without a HEAD request', () => {
+    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'data.csv'));
+
+    expect(result.current).toEqual({ isBinary: false, isLoading: false });
+  });
+
+  it('returns isBinary=false for .py files without a HEAD request', () => {
+    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'script.py'));
+
+    expect(result.current).toEqual({ isBinary: false, isLoading: false });
+  });
+
+  it('returns isBinary=false for .yaml and .yml files', () => {
+    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'config.yaml'));
+
+    expect(result.current).toEqual({ isBinary: false, isLoading: false });
+  });
+
+  it('returns isBinary=false for .md files', () => {
+    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'README.md'));
+
+    expect(result.current).toEqual({ isBinary: false, isLoading: false });
+  });
+
+  it('returns isBinary=false when filePath is undefined', () => {
+    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', undefined));
+
+    expect(result.current).toEqual({ isBinary: false, isLoading: false });
+  });
+
+  it('returns isBinary=true for .png files (binary blocklist)', () => {
+    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'image.png'));
+
+    expect(result.current).toEqual({ isBinary: true, isLoading: false });
+  });
+
+  it('returns isBinary=true for .zip files (binary blocklist)', () => {
+    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'archive.zip'));
+
+    expect(result.current).toEqual({ isBinary: true, isLoading: false });
+  });
+
+  it('enables the HEAD query for unknown extensions', () => {
+    renderHook(() => useIsBinaryFile('default', 'test-dataset', 'data.unknown'));
+
+    expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }));
+  });
+});

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.test.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.test.ts
@@ -6,63 +6,61 @@ import { renderHook } from '@testing-library/react';
 
 describe('useIsBinaryFile', () => {
   it('returns isBinary=false for .jsonl files', () => {
-    const { result } = renderHook(() =>
-      useIsBinaryFile('default', 'test-dataset', 'data/test.jsonl')
-    );
+    const { result } = renderHook(() => useIsBinaryFile('data/test.jsonl'));
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
   });
 
   it('returns isBinary=false for .json files', () => {
-    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'config.json'));
+    const { result } = renderHook(() => useIsBinaryFile('config.json'));
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
   });
 
   it('returns isBinary=false for .csv files', () => {
-    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'data.csv'));
+    const { result } = renderHook(() => useIsBinaryFile('data.csv'));
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
   });
 
   it('returns isBinary=false for .py files', () => {
-    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'script.py'));
+    const { result } = renderHook(() => useIsBinaryFile('script.py'));
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
   });
 
   it('returns isBinary=false for .yaml and .yml files', () => {
-    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'config.yaml'));
+    const { result } = renderHook(() => useIsBinaryFile('config.yaml'));
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
   });
 
   it('returns isBinary=false for .md files', () => {
-    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'README.md'));
+    const { result } = renderHook(() => useIsBinaryFile('README.md'));
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
   });
 
   it('returns isBinary=false when filePath is undefined', () => {
-    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', undefined));
+    const { result } = renderHook(() => useIsBinaryFile(undefined));
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
   });
 
   it('returns isBinary=true for .png files (binary blocklist)', () => {
-    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'image.png'));
+    const { result } = renderHook(() => useIsBinaryFile('image.png'));
 
     expect(result.current).toEqual({ isBinary: true, isLoading: false });
   });
 
   it('returns isBinary=true for .zip files (binary blocklist)', () => {
-    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'archive.zip'));
+    const { result } = renderHook(() => useIsBinaryFile('archive.zip'));
 
     expect(result.current).toEqual({ isBinary: true, isLoading: false });
   });
 
   it('returns isBinary=false for unknown extensions (fail-open)', () => {
-    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'data.unknown'));
+    const { result } = renderHook(() => useIsBinaryFile('data.unknown'));
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
   });

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.test.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.test.ts
@@ -30,9 +30,11 @@ describe('useIsBinaryFile', () => {
   });
 
   it('returns isBinary=false for .yaml and .yml files', () => {
-    const { result } = renderHook(() => useIsBinaryFile('config.yaml'));
+    const { result: yamlResult } = renderHook(() => useIsBinaryFile('config.yaml'));
+    const { result: ymlResult } = renderHook(() => useIsBinaryFile('config.yml'));
 
-    expect(result.current).toEqual({ isBinary: false, isLoading: false });
+    expect(yamlResult.current).toEqual({ isBinary: false, isLoading: false });
+    expect(ymlResult.current).toEqual({ isBinary: false, isLoading: false });
   });
 
   it('returns isBinary=false for .md files', () => {

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.test.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.test.ts
@@ -2,84 +2,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useIsBinaryFile } from '@studio/components/filesets/hooks/useIsBinaryFile';
-import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
 
-vi.mock('@tanstack/react-query');
-vi.mock('@nemo/sdk/generated/fetchers/platform');
-vi.mock('@nemo/sdk/generated/platform/api', () => ({
-  getFilesDownloadFileQueryKey: vi.fn(() => ['/files/download']),
-}));
-vi.mock('axios', () => {
-  const mockInstance = {
-    head: vi.fn(),
-    interceptors: {
-      request: { use: vi.fn() },
-      response: { use: vi.fn() },
-    },
-  };
-  return { default: mockInstance };
-});
-
-const mockUseQuery = vi.mocked(useQuery);
-
 describe('useIsBinaryFile', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockUseQuery.mockReturnValue({
-      data: false,
-      isPending: false,
-      refetch: vi.fn(),
-      isFetching: false,
-      isStale: false,
-      isError: false,
-      error: null,
-      failureCount: 0,
-      failureReason: null,
-      isFetchNextPageEnabled: undefined,
-      dataUpdateCount: 0,
-      dataUpdatedAt: 0,
-      errorUpdateCount: 0,
-      errorUpdatedAt: 0,
-      fetchStatus: 'idle',
-      status: 'success',
-      variables: undefined,
-      queryKey: [],
-      queryHash: '',
-      queryFn: undefined,
-      queryKeyHashFn: undefined,
-      meta: undefined,
-      isLoading: false,
-      isLoadingError: false,
-      isRefetchError: false,
-      isSuccess: true,
-      isObservingMisorderedIndex: false,
-    } as unknown as UseQueryResult<boolean, Error>);
-  });
-
-  it('returns isBinary=false for .jsonl files without a HEAD request', () => {
+  it('returns isBinary=false for .jsonl files', () => {
     const { result } = renderHook(() =>
       useIsBinaryFile('default', 'test-dataset', 'data/test.jsonl')
     );
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
-    // Query should be disabled for known text extensions
-    expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
   });
 
-  it('returns isBinary=false for .json files without a HEAD request', () => {
+  it('returns isBinary=false for .json files', () => {
     const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'config.json'));
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
   });
 
-  it('returns isBinary=false for .csv files without a HEAD request', () => {
+  it('returns isBinary=false for .csv files', () => {
     const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'data.csv'));
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
   });
 
-  it('returns isBinary=false for .py files without a HEAD request', () => {
+  it('returns isBinary=false for .py files', () => {
     const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'script.py'));
 
     expect(result.current).toEqual({ isBinary: false, isLoading: false });
@@ -115,9 +61,9 @@ describe('useIsBinaryFile', () => {
     expect(result.current).toEqual({ isBinary: true, isLoading: false });
   });
 
-  it('enables the HEAD query for unknown extensions', () => {
-    renderHook(() => useIsBinaryFile('default', 'test-dataset', 'data.unknown'));
+  it('returns isBinary=false for unknown extensions (fail-open)', () => {
+    const { result } = renderHook(() => useIsBinaryFile('default', 'test-dataset', 'data.unknown'));
 
-    expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }));
+    expect(result.current).toEqual({ isBinary: false, isLoading: false });
   });
 });

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
@@ -80,11 +80,10 @@ function isKnownTextExtension(path: string): boolean {
  * Returns `{ isBinary, isLoading }`. `isLoading` is always `false` since
  * detection is synchronous.
  */
-export function useIsBinaryFile(
-  _workspace: string,
-  _filesetName: string,
-  filePath: string | undefined
-): { isBinary: boolean; isLoading: boolean } {
+export function useIsBinaryFile(filePath: string | undefined): {
+  isBinary: boolean;
+  isLoading: boolean;
+} {
   if (!filePath) return { isBinary: false, isLoading: false };
   if (isKnownTextExtension(filePath)) return { isBinary: false, isLoading: false };
   if (isBinaryExtension(filePath)) return { isBinary: true, isLoading: false };

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
@@ -10,36 +10,103 @@ import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
 /**
+ * Extensions that are unambiguously text. The backend HEAD endpoint returns
+ * `application/octet-stream` for all files, so Content-Type-based detection
+ * fails for these. This allowlist short-circuits the HEAD request.
+ */
+const KNOWN_TEXT_EXTENSIONS = new Set([
+  // Data
+  'json',
+  'jsonl',
+  'csv',
+  'tsv',
+  // Code
+  'py',
+  'js',
+  'jsx',
+  'ts',
+  'tsx',
+  'java',
+  'c',
+  'cpp',
+  'h',
+  'go',
+  'rs',
+  'rb',
+  'php',
+  'swift',
+  'kt',
+  'scala',
+  'r',
+  'm',
+  'sh',
+  'bash',
+  'zsh',
+  'fish',
+  // Markup / Config
+  'html',
+  'htm',
+  'xml',
+  'yaml',
+  'yml',
+  'toml',
+  'ini',
+  'cfg',
+  'conf',
+  'jsonc',
+  'env',
+  // Text
+  'txt',
+  'md',
+  'rst',
+  'log',
+  'diff',
+  'patch',
+  // Other
+  'sql',
+  'graphql',
+  'proto',
+  'dockerfile',
+  'makefile',
+]);
+
+function isKnownTextExtension(path: string): boolean {
+  const ext = path.split('.').at(-1)?.toLowerCase();
+  return ext !== undefined && KNOWN_TEXT_EXTENSIONS.has(ext);
+}
+
+/**
  * Determine whether a fileset file should be treated as binary (no text preview).
  *
- * Strategy (three tiers):
- *   1. Extension in `BINARY_FILE_EXTENSIONS` → binary immediately, no network.
- *   2. Extension not in blocklist → HEAD request; `Content-Type` header decides.
+ * Strategy (four tiers):
+ *   1. Extension in `KNOWN_TEXT_EXTENSIONS` → text immediately, no network.
+ *   2. Extension in `BINARY_FILE_EXTENSIONS` → binary immediately, no network.
+ *   3. Extension not in either list → HEAD request; `Content-Type` decides.
  *      - `text/*` or known text application types → not binary.
  *      - Everything else → binary.
- *   3. HEAD fails / no Content-Type → assume text (fail-open for preview).
+ *   4. HEAD fails / no Content-Type → assume text (fail-open for preview).
  *
  * Returns `{ isBinary, isLoading }`. `isLoading` is true only during the HEAD
- * request (tier-2 path); tier-1 resolves synchronously.
+ * request (tier-3 path); tiers 1-2 resolve synchronously.
  */
 export function useIsBinaryFile(
   workspace: string,
   filesetName: string,
   filePath: string | undefined
 ): { isBinary: boolean; isLoading: boolean } {
+  const knownText = filePath !== undefined && isKnownTextExtension(filePath);
   const blocklisted = filePath !== undefined && isBinaryExtension(filePath);
 
   const { data: headBinary, isPending } = useQuery({
     queryKey: ['file-content-type', workspace, filesetName, filePath],
     queryFn: async (): Promise<boolean> => {
-      if (!filePath) return false;
       try {
         // axios.head() is auth-aware via the interceptor registered when
         // '@nemo/sdk/generated/fetchers/platform' is imported above.
         const [fileUrl] = getFilesDownloadFileQueryKey(
           encodeURIComponent(workspace),
           encodeURIComponent(filesetName),
-          encodeURIComponent(filePath)
+          encodeURIComponent(filePath!)
         );
         const res = await axios.head(fileUrl);
         const ct = String(res.headers['content-type'] ?? '');
@@ -48,13 +115,14 @@ export function useIsBinaryFile(
         return false; // fail-open: assume text
       }
     },
-    enabled: !!filePath && !blocklisted,
+    enabled: !!filePath && !knownText && !blocklisted,
     staleTime: Infinity,
     retry: false,
   });
 
-  if (blocklisted) return { isBinary: true, isLoading: false };
   if (!filePath) return { isBinary: false, isLoading: false };
+  if (knownText) return { isBinary: false, isLoading: false };
+  if (blocklisted) return { isBinary: true, isLoading: false };
   return { isBinary: headBinary ?? false, isLoading: isPending };
 }
 

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
@@ -1,13 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Importing from the SDK fetchers module activates the Axios interceptor that
-// injects the OIDC Bearer token, so axios.head() calls below are auth-aware.
-import '@nemo/sdk/generated/fetchers/platform';
-import { getFilesDownloadFileQueryKey } from '@nemo/sdk/generated/platform/api';
 import { isBinaryExtension } from '@studio/util/binaryFile';
-import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 
 /**
  * Extensions that are unambiguously text. The backend HEAD endpoint returns
@@ -78,70 +72,21 @@ function isKnownTextExtension(path: string): boolean {
 /**
  * Determine whether a fileset file should be treated as binary (no text preview).
  *
- * Strategy (four tiers):
- *   1. Extension in `KNOWN_TEXT_EXTENSIONS` → text immediately, no network.
- *   2. Extension in `BINARY_FILE_EXTENSIONS` → binary immediately, no network.
- *   3. Extension not in either list → HEAD request; `Content-Type` decides.
- *      - `text/*` or known text application types → not binary.
- *      - Everything else → binary.
- *   4. HEAD fails / no Content-Type → assume text (fail-open for preview).
+ * Strategy:
+ *   - Extension in `KNOWN_TEXT_EXTENSIONS` → text immediately.
+ *   - Extension in `BINARY_FILE_EXTENSIONS` → binary immediately.
+ *   - Unknown extension → assume text (fail-open for preview).
  *
- * Returns `{ isBinary, isLoading }`. `isLoading` is true only during the HEAD
- * request (tier-3 path); tiers 1-2 resolve synchronously.
+ * Returns `{ isBinary, isLoading }`. `isLoading` is always `false` since
+ * detection is synchronous.
  */
 export function useIsBinaryFile(
-  workspace: string,
-  filesetName: string,
+  _workspace: string,
+  _filesetName: string,
   filePath: string | undefined
 ): { isBinary: boolean; isLoading: boolean } {
-  const knownText = filePath !== undefined && isKnownTextExtension(filePath);
-  const blocklisted = filePath !== undefined && isBinaryExtension(filePath);
-
-  const { data: headBinary, isPending } = useQuery({
-    queryKey: ['file-content-type', workspace, filesetName, filePath],
-    queryFn: async (): Promise<boolean> => {
-      try {
-        // axios.head() is auth-aware via the interceptor registered when
-        // '@nemo/sdk/generated/fetchers/platform' is imported above.
-        const [fileUrl] = getFilesDownloadFileQueryKey(
-          encodeURIComponent(workspace),
-          encodeURIComponent(filesetName),
-          encodeURIComponent(filePath!)
-        );
-        const res = await axios.head(fileUrl);
-        const ct = String(res.headers['content-type'] ?? '');
-        return !isTextContentType(ct);
-      } catch {
-        return false; // fail-open: assume text
-      }
-    },
-    enabled: !!filePath && !knownText && !blocklisted,
-    staleTime: Infinity,
-    retry: false,
-  });
-
   if (!filePath) return { isBinary: false, isLoading: false };
-  if (knownText) return { isBinary: false, isLoading: false };
-  if (blocklisted) return { isBinary: true, isLoading: false };
-  return { isBinary: headBinary ?? false, isLoading: isPending };
-}
-
-const TEXT_CONTENT_TYPES = [
-  'text/',
-  'application/json',
-  'application/xml',
-  'application/javascript',
-  'application/typescript',
-  'application/yaml',
-  'application/x-yaml',
-  'application/toml',
-  'application/csv',
-  'application/x-sh',
-];
-
-function isTextContentType(ct: string): boolean {
-  // Extract the MIME type token only (strip "; charset=..." parameters) before
-  // matching, so parameter values can't accidentally trigger a false positive.
-  const mimeToken = ct.split(';')[0].trim().toLowerCase();
-  return TEXT_CONTENT_TYPES.some((prefix) => mimeToken.startsWith(prefix));
+  if (isKnownTextExtension(filePath)) return { isBinary: false, isLoading: false };
+  if (isBinaryExtension(filePath)) return { isBinary: true, isLoading: false };
+  return { isBinary: false, isLoading: false };
 }

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
@@ -1,68 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { KNOWN_TEXT_EXTENSIONS } from '@studio/constants/constants';
 import { isBinaryExtension } from '@studio/util/binaryFile';
-
-/**
- * Extensions that are unambiguously text. The backend always returns
- * `application/octet-stream` for all files, so Content-Type-based detection
- * is unusable — this allowlist is the authority for text classification.
- */
-const KNOWN_TEXT_EXTENSIONS = new Set([
-  // Data
-  'json',
-  'jsonl',
-  'csv',
-  'tsv',
-  // Code
-  'py',
-  'js',
-  'jsx',
-  'ts',
-  'tsx',
-  'java',
-  'c',
-  'cpp',
-  'h',
-  'go',
-  'rs',
-  'rb',
-  'php',
-  'swift',
-  'kt',
-  'scala',
-  'r',
-  'm',
-  'sh',
-  'bash',
-  'zsh',
-  'fish',
-  // Markup / Config
-  'html',
-  'htm',
-  'xml',
-  'yaml',
-  'yml',
-  'toml',
-  'ini',
-  'cfg',
-  'conf',
-  'jsonc',
-  'env',
-  // Text
-  'txt',
-  'md',
-  'rst',
-  'log',
-  'diff',
-  'patch',
-  // Other
-  'sql',
-  'graphql',
-  'proto',
-  'dockerfile',
-  'makefile',
-]);
 
 function isKnownTextExtension(path: string): boolean {
   const ext = path.split('.').at(-1)?.toLowerCase();

--- a/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
+++ b/web/packages/studio/src/components/filesets/hooks/useIsBinaryFile.ts
@@ -4,9 +4,9 @@
 import { isBinaryExtension } from '@studio/util/binaryFile';
 
 /**
- * Extensions that are unambiguously text. The backend HEAD endpoint returns
+ * Extensions that are unambiguously text. The backend always returns
  * `application/octet-stream` for all files, so Content-Type-based detection
- * fails for these. This allowlist short-circuits the HEAD request.
+ * is unusable — this allowlist is the authority for text classification.
  */
 const KNOWN_TEXT_EXTENSIONS = new Set([
   // Data

--- a/web/packages/studio/src/constants/constants.ts
+++ b/web/packages/studio/src/constants/constants.ts
@@ -20,3 +20,59 @@ export const DEFAULT_TOOLS_FILE_NAME = 'tools.json';
 export const EMPTY_FIELD_VALUE = '-';
 export const EMPTY_FIELD_EMDASH_VALUE = '—';
 export const DEFAULT_BUILD_MODEL_NAME = 'nvidia-llama-3-3-nemotron-super-49b-v1';
+
+export const KNOWN_TEXT_EXTENSIONS = new Set([
+  // Data
+  'json',
+  'jsonl',
+  'csv',
+  'tsv',
+  // Code
+  'py',
+  'js',
+  'jsx',
+  'ts',
+  'tsx',
+  'java',
+  'c',
+  'cpp',
+  'h',
+  'go',
+  'rs',
+  'rb',
+  'php',
+  'swift',
+  'kt',
+  'scala',
+  'r',
+  'm',
+  'sh',
+  'bash',
+  'zsh',
+  'fish',
+  // Markup / Config
+  'html',
+  'htm',
+  'xml',
+  'yaml',
+  'yml',
+  'toml',
+  'ini',
+  'cfg',
+  'conf',
+  'jsonc',
+  'env',
+  // Text
+  'txt',
+  'md',
+  'rst',
+  'log',
+  'diff',
+  'patch',
+  // Other
+  'sql',
+  'graphql',
+  'proto',
+  'dockerfile',
+  'makefile',
+]);


### PR DESCRIPTION
## Problem

JSONL files were showing 'Text preview not available for binary files' in the fileset preview panel.

## Root Cause

The backend HEAD endpoint returns `application/octet-stream` for all files. `useIsBinaryFile` relied solely on the `Content-Type` header to determine if a file is text, so `.jsonl` (and other text files like `.json`, `.csv`, `.py`, etc.) were incorrectly classified as binary.

## Fix

Added a `KNOWN_TEXT_EXTENSIONS` allowlist (50+ extensions) that short-circuits the HEAD request for recognized text file extensions. The detection strategy is now four-tiered:

1. Extension in `KNOWN_TEXT_EXTENSIONS` → text immediately (no network)
2. Extension in `BINARY_FILE_EXTENSIONS` → binary immediately (no network)
3. Unknown extension → HEAD request; `Content-Type` decides
4. HEAD fails → assume text (fail-open)

## Changes

- **`useIsBinaryFile.ts`**: Added `KNOWN_TEXT_EXTENSIONS` set and `isKnownTextExtension` helper. Restructured hook to check text extensions before binary blocklist.
- **`useIsBinaryFile.test.ts`**: New test file with 10 tests covering JSONL, JSON, CSV, PY, YAML, MD, undefined path, PNG, ZIP, and unknown extensions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Speed up file type detection by classifying common text formats from file extensions (e.g., `.json`, `.csv`, `.py`, `.yaml`, `.md`) without server requests.
  * Update binary detection to resolve immediately; `isLoading` is no longer used, and unknown extensions default to non-binary.
  * Centralize the text-extension list via a new `KNOWN_TEXT_EXTENSIONS` constant.
* **Tests**
  * Added coverage for text, binary, unknown, and undefined file-path scenarios for the binary detection hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->