### PR TITLE
ci(release): add manual nightly notification toggle

### DIFF
--- a/.github/workflows/release-bundle.yaml
+++ b/.github/workflows/release-bundle.yaml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: ""
+      send_notifications:
+        description: "Whether downstream release jobs should send notifications."
+        required: false
+        type: boolean
+        default: true
     secrets:
       CI_DISPATCH_TOKEN:
         description: "Token with access to send repository dispatch events to the dispatch repo."
@@ -603,6 +608,7 @@ jobs:
           BUNDLE_ARTIFACT_DIGEST: ${{ needs.assemble-release-bundle.outputs.bundle_artifact_digest }}
           RELEASE_TAG: ${{ needs.assemble-release-bundle.outputs.release_tag }}
           RELEASE_CHECKSUMS_DIGEST: ${{ needs.assemble-release-bundle.outputs.release_checksums_digest }}
+          SEND_NOTIFICATIONS: ${{ inputs.send_notifications }}
         run: |
           set -euo pipefail
 
@@ -625,6 +631,7 @@ jobs:
                 --arg artifact_id "${BUNDLE_ARTIFACT_ID}" \
                 --arg artifact_name "${BUNDLE_ARTIFACT_NAME}" \
                 --arg artifact_digest "${BUNDLE_ARTIFACT_DIGEST}" \
+                --argjson send_notifications "${SEND_NOTIFICATIONS}" \
                 '{
                   source: "artifact",
                   repo: $repo,
@@ -632,7 +639,8 @@ jobs:
                   workflow_run_attempt: $workflow_run_attempt,
                   artifact_id: $artifact_id,
                   artifact_name: $artifact_name,
-                  artifact_digest: $artifact_digest
+                  artifact_digest: $artifact_digest,
+                  send_notifications: $send_notifications
                 }')"
               ;;
             release)
@@ -643,12 +651,14 @@ jobs:
                 --arg workflow_run_id "${BUNDLE_WORKFLOW_RUN_ID}" \
                 --arg tag "${RELEASE_TAG}" \
                 --arg checksums_digest "${RELEASE_CHECKSUMS_DIGEST}" \
+                --argjson send_notifications "${SEND_NOTIFICATIONS}" \
                 '{
                   source: "release",
                   repo: $repo,
                   workflow_run_id: $workflow_run_id,
                   tag: $tag,
-                  checksums_digest: $checksums_digest
+                  checksums_digest: $checksums_digest,
+                  send_notifications: $send_notifications
                 }')"
               ;;
             *)

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: ""
+      send_notifications:
+        description: "Send downstream release notifications."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -48,6 +53,7 @@ jobs:
       release_scope: ${{ github.event_name == 'workflow_dispatch' && inputs.release_scope || 'all' }}
       sdk_ids: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk_ids || '' }}
       container_ids: ${{ github.event_name == 'workflow_dispatch' && inputs.container_ids || '' }}
+      send_notifications: ${{ github.event_name != 'workflow_dispatch' || inputs.send_notifications }}
     secrets:
       CI_DISPATCH_TOKEN: ${{ secrets.CI_DISPATCH_TOKEN }}
       CI_DISPATCH_REPO: ${{ secrets.CI_DISPATCH_REPO }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -124,5 +124,4 @@ trigger need a manual image build first.
 
 Nightly builds run automatically at 20:00 PT and publish to `pypi.nvidia.com`. They use the HEAD of `main` and version strings like `0.1.3.dev20260101120000`. No action required from the team.
 
-To trigger a nightly manually: [`release-nightly.yaml`](https://github.com/NVIDIA-NeMo/nemo-platform/actions/workflows/release-nightly.yaml) → **Run workflow** (no inputs required).
-
+To trigger a nightly manually: [`release-nightly.yaml`](https://github.com/NVIDIA-NeMo/nemo-platform/actions/workflows/release-nightly.yaml) → **Run workflow** (no inputs required). Leave `send_notifications` enabled for real reruns; disable it only for quiet smoke/ad-hoc runs.


### PR DESCRIPTION
## Why
Manual nightlies can be used for real reruns or for quiet smoke/ad-hoc validation. Real reruns should keep the current behavior, but operators need an explicit opt-out for downstream notifications when the run is only a quiet validation.

This keeps the normal path unchanged while making the quiet path intentional.

## What changed
- Adds a `send_notifications` boolean input to manual nightly dispatch.
- Defaults the input to `true`, matching scheduled nightly behavior.
- Passes the value through release bundle handoff metadata.
- Adds a short operator note to the release docs.

## Safety
- Default behavior is unchanged for scheduled nightlies and manual reruns.
- Existing reusable workflow callers keep notifications enabled by default.
- The new handoff field is additive; consumers that do not use it continue to work.
- No changes to artifact selection, SDK wheel builds, container selection, tags, labels, or release bundle storage.

## Validation
- `actionlint .github/workflows/release-nightly.yaml .github/workflows/release-bundle.yaml`
- `git diff --check -- .github/workflows/release-nightly.yaml .github/workflows/release-bundle.yaml RELEASING.md`
- Live workflow-dispatch boolean smoke covered both default true and explicit false cases.