### PR TITLE
feat(studio): DataDesigner details profiler results

### DIFF
--- a/web/packages/studio/src/constants/constants.ts
+++ b/web/packages/studio/src/constants/constants.ts
@@ -19,4 +19,4 @@ export const DEFAULT_API_ERR_MSG = 'Invalid API response. Please try again later
 export const DEFAULT_TOOLS_FILE_NAME = 'tools.json';
 export const EMPTY_FIELD_VALUE = '-';
 export const EMPTY_FIELD_EMDASH_VALUE = '—';
-export const DEFAULT_BUILD_MODEL_NAME = 'nvidia-nvidia-llama-3-3-nemotron-super-49b-v1-5';
+export const DEFAULT_BUILD_MODEL_NAME = 'nvidia-llama-3-3-nemotron-super-49b-v1';

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/CategoricalHistogramChart.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/CategoricalHistogramChart.tsx
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Stack, Text } from '@nvidia/foundations-react-core';
+import type { CategoricalHistogramData } from '@studio/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes';
+import { FC, useMemo } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  LabelList,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+interface CategoricalHistogramChartProps {
+  histogram: CategoricalHistogramData;
+}
+
+/** Show at most this many bars; remaining categories are summarized below. */
+const MAX_BARS = 12;
+const CHART_HEIGHT = 220;
+const TICK_STYLE = { fontSize: 11, fill: 'var(--text-color-base)' } as const;
+
+interface HistogramBar {
+  label: string;
+  count: number;
+}
+
+/** Truncate long category labels so the axis stays legible. */
+const truncateLabel = (label: string): string =>
+  label.length > 14 ? `${label.slice(0, 13)}…` : label;
+
+/**
+ * Vertical bar chart of a categorical sampler column's value distribution.
+ * Bars are sorted by frequency and capped at {@link MAX_BARS}; any overflow is
+ * surfaced as a "+N more categories" note so the chart stays readable.
+ */
+export const CategoricalHistogramChart: FC<CategoricalHistogramChartProps> = ({ histogram }) => {
+  const { bars, hiddenCount, hiddenTotal } = useMemo(() => {
+    const all: HistogramBar[] = histogram.categories.map((category, index) => ({
+      label: String(category),
+      count: histogram.counts[index] ?? 0,
+    }));
+    all.sort((a, b) => b.count - a.count);
+    const visible = all.slice(0, MAX_BARS);
+    const hidden = all.slice(MAX_BARS);
+    return {
+      bars: visible,
+      hiddenCount: hidden.length,
+      hiddenTotal: hidden.reduce((sum, bar) => sum + bar.count, 0),
+    };
+  }, [histogram]);
+
+  if (bars.length === 0) {
+    return (
+      <Text kind="body/regular/sm" className="text-muted">
+        No category counts available.
+      </Text>
+    );
+  }
+
+  return (
+    <Stack gap="density-sm">
+      <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+        <BarChart data={bars} margin={{ top: 16, bottom: 8, left: 0, right: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border-color-base)" />
+          <XAxis
+            dataKey="label"
+            tick={TICK_STYLE}
+            tickFormatter={truncateLabel}
+            tickLine={false}
+            interval={0}
+            angle={-35}
+            textAnchor="end"
+            height={56}
+          />
+          <YAxis tick={TICK_STYLE} width={40} allowDecimals={false} tickLine={false} />
+          <Tooltip
+            cursor={{ fill: 'var(--background-color-accent-gray-subtle)' }}
+            contentStyle={{
+              fontSize: 12,
+              backgroundColor: 'var(--background-color-component-tooltip)',
+              borderColor: 'var(--border-color-base)',
+              color: 'var(--text-color-base)',
+            }}
+            labelStyle={{ color: 'var(--text-color-base)' }}
+            itemStyle={{ color: 'var(--text-color-base)' }}
+            formatter={(value: number) => [value.toLocaleString(), 'Count']}
+          />
+          <Bar dataKey="count" name="Count" fill="var(--text-color-brand)" radius={[4, 4, 0, 0]}>
+            <LabelList
+              dataKey="count"
+              position="top"
+              fill="var(--text-color-base)"
+              fontSize={11}
+              formatter={(value: number) => value.toLocaleString()}
+            />
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+      {hiddenCount > 0 && (
+        <Text kind="body/regular/sm" className="text-muted">
+          +{hiddenCount} more {hiddenCount === 1 ? 'category' : 'categories'} (
+          {hiddenTotal.toLocaleString()} records)
+        </Text>
+      )}
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/ColumnProfileCard.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/ColumnProfileCard.tsx
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Badge, Card, Divider, Flex, Stack, Text } from '@nvidia/foundations-react-core';
+import { CategoricalHistogramChart } from '@studio/routes/DataDesignerJobDetailsRoute/CategoricalHistogramChart';
+import {
+  formatPercent,
+  formatStatCount,
+  formatStatDecimal,
+  getCategoricalHistogram,
+  getColumnTypeLabel,
+  getNumericalDistribution,
+  getPercentNull,
+  getPercentUnique,
+  isLLMColumnStatistics,
+  isValidationColumnStatistics,
+  type ColumnStatistics,
+} from '@studio/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes';
+import { FC } from 'react';
+
+interface StatProps {
+  label: string;
+  value: string;
+}
+
+const Stat: FC<StatProps> = ({ label, value }) => (
+  <Stack gap="density-xxs" className="min-w-0">
+    <Text kind="body/regular/xs" className="text-muted uppercase tracking-wide">
+      {label}
+    </Text>
+    <Text kind="body/regular/md" className="truncate">
+      {value}
+    </Text>
+  </Stack>
+);
+
+interface ColumnProfileCardProps {
+  stats: ColumnStatistics;
+}
+
+/**
+ * Builds the column-specific detail body: a bar chart for categorical sampler
+ * distributions, a numeric summary for numerical samplers, token usage for LLM
+ * columns, and valid-record counts for validation columns. Returns `null` when
+ * a column has no extra detail (e.g. a uuid sampler), so the caller can skip the
+ * divider rather than render an empty section.
+ */
+const renderColumnDetail = (stats: ColumnStatistics): React.ReactNode => {
+  const histogram = getCategoricalHistogram(stats);
+  if (histogram) {
+    return <CategoricalHistogramChart histogram={histogram} />;
+  }
+
+  const numerical = getNumericalDistribution(stats);
+  if (numerical) {
+    return (
+      <Flex gap="density-xl" className="flex-wrap">
+        <Stat label="Min" value={formatStatDecimal(numerical.min)} />
+        <Stat label="Max" value={formatStatDecimal(numerical.max)} />
+        <Stat label="Mean" value={formatStatDecimal(numerical.mean)} />
+        <Stat label="Median" value={formatStatDecimal(numerical.median)} />
+        <Stat label="Std dev" value={formatStatDecimal(numerical.stddev)} />
+      </Flex>
+    );
+  }
+
+  if (isLLMColumnStatistics(stats)) {
+    return (
+      <Flex gap="density-xl" className="flex-wrap">
+        <Stat label="Input tokens (avg)" value={formatStatDecimal(stats.input_tokens_mean)} />
+        <Stat label="Output tokens (avg)" value={formatStatDecimal(stats.output_tokens_mean)} />
+      </Flex>
+    );
+  }
+
+  if (isValidationColumnStatistics(stats)) {
+    return (
+      <Flex gap="density-xl" className="flex-wrap">
+        <Stat label="Valid records" value={formatStatCount(stats.num_valid_records)} />
+      </Flex>
+    );
+  }
+
+  return null;
+};
+
+/** A single column's profile rendered as a self-contained card for the grid. */
+export const ColumnProfileCard: FC<ColumnProfileCardProps> = ({ stats }) => {
+  const detail = renderColumnDetail(stats);
+
+  return (
+    <Card className="h-full">
+      <Stack gap="density-md" className="h-full">
+        <Stack gap="density-md">
+          <Stack gap="density-xxs">
+            <Flex justify="between" align="center" gap="density-sm">
+              <Text kind="body/bold/md" className="truncate font-mono">
+                {stats.column_name}
+              </Text>
+              <Badge kind="outline">{getColumnTypeLabel(stats)}</Badge>
+            </Flex>
+            <Text kind="body/regular/xs" className="text-muted font-mono">
+              {stats.simple_dtype}
+            </Text>
+          </Stack>
+
+          <Flex gap="density-xl" className="flex-wrap">
+            <Stat label="Records" value={formatStatCount(stats.num_records)} />
+            <Stat label="Null %" value={formatPercent(getPercentNull(stats))} />
+            <Stat label="Unique %" value={formatPercent(getPercentUnique(stats))} />
+          </Flex>
+          {detail && <Divider />}
+        </Stack>
+
+        {detail}
+      </Stack>
+    </Card>
+  );
+};

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DataDesignerConfigPanel.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DataDesignerConfigPanel.tsx
@@ -11,7 +11,7 @@ import {
   type BuilderConfigSummary,
 } from '@studio/routes/DataDesignerJobDetailsRoute/builderConfig';
 import { useDataDesignerArtifactsFileset } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerArtifactsFileset';
-import { FC, useMemo } from 'react';
+import { useMemo, type FC } from 'react';
 
 export interface DataDesignerConfigPanelProps {
   open: boolean;
@@ -56,9 +56,9 @@ const ConfigSummary: FC<{ summary: BuilderConfigSummary }> = ({ summary }) => (
         <Divider />
         <Stack gap="density-md">
           <Text kind="label/semibold/md">Models</Text>
-          {summary.models.map((model) => (
+          {summary.models.map((model, index) => (
             <KVPair
-              key={model.alias}
+              key={`${model.alias}-${index}`}
               label={model.alias}
               value={model.provider ? `${model.model} (${model.provider})` : model.model}
             />
@@ -72,9 +72,9 @@ const ConfigSummary: FC<{ summary: BuilderConfigSummary }> = ({ summary }) => (
         <Divider />
         <Stack gap="density-md">
           <Text kind="label/semibold/md">Columns</Text>
-          {summary.columns.map((column) => (
+          {summary.columns.map((column, index) => (
             <KVPair
-              key={column.name}
+              key={`${column.name}-${index}`}
               label={column.name}
               value={column.modelAlias ? `${column.type} · ${column.modelAlias}` : column.type}
             />

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DataDesignerConfigPanel.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DataDesignerConfigPanel.tsx
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { KVPair } from '@nemo/common/src/components/KVPair';
+import { Banner, Divider, SidePanel, Spinner, Stack, Text } from '@nvidia/foundations-react-core';
+import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
+import {
+  BUILDER_CONFIG_FILENAME,
+  formatColumnTypeBreakdown,
+  summarizeBuilderConfig,
+  type BuilderConfigSummary,
+} from '@studio/routes/DataDesignerJobDetailsRoute/builderConfig';
+import { useDataDesignerArtifactsFileset } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerArtifactsFileset';
+import { FC, useMemo } from 'react';
+
+export interface DataDesignerConfigPanelProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const ConfigSummary: FC<{ summary: BuilderConfigSummary }> = ({ summary }) => (
+  <Stack gap="density-xl">
+    <Stack gap="density-md">
+      <Text kind="label/semibold/md">Overview</Text>
+      <KVPair
+        label="Columns"
+        value={
+          summary.columnCount > 0
+            ? `${summary.columnCount} (${formatColumnTypeBreakdown(summary)})`
+            : '0'
+        }
+      />
+      {summary.seed ? (
+        <KVPair
+          label="Seed dataset"
+          value={
+            summary.seed.samplingStrategy
+              ? `${summary.seed.type} · ${summary.seed.samplingStrategy}`
+              : summary.seed.type
+          }
+        />
+      ) : null}
+      <KVPair label="Constraints" value={String(summary.constraintCount)} />
+      <KVPair label="Profilers" value={String(summary.profilerCount)} />
+      <KVPair
+        label="Processors"
+        value={summary.processorNames.length > 0 ? summary.processorNames.join(', ') : '0'}
+      />
+      {summary.libraryVersion ? (
+        <KVPair label="Library version" value={summary.libraryVersion} />
+      ) : null}
+    </Stack>
+
+    {summary.models.length > 0 ? (
+      <>
+        <Divider />
+        <Stack gap="density-md">
+          <Text kind="label/semibold/md">Models</Text>
+          {summary.models.map((model) => (
+            <KVPair
+              key={model.alias}
+              label={model.alias}
+              value={model.provider ? `${model.model} (${model.provider})` : model.model}
+            />
+          ))}
+        </Stack>
+      </>
+    ) : null}
+
+    {summary.columns.length > 0 ? (
+      <>
+        <Divider />
+        <Stack gap="density-md">
+          <Text kind="label/semibold/md">Columns</Text>
+          {summary.columns.map((column) => (
+            <KVPair
+              key={column.name}
+              label={column.name}
+              value={column.modelAlias ? `${column.type} · ${column.modelAlias}` : column.type}
+            />
+          ))}
+        </Stack>
+      </>
+    ) : null}
+  </Stack>
+);
+
+export const DataDesignerConfigPanel: FC<DataDesignerConfigPanelProps> = ({ open, onClose }) => {
+  const { filesetWorkspace, filesetName, files, isResultsLoading, isFilesLoading } =
+    useDataDesignerArtifactsFileset();
+
+  const builderConfigPath = useMemo(
+    () =>
+      files.find(
+        (file) =>
+          file.path === BUILDER_CONFIG_FILENAME || file.path.endsWith(`/${BUILDER_CONFIG_FILENAME}`)
+      )?.path,
+    [files]
+  );
+
+  const {
+    data: rawContent,
+    isLoading: isContentLoading,
+    isError: isContentError,
+  } = useDatasetFileContent({
+    workspace: filesetWorkspace,
+    name: filesetName,
+    path: builderConfigPath ?? '',
+    enabled: open && Boolean(filesetWorkspace && filesetName && builderConfigPath),
+  });
+
+  const summary = useMemo(() => {
+    if (!rawContent) {
+      return null;
+    }
+    try {
+      return summarizeBuilderConfig(JSON.parse(rawContent) as unknown);
+    } catch {
+      return null;
+    }
+  }, [rawContent]);
+
+  const isResolving = isResultsLoading || isFilesLoading;
+  const isLoading = isResolving || (Boolean(builderConfigPath) && isContentLoading);
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      onClose();
+    }
+  };
+
+  const renderBody = () => {
+    if (isLoading) {
+      return (
+        <Stack align="center" gap="density-md" padding="density-xl">
+          <Spinner aria-label="Loading job config" />
+          <Text kind="body/regular/sm" className="text-muted">
+            Loading job config...
+          </Text>
+        </Stack>
+      );
+    }
+
+    if (!builderConfigPath) {
+      return (
+        <Text kind="body/regular/md" className="text-muted">
+          No <code>{BUILDER_CONFIG_FILENAME}</code> was found in this job's output fileset. The
+          config is available once the job has produced its artifacts.
+        </Text>
+      );
+    }
+
+    if (isContentError || !summary) {
+      return (
+        <Banner kind="inline" status="error" title="Could not read job config">
+          The <code>{BUILDER_CONFIG_FILENAME}</code> file could not be loaded or parsed.
+        </Banner>
+      );
+    }
+
+    return <ConfigSummary summary={summary} />;
+  };
+
+  return (
+    <SidePanel
+      side="right"
+      open={open}
+      onOpenChange={handleOpenChange}
+      slotHeading="Job config"
+      bordered
+      modal
+      className="max-w-[560px] w-full"
+    >
+      <Stack gap="density-md">{renderBody()}</Stack>
+    </SidePanel>
+  );
+};

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection.tsx
@@ -18,7 +18,7 @@ import {
 } from '@studio/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes';
 import { useDataDesignerJobAnalysis } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerJobAnalysis';
 import { useDataDesignerJobFromRoute } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerJobFromRoute';
-import { FC } from 'react';
+import type { FC } from 'react';
 
 const ColumnGrid: FC<{ children: React.ReactNode }> = ({ children }) => (
   <Grid cols={{ xs: 1, sm: 2, xl: 3 }} gap="density-lg">
@@ -54,7 +54,7 @@ export const DatasetProfilerSection: FC = () => {
     );
   }
 
-  if (isLoading && !hasAnalysis) {
+  if (isLoading && !analysis) {
     return (
       <ColumnGrid>
         {Array.from({ length: 6 }, (_, i) => (

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection.tsx
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
+import {
+  Banner,
+  Flex,
+  Grid,
+  ProgressBar,
+  Skeleton,
+  Stack,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { ColumnProfileCard } from '@studio/routes/DataDesignerJobDetailsRoute/ColumnProfileCard';
+import {
+  formatPercent,
+  getPercentComplete,
+} from '@studio/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes';
+import { useDataDesignerJobAnalysis } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerJobAnalysis';
+import { useDataDesignerJobFromRoute } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerJobFromRoute';
+import { FC } from 'react';
+
+const ColumnGrid: FC<{ children: React.ReactNode }> = ({ children }) => (
+  <Grid cols={{ xs: 1, sm: 2, xl: 3 }} gap="density-lg">
+    {children}
+  </Grid>
+);
+
+export const DatasetProfilerSection: FC = () => {
+  const { workspace, jobName, job } = useDataDesignerJobFromRoute();
+
+  const isTerminal = job?.status != null && PlatformJobTerminalStatuses.includes(job.status);
+
+  const { analysis, hasAnalysis, isLoading, isError } = useDataDesignerJobAnalysis(
+    workspace,
+    jobName,
+    { enabled: isTerminal }
+  );
+
+  // Job still running: the profiler hasn't produced an analysis result yet.
+  if (!isTerminal) {
+    return (
+      <Text kind="body/regular/md" className="text-muted">
+        The dataset profile will appear here once the job completes.
+      </Text>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Banner kind="inline" status="error" title="Failed to load dataset profile">
+        The profiler analysis could not be loaded for this job.
+      </Banner>
+    );
+  }
+
+  if (isLoading && !hasAnalysis) {
+    return (
+      <ColumnGrid>
+        {Array.from({ length: 6 }, (_, i) => (
+          <Skeleton key={i} className="h-40 w-full rounded-lg" />
+        ))}
+      </ColumnGrid>
+    );
+  }
+
+  if (!hasAnalysis) {
+    return (
+      <Text kind="body/regular/md" className="text-muted">
+        No dataset profile was generated for this job.
+      </Text>
+    );
+  }
+
+  const columns = analysis?.column_statistics ?? [];
+  const percentComplete = analysis ? getPercentComplete(analysis) : 0;
+
+  return (
+    <Stack gap="density-2xl" className="w-full">
+      {analysis ? (
+        <Stack gap="2">
+          <Flex justify="between" align="center" className="flex-wrap" gap="density-md">
+            <Text kind="body/regular/md">
+              {analysis.num_records.toLocaleString()} of{' '}
+              {analysis.target_num_records.toLocaleString()} rows
+            </Text>
+            <Text kind="body/regular/sm" className="text-muted">
+              {formatPercent(percentComplete)} complete
+            </Text>
+          </Flex>
+          <ProgressBar
+            kind="determinate"
+            value={percentComplete}
+            aria-label="Dataset completeness"
+          />
+        </Stack>
+      ) : null}
+
+      {columns.length > 0 ? (
+        <ColumnGrid>
+          {columns.map((stats) => (
+            <ColumnProfileCard key={stats.column_name} stats={stats} />
+          ))}
+        </ColumnGrid>
+      ) : (
+        <Text kind="body/regular/md" className="text-muted">
+          The profile did not include any column statistics.
+        </Text>
+      )}
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection.tsx
@@ -17,7 +17,7 @@ import { useDataDesignerArtifactsFileset } from '@studio/routes/DataDesignerJobD
 import { getFilesetDetailsRoute } from '@studio/routes/utils';
 import { getHumanReadableFileSize } from '@studio/util/files';
 import { useQueryClient } from '@tanstack/react-query';
-import { ComponentProps, FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ComponentProps, type FC } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 type FileRow = FilesetFileOutput & { id: string };
@@ -45,6 +45,8 @@ export const JobOutputFilesetSection: FC = () => {
     listFilesParams,
     files,
     isResultsLoading,
+    isResultsError,
+    resultsError,
     isFilesLoading,
     isFilesError: isListFilesError,
     filesError: listFilesError,
@@ -145,6 +147,20 @@ export const JobOutputFilesetSection: FC = () => {
           <Text kind="body/regular/md" className="text-muted">
             Loading job results…
           </Text>
+        </Stack>
+      </Card>
+    );
+  }
+
+  if (isResultsError) {
+    return (
+      <Card>
+        <Stack gap="4">
+          <Banner kind="inline" status="error" title="Could not load job results">
+            {resultsError instanceof Error
+              ? resultsError.message
+              : 'The job results list could not be loaded.'}
+          </Banner>
         </Stack>
       </Card>
     );

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection.tsx
@@ -1,38 +1,26 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { parseFilesetLocation } from '@nemo/common/src/components/DatasetFileSelect/parseFilesetLocation';
 import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
 import { KVPair } from '@nemo/common/src/components/KVPair';
 import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
-import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
-import { useDataDesignerListCreateJobResults } from '@nemo/sdk/generated/data-designer/api';
-import type { CreateJob as DataDesignerJob } from '@nemo/sdk/generated/data-designer/schema';
 import {
   getFilesListFilesetFilesQueryKey,
-  useFilesListFilesetFiles,
   useFilesRetrieveFileset,
 } from '@nemo/sdk/generated/platform/api';
 import type { FilesetFileOutput } from '@nemo/sdk/generated/platform/schema';
 import { Anchor, Banner, Card, Stack, Text } from '@nvidia/foundations-react-core';
 import { FilesetFilePreviewPanel } from '@studio/components/FilesetFilePreviewPanel';
 import type { FileSystemFile } from '@studio/components/FilesTable/utils';
+import { useDataDesignerArtifactsFileset } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerArtifactsFileset';
 import { getFilesetDetailsRoute } from '@studio/routes/utils';
 import { getHumanReadableFileSize } from '@studio/util/files';
 import { useQueryClient } from '@tanstack/react-query';
 import { ComponentProps, FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
-const ARTIFACTS_RESULT_NAME = 'artifacts';
-
 type FileRow = FilesetFileOutput & { id: string };
-
-interface JobOutputFilesetSectionProps {
-  workspace: string;
-  jobName: string;
-  job: DataDesignerJob;
-}
 
 function fileRowToSystemFile(row: FileRow): FileSystemFile {
   return {
@@ -43,50 +31,24 @@ function fileRowToSystemFile(row: FileRow): FileSystemFile {
   };
 }
 
-export const JobOutputFilesetSection: FC<JobOutputFilesetSectionProps> = ({
-  workspace,
-  jobName,
-  job,
-}) => {
+export const JobOutputFilesetSection: FC = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [previewFile, setPreviewFile] = useState<FileSystemFile | null>(null);
 
-  const isTerminal = job.status != null && PlatformJobTerminalStatuses.includes(job.status);
-
-  const { data: resultsResponse, isLoading: isResultsLoading } =
-    useDataDesignerListCreateJobResults(workspace, jobName, {
-      query: {
-        refetchInterval: isTerminal ? false : 3000,
-      },
-    });
-
-  const artifactsResult = useMemo(() => {
-    const data = resultsResponse?.data;
-    if (!data?.length) {
-      return undefined;
-    }
-    const preferred = data.find((r) => r.name === ARTIFACTS_RESULT_NAME);
-    if (preferred) {
-      return preferred;
-    }
-    return data.find((r) => r.artifact_url && parseFilesetLocation(r.artifact_url, workspace));
-  }, [resultsResponse?.data, workspace]);
-
-  const filesetLoc = useMemo(
-    () =>
-      artifactsResult?.artifact_url
-        ? parseFilesetLocation(artifactsResult.artifact_url, workspace)
-        : null,
-    [artifactsResult?.artifact_url, workspace]
-  );
-
-  const filesetWorkspace = filesetLoc?.workspace ?? '';
-  const filesetName = filesetLoc?.name ?? '';
-  const listFilesParams = useMemo(
-    () => (filesetLoc?.filesListPathPrefix ? { path: filesetLoc.filesListPathPrefix } : undefined),
-    [filesetLoc?.filesListPathPrefix]
-  );
+  const {
+    isTerminal,
+    artifactsResult,
+    filesetLoc,
+    filesetWorkspace,
+    filesetName,
+    listFilesParams,
+    files,
+    isResultsLoading,
+    isFilesLoading,
+    isFilesError: isListFilesError,
+    filesError: listFilesError,
+  } = useDataDesignerArtifactsFileset();
 
   const {
     data: filesetMeta,
@@ -99,25 +61,11 @@ export const JobOutputFilesetSection: FC<JobOutputFilesetSectionProps> = ({
     },
   });
 
-  const {
-    data: listFilesResponse,
-    isLoading: isFilesLoading,
-    isError: isListFilesError,
-    error: listFilesError,
-  } = useFilesListFilesetFiles(filesetWorkspace, filesetName, listFilesParams, {
-    query: {
-      enabled: Boolean(filesetWorkspace && filesetName),
-    },
-  });
-
   const dataViewState = useStudioDataViewState({
     defaultPageSize: 10,
   });
 
-  const rows: FileRow[] = useMemo(() => {
-    const fileList = listFilesResponse?.data ?? [];
-    return fileList.map((f) => ({ ...f, id: f.file_ref }));
-  }, [listFilesResponse?.data]);
+  const rows: FileRow[] = useMemo(() => files.map((f) => ({ ...f, id: f.file_ref })), [files]);
 
   const makeColumns: ComponentProps<typeof StudioDataView<FileRow>>['makeColumns'] = useMemo(
     () => (helpers) => [
@@ -190,10 +138,10 @@ export const JobOutputFilesetSection: FC<JobOutputFilesetSectionProps> = ({
     }
   }, [filesetWorkspace, filesetName]);
 
-  if (isResultsLoading && !resultsResponse) {
+  if (isResultsLoading && !artifactsResult) {
     return (
       <Card>
-        <Stack gap="4" padding="8">
+        <Stack gap="4">
           <Text kind="body/regular/md" className="text-muted">
             Loading job results…
           </Text>
@@ -205,8 +153,7 @@ export const JobOutputFilesetSection: FC<JobOutputFilesetSectionProps> = ({
   if (!artifactsResult) {
     return (
       <Card>
-        <Stack gap="4" padding="8">
-          <Text kind="body/bold/lg">Output fileset</Text>
+        <Stack gap="4">
           <Text kind="body/regular/md" className="text-muted">
             {isTerminal
               ? 'No artifacts result was returned for this job.'
@@ -220,8 +167,7 @@ export const JobOutputFilesetSection: FC<JobOutputFilesetSectionProps> = ({
   if (!filesetLoc) {
     return (
       <Card>
-        <Stack gap="4" padding="8">
-          <Text kind="body/bold/lg">Output fileset</Text>
+        <Stack gap="4">
           <KVPair
             label="Artifact URL"
             value={artifactsResult.artifact_url}
@@ -243,7 +189,7 @@ export const JobOutputFilesetSection: FC<JobOutputFilesetSectionProps> = ({
   return (
     <>
       <Card>
-        <Stack gap="2" padding="2">
+        <Stack gap="2">
           <Stack gap="2">
             <Text kind="body/bold/lg">Output fileset</Text>
             <Text kind="body/regular/sm" className="text-muted">
@@ -279,10 +225,6 @@ export const JobOutputFilesetSection: FC<JobOutputFilesetSectionProps> = ({
           </Stack>
 
           <Stack gap="4">
-            <Text kind="label/semibold/md">Files</Text>
-            <Text kind="body/regular/sm" className="text-muted">
-              Select a row to preview the file.
-            </Text>
             <StudioDataView<FileRow>
               dataViewState={dataViewState}
               makeColumns={makeColumns}

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/builderConfig.test.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/builderConfig.test.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  formatColumnTypeBreakdown,
+  summarizeBuilderConfig,
+} from '@studio/routes/DataDesignerJobDetailsRoute/builderConfig';
+
+const fullConfig = {
+  library_version: '1.2.3',
+  data_designer: {
+    columns: [
+      { name: 'product_id', column_type: 'sampler' },
+      { name: 'category', column_type: 'sampler' },
+      { name: 'review_text', column_type: 'llm-text', model_alias: 'review-model' },
+      { name: 'sentiment', column_type: 'llm-structured', model_alias: 'review-model' },
+    ],
+    model_configs: [
+      { alias: 'review-model', model: 'meta/llama-3.1-8b-instruct', provider: 'nvidia' },
+    ],
+    seed_config: { source: { seed_type: 'fileset' }, sampling_strategy: 'shuffle' },
+    constraints: [{}, {}],
+    profilers: [{}],
+    processors: [{ name: 'dedup' }, { name: 'drop-pii' }],
+  },
+};
+
+describe('summarizeBuilderConfig', () => {
+  it('returns null for non-config payloads', () => {
+    expect(summarizeBuilderConfig(null)).toBeNull();
+    expect(summarizeBuilderConfig('not json')).toBeNull();
+    expect(summarizeBuilderConfig({})).toBeNull();
+    expect(summarizeBuilderConfig([])).toBeNull();
+  });
+
+  it('extracts columns, models, seed, and counts from a full config', () => {
+    const summary = summarizeBuilderConfig(fullConfig);
+    expect(summary).not.toBeNull();
+    expect(summary?.columnCount).toBe(4);
+    expect(summary?.columns).toEqual([
+      { name: 'product_id', type: 'sampler', modelAlias: undefined },
+      { name: 'category', type: 'sampler', modelAlias: undefined },
+      { name: 'review_text', type: 'llm-text', modelAlias: 'review-model' },
+      { name: 'sentiment', type: 'llm-structured', modelAlias: 'review-model' },
+    ]);
+    expect(summary?.models).toEqual([
+      { alias: 'review-model', model: 'meta/llama-3.1-8b-instruct', provider: 'nvidia' },
+    ]);
+    expect(summary?.seed).toEqual({ type: 'fileset', samplingStrategy: 'shuffle' });
+    expect(summary?.constraintCount).toBe(2);
+    expect(summary?.profilerCount).toBe(1);
+    expect(summary?.processorNames).toEqual(['dedup', 'drop-pii']);
+    expect(summary?.libraryVersion).toBe('1.2.3');
+  });
+
+  it('orders the column-type breakdown by count then name', () => {
+    const summary = summarizeBuilderConfig(fullConfig);
+    expect(summary?.columnTypeBreakdown).toEqual([
+      { type: 'sampler', count: 2 },
+      { type: 'llm-structured', count: 1 },
+      { type: 'llm-text', count: 1 },
+    ]);
+    expect(formatColumnTypeBreakdown(summary!)).toBe('2 sampler, 1 llm-structured, 1 llm-text');
+  });
+
+  it('tolerates a minimal config and omits the absent seed', () => {
+    const summary = summarizeBuilderConfig({ data_designer: { columns: [] } });
+    expect(summary).not.toBeNull();
+    expect(summary?.columnCount).toBe(0);
+    expect(summary?.models).toEqual([]);
+    expect(summary?.seed).toBeUndefined();
+    expect(summary?.constraintCount).toBe(0);
+    expect(summary?.processorNames).toEqual([]);
+    expect(summary?.libraryVersion).toBeUndefined();
+  });
+
+  it('falls back gracefully for malformed entries', () => {
+    const summary = summarizeBuilderConfig({
+      data_designer: {
+        columns: [{ column_type: 'sampler' }, { name: 'x' }, 'garbage'],
+        model_configs: [{ alias: 'm1' }],
+      },
+    });
+    expect(summary?.columns).toEqual([
+      { name: '(unnamed)', type: 'sampler', modelAlias: undefined },
+      { name: 'x', type: 'unknown', modelAlias: undefined },
+      { name: '(unnamed)', type: 'unknown', modelAlias: undefined },
+    ]);
+    expect(summary?.models).toEqual([{ alias: 'm1', model: '—', provider: undefined }]);
+  });
+});

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/builderConfig.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/builderConfig.ts
@@ -15,32 +15,32 @@
 export const BUILDER_CONFIG_FILENAME = 'builder_config.json';
 
 export interface BuilderConfigColumnSummary {
-  name: string;
-  type: string;
-  modelAlias?: string;
+  readonly name: string;
+  readonly type: string;
+  readonly modelAlias?: string;
 }
 
 export interface BuilderConfigModelSummary {
-  alias: string;
-  model: string;
-  provider?: string;
+  readonly alias: string;
+  readonly model: string;
+  readonly provider?: string;
 }
 
 export interface BuilderConfigSeedSummary {
-  type: string;
-  samplingStrategy?: string;
+  readonly type: string;
+  readonly samplingStrategy?: string;
 }
 
 export interface BuilderConfigSummary {
-  columnCount: number;
-  columns: BuilderConfigColumnSummary[];
-  columnTypeBreakdown: Array<{ type: string; count: number }>;
-  models: BuilderConfigModelSummary[];
-  seed?: BuilderConfigSeedSummary;
-  constraintCount: number;
-  profilerCount: number;
-  processorNames: string[];
-  libraryVersion?: string;
+  readonly columnCount: number;
+  readonly columns: BuilderConfigColumnSummary[];
+  readonly columnTypeBreakdown: Array<{ type: string; count: number }>;
+  readonly models: BuilderConfigModelSummary[];
+  readonly seed?: BuilderConfigSeedSummary;
+  readonly constraintCount: number;
+  readonly profilerCount: number;
+  readonly processorNames: string[];
+  readonly libraryVersion?: string;
 }
 
 const asRecord = (value: unknown): Record<string, unknown> | undefined =>

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/builderConfig.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/builderConfig.ts
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Lightweight reader for the Data Designer `builder_config.json` artifact.
+ *
+ * The file is the serialized `BuilderConfig` Pydantic model
+ * (`{ data_designer: DataDesignerConfig, library_version }`). Rather than mirror
+ * the full discriminated-union config (that's the schema-inspector ticket), this
+ * extracts just the important fields for an at-a-glance summary, parsing
+ * defensively so an unexpected shape degrades gracefully instead of throwing.
+ *
+ * Filename inside the artifacts fileset.
+ */
+export const BUILDER_CONFIG_FILENAME = 'builder_config.json';
+
+export interface BuilderConfigColumnSummary {
+  name: string;
+  type: string;
+  modelAlias?: string;
+}
+
+export interface BuilderConfigModelSummary {
+  alias: string;
+  model: string;
+  provider?: string;
+}
+
+export interface BuilderConfigSeedSummary {
+  type: string;
+  samplingStrategy?: string;
+}
+
+export interface BuilderConfigSummary {
+  columnCount: number;
+  columns: BuilderConfigColumnSummary[];
+  columnTypeBreakdown: Array<{ type: string; count: number }>;
+  models: BuilderConfigModelSummary[];
+  seed?: BuilderConfigSeedSummary;
+  constraintCount: number;
+  profilerCount: number;
+  processorNames: string[];
+  libraryVersion?: string;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+const asArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
+const UNNAMED = '(unnamed)';
+
+/**
+ * Parses raw `builder_config.json` contents into a {@link BuilderConfigSummary}.
+ * Returns `null` when the payload is not a recognizable builder config (missing
+ * the top-level `data_designer` object).
+ */
+export const summarizeBuilderConfig = (raw: unknown): BuilderConfigSummary | null => {
+  const root = asRecord(raw);
+  const dataDesigner = asRecord(root?.data_designer);
+  if (!root || !dataDesigner) {
+    return null;
+  }
+
+  const columns: BuilderConfigColumnSummary[] = asArray(dataDesigner.columns).map((column) => {
+    const record = asRecord(column) ?? {};
+    return {
+      name: asString(record.name) ?? UNNAMED,
+      type: asString(record.column_type) ?? 'unknown',
+      modelAlias: asString(record.model_alias),
+    };
+  });
+
+  const breakdownCounts = new Map<string, number>();
+  for (const column of columns) {
+    breakdownCounts.set(column.type, (breakdownCounts.get(column.type) ?? 0) + 1);
+  }
+  const columnTypeBreakdown = [...breakdownCounts.entries()]
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type));
+
+  const models: BuilderConfigModelSummary[] = asArray(dataDesigner.model_configs).map((model) => {
+    const record = asRecord(model) ?? {};
+    return {
+      alias: asString(record.alias) ?? UNNAMED,
+      model: asString(record.model) ?? '—',
+      provider: asString(record.provider),
+    };
+  });
+
+  const seedConfig = asRecord(dataDesigner.seed_config);
+  const seedSource = asRecord(seedConfig?.source);
+  const seed: BuilderConfigSeedSummary | undefined = seedConfig
+    ? {
+        type: asString(seedSource?.seed_type) ?? 'unknown',
+        samplingStrategy: asString(seedConfig.sampling_strategy),
+      }
+    : undefined;
+
+  const processorNames = asArray(dataDesigner.processors).map(
+    (processor) => asString(asRecord(processor)?.name) ?? UNNAMED
+  );
+
+  return {
+    columnCount: columns.length,
+    columns,
+    columnTypeBreakdown,
+    models,
+    seed,
+    constraintCount: asArray(dataDesigner.constraints).length,
+    profilerCount: asArray(dataDesigner.profilers).length,
+    processorNames,
+    libraryVersion: asString(root.library_version),
+  };
+};
+
+/** Formats the column-type breakdown as a compact label (e.g. `3 sampler, 2 llm-text`). */
+export const formatColumnTypeBreakdown = (summary: BuilderConfigSummary): string =>
+  summary.columnTypeBreakdown.map(({ type, count }) => `${count} ${type}`).join(', ');

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes.test.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes.test.ts
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  describeColumnStats,
+  formatPercent,
+  formatStatCount,
+  formatStatDecimal,
+  getCategoricalHistogram,
+  getColumnTypeLabel,
+  getNumericalDistribution,
+  getPercentComplete,
+  getPercentNull,
+  getPercentUnique,
+  MISSING_VALUE,
+  type ColumnStatistics,
+  type DatasetProfilerResults,
+} from '@studio/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes';
+
+const baseStats = {
+  column_name: 'col',
+  num_records: 100,
+  num_null: 5,
+  num_unique: 80,
+  pyarrow_dtype: 'string',
+  simple_dtype: 'str',
+};
+
+describe('formatStatCount', () => {
+  it('formats numbers with locale separators', () => {
+    expect(formatStatCount(1234)).toBe((1234).toLocaleString());
+  });
+
+  it('renders the calculation-failed sentinel as an em dash', () => {
+    expect(formatStatCount(MISSING_VALUE.CALCULATION_FAILED)).toBe('—');
+  });
+
+  it('renders the output-format-error sentinel as text', () => {
+    expect(formatStatCount(MISSING_VALUE.OUTPUT_FORMAT_ERROR)).toBe('format error');
+  });
+
+  it('renders nullish values as an em dash', () => {
+    expect(formatStatCount(undefined)).toBe('—');
+    expect(formatStatCount(null)).toBe('—');
+  });
+});
+
+describe('formatStatDecimal', () => {
+  it('limits to one fractional digit', () => {
+    expect(formatStatDecimal(12.345)).toBe((12.3).toLocaleString());
+  });
+
+  it('passes sentinels through', () => {
+    expect(formatStatDecimal(MISSING_VALUE.CALCULATION_FAILED)).toBe('—');
+  });
+});
+
+describe('formatPercent', () => {
+  it('formats a percentage to one decimal', () => {
+    expect(formatPercent(42.5)).toBe('42.5%');
+  });
+
+  it('renders undefined as an em dash', () => {
+    expect(formatPercent(undefined)).toBe('—');
+  });
+});
+
+describe('getPercentComplete', () => {
+  it('computes completion percentage', () => {
+    const results = { num_records: 50, target_num_records: 200 } as DatasetProfilerResults;
+    expect(getPercentComplete(results)).toBe(25);
+  });
+
+  it('returns 0 when the target is non-positive', () => {
+    const results = { num_records: 10, target_num_records: 0 } as DatasetProfilerResults;
+    expect(getPercentComplete(results)).toBe(0);
+  });
+});
+
+describe('getPercentNull / getPercentUnique', () => {
+  it('computes percentages from counts', () => {
+    const stats = { ...baseStats, column_type: 'general' } as ColumnStatistics;
+    expect(getPercentNull(stats)).toBe(5);
+    expect(getPercentUnique(stats)).toBe(80);
+  });
+
+  it('returns undefined when a count is a missing-value sentinel', () => {
+    const stats = {
+      ...baseStats,
+      num_null: MISSING_VALUE.CALCULATION_FAILED,
+      num_unique: MISSING_VALUE.CALCULATION_FAILED,
+      column_type: 'general',
+    } as ColumnStatistics;
+    expect(getPercentNull(stats)).toBeUndefined();
+    expect(getPercentUnique(stats)).toBeUndefined();
+  });
+});
+
+describe('getColumnTypeLabel', () => {
+  it('returns the column type for non-sampler columns', () => {
+    const stats = { ...baseStats, column_type: 'llm-text' } as ColumnStatistics;
+    expect(getColumnTypeLabel(stats)).toBe('llm-text');
+  });
+
+  it('includes the sampler subtype for sampler columns', () => {
+    const stats = {
+      ...baseStats,
+      column_type: 'sampler',
+      sampler_type: 'category',
+      distribution_type: 'categorical',
+      distribution: null,
+    } as ColumnStatistics;
+    expect(getColumnTypeLabel(stats)).toBe('sampler · category');
+  });
+});
+
+describe('describeColumnStats (variant → render mapping)', () => {
+  it('summarizes LLM columns with token usage', () => {
+    const stats = {
+      ...baseStats,
+      column_type: 'llm-text',
+      input_tokens_mean: 120.4,
+      input_tokens_median: 100,
+      input_tokens_stddev: 10,
+      output_tokens_mean: 45.9,
+      output_tokens_median: 40,
+      output_tokens_stddev: 5,
+    } as ColumnStatistics;
+    expect(describeColumnStats(stats)).toBe(
+      `Tokens in/out (avg): ${formatStatDecimal(120.4)} / ${formatStatDecimal(45.9)}`
+    );
+  });
+
+  it('summarizes validation columns with valid-record counts', () => {
+    const stats = {
+      ...baseStats,
+      column_type: 'validation',
+      num_valid_records: 95,
+    } as ColumnStatistics;
+    expect(describeColumnStats(stats)).toBe('Valid records: 95');
+  });
+
+  it('summarizes categorical sampler columns with the most common value', () => {
+    const stats = {
+      ...baseStats,
+      column_type: 'sampler',
+      sampler_type: 'category',
+      distribution_type: 'categorical',
+      distribution: {
+        most_common_value: 'positive',
+        least_common_value: 'negative',
+        histogram: { categories: ['positive', 'negative'], counts: [70, 30] },
+      },
+    } as ColumnStatistics;
+    expect(describeColumnStats(stats)).toBe('Most common: positive');
+  });
+
+  it('summarizes numerical sampler columns with min/max/mean', () => {
+    const stats = {
+      ...baseStats,
+      column_type: 'sampler',
+      sampler_type: 'gaussian',
+      distribution_type: 'numerical',
+      distribution: { min: 1, max: 5, mean: 3.2, stddev: 1.1, median: 3 },
+    } as ColumnStatistics;
+    expect(describeColumnStats(stats)).toBe(
+      `min ${formatStatDecimal(1)} · max ${formatStatDecimal(5)} · mean ${formatStatDecimal(3.2)}`
+    );
+  });
+
+  it('falls back to an em dash for plain and unknown column types', () => {
+    expect(describeColumnStats({ ...baseStats, column_type: 'general' } as ColumnStatistics)).toBe(
+      '—'
+    );
+    expect(
+      describeColumnStats({ ...baseStats, column_type: 'some-plugin-type' } as ColumnStatistics)
+    ).toBe('—');
+  });
+
+  it('handles a missing sampler distribution without throwing', () => {
+    const stats = {
+      ...baseStats,
+      column_type: 'sampler',
+      sampler_type: 'uuid',
+      distribution_type: 'other',
+      distribution: null,
+    } as ColumnStatistics;
+    expect(describeColumnStats(stats)).toBe('—');
+  });
+});
+
+describe('getCategoricalHistogram', () => {
+  const histogram = { categories: ['positive', 'negative'], counts: [70, 30] };
+
+  it('returns the histogram for a categorical sampler column', () => {
+    const stats = {
+      ...baseStats,
+      column_type: 'sampler',
+      sampler_type: 'category',
+      distribution_type: 'categorical',
+      distribution: {
+        most_common_value: 'positive',
+        least_common_value: 'negative',
+        histogram,
+      },
+    } as ColumnStatistics;
+    expect(getCategoricalHistogram(stats)).toEqual(histogram);
+  });
+
+  it('returns null for numerical sampler columns', () => {
+    const stats = {
+      ...baseStats,
+      column_type: 'sampler',
+      sampler_type: 'gaussian',
+      distribution_type: 'numerical',
+      distribution: { min: 1, max: 5, mean: 3, stddev: 1, median: 3 },
+    } as ColumnStatistics;
+    expect(getCategoricalHistogram(stats)).toBeNull();
+  });
+
+  it('returns null for non-sampler columns and missing distributions', () => {
+    expect(
+      getCategoricalHistogram({ ...baseStats, column_type: 'llm-text' } as ColumnStatistics)
+    ).toBeNull();
+    expect(
+      getCategoricalHistogram({
+        ...baseStats,
+        column_type: 'sampler',
+        sampler_type: 'uuid',
+        distribution_type: 'other',
+        distribution: null,
+      } as ColumnStatistics)
+    ).toBeNull();
+    expect(
+      getCategoricalHistogram({
+        ...baseStats,
+        column_type: 'sampler',
+        sampler_type: 'category',
+        distribution_type: 'categorical',
+        distribution: MISSING_VALUE.CALCULATION_FAILED,
+      } as ColumnStatistics)
+    ).toBeNull();
+  });
+});
+
+describe('getNumericalDistribution', () => {
+  it('returns the distribution for a numerical sampler column', () => {
+    const distribution = { min: 1, max: 5, mean: 3.2, stddev: 1.1, median: 3 };
+    const stats = {
+      ...baseStats,
+      column_type: 'sampler',
+      sampler_type: 'gaussian',
+      distribution_type: 'numerical',
+      distribution,
+    } as ColumnStatistics;
+    expect(getNumericalDistribution(stats)).toEqual(distribution);
+  });
+
+  it('returns null for categorical and non-sampler columns', () => {
+    const categorical = {
+      ...baseStats,
+      column_type: 'sampler',
+      sampler_type: 'category',
+      distribution_type: 'categorical',
+      distribution: {
+        most_common_value: 'a',
+        least_common_value: 'b',
+        histogram: { categories: ['a', 'b'], counts: [1, 2] },
+      },
+    } as ColumnStatistics;
+    expect(getNumericalDistribution(categorical)).toBeNull();
+    expect(
+      getNumericalDistribution({ ...baseStats, column_type: 'general' } as ColumnStatistics)
+    ).toBeNull();
+  });
+});

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes.ts
@@ -133,7 +133,13 @@ export interface DatasetProfilerResults {
 
 const LLM_COLUMN_TYPES = new Set(['llm-text', 'llm-code', 'llm-structured', 'llm-judge']);
 
-export const isLLMColumnStatistics = (stats: ColumnStatistics): stats is LLMTextColumnStatistics =>
+export type LLMColumnStatistics =
+  | LLMTextColumnStatistics
+  | LLMCodeColumnStatistics
+  | LLMStructuredColumnStatistics
+  | LLMJudgedColumnStatistics;
+
+export const isLLMColumnStatistics = (stats: ColumnStatistics): stats is LLMColumnStatistics =>
   LLM_COLUMN_TYPES.has(stats.column_type);
 
 export const isValidationColumnStatistics = (
@@ -149,7 +155,8 @@ export const getPercentComplete = (results: DatasetProfilerResults): number => {
   if (results.target_num_records <= 0) {
     return 0;
   }
-  return (100 * results.num_records) / results.target_num_records;
+  const percent = (100 * results.num_records) / results.target_num_records;
+  return Math.max(0, Math.min(100, percent));
 };
 
 /** `num_unique / num_records` as a percentage, or undefined when unavailable. */

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes.ts
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Hand-written TypeScript mirror of the Data Designer `DatasetProfilerResults`
+ * Pydantic model (data_designer.config.analysis.dataset_profiler).
+ *
+ */
+
+/** Sentinel emitted by the profiler when a statistic could not be computed. */
+export const MISSING_VALUE = {
+  CALCULATION_FAILED: '--',
+  OUTPUT_FORMAT_ERROR: 'output_format_error',
+} as const;
+
+export type MissingValue = (typeof MISSING_VALUE)[keyof typeof MISSING_VALUE];
+
+/** A numeric statistic that may instead be a {@link MissingValue} sentinel. */
+export type MaybeMissing<T> = T | MissingValue;
+
+export const isMissingValue = (value: unknown): value is MissingValue =>
+  value === MISSING_VALUE.CALCULATION_FAILED || value === MISSING_VALUE.OUTPUT_FORMAT_ERROR;
+
+export interface CategoricalHistogramData {
+  categories: Array<string | number>;
+  counts: number[];
+}
+
+export interface CategoricalDistribution {
+  most_common_value: string | number;
+  least_common_value: string | number;
+  histogram: CategoricalHistogramData;
+}
+
+export interface NumericalDistribution {
+  min: number;
+  max: number;
+  mean: number;
+  stddev: number;
+  median: number;
+}
+
+/** Fields shared by every column-statistics variant (GeneralColumnStatistics). */
+interface BaseColumnStatistics {
+  column_name: string;
+  num_records: MaybeMissing<number>;
+  num_null: MaybeMissing<number>;
+  num_unique: MaybeMissing<number>;
+  pyarrow_dtype: string;
+  simple_dtype: string;
+}
+
+export interface GeneralColumnStatistics extends BaseColumnStatistics {
+  column_type: 'general';
+}
+
+/** Token-usage metrics shared by all LLM-backed column types. */
+interface LLMColumnStatisticsBase extends BaseColumnStatistics {
+  output_tokens_mean: MaybeMissing<number>;
+  output_tokens_median: MaybeMissing<number>;
+  output_tokens_stddev: MaybeMissing<number>;
+  input_tokens_mean: MaybeMissing<number>;
+  input_tokens_median: MaybeMissing<number>;
+  input_tokens_stddev: MaybeMissing<number>;
+}
+
+export interface LLMTextColumnStatistics extends LLMColumnStatisticsBase {
+  column_type: 'llm-text';
+}
+
+export interface LLMCodeColumnStatistics extends LLMColumnStatisticsBase {
+  column_type: 'llm-code';
+}
+
+export interface LLMStructuredColumnStatistics extends LLMColumnStatisticsBase {
+  column_type: 'llm-structured';
+}
+
+export interface LLMJudgedColumnStatistics extends LLMColumnStatisticsBase {
+  column_type: 'llm-judge';
+}
+
+export interface SamplerColumnStatistics extends BaseColumnStatistics {
+  column_type: 'sampler';
+  sampler_type: string;
+  distribution_type: 'categorical' | 'numerical' | 'text' | 'other' | 'unknown';
+  distribution: CategoricalDistribution | NumericalDistribution | MissingValue | null;
+}
+
+export interface SeedDatasetColumnStatistics extends BaseColumnStatistics {
+  column_type: 'seed-dataset';
+}
+
+export interface ValidationColumnStatistics extends BaseColumnStatistics {
+  column_type: 'validation';
+  num_valid_records: MaybeMissing<number>;
+}
+
+export interface ExpressionColumnStatistics extends BaseColumnStatistics {
+  column_type: 'expression';
+}
+
+/**
+ * Plugin-provided column generators dynamically register General-shaped
+ * statistics classes with their own `column_type`, so an unknown discriminator
+ * still carries the base fields.
+ */
+export interface UnknownColumnStatistics extends BaseColumnStatistics {
+  column_type: string;
+}
+
+export type ColumnStatistics =
+  | GeneralColumnStatistics
+  | LLMTextColumnStatistics
+  | LLMCodeColumnStatistics
+  | LLMStructuredColumnStatistics
+  | LLMJudgedColumnStatistics
+  | SamplerColumnStatistics
+  | SeedDatasetColumnStatistics
+  | ValidationColumnStatistics
+  | ExpressionColumnStatistics
+  | UnknownColumnStatistics;
+
+export interface DatasetProfilerResults {
+  num_records: number;
+  target_num_records: number;
+  column_statistics: ColumnStatistics[];
+  side_effect_column_names?: string[] | null;
+  // Advanced profiler results (e.g. JudgeScoreProfilerResults). Rendered as a
+  // follow-up; typed loosely until the schema stabilizes.
+  column_profiles?: unknown[] | null;
+}
+
+const LLM_COLUMN_TYPES = new Set(['llm-text', 'llm-code', 'llm-structured', 'llm-judge']);
+
+export const isLLMColumnStatistics = (stats: ColumnStatistics): stats is LLMTextColumnStatistics =>
+  LLM_COLUMN_TYPES.has(stats.column_type);
+
+export const isValidationColumnStatistics = (
+  stats: ColumnStatistics
+): stats is ValidationColumnStatistics => stats.column_type === 'validation';
+
+export const isSamplerColumnStatistics = (
+  stats: ColumnStatistics
+): stats is SamplerColumnStatistics => stats.column_type === 'sampler';
+
+/** Completion percentage of the dataset (mirrors `percent_complete`). */
+export const getPercentComplete = (results: DatasetProfilerResults): number => {
+  if (results.target_num_records <= 0) {
+    return 0;
+  }
+  return (100 * results.num_records) / results.target_num_records;
+};
+
+/** `num_unique / num_records` as a percentage, or undefined when unavailable. */
+export const getPercentUnique = (stats: ColumnStatistics): number | undefined => {
+  if (
+    isMissingValue(stats.num_unique) ||
+    isMissingValue(stats.num_records) ||
+    stats.num_records <= 0
+  ) {
+    return undefined;
+  }
+  return (100 * stats.num_unique) / stats.num_records;
+};
+
+/** `num_null / num_records` as a percentage, or undefined when unavailable. */
+export const getPercentNull = (stats: ColumnStatistics): number | undefined => {
+  if (
+    isMissingValue(stats.num_null) ||
+    isMissingValue(stats.num_records) ||
+    stats.num_records <= 0
+  ) {
+    return undefined;
+  }
+  return (100 * stats.num_null) / stats.num_records;
+};
+
+const EM_DASH = '—';
+
+/** Render a sentinel-or-undefined value as display text, or `null` if it's a real value. */
+const formatSentinel = (value: MaybeMissing<number> | null | undefined): string | null => {
+  if (value == null) {
+    return EM_DASH;
+  }
+  if (value === MISSING_VALUE.OUTPUT_FORMAT_ERROR) {
+    return 'format error';
+  }
+  if (value === MISSING_VALUE.CALCULATION_FAILED) {
+    return EM_DASH;
+  }
+  return null;
+};
+
+/** Format a whole-number statistic, surfacing missing-value sentinels as text. */
+export const formatStatCount = (value: MaybeMissing<number> | null | undefined): string =>
+  formatSentinel(value) ?? (value as number).toLocaleString();
+
+/** Format a (possibly fractional) statistic, surfacing missing-value sentinels as text. */
+export const formatStatDecimal = (value: MaybeMissing<number> | null | undefined): string =>
+  formatSentinel(value) ??
+  (value as number).toLocaleString(undefined, { maximumFractionDigits: 1 });
+
+/** Format a percentage produced by the getPercent* helpers. */
+export const formatPercent = (value: number | undefined): string =>
+  value == null ? EM_DASH : `${value.toFixed(1)}%`;
+
+/** Human-readable label for a column's generator type (e.g. `sampler · category`). */
+export const getColumnTypeLabel = (stats: ColumnStatistics): string =>
+  isSamplerColumnStatistics(stats) ? `sampler · ${stats.sampler_type}` : stats.column_type;
+
+export const isCategoricalDistribution = (
+  distribution: CategoricalDistribution | NumericalDistribution
+): distribution is CategoricalDistribution => 'histogram' in distribution;
+
+/**
+ * Categorical histogram for a sampler column, or `null` when the column isn't a
+ * sampler, has no distribution, or its distribution isn't categorical. Use this
+ * to decide whether a column should render a bar chart of its value counts.
+ */
+export const getCategoricalHistogram = (
+  stats: ColumnStatistics
+): CategoricalHistogramData | null => {
+  if (!isSamplerColumnStatistics(stats)) {
+    return null;
+  }
+  const { distribution } = stats;
+  if (distribution == null || isMissingValue(distribution)) {
+    return null;
+  }
+  return isCategoricalDistribution(distribution) ? distribution.histogram : null;
+};
+
+/**
+ * Numerical distribution (min/max/mean/median/stddev) for a sampler column, or
+ * `null` when the column isn't a sampler with a numerical distribution.
+ */
+export const getNumericalDistribution = (stats: ColumnStatistics): NumericalDistribution | null => {
+  if (!isSamplerColumnStatistics(stats)) {
+    return null;
+  }
+  const { distribution } = stats;
+  if (distribution == null || isMissingValue(distribution)) {
+    return null;
+  }
+  return isCategoricalDistribution(distribution) ? null : distribution;
+};
+
+const describeSamplerDistribution = (stats: SamplerColumnStatistics): string => {
+  const { distribution } = stats;
+  if (distribution == null) {
+    return EM_DASH;
+  }
+  if (isMissingValue(distribution)) {
+    return formatSentinel(distribution) ?? EM_DASH;
+  }
+  if (isCategoricalDistribution(distribution)) {
+    return `Most common: ${distribution.most_common_value}`;
+  }
+  return `min ${formatStatDecimal(distribution.min)} · max ${formatStatDecimal(
+    distribution.max
+  )} · mean ${formatStatDecimal(distribution.mean)}`;
+};
+
+/**
+ * Variant-specific one-line summary for a column's "Details" cell. LLM columns
+ * surface token usage, validation columns surface valid-record counts, sampler
+ * columns surface their distribution, and everything else falls back to a dash.
+ */
+export const describeColumnStats = (stats: ColumnStatistics): string => {
+  if (isLLMColumnStatistics(stats)) {
+    return `Tokens in/out (avg): ${formatStatDecimal(
+      stats.input_tokens_mean
+    )} / ${formatStatDecimal(stats.output_tokens_mean)}`;
+  }
+  if (isValidationColumnStatistics(stats)) {
+    return `Valid records: ${formatStatCount(stats.num_valid_records)}`;
+  }
+  if (isSamplerColumnStatistics(stats)) {
+    return describeSamplerDistribution(stats);
+  }
+  return EM_DASH;
+};

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
@@ -22,7 +22,7 @@ import { JobOutputFilesetSection } from '@studio/routes/DataDesignerJobDetailsRo
 import { useDataDesignerJobFromRoute } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerJobFromRoute';
 import { getDataDesignerJobListRoute } from '@studio/routes/utils';
 import { ArrowLeft, FileJson } from 'lucide-react';
-import { FC, useState } from 'react';
+import { useState, type FC } from 'react';
 import { Link } from 'react-router-dom';
 
 export const DataDesignerJobDetailsRoute: FC = () => {

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
@@ -3,39 +3,39 @@
 
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
-import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
-import { useDataDesignerGetCreateJob } from '@nemo/sdk/generated/data-designer/api';
-import { Button, Card, Stack, Text } from '@nvidia/foundations-react-core';
+import {
+  Button,
+  Flex,
+  Stack,
+  TabsContent,
+  TabsList,
+  TabsRoot,
+  TabsTrigger,
+  Text,
+} from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { Loading } from '@studio/components/Layouts/Loading';
-import { ROUTE_PARAMS } from '@studio/constants/routes';
-import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { DataDesignerConfigPanel } from '@studio/routes/DataDesignerJobDetailsRoute/DataDesignerConfigPanel';
+import { DatasetProfilerSection } from '@studio/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection';
 import { JobOutputFilesetSection } from '@studio/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection';
+import { useDataDesignerJobFromRoute } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerJobFromRoute';
 import { getDataDesignerJobListRoute } from '@studio/routes/utils';
-import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
-import { ArrowLeft } from 'lucide-react';
-import { FC } from 'react';
+import { ArrowLeft, FileJson } from 'lucide-react';
+import { FC, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 export const DataDesignerJobDetailsRoute: FC = () => {
-  const workspace = useWorkspaceFromPath();
-  const { dataDesignerJobName } = useRequiredPathParams([ROUTE_PARAMS.dataDesignerJobName]);
-
   const {
-    data: job,
+    workspace,
+    jobName: dataDesignerJobName,
+    job,
     isLoading,
     isError,
     refetch,
-  } = useDataDesignerGetCreateJob(workspace, dataDesignerJobName, {
-    query: {
-      refetchInterval: (query) => {
-        const status = query.state.data?.status;
-        const isTerminated = status && PlatformJobTerminalStatuses.includes(status);
-        return isTerminated ? false : 3000;
-      },
-    },
-  });
+  } = useDataDesignerJobFromRoute();
+
+  const [isConfigPanelOpen, setIsConfigPanelOpen] = useState(false);
 
   useBreadcrumbs({
     items: [
@@ -78,25 +78,23 @@ export const DataDesignerJobDetailsRoute: FC = () => {
 
   return (
     <AccessibleTitle title={`Data Designer Job - ${job.name}`}>
-      <Stack className="h-full overflow-auto" gap="density-2xl" padding="density-2xl">
-        <Button asChild kind="secondary">
-          <Link to={getDataDesignerJobListRoute(workspace)}>
-            <ArrowLeft /> Back to Data Designer
-          </Link>
-        </Button>
-
-        <Card>
-          <Stack gap="density-lg">
-            <Text kind="body/bold/2xl">{job.name}</Text>
-            {job.description && (
-              <Text kind="body/regular/md" className="text-muted">
-                {job.description}
-              </Text>
-            )}
-            <Stack direction="row" gap="density-md" align="center">
-              <Text kind="label/semibold/md">Status:</Text>
+      <Stack className="h-full min-h-0" gap="density-2xl" padding="density-2xl">
+        <Stack gap="density-md">
+          <Flex gap="density-md" align="center" justify="between" className="flex-wrap">
+            <Flex gap="density-md" align="center" className="flex-wrap">
+              <Text kind="body/bold/2xl">{job.name}</Text>
               {job.status ? <StatusBadge status={job.status} /> : null}
-            </Stack>
+            </Flex>
+            <Button type="button" kind="secondary" onClick={() => setIsConfigPanelOpen(true)}>
+              <FileJson /> View config
+            </Button>
+          </Flex>
+          {job.description && (
+            <Text kind="body/regular/md" className="text-muted">
+              {job.description}
+            </Text>
+          )}
+          <Flex gap="density-lg" className="flex-wrap">
             {job.created_at && (
               <Text kind="body/regular/sm" className="text-muted">
                 Created: {new Date(job.created_at).toLocaleString()}
@@ -107,11 +105,29 @@ export const DataDesignerJobDetailsRoute: FC = () => {
                 Updated: {new Date(job.updated_at).toLocaleString()}
               </Text>
             )}
-          </Stack>
-        </Card>
+          </Flex>
+        </Stack>
 
-        <JobOutputFilesetSection workspace={workspace} jobName={dataDesignerJobName} job={job} />
+        <TabsRoot defaultValue="profile" className="flex min-h-0 w-full min-w-0 flex-1 flex-col">
+          <TabsList>
+            <TabsTrigger value="profile">Profile</TabsTrigger>
+            <TabsTrigger value="output">Output files</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="profile" className="min-h-0 flex-1 overflow-y-auto px-0">
+            <DatasetProfilerSection />
+          </TabsContent>
+
+          <TabsContent value="output" className="min-h-0 flex-1 overflow-y-auto px-0">
+            <JobOutputFilesetSection />
+          </TabsContent>
+        </TabsRoot>
       </Stack>
+
+      <DataDesignerConfigPanel
+        open={isConfigPanelOpen}
+        onClose={() => setIsConfigPanelOpen(false)}
+      />
     </AccessibleTitle>
   );
 };

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/useDataDesignerArtifactsFileset.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/useDataDesignerArtifactsFileset.ts
@@ -23,10 +23,14 @@ export const useDataDesignerArtifactsFileset = () => {
 
   const isTerminal = job?.status != null && PlatformJobTerminalStatuses.includes(job.status);
 
-  const { data: resultsResponse, isLoading: isResultsLoading } =
-    useDataDesignerListCreateJobResults(workspace, jobName, {
-      query: { refetchInterval: isTerminal ? false : 3000 },
-    });
+  const {
+    data: resultsResponse,
+    isLoading: isResultsLoading,
+    isError: isResultsError,
+    error: resultsError,
+  } = useDataDesignerListCreateJobResults(workspace, jobName, {
+    query: { refetchInterval: isTerminal ? false : 3000 },
+  });
 
   const artifactsResult = useMemo(() => {
     const data = resultsResponse?.data;
@@ -83,6 +87,8 @@ export const useDataDesignerArtifactsFileset = () => {
     listFilesParams,
     files,
     isResultsLoading,
+    isResultsError,
+    resultsError,
     isFilesLoading,
     isFilesError,
     filesError,

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/useDataDesignerArtifactsFileset.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/useDataDesignerArtifactsFileset.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { parseFilesetLocation } from '@nemo/common/src/components/DatasetFileSelect/parseFilesetLocation';
+import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
+import { useDataDesignerListCreateJobResults } from '@nemo/sdk/generated/data-designer/api';
+import { useFilesListFilesetFiles } from '@nemo/sdk/generated/platform/api';
+import type { FilesetFileOutput } from '@nemo/sdk/generated/platform/schema';
+import { useDataDesignerJobFromRoute } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerJobFromRoute';
+import { useMemo } from 'react';
+
+/** Result name under which a job registers its output artifacts fileset. */
+const ARTIFACTS_RESULT_NAME = 'artifacts';
+
+/**
+ * Resolves the output artifacts fileset for the current Data Designer job:
+ * finds the `artifacts` result, parses its fileset location, and lists the
+ * files inside it. Shared by the output-fileset section and the config panel
+ * so both agree on which fileset (and files) belong to the job.
+ */
+export const useDataDesignerArtifactsFileset = () => {
+  const { workspace, jobName, job } = useDataDesignerJobFromRoute();
+
+  const isTerminal = job?.status != null && PlatformJobTerminalStatuses.includes(job.status);
+
+  const { data: resultsResponse, isLoading: isResultsLoading } =
+    useDataDesignerListCreateJobResults(workspace, jobName, {
+      query: { refetchInterval: isTerminal ? false : 3000 },
+    });
+
+  const artifactsResult = useMemo(() => {
+    const data = resultsResponse?.data;
+    if (!data?.length) {
+      return undefined;
+    }
+    const preferred = data.find((r) => r.name === ARTIFACTS_RESULT_NAME);
+    if (preferred) {
+      return preferred;
+    }
+    return data.find((r) => r.artifact_url && parseFilesetLocation(r.artifact_url, workspace));
+  }, [resultsResponse?.data, workspace]);
+
+  const filesetLoc = useMemo(
+    () =>
+      artifactsResult?.artifact_url
+        ? parseFilesetLocation(artifactsResult.artifact_url, workspace)
+        : null,
+    [artifactsResult?.artifact_url, workspace]
+  );
+
+  const filesetWorkspace = filesetLoc?.workspace ?? '';
+  const filesetName = filesetLoc?.name ?? '';
+  const listFilesParams = useMemo(
+    () => (filesetLoc?.filesListPathPrefix ? { path: filesetLoc.filesListPathPrefix } : undefined),
+    [filesetLoc?.filesListPathPrefix]
+  );
+
+  const {
+    data: listFilesResponse,
+    isLoading: isFilesLoading,
+    isError: isFilesError,
+    error: filesError,
+  } = useFilesListFilesetFiles(filesetWorkspace, filesetName, listFilesParams, {
+    query: {
+      enabled: Boolean(filesetWorkspace && filesetName),
+    },
+  });
+
+  const files: FilesetFileOutput[] = useMemo(
+    () => listFilesResponse?.data ?? [],
+    [listFilesResponse?.data]
+  );
+
+  return {
+    workspace,
+    jobName,
+    job,
+    isTerminal,
+    artifactsResult,
+    filesetLoc,
+    filesetWorkspace,
+    filesetName,
+    listFilesParams,
+    files,
+    isResultsLoading,
+    isFilesLoading,
+    isFilesError,
+    filesError,
+  };
+};

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/useDataDesignerJobAnalysis.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/useDataDesignerJobAnalysis.ts
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  dataDesignerDownloadCreateJobResult,
+  getDataDesignerDownloadCreateJobResultQueryKey,
+  useDataDesignerListCreateJobResults,
+} from '@nemo/sdk/generated/data-designer/api';
+import type { DatasetProfilerResults } from '@studio/routes/DataDesignerJobDetailsRoute/datasetProfilerTypes';
+import { useQuery } from '@tanstack/react-query';
+
+/** Result name under which the profiler analysis JSON is registered for a job. */
+const ANALYSIS_RESULT_NAME = 'analysis';
+
+interface UseDataDesignerJobAnalysisOptions {
+  /** Gate the download until the job has reached a terminal status. */
+  enabled?: boolean;
+}
+
+/**
+ * Loads and parses the {@link DatasetProfilerResults} for a Data Designer job.
+ *
+ * The profiler output is exposed as a downloadable JSON result named
+ * `analysis`. We first list the job's results to confirm the analysis exists
+ * (a failed job never produces one) and only then download + parse it, so a
+ * missing profile surfaces as `hasAnalysis: false` rather than a 404.
+ */
+export const useDataDesignerJobAnalysis = (
+  workspace: string,
+  jobName: string,
+  { enabled = true }: UseDataDesignerJobAnalysisOptions = {}
+) => {
+  const { data: resultsResponse, isLoading: isResultsLoading } =
+    useDataDesignerListCreateJobResults(workspace, jobName, {
+      query: { enabled: enabled && Boolean(workspace && jobName) },
+    });
+
+  const hasAnalysis = Boolean(
+    resultsResponse?.data?.some((result) => result.name === ANALYSIS_RESULT_NAME)
+  );
+
+  const analysisQuery = useQuery({
+    queryKey: getDataDesignerDownloadCreateJobResultQueryKey(
+      workspace,
+      jobName,
+      ANALYSIS_RESULT_NAME
+    ),
+    queryFn: async ({ signal }): Promise<DatasetProfilerResults> => {
+      const blob = await dataDesignerDownloadCreateJobResult(
+        workspace,
+        jobName,
+        ANALYSIS_RESULT_NAME,
+        signal
+      );
+      const text = await blob.text();
+      return JSON.parse(text) as DatasetProfilerResults;
+    },
+    enabled: enabled && hasAnalysis,
+  });
+
+  return {
+    analysis: analysisQuery.data,
+    hasAnalysis,
+    isLoading: isResultsLoading || (hasAnalysis && analysisQuery.isLoading),
+    isError: analysisQuery.isError,
+    error: analysisQuery.error,
+  };
+};

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/useDataDesignerJobAnalysis.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/useDataDesignerJobAnalysis.ts
@@ -30,10 +30,14 @@ export const useDataDesignerJobAnalysis = (
   jobName: string,
   { enabled = true }: UseDataDesignerJobAnalysisOptions = {}
 ) => {
-  const { data: resultsResponse, isLoading: isResultsLoading } =
-    useDataDesignerListCreateJobResults(workspace, jobName, {
-      query: { enabled: enabled && Boolean(workspace && jobName) },
-    });
+  const {
+    data: resultsResponse,
+    isLoading: isResultsLoading,
+    isError: isResultsError,
+    error: resultsError,
+  } = useDataDesignerListCreateJobResults(workspace, jobName, {
+    query: { enabled: enabled && Boolean(workspace && jobName) },
+  });
 
   const hasAnalysis = Boolean(
     resultsResponse?.data?.some((result) => result.name === ANALYSIS_RESULT_NAME)
@@ -62,7 +66,7 @@ export const useDataDesignerJobAnalysis = (
     analysis: analysisQuery.data,
     hasAnalysis,
     isLoading: isResultsLoading || (hasAnalysis && analysisQuery.isLoading),
-    isError: analysisQuery.isError,
-    error: analysisQuery.error,
+    isError: isResultsError || analysisQuery.isError,
+    error: resultsError ?? analysisQuery.error,
   };
 };

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/useDataDesignerJobFromRoute.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/useDataDesignerJobFromRoute.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
+import { useDataDesignerGetCreateJob } from '@nemo/sdk/generated/data-designer/api';
+import { ROUTE_PARAMS } from '@studio/constants/routes';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
+
+export const useDataDesignerJobFromRoute = () => {
+  const workspace = useWorkspaceFromPath();
+  const { dataDesignerJobName } = useRequiredPathParams([ROUTE_PARAMS.dataDesignerJobName]);
+
+  const query = useDataDesignerGetCreateJob(workspace, dataDesignerJobName, {
+    query: {
+      refetchInterval: (q) => {
+        const status = q.state.data?.status;
+        const isTerminated = status && PlatformJobTerminalStatuses.includes(status);
+        return isTerminated ? false : 3000;
+      },
+    },
+  });
+
+  return {
+    ...query,
+    workspace,
+    jobName: dataDesignerJobName,
+    job: query.data,
+  };
+};


### PR DESCRIPTION
<img width="1660" height="779" alt="Screenshot 2026-06-23 at 4 44 03 PM" src="https://github.com/user-attachments/assets/4401e970-e301-43c5-b836-d0c0c5419f5a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a richer Data Designer job details experience with tabs for profile and output files.
  * Introduced a configuration side panel to view job settings and summary details.
  * Added column profiling visuals, including categorical histograms and dataset completion progress.

* **Bug Fixes**
  * Improved handling of missing or malformed profiling/config data with clearer empty, loading, and error states.
  * Updated the default build model identifier to a corrected value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->