### PR TITLE
chore: update badge for repo to public badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 ![NEMO Platform](docs/assets/nemo-wordmark.svg)
 
-<!-- Once the repo is public, swap the CI badge back to the dynamic GitHub Actions one:
-     [![CI](https://github.com/NVIDIA-NeMo/nemo-platform/actions/workflows/ci.yaml/badge.svg)](https://github.com/NVIDIA-NeMo/nemo-platform/actions/workflows/ci.yaml) -->
-[![CI](https://img.shields.io/badge/CI-passing-brightgreen?style=flat-square&logo=githubactions&logoColor=white)](https://github.com/NVIDIA-NeMo/nemo-platform/actions/workflows/ci.yaml)
+[![CI](https://github.com/NVIDIA-NeMo/nemo-platform/actions/workflows/ci.yaml/badge.svg)](https://github.com/NVIDIA-NeMo/nemo-platform/actions/workflows/ci.yaml)
 [![License](https://img.shields.io/badge/license-Apache_2.0-D22128?style=flat-square)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11--3.14-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![Docs](https://img.shields.io/static/v1?label=docs&message=docs.nvidia.com%2Fnemo-platform&color=76B900&style=flat-square&logo=readthedocs&logoColor=white)](https://docs.nvidia.com/nemo-platform)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the project’s CI status badge to use a direct GitHub Actions workflow badge, keeping the repository status display current and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->