### PR TITLE
chore: Ensure run_nemo_local uses isolated config

### DIFF
--- a/packages/nmp_testing/src/nmp/testing/utils.py
+++ b/packages/nmp_testing/src/nmp/testing/utils.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import subprocess
+import tempfile
 import time
 import uuid
 from collections.abc import Callable, Sequence
@@ -59,26 +60,32 @@ def run_nemo_local(
     need to point the CLI at a specific platform instance.
 
     Pass ``base_url`` and ``workspace`` to inject ``NMP_BASE_URL`` and
-    ``NMP_WORKSPACE`` directly. Pass ``cwd`` to run from a different directory
-    (e.g. a ``tmp_path`` with a fake ``.git`` marker so ``skills install``
-    writes there instead of the real repo root).
+    ``NMP_WORKSPACE`` directly. The CLI gets an empty temporary
+    ``NMP_CONFIG_FILE`` so test calls do not read a developer's local CLI/SDK
+    config. Pass ``cwd`` to run from a different directory (e.g. a ``tmp_path``
+    with a fake ``.git`` marker so ``skills install`` writes there instead of
+    the real repo root).
     """
-    env = os.environ.copy()
-    if base_url is not None:
-        env["NMP_BASE_URL"] = base_url.rstrip("/")
-    if workspace is not None:
-        env["NMP_WORKSPACE"] = workspace
-    if env_extra:
-        env.update(env_extra)
-    cmd = ["uv", "run", "--project", str(get_repo_root()), "--frozen", "nemo", *args]
-    return subprocess.run(
-        cmd,
-        cwd=cwd or get_repo_root(),
-        env=env,
-        timeout=timeout,
-        capture_output=True,
-        text=True,
-    )
+    with tempfile.TemporaryDirectory(prefix="nmp-cli-config-") as config_dir:
+        env = os.environ.copy()
+        config_path = Path(config_dir) / "config.yaml"
+        config_path.write_text("{}\n")
+        env["NMP_CONFIG_FILE"] = str(config_path)
+        if base_url is not None:
+            env["NMP_BASE_URL"] = base_url.rstrip("/")
+        if workspace is not None:
+            env["NMP_WORKSPACE"] = workspace
+        if env_extra:
+            env.update(env_extra)
+        cmd = ["uv", "run", "--project", str(get_repo_root()), "--frozen", "nemo", *args]
+        return subprocess.run(
+            cmd,
+            cwd=cwd or get_repo_root(),
+            env=env,
+            timeout=timeout,
+            capture_output=True,
+            text=True,
+        )
 
 
 @dataclass


### PR DESCRIPTION
Without this, e2e tests using this helper function pick up the local nemo-platform config, and for instance if you have an expired auth token in there the test run will raise:
> RuntimeError: NeMoPlatform client initialization failed: Access token has expired and no refresh token is available. Re-authenticate with `nemo auth login` to obtain new tokens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local command execution by isolating configuration in a temporary sandbox.
  * Environment settings are now applied more reliably during runs, helping prevent interference from existing local setup.
  * This should make local workflows more consistent and reduce unexpected configuration-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->