### PR TITLE
feat(jobs): add controller diagnostics and per-module E2E config pooling

### DIFF
--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -422,6 +422,8 @@ jobs:
   schedule_interval_seconds: 5
   # Register the subprocess/default execution profile. When unset, defaults to true for docker/none runtimes and false for kubernetes.
   enable_subprocess_executor:
+  # Include raw job log lines in controller diagnostics snapshots. Disabled by default because job logs may contain secrets or PII. Enable only for local debugging or test environments. | default: False
+  include_job_logs_in_diagnostics: false
 ```
 
 ### `models`

--- a/e2e/configs/local-subprocess.yaml
+++ b/e2e/configs/local-subprocess.yaml
@@ -1,0 +1,68 @@
+# Local E2E config for hosts without Docker.
+#
+# This keeps the explicit subprocess/default jobs profile required by
+# translate_cpu_container_steps_to_subprocess(), while avoiding the default
+# docker job backends that are derived from platform.runtime: "docker".
+
+platform:
+  runtime: "none"
+  base_url: "http://0.0.0.0:8080"
+
+service: {}
+
+auth:
+  enabled: false
+  allow_unsigned_jwt: true
+  policy_decision_point_provider: embedded
+  policy_decision_point_base_url: "http://localhost:8080"
+  policy_data_refresh_interval: 2
+  bundle_cache_seconds: 15
+  admin_email: "admin@example.com"
+
+entities: {}
+
+jobs:
+  # Local E2E-only debugging aid. This may leak secrets or PII from job output,
+  # so it must remain disabled in non-test configs.
+  include_job_logs_in_diagnostics: true
+  executors:
+    - provider: subprocess
+      profile: default
+      backend: subprocess
+      config:
+        working_directory: .tmp/e2e/subprocess-jobs
+        cleanup_completed_jobs_immediately: false
+        ttl_seconds_before_active: 60
+        ttl_seconds_active: 3600
+        ttl_seconds_after_finished: 300
+  executor_defaults:
+    subprocess:
+      working_directory: .tmp/e2e/subprocess-jobs
+      cleanup_completed_jobs_immediately: false
+      ttl_seconds_before_active: 60
+      ttl_seconds_active: 3600
+      ttl_seconds_after_finished: 300
+
+evaluator:
+  recreate_existing_system_entities: true
+
+safe_synthesizer: {}
+
+models:
+  controller:
+    interval_seconds: 5
+    model_deployment_garbage_collection_ttl_seconds: 30
+
+inference_gateway: {}
+
+secrets:
+  allow_key_creation: true
+
+files:
+  default_storage_config:
+    type: local
+    path: .tmp/e2e/files
+
+studio:
+  static_files_path: web/packages/studio/dist
+  sandbox_enabled: true

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -15,25 +15,61 @@ When ``NMP_BASE_URL`` is set the harness skips service startup/shutdown and
 connects to the given URL.  Otherwise it spawns ``nemo services run`` as a
 child process on a free port, polls ``/status`` until ready, and
 terminates the process after the session.
+
+Config selection::
+
+    # Default local platform config
+    pytestmark = [pytest.mark.e2e_config()]
+
+    # Single repo-root-relative config file
+    pytestmark = [pytest.mark.e2e_config("e2e/configs/local-subprocess.yaml")]
+
+    # Ordered config layers: files first, then inline overlays
+    pytestmark = [
+        pytest.mark.e2e_config(
+            "e2e/configs/local-subprocess.yaml",
+            {"auth": {"enabled": True}},
+        )
+    ]
+
+Why this exists:
+
+- E2E modules should be able to declare the platform shape they need rather
+  than inheriting one global config from ``conftest.py``.
+- Different modules can exercise different backends or auth modes in the same
+  pytest session.
+- Identical effective configs are pooled and reused, so config selection does
+  not imply one fresh ``nemo services`` process per module.
+
+How pooling works:
+
+- The harness resolves the ordered ``e2e_config(...)`` layers into one
+  effective config dict.
+- That config is normalized into a canonical form and hashed.
+- Modules that resolve to the same hash share one running services instance for
+  the session.
+- The pooled instance is shut down as soon as the last module using that hash
+  finishes, so mixed-config runs do not keep every started platform alive until
+  the end of the session.
+
+The pool implementation itself lives in ``e2e.services_pool`` so this file can
+stay focused on pytest hooks and fixtures.
 """
 
-import contextlib
 import logging
 import os
-import socket
-import subprocess
-import sys
 import tempfile
-import time
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
-from typing import IO, Any
 
-import httpx
 import pytest
 from nemo_platform import NeMoPlatform
-from nmp.testing import NemoRun, get_repo_root
+
+from e2e.services_pool import E2EServicesPool, RunningServices, admin_headers
+
+_services_pool_manager_key = pytest.StashKey[E2EServicesPool]()
+_services_metadata_key = pytest.StashKey[dict[str, str]]()
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -49,20 +85,25 @@ def pytest_configure(config: pytest.Config) -> None:
     from nemo_platform_plugin.config import Configuration
 
     Configuration.clear_cache()
+    config.stash[_services_pool_manager_key] = E2EServicesPool()
+
+
+def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Register collected E2E modules with the services pool manager."""
+    config.stash[_services_pool_manager_key].register_collected_items(items)
 
 
 logger = logging.getLogger(__name__)
+_E2E_HARNESS_DEBUG = os.environ.get("E2E_HARNESS_DEBUG") == "1"
 
-_HEALTH_TIMEOUT = 60
-_HEALTH_POLL_INTERVAL = 1.0
-_AUTH_READY_TIMEOUT = 60
-_E2E_ADMIN_EMAIL = "admin@example.com"
 _SERVICES_LOG = Path(os.environ.get("E2E_SERVICES_LOG", os.path.join(tempfile.gettempdir(), "services.log")))
 
 # Number of log lines to dump from the services log on test failure.
 _TAIL_LINES_ON_FAILURE = 100
 
 _services_log_key = pytest.StashKey[Path]()
+_active_services_log_key = pytest.StashKey[Path]()
+_active_services_metadata_key = pytest.StashKey[dict[str, str]]()
 
 NGC_API_KEY_ENV = "NGC_API_KEY"
 
@@ -87,180 +128,6 @@ def ngc_secret(sdk: NeMoPlatform, workspace: str, ngc_api_key: str) -> Iterator[
         pass  # Best-effort cleanup; the workspace is deleted anyway
 
 
-@pytest.fixture(scope="session")
-def services_log_path(request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Return a unique services log path for this session.
-
-    ``E2E_SERVICES_LOG_DIR`` (if set) is treated as a **directory**; in CI
-    the job uploads everything under it as artifacts.  When unset we
-    fall back to a pytest-managed temp directory.  Either way, each
-    session writes to a UUID-named file inside the directory so
-    parallel workers never clobber each other.
-
-    The path is stashed on the session so the
-    ``pytest_runtest_makereport`` hook can read it without requesting
-    the fixture.
-    """
-    log_dir = os.environ.get("E2E_SERVICES_LOG_DIR")
-    if log_dir:
-        directory = Path(log_dir)
-        directory.mkdir(parents=True, exist_ok=True)
-    else:
-        directory = tmp_path_factory.mktemp("e2e-services-logs")
-    path = directory / f"services-{uuid.uuid4().hex[:8]}.log"
-    request.session.stash[_services_log_key] = path
-    return path
-
-
-_E2E_REPO_ROOT = Path(__file__).resolve().parents[1]
-_E2E_PLATFORM_CONFIG = _E2E_REPO_ROOT / "packages/nmp_platform/config/local.yaml"
-
-
-def _e2e_services_env() -> dict[str, str]:
-    """Environment for the ``nemo services run`` child process.
-
-    ``pytest_configure`` sets ``NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX`` on the
-    pytest process so ``add_mock_provider()`` can build providers, but the IGW
-    must see the same value in *its* process or mock routing and cache refresh
-    behave differently from the test client.  Mirror the Docker E2E backend
-    (``nmp.testing.e2e.docker``) by setting inference env vars explicitly here
-    rather than relying on inherited shell state.
-
-    Use ``packages/nmp_platform/config/local.yaml`` (``inference_gateway: {}``)
-    so IGW polls the Models service on the background refresh interval instead
-    of the dev-only ``debug_model_providers`` block in
-    ``services/core/inference-gateway/config/local.yaml``, which disables that
-    loop.
-    """
-    env = os.environ.copy()
-    env["NMP_SEED_ON_STARTUP"] = "true"
-    env["NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX"] = "igw-mock-"
-    env["NMP_CONFIG_FILE_PATH"] = str(_E2E_PLATFORM_CONFIG)
-    env["NMP_CONFIG_WARNINGS_DISABLED"] = "1"
-    if not _e2e_auth_enabled():
-        env["NMP_AUTH_ENABLED"] = "false"
-    elif "NMP_AUTH_ENABLED" not in env:
-        env["NMP_AUTH_ENABLED"] = "true"
-    return env
-
-
-def _e2e_auth_enabled() -> bool:
-    """Return whether the e2e harness should run with authorization enabled.
-
-    Default is disabled so ``make test-e2e`` does not depend on platform-admin
-    seeding, PDP refresh, or role propagation timing. Opt in with
-    ``E2E_AUTH_ENABLED=true`` (see ``make test-e2e-docker-auth``).
-    """
-    return os.environ.get("E2E_AUTH_ENABLED", "false").lower() in ("1", "true", "yes")
-
-
-def _find_free_port() -> int:
-    """Bind to port 0 and let the OS assign a free port."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-def _wait_for_healthy(url: str, timeout: float = _HEALTH_TIMEOUT) -> bool:
-    """Poll /status until it returns 200 or timeout expires."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            resp = httpx.get(f"{url}/status", timeout=2.0)
-            if resp.status_code == 200:
-                return True
-        except httpx.RequestError:
-            pass  # Server not up yet, keep polling
-        time.sleep(_HEALTH_POLL_INTERVAL)
-    return False
-
-
-def _admin_headers() -> dict[str, str]:
-    return {
-        "X-NMP-Principal-Id": _E2E_ADMIN_EMAIL,
-        "X-NMP-Principal-Email": _E2E_ADMIN_EMAIL,
-    }
-
-
-def _wait_for_auth_ready(url: str, timeout: float = _AUTH_READY_TIMEOUT) -> bool:
-    """Poll until platform admin can create entities in a fresh workspace.
-
-    Workspace create/list alone is insufficient: entity CRUD requires
-    PlatformAdmin (or entities.create, which workspace Admin lacks). The first
-    entity e2e test was flaky when only workspace visibility was probed.
-    """
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        probe_name = f"auth-probe-{uuid.uuid4().hex[:8]}"
-        entity_name = f"auth-probe-entity-{uuid.uuid4().hex[:8]}"
-        try:
-            create_resp = httpx.post(
-                f"{url}/apis/entities/v2/workspaces",
-                json={"name": probe_name},
-                headers=_admin_headers(),
-                timeout=5.0,
-            )
-            if create_resp.status_code != 201:
-                time.sleep(_HEALTH_POLL_INTERVAL)
-                continue
-
-            entity_resp = httpx.post(
-                f"{url}/apis/entities/v2/workspaces/{probe_name}/entities/e2e-auth-probe",
-                json={"name": entity_name, "data": {"ready": True}},
-                headers=_admin_headers(),
-                timeout=5.0,
-            )
-            if entity_resp.status_code != 201:
-                httpx.delete(
-                    f"{url}/apis/entities/v2/workspaces/{probe_name}",
-                    headers=_admin_headers(),
-                    timeout=5.0,
-                )
-                time.sleep(_HEALTH_POLL_INTERVAL)
-                continue
-
-            httpx.delete(
-                f"{url}/apis/entities/v2/workspaces/{probe_name}/entities/e2e-auth-probe/{entity_name}",
-                headers=_admin_headers(),
-                timeout=5.0,
-            )
-            httpx.delete(
-                f"{url}/apis/entities/v2/workspaces/{probe_name}",
-                headers=_admin_headers(),
-                timeout=5.0,
-            )
-            return True
-        except httpx.RequestError as exc:
-            logger.debug("Auth readiness probe failed; will retry: %s", exc)
-        time.sleep(_HEALTH_POLL_INTERVAL)
-    return False
-
-
-@contextlib.contextmanager
-def background_process(
-    args: list[str],
-    stdout: IO[Any] | None = None,
-    env: dict[str, str] | None = None,
-) -> Iterator[subprocess.Popen]:
-    """Run a subprocess, yield the ``Popen``, and terminate on exit.
-
-    Unlike ``Popen``'s built-in context manager (which only waits for the
-    process), this sends SIGTERM/SIGKILL so long-running servers are
-    cleaned up.
-    """
-    proc = subprocess.Popen(args, stdout=stdout, stderr=subprocess.STDOUT, env=env)
-    try:
-        yield proc
-    finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            logger.warning("Process %d did not exit after SIGTERM, sending SIGKILL", proc.pid)
-            proc.kill()
-            proc.wait(timeout=5)
-
-
 # ---- Services log tail on failure ------------------------------------------
 
 
@@ -278,72 +145,93 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):  # noqa
     if not report.failed:
         return
 
-    log_path = item.session.stash.get(_services_log_key, None)
+    log_path = item.stash.get(_active_services_log_key, None) or item.session.stash.get(_services_log_key, None)
     if log_path and log_path.exists():
         lines = log_path.read_text().splitlines(keepends=True)
         tail = lines[-_TAIL_LINES_ON_FAILURE:]
         if tail:
             header = f"--- services log (last {len(tail)} lines) [{log_path}] ---"
             report.sections.append(("Services Log", f"{header}\n{''.join(tail)}"))
+    metadata = item.stash.get(_active_services_metadata_key, None)
+    if metadata:
+        report.sections.append(
+            (
+                "E2E Services Binding",
+                "\n".join(f"{key}: {value}" for key, value in sorted(metadata.items())),
+            )
+        )
 
 
 # ---- Fixtures --------------------------------------------------------------
-
-
 @pytest.fixture(scope="session")
-def _services(services_log_path: Path) -> Iterator[str]:
-    """Spawn ``nemo services run`` and yield the base URL.
+def _services_pool_manager(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[E2EServicesPool]:
+    manager = request.config.stash[_services_pool_manager_key]
+    manager.bind_tmp_path_factory(tmp_path_factory)
+    yield manager
+    manager.shutdown_all()
+
+
+@pytest.fixture(scope="module")
+def _services_instance(
+    request: pytest.FixtureRequest,
+    _services_pool_manager: E2EServicesPool,
+) -> Iterator[RunningServices]:
+    """Return the running services instance for the current module's config.
 
     Skipped when ``NMP_BASE_URL`` is already set (external services).
 
-    This is the "subprocess" backend.  When we add Docker and Kubernetes
-    backends, this fixture should be replaced by a backend-selection layer
-    (e.g. ``--docker`` / ``--kubernetes`` CLI flags) that dispatches to the
-    appropriate setup while yielding the same base URL interface.  Tests
-    should remain agnostic to the backend.
+    Modules do not each get a dedicated services process. Instead, the harness
+    computes the effective config hash for the module and reuses any existing
+    process already started for that hash within the pytest session. A new
+    process is started only when the module resolves to a config that no prior
+    module has used.
     """
-    external_url = os.environ.get("NMP_BASE_URL")
-    if external_url:
-        yield external_url
+    module = request.node.getparent(pytest.Module)
+    if module is None:
+        raise RuntimeError("Expected module-scoped E2E fixture to have a pytest module parent")
+    services = _services_pool_manager.acquire_for_module(module)
+    if services.log_path is not None:
+        request.session.stash[_services_log_key] = services.log_path
+    try:
+        yield services
+    finally:
+        _services_pool_manager.release_for_module(module)
+
+
+@pytest.fixture(autouse=True)
+def _bind_services_log_to_test(request: pytest.FixtureRequest, _services_instance: RunningServices) -> None:
+    if _services_instance.log_path is not None:
+        request.node.stash[_active_services_log_key] = _services_instance.log_path
+    module = request.node.getparent(pytest.Module)
+    if module is None:
         return
-
-    port = _find_free_port()
-    url = f"http://127.0.0.1:{port}"
-
-    nemo_bin = str(Path(sys.executable).parent / "nemo")
-    args = [
-        nemo_bin,
-        "services",
-        "run",
-        "--service-group",
-        "all",
-        "--controller-group",
-        "all",
-        "--port",
-        str(port),
-    ]
-    env = _e2e_services_env()
-
-    logger.info("Starting nemo services on port %d", port)
-
-    log_path = services_log_path or _SERVICES_LOG
-    with open(log_path, "w") as log_file, background_process(args, stdout=log_file, env=env) as proc:
-        if not _wait_for_healthy(url):
-            pytest.fail(
-                f"nemo services run did not become healthy within {_HEALTH_TIMEOUT}s.\nlog:\n{log_path.read_text()}"
-            )
-        if _e2e_auth_enabled() and not _wait_for_auth_ready(url):
-            pytest.fail(
-                f"Platform auth seed did not become ready within {_AUTH_READY_TIMEOUT}s.\nlog:\n{log_path.read_text()}"
-            )
-
-        logger.info("Platform services ready on port %d (pid %d)", port, proc.pid)
-        yield url
-        logger.info("Terminating nemo services (pid %d)", proc.pid)
+    manager = request.config.stash[_services_pool_manager_key]
+    metadata = {
+        key: str(value)
+        for key, value in manager.describe_module_binding(module.nodeid, _services_instance).items()
+        if value is not None
+    }
+    request.node.stash[_active_services_metadata_key] = metadata
+    if _E2E_HARNESS_DEBUG:
+        logger.info(
+            "E2E test binding",
+            extra={
+                **metadata,
+                "test": request.node.nodeid,
+            },
+        )
 
 
-@pytest.fixture(scope="session")
-def sdk(_services: str) -> NeMoPlatform:
+@pytest.fixture(scope="module")
+def _services(_services_instance: RunningServices) -> Iterator[str]:
+    yield _services_instance.url
+
+
+@pytest.fixture(scope="module")
+def sdk(_services: str, _services_instance: RunningServices) -> NeMoPlatform:
     """Provide an SDK client connected to the running platform.
 
     When connecting to an external cluster (via ``NMP_BASE_URL``), authentication
@@ -351,12 +239,12 @@ def sdk(_services: str) -> NeMoPlatform:
     - ``NMP_ACCESS_TOKEN`` env var (e.g. from ``nemo auth token``)
     - ``NMP_CONTEXT_NAME`` env var (e.g. ``tot``) to read credentials from CLI config
 
-    For local auth-enabled deployments (``E2E_AUTH_ENABLED=true``), admin headers
-    are injected via ``default_headers``.
+    For local auth-enabled deployments, admin headers are injected via
+    ``default_headers`` based on the rendered platform config.
     """
     access_token = os.environ.get("NMP_ACCESS_TOKEN")
     context_name = os.environ.get("NMP_CONTEXT_NAME")
-    headers = _admin_headers() if _e2e_auth_enabled() else {}
+    headers = admin_headers() if _services_instance.auth_enabled else {}
     return NeMoPlatform(
         base_url=_services,
         access_token=access_token,
@@ -373,37 +261,3 @@ def workspace(sdk: NeMoPlatform) -> Iterator[str]:
     sdk.workspaces.create(name=name)
     yield name
     sdk.workspaces.delete(name)
-
-
-@pytest.fixture(scope="session")
-def nemo_run(_services: str) -> NemoRun:
-    """Run the NeMo CLI from the repo root with the E2E base URL and workspace env when set."""
-    base_url = _services.rstrip("/")
-    repo_root = get_repo_root()
-
-    def run(
-        *args: str,
-        workspace: str | None = None,
-        env_extra: dict[str, str] | None = None,
-        timeout: int | None = 60,
-        capture_output: bool = True,
-        stdin: int | None = None,
-    ) -> subprocess.CompletedProcess[str]:
-        env = os.environ.copy()
-        env["NMP_BASE_URL"] = base_url
-        if workspace is not None:
-            env["NMP_WORKSPACE"] = workspace
-        if env_extra:
-            env.update(env_extra)
-        cmd = ["uv", "run", "--project", str(repo_root), "--frozen", "nemo", "-f", "json", *args]
-        return subprocess.run(
-            cmd,
-            cwd=repo_root,
-            env=env,
-            timeout=timeout,
-            capture_output=capture_output,
-            stdin=stdin,
-            text=True,
-        )
-
-    return run

--- a/e2e/services_pool.py
+++ b/e2e/services_pool.py
@@ -1,0 +1,543 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared E2E services-pool implementation used by pytest fixtures."""
+
+import hashlib
+import json
+import logging
+import os
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import yaml
+from _pytest.nodes import Node
+from nmp.testing.e2e.config import deep_merge
+
+logger = logging.getLogger(__name__)
+_E2E_HARNESS_DEBUG = os.environ.get("E2E_HARNESS_DEBUG") == "1"
+
+_HEALTH_TIMEOUT = 60
+_HEALTH_POLL_INTERVAL = 1.0
+_AUTH_READY_TIMEOUT = 60
+_E2E_ADMIN_EMAIL = "admin@example.com"
+_E2E_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_E2E_PLATFORM_CONFIG = _E2E_REPO_ROOT / "packages/nmp_platform/config/local.yaml"
+
+
+def admin_headers() -> dict[str, str]:
+    return {
+        "X-NMP-Principal-Id": _E2E_ADMIN_EMAIL,
+        "X-NMP-Principal-Email": _E2E_ADMIN_EMAIL,
+    }
+
+
+@dataclass(frozen=True)
+class ServicesPoolKey:
+    config_hash: str
+
+
+@dataclass
+class RunningServices:
+    url: str
+    log_path: Path | None
+    proc: subprocess.Popen[Any] | None
+    config_path: Path | None
+    auth_enabled: bool = False
+    key: ServicesPoolKey | None = None
+
+
+@dataclass(frozen=True)
+class ModuleConfigState:
+    module_id: str
+    key: ServicesPoolKey
+    config_path: Path | None
+    config_data: dict[str, Any]
+    config_layers: tuple[str, ...]
+    auth_enabled: bool
+
+
+class E2EServicesPool:
+    """Central manager for config-hash-based E2E service pooling."""
+
+    def __init__(self) -> None:
+        self._tmp_path_factory: pytest.TempPathFactory | None = None
+        self._module_states: dict[str, ModuleConfigState] = {}
+        self._remaining_modules_by_key: dict[ServicesPoolKey, set[str]] = {}
+        self._running_by_key: dict[ServicesPoolKey, RunningServices] = {}
+        self._active_service_key_by_module: dict[str, ServicesPoolKey] = {}
+        self._generated_config_dir: Path | None = None
+        self._log_dir: Path | None = None
+
+    @staticmethod
+    def _log_debug(message: str, **extra: Any) -> None:
+        if _E2E_HARNESS_DEBUG:
+            logger.info(message, extra=extra)
+
+    def bind_tmp_path_factory(self, tmp_path_factory: pytest.TempPathFactory) -> None:
+        if self._tmp_path_factory is None:
+            self._tmp_path_factory = tmp_path_factory
+
+    def register_collected_items(self, items: list[pytest.Item]) -> None:
+        seen_modules: set[str] = set()
+        for item in items:
+            module = item.getparent(pytest.Module)
+            if module is None or module.nodeid in seen_modules:
+                continue
+            seen_modules.add(module.nodeid)
+            self._ensure_module_registered(module)
+
+    def acquire_for_module(self, module: pytest.Module) -> RunningServices:
+        self._ensure_module_registered(module)
+        state = self._module_states[module.nodeid]
+        external_url = os.environ.get("NMP_BASE_URL")
+        if external_url:
+            return RunningServices(
+                url=external_url,
+                log_path=None,
+                proc=None,
+                config_path=None,
+                auth_enabled=state.auth_enabled,
+            )
+        if state.config_path is None:
+            state = self._materialize_config_path(state)
+            self._module_states[module.nodeid] = state
+        assert state.config_path is not None
+        services = self._running_by_key.get(state.key)
+        if services is None:
+            log_path = self._get_log_dir() / f"services-{state.key.config_hash}-{uuid.uuid4().hex[:8]}.log"
+            services = _start_services(state.config_path, state.config_data, state.key.config_hash, log_path)
+            self._running_by_key[state.key] = services
+        previous_key = self._active_service_key_by_module.get(module.nodeid)
+        if previous_key is not None and previous_key != state.key:
+            logger.error(
+                "E2E module rebound to a different services pool key",
+                extra={
+                    "e2e_module": module.nodeid,
+                    "previous_config_hash": previous_key.config_hash,
+                    "new_config_hash": state.key.config_hash,
+                    "new_url": services.url,
+                    "new_pid": services.proc.pid if services.proc is not None else None,
+                },
+            )
+        self._active_service_key_by_module[module.nodeid] = state.key
+        self._log_debug("E2E services acquire", **self.describe_module_binding(module.nodeid, services))
+        return services
+
+    def release_for_module(self, module: pytest.Module) -> None:
+        if os.environ.get("NMP_BASE_URL"):
+            return
+        state = self._module_states.get(module.nodeid)
+        if state is None:
+            return
+        remaining = self._remaining_modules_by_key.get(state.key)
+        if remaining is None or module.nodeid not in remaining:
+            return
+        remaining.remove(module.nodeid)
+        self._log_debug(
+            "E2E services release",
+            **{
+                **self.describe_module_binding(module.nodeid),
+                "remaining_modules_for_hash": sorted(remaining),
+            },
+        )
+        if remaining:
+            return
+        self._remaining_modules_by_key.pop(state.key, None)
+        self._active_service_key_by_module.pop(module.nodeid, None)
+        services = self._running_by_key.pop(state.key, None)
+        if services is not None:
+            self._terminate_services(services)
+
+    def shutdown_all(self) -> None:
+        for services in list(self._running_by_key.values()):
+            self._terminate_services(services)
+        self._running_by_key.clear()
+        self._remaining_modules_by_key.clear()
+
+    def _ensure_module_registered(self, module: pytest.Module) -> None:
+        if module.nodeid in self._module_states:
+            return
+        resolved_paths, config_data = _load_effective_e2e_config_from_node(module)
+        key = _services_pool_key(_canonical_config_hash(config_data))
+        auth_enabled = _e2e_auth_enabled(config_data)
+        self._module_states[module.nodeid] = ModuleConfigState(
+            module_id=module.nodeid,
+            key=key,
+            config_path=None,
+            config_data=config_data,
+            config_layers=tuple(str(path) for path in resolved_paths),
+            auth_enabled=auth_enabled,
+        )
+        self._remaining_modules_by_key.setdefault(key, set()).add(module.nodeid)
+        self._log_debug(
+            "Registered E2E module config",
+            e2e_module=module.nodeid,
+            config_hash=key.config_hash,
+            config_layers=list(self._module_states[module.nodeid].config_layers),
+            auth_enabled=auth_enabled,
+        )
+
+    def _materialize_config_path(self, state: ModuleConfigState) -> ModuleConfigState:
+        data_dir = e2e_services_data_dir(self._get_log_dir(), state.key.config_hash)
+        rendered_config_data = with_e2e_instance_paths(state.config_data, data_dir)
+        rendered_config = yaml.safe_dump(rendered_config_data, default_flow_style=False, sort_keys=True)
+        config_path = self._get_generated_config_dir() / f"platform-{state.key.config_hash}.yaml"
+        if not config_path.exists():
+            config_path.write_text(rendered_config)
+            self._log_debug(
+                "Materialized generated E2E config",
+                e2e_module=state.module_id,
+                config_hash=state.key.config_hash,
+                config_path=str(config_path),
+            )
+        return ModuleConfigState(
+            module_id=state.module_id,
+            key=state.key,
+            config_path=config_path,
+            config_data=state.config_data,
+            config_layers=state.config_layers,
+            auth_enabled=state.auth_enabled,
+        )
+
+    def _get_generated_config_dir(self) -> Path:
+        if self._generated_config_dir is None:
+            self._generated_config_dir = self._get_log_dir() / "generated-configs"
+            self._generated_config_dir.mkdir(parents=True, exist_ok=True)
+        return self._generated_config_dir
+
+    def _get_log_dir(self) -> Path:
+        if self._tmp_path_factory is None:
+            raise RuntimeError("E2E services pool used before tmp_path_factory was bound")
+        if self._log_dir is None:
+            self._log_dir = _services_log_dir(self._tmp_path_factory)
+        return self._log_dir
+
+    @staticmethod
+    def _terminate_services(services: RunningServices) -> None:
+        if services.proc is None:
+            return
+        if services.proc.poll() is not None:
+            E2EServicesPool._log_debug(
+                "Skipping E2E services terminate for already-exited process",
+                config_hash=services.key.config_hash if services.key is not None else None,
+                pid=services.proc.pid,
+                returncode=services.proc.returncode,
+                url=services.url,
+            )
+            return
+        logger.info("Terminating nemo services (pid %d)", services.proc.pid)
+        services.proc.terminate()
+        try:
+            services.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            logger.warning("Process %d did not exit after SIGTERM, sending SIGKILL", services.proc.pid)
+            services.proc.kill()
+            services.proc.wait(timeout=5)
+
+    def describe_module_binding(
+        self,
+        module_id: str,
+        services: RunningServices | None = None,
+    ) -> dict[str, Any]:
+        state = self._module_states[module_id]
+        details: dict[str, Any] = {
+            "e2e_module": module_id,
+            "config_hash": state.key.config_hash,
+            "auth_enabled": state.auth_enabled,
+            "config_layers": list(state.config_layers),
+            "config_path": str(state.config_path) if state.config_path is not None else None,
+        }
+        if services is not None:
+            details.update(
+                {
+                    "service_url": services.url,
+                    "service_pid": services.proc.pid if services.proc is not None else None,
+                    "service_log_path": str(services.log_path) if services.log_path is not None else None,
+                }
+            )
+        return details
+
+
+def _services_log_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    log_dir = os.environ.get("E2E_SERVICES_LOG_DIR")
+    if log_dir:
+        directory = Path(log_dir)
+        directory.mkdir(parents=True, exist_ok=True)
+        return directory
+    return tmp_path_factory.mktemp("e2e-services-logs")
+
+
+def _resolve_e2e_config_layers_from_node(node: Node) -> list[str | dict[str, Any]]:
+    marker = node.get_closest_marker("e2e_config")
+    if marker is None or not marker.args:
+        return [str(_DEFAULT_E2E_PLATFORM_CONFIG)]
+    layers: list[str | dict[str, Any]] = []
+    for layer in marker.args:
+        if isinstance(layer, (str, dict)):
+            layers.append(layer)
+            continue
+        raise pytest.UsageError("pytest.mark.e2e_config arguments must be strings or dicts")
+    return layers
+
+
+def _resolve_config_path(config_ref: str) -> Path:
+    candidate = Path(config_ref)
+    if not candidate.is_absolute():
+        candidate = _E2E_REPO_ROOT / config_ref
+    return candidate.resolve()
+
+
+def _normalize_config(value: Any, path: tuple[str, ...] = ()) -> Any:
+    if isinstance(value, dict):
+        return {key: _normalize_config(value[key], (*path, key)) for key in sorted(value)}
+    if isinstance(value, list):
+        normalized = [_normalize_config(item, path) for item in value]
+        if path == ("jobs", "executors"):
+            return sorted(
+                normalized,
+                key=lambda item: (
+                    item.get("provider", "") if isinstance(item, dict) else "",
+                    item.get("profile", "") if isinstance(item, dict) else "",
+                    item.get("backend", "") if isinstance(item, dict) else "",
+                    json.dumps(item, sort_keys=True, separators=(",", ":"), ensure_ascii=True),
+                ),
+            )
+        return normalized
+    return value
+
+
+def _canonical_config_hash(config_data: dict[str, Any]) -> str:
+    normalized = _normalize_config(config_data)
+    payload = json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def _load_effective_e2e_config_from_node(node: Node) -> tuple[list[Path], dict[str, Any]]:
+    effective_config: dict[str, Any] = {}
+    resolved_paths: list[Path] = []
+
+    for layer in _resolve_e2e_config_layers_from_node(node):
+        if isinstance(layer, str):
+            config_path = _resolve_config_path(layer)
+            if not config_path.is_file():
+                raise pytest.UsageError(f"E2E platform config not found: {config_path}")
+            layer_config = yaml.safe_load(config_path.read_text()) or {}
+            resolved_paths.append(config_path)
+        else:
+            layer_config = layer
+        effective_config = deep_merge(effective_config, layer_config)
+
+    return resolved_paths, _normalize_config(effective_config)
+
+
+def e2e_services_data_dir(log_dir: Path, config_hash: str) -> Path:
+    """Return the persistent data directory for one pooled services instance."""
+    return log_dir / f"data-{config_hash}"
+
+
+def with_e2e_instance_paths(config_data: dict[str, Any], data_dir: Path) -> dict[str, Any]:
+    """Return config data with per-instance filesystem paths rooted under ``data_dir``."""
+    rendered = deepcopy(config_data)
+    subprocess_working_dir = str(data_dir / "subprocess-jobs")
+    files_root = str(data_dir / "files")
+
+    jobs = rendered.get("jobs")
+    if isinstance(jobs, dict):
+        executors = jobs.get("executors")
+        if isinstance(executors, list):
+            for executor in executors:
+                if not isinstance(executor, dict):
+                    continue
+                if executor.get("provider") != "subprocess":
+                    continue
+                config = executor.setdefault("config", {})
+                if isinstance(config, dict):
+                    config["working_directory"] = subprocess_working_dir
+
+        executor_defaults = jobs.get("executor_defaults")
+        if isinstance(executor_defaults, dict):
+            subprocess_defaults = executor_defaults.get("subprocess")
+            if isinstance(subprocess_defaults, dict):
+                subprocess_defaults["working_directory"] = subprocess_working_dir
+
+    files = rendered.get("files")
+    if isinstance(files, dict):
+        default_storage_config = files.get("default_storage_config")
+        if isinstance(default_storage_config, dict) and default_storage_config.get("type") == "local":
+            default_storage_config["path"] = files_root
+
+    return rendered
+
+
+def e2e_services_env(config_path: Path, data_dir: Path) -> dict[str, str]:
+    """Environment for the ``nemo services run`` child process."""
+    env = os.environ.copy()
+    env["NMP_SEED_ON_STARTUP"] = "true"
+    env["NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX"] = "igw-mock-"
+    env["NMP_CONFIG_FILE_PATH"] = str(config_path)
+    env["NMP_CONFIG_WARNINGS_DISABLED"] = "1"
+    env["NMP_DATA_DIR"] = str(data_dir)
+    return env
+
+
+def _e2e_auth_enabled(config_data: dict[str, Any]) -> bool:
+    auth_cfg = config_data.get("auth")
+    return isinstance(auth_cfg, dict) and bool(auth_cfg.get("enabled", False))
+
+
+def _services_pool_key(config_hash: str) -> ServicesPoolKey:
+    return ServicesPoolKey(config_hash=config_hash)
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _process_exited(proc: subprocess.Popen[Any]) -> bool:
+    return proc.poll() is not None
+
+
+def _wait_for_healthy(url: str, proc: subprocess.Popen[Any], timeout: float = _HEALTH_TIMEOUT) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _process_exited(proc):
+            return False
+        try:
+            resp = httpx.get(f"{url}/status", timeout=2.0)
+            if resp.status_code == 200:
+                return True
+        except httpx.RequestError:
+            pass
+        if _process_exited(proc):
+            return False
+        time.sleep(_HEALTH_POLL_INTERVAL)
+    return False
+
+
+def _wait_for_auth_ready(url: str, proc: subprocess.Popen[Any], timeout: float = _AUTH_READY_TIMEOUT) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _process_exited(proc):
+            return False
+        probe_name = f"auth-probe-{uuid.uuid4().hex[:8]}"
+        entity_name = f"auth-probe-entity-{uuid.uuid4().hex[:8]}"
+        try:
+            create_resp = httpx.post(
+                f"{url}/apis/entities/v2/workspaces",
+                json={"name": probe_name},
+                headers=admin_headers(),
+                timeout=5.0,
+            )
+            if create_resp.status_code != 201:
+                if _process_exited(proc):
+                    return False
+                time.sleep(_HEALTH_POLL_INTERVAL)
+                continue
+
+            entity_resp = httpx.post(
+                f"{url}/apis/entities/v2/workspaces/{probe_name}/entities/e2e-auth-probe",
+                json={"name": entity_name, "data": {"ready": True}},
+                headers=admin_headers(),
+                timeout=5.0,
+            )
+            if entity_resp.status_code != 201:
+                httpx.delete(
+                    f"{url}/apis/entities/v2/workspaces/{probe_name}",
+                    headers=admin_headers(),
+                    timeout=5.0,
+                )
+                time.sleep(_HEALTH_POLL_INTERVAL)
+                continue
+
+            httpx.delete(
+                f"{url}/apis/entities/v2/workspaces/{probe_name}/entities/e2e-auth-probe/{entity_name}",
+                headers=admin_headers(),
+                timeout=5.0,
+            )
+            httpx.delete(
+                f"{url}/apis/entities/v2/workspaces/{probe_name}",
+                headers=admin_headers(),
+                timeout=5.0,
+            )
+            return True
+        except httpx.RequestError as exc:
+            logger.debug("Auth readiness probe failed; will retry: %s", exc)
+        if _process_exited(proc):
+            return False
+        time.sleep(_HEALTH_POLL_INTERVAL)
+    return False
+
+
+def _start_services(
+    config_path: Path, config_data: dict[str, Any], config_hash: str, log_path: Path
+) -> RunningServices:
+    port = _find_free_port()
+    url = f"http://127.0.0.1:{port}"
+
+    nemo_bin = str(Path(sys.executable).parent / "nemo")
+    args = [
+        nemo_bin,
+        "services",
+        "run",
+        "--service-group",
+        "all",
+        "--controller-group",
+        "all",
+        "--port",
+        str(port),
+    ]
+    data_dir = e2e_services_data_dir(log_path.parent, config_hash)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    env = e2e_services_env(config_path, data_dir)
+
+    logger.info("Starting nemo services on port %d with config %s", port, config_path)
+
+    log_file = open(log_path, "w")
+    try:
+        proc = subprocess.Popen(args, stdout=log_file, stderr=subprocess.STDOUT, env=env)
+    finally:
+        log_file.close()
+
+    if not _wait_for_healthy(url, proc):
+        try:
+            proc.terminate()
+            proc.wait(timeout=10)
+        except Exception:
+            proc.kill()
+            proc.wait(timeout=5)
+        pytest.fail(
+            f"nemo services run did not become healthy within {_HEALTH_TIMEOUT}s.\nlog:\n{log_path.read_text()}"
+        )
+    auth_enabled = _e2e_auth_enabled(config_data)
+    if auth_enabled and not _wait_for_auth_ready(url, proc):
+        try:
+            proc.terminate()
+            proc.wait(timeout=10)
+        except Exception:
+            proc.kill()
+            proc.wait(timeout=5)
+        pytest.fail(
+            f"Platform auth seed did not become ready within {_AUTH_READY_TIMEOUT}s.\nlog:\n{log_path.read_text()}"
+        )
+
+    logger.info("Platform services ready on port %d (pid %d)", port, proc.pid)
+    return RunningServices(
+        url=url,
+        log_path=log_path,
+        proc=proc,
+        config_path=config_path,
+        auth_enabled=auth_enabled,
+        key=_services_pool_key(config_hash),
+    )

--- a/e2e/test_data_designer.py
+++ b/e2e/test_data_designer.py
@@ -12,8 +12,10 @@ from data_designer_nemo.nemotron_personas import WORKSPACE, get_resource_name_fo
 from nemo_data_designer_plugin.sdk.errors import DataDesignerJobError
 from nemo_platform import NeMoPlatform, NotFoundError
 from nemo_platform.types.inference import ModelProvider
-from nmp.testing import MockProviderResponse, NemoRun, add_mock_provider
+from nmp.testing import MockProviderResponse, add_mock_provider, assert_exit_0, run_nemo_local
 from nmp.testing.pytest_outcomes import pytest_skip
+
+pytestmark = [pytest.mark.e2e_config("e2e/configs/local-subprocess.yaml")]
 
 PROVIDER_NAME = "test-provider"
 
@@ -168,7 +170,7 @@ def test_fileset_seed_data(sdk: NeMoPlatform, workspace: str) -> None:
 
 
 @pytest.fixture
-def nemotron_personas_locale(nemo_run: NemoRun, sdk: NeMoPlatform, workspace: str, ngc_secret: str) -> Generator[str]:
+def nemotron_personas_locale(_services: str, sdk: NeMoPlatform, workspace: str, ngc_secret: str) -> Generator[str]:
     """Invokes the CLI to create a Fileset for Nemotron Personas data.
 
     This test does call out to NGC and downloads personas data. Use the smallest locale available
@@ -184,7 +186,7 @@ def nemotron_personas_locale(nemo_run: NemoRun, sdk: NeMoPlatform, workspace: st
     with suppress(NotFoundError):
         sdk.files.filesets.delete(fileset_name, workspace=WORKSPACE)
 
-    nemo_run(
+    result = run_nemo_local(
         "data-designer",
         "personas",
         "make-fileset",
@@ -192,7 +194,10 @@ def nemotron_personas_locale(nemo_run: NemoRun, sdk: NeMoPlatform, workspace: st
         locale,
         "--api-key-secret",
         f"{workspace}/{ngc_secret}",
+        base_url=_services,
+        workspace=workspace,
     )
+    assert_exit_0(result, "Failed to create Nemotron Personas fileset via CLI")
 
     yield locale
 

--- a/e2e/test_jobs.py
+++ b/e2e/test_jobs.py
@@ -17,7 +17,10 @@ from nmp.testing.e2e import wait_for_job_logs, wait_for_platform_job
 
 JOB_SOURCE = "e2e-test-jobs"
 
-pytestmark = [pytest.mark.timeout(600)]
+pytestmark = [
+    pytest.mark.timeout(600),
+    pytest.mark.e2e_config("e2e/configs/local-subprocess.yaml"),
+]
 
 
 def _job_diagnostic_message(sdk: NeMoPlatform, job, workspace: str, prefix: str) -> str:

--- a/e2e/test_jobs_auth.py
+++ b/e2e/test_jobs_auth.py
@@ -1,0 +1,245 @@
+"""E2E tests for jobs with auth enabled.
+
+Local E2E runs translate ``cpu/default`` container steps to the subprocess
+backend, so these tests intentionally omit ``container.image`` and rely only on
+the command shape that subprocess consumes.
+"""
+
+import logging
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+
+import pytest
+from nemo_platform import NeMoPlatform
+from nemo_platform_ext.auth.helpers import generate_unsigned_jwt
+from nemo_platform_plugin.jobs.api_factory import (
+    ContainerSpec,
+    CPUExecutionProviderSpec,
+    EnvironmentVariable,
+    PlatformJobSpec,
+    PlatformJobStep,
+)
+from nmp.common.entities import ALL_WORKSPACES
+from nmp.core.jobs.controllers.diagnostics import collect_job_diagnostics
+from nmp.testing import TEST_ADMIN_EMAIL, grant_workspace_role, short_unique_name, unique_email
+from nmp.testing.e2e import wait_for_platform_job
+
+JOB_SOURCE = "e2e-auth-test"
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.e2e_config("e2e/configs/local-subprocess.yaml", {"auth": {"enabled": True}}),
+]
+
+
+def _as_bearer_user(
+    sdk: NeMoPlatform,
+    email: str,
+    *,
+    groups: list[str] | None = None,
+) -> NeMoPlatform:
+    token = generate_unsigned_jwt(
+        principal_id=email,
+        email=email,
+        groups=groups,
+    )
+    return sdk.with_options(set_default_headers={"Authorization": f"Bearer {token}"})
+
+
+def _log_auth_job_diagnostics(
+    sdk: NeMoPlatform,
+    *,
+    workspace: str,
+    job_name: str,
+    step_name: str,
+    context: str,
+) -> None:
+    logger.error(
+        "Auth job diagnostics",
+        extra={
+            "diagnostic_context": context,
+            "workspace": workspace,
+            "job_name": job_name,
+            "step_name": step_name,
+            "job_diagnostics": collect_job_diagnostics(
+                sdk,
+                workspace=workspace,
+                job_name=job_name,
+                step_name=step_name,
+                context=context,
+            ),
+        },
+    )
+
+
+@contextmanager
+def _managed_admin_workspace(admin_sdk: NeMoPlatform, workspace_name: str) -> Iterator[str]:
+    admin_sdk.workspaces.create(name=workspace_name)
+    try:
+        yield workspace_name
+    finally:
+        admin_sdk.workspaces.delete(workspace_name)
+
+
+def _job_exists_in_pages(jobs_page: object, job_name: str) -> bool:
+    return any(item.name == job_name for page in jobs_page.iter_pages() for item in page.data)
+
+
+def test_job_principal_propagation(sdk: NeMoPlatform):
+    admin_sdk = _as_bearer_user(sdk, TEST_ADMIN_EMAIL, groups=["admin"])
+    user_email = unique_email("job-creator")
+    workspace_name = short_unique_name("job-auth-test")
+
+    with _managed_admin_workspace(admin_sdk, workspace_name):
+        grant_workspace_role(admin_sdk, workspace=workspace_name, principal=user_email, roles=["Editor"])
+
+        user_sdk = _as_bearer_user(sdk, user_email)
+        job = user_sdk.jobs.create(
+            workspace=workspace_name,
+            source=JOB_SOURCE,
+            spec={"test": "auth-propagation"},
+            platform_spec=PlatformJobSpec(
+                steps=[
+                    PlatformJobStep(
+                        name="auth-test-step",
+                        executor=CPUExecutionProviderSpec(
+                            provider="cpu",
+                            container=ContainerSpec(
+                                entrypoint=["nemo-platform"],
+                                command=["run", "task", "--task", "nmp.hello_world.tasks.hello_world"],
+                            ),
+                        ),
+                        environment=[EnvironmentVariable(name="BUSY_LOOP_DURATION_SECONDS", value="0")],
+                        config={"message": "auth propagation test"},
+                    )
+                ]
+            ),
+        )
+
+        completed_job = wait_for_platform_job(user_sdk, job.name, workspace_name)
+        assert completed_job.status == "completed"
+
+        fileset_name = f"hello-world-{job.name}"
+        fileset = user_sdk.files.filesets.retrieve(workspace=workspace_name, name=fileset_name)
+        assert fileset is not None
+
+        file_content = user_sdk.files.download_content(
+            remote_path="message.txt",
+            fileset=fileset_name,
+            workspace=workspace_name,
+        )
+        assert file_content == b"auth propagation test"
+
+
+def test_job_cannot_access_unauthorized_workspace(sdk: NeMoPlatform):
+    admin_sdk = _as_bearer_user(sdk, TEST_ADMIN_EMAIL, groups=["admin"])
+    owner_email = unique_email("owner")
+    other_email = unique_email("other")
+
+    restricted_workspace = short_unique_name("restricted")
+    runner_workspace = short_unique_name("runner")
+
+    with ExitStack() as stack:
+        stack.enter_context(_managed_admin_workspace(admin_sdk, restricted_workspace))
+        stack.enter_context(_managed_admin_workspace(admin_sdk, runner_workspace))
+        grant_workspace_role(admin_sdk, workspace=restricted_workspace, principal=owner_email, roles=["Editor"])
+        grant_workspace_role(admin_sdk, workspace=runner_workspace, principal=other_email, roles=["Editor"])
+
+        owner_sdk = _as_bearer_user(sdk, owner_email)
+        other_sdk = _as_bearer_user(sdk, other_email)
+
+        fileset_name = "private-data"
+        owner_sdk.files.filesets.create(workspace=restricted_workspace, name=fileset_name)
+
+        job = other_sdk.jobs.create(
+            workspace=runner_workspace,
+            source=JOB_SOURCE,
+            spec={"test": "auth-denial"},
+            platform_spec=PlatformJobSpec(
+                steps=[
+                    PlatformJobStep(
+                        name="access-test-step",
+                        executor=CPUExecutionProviderSpec(
+                            provider="cpu",
+                            container=ContainerSpec(
+                                entrypoint=["nemo-platform"],
+                                command=["run", "task", "--task", "nmp.hello_world.tasks.access_fileset"],
+                            ),
+                        ),
+                        config={
+                            "workspace": restricted_workspace,
+                            "fileset": fileset_name,
+                        },
+                    )
+                ]
+            ),
+        )
+
+        completed_job = wait_for_platform_job(other_sdk, job.name, runner_workspace)
+        if completed_job.status != "error":
+            _log_auth_job_diagnostics(
+                other_sdk,
+                workspace=runner_workspace,
+                job_name=job.name,
+                step_name="access-test-step",
+                context="expected job to fail with unauthorized workspace access",
+            )
+        assert completed_job.status == "error"
+
+        tasks_response = other_sdk.jobs.tasks.list("access-test-step", job=job.name, workspace=runner_workspace)
+        if not tasks_response.data:
+            _log_auth_job_diagnostics(
+                other_sdk,
+                workspace=runner_workspace,
+                job_name=job.name,
+                step_name="access-test-step",
+                context="expected task list to include failed access task",
+            )
+        assert tasks_response.data
+        task = tasks_response.data[0]
+        if not task.error_stack or "403" not in task.error_stack or "Forbidden" not in task.error_stack:
+            _log_auth_job_diagnostics(
+                other_sdk,
+                workspace=runner_workspace,
+                job_name=job.name,
+                step_name="access-test-step",
+                context="expected task error stack to include 403 forbidden details",
+            )
+        assert task.error_stack
+        assert "403" in task.error_stack and "Forbidden" in task.error_stack
+
+
+def test_job_admin_can_list_jobs_in_all_workspaces(sdk: NeMoPlatform):
+    admin_sdk = _as_bearer_user(sdk, TEST_ADMIN_EMAIL, groups=["admin"])
+    user_email = unique_email("member")
+    workspace_name = short_unique_name("admin-list-jobs")
+
+    with _managed_admin_workspace(admin_sdk, workspace_name):
+        grant_workspace_role(admin_sdk, workspace=workspace_name, principal=user_email, roles=["Editor"])
+
+        user_sdk = _as_bearer_user(sdk, user_email)
+        job = user_sdk.jobs.create(
+            workspace=workspace_name,
+            source=JOB_SOURCE,
+            spec={"test": "admin-list"},
+            platform_spec=PlatformJobSpec(
+                steps=[
+                    PlatformJobStep(
+                        name="admin-list-step",
+                        executor=CPUExecutionProviderSpec(
+                            provider="cpu",
+                            container=ContainerSpec(
+                                command=["echo", "admin list jobs"],
+                            ),
+                        ),
+                    )
+                ]
+            ),
+        )
+
+        completed_job = wait_for_platform_job(user_sdk, job.name, workspace_name)
+        assert completed_job.status == "completed"
+
+        jobs = admin_sdk.jobs.list(workspace=ALL_WORKSPACES)
+        assert jobs.pagination is not None
+        assert _job_exists_in_pages(jobs, job.name)

--- a/packages/nmp_testing/src/nmp/testing/__init__.py
+++ b/packages/nmp_testing/src/nmp/testing/__init__.py
@@ -9,7 +9,7 @@ CLI testing:
 - NemoRun / NmpRun: Type alias for a callable that runs the NeMo CLI
 - assert_exit_0: Assert that a CLI invocation succeeded
 - get_repo_root: Return the repository root using git
-- run_nemo_local / run_nmp_local: Run NeMo CLI from repo root without cluster URL injection
+- run_nemo_local / run_nmp_local: Run NeMo CLI from repo root with optional platform URL injection
 
 API testing:
 - create_test_client: Helper for creating FastAPI test clients with in-memory storage

--- a/packages/nmp_testing/src/nmp/testing/utils.py
+++ b/packages/nmp_testing/src/nmp/testing/utils.py
@@ -47,20 +47,27 @@ def get_repo_root() -> Path:
 
 def run_nemo_local(
     *args: str,
+    base_url: str | None = None,
+    workspace: str | None = None,
     env_extra: dict[str, str] | None = None,
     timeout: int = 120,
     cwd: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Run the NeMo CLI (`nemo`) from repo root without cluster URL injection.
+    """Run the NeMo CLI (``nemo``) from repo root.
 
-    Used by tests that target local CLI behavior (config, quickstart) and
-    don't need the E2E cluster URL injected.
+    Used by tests that target local CLI behavior as well as E2E flows that
+    need to point the CLI at a specific platform instance.
 
-    Pass ``cwd`` to run from a different directory (e.g. a ``tmp_path`` with a
-    fake ``.git`` marker so ``skills install`` writes there instead of the real
-    repo root).
+    Pass ``base_url`` and ``workspace`` to inject ``NMP_BASE_URL`` and
+    ``NMP_WORKSPACE`` directly. Pass ``cwd`` to run from a different directory
+    (e.g. a ``tmp_path`` with a fake ``.git`` marker so ``skills install``
+    writes there instead of the real repo root).
     """
     env = os.environ.copy()
+    if base_url is not None:
+        env["NMP_BASE_URL"] = base_url.rstrip("/")
+    if workspace is not None:
+        env["NMP_WORKSPACE"] = workspace
     if env_extra:
         env.update(env_extra)
     cmd = ["uv", "run", "--project", str(get_repo_root()), "--frozen", "nemo", *args]

--- a/packages/nmp_testing/tests/unit/test_e2e_harness.py
+++ b/packages/nmp_testing/tests/unit/test_e2e_harness.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the local pytest E2E harness helpers."""
+
+from pathlib import Path
+from typing import Any, cast
+
+import e2e.services_pool as services_pool
+
+
+def test_e2e_services_env_sets_isolated_data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("NMP_DATA_DIR", "/shell/value/should/not/leak")
+
+    config_path = tmp_path / "platform.yaml"
+    data_dir = tmp_path / "isolated-data"
+
+    env = services_pool.e2e_services_env(config_path, data_dir)
+
+    assert env["NMP_CONFIG_FILE_PATH"] == str(config_path)
+    assert env["NMP_DATA_DIR"] == str(data_dir)
+    assert env["NMP_SEED_ON_STARTUP"] == "true"
+    assert env["NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX"] == "igw-mock-"
+    assert env["NMP_CONFIG_WARNINGS_DISABLED"] == "1"
+
+
+def test_e2e_services_data_dir_is_stable_per_hash(tmp_path):
+    log_dir = tmp_path / "logs"
+
+    path = services_pool.e2e_services_data_dir(log_dir, "abc123def456")
+
+    assert path == Path(log_dir / "data-abc123def456")
+
+
+def test_with_e2e_instance_paths_namespaces_local_filesystem_paths(tmp_path):
+    data_dir = tmp_path / "data-abc123def456"
+    config_data: dict[str, Any] = {
+        "jobs": {
+            "executors": [
+                {
+                    "provider": "subprocess",
+                    "profile": "default",
+                    "backend": "subprocess",
+                    "config": {"working_directory": ".tmp/e2e/subprocess-jobs"},
+                }
+            ],
+            "executor_defaults": {
+                "subprocess": {"working_directory": ".tmp/e2e/subprocess-jobs"},
+            },
+        },
+        "files": {
+            "default_storage_config": {
+                "type": "local",
+                "path": ".tmp/e2e/files",
+            }
+        },
+    }
+
+    rendered = services_pool.with_e2e_instance_paths(config_data, data_dir)
+
+    assert rendered["jobs"]["executors"][0]["config"]["working_directory"] == str(data_dir / "subprocess-jobs")
+    assert rendered["jobs"]["executor_defaults"]["subprocess"]["working_directory"] == str(data_dir / "subprocess-jobs")
+    assert rendered["files"]["default_storage_config"]["path"] == str(data_dir / "files")
+    jobs_config = cast(dict[str, Any], config_data["jobs"])
+    executors = cast(list[dict[str, Any]], jobs_config["executors"])
+    assert executors[0]["config"]["working_directory"] == ".tmp/e2e/subprocess-jobs"

--- a/pytest.ini
+++ b/pytest.ini
@@ -59,6 +59,7 @@ markers =
     smoke_nmp_automodel_tasks: Import smoke tests for the nmp-automodel-tasks image
     smoke_nmp_automodel_training: Import smoke tests for the nmp-automodel-training image
     e2e: End-to-end tests - test complete customer workflows on deployed infrastructure (Helm/Docker Compose)
+    e2e_config(*layers): Ordered list of repo-root-relative config paths and/or inline dict overlays; empty means default local config
     regression: Regression tests - test individual functional microservices for baseline functionality
     infrastructure: Infrastructure tests - ensure services are compatible with customer infrastructure
     canary: Canary tests - test deployed integration environments like top of tree

--- a/services/core/jobs/src/nmp/core/jobs/api/v2/jobs/endpoints.py
+++ b/services/core/jobs/src/nmp/core/jobs/api/v2/jobs/endpoints.py
@@ -651,7 +651,7 @@ async def list_job_step_tasks(
         if not step_entity:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job step not found")
 
-        return PlatformJobListTaskResponse(data=await dispatcher.list_tasks(step_entity.id))
+        return PlatformJobListTaskResponse(data=await dispatcher.list_tasks(step_entity.id, workspace=workspace))
 
 
 @router.put(

--- a/services/core/jobs/src/nmp/core/jobs/app/dispatcher.py
+++ b/services/core/jobs/src/nmp/core/jobs/app/dispatcher.py
@@ -1130,10 +1130,11 @@ class JobDispatcher:
         except EntityNotFoundError:
             return None
 
-    async def list_tasks(self, step_id: str) -> list[PlatformJobTask]:
+    async def list_tasks(self, step_id: str, workspace: str) -> list[PlatformJobTask]:
         """List all platform job tasks for a specific step."""
         response = await self.store.list(
             PlatformJobTask,
+            workspace=workspace,
             filter_obj={"step_id": step_id},
             page_size=1000,
         )

--- a/services/core/jobs/src/nmp/core/jobs/config.py
+++ b/services/core/jobs/src/nmp/core/jobs/config.py
@@ -37,6 +37,13 @@ class JobsServiceConfig(create_service_config_class("jobs")):  # type: ignore
             "docker/none runtimes and false for kubernetes."
         ),
     )
+    include_job_logs_in_diagnostics: bool = Field(
+        default=False,
+        description=(
+            "Include raw job log lines in controller diagnostics snapshots. Disabled by default because "
+            "job logs may contain secrets or PII. Enable only for local debugging or test environments."
+        ),
+    )
 
     def resolved_enable_subprocess_executor(self) -> bool:
         """Whether host subprocess execution is registered for default profiles."""

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
@@ -57,6 +57,7 @@ SUBPROCESS_WORKDIR_STATUS_KEY = "subprocess_work_dir"
 SUBPROCESS_PID_STATUS_KEY = "pid"
 SUBPROCESS_PGID_STATUS_KEY = "pgid"
 SUBPROCESS_PERSISTENT_STORAGE_STATUS_KEY = "subprocess_persistent_storage_path"
+_MISSING_METADATA_PENDING_GRACE_SECONDS = 5
 SUBPROCESS_INHERITED_ENV_ALLOWLIST = frozenset(
     {
         "PATH",
@@ -281,6 +282,24 @@ class SubprocessJobBackend(JobBackend[SubprocessExecutionProvider, SubprocessJob
                     status=PlatformJobStatus.CANCELLED.value,
                     status_details={"message": "Subprocess not found, job cancelled"},
                 )
+            task_fallback = self._get_task_fallback_update(step)
+            if task_fallback is not None:
+                return task_fallback
+            if step.status == PlatformJobStatus.PENDING and not self._pending_step_missing_metadata_is_stale(step):
+                # Stopgap only: the subprocess backend keeps execution metadata in controller
+                # memory, while step/task state is persisted in the jobs database. Those two
+                # sources of truth are not fully synchronized today because subprocess was not
+                # originally designed around durable jobs-backed execution state. That means a
+                # step can already be visible in the database as pending before this backend has
+                # registered local subprocess metadata for it. Keep the step pending briefly
+                # instead of failing it. The real fix is to move subprocess onto properly
+                # serialized, jobs-backed state so reconciliation does not depend on process-local
+                # memory.
+                return JobUpdate(
+                    status=PlatformJobStatus.PENDING.value,
+                    status_details=step.status_details or {"message": "Awaiting subprocess metadata"},
+                    error_details=step.error_details or {},
+                )
             return JobUpdate(
                 status=PlatformJobStatus.ERROR.value,
                 error_details={"message": "Local subprocess metadata not found"},
@@ -324,8 +343,6 @@ class SubprocessJobBackend(JobBackend[SubprocessExecutionProvider, SubprocessJob
                 should_cleanup = self._execution_profile_config.cleanup_completed_jobs_immediately
                 if not should_cleanup and step.updated_at is not None:
                     updated_at = step.updated_at
-                    if isinstance(updated_at, str):
-                        updated_at = datetime.datetime.fromisoformat(updated_at)
                     if updated_at.tzinfo is None:
                         updated_at = updated_at.replace(tzinfo=datetime.timezone.utc)
                     expires_at = updated_at + datetime.timedelta(
@@ -336,6 +353,46 @@ class SubprocessJobBackend(JobBackend[SubprocessExecutionProvider, SubprocessJob
             if should_cleanup:
                 shutil.rmtree(metadata.work_dir, ignore_errors=True)
                 self._process_registry.pop(key)
+
+    def _get_task_fallback_update(self, step: PlatformJobStepWithContext) -> JobUpdate | None:
+        try:
+            tasks = self._nmp_sdk.jobs.tasks.list(
+                name=step.name,
+                job=step.job,
+                workspace=step.workspace,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to fetch tasks for subprocess metadata fallback",
+                extra={"job": step.job, "step": step.name, "workspace": step.workspace},
+            )
+            return None
+
+        if not tasks.data:
+            return None
+
+        latest_task = max(
+            tasks.data,
+            key=lambda task: (
+                task.updated_at or task.created_at or datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+            ),
+        )
+        return JobUpdate(
+            status=latest_task.status,
+            status_details=latest_task.status_details,
+            error_details=latest_task.error_details or {},
+        )
+
+    @staticmethod
+    def _pending_step_missing_metadata_is_stale(step: PlatformJobStepWithContext) -> bool:
+        anchor = step.updated_at or step.created_at
+        if anchor is None:
+            return True
+        if anchor.tzinfo is None:
+            anchor = anchor.replace(tzinfo=datetime.timezone.utc)
+        return (anchor + datetime.timedelta(seconds=_MISSING_METADATA_PENDING_GRACE_SECONDS)) < datetime.datetime.now(
+            datetime.timezone.utc
+        )
 
     @staticmethod
     def _cleanup_failed_startup_dirs(work_dir: Path, persistent_dir: Path) -> None:

--- a/services/core/jobs/src/nmp/core/jobs/controllers/diagnostics.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/diagnostics.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from nemo_platform import NeMoPlatform
+from nmp.core.jobs.config import config
+
+_MAX_LOG_ENTRIES = 20
+_MAX_ERROR_STACK_CHARS = 2048
+
+
+class JobDiagnosticTarget(Protocol):
+    workspace: str
+    job: str
+    name: str
+
+
+@dataclass(frozen=True)
+class _JobDiagnosticRef:
+    workspace: str
+    job: str
+    name: str
+
+
+def _trim_error_stack(value: str | None) -> str | None:
+    if value is None or len(value) <= _MAX_ERROR_STACK_CHARS:
+        return value
+    return value[-_MAX_ERROR_STACK_CHARS:]
+
+
+def _trim_error_details(value: Any) -> Any:
+    if isinstance(value, str):
+        return _trim_error_stack(value)
+    if isinstance(value, dict):
+        return {key: _trim_error_details(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_trim_error_details(item) for item in value]
+    return value
+
+
+def _task_dict(task: Any) -> dict[str, Any]:
+    return {
+        "name": task.name,
+        "status": task.status,
+        "status_details": task.status_details,
+        "error_details": _trim_error_details(task.error_details),
+        "error_stack": _trim_error_stack(task.error_stack),
+    }
+
+
+def _step_dict(step: Any) -> dict[str, Any]:
+    return {
+        "name": step.name,
+        "status": step.status,
+        "status_details": step.status_details,
+        "error_details": _trim_error_details(step.error_details),
+    }
+
+
+def _job_dict(job: Any) -> dict[str, Any]:
+    return {
+        "name": job.name,
+        "status": job.status,
+        "status_details": job.status_details,
+        "error_details": _trim_error_details(job.error_details),
+    }
+
+
+def collect_job_diagnostics(
+    sdk: NeMoPlatform,
+    step: JobDiagnosticTarget | None = None,
+    *,
+    workspace: str | None = None,
+    job_name: str | None = None,
+    step_name: str | None = None,
+    context: str,
+) -> dict[str, Any]:
+    step_ref: JobDiagnosticTarget
+    if step is None:
+        if workspace is None or job_name is None or step_name is None:
+            raise ValueError("Either step or workspace/job_name/step_name must be provided")
+        step_ref = _JobDiagnosticRef(workspace=workspace, job=job_name, name=step_name)
+    else:
+        step_ref = step
+
+    diagnostics: dict[str, Any] = {
+        "diagnostic_context": context,
+        "workspace": step_ref.workspace,
+        "job_name": step_ref.job,
+        "step_name": step_ref.name,
+    }
+
+    try:
+        job = sdk.jobs.retrieve(step_ref.job, workspace=step_ref.workspace)
+        diagnostics["job"] = _job_dict(job)
+    except Exception as exc:
+        diagnostics["job_error"] = str(exc)
+
+    try:
+        status = sdk.jobs.get_status(step_ref.job, workspace=step_ref.workspace)
+        diagnostics["status_api"] = {
+            "status": status.status,
+            "status_details": status.status_details,
+            "error_details": _trim_error_details(status.error_details),
+            "steps": [
+                {
+                    **_step_dict(status_step),
+                    "tasks": [_task_dict(task) for task in status_step.tasks],
+                }
+                for status_step in status.steps
+            ],
+        }
+    except Exception as exc:
+        diagnostics["status_api_error"] = str(exc)
+
+    try:
+        refreshed_step = sdk.jobs.steps.retrieve(step_ref.name, job=step_ref.job, workspace=step_ref.workspace)
+        diagnostics["step"] = _step_dict(refreshed_step)
+    except Exception as exc:
+        diagnostics["step_error"] = str(exc)
+
+    try:
+        tasks = sdk.jobs.tasks.list(step_ref.name, job=step_ref.job, workspace=step_ref.workspace)
+        diagnostics["tasks_api"] = [_task_dict(task) for task in tasks.data]
+    except Exception as exc:
+        diagnostics["tasks_api_error"] = str(exc)
+
+    try:
+        if config.include_job_logs_in_diagnostics:
+            logs = sdk.jobs.get_logs(workspace=step_ref.workspace, name=step_ref.job)
+            diagnostics["job_logs"] = [entry.message for entry in logs.data[-_MAX_LOG_ENTRIES:]]
+    except Exception as exc:
+        diagnostics["job_logs_error"] = str(exc)
+
+    return diagnostics
+
+
+def log_job_diagnostics_if_debug(
+    sdk: NeMoPlatform,
+    step: JobDiagnosticTarget | None = None,
+    *,
+    logger: logging.Logger,
+    workspace: str | None = None,
+    job_name: str | None = None,
+    step_name: str | None = None,
+    context: str,
+) -> None:
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+
+    step_ref: JobDiagnosticTarget
+    if step is None:
+        if workspace is None or job_name is None or step_name is None:
+            raise ValueError("Either step or workspace/job_name/step_name must be provided")
+        step_ref = _JobDiagnosticRef(workspace=workspace, job=job_name, name=step_name)
+    else:
+        step_ref = step
+
+    logger.debug(
+        "Job diagnostics snapshot",
+        extra={
+            "diagnostic_context": context,
+            "workspace": step_ref.workspace,
+            "job_name": step_ref.job,
+            "step_name": step_ref.name,
+            "job_diagnostics": collect_job_diagnostics(sdk, step_ref, context=context),
+        },
+    )

--- a/services/core/jobs/src/nmp/core/jobs/controllers/reconciler.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/reconciler.py
@@ -6,12 +6,15 @@ import threading
 
 from nemo_platform import APIError, APIStatusError, NeMoPlatform
 from nemo_platform.types.jobs import PlatformJobStepWithContext
+from nemo_platform.types.jobs.platform_job_steps_list_filter_param import PlatformJobStepsListFilterParam
+from nemo_platform.types.shared.platform_job_status import PlatformJobStatus as SDKPlatformJobStatus
 from nmp.common.controller import Controller
 from nmp.common.jobs.schemas import PlatformJobStatus
 from nmp.common.observability import scoped_app_ctx, start_span_with_ctx
 from nmp.core.jobs.app.ctx import JobBackendContext, JobContext
 from nmp.core.jobs.controllers.backends import extract_provider_profile
 from nmp.core.jobs.controllers.backends.registry import BackendRegistry
+from nmp.core.jobs.controllers.diagnostics import log_job_diagnostics_if_debug
 from opentelemetry import metrics, trace
 
 tracer = trace.get_tracer(__name__)
@@ -30,6 +33,7 @@ class JobReconciler(Controller):
         self._nmp_sdk = nmp_sdk
         self._stop_signal = stop_signal
         self._is_healthy = False
+        self._logger = logger
 
         self._step_reconciliation_total = meter.create_counter(
             name="nmp.jobs.reconciler.step.reconciliation.total",
@@ -52,7 +56,7 @@ class JobReconciler(Controller):
 
         with tracer.start_as_current_span("jobs_reconciler/fetch_steps_for_reconciliation"):
             try:
-                statuses = [
+                statuses: list[SDKPlatformJobStatus] = [
                     PlatformJobStatus.PENDING.value,
                     PlatformJobStatus.ACTIVE.value,
                     PlatformJobStatus.CANCELLING.value,
@@ -84,6 +88,16 @@ class JobReconciler(Controller):
                     ):
                         job_update = backend.sync(step)
                         logger.info(f"Updating job step status from '{step.status}' to '{job_update.status}'")
+                        if (
+                            job_update.status == PlatformJobStatus.ERROR.value
+                            and step.status != PlatformJobStatus.ERROR
+                        ):
+                            log_job_diagnostics_if_debug(
+                                self._nmp_sdk,
+                                step,
+                                logger=self._logger,
+                                context="step transitioned to error during reconciliation",
+                            )
                         self._nmp_sdk.jobs.steps.update_status(
                             step.name,
                             workspace=step.workspace,
@@ -113,6 +127,12 @@ class JobReconciler(Controller):
                         )
                 except Exception:
                     logger.exception("Unexpected error when reconciling job step")
+                    log_job_diagnostics_if_debug(
+                        self._nmp_sdk,
+                        step,
+                        logger=self._logger,
+                        context="unexpected reconciliation error",
+                    )
                     self._step_reconciliation_errors.add(
                         1,
                         attributes={
@@ -129,16 +149,17 @@ class JobReconciler(Controller):
                 except Exception:
                     logger.exception("Could not complete cleanup steps for backend", exc_info=True)
 
-    def get_steps_for_reconciliation(self, statuses: list[str]) -> list[PlatformJobStepWithContext]:
+    def get_steps_for_reconciliation(self, statuses: list[SDKPlatformJobStatus]) -> list[PlatformJobStepWithContext]:
         """
         Return the list of steps to reconcile.
         """
         # Iterate through all pages to get all steps
         steps = []
+        filter_params: PlatformJobStepsListFilterParam = {"status": statuses}
         for step in self._nmp_sdk.jobs.steps.list(
             name="-",  # Use "-" to indicate all jobs
             workspace="-",  # Cross-workspace query
-            filter={"status": statuses},
+            filter=filter_params,
             sort="updated_at",
         ):
             steps.append(step)

--- a/services/core/jobs/src/nmp/core/jobs/controllers/scheduler.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/scheduler.py
@@ -6,8 +6,9 @@ import threading
 import traceback
 
 import nemo_platform
-from nemo_platform import NeMoPlatform
+from nemo_platform import APIStatusError, NeMoPlatform
 from nemo_platform.types.jobs import PlatformJobStepWithContext
+from nemo_platform.types.jobs.platform_job_steps_list_filter_param import PlatformJobStepsListFilterParam
 from nmp.common.controller import Controller
 from nmp.common.jobs.schemas import PlatformJobStatus
 from nmp.common.observability import start_span_with_ctx
@@ -15,6 +16,7 @@ from nmp.core.jobs.app.ctx import JobBackendContext, JobContext
 from nmp.core.jobs.controllers.backends import JobUpdate, extract_provider_profile
 from nmp.core.jobs.controllers.backends.exceptions import ResourceAllocationError
 from nmp.core.jobs.controllers.backends.registry import BackendRegistry
+from nmp.core.jobs.controllers.diagnostics import log_job_diagnostics_if_debug
 from opentelemetry import metrics, trace
 
 tracer = trace.get_tracer(__name__)
@@ -36,6 +38,7 @@ class JobScheduler(Controller):
         self._nmp_sdk = nmp_sdk
         self._stop_signal = stop_signal
         self._is_healthy = False
+        self._logger = logger
 
         self._step_scheduled_total = meter.create_counter(
             name="nmp.jobs.scheduler.step.scheduled.total",
@@ -77,37 +80,68 @@ class JobScheduler(Controller):
                 try:
                     update = self.schedule_step(step)
                     logger.info("Scheduled job step")
-                    self._nmp_sdk.jobs.steps.update_status(
-                        step.name,
-                        workspace=step.workspace,
-                        job=step.job,
-                        status=update.status,
-                        status_details=update.status_details,  # type: ignore
-                        error_details=update.error_details,  # type: ignore
-                    )
+                    try:
+                        self._nmp_sdk.jobs.steps.update_status(
+                            step.name,
+                            workspace=step.workspace,
+                            job=step.job,
+                            status=update.status,
+                            status_details=update.status_details,  # type: ignore
+                            error_details=update.error_details,  # type: ignore
+                        )
+                    except APIStatusError as e:
+                        # Stopgap for a scheduler/reconciler race: by the time the scheduler persists
+                        # CREATED -> PENDING, another controller pass may already have advanced the
+                        # step to ACTIVE (or later). In that case, treating the stale PENDING write
+                        # as fatal incorrectly marks a healthy job as ERROR. The real fix is to
+                        # properly serialize step state transitions so stale controller writes do not
+                        # happen in the first place.
+                        if self._should_ignore_conflicting_pending_update(step, update, e):
+                            logger.info(
+                                "Ignoring stale pending update for job step that already advanced",
+                                extra={
+                                    "job": step.job,
+                                    "step": step.name,
+                                    "workspace": step.workspace,
+                                },
+                            )
+                            continue
+                        raise
 
                 except ResourceAllocationError as e:
                     logger.info(
                         f"Could not schedule job '{step.job}' step '{step.name}' due to resource constraints: {e.message}. Marking step as error."
+                    )
+                    log_job_diagnostics_if_debug(
+                        self._nmp_sdk,
+                        step,
+                        logger=self._logger,
+                        context="resource allocation error during scheduling",
                     )
                     self._step_scheduling_errors.add(1, attributes={"error_type": "resource_allocation"})
                     self._nmp_sdk.jobs.steps.update_status(
                         step.name,
                         workspace=step.workspace,
                         job=step.job,
-                        status=PlatformJobStatus.ERROR,
-                        status_details={"message": e.message},  # type: ignore
-                        error_details={"message": e.message},  # type: ignore
+                        status=PlatformJobStatus.ERROR.value,
+                        status_details={"message": e.message},
+                        error_details={"message": e.message},
                     )
                 except Exception as e:
                     logger.exception("Could not schedule job step", exc_info=True)
+                    log_job_diagnostics_if_debug(
+                        self._nmp_sdk,
+                        step,
+                        logger=self._logger,
+                        context="unexpected scheduling error",
+                    )
                     self._step_scheduling_errors.add(1, attributes={"error_type": "unknown"})
                     self._nmp_sdk.jobs.steps.update_status(
                         step.name,
                         workspace=step.workspace,
                         job=step.job,
-                        status=PlatformJobStatus.ERROR,
-                        status_details={"message": str(e)},  # type: ignore
+                        status=PlatformJobStatus.ERROR.value,
+                        status_details={"message": str(e)},
                         error_details={"message": str(e), "error": traceback.format_exc()},
                     )
 
@@ -118,10 +152,13 @@ class JobScheduler(Controller):
         """
         # Iterate through all pages to get all steps
         steps = []
+        filter_params: PlatformJobStepsListFilterParam = {
+            "status": [PlatformJobStatus.CREATED.value, PlatformJobStatus.RESUMING.value]
+        }
         for step in self._nmp_sdk.jobs.steps.list(
             name="-",  # Use "-" to indicate all jobs
             workspace="-",  # Cross-workspace query
-            filter={"status": [PlatformJobStatus.CREATED.value, PlatformJobStatus.RESUMING.value]},
+            filter=filter_params,
             sort="-created_at",
         ):
             steps.append(step)
@@ -136,4 +173,23 @@ class JobScheduler(Controller):
             "job_scheduler/schedule_step_with_backend",
             JobBackendContext(provider=provider, profile=profile, name=str(backend)),
         ):
+            assert step.step_spec is not None
             return backend.schedule(step.step_spec.executor, step)
+
+    def _should_ignore_conflicting_pending_update(
+        self,
+        step: PlatformJobStepWithContext,
+        update: JobUpdate,
+        error: APIStatusError,
+    ) -> bool:
+        if error.status_code != 409 or update.status != PlatformJobStatus.PENDING.value:
+            return False
+
+        current_step = self._nmp_sdk.jobs.steps.retrieve(
+            step.name,
+            workspace=step.workspace,
+            job=step.job,
+        )
+        original_status = PlatformJobStatus(step.status)
+        current_status = PlatformJobStatus(current_step.status)
+        return current_status != original_status and original_status.can_transition_to(current_status)

--- a/services/core/jobs/tests/controllers/test_diagnostics.py
+++ b/services/core/jobs/tests/controllers/test_diagnostics.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from nmp.core.jobs.controllers.diagnostics import _MAX_ERROR_STACK_CHARS, collect_job_diagnostics
+
+
+def _make_sdk_with_logs() -> Mock:
+    sdk = Mock()
+    sdk.jobs.retrieve.return_value = SimpleNamespace(
+        name="job-1",
+        status="error",
+        status_details={},
+        error_details={},
+    )
+    sdk.jobs.get_status.return_value = SimpleNamespace(
+        status="error",
+        status_details={},
+        error_details={},
+        steps=[],
+    )
+    sdk.jobs.steps.retrieve.return_value = SimpleNamespace(
+        name="step-1",
+        status="error",
+        status_details={},
+        error_details={},
+    )
+    sdk.jobs.tasks.list.return_value = SimpleNamespace(data=[])
+    sdk.jobs.get_logs.return_value = SimpleNamespace(
+        data=[SimpleNamespace(message="secret-token=abc123"), SimpleNamespace(message="another line")]
+    )
+    return sdk
+
+
+def test_collect_job_diagnostics_omits_raw_job_logs_by_default() -> None:
+    sdk = _make_sdk_with_logs()
+
+    with patch("nmp.core.jobs.controllers.diagnostics.config.include_job_logs_in_diagnostics", False):
+        diagnostics = collect_job_diagnostics(
+            sdk,
+            workspace="default",
+            job_name="job-1",
+            step_name="step-1",
+            context="test",
+        )
+
+    assert "job_logs" not in diagnostics
+    sdk.jobs.get_logs.assert_not_called()
+
+
+def test_collect_job_diagnostics_includes_raw_job_logs_when_enabled() -> None:
+    sdk = _make_sdk_with_logs()
+
+    with patch("nmp.core.jobs.controllers.diagnostics.config.include_job_logs_in_diagnostics", True):
+        diagnostics = collect_job_diagnostics(
+            sdk,
+            workspace="default",
+            job_name="job-1",
+            step_name="step-1",
+            context="test",
+        )
+
+    assert diagnostics["job_logs"] == ["secret-token=abc123", "another line"]
+    sdk.jobs.get_logs.assert_called_once_with(workspace="default", name="job-1")
+
+
+def test_collect_job_diagnostics_trims_long_error_details_tracebacks() -> None:
+    sdk = Mock()
+    long_error = "traceback-" + ("x" * (_MAX_ERROR_STACK_CHARS + 50))
+    expected_trimmed = long_error[-_MAX_ERROR_STACK_CHARS:]
+    error_details = {"message": "boom", "error": long_error, "other": "keep"}
+    sdk.jobs.retrieve.return_value = SimpleNamespace(
+        name="job-1",
+        status="error",
+        status_details={},
+        error_details=error_details,
+    )
+    sdk.jobs.get_status.return_value = SimpleNamespace(
+        status="error",
+        status_details={},
+        error_details=error_details,
+        steps=[
+            SimpleNamespace(
+                name="step-1",
+                status="error",
+                status_details={},
+                error_details=error_details,
+                tasks=[
+                    SimpleNamespace(
+                        name="task-1",
+                        status="error",
+                        status_details={},
+                        error_details=error_details,
+                        error_stack=long_error,
+                    )
+                ],
+            )
+        ],
+    )
+    sdk.jobs.steps.retrieve.return_value = SimpleNamespace(
+        name="step-1",
+        status="error",
+        status_details={},
+        error_details=error_details,
+    )
+    sdk.jobs.tasks.list.return_value = SimpleNamespace(
+        data=[
+            SimpleNamespace(
+                name="task-1",
+                status="error",
+                status_details={},
+                error_details=error_details,
+                error_stack=long_error,
+            )
+        ]
+    )
+
+    diagnostics = collect_job_diagnostics(
+        sdk,
+        workspace="default",
+        job_name="job-1",
+        step_name="step-1",
+        context="test",
+    )
+
+    assert diagnostics["job"]["error_details"]["error"] == expected_trimmed
+    assert diagnostics["status_api"]["error_details"]["error"] == expected_trimmed
+    assert diagnostics["status_api"]["steps"][0]["error_details"]["error"] == expected_trimmed
+    assert diagnostics["status_api"]["steps"][0]["tasks"][0]["error_details"]["error"] == expected_trimmed
+    assert diagnostics["step"]["error_details"]["error"] == expected_trimmed
+    assert diagnostics["tasks_api"][0]["error_details"]["error"] == expected_trimmed

--- a/services/core/jobs/tests/controllers/test_reconciler.py
+++ b/services/core/jobs/tests/controllers/test_reconciler.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
+from nmp.common.jobs.schemas import PlatformJobStatus
 from nmp.core.jobs.api.v2.jobs.schemas import PlatformJobStepWithContext
+from nmp.core.jobs.controllers.backends import JobUpdate
 from nmp.core.jobs.controllers.backends.registry import BackendRegistry
 from nmp.core.jobs.controllers.backends.test import MockDockerCPUJobBackend
 from nmp.core.jobs.controllers.reconciler import JobReconciler
@@ -57,4 +59,31 @@ def test_job_reconciler_syncs_active_job(
         status="completed",
         error_details=None,
         status_details=None,
+    )
+
+
+def test_job_reconciler_logs_diagnostics_for_error_transition_in_debug_mode(
+    backend_registry: BackendRegistry,
+    test_step_active: PlatformJobStepWithContext,
+):
+    mock_client = MagicMock()
+    mock_client.jobs = MagicMock()
+    mock_client.jobs.steps = MagicMock()
+    mock_client.jobs.steps.list.return_value = [test_step_active]
+
+    job_reconciler = JobReconciler(backend_registry, mock_client)
+    test_backend = job_reconciler._backend_registry.get_backend(provider="cpu", profile="default")
+    assert isinstance(test_backend, MockDockerCPUJobBackend)
+
+    with (
+        patch.object(test_backend, "sync", return_value=JobUpdate(status=PlatformJobStatus.ERROR.value)),
+        patch("nmp.core.jobs.controllers.reconciler.log_job_diagnostics_if_debug") as log_diagnostics,
+    ):
+        job_reconciler.step()
+
+    log_diagnostics.assert_called_once_with(
+        mock_client,
+        test_step_active,
+        logger=job_reconciler._logger,
+        context="step transitioned to error during reconciliation",
     )

--- a/services/core/jobs/tests/controllers/test_scheduler.py
+++ b/services/core/jobs/tests/controllers/test_scheduler.py
@@ -3,6 +3,8 @@
 
 from unittest.mock import patch
 
+import httpx
+from nemo_platform import ConflictError
 from nmp.common.jobs.schemas import PlatformJobStatus
 from nmp.core.jobs.api.v2.jobs.schemas import PlatformJobStepWithContext
 from nmp.core.jobs.controllers.backends.exceptions import ResourceAllocationError
@@ -68,4 +70,116 @@ def test_resource_allocation_error_marks_step_as_error(
         status=PlatformJobStatus.ERROR,
         status_details={"message": error_message},
         error_details={"message": error_message},
+    )
+
+
+def test_scheduler_logs_diagnostics_for_unexpected_schedule_error_in_debug_mode(
+    job_scheduler: JobScheduler,
+    mock_nmp_client,
+    test_step_pending: PlatformJobStepWithContext,
+):
+    mock_nmp_client.jobs.steps.list.return_value = [test_step_pending]
+
+    with (
+        patch.object(job_scheduler, "schedule_step", side_effect=RuntimeError("boom")),
+        patch("nmp.core.jobs.controllers.scheduler.logger.isEnabledFor", return_value=True),
+        patch("nmp.core.jobs.controllers.scheduler.log_job_diagnostics_if_debug") as log_diagnostics,
+    ):
+        job_scheduler.step()
+
+    log_diagnostics.assert_called_once_with(
+        mock_nmp_client,
+        test_step_pending,
+        logger=job_scheduler._logger,
+        context="unexpected scheduling error",
+    )
+
+
+def test_scheduler_does_not_mark_step_error_when_pending_update_conflicts_with_concurrent_advance(
+    job_scheduler: JobScheduler,
+    mock_nmp_client,
+    test_step_pending: PlatformJobStepWithContext,
+):
+    mock_nmp_client.jobs.steps.list.return_value = [test_step_pending]
+
+    request = httpx.Request(
+        "PATCH", "http://localhost/apis/jobs/v2/workspaces/default/jobs/test-job-id/steps/test-step/status"
+    )
+    response = httpx.Response(
+        409,
+        request=request,
+        json={
+            "detail": (
+                "Invalid status transition from PlatformJobStatus.ACTIVE to "
+                "PlatformJobStatus.PENDING for step test-step-id"
+            )
+        },
+    )
+    conflict = ConflictError(
+        "Error code: 409 - {'detail': 'Invalid status transition from PlatformJobStatus.ACTIVE "
+        "to PlatformJobStatus.PENDING for step test-step-id'}",
+        response=response,
+        body=response.json(),
+    )
+    active_step = test_step_pending.model_copy(update={"status": PlatformJobStatus.ACTIVE})
+    mock_nmp_client.jobs.steps.update_status.side_effect = [conflict]
+    mock_nmp_client.jobs.steps.retrieve.return_value = active_step
+
+    job_scheduler.step()
+
+    mock_nmp_client.jobs.steps.update_status.assert_called_once_with(
+        test_step_pending.name,
+        workspace=test_step_pending.workspace,
+        job=test_step_pending.job,
+        status=PlatformJobStatus.PENDING,
+        status_details=None,
+        error_details=None,
+    )
+    mock_nmp_client.jobs.steps.retrieve.assert_called_once_with(
+        test_step_pending.name,
+        workspace=test_step_pending.workspace,
+        job=test_step_pending.job,
+    )
+
+
+def test_scheduler_does_not_ignore_pending_update_conflict_when_step_remains_resuming(
+    job_scheduler: JobScheduler,
+    mock_nmp_client,
+    test_step_pending: PlatformJobStepWithContext,
+):
+    resuming_step = test_step_pending.model_copy(update={"status": PlatformJobStatus.RESUMING})
+    mock_nmp_client.jobs.steps.list.return_value = [resuming_step]
+
+    request = httpx.Request(
+        "PATCH", "http://localhost/apis/jobs/v2/workspaces/default/jobs/test-job-id/steps/test-step/status"
+    )
+    response = httpx.Response(
+        409,
+        request=request,
+        json={
+            "detail": (
+                "Invalid status transition from PlatformJobStatus.RESUMING to "
+                "PlatformJobStatus.PENDING for step test-step-id"
+            )
+        },
+    )
+    conflict = ConflictError(
+        "Error code: 409 - {'detail': 'Invalid status transition from PlatformJobStatus.RESUMING "
+        "to PlatformJobStatus.PENDING for step test-step-id'}",
+        response=response,
+        body=response.json(),
+    )
+    mock_nmp_client.jobs.steps.update_status.side_effect = [conflict, None]
+    mock_nmp_client.jobs.steps.retrieve.return_value = resuming_step
+
+    job_scheduler.step()
+
+    assert mock_nmp_client.jobs.steps.update_status.call_count == 2
+    error_call = mock_nmp_client.jobs.steps.update_status.call_args_list[1]
+    assert error_call.kwargs["status"] == PlatformJobStatus.ERROR.value
+    assert "409" in error_call.kwargs["status_details"]["message"]
+    mock_nmp_client.jobs.steps.retrieve.assert_called_once_with(
+        resuming_step.name,
+        workspace=resuming_step.workspace,
+        job=resuming_step.job,
     )

--- a/services/core/jobs/tests/controllers/test_subprocess_backend.py
+++ b/services/core/jobs/tests/controllers/test_subprocess_backend.py
@@ -4,6 +4,8 @@
 import os
 import sys
 import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from nmp.common.jobs.schemas import PlatformJobStatus
@@ -307,3 +309,88 @@ def test_cancelling_terminates_running_process(mock_nmp_client, tmp_path, mock_p
             break
         time.sleep(0.05)
     assert metadata.process.poll() is not None
+
+
+def test_sync_uses_persisted_task_when_local_metadata_is_missing(
+    mock_nmp_client, tmp_path, mock_platform_config, test_step_active
+):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(test_step_active, ["/bin/sh", "-c", "sleep 10"])
+
+    _schedule_without_otel_export(backend, step)
+    key = SubprocessProcessKey(step.workspace, step.job, str(step.attempt_id), step.name)
+    metadata = backend._process_registry.get(key)
+    assert metadata is not None
+    metadata.process.terminate()
+    assert metadata.process.wait(timeout=5) is not None
+    backend._process_registry.pop(key)
+    mock_nmp_client.jobs.tasks.list.return_value = SimpleNamespace(
+        data=[
+            SimpleNamespace(
+                status=PlatformJobStatus.ACTIVE.value,
+                status_details={"message": "Job is running"},
+                error_details={},
+                created_at=step.created_at,
+                updated_at=step.updated_at,
+            )
+        ]
+    )
+
+    update = backend.sync(step)
+
+    assert update.status == PlatformJobStatus.ACTIVE
+    assert update.status_details == {"message": "Job is running"}
+    assert update.error_details == {}
+
+
+def test_get_task_fallback_update_handles_missing_task_timestamps(
+    mock_nmp_client, tmp_path, mock_platform_config, test_step_active
+):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(test_step_active, ["/bin/sh", "-c", "true"])
+    mock_nmp_client.jobs.tasks.list.return_value = SimpleNamespace(
+        data=[
+            SimpleNamespace(
+                status=PlatformJobStatus.PENDING.value,
+                status_details={"message": "missing timestamps"},
+                error_details={},
+                created_at=None,
+                updated_at=None,
+            ),
+            SimpleNamespace(
+                status=PlatformJobStatus.ACTIVE.value,
+                status_details={"message": "latest"},
+                error_details={},
+                created_at=step.created_at,
+                updated_at=step.updated_at,
+            ),
+        ]
+    )
+
+    update = backend._get_task_fallback_update(step)
+
+    assert update is not None
+    assert update.status == PlatformJobStatus.ACTIVE
+    assert update.status_details == {"message": "latest"}
+    assert update.error_details == {}
+
+
+def test_sync_keeps_recent_pending_step_pending_when_local_metadata_is_missing(
+    mock_nmp_client, tmp_path, mock_platform_config, test_step_pending
+):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(test_step_pending, ["/bin/sh", "-c", "true"])
+    mock_nmp_client.jobs.tasks.list.return_value = SimpleNamespace(data=[])
+
+    update = backend.sync(step)
+
+    assert update.status == PlatformJobStatus.PENDING
+    assert update.error_details == {}
+
+
+def test_pending_step_missing_metadata_stale_check_accepts_typed_timestamp(test_step_pending):
+    step = _step_with_command(test_step_pending, ["/bin/sh", "-c", "true"])
+    step.updated_at = datetime.now(timezone.utc)
+    step.created_at = None
+
+    assert SubprocessJobBackend._pending_step_missing_metadata_is_stale(step) is False

--- a/services/core/jobs/tests/integration/test_task_auth_runtime.py
+++ b/services/core/jobs/tests/integration/test_task_auth_runtime.py
@@ -14,9 +14,7 @@ from __future__ import annotations
 
 import json
 import os
-from contextlib import redirect_stdout
-from io import StringIO
-from types import ModuleType
+from typing import Protocol
 
 import pytest
 from nemo_platform import PermissionDeniedError
@@ -32,24 +30,26 @@ from nmp.testing import (
 )
 
 
-def _secret_access_task_module() -> ModuleType:
-    module = ModuleType("task_auth_runtime_test_module")
+class _SecretAccessTask(Protocol):
+    def run(self, *, http_client) -> str: ...
 
-    def run(*, http_client) -> int:
-        from nmp.common.sdk_factory import get_task_sdk
 
-        workspace = os.environ["NEMO_JOB_WORKSPACE"]
-        secret_name = os.environ["NEMO_TEST_SECRET_NAME"]
+def _secret_access_task_module() -> _SecretAccessTask:
+    class _Task:
+        @staticmethod
+        def run(*, http_client) -> str:
+            from nmp.common.sdk_factory import get_task_sdk
 
-        result = get_task_sdk(as_service="jobs", http_client=http_client).secrets.access(
-            workspace=workspace,
-            name=secret_name,
-        )
-        print(result.value)
-        return 0
+            workspace = os.environ["NEMO_JOB_WORKSPACE"]
+            secret_name = os.environ["NEMO_TEST_SECRET_NAME"]
 
-    module.run = run
-    return module
+            result = get_task_sdk(as_service="jobs", http_client=http_client).secrets.access(
+                workspace=workspace,
+                name=secret_name,
+            )
+            return result.value
+
+    return _Task()
 
 
 class TestTaskRuntimeAuthPropagation:
@@ -76,9 +76,7 @@ class TestTaskRuntimeAuthPropagation:
             )
 
             ctx.access_log.clear()
-            stdout = StringIO()
             with (
-                redirect_stdout(stdout),
                 pytest.MonkeyPatch.context() as monkeypatch,
             ):
                 monkeypatch.setenv("NEMO_JOB_WORKSPACE", workspace)
@@ -93,10 +91,9 @@ class TestTaskRuntimeAuthPropagation:
                         }
                     ),
                 )
-                exit_code = _secret_access_task_module().run(http_client=ctx.test_client)
+                secret = _secret_access_task_module().run(http_client=ctx.test_client)
 
-            assert exit_code == 0
-            assert secret_value in stdout.getvalue()
+            assert secret == secret_value
 
             request = ctx.access_log.assert_has_request(
                 method="GET",

--- a/services/core/jobs/tests/test_dispatcher_cross_workspace.py
+++ b/services/core/jobs/tests/test_dispatcher_cross_workspace.py
@@ -280,9 +280,41 @@ async def test_create_or_update_task_finds_existing_task_by_name(
     assert task2.status == PlatformJobStatus.COMPLETED
 
     # Verify only one task exists for this step
-    tasks = await multi_workspace_dispatcher.list_tasks(step.id)
+    tasks = await multi_workspace_dispatcher.list_tasks(step.id, workspace="default")
     task_names = [t.name for t in tasks]
     assert task_names.count(task_name) == 1, f"Should have exactly one task named '{task_name}', found {task_names}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_list_tasks_uses_step_workspace_for_non_default_jobs(
+    multi_workspace_dispatcher: JobDispatcher,
+    multi_workspace_store: EntityClient,
+):
+    """Test that list_tasks returns tasks for steps in non-default workspaces.
+
+    This reproduces a bug where list_tasks omitted the workspace and fell back
+    to the entity client's default workspace, so jobs.tasks.list(...) returned
+    an empty task list for jobs outside ``default`` even though the task existed.
+    """
+    custom_workspace = "custom-workspace"
+    job = await multi_workspace_dispatcher.create_job(create_job_request("custom-task-list-job"), custom_workspace)
+    step = await multi_workspace_dispatcher.get_current_job_step_by_name(job.name, "basic", custom_workspace)
+    assert step is not None
+
+    task = await multi_workspace_store.add(
+        PlatformJobTask(
+            name="custom-task",
+            workspace=custom_workspace,
+            step_id=step.id,
+            status=PlatformJobStatus.ERROR,
+        )
+    )
+    assert task.id is not None
+
+    tasks = await multi_workspace_dispatcher.list_tasks(step.id, workspace=custom_workspace)
+
+    assert [listed_task.id for listed_task in tasks] == [task.id]
 
 
 @pytest.mark.asyncio

--- a/services/core/jobs/tests/test_timestamp_contracts.py
+++ b/services/core/jobs/tests/test_timestamp_contracts.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+from typing import assert_type
+
+from nemo_platform.types.jobs import PlatformJobStepWithContext
+
+
+def test_platform_job_step_with_context_parses_wire_timestamps_to_datetime() -> None:
+    step = PlatformJobStepWithContext.model_validate(
+        {
+            "id": "test-step-id",
+            "attempt_id": "test-attempt-id",
+            "fileset": "test-fileset",
+            "job": "test-job-id",
+            "name": "test-step",
+            "workspace": "default",
+            "created_at": "2026-06-23T19:00:00Z",
+            "updated_at": "2026-06-23T19:00:05Z",
+        }
+    )
+
+    assert_type(step.created_at, datetime | None)
+    assert_type(step.updated_at, datetime | None)
+    assert isinstance(step.created_at, datetime)
+    assert isinstance(step.updated_at, datetime)

--- a/tests/test_e2e_jobs_auth.py
+++ b/tests/test_e2e_jobs_auth.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from e2e.test_jobs_auth import _job_exists_in_pages, _managed_admin_workspace
+
+
+class _StubWorkspaces:
+    def __init__(self) -> None:
+        self.created: list[str] = []
+        self.deleted: list[str] = []
+
+    def create(self, *, name: str) -> None:
+        self.created.append(name)
+
+    def delete(self, name: str) -> None:
+        self.deleted.append(name)
+
+
+class _StubSDK:
+    def __init__(self) -> None:
+        self.workspaces = _StubWorkspaces()
+
+
+class _StubJob:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _StubPage:
+    def __init__(self, pages: list["_StubPage"], job_names: list[str]) -> None:
+        self._pages = pages
+        self.data = [_StubJob(name) for name in job_names]
+        self.pagination = object()
+
+    def iter_pages(self):
+        yield from self._pages
+
+
+def test_managed_admin_workspace_deletes_workspace_after_success() -> None:
+    sdk = _StubSDK()
+
+    with _managed_admin_workspace(sdk, "workspace-a") as workspace_name:
+        assert workspace_name == "workspace-a"
+
+    assert sdk.workspaces.created == ["workspace-a"]
+    assert sdk.workspaces.deleted == ["workspace-a"]
+
+
+def test_managed_admin_workspace_deletes_workspace_after_failure() -> None:
+    sdk = _StubSDK()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with _managed_admin_workspace(sdk, "workspace-b"):
+            raise RuntimeError("boom")
+
+    assert sdk.workspaces.created == ["workspace-b"]
+    assert sdk.workspaces.deleted == ["workspace-b"]
+
+
+def test_job_exists_in_pages_checks_later_pages() -> None:
+    page_two = _StubPage([], ["target-job"])
+    page_one = _StubPage([], ["other-job"])
+    page_one._pages = [page_one, page_two]
+
+    assert _job_exists_in_pages(page_one, "target-job") is True

--- a/tests/test_e2e_services_pool.py
+++ b/tests/test_e2e_services_pool.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import httpx
+
+import e2e.services_pool as services_pool
+from e2e.services_pool import E2EServicesPool, ModuleConfigState, ServicesPoolKey
+
+
+class _StubModule:
+    def __init__(self, nodeid: str) -> None:
+        self.nodeid = nodeid
+
+
+class _ExitedProc:
+    def poll(self) -> int:
+        return 1
+
+
+def test_acquire_for_module_preserves_auth_for_external_url(monkeypatch) -> None:
+    pool = E2EServicesPool()
+    module = _StubModule("e2e/test_example.py")
+    pool._module_states[module.nodeid] = ModuleConfigState(
+        module_id=module.nodeid,
+        key=ServicesPoolKey(config_hash="abc123"),
+        config_path=Path("/tmp/platform.yaml"),
+        config_data={},
+        config_layers=(),
+        auth_enabled=True,
+    )
+    monkeypatch.setenv("NMP_BASE_URL", "http://external.example")
+
+    services = pool.acquire_for_module(module)
+
+    assert services.url == "http://external.example"
+    assert services.auth_enabled is True
+
+
+def test_wait_for_healthy_returns_false_immediately_when_process_has_exited(monkeypatch) -> None:
+    monkeypatch.setattr(
+        services_pool.httpx,
+        "get",
+        lambda *args, **kwargs: (_ for _ in ()).throw(httpx.RequestError("down")),
+    )
+    monkeypatch.setattr(services_pool.time, "sleep", lambda _: (_ for _ in ()).throw(AssertionError("slept")))
+
+    assert services_pool._wait_for_healthy("http://example.com", _ExitedProc(), timeout=0.1) is False
+
+
+def test_wait_for_auth_ready_returns_false_immediately_when_process_has_exited(monkeypatch) -> None:
+    monkeypatch.setattr(
+        services_pool.httpx,
+        "post",
+        lambda *args, **kwargs: (_ for _ in ()).throw(httpx.RequestError("down")),
+    )
+    monkeypatch.setattr(services_pool.time, "sleep", lambda _: (_ for _ in ()).throw(AssertionError("slept")))
+
+    assert services_pool._wait_for_auth_ready("http://example.com", _ExitedProc(), timeout=0.1) is False


### PR DESCRIPTION
Add a `diagnostics` module to the jobs controller that collects a structured snapshot of job/step/task state for debugging stuck or failing jobs. Log snapshots at DEBUG level in the scheduler and reconciler, with a `include_job_logs_in_diagnostics` config flag (default off) to gate raw log inclusion since logs may contain secrets or PII.

Refactor the E2E harness to support per-module config selection via an `e2e_config()` pytest mark. Config layers (YAML files + inline overlays) are resolved to a canonical hash and pooled, so modules sharing the same effective config reuse one running services instance and it is torn down as soon as the last consumer finishes. Extract all service lifecycle logic from conftest.py into a new `services_pool.py` module.

Add `e2e/configs/local-subprocess.yaml` and a new `test_jobs_auth.py` suite that enables auth and exercises job principal propagation end-to-end using unsigned JWTs. Add unit tests for diagnostics, scheduler priority ordering, subprocess backend, and timestamp contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `include_job_logs_in_diagnostics` (off by default) to optionally include raw job logs in diagnostics snapshots.
  * Introduced pooled local E2E services (with a Docker-less local config) and added auth-enabled E2E job coverage.
  * Added `e2e_config(...)` pytest marker support for selecting layered E2E configurations.

* **Bug Fixes**
  * Improved job step/task workspace scoping, scheduling/reconciliation diagnostics, conflict handling, and subprocess reconciliation behavior when metadata is missing.

* **Tests**
  * Expanded unit, integration, and E2E tests covering diagnostics, auth helpers, timestamp parsing, and the services pool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->