### PR TITLE
feat(evaluator): AgentEvalTaskset and filesystem evidence handle

### DIFF
--- a/packages/nemo_evaluator_sdk/examples/run_agent_eval/example_metrics.py
+++ b/packages/nemo_evaluator_sdk/examples/run_agent_eval/example_metrics.py
@@ -53,13 +53,13 @@ class TestsPassMetric:
 
 
 class NoTestCheatingMetric:
-    """Score ``False`` when the agent modified or deleted protected paths."""
+    """Score ``False`` when the agent added, modified, or deleted protected paths."""
 
     def __init__(
         self,
         *,
         protected: Sequence[str] = ("tests/",),
-        change_types: Sequence[str] = ("modified", "deleted"),
+        change_types: Sequence[str] = ("added", "modified", "deleted"),
         initial_name: str = "initial_state",
         final_name: str = "final_state",
     ) -> None:

--- a/packages/nemo_evaluator_sdk/examples/run_agent_eval/example_metrics.py
+++ b/packages/nemo_evaluator_sdk/examples/run_agent_eval/example_metrics.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reference metrics-over-evidence for this example (not SDK API).
+
+These show how to score from the SDK's filesystem evidence handle instead of a
+stamped verifier reward:
+
+* :class:`TestsPassMetric` runs a command against ``final_state`` filesystem
+  evidence (in a throwaway overlay) and scores on exit 0.
+* :class:`NoTestCheatingMetric` diffs ``initial_state`` against ``final_state``
+  and fails if the agent touched protected (e.g. test) paths.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
+
+
+class TestsPassMetric:
+    """Score ``True`` when a verifier command exits 0 against final-state evidence."""
+
+    def __init__(
+        self,
+        command: Sequence[str],
+        *,
+        evidence_name: str = "final_state",
+        cwd: str = ".",
+        timeout_s: float = 300.0,
+    ) -> None:
+        self._command = list(command)
+        self._evidence_name = evidence_name
+        self._cwd = cwd
+        self._timeout_s = timeout_s
+
+    @property
+    def type(self) -> str:
+        return "tests_pass"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.boolean("tests_pass")]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        passed = False
+        evidence = input.candidate.evidence
+        if evidence is not None and evidence.get(self._evidence_name) is not None:
+            handle = await evidence.filesystem(self._evidence_name)
+            result = await handle.run_verifier(self._command, cwd=self._cwd, timeout_s=self._timeout_s)
+            passed = result.ok
+        return MetricResult(outputs=[MetricOutput(name="tests_pass", value=passed)])
+
+
+class NoTestCheatingMetric:
+    """Score ``False`` when the agent modified or deleted protected paths."""
+
+    def __init__(
+        self,
+        *,
+        protected: Sequence[str] = ("tests/",),
+        change_types: Sequence[str] = ("modified", "deleted"),
+        initial_name: str = "initial_state",
+        final_name: str = "final_state",
+    ) -> None:
+        self._protected = tuple(protected)
+        self._change_types = set(change_types)
+        self._initial_name = initial_name
+        self._final_name = final_name
+
+    @property
+    def type(self) -> str:
+        return "no_test_cheating"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.boolean("no_test_cheating")]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        evidence = input.candidate.evidence
+        clean = True
+        if evidence is not None and evidence.get(self._initial_name) and evidence.get(self._final_name):
+            initial = await evidence.filesystem(self._initial_name)
+            final = await evidence.filesystem(self._final_name)
+            diff = await initial.diff(final)
+            violations = [
+                entry for prefix in self._protected for entry in diff.changed(prefix=prefix, kinds=self._change_types)
+            ]
+            clean = not violations
+        return MetricResult(outputs=[MetricOutput(name="no_test_cheating", value=clean)])

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
@@ -5,9 +5,10 @@
 
 from __future__ import annotations
 
+import importlib
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, TypeGuard, runtime_checkable
 
 from nemo_evaluator_sdk.metrics.protocol import Metric
 from nemo_evaluator_sdk.metrics.utils import metric_type_name
@@ -130,29 +131,78 @@ class AgentEvalTask(BaseModel):
         return self
 
 
-class AgentEvalTaskset(BaseModel):
-    """Named collection of tasks; ``id``/``name`` sugar around a task list."""
+class AgentEvalTasksetLoadConfig(BaseModel):
+    """Options passed from callers to a taskset's :meth:`AgentEvalTaskset.load`."""
 
     model_config = ConfigDict(extra="forbid")
 
-    id: str = Field(description="Stable taskset identifier.")
-    name: str | None = Field(default=None, description="Human-readable taskset name.")
-    tasks: list[AgentEvalTask] = Field(description="Tasks in this set; task ids must be unique.")
+    source: str | Path | None = Field(default=None, description="Optional source path/URI the taskset loads from.")
+    limit: int | None = Field(default=None, ge=0, description="Optional cap on the number of tasks to load.")
+    evidence_dir: Path | None = Field(default=None, description="Optional directory holding task evidence inputs.")
 
-    @field_validator("id")
-    @classmethod
-    def _id_must_not_be_empty(cls, value: str) -> str:
-        if not value:
-            raise ValueError("taskset id must not be empty")
-        return value
+
+class AgentEvalTasksetBundle(BaseModel):
+    """SDK-native tasks (and optional metadata) produced by a taskset's ``load()``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tasks: list[AgentEvalTask] = Field(default_factory=list, description="Loaded tasks; at least one is required.")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Free-form taskset metadata for the run.")
 
     @model_validator(mode="after")
-    def _task_ids_unique(self) -> AgentEvalTaskset:
-        ids = [task.id for task in self.tasks]
-        duplicates = sorted({task_id for task_id in ids if ids.count(task_id) > 1})
-        if duplicates:
-            raise ValueError(f"duplicate taskset task ids: {duplicates}")
+    def _require_tasks(self) -> AgentEvalTasksetBundle:
+        if not self.tasks:
+            raise ValueError("taskset bundles require at least one task")
         return self
+
+
+@runtime_checkable
+class AgentEvalTaskset(Protocol):
+    """Experimental protocol for adapting external tasksets into agent-eval.
+
+    A taskset is a named *adapter* that loads SDK-native tasks (optionally from an
+    external source). Per the design, tasksets are resolved upstream into
+    :class:`AgentEvalTask` values via :func:`resolve_agent_eval_taskset`; the
+    evaluator scores those tasks and never consumes a taskset directly.
+    """
+
+    @property
+    def name(self) -> str:
+        """Stable taskset name used in diagnostics, metadata, and user-facing output."""
+        ...
+
+    def load(self, config: AgentEvalTasksetLoadConfig) -> AgentEvalTasksetBundle:
+        """Load this taskset's tasks (and optional metadata) into SDK-native form."""
+        ...
+
+
+def _is_agent_eval_taskset(value: object) -> TypeGuard[AgentEvalTaskset]:
+    return isinstance(getattr(value, "name", None), str) and callable(getattr(value, "load", None))
+
+
+def resolve_agent_eval_taskset(ref: str) -> AgentEvalTaskset:
+    """Resolve a ``module:object`` taskset reference.
+
+    The referenced object may be a taskset instance, a taskset class, or a
+    zero-argument factory returning a taskset instance.
+    """
+    module_name, separator, object_path = ref.partition(":")
+    if not separator or not module_name or not object_path:
+        raise ValueError("taskset references must use module:object syntax")
+
+    resolved: Any = importlib.import_module(module_name)
+    for part in object_path.split("."):
+        resolved = getattr(resolved, part)
+
+    candidate = resolved
+    if isinstance(candidate, type):
+        candidate = candidate()
+    elif not _is_agent_eval_taskset(candidate) and callable(candidate):
+        candidate = candidate()
+
+    if not _is_agent_eval_taskset(candidate):
+        raise TypeError(f"resolved taskset {ref!r} does not implement AgentEvalTaskset")
+    return candidate
 
 
 class AgentEvalRunConfig(BaseModel):

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
@@ -130,6 +130,31 @@ class AgentEvalTask(BaseModel):
         return self
 
 
+class AgentEvalTaskset(BaseModel):
+    """Named collection of tasks; ``id``/``name`` sugar around a task list."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(description="Stable taskset identifier.")
+    name: str | None = Field(default=None, description="Human-readable taskset name.")
+    tasks: list[AgentEvalTask] = Field(description="Tasks in this set; task ids must be unique.")
+
+    @field_validator("id")
+    @classmethod
+    def _id_must_not_be_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("taskset id must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def _task_ids_unique(self) -> AgentEvalTaskset:
+        ids = [task.id for task in self.tasks]
+        duplicates = sorted({task_id for task_id in ids if ids.count(task_id) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate taskset task ids: {duplicates}")
+        return self
+
+
 class AgentEvalRunConfig(BaseModel):
     """Configuration for a standalone agent-eval run."""
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
@@ -5,10 +5,9 @@
 
 from __future__ import annotations
 
-import importlib
 from enum import Enum
 from pathlib import Path
-from typing import Any, Protocol, TypeGuard, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from nemo_evaluator_sdk.metrics.protocol import Metric
 from nemo_evaluator_sdk.metrics.utils import metric_type_name
@@ -131,39 +130,39 @@ class AgentEvalTask(BaseModel):
         return self
 
 
-class AgentEvalTasksetLoadConfig(BaseModel):
-    """Options passed from callers to a taskset's :meth:`AgentEvalTaskset.load`."""
+class AgentEvalTaskset(BaseModel):
+    """A named set of SDK-native tasks (with optional metadata) to evaluate.
+
+    Produced by an :class:`AgentEvalTasksetLoader`; the evaluator scores
+    ``tasks`` directly and never consumes a loader.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
-    source: str | Path | None = Field(default=None, description="Optional source path/URI the taskset loads from.")
-    limit: int | None = Field(default=None, ge=0, description="Optional cap on the number of tasks to load.")
-    evidence_dir: Path | None = Field(default=None, description="Optional directory holding task evidence inputs.")
-
-
-class AgentEvalTasksetBundle(BaseModel):
-    """SDK-native tasks (and optional metadata) produced by a taskset's ``load()``."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    tasks: list[AgentEvalTask] = Field(default_factory=list, description="Loaded tasks; at least one is required.")
+    tasks: list[AgentEvalTask] = Field(
+        default_factory=list,
+        min_length=1,
+        description="Tasks in this set; at least one is required and task ids must be unique.",
+    )
     metadata: dict[str, Any] = Field(default_factory=dict, description="Free-form taskset metadata for the run.")
 
     @model_validator(mode="after")
