### PR TITLE
feat(studio): add chat history naming

### DIFF
--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -18,6 +18,7 @@ import { Button, Text, Tooltip } from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/dataViews/ExperimentGroupDataView/Empty';
 import {
   type ExperimentRow,
+  type ListExperimentsSortParam,
   useExperimentGroupExperiments,
 } from '@studio/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
@@ -30,7 +31,24 @@ import { useNavigate } from 'react-router-dom';
 export type { ExperimentRow };
 
 const SORTABLE_FIELDS = ['name', 'created_at'] as const;
-const DEFAULT_SORT = '-created_at';
+const DEFAULT_SORT: ListExperimentsSortParam = '-created_at';
+const SORT_PARAMS = [
+  'name',
+  '-name',
+  'created_at',
+  '-created_at',
+] as const satisfies readonly ListExperimentsSortParam[];
+const SORT_PARAM_SET: ReadonlySet<string> = new Set(SORT_PARAMS);
+
+const isListExperimentsSortParam = (sort: string): sort is ListExperimentsSortParam =>
+  SORT_PARAM_SET.has(sort);
+
+const getExperimentSortParam = (
+  sortingState: Parameters<typeof getSortParamWithWhitelist>[0]
+): ListExperimentsSortParam => {
+  const sort = getSortParamWithWhitelist(sortingState, SORTABLE_FIELDS, DEFAULT_SORT);
+  return isListExperimentsSortParam(sort) ? sort : DEFAULT_SORT;
+};
 
 interface ExperimentGroupDataViewProps {
   experimentGroupName: string;
@@ -69,11 +87,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
 
   const page = dataViewState.pagination.state.pageIndex + 1;
   const pageSize = dataViewState.pagination.state.pageSize;
-  const sortParam = getSortParamWithWhitelist(
-    dataViewState.sorting.state,
-    SORTABLE_FIELDS,
-    DEFAULT_SORT
-  );
+  const sortParam = getExperimentSortParam(dataViewState.sorting.state);
 
   const {
     rows: orderedData,

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.ts
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.ts
@@ -19,7 +19,7 @@ import { useCallback, useMemo, useRef } from 'react';
 
 /** An API response plus the stable `id` the data view needs. */
 export type ExperimentRow = ExperimentResponse & { id: string };
-type ListExperimentsSortParam = NonNullable<ListExperimentsParams['sort']>;
+export type ListExperimentsSortParam = NonNullable<ListExperimentsParams['sort']>;
 
 const toRows = (experiments: ExperimentResponse[] | undefined): ExperimentRow[] =>
   (experiments ?? []).map((experiment) => ({
@@ -41,7 +41,7 @@ export interface UseExperimentGroupExperimentsParams {
   search: string;
   page: number;
   pageSize: number;
-  sort: string;
+  sort: ListExperimentsSortParam;
 }
 
 export interface ExperimentGroupExperiments {
@@ -120,7 +120,7 @@ export function useExperimentGroupExperiments({
     {
       page,
       page_size: pageSize,
-      sort: sort as ListExperimentsSortParam,
+      sort,
       filter: { ...baseFilter, is_pinned: false } as ExperimentFilter,
     },
     listQueryOptions

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.ts
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.ts
@@ -12,13 +12,14 @@ import {
 import type {
   ExperimentFilter,
   ExperimentResponse,
-  ListExperimentsSort,
+  ListExperimentsParams,
 } from '@nemo/sdk/generated/platform/schema';
 import { keepPreviousData, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useRef } from 'react';
 
 /** An API response plus the stable `id` the data view needs. */
 export type ExperimentRow = ExperimentResponse & { id: string };
+type ListExperimentsSortParam = NonNullable<ListExperimentsParams['sort']>;
 
 const toRows = (experiments: ExperimentResponse[] | undefined): ExperimentRow[] =>
   (experiments ?? []).map((experiment) => ({
@@ -119,7 +120,7 @@ export function useExperimentGroupExperiments({
     {
       page,
       page_size: pageSize,
-      sort: sort as ListExperimentsSort,
+      sort: sort as ListExperimentsSortParam,
       filter: { ...baseFilter, is_pinned: false } as ExperimentFilter,
     },
     listQueryOptions

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeHistoryPanel.test.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/ClaudeCodeHistoryPanel.test.tsx
@@ -62,6 +62,13 @@ describe('ClaudeCodeHistoryPanel', () => {
         token_count: 100,
         tool_call_count: 1,
         tool_calls: ['Bash'],
+        chat_artifacts: {
+          selections: [],
+          files: [],
+          links: [],
+          jobs: [],
+          tools: [],
+        },
       },
     ]);
 

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/historyPanel/HistorySessionButton.tsx
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/historyPanel/HistorySessionButton.tsx
@@ -3,7 +3,10 @@
 
 import { Flex, Stack, Text } from '@nvidia/foundations-react-core';
 import { ToolCallSummary } from '@studio/routes/agents/ClaudeCodeChatRoute/historyPanel/ArtifactSections';
-import { getCompactRelativeTime } from '@studio/routes/agents/ClaudeCodeChatRoute/historyPanel/helpers';
+import {
+  getCompactRelativeTime,
+  getHistorySessionTitle,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/historyPanel/helpers';
 import type { ClaudeCodeHistorySession } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
 import cn from 'classnames';
 import { MessageSquare } from 'lucide-react';
@@ -16,41 +19,48 @@ export const HistorySessionButton = ({
   active: boolean;
   onSelect: () => void;
   session: ClaudeCodeHistorySession;
-}) => (
-  <button
-    type="button"
-    aria-current={active ? 'page' : undefined}
-    title={new Date(session.mtime * 1000).toLocaleString()}
-    className={cn(
-      'w-full cursor-pointer border-b border-base px-density-md py-density-sm text-left transition-colors hover:bg-surface-sunken focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent',
-      active && 'bg-surface-sunken'
-    )}
-    onClick={onSelect}
-  >
-    <Stack gap="density-xs">
-      <Flex align="center" gap="density-sm">
-        <span
-          className={cn(
-            'flex size-6 shrink-0 items-center justify-center text-secondary',
-            active && 'text-accent'
-          )}
-        >
-          <MessageSquare size={12} />
-        </span>
-        <Flex align="center" justify="between" gap="density-sm" className="min-w-0 flex-1">
-          <Text kind="body/regular/sm" className="min-w-0 flex-1 line-clamp-2">
-            {session.first_prompt || 'Claude Code session'}
-          </Text>
-          <Text kind="body/regular/sm" color="secondary" className="shrink-0 whitespace-nowrap">
-            {getCompactRelativeTime(session.mtime)}
-          </Text>
-        </Flex>
-      </Flex>
-      {session.tool_calls.length > 0 && (
-        <div className="pl-8">
-          <ToolCallSummary toolCalls={session.tool_calls} />
-        </div>
+}) => {
+  const sessionTitle = getHistorySessionTitle(session);
+  const timestamp = new Date(session.mtime * 1000).toLocaleString();
+  const prompt = session.first_prompt.trim();
+  const tooltip = prompt ? `${timestamp}\n\n${prompt}` : timestamp;
+
+  return (
+    <button
+      type="button"
+      aria-current={active ? 'page' : undefined}
+      title={tooltip}
+      className={cn(
+        'w-full cursor-pointer border-b border-base px-density-md py-density-sm text-left transition-colors hover:bg-surface-sunken focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent',
+        active && 'bg-surface-sunken'
       )}
-    </Stack>
-  </button>
-);
+      onClick={onSelect}
+    >
+      <Stack gap="density-xs">
+        <Flex align="center" gap="density-sm">
+          <span
+            className={cn(
+              'flex size-6 shrink-0 items-center justify-center text-secondary',
+              active && 'text-accent'
+            )}
+          >
+            <MessageSquare size={12} />
+          </span>
+          <Flex align="center" justify="between" gap="density-sm" className="min-w-0 flex-1">
+            <Text kind="body/regular/sm" className="min-w-0 flex-1 line-clamp-2">
+              {sessionTitle}
+            </Text>
+            <Text kind="body/regular/sm" color="secondary" className="shrink-0 whitespace-nowrap">
+              {getCompactRelativeTime(session.mtime)}
+            </Text>
+          </Flex>
+        </Flex>
+        {session.tool_calls.length > 0 && (
+          <div className="pl-8">
+            <ToolCallSummary toolCalls={session.tool_calls} />
+          </div>
+        )}
+      </Stack>
+    </button>
+  );
+};

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/historyPanel/helpers.test.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/historyPanel/helpers.test.ts
@@ -38,10 +38,10 @@ describe('getHistorySessionTitle', () => {
       getHistorySessionTitle(
         makeSession({
           first_prompt:
-            "In our coding agent interface in Studio (which I already have running) we currently have a chat history panel. The chats in this panel have very long wordy names - we're pulling them from our coding agent directly. Is it possible for us to give them concise relevant names to improve chat discovery?",
+            'On the evaluations dashboard, reviewers scan through dozens of saved runs every morning. The run cards include full agent notes and take up too much room. Is it possible for us to show compact outcome labels for faster triage?',
         })
       )
-    ).toBe('Give concise relevant names to improve chat discovery');
+    ).toBe('Show compact outcome labels for faster triage');
   });
 
   it('keeps direct prompts readable', () => {

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/historyPanel/helpers.test.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/historyPanel/helpers.test.ts
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getHistorySessionTitle } from '@studio/routes/agents/ClaudeCodeChatRoute/historyPanel/helpers';
+import type {
+  ClaudeCodeChatArtifacts,
+  ClaudeCodeHistorySession,
+} from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+
+const emptyArtifacts: ClaudeCodeChatArtifacts = {
+  selections: [],
+  files: [],
+  links: [],
+  jobs: [],
+  tools: [],
+};
+
+const makeSession = ({
+  chat_artifacts = emptyArtifacts,
+  first_prompt = '',
+}: {
+  chat_artifacts?: ClaudeCodeChatArtifacts;
+  first_prompt?: string;
+}): ClaudeCodeHistorySession => ({
+  session_id: 'session-1',
+  mtime: 0,
+  first_prompt,
+  message_count: first_prompt ? 1 : 0,
+  token_count: 0,
+  tool_call_count: 0,
+  tool_calls: [],
+  chat_artifacts,
+});
+
+describe('getHistorySessionTitle', () => {
+  it('turns a long contextual prompt into the latest actionable request', () => {
+    expect(
+      getHistorySessionTitle(
+        makeSession({
+          first_prompt:
+            "In our coding agent interface in Studio (which I already have running) we currently have a chat history panel. The chats in this panel have very long wordy names - we're pulling them from our coding agent directly. Is it possible for us to give them concise relevant names to improve chat discovery?",
+        })
+      )
+    ).toBe('Give concise relevant names to improve chat discovery');
+  });
+
+  it('keeps direct prompts readable', () => {
+    expect(
+      getHistorySessionTitle(makeSession({ first_prompt: 'Review the latest agent work' }))
+    ).toBe('Review the latest agent work');
+  });
+
+  it('removes request framing from one-sentence prompts', () => {
+    expect(
+      getHistorySessionTitle(
+        makeSession({ first_prompt: 'Can you please review the latest agent work?' })
+      )
+    ).toBe('Review the latest agent work');
+  });
+
+  it('falls back to artifacts when no prompt is available', () => {
+    expect(
+      getHistorySessionTitle(
+        makeSession({
+          chat_artifacts: {
+            ...emptyArtifacts,
+            agent: 'beach-finder',
+          },
+        })
+      )
+    ).toBe('Agent beach-finder');
+  });
+});

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/historyPanel/helpers.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/historyPanel/helpers.ts
@@ -5,7 +5,29 @@ import type { ClaudeCodePanelTab } from '@studio/routes/agents/ClaudeCodeChatRou
 import type {
   ClaudeCodeChatArtifacts,
   ClaudeCodeChatFileArtifact,
+  ClaudeCodeHistorySession,
 } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
+
+const MAX_HISTORY_TITLE_WORDS = 8;
+const MAX_HISTORY_TITLE_CHARS = 72;
+
+const ACTIONABLE_OPENERS = [
+  /^(?:please\s+)?(?:can|could|would|will|should)\s+(?:you|we)\b/i,
+  /^is\s+it\s+possible\b/i,
+  /^(?:i|we)\s+(?:need|want)\s+to\b/i,
+  /^i(?:'d| would)\s+like(?:\s+you)?\s+to\b/i,
+  /^help(?:\s+(?:me|us))?\b/i,
+  /^let'?s\b/i,
+];
+
+const REQUEST_PREFIXES = [
+  /^(?:please\s+)?(?:can|could|would|will|should)\s+(?:you|we)\s+/i,
+  /^is\s+it\s+possible(?:\s+for\s+(?:us|you|me))?\s+to\s+/i,
+  /^(?:i|we)\s+(?:need|want)\s+to\s+/i,
+  /^i(?:'d| would)\s+like(?:\s+you)?\s+to\s+/i,
+  /^help(?:\s+(?:me|us))?(?:\s+to)?\s+/i,
+  /^let'?s\s+/i,
+];
 
 export const isClaudeCodePanelTab = (value: string): value is ClaudeCodePanelTab =>
   value === 'history' || value === 'skills';
@@ -33,6 +55,84 @@ export const getFileLabel = (file: ClaudeCodeChatFileArtifact): string => {
   const parts = file.path.split('/');
   return parts[parts.length - 1] || file.path;
 };
+
+const getCleanTitleText = (value: string): string =>
+  value
+    .replace(/\([^()]*\)/g, ' ')
+    .replace(/[`*_#>]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const splitPromptSentences = (prompt: string): string[] =>
+  (prompt.match(/[^.!?]+[.!?]*/g) ?? [prompt])
+    .map((sentence) =>
+      getCleanTitleText(sentence)
+        .replace(/[.!?]+$/g, '')
+        .trim()
+    )
+    .filter(Boolean);
+
+const isActionableSentence = (sentence: string): boolean =>
+  ACTIONABLE_OPENERS.some((pattern) => pattern.test(sentence));
+
+const getPromptTitleSource = (prompt: string): string => {
+  const sentences = splitPromptSentences(prompt);
+
+  for (let index = sentences.length - 1; index >= 0; index -= 1) {
+    if (isActionableSentence(sentences[index])) return sentences[index];
+  }
+
+  return sentences[0] ?? getCleanTitleText(prompt);
+};
+
+const stripRequestPrefix = (text: string): string => {
+  let title = text;
+
+  for (const pattern of REQUEST_PREFIXES) {
+    title = title.replace(pattern, '');
+  }
+
+  return title.replace(/^please\s+/i, '').replace(/^give\s+(?:it|them|this|that)\s+/i, 'give ');
+};
+
+const capitalizeTitle = (title: string): string =>
+  title ? `${title.charAt(0).toLocaleUpperCase()}${title.slice(1)}` : title;
+
+const limitTitleLength = (title: string): string => {
+  const words = title.split(/\s+/).filter(Boolean);
+  let limited = words.slice(0, MAX_HISTORY_TITLE_WORDS).join(' ');
+
+  if (limited.length > MAX_HISTORY_TITLE_CHARS) {
+    limited = `${limited.slice(0, MAX_HISTORY_TITLE_CHARS - 3).trimEnd()}...`;
+  }
+
+  return limited;
+};
+
+const getPromptHistoryTitle = (prompt: string): string | undefined => {
+  const source = getPromptTitleSource(prompt);
+  const title = capitalizeTitle(
+    stripRequestPrefix(source)
+      .replace(/[,:;\s-]+$/g, '')
+      .trim()
+  );
+  return title ? limitTitleLength(title) : undefined;
+};
+
+const getArtifactHistoryTitle = (artifacts: ClaudeCodeChatArtifacts): string | undefined => {
+  if (artifacts.agent) return `Agent ${getCleanTitleText(artifacts.agent)}`;
+  if (artifacts.jobs.length) return `Job ${getCleanTitleText(artifacts.jobs[0].name)}`;
+  if (artifacts.files.length) {
+    const file = artifacts.files[0];
+    return `${getCleanTitleText(file.action)} ${getFileLabel(file)}`;
+  }
+  return undefined;
+};
+
+export const getHistorySessionTitle = (session: ClaudeCodeHistorySession): string =>
+  getPromptHistoryTitle(session.first_prompt) ??
+  getArtifactHistoryTitle(session.chat_artifacts) ??
+  'Claude Code session';
 
 export const getSelectedArtifactModel = (artifacts: ClaudeCodeChatArtifacts): string | undefined =>
   artifacts.model_source === 'selection' || artifacts.model_source === 'spec'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session history entries now show smarter, human-readable titles based on the most actionable prompt, with artifact-based fallbacks when prompts are missing.
  * History tooltips always include a localized timestamp, and now show the prompt text only when it’s present.

* **Bug Fixes**
  * Improved title generation to better clean, extract, and format prompt content (framing, punctuation, and length).
  * Experiment sorting now consistently uses validated, supported sort options.

* **Tests**
  * Updated mocked history session fixtures and added unit tests covering title-generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->