### PR TITLE
feat(studio): add @axe-core/playwright accessibility harness

### DIFF
--- a/web/packages/studio/e2e-tests/a11y/a11y.test.ts
+++ b/web/packages/studio/e2e-tests/a11y/a11y.test.ts
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { runAxeScan } from '@e2e-tests/a11y/axe';
+import { disableAuthForTest } from '@e2e-tests/utils/pageUtils';
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Fixed mock data — no live backend required.
+// All API calls are intercepted by page.route() before any navigation.
+// ---------------------------------------------------------------------------
+
+const MOCK_WORKSPACE = {
+  id: 'mock-workspace-id',
+  name: 'default',
+  description: 'Mock workspace for accessibility tests',
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+};
+
+const fulfillJson = (route: Route, body: unknown) =>
+  route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+/**
+ * Intercept NMP API calls and return fixed mock responses.
+ *
+ * Playwright uses LIFO for route handlers, so the workspace-specific route is
+ * registered last and therefore runs before the catch-all.
+ */
+const setupApiMocks = async (page: Page): Promise<void> => {
+  // Catch-all: empty success for any unmatched API route
+  await page.route('**/apis/**', (route) => fulfillJson(route, {}));
+
+  // WorkspaceProvider calls this on every authenticated page load
+  await page.route('**/apis/entities/v2/workspaces/default', (route) =>
+    fulfillJson(route, MOCK_WORKSPACE)
+  );
+};
+
+test.describe('Accessibility — Studio routes (axe / WCAG 2.x A+AA)', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupApiMocks(page);
+    await disableAuthForTest(page);
+  });
+
+  test('workspace dashboard has no axe violations', async ({ page }) => {
+    await page.goto('/workspaces/default/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const results = await runAxeScan(page);
+
+    expect(
+      results.violations,
+      `axe violations on /workspaces/default/dashboard:\n${formatViolations(results.violations)}`
+    ).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface AxeViolation {
+  id: string;
+  description: string;
+  nodes: Array<{ html: string }>;
+}
+
+const formatViolations = (violations: AxeViolation[]): string =>
+  violations
+    .map(
+      (v) =>
+        `  [${v.id}] ${v.description}\n` +
+        v.nodes.map((n) => `    → ${n.html.slice(0, 120)}`).join('\n')
+    )
+    .join('\n');

--- a/web/packages/studio/e2e-tests/a11y/axe.ts
+++ b/web/packages/studio/e2e-tests/a11y/axe.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AxeBuilder } from '@axe-core/playwright';
+import type { Page } from '@playwright/test';
+
+/**
+ * WCAG 2.x conformance tags targeted by our accessibility harness.
+ * Covers levels A and AA for WCAG 2.0, 2.1, and 2.2.
+ */
+const A11Y_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'] as const;
+
+/** Return type of a single axe scan — re-exported from @axe-core/playwright's analyze(). */
+export type AxeScanResult = Awaited<ReturnType<AxeBuilder['analyze']>>;
+
+/**
+ * Runs an axe accessibility scan on the current page state.
+ *
+ * Returns the raw AxeResults so callers can assert on violations,
+ * incomplete checks, or passes as appropriate for their test.
+ */
+export const runAxeScan = async (page: Page): Promise<AxeScanResult> =>
+  new AxeBuilder({ page }).withTags([...A11Y_TAGS]).analyze();

--- a/web/packages/studio/package.json
+++ b/web/packages/studio/package.json
@@ -93,6 +93,7 @@
     "@nemo/testing": "workspace:*",
     "@huggingface/hub": "^1.0.0",
     "@nvidia/foundations-tailwind-plugin": "catalog:",
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.57.0",
     "@storybook/react": "catalog:",
     "@tailwindcss/postcss": "catalog:",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -729,6 +729,9 @@ importers:
         specifier: ^5.0.3
         version: 5.0.12(@types/react@19.2.14)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.12.1(playwright-core@1.58.2)
       '@huggingface/hub':
         specifier: ^1.0.0
         version: 1.1.2
@@ -950,6 +953,11 @@ packages:
         optional: true
       react:
         optional: true
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -7668,6 +7676,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.7
+
+  '@axe-core/playwright@4.12.1(playwright-core@1.58.2)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.58.2
 
   '@babel/code-frame@7.29.0':
     dependencies:


### PR DESCRIPTION
Install @axe-core/playwright and expose a runAxeScan() helper that runs AxeBuilder with wcag2a/2aa/21a/21aa/22a/22aa tags. Add an a11y.test.ts that intercepts all NMP API calls with page.route() mocks (no live backend required) and runs axe against the workspace dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated accessibility coverage for Studio routes using Playwright.
  * Introduced a reusable accessibility scan helper for WCAG A/AA checks.

* **Bug Fixes**
  * Added a test for the default dashboard route to verify it has no accessibility violations.
  * Mocked API responses and disabled authentication in the test run to make checks reliable and repeatable.

* **Chores**
  * Added accessibility testing support as a development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->