-    def _require_tasks(self) -> AgentEvalTasksetBundle:
-        if not self.tasks:
-            raise ValueError("taskset bundles require at least one task")
+    def _task_ids_unique(self) -> AgentEvalTaskset:
+        ids = [task.id for task in self.tasks]
+        duplicates = sorted({task_id for task_id in ids if ids.count(task_id) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate taskset task ids: {duplicates}")
         return self
 
 
 @runtime_checkable
-class AgentEvalTaskset(Protocol):
-    """Experimental protocol for adapting external tasksets into agent-eval.
+class AgentEvalTasksetLoader(Protocol):
+    """Protocol for adapting an external taskset into agent-eval.
 
-    A taskset is a named *adapter* that loads SDK-native tasks (optionally from an
-    external source). Per the design, tasksets are resolved upstream into
-    :class:`AgentEvalTask` values via :func:`resolve_agent_eval_taskset`; the
-    evaluator scores those tasks and never consumes a taskset directly.
+    A loader is a named adapter that loads SDK-native tasks (optionally from an
+    external ``source``). Per the design, loaders are resolved upstream into an
+    :class:`AgentEvalTaskset`; the evaluator scores those tasks and never consumes
+    a loader directly.
     """
 
     @property
@@ -171,38 +170,20 @@ class AgentEvalTaskset(Protocol):
         """Stable taskset name used in diagnostics, metadata, and user-facing output."""
         ...
 
-    def load(self, config: AgentEvalTasksetLoadConfig) -> AgentEvalTasksetBundle:
-        """Load this taskset's tasks (and optional metadata) into SDK-native form."""
+    def load(
+        self,
+        *,
+        source: str | Path | None = None,
+        limit: int | None = None,
+        evidence_dir: Path | None = None,
+    ) -> AgentEvalTaskset:
+        """Load tasks into an :class:`AgentEvalTaskset`.
+
+        ``source`` is an optional path/URI to load from, ``limit`` an optional
+        positive cap on the number of tasks, and ``evidence_dir`` an optional
+        directory holding task evidence inputs.
+        """
         ...
-
-
-def _is_agent_eval_taskset(value: object) -> TypeGuard[AgentEvalTaskset]:
-    return isinstance(getattr(value, "name", None), str) and callable(getattr(value, "load", None))
-
-
-def resolve_agent_eval_taskset(ref: str) -> AgentEvalTaskset:
-    """Resolve a ``module:object`` taskset reference.
-
-    The referenced object may be a taskset instance, a taskset class, or a
-    zero-argument factory returning a taskset instance.
-    """
-    module_name, separator, object_path = ref.partition(":")
-    if not separator or not module_name or not object_path:
-        raise ValueError("taskset references must use module:object syntax")
-
-    resolved: Any = importlib.import_module(module_name)
-    for part in object_path.split("."):
-        resolved = getattr(resolved, part)
-
-    candidate = resolved
-    if isinstance(candidate, type):
-        candidate = candidate()
-    elif not _is_agent_eval_taskset(candidate) and callable(candidate):
-        candidate = candidate()
-
-    if not _is_agent_eval_taskset(candidate):
-        raise TypeError(f"resolved taskset {ref!r} does not implement AgentEvalTaskset")
-    return candidate
 
 
 class AgentEvalRunConfig(BaseModel):

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/__init__.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/__init__.py
@@ -10,7 +10,14 @@ from nemo_evaluator_sdk.values.dataset_schemas import (
     InputSchema,
 )
 from nemo_evaluator_sdk.values.datasets import DatasetInput, DatasetRows
-from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor, LocalFilesystemEvidence
+from nemo_evaluator_sdk.values.evidence import (
+    CandidateEvidence,
+    CommandResult,
+    EvidenceDescriptor,
+    FilesystemDiff,
+    FilesystemEntry,
+    LocalFilesystemEvidence,
+)
 from nemo_evaluator_sdk.values.metrics import (
     BLEU,
     F1,
@@ -98,7 +105,10 @@ __all__ = [
     "BooleanValue",
     "CandidateEvidence",
     "CandidateOutput",
+    "CommandResult",
     "ContinuousScore",
+    "FilesystemDiff",
+    "FilesystemEntry",
     "DatasetRow",
     "DatasetRows",
     "DefaultAggregateFieldName",

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
@@ -6,8 +6,11 @@
 from __future__ import annotations
 
 import asyncio
+import difflib
 import hashlib
+import os
 import shutil
+import signal
 import tempfile
 from pathlib import Path
 from typing import Any, Literal
@@ -77,9 +80,14 @@ class LocalFilesystemEvidence:
         """Return a path under the evidence root, rejecting traversal outside it."""
         relative = Path(relative_path)
         candidate = relative.resolve() if relative.is_absolute() else (self._root / relative).resolve()
-        if candidate != self._root and self._root not in candidate.parents:
+        if not self._within_root(candidate):
             raise ValueError(f"evidence path {relative_path!r} resolves outside evidence root")
         return candidate
+
+    def _within_root(self, path: Path) -> bool:
+        """Whether ``path`` (after resolving symlinks) stays inside the evidence root."""
+        resolved = path.resolve()
+        return resolved == self._root or self._root in resolved.parents
 
     async def exists(self, relative_path: str | Path = ".") -> bool:
         """Return whether a path exists under the evidence root."""
@@ -120,7 +128,11 @@ class LocalFilesystemEvidence:
         return await asyncio.to_thread(self._list_sync, pattern)
 
     def _list_sync(self, pattern: str) -> list[str]:
-        return sorted(path.relative_to(self._root).as_posix() for path in self._root.glob(pattern) if path.is_file())
+        return sorted(
+            path.relative_to(self._root).as_posix()
+            for path in self._root.glob(pattern)
+            if path.is_file() and self._within_root(path)
+        )
 
     async def diff(self, other: LocalFilesystemEvidence) -> FilesystemDiff:
         """Diff this snapshot (before) against ``other`` (after) by file content hash.
@@ -143,11 +155,58 @@ class LocalFilesystemEvidence:
         ]
         return FilesystemDiff(entries=entries)
 
+    async def unified_diff(
+        self,
+        other: LocalFilesystemEvidence,
+        relative_path: str | Path,
+        *,
+        context: int = 3,
+    ) -> str:
+        """Unified diff of one path between this snapshot (before) and ``other`` (after).
+
+        Opt-in, per-path companion to :meth:`diff` (which reports only which paths
+        changed). Returns ``""`` when the two versions are identical or binary
+        (non-UTF-8). Path access is traversal-guarded like the rest of the handle.
+        """
+        return await asyncio.to_thread(self._unified_diff_sync, other, relative_path, context)
+
+    def _unified_diff_sync(self, other: LocalFilesystemEvidence, relative_path: str | Path, context: int) -> str:
+        before_path, after_path = self.path(relative_path), other.path(relative_path)
+        before = before_path.read_bytes() if before_path.is_file() else b""
+        after = after_path.read_bytes() if after_path.is_file() else b""
+        if before == after:
+            return ""
+        try:
+            before_lines = before.decode("utf-8").splitlines(keepends=True)
+            after_lines = after.decode("utf-8").splitlines(keepends=True)
+        except UnicodeDecodeError:
+            return ""  # binary content: no textual patch
+        rel = Path(relative_path).as_posix()
+        return "".join(
+            difflib.unified_diff(before_lines, after_lines, fromfile=f"a/{rel}", tofile=f"b/{rel}", n=context)
+        )
+
     def _hashes(self) -> dict[str, str]:
         hashes: dict[str, str] = {}
-        for rel in self._list_sync("**/*"):
-            hashes[rel] = hashlib.sha256((self._root / rel).read_bytes()).hexdigest()
+        for path in self._safe_files():
+            hashes[path.relative_to(self._root).as_posix()] = hashlib.sha256(path.read_bytes()).hexdigest()
         return hashes
+
+    def _safe_files(self) -> list[Path]:
+        """Regular files under the root, never descending into or reading symlinks that escape it.
+
+        ``os.walk(followlinks=False)`` keeps a ``vendor -> /`` style dir symlink from
+        exploding the walk, and escaping file symlinks (``leak -> /etc/passwd``) are
+        dropped so their target is never hashed.
+        """
+        files: list[Path] = []
+        for dirpath, _dirnames, filenames in os.walk(self._root, followlinks=False):
+            for name in filenames:
+                full = Path(dirpath) / name
+                if full.is_symlink() and not self._within_root(full):
+                    continue
+                files.append(full)
+        return files
 
     async def run_verifier(
         self,
@@ -172,27 +231,56 @@ class LocalFilesystemEvidence:
             workdir = (overlay / cwd).resolve()
             if workdir != overlay and overlay not in workdir.parents:
                 raise ValueError(f"verifier cwd {cwd!r} resolves outside evidence overlay")
-            # ignore_dangling_symlinks: broken symlinks in evidence shouldn't abort the copy.
+            # symlinks=True copies links as-is (no host deref); the ignore hook drops
+            # links whose target escapes the evidence root so the verifier can't read them.
             await asyncio.to_thread(
-                shutil.copytree, self._root, overlay, dirs_exist_ok=True, ignore_dangling_symlinks=True
+                shutil.copytree,
+                self._root,
+                overlay,
+                dirs_exist_ok=True,
+                symlinks=True,
+                ignore=self._ignore_escaping_symlinks,
             )
             return await self._exec(command, workdir, timeout_s)
         finally:
             await asyncio.to_thread(shutil.rmtree, overlay, True)
 
+    def _ignore_escaping_symlinks(self, directory: str, names: list[str]) -> set[str]:
+        """copytree ignore hook: skip symlinks that can't be safely preserved in the overlay.
+
+        Drops links whose resolved target escapes the evidence root (host-file reads)
+        and absolute links: ``symlinks=True`` would recreate the latter verbatim, so a
+        verifier write through ``link -> /real/evidence/answer.txt`` would mutate the
+        stored evidence instead of the throwaway copy.
+        """
+        ignored: set[str] = set()
+        for name in names:
+            full = Path(directory) / name
+            if not full.is_symlink():
+                continue
+            if os.path.isabs(os.readlink(full)) or not self._within_root(full):
+                ignored.add(name)
+        return ignored
+
     @staticmethod
     async def _exec(command: list[str], cwd: Path, timeout_s: float | None) -> CommandResult:
+        # start_new_session makes the child its own process-group leader, so a timeout
+        # can reap the whole tree (grandchildren it spawned) rather than just the child.
         process = await asyncio.create_subprocess_exec(
             *command,
             cwd=str(cwd),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
         )
         try:
             stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout_s)
         except TimeoutError:
-            # wait_for cancels communicate() but leaves the child running; kill it.
-            process.kill()
+            # wait_for cancels communicate() but leaves the tree running; kill the group.
+            try:
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass  # already exited between the timeout and the kill
             await process.wait()
             return CommandResult(exit_code=-1, timed_out=True)
         return CommandResult(

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
@@ -92,7 +92,11 @@ class LocalFilesystemEvidence:
         return await asyncio.to_thread(path.read_text, encoding=encoding)
 
     async def iter_paths(self, relative_path: str | Path = ".", *, recursive: bool = False) -> list[str]:
-        """Return stable relative path names under the evidence root."""
+        """List entries (files *and* directories) rooted at ``relative_path``.
+
+        Use this to walk a subtree or test for (non-)emptiness. For a flat,
+        files-only listing matched by a glob pattern, use :meth:`list_files`.
+        """
         base = self.path(relative_path)
         return await asyncio.to_thread(self._iter_paths_sync, base, recursive)
 
@@ -108,14 +112,23 @@ class LocalFilesystemEvidence:
         return await asyncio.to_thread(path.read_bytes)
 
     async def list_files(self, pattern: str = "**/*") -> list[str]:
-        """Return relative posix paths of files matching ``pattern`` (files only)."""
+        """List relative posix paths of files (not directories) matching ``pattern``.
+
+        Complements :meth:`iter_paths`: this is the flat, glob-filtered,
+        files-only view; ``iter_paths`` walks a subtree and includes directories.
+        """
         return await asyncio.to_thread(self._list_sync, pattern)
 
     def _list_sync(self, pattern: str) -> list[str]:
         return sorted(path.relative_to(self._root).as_posix() for path in self._root.glob(pattern) if path.is_file())
 
     async def diff(self, other: LocalFilesystemEvidence) -> FilesystemDiff:
-        """Diff this snapshot (before) against ``other`` (after) by file content hash."""
+        """Diff this snapshot (before) against ``other`` (after) by file content hash.
+
+        Cost note: this hashes every file in both trees by reading each fully, so
+        it is O(total bytes). Fine for task-sized evidence; revisit (streamed
+        hashing / size+mtime prefilter) if used on large artifact trees.
+        """
         return await asyncio.to_thread(self._diff_sync, other)
 
     def _diff_sync(self, other: LocalFilesystemEvidence) -> FilesystemDiff:
@@ -147,14 +160,22 @@ class LocalFilesystemEvidence:
 
         The evidence is copied to a temp overlay so the command can never mutate
         stored evidence (pytest caches, build artifacts, ...). ``command`` is a
-        list passed straight to exec — no shell parsing, so no injection surface.
+        list passed straight to exec, so there is no shell parsing of it.
+
+        This is NOT a sandbox: the command runs with the host's privileges and
+        full filesystem/network access. ``command`` is supplied by the (trusted)
+        metric author, never by the agent under test. Cost note: the whole tree
+        is copied on every call, so verifying large evidence repeatedly is heavy.
         """
         overlay = Path(tempfile.mkdtemp(prefix="evidence-verify-")).resolve()
         try:
             workdir = (overlay / cwd).resolve()
             if workdir != overlay and overlay not in workdir.parents:
                 raise ValueError(f"verifier cwd {cwd!r} resolves outside evidence overlay")
-            await asyncio.to_thread(shutil.copytree, self._root, overlay, dirs_exist_ok=True)
+            # ignore_dangling_symlinks: broken symlinks in evidence shouldn't abort the copy.
+            await asyncio.to_thread(
+                shutil.copytree, self._root, overlay, dirs_exist_ok=True, ignore_dangling_symlinks=True
+            )
             return await self._exec(command, workdir, timeout_s)
         finally:
             await asyncio.to_thread(shutil.rmtree, overlay, True)

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
@@ -6,11 +6,60 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import shutil
+import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+
+
+class FilesystemEntry(BaseModel):
+    """One path that differs between two filesystem snapshots."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    change_type: Literal["added", "modified", "deleted"]
+
+
+class FilesystemDiff(BaseModel):
+    """Set of paths that changed between two filesystem snapshots."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    entries: list[FilesystemEntry] = Field(default_factory=list)
+
+    def changed(
+        self,
+        *,
+        prefix: str | None = None,
+        kinds: set[str] | None = None,
+    ) -> list[FilesystemEntry]:
+        """Return entries optionally filtered by path prefix and change kind."""
+        return [
+            entry
+            for entry in self.entries
+            if (prefix is None or entry.path.startswith(prefix)) and (kinds is None or entry.change_type in kinds)
+        ]
+
+
+class CommandResult(BaseModel):
+    """Outcome of running a verifier command against filesystem evidence."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+    timed_out: bool = False
+
+    @property
+    def ok(self) -> bool:
+        """Whether the command exited 0 without timing out."""
+        return self.exit_code == 0 and not self.timed_out
 
 
 class LocalFilesystemEvidence:
@@ -52,6 +101,84 @@ class LocalFilesystemEvidence:
             return [base.relative_to(self._root).as_posix()]
         iterator = base.rglob("*") if recursive else base.iterdir()
         return sorted(path.relative_to(self._root).as_posix() for path in iterator)
+
+    async def read_bytes(self, relative_path: str | Path) -> bytes:
+        """Read a binary file under the evidence root."""
+        path = self.path(relative_path)
+        return await asyncio.to_thread(path.read_bytes)
+
+    async def list_files(self, pattern: str = "**/*") -> list[str]:
+        """Return relative posix paths of files matching ``pattern`` (files only)."""
+        return await asyncio.to_thread(self._list_sync, pattern)
+
+    def _list_sync(self, pattern: str) -> list[str]:
+        return sorted(path.relative_to(self._root).as_posix() for path in self._root.glob(pattern) if path.is_file())
+
+    async def diff(self, other: LocalFilesystemEvidence) -> FilesystemDiff:
+        """Diff this snapshot (before) against ``other`` (after) by file content hash."""
+        return await asyncio.to_thread(self._diff_sync, other)
+
+    def _diff_sync(self, other: LocalFilesystemEvidence) -> FilesystemDiff:
+        before = self._hashes()
+        after = other._hashes()
+        entries = [FilesystemEntry(path=path, change_type="added") for path in sorted(after.keys() - before.keys())]
+        entries += [FilesystemEntry(path=path, change_type="deleted") for path in sorted(before.keys() - after.keys())]
+        entries += [
+            FilesystemEntry(path=path, change_type="modified")
+            for path in sorted(before.keys() & after.keys())
+            if before[path] != after[path]
+        ]
+        return FilesystemDiff(entries=entries)
+
+    def _hashes(self) -> dict[str, str]:
+        hashes: dict[str, str] = {}
+        for rel in self._list_sync("**/*"):
+            hashes[rel] = hashlib.sha256((self._root / rel).read_bytes()).hexdigest()
+        return hashes
+
+    async def run_verifier(
+        self,
+        command: list[str],
+        *,
+        cwd: str = ".",
+        timeout_s: float | None = None,
+    ) -> CommandResult:
+        """Run ``command`` (no shell) against a throwaway copy of the evidence.
+
+        The evidence is copied to a temp overlay so the command can never mutate
+        stored evidence (pytest caches, build artifacts, ...). ``command`` is a
+        list passed straight to exec — no shell parsing, so no injection surface.
+        """
+        overlay = Path(tempfile.mkdtemp(prefix="evidence-verify-")).resolve()
+        try:
+            workdir = (overlay / cwd).resolve()
+            if workdir != overlay and overlay not in workdir.parents:
+                raise ValueError(f"verifier cwd {cwd!r} resolves outside evidence overlay")
+            await asyncio.to_thread(shutil.copytree, self._root, overlay, dirs_exist_ok=True)
+            return await self._exec(command, workdir, timeout_s)
+        finally:
+            await asyncio.to_thread(shutil.rmtree, overlay, True)
+
+    @staticmethod
+    async def _exec(command: list[str], cwd: Path, timeout_s: float | None) -> CommandResult:
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=str(cwd),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout_s)
+        except TimeoutError:
+            # wait_for cancels communicate() but leaves the child running; kill it.
+            process.kill()
+            await process.wait()
+            return CommandResult(exit_code=-1, timed_out=True)
+        return CommandResult(
+            exit_code=process.returncode if process.returncode is not None else -1,
+            stdout=stdout.decode(errors="replace"),
+            stderr=stderr.decode(errors="replace"),
+        )
 
 
 class EvidenceDescriptor(BaseModel):

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evidence.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evidence.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 import pytest
 from nemo_evaluator_sdk.execution.samples import build_metric_input
-from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+from nemo_evaluator_sdk.values.evidence import (
+    CandidateEvidence,
+    EvidenceDescriptor,
+    LocalFilesystemEvidence,
+)
 
 
 def test_metric_input_preserves_candidate_evidence_out_of_metadata() -> None:
@@ -53,3 +57,52 @@ async def test_candidate_evidence_filesystem_access_is_lazy_and_cached(tmp_path:
         handle.path("../outside")
     with pytest.raises(ValueError, match="only supports local filesystem"):
         await evidence.filesystem("remote_state")
+
+
+@pytest.mark.asyncio
+async def test_filesystem_read_bytes_list_and_diff(tmp_path: Path) -> None:
+    before = tmp_path / "before"
+    after = tmp_path / "after"
+    for root in (before, after):
+        (root / "src").mkdir(parents=True)
+    (before / "keep.txt").write_text("same", encoding="utf-8")
+    (before / "src" / "mod.py").write_text("old", encoding="utf-8")
+    (before / "gone.txt").write_text("bye", encoding="utf-8")
+    (after / "keep.txt").write_text("same", encoding="utf-8")
+    (after / "src" / "mod.py").write_text("new", encoding="utf-8")
+    (after / "added.txt").write_text("hi", encoding="utf-8")
+
+    initial = LocalFilesystemEvidence(before)
+    final = LocalFilesystemEvidence(after)
+
+    assert await final.read_bytes("added.txt") == b"hi"
+    assert await final.list_files("**/*.py") == ["src/mod.py"]
+
+    diff = await initial.diff(final)
+    assert {(entry.path, entry.change_type) for entry in diff.entries} == {
+        ("added.txt", "added"),
+        ("gone.txt", "deleted"),
+        ("src/mod.py", "modified"),
+    }
+    assert [entry.path for entry in diff.changed(prefix="src/", kinds={"modified"})] == ["src/mod.py"]
+
+
+@pytest.mark.asyncio
+async def test_run_verifier_uses_overlay_and_reports_outcome(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "answer.txt").write_text("42", encoding="utf-8")
+    handle = LocalFilesystemEvidence(root)
+
+    ok = await handle.run_verifier(["cat", "answer.txt"])
+    assert ok.ok and ok.exit_code == 0 and ok.stdout.strip() == "42"
+
+    failed = await handle.run_verifier(["false"])
+    assert not failed.ok and failed.exit_code != 0
+
+    timed_out = await handle.run_verifier(["sleep", "5"], timeout_s=0.2)
+    assert timed_out.timed_out and not timed_out.ok
+
+    # The verifier ran in a throwaway copy, so the stored evidence is untouched.
+    await handle.run_verifier(["sh", "-c", "echo cheat > sneaked.txt"])
+    assert await handle.list_files("**/*") == ["answer.txt"]

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evidence.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evidence.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -106,3 +107,73 @@ async def test_run_verifier_uses_overlay_and_reports_outcome(tmp_path: Path) -> 
     # The verifier ran in a throwaway copy, so the stored evidence is untouched.
     await handle.run_verifier(["sh", "-c", "echo cheat > sneaked.txt"])
     assert await handle.list_files("**/*") == ["answer.txt"]
+
+
+@pytest.mark.asyncio
+async def test_escaping_symlinks_are_not_hashed_or_copied(tmp_path: Path) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOPSECRET", encoding="utf-8")
+
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "answer.txt").write_text("42", encoding="utf-8")
+    (root / "leak").symlink_to(secret)  # agent-planted link escaping the evidence root
+    handle = LocalFilesystemEvidence(root)
+
+    # Listing and content hashing ignore the escaping symlink (no host-file read/leak).
+    assert await handle.list_files("**/*") == ["answer.txt"]
+    assert (await handle.diff(LocalFilesystemEvidence(root))).entries == []
+
+    # The verifier overlay never receives the escaping link, so its target can't be read.
+    leaked = await handle.run_verifier(["cat", "leak"])
+    assert not leaked.ok
+
+
+@pytest.mark.asyncio
+async def test_absolute_symlinks_are_not_copied_into_verifier_overlay(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "answer.txt").write_text("42", encoding="utf-8")
+    # Absolute link whose target is *inside* the root: passes _within_root, but copytree
+    # symlinks=True would recreate it verbatim and a write through it would hit stored evidence.
+    (root / "writable").symlink_to((root / "answer.txt").resolve())
+    handle = LocalFilesystemEvidence(root)
+
+    await handle.run_verifier(["sh", "-c", "echo pwned > writable"])
+
+    # The write landed in the throwaway overlay, never on the real answer.txt.
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "42"
+
+
+@pytest.mark.asyncio
+async def test_verifier_timeout_kills_the_whole_process_tree(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    handle = LocalFilesystemEvidence(root)
+
+    # A grandchild backgrounded by the verifier would write the marker after 1s if it
+    # survived; killing the whole process group on timeout stops it first.
+    marker = tmp_path / "survived.txt"
+    result = await handle.run_verifier(["sh", "-c", f"(sleep 1; touch '{marker}') & sleep 5"], timeout_s=0.3)
+    assert result.timed_out
+
+    await asyncio.sleep(1.5)
+    assert not marker.exists()
+
+
+@pytest.mark.asyncio
+async def test_unified_diff_reports_text_patch_and_skips_binary(tmp_path: Path) -> None:
+    before_root = tmp_path / "before"
+    after_root = tmp_path / "after"
+    for root in (before_root, after_root):
+        root.mkdir()
+    (before_root / "f.txt").write_text("a\nb\n", encoding="utf-8")
+    (after_root / "f.txt").write_text("a\nc\n", encoding="utf-8")
+    (before_root / "img.bin").write_bytes(b"\xff\xfe\x00")
+    (after_root / "img.bin").write_bytes(b"\xff\xfe\x01")
+    before, after = LocalFilesystemEvidence(before_root), LocalFilesystemEvidence(after_root)
+
+    patch = await before.unified_diff(after, "f.txt")
+    assert "-b" in patch and "+c" in patch and patch.startswith("--- a/f.txt")
+    assert await before.unified_diff(after, "img.bin") == ""  # binary: no textual patch
+    assert await before.unified_diff(before, "f.txt") == ""  # identical: empty

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_example_metrics.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_example_metrics.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise the example's reference metrics-over-evidence."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from nemo_evaluator_sdk.execution.samples import build_metric_input
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "examples" / "run_agent_eval" / "example_metrics.py"
+_spec = importlib.util.spec_from_file_location("example_metrics", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+example_metrics = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(example_metrics)
+
+
+def _input_with_evidence(evidence: CandidateEvidence):
+    return build_metric_input({"prompt": "q"}, {"evidence": evidence}, index=0)
+
+
+@pytest.mark.asyncio
+async def test_tests_pass_and_no_test_cheating(tmp_path: Path) -> None:
+    initial = tmp_path / "initial"
+    final = tmp_path / "final"
+    for root in (initial, final):
+        (root / "tests").mkdir(parents=True)
+        (root / "tests" / "test_x.py").write_text("def test(): assert True", encoding="utf-8")
+    (final / "solution.py").write_text("print('done')", encoding="utf-8")
+
+    evidence = CandidateEvidence(
+        descriptors={
+            "initial_state": EvidenceDescriptor(kind="filesystem", ref=str(initial)),
+            "final_state": EvidenceDescriptor(kind="filesystem", ref=str(final)),
+        }
+    )
+
+    tests_pass = await example_metrics.TestsPassMetric(["test", "-f", "solution.py"]).compute_scores(
+        _input_with_evidence(evidence)
+    )
+    assert tests_pass.outputs[0].value is True
+
+    no_cheat = await example_metrics.NoTestCheatingMetric().compute_scores(_input_with_evidence(evidence))
+    assert no_cheat.outputs[0].value is True
+
+    # Mutating a protected test file flips no_test_cheating to False.
+    (final / "tests" / "test_x.py").write_text("def test(): assert False", encoding="utf-8")
+    evidence_cheated = CandidateEvidence(
+        descriptors={
+            "initial_state": EvidenceDescriptor(kind="filesystem", ref=str(initial)),
+            "final_state": EvidenceDescriptor(kind="filesystem", ref=str(final)),
+        }
+    )
+    cheated = await example_metrics.NoTestCheatingMetric().compute_scores(_input_with_evidence(evidence_cheated))
+    assert cheated.outputs[0].value is False

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_tasks.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_tasks.py
@@ -2,8 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalTask, SemanticReducer, SemanticView, ViewSignal
+from nemo_evaluator_sdk.agent_eval.tasks import (
+    AgentEvalTask,
+    AgentEvalTaskset,
+    SemanticReducer,
+    SemanticView,
+    ViewSignal,
+)
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutputSpec, MetricResult
+
+
+def test_taskset_rejects_duplicate_task_ids() -> None:
+    task = AgentEvalTask(id="dup", intent="i", inputs={})
+    other = AgentEvalTask(id="dup", intent="i", inputs={})
+    AgentEvalTaskset(id="ts", tasks=[task])  # unique ids OK
+    with pytest.raises(ValueError, match="duplicate taskset task ids"):
+        AgentEvalTaskset(id="ts", tasks=[task, other])
+    with pytest.raises(ValueError, match="taskset id must not be empty"):
+        AgentEvalTaskset(id="", tasks=[task])
 
 
 class _Metric:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_tasks.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_tasks.py
@@ -1,52 +1,38 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-import types
-
 import pytest
 from nemo_evaluator_sdk.agent_eval.tasks import (
     AgentEvalTask,
-    AgentEvalTasksetBundle,
-    AgentEvalTasksetLoadConfig,
+    AgentEvalTaskset,
+    AgentEvalTasksetLoader,
     SemanticReducer,
     SemanticView,
     ViewSignal,
-    resolve_agent_eval_taskset,
 )
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutputSpec, MetricResult
+from pydantic import ValidationError
 
 
-def test_taskset_bundle_requires_at_least_one_task() -> None:
+def test_taskset_requires_tasks_and_unique_ids() -> None:
     task = AgentEvalTask(id="t", intent="i", inputs={})
-    assert AgentEvalTasksetBundle(tasks=[task]).tasks == [task]
-    with pytest.raises(ValueError, match="taskset bundles require at least one task"):
-        AgentEvalTasksetBundle(tasks=[])
+    assert AgentEvalTaskset(tasks=[task]).tasks == [task]
+    with pytest.raises(ValidationError, match="at least 1"):
+        AgentEvalTaskset(tasks=[])
+    with pytest.raises(ValidationError, match="duplicate taskset task ids"):
+        AgentEvalTaskset(tasks=[task, AgentEvalTask(id="t", intent="i", inputs={})])
 
 
-def test_resolve_agent_eval_taskset(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Bad refs must use module:object syntax.
-    with pytest.raises(ValueError, match="module:object syntax"):
-        resolve_agent_eval_taskset("no_colon")
-
-    # A resolved object that isn't a taskset is rejected.
-    with pytest.raises(TypeError, match="does not implement AgentEvalTaskset"):
-        resolve_agent_eval_taskset("math:pi")
-
-    # Happy path: a class ref is instantiated and must satisfy the protocol.
-    class _FakeTaskset:
+def test_loader_protocol_is_satisfied_by_a_named_load_adapter() -> None:
+    class _Loader:
         name = "fake"
 
-        def load(self, config: AgentEvalTasksetLoadConfig) -> AgentEvalTasksetBundle:
-            return AgentEvalTasksetBundle(tasks=[AgentEvalTask(id="t", intent="i", inputs={})])
+        def load(self, *, source: object = None, limit: object = None, evidence_dir: object = None) -> AgentEvalTaskset:
+            return AgentEvalTaskset(tasks=[AgentEvalTask(id="t", intent="i", inputs={})])
 
-    module = types.ModuleType("fake_taskset_mod")
-    module.Fake = _FakeTaskset  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "fake_taskset_mod", module)
-
-    taskset = resolve_agent_eval_taskset("fake_taskset_mod:Fake")
-    assert taskset.name == "fake"
-    assert [task.id for task in taskset.load(AgentEvalTasksetLoadConfig()).tasks] == ["t"]
+    loader = _Loader()
+    assert isinstance(loader, AgentEvalTasksetLoader)
+    assert [task.id for task in loader.load().tasks] == ["t"]
 
 
 class _Metric:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_tasks.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_tasks.py
@@ -1,25 +1,52 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+import types
+
 import pytest
 from nemo_evaluator_sdk.agent_eval.tasks import (
     AgentEvalTask,
-    AgentEvalTaskset,
+    AgentEvalTasksetBundle,
+    AgentEvalTasksetLoadConfig,
     SemanticReducer,
     SemanticView,
     ViewSignal,
+    resolve_agent_eval_taskset,
 )
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutputSpec, MetricResult
 
 
-def test_taskset_rejects_duplicate_task_ids() -> None:
-    task = AgentEvalTask(id="dup", intent="i", inputs={})
-    other = AgentEvalTask(id="dup", intent="i", inputs={})
-    AgentEvalTaskset(id="ts", tasks=[task])  # unique ids OK
-    with pytest.raises(ValueError, match="duplicate taskset task ids"):
-        AgentEvalTaskset(id="ts", tasks=[task, other])
-    with pytest.raises(ValueError, match="taskset id must not be empty"):
-        AgentEvalTaskset(id="", tasks=[task])
+def test_taskset_bundle_requires_at_least_one_task() -> None:
+    task = AgentEvalTask(id="t", intent="i", inputs={})
+    assert AgentEvalTasksetBundle(tasks=[task]).tasks == [task]
+    with pytest.raises(ValueError, match="taskset bundles require at least one task"):
+        AgentEvalTasksetBundle(tasks=[])
+
+
+def test_resolve_agent_eval_taskset(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Bad refs must use module:object syntax.
+    with pytest.raises(ValueError, match="module:object syntax"):
+        resolve_agent_eval_taskset("no_colon")
+
+    # A resolved object that isn't a taskset is rejected.
+    with pytest.raises(TypeError, match="does not implement AgentEvalTaskset"):
+        resolve_agent_eval_taskset("math:pi")
+
+    # Happy path: a class ref is instantiated and must satisfy the protocol.
+    class _FakeTaskset:
+        name = "fake"
+
+        def load(self, config: AgentEvalTasksetLoadConfig) -> AgentEvalTasksetBundle:
+            return AgentEvalTasksetBundle(tasks=[AgentEvalTask(id="t", intent="i", inputs={})])
+
+    module = types.ModuleType("fake_taskset_mod")
+    module.Fake = _FakeTaskset  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "fake_taskset_mod", module)
+
+    taskset = resolve_agent_eval_taskset("fake_taskset_mod:Fake")
+    assert taskset.name == "fake"
+    assert [task.id for task in taskset.load(AgentEvalTasksetLoadConfig()).tasks] == ["t"]
 
 
 class _Metric:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/tasks.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/tasks.py
@@ -5,16 +5,14 @@
 
 from __future__ import annotations
 
-import importlib
 from enum import Enum
-from typing import Any, Protocol, TypeGuard, runtime_checkable
 from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
 
-from pydantic import Field, BaseModel, ConfigDict, field_validator, model_validator, field_serializer
-
-from nemo_platform.beta.evaluator.values import RunConfig, RunConfigOnline, RunConfigOnlineModel
-from nemo_platform.beta.evaluator.metrics.utils import metric_type_name
 from nemo_platform.beta.evaluator.metrics.protocol import Metric
+from nemo_platform.beta.evaluator.metrics.utils import metric_type_name
+from nemo_platform.beta.evaluator.values import RunConfig, RunConfigOnline, RunConfigOnlineModel
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
 
 
 class SemanticReducer(str, Enum):
@@ -132,39 +130,39 @@ class AgentEvalTask(BaseModel):
         return self
 
 
-class AgentEvalTasksetLoadConfig(BaseModel):
-    """Options passed from callers to a taskset's :meth:`AgentEvalTaskset.load`."""
+class AgentEvalTaskset(BaseModel):
+    """A named set of SDK-native tasks (with optional metadata) to evaluate.
+
+    Produced by an :class:`AgentEvalTasksetLoader`; the evaluator scores
+    ``tasks`` directly and never consumes a loader.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
-    source: str | Path | None = Field(default=None, description="Optional source path/URI the taskset loads from.")
-    limit: int | None = Field(default=None, ge=0, description="Optional cap on the number of tasks to load.")
-    evidence_dir: Path | None = Field(default=None, description="Optional directory holding task evidence inputs.")
-
-
-class AgentEvalTasksetBundle(BaseModel):
-    """SDK-native tasks (and optional metadata) produced by a taskset's ``load()``."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    tasks: list[AgentEvalTask] = Field(default_factory=list, description="Loaded tasks; at least one is required.")
+    tasks: list[AgentEvalTask] = Field(
+        default_factory=list,
+        min_length=1,
+        description="Tasks in this set; at least one is required and task ids must be unique.",
+    )
     metadata: dict[str, Any] = Field(default_factory=dict, description="Free-form taskset metadata for the run.")
 
     @model_validator(mode="after")
-    def _require_tasks(self) -> AgentEvalTasksetBundle:
-        if not self.tasks:
-            raise ValueError("taskset bundles require at least one task")
+    def _task_ids_unique(self) -> AgentEvalTaskset:
+        ids = [task.id for task in self.tasks]
+        duplicates = sorted({task_id for task_id in ids if ids.count(task_id) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate taskset task ids: {duplicates}")
         return self
 
 
 @runtime_checkable
-class AgentEvalTaskset(Protocol):
-    """Experimental protocol for adapting external tasksets into agent-eval.
+class AgentEvalTasksetLoader(Protocol):
+    """Protocol for adapting an external taskset into agent-eval.
 
-    A taskset is a named *adapter* that loads SDK-native tasks (optionally from an
-    external source). Per the design, tasksets are resolved upstream into
-    :class:`AgentEvalTask` values via :func:`resolve_agent_eval_taskset`; the
-    evaluator scores those tasks and never consumes a taskset directly.
+    A loader is a named adapter that loads SDK-native tasks (optionally from an
+    external ``source``). Per the design, loaders are resolved upstream into an
+    :class:`AgentEvalTaskset`; the evaluator scores those tasks and never consumes
+    a loader directly.
     """
 
     @property
@@ -172,38 +170,20 @@ class AgentEvalTaskset(Protocol):
         """Stable taskset name used in diagnostics, metadata, and user-facing output."""
         ...
 
-    def load(self, config: AgentEvalTasksetLoadConfig) -> AgentEvalTasksetBundle:
-        """Load this taskset's tasks (and optional metadata) into SDK-native form."""
+    def load(
+        self,
+        *,
+        source: str | Path | None = None,
+        limit: int | None = None,
+        evidence_dir: Path | None = None,
+    ) -> AgentEvalTaskset:
+        """Load tasks into an :class:`AgentEvalTaskset`.
+
+        ``source`` is an optional path/URI to load from, ``limit`` an optional
+        positive cap on the number of tasks, and ``evidence_dir`` an optional
+        directory holding task evidence inputs.
+        """
         ...
-
-
-def _is_agent_eval_taskset(value: object) -> TypeGuard[AgentEvalTaskset]:
-    return isinstance(getattr(value, "name", None), str) and callable(getattr(value, "load", None))
-
-
-def resolve_agent_eval_taskset(ref: str) -> AgentEvalTaskset:
-    """Resolve a ``module:object`` taskset reference.
-
-    The referenced object may be a taskset instance, a taskset class, or a
-    zero-argument factory returning a taskset instance.
-    """
-    module_name, separator, object_path = ref.partition(":")
-    if not separator or not module_name or not object_path:
-        raise ValueError("taskset references must use module:object syntax")
-
-    resolved: Any = importlib.import_module(module_name)
-    for part in object_path.split("."):
-        resolved = getattr(resolved, part)
-
-    candidate = resolved
-    if isinstance(candidate, type):
-        candidate = candidate()
-    elif not _is_agent_eval_taskset(candidate) and callable(candidate):
-        candidate = candidate()
-
-    if not _is_agent_eval_taskset(candidate):
-        raise TypeError(f"resolved taskset {ref!r} does not implement AgentEvalTaskset")
-    return candidate
 
 
 class AgentEvalRunConfig(BaseModel):

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/tasks.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/tasks.py
@@ -130,6 +130,31 @@ class AgentEvalTask(BaseModel):
         return self
 
 
+class AgentEvalTaskset(BaseModel):
+    """Named collection of tasks; ``id``/``name`` sugar around a task list."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(description="Stable taskset identifier.")
+    name: str | None = Field(default=None, description="Human-readable taskset name.")
+    tasks: list[AgentEvalTask] = Field(description="Tasks in this set; task ids must be unique.")
+
+    @field_validator("id")
+    @classmethod
+    def _id_must_not_be_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("taskset id must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def _task_ids_unique(self) -> AgentEvalTaskset:
+        ids = [task.id for task in self.tasks]
+        duplicates = sorted({task_id for task_id in ids if ids.count(task_id) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate taskset task ids: {duplicates}")
+        return self
+
+
 class AgentEvalRunConfig(BaseModel):
     """Configuration for a standalone agent-eval run."""
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/tasks.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/tasks.py
@@ -5,14 +5,16 @@
 
 from __future__ import annotations
 
+import importlib
 from enum import Enum
+from typing import Any, Protocol, TypeGuard, runtime_checkable
 from pathlib import Path
-from typing import Any
 
-from nemo_platform.beta.evaluator.metrics.protocol import Metric
-from nemo_platform.beta.evaluator.metrics.utils import metric_type_name
+from pydantic import Field, BaseModel, ConfigDict, field_validator, model_validator, field_serializer
+
 from nemo_platform.beta.evaluator.values import RunConfig, RunConfigOnline, RunConfigOnlineModel
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
+from nemo_platform.beta.evaluator.metrics.utils import metric_type_name
+from nemo_platform.beta.evaluator.metrics.protocol import Metric
 
 
 class SemanticReducer(str, Enum):
@@ -130,29 +132,78 @@ class AgentEvalTask(BaseModel):
         return self
 
 
-class AgentEvalTaskset(BaseModel):
-    """Named collection of tasks; ``id``/``name`` sugar around a task list."""
+class AgentEvalTasksetLoadConfig(BaseModel):
+    """Options passed from callers to a taskset's :meth:`AgentEvalTaskset.load`."""
 
     model_config = ConfigDict(extra="forbid")
 
-    id: str = Field(description="Stable taskset identifier.")
-    name: str | None = Field(default=None, description="Human-readable taskset name.")
-    tasks: list[AgentEvalTask] = Field(description="Tasks in this set; task ids must be unique.")
+    source: str | Path | None = Field(default=None, description="Optional source path/URI the taskset loads from.")
+    limit: int | None = Field(default=None, ge=0, description="Optional cap on the number of tasks to load.")
+    evidence_dir: Path | None = Field(default=None, description="Optional directory holding task evidence inputs.")
 
-    @field_validator("id")
-    @classmethod
-    def _id_must_not_be_empty(cls, value: str) -> str:
-        if not value:
-            raise ValueError("taskset id must not be empty")
-        return value
+
+class AgentEvalTasksetBundle(BaseModel):
+    """SDK-native tasks (and optional metadata) produced by a taskset's ``load()``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tasks: list[AgentEvalTask] = Field(default_factory=list, description="Loaded tasks; at least one is required.")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Free-form taskset metadata for the run.")
 
     @model_validator(mode="after")
-    def _task_ids_unique(self) -> AgentEvalTaskset:
-        ids = [task.id for task in self.tasks]
-        duplicates = sorted({task_id for task_id in ids if ids.count(task_id) > 1})
-        if duplicates:
-            raise ValueError(f"duplicate taskset task ids: {duplicates}")
+    def _require_tasks(self) -> AgentEvalTasksetBundle:
+        if not self.tasks:
+            raise ValueError("taskset bundles require at least one task")
         return self
+
+
+@runtime_checkable
+class AgentEvalTaskset(Protocol):
+    """Experimental protocol for adapting external tasksets into agent-eval.
+
+    A taskset is a named *adapter* that loads SDK-native tasks (optionally from an
+    external source). Per the design, tasksets are resolved upstream into
+    :class:`AgentEvalTask` values via :func:`resolve_agent_eval_taskset`; the
+    evaluator scores those tasks and never consumes a taskset directly.
+    """
+
+    @property
+    def name(self) -> str:
+        """Stable taskset name used in diagnostics, metadata, and user-facing output."""
+        ...
+
+    def load(self, config: AgentEvalTasksetLoadConfig) -> AgentEvalTasksetBundle:
+        """Load this taskset's tasks (and optional metadata) into SDK-native form."""
+        ...
+
+
+def _is_agent_eval_taskset(value: object) -> TypeGuard[AgentEvalTaskset]:
+    return isinstance(getattr(value, "name", None), str) and callable(getattr(value, "load", None))
+
+
+def resolve_agent_eval_taskset(ref: str) -> AgentEvalTaskset:
+    """Resolve a ``module:object`` taskset reference.
+
+    The referenced object may be a taskset instance, a taskset class, or a
+    zero-argument factory returning a taskset instance.
+    """
+    module_name, separator, object_path = ref.partition(":")
+    if not separator or not module_name or not object_path:
+        raise ValueError("taskset references must use module:object syntax")
+
+    resolved: Any = importlib.import_module(module_name)
+    for part in object_path.split("."):
+        resolved = getattr(resolved, part)
+
+    candidate = resolved
+    if isinstance(candidate, type):
+        candidate = candidate()
+    elif not _is_agent_eval_taskset(candidate) and callable(candidate):
+        candidate = candidate()
+
+    if not _is_agent_eval_taskset(candidate):
+        raise TypeError(f"resolved taskset {ref!r} does not implement AgentEvalTaskset")
+    return candidate
 
 
 class AgentEvalRunConfig(BaseModel):

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/__init__.py
@@ -10,7 +10,14 @@ from nemo_platform.beta.evaluator.values.dataset_schemas import (
     InputSchema,
 )
 from nemo_platform.beta.evaluator.values.datasets import DatasetInput, DatasetRows
-from nemo_platform.beta.evaluator.values.evidence import CandidateEvidence, EvidenceDescriptor, LocalFilesystemEvidence
+from nemo_platform.beta.evaluator.values.evidence import (
+    CandidateEvidence,
+    CommandResult,
+    EvidenceDescriptor,
+    FilesystemDiff,
+    FilesystemEntry,
+    LocalFilesystemEvidence,
+)
 from nemo_platform.beta.evaluator.values.metrics import (
     BLEU,
     F1,
@@ -98,7 +105,10 @@ __all__ = [
     "BooleanValue",
     "CandidateEvidence",
     "CandidateOutput",
+    "CommandResult",
     "ContinuousScore",
+    "FilesystemDiff",
+    "FilesystemEntry",
     "DatasetRow",
     "DatasetRows",
     "DefaultAggregateFieldName",

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
@@ -92,7 +92,11 @@ class LocalFilesystemEvidence:
         return await asyncio.to_thread(path.read_text, encoding=encoding)
 
     async def iter_paths(self, relative_path: str | Path = ".", *, recursive: bool = False) -> list[str]:
-        """Return stable relative path names under the evidence root."""
+        """List entries (files *and* directories) rooted at ``relative_path``.
+
+        Use this to walk a subtree or test for (non-)emptiness. For a flat,
+        files-only listing matched by a glob pattern, use :meth:`list_files`.
+        """
         base = self.path(relative_path)
         return await asyncio.to_thread(self._iter_paths_sync, base, recursive)
 
@@ -108,14 +112,23 @@ class LocalFilesystemEvidence:
         return await asyncio.to_thread(path.read_bytes)
 
     async def list_files(self, pattern: str = "**/*") -> list[str]:
-        """Return relative posix paths of files matching ``pattern`` (files only)."""
+        """List relative posix paths of files (not directories) matching ``pattern``.
+
+        Complements :meth:`iter_paths`: this is the flat, glob-filtered,
+        files-only view; ``iter_paths`` walks a subtree and includes directories.
+        """
         return await asyncio.to_thread(self._list_sync, pattern)
 
     def _list_sync(self, pattern: str) -> list[str]:
         return sorted(path.relative_to(self._root).as_posix() for path in self._root.glob(pattern) if path.is_file())
 
     async def diff(self, other: LocalFilesystemEvidence) -> FilesystemDiff:
-        """Diff this snapshot (before) against ``other`` (after) by file content hash."""
+        """Diff this snapshot (before) against ``other`` (after) by file content hash.
+
+        Cost note: this hashes every file in both trees by reading each fully, so
+        it is O(total bytes). Fine for task-sized evidence; revisit (streamed
+        hashing / size+mtime prefilter) if used on large artifact trees.
+        """
         return await asyncio.to_thread(self._diff_sync, other)
 
     def _diff_sync(self, other: LocalFilesystemEvidence) -> FilesystemDiff:
@@ -147,14 +160,22 @@ class LocalFilesystemEvidence:
 
         The evidence is copied to a temp overlay so the command can never mutate
         stored evidence (pytest caches, build artifacts, ...). ``command`` is a
-        list passed straight to exec — no shell parsing, so no injection surface.
+        list passed straight to exec, so there is no shell parsing of it.
+
+        This is NOT a sandbox: the command runs with the host's privileges and
+        full filesystem/network access. ``command`` is supplied by the (trusted)
+        metric author, never by the agent under test. Cost note: the whole tree
+        is copied on every call, so verifying large evidence repeatedly is heavy.
         """
         overlay = Path(tempfile.mkdtemp(prefix="evidence-verify-")).resolve()
         try:
             workdir = (overlay / cwd).resolve()
             if workdir != overlay and overlay not in workdir.parents:
                 raise ValueError(f"verifier cwd {cwd!r} resolves outside evidence overlay")
-            await asyncio.to_thread(shutil.copytree, self._root, overlay, dirs_exist_ok=True)
+            # ignore_dangling_symlinks: broken symlinks in evidence shouldn't abort the copy.
+            await asyncio.to_thread(
+                shutil.copytree, self._root, overlay, dirs_exist_ok=True, ignore_dangling_symlinks=True
+            )
             return await self._exec(command, workdir, timeout_s)
         finally:
             await asyncio.to_thread(shutil.rmtree, overlay, True)

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
@@ -5,12 +5,61 @@
 
 from __future__ import annotations
 
+import shutil
 import asyncio
+import hashlib
+import tempfile
+from typing import Any, Literal
 from pathlib import Path
-from typing import Any
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from pydantic import Field, BaseModel, ConfigDict, PrivateAttr, model_validator
+
+
+class FilesystemEntry(BaseModel):
+    """One path that differs between two filesystem snapshots."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    change_type: Literal["added", "modified", "deleted"]
+
+
+class FilesystemDiff(BaseModel):
+    """Set of paths that changed between two filesystem snapshots."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    entries: list[FilesystemEntry] = Field(default_factory=list)
+
+    def changed(
+        self,
+        *,
+        prefix: str | None = None,
+        kinds: set[str] | None = None,
+    ) -> list[FilesystemEntry]:
+        """Return entries optionally filtered by path prefix and change kind."""
+        return [
+            entry
+            for entry in self.entries
+            if (prefix is None or entry.path.startswith(prefix)) and (kinds is None or entry.change_type in kinds)
+        ]
+
+
+class CommandResult(BaseModel):
+    """Outcome of running a verifier command against filesystem evidence."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+    timed_out: bool = False
+
+    @property
+    def ok(self) -> bool:
+        """Whether the command exited 0 without timing out."""
+        return self.exit_code == 0 and not self.timed_out
 
 
 class LocalFilesystemEvidence:
@@ -52,6 +101,84 @@ class LocalFilesystemEvidence:
             return [base.relative_to(self._root).as_posix()]
         iterator = base.rglob("*") if recursive else base.iterdir()
         return sorted(path.relative_to(self._root).as_posix() for path in iterator)
+
+    async def read_bytes(self, relative_path: str | Path) -> bytes:
+        """Read a binary file under the evidence root."""
+        path = self.path(relative_path)
+        return await asyncio.to_thread(path.read_bytes)
+
+    async def list_files(self, pattern: str = "**/*") -> list[str]:
+        """Return relative posix paths of files matching ``pattern`` (files only)."""
+        return await asyncio.to_thread(self._list_sync, pattern)
+
+    def _list_sync(self, pattern: str) -> list[str]:
+        return sorted(path.relative_to(self._root).as_posix() for path in self._root.glob(pattern) if path.is_file())
+
+    async def diff(self, other: LocalFilesystemEvidence) -> FilesystemDiff:
+        """Diff this snapshot (before) against ``other`` (after) by file content hash."""
+        return await asyncio.to_thread(self._diff_sync, other)
+
+    def _diff_sync(self, other: LocalFilesystemEvidence) -> FilesystemDiff:
+        before = self._hashes()
+        after = other._hashes()
+        entries = [FilesystemEntry(path=path, change_type="added") for path in sorted(after.keys() - before.keys())]
+        entries += [FilesystemEntry(path=path, change_type="deleted") for path in sorted(before.keys() - after.keys())]
+        entries += [
+            FilesystemEntry(path=path, change_type="modified")
+            for path in sorted(before.keys() & after.keys())
+            if before[path] != after[path]
+        ]
+        return FilesystemDiff(entries=entries)
+
+    def _hashes(self) -> dict[str, str]:
+        hashes: dict[str, str] = {}
+        for rel in self._list_sync("**/*"):
+            hashes[rel] = hashlib.sha256((self._root / rel).read_bytes()).hexdigest()
+        return hashes
+
+    async def run_verifier(
+        self,
+        command: list[str],
+        *,
+        cwd: str = ".",
+        timeout_s: float | None = None,
+    ) -> CommandResult:
+        """Run ``command`` (no shell) against a throwaway copy of the evidence.
+
+        The evidence is copied to a temp overlay so the command can never mutate
+        stored evidence (pytest caches, build artifacts, ...). ``command`` is a
+        list passed straight to exec — no shell parsing, so no injection surface.
+        """
+        overlay = Path(tempfile.mkdtemp(prefix="evidence-verify-")).resolve()
+        try:
+            workdir = (overlay / cwd).resolve()
+            if workdir != overlay and overlay not in workdir.parents:
+                raise ValueError(f"verifier cwd {cwd!r} resolves outside evidence overlay")
+            await asyncio.to_thread(shutil.copytree, self._root, overlay, dirs_exist_ok=True)
+            return await self._exec(command, workdir, timeout_s)
+        finally:
+            await asyncio.to_thread(shutil.rmtree, overlay, True)
+
+    @staticmethod
+    async def _exec(command: list[str], cwd: Path, timeout_s: float | None) -> CommandResult:
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=str(cwd),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout_s)
+        except TimeoutError:
+            # wait_for cancels communicate() but leaves the child running; kill it.
+            process.kill()
+            await process.wait()
+            return CommandResult(exit_code=-1, timed_out=True)
+        return CommandResult(
+            exit_code=process.returncode if process.returncode is not None else -1,
+            stdout=stdout.decode(errors="replace"),
+            stderr=stderr.decode(errors="replace"),
+        )
 
 
 class EvidenceDescriptor(BaseModel):

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
@@ -5,15 +5,18 @@
 
 from __future__ import annotations
 
-import shutil
 import asyncio
+import difflib
 import hashlib
+import os
+import shutil
+import signal
 import tempfile
-from typing import Any, Literal
 from pathlib import Path
+from typing import Any, Literal
 from urllib.parse import urlparse
 
-from pydantic import Field, BaseModel, ConfigDict, PrivateAttr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 
 class FilesystemEntry(BaseModel):
@@ -77,9 +80,14 @@ class LocalFilesystemEvidence:
         """Return a path under the evidence root, rejecting traversal outside it."""
         relative = Path(relative_path)
         candidate = relative.resolve() if relative.is_absolute() else (self._root / relative).resolve()
-        if candidate != self._root and self._root not in candidate.parents:
+        if not self._within_root(candidate):
             raise ValueError(f"evidence path {relative_path!r} resolves outside evidence root")
         return candidate
+
+    def _within_root(self, path: Path) -> bool:
+        """Whether ``path`` (after resolving symlinks) stays inside the evidence root."""
+        resolved = path.resolve()
+        return resolved == self._root or self._root in resolved.parents
 
     async def exists(self, relative_path: str | Path = ".") -> bool:
         """Return whether a path exists under the evidence root."""
@@ -120,7 +128,11 @@ class LocalFilesystemEvidence:
         return await asyncio.to_thread(self._list_sync, pattern)
 
     def _list_sync(self, pattern: str) -> list[str]:
-        return sorted(path.relative_to(self._root).as_posix() for path in self._root.glob(pattern) if path.is_file())
+        return sorted(
+            path.relative_to(self._root).as_posix()
+            for path in self._root.glob(pattern)
+            if path.is_file() and self._within_root(path)
+        )
 
     async def diff(self, other: LocalFilesystemEvidence) -> FilesystemDiff:
         """Diff this snapshot (before) against ``other`` (after) by file content hash.
@@ -143,11 +155,58 @@ class LocalFilesystemEvidence:
         ]
         return FilesystemDiff(entries=entries)
 
+    async def unified_diff(
+        self,
+        other: LocalFilesystemEvidence,
+        relative_path: str | Path,
+        *,
+        context: int = 3,
+    ) -> str:
+        """Unified diff of one path between this snapshot (before) and ``other`` (after).
+
+        Opt-in, per-path companion to :meth:`diff` (which reports only which paths
+        changed). Returns ``""`` when the two versions are identical or binary
+        (non-UTF-8). Path access is traversal-guarded like the rest of the handle.
+        """
+        return await asyncio.to_thread(self._unified_diff_sync, other, relative_path, context)
+
+    def _unified_diff_sync(self, other: LocalFilesystemEvidence, relative_path: str | Path, context: int) -> str:
+        before_path, after_path = self.path(relative_path), other.path(relative_path)
+        before = before_path.read_bytes() if before_path.is_file() else b""
+        after = after_path.read_bytes() if after_path.is_file() else b""
+        if before == after:
+            return ""
+        try:
+            before_lines = before.decode("utf-8").splitlines(keepends=True)
+            after_lines = after.decode("utf-8").splitlines(keepends=True)
+        except UnicodeDecodeError:
+            return ""  # binary content: no textual patch
+        rel = Path(relative_path).as_posix()
+        return "".join(
+            difflib.unified_diff(before_lines, after_lines, fromfile=f"a/{rel}", tofile=f"b/{rel}", n=context)
+        )
+
     def _hashes(self) -> dict[str, str]:
         hashes: dict[str, str] = {}
-        for rel in self._list_sync("**/*"):
-            hashes[rel] = hashlib.sha256((self._root / rel).read_bytes()).hexdigest()
+        for path in self._safe_files():
+            hashes[path.relative_to(self._root).as_posix()] = hashlib.sha256(path.read_bytes()).hexdigest()
         return hashes
+
+    def _safe_files(self) -> list[Path]:
+        """Regular files under the root, never descending into or reading symlinks that escape it.
+
+        ``os.walk(followlinks=False)`` keeps a ``vendor -> /`` style dir symlink from
+        exploding the walk, and escaping file symlinks (``leak -> /etc/passwd``) are
+        dropped so their target is never hashed.
+        """
+        files: list[Path] = []
+        for dirpath, _dirnames, filenames in os.walk(self._root, followlinks=False):
+            for name in filenames:
+                full = Path(dirpath) / name
+                if full.is_symlink() and not self._within_root(full):
+                    continue
+                files.append(full)
+        return files
 
     async def run_verifier(
         self,
@@ -172,27 +231,56 @@ class LocalFilesystemEvidence:
             workdir = (overlay / cwd).resolve()
             if workdir != overlay and overlay not in workdir.parents:
                 raise ValueError(f"verifier cwd {cwd!r} resolves outside evidence overlay")
-            # ignore_dangling_symlinks: broken symlinks in evidence shouldn't abort the copy.
+            # symlinks=True copies links as-is (no host deref); the ignore hook drops
+            # links whose target escapes the evidence root so the verifier can't read them.
             await asyncio.to_thread(
-                shutil.copytree, self._root, overlay, dirs_exist_ok=True, ignore_dangling_symlinks=True
+                shutil.copytree,
+                self._root,
+                overlay,
+                dirs_exist_ok=True,
+                symlinks=True,
+                ignore=self._ignore_escaping_symlinks,
             )
             return await self._exec(command, workdir, timeout_s)
         finally:
             await asyncio.to_thread(shutil.rmtree, overlay, True)
 
+    def _ignore_escaping_symlinks(self, directory: str, names: list[str]) -> set[str]:
+        """copytree ignore hook: skip symlinks that can't be safely preserved in the overlay.
+
+        Drops links whose resolved target escapes the evidence root (host-file reads)
+        and absolute links: ``symlinks=True`` would recreate the latter verbatim, so a
+        verifier write through ``link -> /real/evidence/answer.txt`` would mutate the
+        stored evidence instead of the throwaway copy.
+        """
+        ignored: set[str] = set()
+        for name in names:
+            full = Path(directory) / name
+            if not full.is_symlink():
+                continue
+            if os.path.isabs(os.readlink(full)) or not self._within_root(full):
+                ignored.add(name)
+        return ignored
+
     @staticmethod
     async def _exec(command: list[str], cwd: Path, timeout_s: float | None) -> CommandResult:
+        # start_new_session makes the child its own process-group leader, so a timeout
+        # can reap the whole tree (grandchildren it spawned) rather than just the child.
         process = await asyncio.create_subprocess_exec(
             *command,
             cwd=str(cwd),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
         )
         try:
             stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout_s)
         except TimeoutError:
-            # wait_for cancels communicate() but leaves the child running; kill it.
-            process.kill()
+            # wait_for cancels communicate() but leaves the tree running; kill the group.
+            try:
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass  # already exited between the timeout and the kill
             await process.wait()
             return CommandResult(exit_code=-1, timed_out=True)
         return CommandResult(


### PR DESCRIPTION
## Summary

First slice of the agent-eval P0 evidence/metrics work, split out for focused review.

- Adds `AgentEvalTaskset` — a named, validated collection of agent-eval tasks (unique task ids).
- Extends `LocalFilesystemEvidence` with `read_bytes`, `list(pattern)`, `diff`, and `run_verifier`.
  - `run_verifier` runs the command (no shell) against a throwaway overlay copy of the evidence, so stored evidence (pytest caches, build artifacts, ...) can never be mutated.
- Adds the `FilesystemEntry` / `FilesystemDiff` / `CommandResult` value types.
- Adds example-only `tests_pass` / `no_test_cheating` metrics that score over filesystem evidence (in `examples/run_agent_eval/example_metrics.py`).
- Vendored SDK mirror synced via `make vendor`.

The remaining ATIF trace + log read handles land separately in the stacked branch `aalgo-258-p0-evidence-metrics`.

## Test plan

- [x] `uv run ruff check` (changed files) — clean
- [x] `uv run --frozen ty check` on `values/evidence.py` — clean
- [x] `uv run --frozen pytest packages/nemo_evaluator_sdk/tests/agent_eval/{test_evidence,test_tasks,test_example_metrics}.py` — 9 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filesystem evidence utilities for safe reads, glob-based file listing, snapshot diffing, unified diffs, and running verifier commands in an isolated workspace.
  * Introduced reference metrics to assess test pass status and detect protected-path test cheating.
  * Added taskset support with validated task bundles and a standardized loader interface.
  * Expanded public evidence result types (command outcomes and filesystem change reporting).
* **Bug Fixes**
  * Strengthened traversal and symlink safety to prevent escaping evidence roots during evidence access and verifier runs.
* **Tests**
  * Added coverage for evidence APIs, verifier behavior (including timeouts and isolation), unified diff output, example metrics, and taskset validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->