### PR TITLE
chore: rename switchyard to switchyard-vendored

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -360,7 +360,7 @@ nemo-safe-synthesizer-plugin = [
 # Generated from [tool.bundle-package]; do not edit by hand.
 nemo-switchyard = [
   "nemo-platform-plugin",
-  "switchyard",
+  "switchyard-vendored",
 ]
 
 # Generated from [tool.bundle-package]; do not edit by hand.
@@ -446,7 +446,7 @@ studio-service = [
 ]
 
 # Generated from [tool.bundle-package]; do not edit by hand.
-switchyard = [
+switchyard-vendored = [
   "openai>=2.34.0,<3.0",
   "anthropic>=0.99.0,<1.0",
   "httpx>=0.28.1,<1.0",
@@ -589,7 +589,7 @@ nemo-evaluator-sdk = { source = "../../packages/nemo_evaluator_sdk/src/nemo_eval
 data-designer-nemo = { source = "../../packages/data_designer_nemo/src/data_designer_nemo", module = "data_designer_nemo" }
 nmp-platform-runner = { source = "../../packages/nmp_platform_runner/src/nmp/platform_runner", module = "nmp/platform_runner", deps_group = "services" }
 garak-api = { source = "../../packages/garak_api/garakapi", module = "garakapi", deps_group = "auditor-service" }
-switchyard = { source = "../../plugins/nemo-switchyard/vendor/switchyard/switchyard", module = "switchyard" }
+switchyard-vendored = { source = "../../plugins/nemo-switchyard/vendor/switchyard/switchyard", module = "switchyard" }
 
 # Default first-party plugins
 nemo-agents-plugin = { source = "../../plugins/nemo-agents/src/nemo_agents_plugin", module = "nemo_agents_plugin", inherit = { "entry-points" = ["nemo.*", "nat.plugins"] } }

--- a/plugins/nemo-switchyard/pyproject.toml
+++ b/plugins/nemo-switchyard/pyproject.toml
@@ -5,13 +5,13 @@ description = "Switchyard inference middleware plugin for NeMo Inference Gateway
 requires-python = ">=3.11,<3.15"
 dependencies = [
     "nemo-platform-plugin",
-    "switchyard",
+    "switchyard-vendored",
 ]
 
 [tool.uv.sources]
 # Vendored snapshot of switchyard at commit 9407922 — see vendor/switchyard/README.md.
 # Swap to a git submodule once CI has reliable access to the upstream repo.
-switchyard = { path = "vendor/switchyard", editable = true }
+switchyard-vendored = { path = "vendor/switchyard", editable = true }
 
 [project.entry-points."nemo.inference_middleware"]
 nemo-switchyard = "nemo_switchyard.middleware:SwitchyardMiddleware"

--- a/plugins/nemo-switchyard/vendor/switchyard/pyproject.toml
+++ b/plugins/nemo-switchyard/vendor/switchyard/pyproject.toml
@@ -10,7 +10,7 @@ requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "switchyard"
+name = "switchyard-vendored"
 version = "0.1.0+vendored.9407922"
 description = "Vendored subset of Switchyard (lib + telemetry) for the NeMo Platform nemo-switchyard plugin"
 readme = "README.md"

--- a/third_party/osv-licenses.json
+++ b/third_party/osv-licenses.json
@@ -6591,12 +6591,15 @@
           },
           "vulnerabilities": [
             {
-              "modified": "2026-06-16T23:45:08Z",
+              "modified": "2026-06-23T18:29:29Z",
               "published": "2026-06-16T23:38:26Z",
               "schema_version": "1.7.5",
               "id": "GHSA-4xpc-pv4p-pm3w",
               "aliases": [
                 "CVE-2026-49468"
+              ],
+              "related": [
+                "CGA-g6cx-6c7p-wp3m"
               ],
               "summary": "LiteLLM: Authentication Bypass via Host Header Injection",
               "details": "### Impact\n\nA Host-header parsing flaw in the LiteLLM proxy could, under specific conditions, allow unauthenticated access to protected management routes.\n\nThe auth layer derived the effective route from `request.url.path` in `litellm/proxy/auth/auth_utils.py::get_request_route()`, which Starlette reconstructs from the `Host` header. A crafted `Host` could therefore make the auth gate evaluate a different route from the one FastAPI dispatched.\n\n**Most deployments are not affected.** The bypass is blocked by any upstream layer that validates or normalizes `Host`, such as:\n\n- a CDN or WAF, such as Cloudflare\n- a reverse proxy with `server_name` allowlists\n- a host-based load balancer\n\n**LiteLLM Cloud customers are not affected.**\n\n### Patches\n\nFixed in **`1.84.0`**. Upgrade to `1.84.0` or later. No configuration change is required.\n\n### Workarounds\n\nIf upgrading is not immediately possible, place the proxy behind an upstream component that validates or normalizes the `Host` header before forwarding (a CDN/WAF, a reverse proxy with explicit `server_name` allowlists, or a cloud load balancer with host-based routing rules), or otherwise restrict network access to the proxy listener.\n\n### References\n\n- Patched release: [`v1.84.0`](https://github.com/BerriAI/litellm/releases/tag/v1.84.0)\n\n**Discovery Credit**: Le The Thang (KCSC) and Kim Ngoc Chung (One Mount Group)",

--- a/third_party/requirements-main.txt
+++ b/third_party/requirements-main.txt
@@ -276,7 +276,7 @@ anthropic==0.101.0 ; (platform_machine == 'arm64' and sys_platform == 'darwin') 
     # via
     #   nemo-agents-plugin
     #   nemo-platform-plugin
-    #   switchyard
+    #   switchyard-vendored
 anyascii==0.3.3 ; (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:c94e9dd9d47b3d9494eca305fef9447d00b4bf1a32aff85aa746fa3ec7fb95c3 \
     --hash=sha256:f5ab5e53c8781a36b5a40e1296a0eeda2f48c649ef10c3921c1381b1d00dee7a
@@ -955,7 +955,7 @@ httpx==0.28.1 ; (platform_machine == 'arm64' and sys_platform == 'darwin') or (p
     #   nvidia-nat-core
     #   oci-openai
     #   openai
-    #   switchyard
+    #   switchyard-vendored
 httpx-retries==0.4.6 ; (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:a076d8a5ede5d5794e9c241da17b15b393b482129ddd2fdf1fa56a3fa1f28a7f \
     --hash=sha256:d66d912173b844e065ffb109345a453b922f4c2cd9c9e11139304cb33e7a1ee1
@@ -1647,7 +1647,7 @@ openai==2.35.0 ; (platform_machine == 'arm64' and sys_platform == 'darwin') or (
     #   nmp-guardrails
     #   oci-openai
     #   ragas
-    #   switchyard
+    #   switchyard-vendored
 openapi-pydantic==0.5.1 ; (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146 \
     --hash=sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d
@@ -2190,7 +2190,7 @@ pydantic==2.12.5 ; (platform_machine == 'arm64' and sys_platform == 'darwin') or
     #   pydantic-settings
     #   ragas
     #   sqlmodel
-    #   switchyard
+    #   switchyard-vendored
 pydantic-core==2.41.5 ; (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') \
     --hash=sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740 \
     --hash=sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84 \

--- a/uv.lock
+++ b/uv.lock
@@ -4374,7 +4374,7 @@ all = [
     { name = "sqlalchemy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "sqlmodel", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "streaming-form-data", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "switchyard", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "switchyard-vendored", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tenacity", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "types-aioboto3", extra = ["s3"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4670,7 +4670,7 @@ nemo-safe-synthesizer-plugin = [
 ]
 nemo-switchyard = [
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "switchyard", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "switchyard-vendored", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nmp-common = [
     { name = "aiofiles", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4738,7 +4738,7 @@ plugins = [
     { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "switchyard", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "switchyard-vendored", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "uvicorn", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
@@ -4813,7 +4813,7 @@ services = [
     { name = "sqlalchemy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "sqlmodel", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "streaming-form-data", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "switchyard", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "switchyard-vendored", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tenacity", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "types-aioboto3", extra = ["s3"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4827,7 +4827,7 @@ studio-service = [
     { name = "nmp-common", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "uvicorn", extra = ["standard"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-switchyard = [
+switchyard-vendored = [
     { name = "anthropic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "openai", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4867,7 +4867,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'nemo-platform-plugin'", specifier = ">=0.88.0" },
     { name = "anthropic", marker = "extra == 'plugins'", specifier = ">=0.88.0" },
     { name = "anthropic", marker = "extra == 'services'", specifier = ">=0.88.0" },
-    { name = "anthropic", marker = "extra == 'switchyard'", specifier = ">=0.99.0,<1.0" },
+    { name = "anthropic", marker = "extra == 'switchyard-vendored'", specifier = ">=0.99.0,<1.0" },
     { name = "anyio", marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "anyio", marker = "extra == 'core-service'", specifier = ">=4.0.0" },
     { name = "anyio", marker = "extra == 'data-designer-nemo'", specifier = ">=4.0" },
@@ -5010,7 +5010,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'plugins'", specifier = ">=0.27.2" },
     { name = "httpx", marker = "extra == 'services'", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'services'", specifier = ">=0.27.2" },
-    { name = "httpx", marker = "extra == 'switchyard'", specifier = ">=0.28.1,<1.0" },
+    { name = "httpx", marker = "extra == 'switchyard-vendored'", specifier = ">=0.28.1,<1.0" },
     { name = "httpx-aiohttp", marker = "extra == 'aiohttp'", specifier = ">=0.1.9" },
     { name = "huggingface-hub", marker = "extra == 'nmp-common'", specifier = ">=1.0.1,<2.0.0" },
     { name = "hvac", marker = "extra == 'all'", specifier = ">=2.3.0" },
@@ -5144,7 +5144,7 @@ requires-dist = [
     { name = "openai", marker = "extra == 'nemo-platform-plugin'", specifier = ">=1.109.1" },
     { name = "openai", marker = "extra == 'nemo-platform-sdk'" },
     { name = "openai", marker = "extra == 'services'", specifier = ">=1.61.0" },
-    { name = "openai", marker = "extra == 'switchyard'", specifier = ">=2.34.0,<3.0" },
+    { name = "openai", marker = "extra == 'switchyard-vendored'", specifier = ">=2.34.0,<3.0" },
     { name = "opentelemetry-distro", marker = "extra == 'all'", specifier = ">=0.41b0" },
     { name = "opentelemetry-distro", marker = "extra == 'guardrails-service'", specifier = ">=0.41b0" },
     { name = "opentelemetry-distro", marker = "extra == 'services'", specifier = ">=0.41b0" },
@@ -5225,7 +5225,7 @@ requires-dist = [
     { name = "pydantic", marker = "extra == 'services'", specifier = ">=2.9.2,<3.0.0" },
     { name = "pydantic", marker = "extra == 'services'", specifier = ">=2.10.3" },
     { name = "pydantic", marker = "extra == 'services'", specifier = ">=2.10.6" },
-    { name = "pydantic", marker = "extra == 'switchyard'", specifier = ">=2.13.3,<3.0" },
+    { name = "pydantic", marker = "extra == 'switchyard-vendored'", specifier = ">=2.13.3,<3.0" },
     { name = "pydantic", extras = ["email"], marker = "extra == 'all'", specifier = ">=2.9.2" },
     { name = "pydantic", extras = ["email"], marker = "extra == 'nemo-safe-synthesizer-plugin'", specifier = ">=2.9.2" },
     { name = "pydantic", extras = ["email"], marker = "extra == 'plugins'", specifier = ">=2.9.2" },
@@ -5316,10 +5316,10 @@ requires-dist = [
     { name = "streaming-form-data", marker = "extra == 'files-service'", specifier = ">=1.19.1" },
     { name = "streaming-form-data", marker = "extra == 'services'", specifier = ">=1.19.1" },
     { name = "structlog", marker = "extra == 'nmp-common'", specifier = ">=24.1.0" },
-    { name = "switchyard", marker = "extra == 'all'" },
-    { name = "switchyard", marker = "extra == 'nemo-switchyard'" },
-    { name = "switchyard", marker = "extra == 'plugins'" },
-    { name = "switchyard", marker = "extra == 'services'" },
+    { name = "switchyard-vendored", marker = "extra == 'all'" },
+    { name = "switchyard-vendored", marker = "extra == 'nemo-switchyard'" },
+    { name = "switchyard-vendored", marker = "extra == 'plugins'" },
+    { name = "switchyard-vendored", marker = "extra == 'services'" },
     { name = "tenacity", marker = "extra == 'all'", specifier = ">=8.5.0" },
     { name = "tenacity", marker = "extra == 'core-service'", specifier = ">=8.5.0" },
     { name = "tenacity", marker = "extra == 'models-service'", specifier = ">=8.5.0" },
@@ -5379,7 +5379,7 @@ requires-dist = [
     { name = "yara-python", marker = "extra == 'guardrails-service'", specifier = "==4.5.1" },
     { name = "yara-python", marker = "extra == 'services'", specifier = "==4.5.1" },
 ]
-provides-extras = ["aiohttp", "all", "auditor-service", "auth-service", "core-service", "data-designer-nemo", "entities-service", "files-service", "guardrails-service", "hello-world-service", "inference-gateway-service", "intake-service", "jobs-service", "models-service", "nemo-agents-example-calculator", "nemo-agents-plugin", "nemo-anonymizer-plugin", "nemo-auditor-plugin", "nemo-data-designer-plugin", "nemo-evaluator-plugin", "nemo-evaluator-sdk", "nemo-guardrails-plugin", "nemo-platform-plugin", "nemo-platform-sdk", "nemo-safe-synthesizer-plugin", "nemo-switchyard", "nmp-common", "platform-seed-service", "plugins", "secrets-service", "services", "studio-service", "switchyard"]
+provides-extras = ["aiohttp", "all", "auditor-service", "auth-service", "core-service", "data-designer-nemo", "entities-service", "files-service", "guardrails-service", "hello-world-service", "inference-gateway-service", "intake-service", "jobs-service", "models-service", "nemo-agents-example-calculator", "nemo-agents-plugin", "nemo-anonymizer-plugin", "nemo-auditor-plugin", "nemo-data-designer-plugin", "nemo-evaluator-plugin", "nemo-evaluator-sdk", "nemo-guardrails-plugin", "nemo-platform-plugin", "nemo-platform-sdk", "nemo-safe-synthesizer-plugin", "nemo-switchyard", "nmp-common", "platform-seed-service", "plugins", "secrets-service", "services", "studio-service", "switchyard-vendored"]
 
 [[package]]
 name = "nemo-platform-ext"
@@ -5775,13 +5775,13 @@ version = "0.1.0"
 source = { editable = "plugins/nemo-switchyard" }
 dependencies = [
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "switchyard", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "switchyard-vendored", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
-    { name = "switchyard", editable = "plugins/nemo-switchyard/vendor/switchyard" },
+    { name = "switchyard-vendored", editable = "plugins/nemo-switchyard/vendor/switchyard" },
 ]
 
 [[package]]
@@ -10061,7 +10061,7 @@ wheels = [
 ]
 
 [[package]]
-name = "switchyard"
+name = "switchyard-vendored"
 version = "0.1.0+vendored.9407922"
 source = { editable = "plugins/nemo-switchyard/vendor/switchyard" }
 dependencies = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Switchyard dependency wiring to use the new vendored package identifier across the platform and plugin.
  * Kept the vendored source/path and behavior the same, while aligning all references to the new name.
  * Refreshed third-party metadata (OSV license/vulnerability details and requirements attribution comments) to reflect the latest recorded information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->