### PR TITLE
docs: note uv PATH gotcha for Cursor Cloud setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,7 @@ Ensure all pre-commit hooks pass by running `uv run pre-commit run -a`. A clean 
 ### Bootstrap prerequisites
 
 - **uv version pin:** Root `pyproject.toml` requires `uv>=0.9.14,<0.10.0`. Newer uv releases (e.g. 0.11.x) fail `uv sync` with a version mismatch. Install the pinned range before bootstrapping: `pip install 'uv>=0.9.14,<0.10.0'`.
+- **uv PATH gotcha:** the pip install lands `uv` in `~/.local/bin`, which is on PATH for login shells (`~/.profile`) but not for the default non-login tool shell. `~/.local/bin` has been added to `~/.bashrc` so interactive shells resolve it; if a shell still reports `uv: command not found`, prefix commands with `PATH="$HOME/.local/bin:$PATH"`.
 - **Native build deps:** `make bootstrap-python` builds `annoy` (via `nemoguardrails`). Install system headers once per VM image: `sudo apt-get install -y python3-dev build-essential`.
 - **Python bootstrap:** Run `make bootstrap-python` from repo root (creates `.venv`, runs `uv sync --frozen --all-packages`). See [SETUP.md](SETUP.md) for the full playbook.
 - **Studio (optional):** `make bootstrap-studio` requires Node **22.18.x** and pnpm per `web/package.json` engines. The VM may ship an older Node (e.g. 22.14); API services still run without Studio assets. Upgrade Node then run `make bootstrap-studio` if you need `http://localhost:8080/studio/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for NeMo Platform and records one non-obvious caveat discovered during setup.

The dependency-refresh layer (install pinned `uv`, `uv sync --frozen --all-packages`) is captured in the Cloud Agent update script. This PR only adds a durable note to `AGENTS.md`: the pip-installed `uv` binary lands in `~/.local/bin`, which is on PATH for login shells but not the default non-login tool shell. `~/.local/bin` was added to `~/.bashrc` so interactive shells resolve it.

## Environment verification

Bootstrapped with `make bootstrap-python` (uv sync), then started all services via `nemo services run --service-group all`.

- Lint: `uv run ruff check` -> All checks passed
- Tests: `make test-package PACKAGE=nmp_common` -> 1029 passed, 1 failed (pre-existing, Docker-dependent config test; documented in AGENTS.md)
- Health: `curl /health/ready` -> `{"status":"ready"}`
- Hello-world task: created workspace `cursor-smoke` via the CLI and confirmed it persists in `nemo workspaces list`

[nemo_env_smoke.log](https://cursor.com/agents/bc-cd739d38-99af-4e50-9040-8d7eda96a7f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnemo_env_smoke.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd739d38-99af-4e50-9040-8d7eda96a7f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd739d38-99af-4e50-9040-8d7eda96a7f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

