### PR TITLE
chore: upgrade the python base container used in some other builds

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -53,7 +53,7 @@ variable "MAMBA_SSM_WHEEL_CONTEXT" {
 }
 
 variable "DISTROLESS_BASE" {
-  default = "nvcr.io/nvidia/distroless/python:3.11-v4.0.9"
+  default = "nvcr.io/nvidia/distroless/python:3.11-v4.0.8"
 }
 
 variable "DOCKERHUB_MIRROR" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -53,7 +53,7 @@ variable "MAMBA_SSM_WHEEL_CONTEXT" {
 }
 
 variable "DISTROLESS_BASE" {
-  default = "nvcr.io/nvidia/distroless/python:3.11-v4.0.3"
+  default = "nvcr.io/nvidia/distroless/python:3.11-v4.0.9"
 }
 
 variable "DOCKERHUB_MIRROR" {

--- a/docker/Dockerfile.bake
+++ b/docker/Dockerfile.bake
@@ -2,7 +2,7 @@
 # Common Build Targets.  Please use `docker buildx bake` to build.  See `README.md`
 #######
 
-ARG DISTROLESS_BASE=nvcr.io/nvidia/distroless/python:3.11-v4.0.9
+ARG DISTROLESS_BASE=nvcr.io/nvidia/distroless/python:3.11-v4.0.8
 
 #root-uv-binary-base
     FROM ghcr.io/astral-sh/uv:0.9.14 AS root-uv-binary-base

--- a/docker/Dockerfile.bake
+++ b/docker/Dockerfile.bake
@@ -27,7 +27,7 @@ ARG DISTROLESS_BASE=nvcr.io/nvidia/distroless/python:3.11-v4.0.8
 
 #root-python-3-11:
     # Copy uv and install other utilities
-    FROM python:3.11.13-slim-bookworm AS root-python-3-11
+    FROM python:3.11.15-slim-bookworm AS root-python-3-11
     RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \

--- a/docker/Dockerfile.bake
+++ b/docker/Dockerfile.bake
@@ -2,7 +2,7 @@
 # Common Build Targets.  Please use `docker buildx bake` to build.  See `README.md`
 #######
 
-ARG DISTROLESS_BASE=nvcr.io/nvidia/distroless/python:3.11-v4.0.3
+ARG DISTROLESS_BASE=nvcr.io/nvidia/distroless/python:3.11-v4.0.9
 
 #root-uv-binary-base
     FROM ghcr.io/astral-sh/uv:0.9.14 AS root-uv-binary-base

--- a/docker/base/Dockerfile.nmp-python-base
+++ b/docker/base/Dockerfile.nmp-python-base
@@ -16,7 +16,7 @@ FROM ${BASE_REGISTRY}/nmp-python-base:${BASE_TAG_PYTHON} AS nmp-python-base
 FROM ${BASE_REGISTRY}/nmp-python-dev-base:${BASE_TAG_PYTHON} AS nmp-python-dev-base
 
 # nmp-python-base-builder: Builds the minimal runtime base from scratch.
-FROM python:3.11.14-slim-bookworm AS nmp-python-base-builder
+FROM python:3.11.15-slim-bookworm AS nmp-python-base-builder
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     build-essential \


### PR DESCRIPTION
This is probably the lowest effort clear update needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default distroless Python 3.11 runtime base image to a newer version to improve stability and compatibility.
* **Chores**
  * Bumped the underlying Python 3.11 slim base images used during builds to the latest patch release, keeping runtime images aligned with recent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->