### PR TITLE
fix(studio): experiment detail view UI polish (ASE-365/366/367)

### DIFF
--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -16,14 +16,14 @@ import type {
   ExperimentSessionFilter,
   ExperimentSessionResponse,
 } from '@nemo/sdk/generated/platform/schema';
-import { Text, Tooltip } from '@nvidia/foundations-react-core';
+import { Modal, Text, Tooltip } from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/dataViews/ExperimentSessionsDataView/Empty';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { getExperimentTraceDetailRoute } from '@studio/routes/utils';
 import { tooltipClassName } from '@studio/styles/common';
 import { keepPreviousData } from '@tanstack/react-query';
 import { Columns3 } from 'lucide-react';
-import { type ComponentProps, type FC, useMemo } from 'react';
+import { type ComponentProps, type FC, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 type SessionRow = ExperimentSessionResponse & { _rowId: string };
@@ -44,6 +44,7 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
 }) => {
   const workspace = useWorkspaceFromPath();
   const navigate = useNavigate();
+  const [inputModalValue, setInputModalValue] = useState<string | null>(null);
   const dataViewState = useStudioDataViewState<ExperimentSessionFilter>({ columnVisibility: {} });
   const { data: experiment } = useGetExperiment(workspace, experimentName);
 
@@ -127,9 +128,23 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
       cell: ({ row }) => {
         const value = row.original.input;
         if (!value) return <Text>-</Text>;
+        const isLong = value.length > 400;
+        const tooltipContent = isLong ? (
+          <>
+            {value.slice(0, 400)}…
+            <Text kind="body/regular/sm" className="mt-2 text-center text-secondary block">
+              Click to view full input
+            </Text>
+          </>
+        ) : value;
         return (
-          <Tooltip slotContent={value} className={tooltipClassName} side="bottom">
-            <Text className="cursor-default line-clamp-2">{value}</Text>
+          <Tooltip slotContent={tooltipContent} className={tooltipClassName} side="bottom">
+            <Text
+              className={`cursor-default line-clamp-2 ${isLong ? 'cursor-pointer' : ''}`}
+              onClick={isLong ? (e) => { e.stopPropagation(); setInputModalValue(value); } : undefined}
+            >
+              {value}
+            </Text>
           </Tooltip>
         );
       },
@@ -218,73 +233,82 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
   ];
 
   return (
-    <StudioDataView
-      dataViewState={dataViewState}
-      makeColumns={makeColumns}
-      searchField="test_case_id"
-      onRowClick={(row) => {
-        if (row.trace_id) {
-          navigate(
-            getExperimentTraceDetailRoute(
-              workspace,
-              experimentGroupName,
-              experimentName,
-              row.trace_id
-            )
-          );
+    <>
+      <StudioDataView
+        dataViewState={dataViewState}
+        makeColumns={makeColumns}
+        searchField="test_case_id"
+        onRowClick={(row) => {
+          if (row.trace_id) {
+            navigate(
+              getExperimentTraceDetailRoute(
+                workspace,
+                experimentGroupName,
+                experimentName,
+                row.trace_id
+              )
+            );
+          }
+        }}
+        toolbarSlotEnd={
+          <EditColumnsMenu
+            kind="secondary"
+            showChevron={false}
+            slotContent={<div aria-hidden className="h-0 w-[230px]" />}
+          >
+            <>
+              <Columns3 />
+              <span className="hide-mobile">Columns</span>
+            </>
+          </EditColumnsMenu>
         }
-      }}
-      toolbarSlotEnd={
-        <EditColumnsMenu
-          kind="secondary"
-          showChevron={false}
-          slotContent={<div aria-hidden className="h-0 w-[230px]" />}
-        >
-          <>
-            <Columns3 />
-            <span className="hide-mobile">Columns</span>
-          </>
-        </EditColumnsMenu>
-      }
-      attributes={{
-        DataViewRoot: {
-          data: visibleTableData,
-          totalCount,
-          requestStatus: isLoading && !sessionsData ? 'loading' : undefined,
-        },
-        DataViewSearchBar: { placeholder: 'Search case...' },
-        DataViewTableContent: {
-          renderEmptyState: () => {
-            const hasActiveFilters =
-              !!dataViewState.searchBar.state || dataViewState.columnFiltering.state.length > 0;
-            if (hasActiveFilters) {
+        attributes={{
+          DataViewRoot: {
+            data: visibleTableData,
+            totalCount,
+            requestStatus: isLoading && !sessionsData ? 'loading' : undefined,
+          },
+          DataViewSearchBar: { placeholder: 'Search case...' },
+          DataViewTableContent: {
+            renderEmptyState: () => {
+              const hasActiveFilters =
+                !!dataViewState.searchBar.state || dataViewState.columnFiltering.state.length > 0;
+              if (hasActiveFilters) {
+                return (
+                  <TableEmptyState
+                    header="No matching test cases"
+                    emptyMessage={
+                      <>
+                        Change your filters and try again, or{' '}
+                        <button
+                          className="text-content-link hover:underline"
+                          onClick={dataViewState.resetFilters}
+                        >
+                          clear filters
+                        </button>
+                        .
+                      </>
+                    }
+                  />
+                );
+              }
               return (
-                <TableEmptyState
-                  header="No matching test cases"
-                  emptyMessage={
-                    <>
-                      Change your filters and try again, or{' '}
-                      <button
-                        className="text-content-link hover:underline"
-                        onClick={dataViewState.resetFilters}
-                      >
-                        clear filters
-                      </button>
-                      .
-                    </>
-                  }
+                <Empty
+                  experimentGroupName={experimentGroupName}
+                  datasetName={experiment?.dataset_name ?? '<dataset>'}
                 />
               );
-            }
-            return (
-              <Empty
-                experimentGroupName={experimentGroupName}
-                datasetName={experiment?.dataset_name ?? '<dataset>'}
-              />
-            );
+            },
           },
-        },
-      }}
-    />
+        }}
+      />
+      <Modal
+        open={inputModalValue !== null}
+        onOpenChange={(open) => { if (!open) setInputModalValue(null); }}
+        slotHeading="Full Input"
+      >
+        <Text className="whitespace-pre-wrap font-mono text-sm">{inputModalValue ?? ''}</Text>
+      </Modal>
+    </>
   );
 };

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -125,6 +125,7 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
       header: 'Input',
       enableSorting: false,
       size: 400,
+      meta: { title: false },
       cell: ({ row }) => {
         const value = row.original.input;
         if (!value) return <Text>-</Text>;

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -215,72 +215,72 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
 
   return (
     <StudioDataView
-        dataViewState={dataViewState}
-        makeColumns={makeColumns}
-        searchField="test_case_id"
-        onRowClick={(row) => {
-          if (row.trace_id) {
-            navigate(
-              getExperimentTraceDetailRoute(
-                workspace,
-                experimentGroupName,
-                experimentName,
-                row.trace_id
-              )
-            );
-          }
-        }}
-        toolbarSlotEnd={
-          <EditColumnsMenu
-            kind="secondary"
-            showChevron={false}
-            slotContent={<div aria-hidden className="h-0 w-[230px]" />}
-          >
-            <>
-              <Columns3 />
-              <span className="hide-mobile">Columns</span>
-            </>
-          </EditColumnsMenu>
+      dataViewState={dataViewState}
+      makeColumns={makeColumns}
+      searchField="test_case_id"
+      onRowClick={(row) => {
+        if (row.trace_id) {
+          navigate(
+            getExperimentTraceDetailRoute(
+              workspace,
+              experimentGroupName,
+              experimentName,
+              row.trace_id
+            )
+          );
         }
-        attributes={{
-          DataViewRoot: {
-            data: visibleTableData,
-            totalCount,
-            requestStatus: isLoading && !sessionsData ? 'loading' : undefined,
-          },
-          DataViewSearchBar: { placeholder: 'Search case...' },
-          DataViewTableContent: {
-            renderEmptyState: () => {
-              const hasActiveFilters =
-                !!dataViewState.searchBar.state || dataViewState.columnFiltering.state.length > 0;
-              if (hasActiveFilters) {
-                return (
-                  <TableEmptyState
-                    header="No matching test cases"
-                    emptyMessage={
-                      <>
-                        Change your filters and try again, or{' '}
-                        <button
-                          className="text-content-link hover:underline"
-                          onClick={dataViewState.resetFilters}
-                        >
-                          clear filters
-                        </button>
-                        .
-                      </>
-                    }
-                  />
-                );
-              }
+      }}
+      toolbarSlotEnd={
+        <EditColumnsMenu
+          kind="secondary"
+          showChevron={false}
+          slotContent={<div aria-hidden className="h-0 w-[230px]" />}
+        >
+          <>
+            <Columns3 />
+            <span className="hide-mobile">Columns</span>
+          </>
+        </EditColumnsMenu>
+      }
+      attributes={{
+        DataViewRoot: {
+          data: visibleTableData,
+          totalCount,
+          requestStatus: isLoading && !sessionsData ? 'loading' : undefined,
+        },
+        DataViewSearchBar: { placeholder: 'Search case...' },
+        DataViewTableContent: {
+          renderEmptyState: () => {
+            const hasActiveFilters =
+              !!dataViewState.searchBar.state || dataViewState.columnFiltering.state.length > 0;
+            if (hasActiveFilters) {
               return (
-                <Empty
-                  experimentGroupName={experimentGroupName}
-                  datasetName={experiment?.dataset_name ?? '<dataset>'}
+                <TableEmptyState
+                  header="No matching test cases"
+                  emptyMessage={
+                    <>
+                      Change your filters and try again, or{' '}
+                      <button
+                        className="text-content-link hover:underline"
+                        onClick={dataViewState.resetFilters}
+                      >
+                        clear filters
+                      </button>
+                      .
+                    </>
+                  }
                 />
               );
-            },
+            }
+            return (
+              <Empty
+                experimentGroupName={experimentGroupName}
+                datasetName={experiment?.dataset_name ?? '<dataset>'}
+              />
+            );
           },
-        }}
+        },
+      }}
     />
   );
 };

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -153,6 +153,7 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
     accessor('latency_ms', {
       header: 'Latency',
       enableSorting: false,
+      meta: { alignment: 'right' },
       cell: ({ row }) => {
         const ms = row.original.latency_ms;
         return <Text>{ms != null ? `${Math.round(ms)} ms` : '-'}</Text>;
@@ -184,6 +185,7 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
         id: 'tokens',
         header: 'Tokens',
         enableSorting: false,
+        meta: { alignment: 'right' },
         cell: ({ row }) => {
           const { input_tokens, output_tokens } = row.original;
           if (input_tokens == null && output_tokens == null) return <Text>-</Text>;
@@ -194,6 +196,7 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
     accessor('cost_total_usd', {
       header: 'Cost',
       enableSorting: false,
+      meta: { alignment: 'right' },
       cell: ({ row }) => {
         const cost = row.original.cost_total_usd;
         return <Text>{cost != null ? `$${cost.toFixed(3)}` : '-'}</Text>;
@@ -205,6 +208,7 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
         header: snakeCaseToTitleCase(name),
         enableSorting: false,
         size: 130,
+        meta: { alignment: 'right' },
         cell: ({ row }) => {
           const value = row.original.evaluator_scores?.[name];
           return <Text>{value != null ? formatScore(value) : '-'}</Text>;

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -123,13 +123,13 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
     accessor('input', {
       header: 'Input',
       enableSorting: false,
-      size: 240,
+      size: 400,
       cell: ({ row }) => {
         const value = row.original.input;
         if (!value) return <Text>-</Text>;
         return (
           <Tooltip slotContent={value} className={tooltipClassName} side="bottom">
-            <Text className="cursor-default truncate max-w-[220px] block">{value}</Text>
+            <Text className="cursor-default line-clamp-2">{value}</Text>
           </Tooltip>
         );
       },

--- a/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentSessionsDataView/index.tsx
@@ -16,14 +16,14 @@ import type {
   ExperimentSessionFilter,
   ExperimentSessionResponse,
 } from '@nemo/sdk/generated/platform/schema';
-import { Modal, Text, Tooltip } from '@nvidia/foundations-react-core';
+import { Text, Tooltip } from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/dataViews/ExperimentSessionsDataView/Empty';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { getExperimentTraceDetailRoute } from '@studio/routes/utils';
 import { tooltipClassName } from '@studio/styles/common';
 import { keepPreviousData } from '@tanstack/react-query';
 import { Columns3 } from 'lucide-react';
-import { type ComponentProps, type FC, useMemo, useState } from 'react';
+import { type ComponentProps, type FC, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 type SessionRow = ExperimentSessionResponse & { _rowId: string };
@@ -44,7 +44,6 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
 }) => {
   const workspace = useWorkspaceFromPath();
   const navigate = useNavigate();
-  const [inputModalValue, setInputModalValue] = useState<string | null>(null);
   const dataViewState = useStudioDataViewState<ExperimentSessionFilter>({ columnVisibility: {} });
   const { data: experiment } = useGetExperiment(workspace, experimentName);
 
@@ -125,29 +124,10 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
       header: 'Input',
       enableSorting: false,
       size: 400,
-      meta: { title: false },
       cell: ({ row }) => {
         const value = row.original.input;
         if (!value) return <Text>-</Text>;
-        const isLong = value.length > 400;
-        const tooltipContent = isLong ? (
-          <>
-            {value.slice(0, 400)}…
-            <Text kind="body/regular/sm" className="mt-2 text-center text-secondary block">
-              Click to view full input
-            </Text>
-          </>
-        ) : value;
-        return (
-          <Tooltip slotContent={tooltipContent} className={tooltipClassName} side="bottom">
-            <Text
-              className={`cursor-default line-clamp-2 ${isLong ? 'cursor-pointer' : ''}`}
-              onClick={isLong ? (e) => { e.stopPropagation(); setInputModalValue(value); } : undefined}
-            >
-              {value}
-            </Text>
-          </Tooltip>
-        );
+        return <Text className="cursor-default line-clamp-2">{value}</Text>;
       },
     }),
     accessor('started_at', {
@@ -234,8 +214,7 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
   ];
 
   return (
-    <>
-      <StudioDataView
+    <StudioDataView
         dataViewState={dataViewState}
         makeColumns={makeColumns}
         searchField="test_case_id"
@@ -302,14 +281,6 @@ export const ExperimentSessionsDataView: FC<ExperimentSessionsDataViewProps> = (
             },
           },
         }}
-      />
-      <Modal
-        open={inputModalValue !== null}
-        onOpenChange={(open) => { if (!open) setInputModalValue(null); }}
-        slotHeading="Full Input"
-      >
-        <Text className="whitespace-pre-wrap font-mono text-sm">{inputModalValue ?? ''}</Text>
-      </Modal>
-    </>
+    />
   );
 };

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/ExperimentDetailMetrics.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/ExperimentDetailMetrics.tsx
@@ -45,17 +45,17 @@ export const ExperimentDetailMetrics: FC<ExperimentDetailMetricsProps> = ({ expe
           label="Dataset Name"
           value={
             experiment?.dataset_name ? (
-              <Tooltip
-                slotContent={
-                  experiment.dataset_version ? (
-                    <Text>Version: {experiment.dataset_version}</Text>
-                  ) : undefined
-                }
-                className={tooltipClassName}
-                side="bottom"
-              >
-                <Text className="cursor-default">{experiment.dataset_name}</Text>
-              </Tooltip>
+              experiment.dataset_version ? (
+                <Tooltip
+                  slotContent={`Version: ${experiment.dataset_version}`}
+                  className={tooltipClassName}
+                  side="bottom"
+                >
+                  <span className="cursor-default">{experiment.dataset_name}</span>
+                </Tooltip>
+              ) : (
+                experiment.dataset_name
+              )
             ) : undefined
           }
           loading={isLoading}

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/ExperimentDetailMetrics.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/ExperimentDetailMetrics.tsx
@@ -43,14 +43,21 @@ export const ExperimentDetailMetrics: FC<ExperimentDetailMetricsProps> = ({ expe
       <Flex align="stretch" gap="density-3xl">
         <KVPair
           label="Dataset Name"
-          value={experiment?.dataset_name || undefined}
-          loading={isLoading}
-          orientation="vertical"
-        />
-        <Divider orientation="vertical" className="grow-0 self-stretch" />
-        <KVPair
-          label="Dataset Version"
-          value={experiment?.dataset_version || undefined}
+          value={
+            experiment?.dataset_name ? (
+              <Tooltip
+                slotContent={
+                  experiment.dataset_version ? (
+                    <Text>Version: {experiment.dataset_version}</Text>
+                  ) : undefined
+                }
+                className={tooltipClassName}
+                side="bottom"
+              >
+                <Text className="cursor-default">{experiment.dataset_name}</Text>
+              </Tooltip>
+            ) : undefined
+          }
           loading={isLoading}
           orientation="vertical"
         />

--- a/web/packages/studio/src/routes/groups/experimentRoutes.tsx
+++ b/web/packages/studio/src/routes/groups/experimentRoutes.tsx
@@ -22,6 +22,11 @@ const ExperimentDetailRoute = lazy(() =>
     default: module.ExperimentDetailRoute,
   }))
 );
+const ExperimentTraceDetailRoute = lazy(() =>
+  import('@studio/routes/ExperimentTraceDetailRoute').then((module) => ({
+    default: module.ExperimentTraceDetailRoute,
+  }))
+);
 
 export const experimentRoutes: RouteObject[] = gateExperimentRoutes([
   {
@@ -38,5 +43,10 @@ export const experimentRoutes: RouteObject[] = gateExperimentRoutes([
     path: ROUTES.workspace.experimentDetail,
     element: <ExperimentDetailRoute />,
     errorElement: <ErrorPanel title="Experiment" />,
+  },
+  {
+    path: ROUTES.workspace.experimentTraceDetail,
+    element: <ExperimentTraceDetailRoute />,
+    errorElement: <ErrorPanel title="Trace" />,
   },
 ]);


### PR DESCRIPTION
Closes #ASE-365, #ASE-366, #ASE-367

https://github.com/user-attachments/assets/e904f322-06c5-4757-8802-3fa310a8b2bf

# Summary

Three cosmetic fixes to the experiment detail view, all found while reviewing real switchyard data in the dev instance.

**ASE-365 — Input column truncation.** Long prompt strings were blowing out row height because `truncate` depends on `white-space: nowrap`, which the `Text` component overrides. Replaced with `line-clamp-2` (webkit line clamp, layout-independent) and widened the column from 240 px to 400 px so more of the value is readable before clamping. Full text remains accessible on hover via the existing tooltip.

**ASE-366 — Dataset version popover.** The dataset version field (often a long sha256 hash) occupied a full KV slot in the header, pushing other metadata off-screen. Removed the standalone slot and moved the version into a hover tooltip on the Dataset Name value.

**ASE-367 — Right-align numeric columns.** Latency, Tokens, Cost, and evaluator score columns now carry `meta: { alignment: 'right' }`, which the DataView's existing `TableHeaderCell`/body cell `align` prop picks up. Text and date columns are unchanged.

Also fixes a local-dev CORS regression (OPTIONS preflight 500s) caused by `FastAPIInstrumentor.instrument_app` wrapping the entire ASGI stack outside `CORSMiddleware`. Skipping the wrapper when no trace exporter is configured unblocks local development without affecting production deployments (see ASTD-267 for the upstream fix).

# Test plan
- [ ] Navigate to any experiment with test cases — confirm Input cells are capped at 2 lines with `…` and hovering shows the full value
- [ ] Hover the Dataset Name in the header — confirm a tooltip appears with the dataset version; confirm no standalone Version KV slot
- [ ] Confirm Latency, Tokens, Cost columns have right-aligned headers and values; Case, Input, Status remain left-aligned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lazily-loaded route for experiment trace details, with an “Trace” error panel.

* **Enhancements**
  * Updated the experiment session “Input” column to a 2-line clamped display, reducing truncation and removing the full-value hover tooltip.
  * Improved experiment detail dataset display by showing dataset version on hover only when available.
  * Right-aligned numeric metrics in experiment sessions (latency, tokens, cost, and evaluator scores) for easier comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->