### PR TITLE
fix: nss image, remove ffmpeg, force wandb version

### DIFF
--- a/docker/Dockerfile.nmp-automodel-base
+++ b/docker/Dockerfile.nmp-automodel-base
@@ -105,7 +105,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     "tornado>=6.5.5,<7" \
     "urllib3>=2.7.0,<3" \
     "mlflow-skinny>=3.11.1,<3.12.0" \
-    "grpcio>=1.81.1,<2"
+    "grpcio>=1.81.1,<2" \
+    "wandb==0.27.2"
 
 # Published base image (same filesystem as builder).
 FROM ${PYTORCH_BASE} AS nmp-automodel-base

--- a/docker/Dockerfile.safe-synthesizer-tasks
+++ b/docker/Dockerfile.safe-synthesizer-tasks
@@ -9,7 +9,7 @@
 # Global ARGs (must be declared before first FROM to be usable in FROM statements)
 # =============================================================================
 ARG PYTHON_VERSION=3.13
-ARG PYTHON_IMAGE=python:${PYTHON_VERSION}-slim-bookworm
+ARG PYTHON_IMAGE=python:${PYTHON_VERSION}-slim-trixie
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.9.30
 ARG SAFE_SYNTHESIZER_RUNTIME_PACKAGE="nemo-safe-synthesizer[engine,cu129]==0.1.2"
 ARG FLASHINFER_CU129_INDEX_URL="https://flashinfer.ai/whl/cu129"
@@ -109,7 +109,10 @@ RUN printf '%s\n' \
         > /tmp/safe-synthesizer-runtime.txt && \
     printf '%s\n' \
         "${VLLM_CU129_WHEEL}" \
-        > /tmp/vllm-cu129.txt
+        > /tmp/vllm-cu129.txt && \
+    printf '%s\n' \
+        wandb==0.27.2 \
+        > /tmp/safe-synthesizer-overrides.txt
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     UV_CACHE_DIR=/root/.cache/uv uv pip install --python /opt/venv/bin/python \
@@ -117,6 +120,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra-index-url "${PYTORCH_CU129_INDEX_URL}" \
         --index-strategy unsafe-best-match \
         --torch-backend cu129 \
+        --overrides /tmp/safe-synthesizer-overrides.txt \
         --excludes /tmp/exclude-flashinfer-torch-vllm.txt \
         --requirements /tmp/safe-synthesizer-runtime.txt
 
@@ -127,6 +131,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra-index-url "${PYTORCH_CU129_INDEX_URL}" \
         --index-strategy unsafe-best-match \
         --torch-backend cu129 \
+        --overrides /tmp/safe-synthesizer-overrides.txt \
         --excludes /tmp/exclude-torch-vllm.txt \
         --requirements /tmp/safe-synthesizer-runtime.txt
 
@@ -137,6 +142,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra-index-url "${PYTORCH_CU129_INDEX_URL}" \
         --index-strategy unsafe-best-match \
         --torch-backend cu129 \
+        --overrides /tmp/safe-synthesizer-overrides.txt \
         --excludes /tmp/exclude-vllm.txt \
         --requirements /tmp/safe-synthesizer-runtime.txt
 
@@ -147,6 +153,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra-index-url "${PYTORCH_CU129_INDEX_URL}" \
         --index-strategy unsafe-best-match \
         --torch-backend cu129 \
+        --overrides /tmp/safe-synthesizer-overrides.txt \
         --requirements /tmp/safe-synthesizer-runtime.txt \
         --requirements /tmp/vllm-cu129.txt
 

--- a/docker/automodel/no_override_requirements.txt
+++ b/docker/automodel/no_override_requirements.txt
@@ -8,3 +8,6 @@ tokenizers; sys_platform == 'never'
 accelerate; sys_platform == 'never'
 safetensors; sys_platform == 'never'
 numpy; sys_platform == 'never'
+
+# Keep W&B's bundled wandb-core binary on a build with patched go-git/go-billy.
+wandb==0.27.2

--- a/docker/scripts/cve-cleanup.sh
+++ b/docker/scripts/cve-cleanup.sh
@@ -8,9 +8,12 @@ set -e
 # overlayfs whiteouts that also hide the hard-linked venv files (e.g.
 # typing_extensions, pydantic), breaking imports at runtime.
 
-# remove wandb-core gobinary (unused)
-rm -f /app/.venv/lib/python3.11/site-packages/wandb/bin/wandb-core
-rm -f /opt/venv/lib/python3.12/site-packages/wandb/bin/wandb-core
+# Remove unused bundled ffmpeg binaries with their own vulnerability surface.
+for venv in /app/.venv /opt/venv; do
+    if [ -d "${venv}" ]; then
+        find "${venv}" -type f \( -name ffmpeg -o -name 'ffmpeg-*' \) -delete
+    fi
+done
 
 # remove nsight cli (unused) - nic_sampler vulnerable
 rm -rf /usr/local/cuda/NsightSystems-cli-*
@@ -45,5 +48,3 @@ rm -rf /usr/local/lib/python3.12/dist-packages/urllib3 \
 rm -rf /usr/local/lib/python3.12/dist-packages/mlflow \
        /usr/local/lib/python3.12/dist-packages/mlflow-*.dist-info \
        /usr/local/lib/python3.12/dist-packages/mlflow_skinny-*.dist-info
-rm -rf /usr/local/lib/python3.12/dist-packages/wandb \
-       /usr/local/lib/python3.12/dist-packages/wandb-*.dist-info

--- a/docker/unsloth/no_override_requirements.txt
+++ b/docker/unsloth/no_override_requirements.txt
@@ -9,3 +9,6 @@ torchaudio; sys_platform == 'never'
 tokenizers; sys_platform == 'never'
 accelerate; sys_platform == 'never'
 safetensors; sys_platform == 'never'
+
+# Keep W&B's bundled wandb-core binary on a build with patched go-git/go-billy.
+wandb==0.27.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated container builds to use a newer Python base image and applied a consistent package pin to improve build reliability.
  * Adjusted cleanup steps to remove outdated bundled binaries more safely across environments.

* **Chores**
  * Added an explicit version pin for a key package in multiple build configurations to keep dependency behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->