### PR TITLE
feat(deployments): move prerequisites to Deployment and harden reconcile lifecycle

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/controller.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/controller.py
@@ -106,6 +106,8 @@ class NemoController(_NamedPlugin):
         :meth:`reconcile_one` with ``raise NotImplementedError``.
         """
         for obj in await self.list_objects():
+            if self.stop_requested():
+                return
             try:
                 await self.reconcile_one(obj)
             except Exception:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/controller.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/controller.py
@@ -39,6 +39,8 @@ The framework manages the reconcile loop:
    :meth:`reconcile_one` for each result with per-item error isolation.
 4. On SIGINT/SIGTERM the platform sets a stop signal, waits for the current
    ``reconcile()`` call to complete, then calls ``on_shutdown()``.
+   Controllers that override :meth:`reconcile` may call :meth:`stop_requested`
+   between phases or per-item iterations to exit early during shutdown.
 
 Plugin authors do **not** manage signals or threads — implement cleanup in
 :meth:`on_shutdown` and the framework guarantees it is called after the last
@@ -48,6 +50,7 @@ reconcile cycle completes.
 from __future__ import annotations
 
 import logging
+import threading
 from abc import abstractmethod
 from typing import ClassVar
 
@@ -81,6 +84,15 @@ class NemoController(_NamedPlugin):
 
     name: ClassVar[str]
     dependencies: ClassVar[list[str]] = []
+    _stop_signal: threading.Event | None = None
+
+    def set_stop_signal(self, stop_signal: threading.Event | None) -> None:
+        """Register the platform shutdown signal for cooperative cancellation."""
+        self._stop_signal = stop_signal
+
+    def stop_requested(self) -> bool:
+        """Return True when the platform has requested shutdown."""
+        return self._stop_signal is not None and self._stop_signal.is_set()
 
     async def reconcile(self) -> None:
         """Run one full reconciliation cycle.

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/plugin_adapter.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/plugin_adapter.py
@@ -187,6 +187,7 @@ def make_controller_run_func(controller_cls: type[NemoController]) -> Callable[[
 
     def run(stop_signal: threading.Event) -> None:
         controller = controller_cls()
+        controller.set_stop_signal(stop_signal)
         adapter = NemoControllerAdapter(controller)
 
         if not _wait_for_controller_dependencies(controller_cls, stop_signal):

--- a/plugins/nemo-deployments/README.md
+++ b/plugins/nemo-deployments/README.md
@@ -19,6 +19,7 @@ which list query failed without losing that signal behind a single boolean.
 Per-config drift backoff overrides live on `DeploymentConfig.driftRecovery`; unset fields
 fall back to `DeploymentsConfig.controller`.
 
-Prerequisites are currently declared on `DeploymentConfig` and resolve to a single
-deployment per config name in a workspace. Multiple deployments sharing one config is
-unsupported until prerequisites move to the `Deployment` entity (follow-up work).
+Prerequisites are declared on each `Deployment` and reference other deployment
+names in the same workspace (bare name or `workspace/name`). The controller loads
+terminal prerequisite deployments from the entity store when they are not in the
+active non-terminal list.

--- a/plugins/nemo-deployments/openapi/openapi.yaml
+++ b/plugins/nemo-deployments/openapi/openapi.yaml
@@ -686,11 +686,6 @@ components:
           type: integer
           title: Backoff Limit
           default: 6
-        prerequisites:
-          items:
-            $ref: '#/components/schemas/Prerequisite'
-          type: array
-          title: Prerequisites
         drift_recovery:
           $ref: '#/components/schemas/DriftRecoveryPolicy'
         labels:
@@ -724,6 +719,11 @@ components:
         executor:
           title: Executor
           type: string
+        prerequisites:
+          items:
+            $ref: '#/components/schemas/Prerequisite'
+          type: array
+          title: Prerequisites
       type: object
       required:
       - name
@@ -784,6 +784,11 @@ components:
           title: Executor
           description: Named executor registry entry; falls back to plugin default_executor.
           type: string
+        prerequisites:
+          items:
+            $ref: '#/components/schemas/Prerequisite'
+          type: array
+          title: Prerequisites
         status:
           type: string
           enum:
@@ -928,11 +933,6 @@ components:
           type: integer
           title: Backofflimit
           default: 6
-        prerequisites:
-          items:
-            $ref: '#/components/schemas/Prerequisite'
-          type: array
-          title: Prerequisites
         driftRecovery:
           $ref: '#/components/schemas/DriftRecoveryPolicy'
         labels:
@@ -1264,9 +1264,8 @@ components:
         deployment_name:
           type: string
           title: Deployment Name
-          description: Name of another DeploymentConfig in the same workspace whose
-            corresponding Deployment must satisfy condition before this deployment
-            may start.
+          description: Name of another Deployment in the same workspace (or workspace/name)
+            that must satisfy condition before this deployment may start.
         condition:
           type: string
           enum:

--- a/plugins/nemo-deployments/openapi/openapi.yaml
+++ b/plugins/nemo-deployments/openapi/openapi.yaml
@@ -1417,6 +1417,7 @@ components:
           enum:
           - PENDING
           - BOUND
+          - DELETING
           - RELEASED
           - FAILED
           title: Status
@@ -1496,6 +1497,7 @@ components:
           enum:
           - PENDING
           - BOUND
+          - DELETING
           - RELEASED
           - FAILED
           title: Status

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/api/v2/deployment_configs.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/api/v2/deployment_configs.py
@@ -16,12 +16,6 @@ from nemo_deployments_plugin.schema import (
     DeploymentConfigFilter,
     DeploymentConfigPage,
 )
-from nemo_deployments_plugin.validation import (
-    PrerequisiteCycleError,
-    build_existing_prerequisite_map,
-    detect_prerequisite_cycle,
-    prerequisite_names,
-)
 from nemo_platform_plugin.api.filters import make_filter_obj_dep
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityConflictError, NemoEntityNotFoundError
 from nemo_platform_plugin.schema import PaginationData
@@ -33,45 +27,12 @@ router = APIRouter()
 _config_filter_dep = make_filter_obj_dep(DeploymentConfigFilter)
 
 
-async def _list_all_deployment_configs(
-    entity_client: NemoEntitiesClient,
-    workspace: str,
-) -> list[DeploymentConfig]:
-    """Page through all deployment configs for prerequisite graph validation."""
-    page = 1
-    configs: list[DeploymentConfig] = []
-    while True:
-        result = await entity_client.list(
-            DeploymentConfig,
-            workspace=workspace,
-            page=page,
-            page_size=100,
-        )
-        configs.extend(result.data)
-        if result.pagination is None or page >= result.pagination.total_pages:
-            break
-        page += 1
-    return configs
-
-
 @router.post("/deployment-configs", response_model=DeploymentConfig, status_code=201, tags=["Deployment Configs"])
 async def create_deployment_config(
     workspace: str,
     body: CreateDeploymentConfigRequest,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
 ) -> DeploymentConfig:
-    prereq_names = prerequisite_names(body.prerequisites)
-    try:
-        existing_configs = await _list_all_deployment_configs(entity_client, workspace)
-        existing_map = build_existing_prerequisite_map(existing_configs)
-        detect_prerequisite_cycle(
-            config_name=body.name,
-            prerequisites=prereq_names,
-            existing=existing_map,
-        )
-    except PrerequisiteCycleError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
     config = DeploymentConfig(
         name=body.name,
         workspace=workspace,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/api/v2/deployments.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/api/v2/deployments.py
@@ -16,6 +16,7 @@ from nemo_deployments_plugin.schema import CreateDeploymentRequest, DeploymentFi
 from nemo_deployments_plugin.validation import (
     PrerequisiteCycleError,
     build_existing_prerequisite_map,
+    deployment_graph_key,
     detect_prerequisite_cycle,
     prerequisite_names,
 )
@@ -81,7 +82,7 @@ async def create_deployment(
         existing_deployments = await list_all_pages(entity_client, Deployment, workspace=workspace)
         existing_map = build_existing_prerequisite_map(existing_deployments)
         detect_prerequisite_cycle(
-            deployment_name=body.name,
+            deployment_name=deployment_graph_key(workspace, body.name),
             prerequisites=prereq_names,
             existing=existing_map,
         )

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/api/v2/deployments.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/api/v2/deployments.py
@@ -11,7 +11,14 @@ from typing import cast
 from fastapi import APIRouter, Depends, HTTPException, Query
 from nemo_deployments_plugin.api.v2.dependencies import get_entity_client
 from nemo_deployments_plugin.entities import Deployment, DeploymentConfig, DeploymentStatus
+from nemo_deployments_plugin.reconciler.entity_client import list_all_pages
 from nemo_deployments_plugin.schema import CreateDeploymentRequest, DeploymentFilter, DeploymentPage
+from nemo_deployments_plugin.validation import (
+    PrerequisiteCycleError,
+    build_existing_prerequisite_map,
+    detect_prerequisite_cycle,
+    prerequisite_names,
+)
 from nemo_platform_plugin.api.filters import make_filter_obj_dep
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityConflictError, NemoEntityNotFoundError
 from nemo_platform_plugin.filter_ops import ComparisonOperation, FilterOperator
@@ -69,12 +76,25 @@ async def create_deployment(
             detail=(f"DeploymentConfig '{config_name}' not found in workspace '{config_workspace}'."),
         ) from exc
 
+    prereq_names = prerequisite_names(body.prerequisites, workspace)
+    try:
+        existing_deployments = await list_all_pages(entity_client, Deployment, workspace=workspace)
+        existing_map = build_existing_prerequisite_map(existing_deployments)
+        detect_prerequisite_cycle(
+            deployment_name=body.name,
+            prerequisites=prereq_names,
+            existing=existing_map,
+        )
+    except PrerequisiteCycleError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     deployment = Deployment(
         name=body.name,
         workspace=workspace,
         deployment_config=config_name,
         desired_state=body.desired_state,
         executor=body.executor,
+        prerequisites=body.prerequisites,
         status="PENDING",
     )
     try:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/api/v2/volumes.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/api/v2/volumes.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from nemo_deployments_plugin.api.v2.dependencies import get_entity_client
 from nemo_deployments_plugin.entities import Volume
@@ -15,6 +17,8 @@ from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityCon
 from nemo_platform_plugin.schema import PaginationData
 
 router = APIRouter()
+
+logger = logging.getLogger(__name__)
 
 _volume_filter_dep = make_filter_obj_dep(VolumeFilter)
 
@@ -99,9 +103,20 @@ async def delete_volume(
         )
 
     try:
-        await entity_client.delete(Volume, name=name, workspace=workspace)
+        volume = await entity_client.get(Volume, name=name, workspace=workspace)
     except NemoEntityNotFoundError as exc:
         raise HTTPException(
             status_code=404,
             detail=f"Volume '{name}' not found in workspace '{workspace}'.",
+        ) from exc
+
+    volume.status = "DELETING"
+    try:
+        await entity_client.update(volume)
+    except NemoEntityNotFoundError:
+        logger.info("Volume already deleted before status update")
+    except NemoEntityConflictError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Volume '{name}' is being modified concurrently.",
         ) from exc

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/config.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/config.py
@@ -33,6 +33,14 @@ class ControllerConfig(BaseModel):
         ge=0,
         description="Run orphaned backend resource cleanup after this many seconds (0 disables).",
     )
+    terminal_orphan_grace_seconds: int = Field(
+        default=3600,
+        ge=0,
+        description=(
+            "Keep terminal deployment backend resources (SUCCEEDED/FAILED) protected from "
+            "orphan cleanup for this many seconds after the terminal status transition (0 disables)."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_backoff(self) -> ControllerConfig:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/controller.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/controller.py
@@ -153,10 +153,11 @@ class DeploymentsController(NemoController):
             orphan_interval > 0
             and self._orphan_cleanup_elapsed_seconds >= orphan_interval
             and self._deployments_list_ok
-            and self._terminal_deployments_list_ok
             and not self.stop_requested()
         ):
             terminal_deployments = await self._list_terminal_deployments_for_orphan_grace()
+            if not self._terminal_deployments_list_ok:
+                return
             known_ids = _orphan_protected_ids(
                 deployments,
                 terminal_deployments,
@@ -300,6 +301,14 @@ class DeploymentsController(NemoController):
                         "Prerequisite deployment '%s' not yet available in workspace '%s'",
                         name,
                         workspace,
+                    )
+                    continue
+                except Exception:
+                    logger.warning(
+                        "Failed to load prerequisite deployment '%s' in workspace '%s'",
+                        name,
+                        workspace,
+                        exc_info=True,
                     )
                     continue
                 deployments_by_name[key] = dep

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/controller.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/controller.py
@@ -6,18 +6,19 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from typing import ClassVar
 
 from nemo_deployments_plugin.backends.registry import ExecutorRegistry, ExecutorSpec
 from nemo_deployments_plugin.config import ControllerConfig, DeploymentsConfig
 from nemo_deployments_plugin.entities import Deployment, DeploymentConfig, Volume
 from nemo_deployments_plugin.reconciler.deployment_reconciler import DeploymentReconciler
-from nemo_deployments_plugin.reconciler.entity_client import get_deployment_for_config_name, list_all_pages
+from nemo_deployments_plugin.reconciler.entity_client import list_all_pages
 from nemo_deployments_plugin.reconciler.orphan_cleanup import reconcile_orphans
+from nemo_deployments_plugin.reconciler.prerequisite import parse_deployment_ref
 from nemo_deployments_plugin.reconciler.volume_mounts import collect_volume_mount_names
 from nemo_deployments_plugin.reconciler.volume_reconciler import VolumeReconciler
 from nemo_deployments_plugin.types import NON_TERMINAL_DEPLOYMENT_STATUSES, NON_TERMINAL_VOLUME_STATUSES
-from nemo_deployments_plugin.validation import prerequisite_names
 from nemo_platform.resources.entities import AsyncEntitiesResource
 from nemo_platform_plugin.controller import NemoController
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityConflictError, NemoEntityNotFoundError
@@ -25,6 +26,8 @@ from nemo_platform_plugin.filter_ops import ComparisonOperation, FilterOperator
 from nemo_platform_plugin.sdk_provider import get_async_platform_sdk
 
 logger = logging.getLogger(__name__)
+
+_TERMINAL_ORPHAN_STATUSES = ("SUCCEEDED", "FAILED")
 
 
 class DeploymentsController(NemoController):
@@ -43,6 +46,7 @@ class DeploymentsController(NemoController):
         self._orphan_cleanup_elapsed_seconds: float = 0.0
         self._deployments_list_ok: bool = True
         self._volumes_list_ok: bool = True
+        self._terminal_deployments_list_ok: bool = True
 
     @property
     def is_healthy(self) -> bool:
@@ -102,16 +106,26 @@ class DeploymentsController(NemoController):
             raise RuntimeError("DeploymentsController.reconcile() called before on_startup()")
 
         deployments = await self._list_deployments()
+        if self.stop_requested():
+            return
+
         volumes = await self._list_volumes()
+        if self.stop_requested():
+            return
+
         configs = await self._load_configs(deployments)
         self._deployment_reconciler.set_config_cache(configs)
 
-        by_name, by_config = _index_deployments(deployments)
+        deployments_by_name = _index_deployments(deployments)
         volumes_by_name = _index_volumes(volumes)
         await self._ensure_volume_refs_loaded(configs, volumes_by_name)
-        await self._ensure_prerequisite_refs_loaded(configs, by_name, by_config)
+        await self._ensure_prerequisite_refs_loaded(deployments, deployments_by_name)
+        if self.stop_requested():
+            return
 
         for volume in volumes:
+            if self.stop_requested():
+                return
             try:
                 await self._volume_reconciler.reconcile_one(volume)
             except NemoEntityConflictError:
@@ -120,11 +134,12 @@ class DeploymentsController(NemoController):
                 logger.exception("Error reconciling volume %s/%s", volume.workspace, volume.name)
 
         for deployment in deployments:
+            if self.stop_requested():
+                return
             try:
                 await self._deployment_reconciler.reconcile_one(
                     deployment,
-                    deployments_by_config=by_config,
-                    deployments_by_name=by_name,
+                    deployments_by_name=deployments_by_name,
                     volumes_by_name=volumes_by_name,
                 )
             except NemoEntityConflictError:
@@ -138,8 +153,15 @@ class DeploymentsController(NemoController):
             orphan_interval > 0
             and self._orphan_cleanup_elapsed_seconds >= orphan_interval
             and self._deployments_list_ok
+            and self._terminal_deployments_list_ok
+            and not self.stop_requested()
         ):
-            known_ids = {f"{d.workspace}/{d.name}" for d in deployments}
+            terminal_deployments = await self._list_terminal_deployments_for_orphan_grace()
+            known_ids = _orphan_protected_ids(
+                deployments,
+                terminal_deployments,
+                self.controller_config.terminal_orphan_grace_seconds,
+            )
             await reconcile_orphans(self._registry.all_backends(), known_ids)
             self._orphan_cleanup_elapsed_seconds = 0.0
 
@@ -183,6 +205,27 @@ class DeploymentsController(NemoController):
         except Exception:
             logger.exception("Failed to list non-terminal volumes")
             self._volumes_list_ok = False
+            return []
+
+    async def _list_terminal_deployments_for_orphan_grace(self) -> list[Deployment]:
+        grace_seconds = self.controller_config.terminal_orphan_grace_seconds
+        if grace_seconds <= 0:
+            return []
+        try:
+            deployments = await list_all_pages(
+                self.entities,
+                Deployment,
+                filter_operation=ComparisonOperation(
+                    operator=FilterOperator.IN,
+                    field="status",
+                    value=list(_TERMINAL_ORPHAN_STATUSES),
+                ),
+            )
+            self._terminal_deployments_list_ok = True
+            return deployments
+        except Exception:
+            logger.exception("Failed to list terminal deployments for orphan grace")
+            self._terminal_deployments_list_ok = False
             return []
 
     async def _load_configs(self, deployments: list[Deployment]) -> dict[tuple[str, str], DeploymentConfig]:
@@ -231,62 +274,73 @@ class DeploymentsController(NemoController):
 
     async def _ensure_prerequisite_refs_loaded(
         self,
-        configs: dict[tuple[str, str], DeploymentConfig],
-        by_name: dict[tuple[str, str], Deployment],
-        by_config: dict[tuple[str, str], Deployment],
+        deployments: list[Deployment],
+        deployments_by_name: dict[tuple[str, str], Deployment],
     ) -> None:
         """Load prerequisite deployments from entity store (including terminal states)."""
-        for (workspace, _config_name), config in configs.items():
-            for prereq_config_name in prerequisite_names(config.prerequisites):
-                key_by_config = (workspace, prereq_config_name)
-                if key_by_config in by_config or (workspace, prereq_config_name) in by_name:
+        for deployment in deployments:
+            for prerequisite in deployment.prerequisites:
+                try:
+                    workspace, name = parse_deployment_ref(prerequisite.deployment_name, deployment.workspace)
+                except ValueError:
+                    logger.warning(
+                        "Invalid prerequisite ref '%s' on deployment '%s' in workspace '%s'",
+                        prerequisite.deployment_name,
+                        deployment.name,
+                        deployment.workspace,
+                    )
+                    continue
+                key = (workspace, name)
+                if key in deployments_by_name:
                     continue
                 try:
-                    dep = await get_deployment_for_config_name(
-                        self.entities,
-                        workspace=workspace,
-                        config_name=prereq_config_name,
-                    )
+                    dep = await self.entities.get(Deployment, name=name, workspace=workspace)
                 except NemoEntityNotFoundError:
                     logger.debug(
                         "Prerequisite deployment '%s' not yet available in workspace '%s'",
-                        prereq_config_name,
+                        name,
                         workspace,
                     )
                     continue
-                if dep is None:
-                    logger.debug(
-                        "Prerequisite deployment '%s' not yet available in workspace '%s'",
-                        prereq_config_name,
-                        workspace,
-                    )
-                    continue
-                by_name[(workspace, dep.name)] = dep
-                by_config[(workspace, dep.deployment_config)] = dep
-                if dep.name != prereq_config_name:
-                    by_config[key_by_config] = dep
+                deployments_by_name[key] = dep
 
 
 def _index_volumes(volumes: list[Volume]) -> dict[tuple[str, str], Volume]:
     return {(volume.workspace, volume.name): volume for volume in volumes}
 
 
-def _index_deployments(
-    deployments: list[Deployment],
-) -> tuple[dict[tuple[str, str], Deployment], dict[tuple[str, str], Deployment]]:
-    by_name: dict[tuple[str, str], Deployment] = {}
-    by_config: dict[tuple[str, str], Deployment] = {}
-    for deployment in deployments:
-        by_name[(deployment.workspace, deployment.name)] = deployment
-        config_key = (deployment.workspace, deployment.deployment_config)
-        existing = by_config.get(config_key)
-        if existing is None or deployment.name == deployment.deployment_config:
-            by_config[config_key] = deployment
-        elif existing.name != deployment.deployment_config:
-            logger.warning(
-                "Multiple deployments share DeploymentConfig '%s' in workspace '%s'; prerequisite lookup uses '%s'",
-                deployment.deployment_config,
-                deployment.workspace,
-                by_config[config_key].name,
-            )
-    return by_name, by_config
+def _index_deployments(deployments: list[Deployment]) -> dict[tuple[str, str], Deployment]:
+    return {(deployment.workspace, deployment.name): deployment for deployment in deployments}
+
+
+def _orphan_protected_ids(
+    active_deployments: list[Deployment],
+    terminal_deployments: list[Deployment],
+    grace_seconds: int,
+) -> set[str]:
+    known_ids = {f"{deployment.workspace}/{deployment.name}" for deployment in active_deployments}
+    if grace_seconds <= 0:
+        return known_ids
+
+    now = datetime.now(timezone.utc)
+    for deployment in terminal_deployments:
+        if _terminal_within_grace(deployment, grace_seconds, now):
+            known_ids.add(f"{deployment.workspace}/{deployment.name}")
+    return known_ids
+
+
+def _terminal_within_grace(deployment: Deployment, grace_seconds: int, now: datetime) -> bool:
+    if deployment.status not in _TERMINAL_ORPHAN_STATUSES:
+        return False
+    terminal_at = _terminal_timestamp(deployment)
+    if terminal_at is None:
+        # Missing history: prefer protecting backend resources over premature orphan delete.
+        return True
+    return (now - terminal_at).total_seconds() < grace_seconds
+
+
+def _terminal_timestamp(deployment: Deployment) -> datetime | None:
+    for event in reversed(deployment.status_history):
+        if event.status in _TERMINAL_ORPHAN_STATUSES and event.timestamp:
+            return datetime.fromisoformat(event.timestamp)
+    return None

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
@@ -209,8 +209,8 @@ class DriftRecoveryPolicy(BaseModel):
 class Prerequisite(BaseModel):
     deployment_name: str = Field(
         description=(
-            "Name of another DeploymentConfig in the same workspace whose corresponding "
-            "Deployment must satisfy condition before this deployment may start."
+            "Name of another Deployment in the same workspace (or workspace/name) that must "
+            "satisfy condition before this deployment may start."
         ),
     )
     condition: PrerequisiteCondition = Field(
@@ -237,7 +237,6 @@ class DeploymentConfig(NemoEntity, entity_type=ENTITY_TYPE_DEPLOYMENT_CONFIG):
     config_files: list[ConfigFile] = Field(default_factory=list, alias="configFiles")
     restart_policy: RestartPolicy = Field(default="Always", alias="restartPolicy")
     backoff_limit: int = Field(default=6, alias="backoffLimit")
-    prerequisites: list[Prerequisite] = Field(default_factory=list)
     drift_recovery: DriftRecoveryPolicy = Field(default_factory=DriftRecoveryPolicy, alias="driftRecovery")
     labels: dict[str, str] = Field(default_factory=dict)
     backend_config: DeploymentBackendConfig = Field(default_factory=DeploymentBackendConfig, alias="backendConfig")
@@ -254,6 +253,7 @@ class Deployment(NemoEntity, entity_type=ENTITY_TYPE_DEPLOYMENT):
         default=None,
         description="Named executor registry entry; falls back to plugin default_executor.",
     )
+    prerequisites: list[Prerequisite] = Field(default_factory=list)
     status: DeploymentStatus = Field(default="PENDING")
     status_message: str = Field(default="")
     endpoints: list[Endpoint] = Field(default_factory=list)

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/deployment_reconciler.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/deployment_reconciler.py
@@ -82,7 +82,6 @@ class DeploymentReconciler:
         self,
         deployment: Deployment,
         *,
-        deployments_by_config: dict[tuple[str, str], Deployment],
         deployments_by_name: dict[tuple[str, str], Deployment],
         volumes_by_name: dict[tuple[str, str], Volume],
     ) -> None:
@@ -109,12 +108,10 @@ class DeploymentReconciler:
         if deployment.status == "PENDING":
             prereq = prerequisites_met(
                 deployment,
-                config,
-                deployments_by_config=deployments_by_config,
                 deployments_by_name=deployments_by_name,
             )
             if not prereq.met:
-                if _prerequisite_failed(prereq, deployments_by_config, deployments_by_name, deployment):
+                if _prerequisite_failed(prereq, deployments_by_name):
                     await self._update_deployment_status_failure(deployment, prereq.reason)
                     return
                 await self._update_deployment_status_pending(deployment, prereq.reason)
@@ -317,16 +314,13 @@ class DeploymentReconciler:
 
 def _prerequisite_failed(
     result: PrerequisiteResult,
-    deployments_by_config: dict[tuple[str, str], Deployment],
     deployments_by_name: dict[tuple[str, str], Deployment],
-    deployment: Deployment,
 ) -> bool:
     if result.blocking_prerequisite is None:
         return "failed" in result.reason.lower()
-    workspace = deployment.workspace
-    target = deployments_by_config.get((workspace, result.blocking_prerequisite))
-    if target is None:
-        target = deployments_by_name.get((workspace, result.blocking_prerequisite))
+    if result.blocking_workspace is None or result.blocking_name is None:
+        return False
+    target = deployments_by_name.get((result.blocking_workspace, result.blocking_name))
     return target is not None and target.status == "FAILED"
 
 

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/entity_client.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/entity_client.py
@@ -1,16 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Entity client helpers for paginated listing and prerequisite resolution."""
+"""Entity client helpers for paginated listing."""
 
 from __future__ import annotations
 
 from typing import TypeVar
 
-from nemo_deployments_plugin.entities import Deployment
 from nemo_platform_plugin.entity import NemoEntity
-from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
-from nemo_platform_plugin.filter_ops import ComparisonOperation, FilterOperator
+from nemo_platform_plugin.entity_client import NemoEntitiesClient
+from nemo_platform_plugin.filter_ops import ComparisonOperation
 
 EntityT = TypeVar("EntityT", bound=NemoEntity)
 
@@ -42,33 +41,3 @@ async def list_all_pages(
             break
         page += 1
     return collected
-
-
-async def get_deployment_for_config_name(
-    entities: NemoEntitiesClient,
-    *,
-    workspace: str,
-    config_name: str,
-) -> Deployment | None:
-    """Resolve a Deployment entity for a DeploymentConfig name (any terminal status)."""
-    deployments = await list_all_pages(
-        entities,
-        Deployment,
-        workspace=workspace,
-        filter_operation=ComparisonOperation(
-            operator=FilterOperator.EQ,
-            field="deployment_config",
-            value=config_name,
-        ),
-    )
-    if deployments:
-        return deployments[0]
-
-    try:
-        dep = await entities.get(Deployment, name=config_name, workspace=workspace)
-    except NemoEntityNotFoundError:
-        return None
-
-    if dep.deployment_config == config_name:
-        return dep
-    return None

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/prerequisite.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/prerequisite.py
@@ -29,16 +29,6 @@ def parse_deployment_ref(ref: str, default_workspace: str) -> tuple[str, str]:
     return default_workspace, ref
 
 
-def _find_prerequisite_deployment(
-    prerequisite: Prerequisite,
-    deployment: Deployment,
-    deployments_by_name: dict[tuple[str, str], Deployment],
-) -> Deployment | None:
-    """Resolve the Deployment entity for a prerequisite deployment name."""
-    workspace, name = parse_deployment_ref(prerequisite.deployment_name, deployment.workspace)
-    return deployments_by_name.get((workspace, name))
-
-
 def _condition_met(prerequisite: Prerequisite, target: Deployment) -> bool:
     if prerequisite.condition == "ready":
         return target.status == "READY"
@@ -55,8 +45,15 @@ def prerequisites_met(
         return PrerequisiteResult(met=True)
 
     for prerequisite in deployment.prerequisites:
-        workspace, name = parse_deployment_ref(prerequisite.deployment_name, deployment.workspace)
-        target = _find_prerequisite_deployment(prerequisite, deployment, deployments_by_name)
+        try:
+            workspace, name = parse_deployment_ref(prerequisite.deployment_name, deployment.workspace)
+        except ValueError:
+            return PrerequisiteResult(
+                met=False,
+                reason=f"Invalid prerequisite ref '{prerequisite.deployment_name}'",
+                blocking_prerequisite=prerequisite.deployment_name,
+            )
+        target = deployments_by_name.get((workspace, name))
         if target is None:
             return PrerequisiteResult(
                 met=False,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/prerequisite.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/prerequisite.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from nemo_deployments_plugin.entities import Deployment, DeploymentConfig, Prerequisite
+from nemo_deployments_plugin.entities import Deployment, Prerequisite
 
 
 @dataclass(frozen=True)
@@ -15,25 +15,28 @@ class PrerequisiteResult:
     met: bool
     reason: str = ""
     blocking_prerequisite: str | None = None
+    blocking_workspace: str | None = None
+    blocking_name: str | None = None
+
+
+def parse_deployment_ref(ref: str, default_workspace: str) -> tuple[str, str]:
+    """Return (workspace, deployment_name) from a bare name or workspace/name ref."""
+    if "/" in ref:
+        workspace, name = ref.split("/", 1)
+        if not workspace or not name:
+            raise ValueError(f"Invalid deployment ref '{ref}'; expected 'name' or 'workspace/name'.")
+        return workspace, name
+    return default_workspace, ref
 
 
 def _find_prerequisite_deployment(
     prerequisite: Prerequisite,
     deployment: Deployment,
-    deployments_by_config: dict[tuple[str, str], Deployment],
     deployments_by_name: dict[tuple[str, str], Deployment],
 ) -> Deployment | None:
-    """Resolve the Deployment entity for a prerequisite DeploymentConfig name."""
-    workspace = deployment.workspace
-    key_by_config = (workspace, prerequisite.deployment_name)
-    target = deployments_by_config.get(key_by_config)
-    if target is not None:
-        return target
-    key_by_name = (workspace, prerequisite.deployment_name)
-    target = deployments_by_name.get(key_by_name)
-    if target is not None and target.deployment_config == prerequisite.deployment_name:
-        return target
-    return None
+    """Resolve the Deployment entity for a prerequisite deployment name."""
+    workspace, name = parse_deployment_ref(prerequisite.deployment_name, deployment.workspace)
+    return deployments_by_name.get((workspace, name))
 
 
 def _condition_met(prerequisite: Prerequisite, target: Deployment) -> bool:
@@ -44,39 +47,39 @@ def _condition_met(prerequisite: Prerequisite, target: Deployment) -> bool:
 
 def prerequisites_met(
     deployment: Deployment,
-    config: DeploymentConfig,
     *,
-    deployments_by_config: dict[tuple[str, str], Deployment],
     deployments_by_name: dict[tuple[str, str], Deployment],
 ) -> PrerequisiteResult:
-    """Evaluate DeploymentConfig.prerequisites against current deployment states."""
-    if not config.prerequisites:
+    """Evaluate Deployment.prerequisites against current deployment states."""
+    if not deployment.prerequisites:
         return PrerequisiteResult(met=True)
 
-    for prerequisite in config.prerequisites:
-        target = _find_prerequisite_deployment(
-            prerequisite,
-            deployment,
-            deployments_by_config,
-            deployments_by_name,
-        )
+    for prerequisite in deployment.prerequisites:
+        workspace, name = parse_deployment_ref(prerequisite.deployment_name, deployment.workspace)
+        target = _find_prerequisite_deployment(prerequisite, deployment, deployments_by_name)
         if target is None:
             return PrerequisiteResult(
                 met=False,
                 reason=f"Waiting for prerequisite deployment '{prerequisite.deployment_name}'",
                 blocking_prerequisite=prerequisite.deployment_name,
+                blocking_workspace=workspace,
+                blocking_name=name,
             )
         if target.status == "FAILED":
             return PrerequisiteResult(
                 met=False,
                 reason=f"Prerequisite '{prerequisite.deployment_name}' failed",
                 blocking_prerequisite=prerequisite.deployment_name,
+                blocking_workspace=workspace,
+                blocking_name=name,
             )
         if not _condition_met(prerequisite, target):
             return PrerequisiteResult(
                 met=False,
                 reason=f"Waiting for prerequisite '{prerequisite.deployment_name}' ({prerequisite.condition})",
                 blocking_prerequisite=prerequisite.deployment_name,
+                blocking_workspace=workspace,
+                blocking_name=name,
             )
 
     return PrerequisiteResult(met=True)

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/volume_reconciler.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/volume_reconciler.py
@@ -46,15 +46,14 @@ class VolumeReconciler:
         try:
             backend = self._registry.resolve(None)
         except ExecutorNotFoundError:
-            logger.warning("No executor for volume delete of %s — removing entity only", volume_id)
-            backend = None
+            logger.warning("No executor for volume delete of %s — will retry", volume_id, exc_info=True)
+            return
 
-        if backend is not None:
-            try:
-                await backend.delete_volume(volume.workspace, volume.name)
-            except Exception:
-                logger.warning("Backend delete failed for volume %s — will retry", volume_id, exc_info=True)
-                return
+        try:
+            await backend.delete_volume(volume.workspace, volume.name)
+        except Exception:
+            logger.warning("Backend delete failed for volume %s — will retry", volume_id, exc_info=True)
+            return
 
         try:
             await self._entities.delete(Volume, name=volume.name, workspace=volume.workspace)

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/volume_reconciler.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/volume_reconciler.py
@@ -10,7 +10,7 @@ import logging
 from nemo_deployments_plugin.backends.base import DeploymentBackend, VolumeStatusUpdate
 from nemo_deployments_plugin.backends.registry import ExecutorNotFoundError, ExecutorRegistry
 from nemo_deployments_plugin.entities import Volume
-from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityConflictError
+from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityConflictError, NemoEntityNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,10 @@ class VolumeReconciler:
         self._registry = registry
 
     async def reconcile_one(self, volume: Volume) -> None:
+        if volume.status == "DELETING":
+            await self._reconcile_delete(volume)
+            return
+
         try:
             backend = self._registry.resolve(None)
         except ExecutorNotFoundError as exc:
@@ -36,6 +40,31 @@ class VolumeReconciler:
             await self._reconcile_create(volume, backend)
         elif volume.status == "BOUND":
             await self._reconcile_read(volume, backend)
+
+    async def _reconcile_delete(self, volume: Volume) -> None:
+        volume_id = f"{volume.workspace}/{volume.name}"
+        try:
+            backend = self._registry.resolve(None)
+        except ExecutorNotFoundError:
+            logger.warning("No executor for volume delete of %s — removing entity only", volume_id)
+            backend = None
+
+        if backend is not None:
+            try:
+                await backend.delete_volume(volume.workspace, volume.name)
+            except Exception:
+                logger.warning("Backend delete failed for volume %s — will retry", volume_id, exc_info=True)
+                return
+
+        try:
+            await self._entities.delete(Volume, name=volume.name, workspace=volume.workspace)
+            logger.info("Deleted volume entity %s", volume_id)
+        except NemoEntityNotFoundError:
+            logger.debug("Volume entity %s already deleted", volume_id)
+        except NemoEntityConflictError:
+            raise
+        except Exception:
+            logger.exception("Failed to delete volume entity %s", volume_id)
 
     async def _reconcile_create(self, volume: Volume, backend: DeploymentBackend) -> None:
         backend_config = volume.backend_config.model_dump(by_alias=True, exclude_none=True)

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/schema.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/schema.py
@@ -36,7 +36,6 @@ class CreateDeploymentConfigRequest(BaseModel):
     config_files: list[ConfigFile] = Field(default_factory=list)
     restart_policy: RestartPolicy = "Always"
     backoff_limit: int = 6
-    prerequisites: list[Prerequisite] = Field(default_factory=list)
     drift_recovery: DriftRecoveryPolicy | None = None
     labels: dict[str, str] = Field(default_factory=dict)
     backend_config: DeploymentBackendConfig = Field(default_factory=DeploymentBackendConfig)
@@ -49,6 +48,7 @@ class CreateDeploymentRequest(BaseModel):
     )
     desired_state: DesiredState = "READY"
     executor: str | None = None
+    prerequisites: list[Prerequisite] = Field(default_factory=list)
 
 
 class CreateVolumeRequest(BaseModel):

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/types.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/types.py
@@ -18,7 +18,7 @@ DeploymentStatus = Literal[
     "LOST",
     "DELETING",
 ]
-VolumeStatus = Literal["PENDING", "BOUND", "RELEASED", "FAILED"]
+VolumeStatus = Literal["PENDING", "BOUND", "DELETING", "RELEASED", "FAILED"]
 DesiredState = Literal["READY", "STOPPED"]
 RestartPolicy = Literal["Always", "OnFailure", "Never"]
 AccessMode = Literal["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"]
@@ -32,7 +32,7 @@ NON_TERMINAL_DEPLOYMENT_STATUSES: tuple[DeploymentStatus, ...] = (
     "LOST",
     "DELETING",
 )
-NON_TERMINAL_VOLUME_STATUSES: tuple[VolumeStatus, ...] = ("PENDING", "BOUND")
+NON_TERMINAL_VOLUME_STATUSES: tuple[VolumeStatus, ...] = ("PENDING", "BOUND", "DELETING")
 
 
 class Endpoint(BaseModel):

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/validation.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/validation.py
@@ -43,12 +43,15 @@ def detect_prerequisite_cycle(
         dfs(node)
 
 
+def deployment_graph_key(workspace: str, name: str) -> str:
+    """Return a stable graph node id for a deployment in prerequisite cycle detection."""
+    return f"{workspace}/{name}"
+
+
 def normalized_prerequisite_name(ref: str, workspace: str) -> str:
-    """Return a graph node name for prerequisite cycle detection within a workspace."""
+    """Return a graph node name for prerequisite cycle detection."""
     ref_workspace, name = parse_deployment_ref(ref, workspace)
-    if ref_workspace == workspace:
-        return name
-    return f"{ref_workspace}/{name}"
+    return deployment_graph_key(ref_workspace, name)
 
 
 def prerequisite_names(prerequisites: list[Prerequisite], workspace: str) -> list[str]:
@@ -58,5 +61,6 @@ def prerequisite_names(prerequisites: list[Prerequisite], workspace: str) -> lis
 def build_existing_prerequisite_map(deployments: list[Deployment]) -> dict[str, list[str]]:
     graph: dict[str, list[str]] = defaultdict(list)
     for deployment in deployments:
-        graph[deployment.name] = prerequisite_names(deployment.prerequisites, deployment.workspace)
+        key = deployment_graph_key(deployment.workspace, deployment.name)
+        graph[key] = prerequisite_names(deployment.prerequisites, deployment.workspace)
     return dict(graph)

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/validation.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/validation.py
@@ -1,13 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Prerequisite graph validation for DeploymentConfig entities."""
+"""Prerequisite graph validation for Deployment entities."""
 
 from __future__ import annotations
 
 from collections import defaultdict
 
-from nemo_deployments_plugin.entities import DeploymentConfig, Prerequisite
+from nemo_deployments_plugin.entities import Deployment, Prerequisite
+from nemo_deployments_plugin.reconciler.prerequisite import parse_deployment_ref
 
 
 class PrerequisiteCycleError(ValueError):
@@ -16,20 +17,20 @@ class PrerequisiteCycleError(ValueError):
 
 def detect_prerequisite_cycle(
     *,
-    config_name: str,
+    deployment_name: str,
     prerequisites: list[str],
     existing: dict[str, list[str]],
 ) -> None:
     """Detect cycles in the prerequisite graph within a workspace."""
     graph: dict[str, list[str]] = {name: list(deps) for name, deps in existing.items()}
-    graph[config_name] = list(prerequisites)
+    graph[deployment_name] = list(prerequisites)
 
     visited: set[str] = set()
     stack: set[str] = set()
 
     def dfs(node: str) -> None:
         if node in stack:
-            raise PrerequisiteCycleError(f"Prerequisite cycle detected involving deployment config '{node}'.")
+            raise PrerequisiteCycleError(f"Prerequisite cycle detected involving deployment '{node}'.")
         if node in visited:
             return
         visited.add(node)
@@ -42,12 +43,20 @@ def detect_prerequisite_cycle(
         dfs(node)
 
 
-def prerequisite_names(prerequisites: list[Prerequisite]) -> list[str]:
-    return [prerequisite.deployment_name for prerequisite in prerequisites]
+def normalized_prerequisite_name(ref: str, workspace: str) -> str:
+    """Return a graph node name for prerequisite cycle detection within a workspace."""
+    ref_workspace, name = parse_deployment_ref(ref, workspace)
+    if ref_workspace == workspace:
+        return name
+    return f"{ref_workspace}/{name}"
 
 
-def build_existing_prerequisite_map(configs: list[DeploymentConfig]) -> dict[str, list[str]]:
+def prerequisite_names(prerequisites: list[Prerequisite], workspace: str) -> list[str]:
+    return [normalized_prerequisite_name(prerequisite.deployment_name, workspace) for prerequisite in prerequisites]
+
+
+def build_existing_prerequisite_map(deployments: list[Deployment]) -> dict[str, list[str]]:
     graph: dict[str, list[str]] = defaultdict(list)
-    for cfg in configs:
-        graph[cfg.name] = prerequisite_names(cfg.prerequisites)
+    for deployment in deployments:
+        graph[deployment.name] = prerequisite_names(deployment.prerequisites, deployment.workspace)
     return dict(graph)

--- a/plugins/nemo-deployments/tests/unit/reconciler/conftest.py
+++ b/plugins/nemo-deployments/tests/unit/reconciler/conftest.py
@@ -38,7 +38,8 @@ class MockDeploymentBackend(DeploymentBackend):
         self.volume_create_status = volume_create_status or VolumeStatusUpdate(status="BOUND")
         self.create_calls: list[dict[str, Any]] = []
         self.read_calls: list[tuple[str, str]] = []
-        self.delete_calls: list[tuple[str, str]] = []
+        self.deployment_delete_calls: list[tuple[str, str]] = []
+        self.volume_delete_calls: list[tuple[str, str]] = []
         super().__init__(sdk or AsyncMock(), config or {})
 
     def shutdown(self) -> None:
@@ -53,7 +54,7 @@ class MockDeploymentBackend(DeploymentBackend):
         return self.read_status_result
 
     async def delete_deployment(self, workspace: str, name: str) -> BackendStatusUpdate:
-        self.delete_calls.append((workspace, name))
+        self.deployment_delete_calls.append((workspace, name))
         return self.delete_status
 
     async def list_managed_deployment_names(self) -> list[str]:
@@ -69,7 +70,7 @@ class MockDeploymentBackend(DeploymentBackend):
         return VolumeStatusUpdate(status="BOUND")
 
     async def delete_volume(self, workspace: str, name: str) -> VolumeStatusUpdate:
-        self.delete_calls.append((workspace, name))
+        self.volume_delete_calls.append((workspace, name))
         return VolumeStatusUpdate(status="RELEASED")
 
 

--- a/plugins/nemo-deployments/tests/unit/reconciler/conftest.py
+++ b/plugins/nemo-deployments/tests/unit/reconciler/conftest.py
@@ -69,6 +69,7 @@ class MockDeploymentBackend(DeploymentBackend):
         return VolumeStatusUpdate(status="BOUND")
 
     async def delete_volume(self, workspace: str, name: str) -> VolumeStatusUpdate:
+        self.delete_calls.append((workspace, name))
         return VolumeStatusUpdate(status="RELEASED")
 
 

--- a/plugins/nemo-deployments/tests/unit/reconciler/test_controller.py
+++ b/plugins/nemo-deployments/tests/unit/reconciler/test_controller.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import threading
+from datetime import datetime, timedelta, timezone
 from typing import cast
 from unittest.mock import AsyncMock, patch
 
@@ -10,8 +12,8 @@ import pytest
 from helpers import list_response, make_deployment, make_deployment_config, make_volume
 from nemo_deployments_plugin.backends.registry import ExecutorRegistry
 from nemo_deployments_plugin.config import ControllerConfig
-from nemo_deployments_plugin.controller import DeploymentsController
-from nemo_deployments_plugin.entities import DeploymentConfig, Prerequisite
+from nemo_deployments_plugin.controller import DeploymentsController, _orphan_protected_ids
+from nemo_deployments_plugin.entities import Deployment, DeploymentConfig, Prerequisite, StatusEvent
 from nemo_platform_plugin.entity_client import NemoEntityConflictError
 
 
@@ -120,6 +122,34 @@ async def test_controller_unhealthy_when_deployments_fail_volumes_ok() -> None:
 
 @pytest.mark.asyncio
 @patch("nemo_deployments_plugin.controller.reconcile_orphans")
+async def test_orphan_cleanup_skipped_when_terminal_list_fails(mock_orphans: AsyncMock) -> None:
+    ctrl = DeploymentsController()
+    dep = make_deployment()
+
+    mock_entities = AsyncMock()
+    mock_entities.list.side_effect = [
+        list_response([dep]),
+        list_response([]),
+        RuntimeError("terminal list failed"),
+    ]
+
+    mock_registry = _stub_registry()
+    mock_dep_reconciler = AsyncMock()
+    mock_dep_reconciler.set_config_cache = lambda configs: None
+
+    ctrl._entities = mock_entities
+    ctrl._registry = mock_registry
+    ctrl._controller_config = ControllerConfig(orphan_cleanup_interval_seconds=10)
+    ctrl._deployment_reconciler = mock_dep_reconciler
+    ctrl._volume_reconciler = AsyncMock()
+
+    await ctrl.reconcile()
+    await ctrl.reconcile()
+    mock_orphans.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("nemo_deployments_plugin.controller.reconcile_orphans")
 async def test_orphan_cleanup_skipped_when_deployments_list_fails(mock_orphans: AsyncMock) -> None:
     ctrl = DeploymentsController()
     ctrl._entities = AsyncMock()
@@ -146,6 +176,7 @@ async def test_controller_runs_orphan_cleanup_on_interval(mock_orphans: AsyncMoc
         list_response([dep]),
         list_response([]),
         list_response([dep]),
+        list_response([]),
         list_response([]),
     ]
 
@@ -198,14 +229,13 @@ async def test_controller_fetches_terminal_prerequisite_for_dag() -> None:
     server = make_deployment("server")
     server.deployment_config = "server"
     server.status = "PENDING"
+    server.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
     server_cfg = make_deployment_config("server")
-    server_cfg.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
 
     mock_entities = AsyncMock()
     mock_entities.list.side_effect = [
         list_response([server]),
         list_response([]),
-        list_response([puller]),
     ]
 
     async def mock_get(entity_cls, name: str, workspace: str = "default", **_kwargs: object):
@@ -213,7 +243,9 @@ async def test_controller_fetches_terminal_prerequisite_for_dag() -> None:
             if name == "server":
                 return server_cfg
             return make_deployment_config(name, workspace)
-        raise AssertionError(f"unexpected get: {entity_cls}")
+        if entity_cls is Deployment and name == "puller":
+            return puller
+        raise AssertionError(f"unexpected get: {entity_cls} {name}")
 
     mock_entities.get.side_effect = mock_get
 
@@ -236,8 +268,8 @@ async def test_controller_fetches_terminal_prerequisite_for_dag() -> None:
 
 
 @pytest.mark.asyncio
-async def test_controller_fetches_prerequisite_when_deployment_name_differs_from_config() -> None:
-    """Prerequisite references DeploymentConfig name; entity name may differ."""
+async def test_controller_fetches_prerequisite_by_deployment_name() -> None:
+    """Prerequisite references Deployment entity name, not DeploymentConfig name."""
     ctrl = DeploymentsController()
     puller = make_deployment("puller-run-1")
     puller.deployment_config = "puller"
@@ -246,14 +278,13 @@ async def test_controller_fetches_prerequisite_when_deployment_name_differs_from
     server = make_deployment("server")
     server.deployment_config = "server"
     server.status = "PENDING"
+    server.prerequisites = [Prerequisite(deployment_name="puller-run-1", condition="succeeded")]
     server_cfg = make_deployment_config("server")
-    server_cfg.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
 
     mock_entities = AsyncMock()
     mock_entities.list.side_effect = [
         list_response([server]),
         list_response([]),
-        list_response([puller]),
     ]
 
     async def mock_get(entity_cls, name: str, workspace: str = "default", **_kwargs: object):
@@ -261,6 +292,8 @@ async def test_controller_fetches_prerequisite_when_deployment_name_differs_from
             if name == "server":
                 return server_cfg
             return make_deployment_config(name, workspace)
+        if entity_cls is Deployment and name == "puller-run-1":
+            return puller
         raise AssertionError(f"unexpected get: {entity_cls} {name}")
 
     mock_entities.get.side_effect = mock_get
@@ -277,6 +310,70 @@ async def test_controller_fetches_prerequisite_when_deployment_name_differs_from
     await ctrl.reconcile()
 
     call_args = mock_dep_reconciler.reconcile_one.await_args
-    by_config = call_args.kwargs["deployments_by_config"]
-    assert ("default", "puller") in by_config
-    assert by_config[("default", "puller")].name == "puller-run-1"
+    by_name = call_args.kwargs["deployments_by_name"]
+    assert ("default", "puller-run-1") in by_name
+    assert by_name[("default", "puller-run-1")].name == "puller-run-1"
+
+
+@pytest.mark.asyncio
+async def test_controller_stops_mid_reconcile_when_stop_requested() -> None:
+    ctrl = DeploymentsController()
+    dep1 = make_deployment("dep1")
+    dep2 = make_deployment("dep2")
+    stop = threading.Event()
+
+    mock_entities = AsyncMock()
+    mock_entities.list.side_effect = [
+        list_response([dep1, dep2]),
+        list_response([]),
+    ]
+
+    mock_dep_reconciler = AsyncMock()
+    mock_dep_reconciler.set_config_cache = lambda configs: None
+
+    async def reconcile_and_stop(deployment: object, **kwargs: object) -> None:
+        stop.set()
+
+    mock_dep_reconciler.reconcile_one.side_effect = reconcile_and_stop
+
+    ctrl.set_stop_signal(stop)
+    ctrl._entities = mock_entities
+    ctrl._registry = _stub_registry()
+    ctrl._controller_config = ControllerConfig(orphan_cleanup_interval_seconds=0)
+    ctrl._deployment_reconciler = mock_dep_reconciler
+    ctrl._volume_reconciler = AsyncMock()
+
+    await ctrl.reconcile()
+
+    assert mock_dep_reconciler.reconcile_one.await_count == 1
+
+
+def test_orphan_protected_ids_includes_terminal_within_grace() -> None:
+    active = make_deployment("active")
+    terminal = make_deployment("done")
+    terminal.status = "SUCCEEDED"
+    recent = datetime.now(timezone.utc) - timedelta(seconds=30)
+    terminal.status_history = [StatusEvent(status="SUCCEEDED", timestamp=recent.isoformat())]
+
+    known = _orphan_protected_ids([active], [terminal], grace_seconds=3600)
+    assert "default/active" in known
+    assert "default/done" in known
+
+
+def test_orphan_protected_ids_excludes_terminal_after_grace() -> None:
+    terminal = make_deployment("done")
+    terminal.status = "SUCCEEDED"
+    old = datetime.now(timezone.utc) - timedelta(seconds=7200)
+    terminal.status_history = [StatusEvent(status="SUCCEEDED", timestamp=old.isoformat())]
+
+    known = _orphan_protected_ids([], [terminal], grace_seconds=3600)
+    assert "default/done" not in known
+
+
+def test_orphan_protected_ids_includes_terminal_without_history() -> None:
+    terminal = make_deployment("done")
+    terminal.status = "SUCCEEDED"
+    terminal.status_history = []
+
+    known = _orphan_protected_ids([], [terminal], grace_seconds=3600)
+    assert "default/done" in known

--- a/plugins/nemo-deployments/tests/unit/reconciler/test_deployment_reconciler.py
+++ b/plugins/nemo-deployments/tests/unit/reconciler/test_deployment_reconciler.py
@@ -25,9 +25,7 @@ async def test_pending_creates_deployment(
     cfg = make_deployment_config()
     deployment_reconciler.set_config_cache({("default", "cfg1"): cfg})
 
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
     assert len(mock_backend.create_calls) == 1
     assert dep.status == "STARTING"
@@ -42,12 +40,10 @@ async def test_prerequisite_gating_stays_pending(
     dep = make_deployment("server")
     dep.deployment_config = "server"
     cfg = make_deployment_config("server")
-    cfg.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
+    dep.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
     deployment_reconciler.set_config_cache({("default", "server"): cfg})
 
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
     assert dep.status == "PENDING"
     assert "Waiting" in dep.status_message
@@ -65,14 +61,12 @@ async def test_prerequisite_failure_marks_parent_failed(
     server = make_deployment("server")
     server.deployment_config = "server"
     cfg = make_deployment_config("server")
-    cfg.prerequisites = [Prerequisite(deployment_name="puller")]
+    server.prerequisites = [Prerequisite(deployment_name="puller")]
     deployment_reconciler.set_config_cache({("default", "server"): cfg})
     by_name = {("default", "puller"): puller}
-    by_config = {("default", "puller"): puller}
 
     await deployment_reconciler.reconcile_one(
         server,
-        deployments_by_config=by_config,
         deployments_by_name=by_name,
         volumes_by_name=NO_VOLUMES,
     )
@@ -92,9 +86,7 @@ async def test_ready_monitoring(
     deployment_reconciler.set_config_cache({("default", "cfg1"): cfg})
     mock_backend.read_status_result = BackendStatusUpdate(status="READY", status_message="healthy")
 
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
     assert mock_backend.read_calls == [("default", "dep1")]
     assert dep.status == "READY"
@@ -116,9 +108,7 @@ async def test_on_failure_succeeded_terminal(
         exit_code=0,
     )
 
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
     assert dep.status == "SUCCEEDED"
     assert dep.exit_code == 0
@@ -135,9 +125,7 @@ async def test_desired_stopped_deletes(
     cfg = make_deployment_config()
     deployment_reconciler.set_config_cache({("default", "cfg1"): cfg})
 
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
     assert mock_backend.delete_calls == [("default", "dep1")]
     mock_entities.delete.assert_awaited_once()
@@ -153,9 +141,7 @@ async def test_delete_proceeds_when_config_missing(
     dep.desired_state = "STOPPED"
     mock_entities.get.side_effect = NemoEntityNotFoundError("missing")
 
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
     assert mock_backend.delete_calls == [("default", "dep1")]
     mock_entities.delete.assert_awaited_once()
@@ -175,9 +161,7 @@ async def test_delete_retains_deleting_when_backend_delete_fails(
 
     mock_backend.delete_deployment = failing_delete  # type: ignore[method-assign]
 
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
     assert dep.status == "DELETING"
     mock_entities.delete.assert_not_awaited()
@@ -193,9 +177,7 @@ async def test_delete_clears_drift_recovery_cache(
     dep.desired_state = "STOPPED"
     deployment_reconciler._drift_cache.add_attempt("default/dep1")
 
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
     assert deployment_reconciler._drift_cache.get_attempts("default/dep1") == 0
 
@@ -214,9 +196,7 @@ async def test_drift_recovery_recreate(
     mock_backend.create_status = BackendStatusUpdate(status="STARTING", status_message="recreated")
 
     dep.status = "LOST"
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
     assert len(mock_backend.create_calls) == 1
     assert dep.status == "STARTING"
@@ -239,9 +219,7 @@ async def test_drift_recovery_exhausted(
 
     mock_backend.read_status_result = BackendStatusUpdate(status="LOST")
     dep.status = "LOST"
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
     assert dep.status == "FAILED"
     assert "Drift recovery failed" in dep.status_message
@@ -260,7 +238,6 @@ async def test_conflict_propagates_from_save(
     with pytest.raises(NemoEntityConflictError):
         await deployment_reconciler.reconcile_one(
             dep,
-            deployments_by_config={},
             deployments_by_name={},
             volumes_by_name=NO_VOLUMES,
         )
@@ -274,9 +251,7 @@ async def test_missing_config_marks_failed(
     dep = make_deployment()
     mock_entities.get.side_effect = NemoEntityNotFoundError("missing")
 
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
     assert dep.status == "FAILED"
     assert "DeploymentConfig" in dep.status_message
@@ -297,7 +272,6 @@ async def test_executor_not_found_marks_failed(
 
     await reconciler.reconcile_one(
         dep,
-        deployments_by_config={},
         deployments_by_name={},
         volumes_by_name=NO_VOLUMES,
     )
@@ -342,7 +316,6 @@ async def test_on_failure_failed_exit(
 
     await deployment_reconciler.reconcile_one(
         dep,
-        deployments_by_config={},
         deployments_by_name={},
         volumes_by_name=NO_VOLUMES,
     )
@@ -366,7 +339,6 @@ async def test_drift_recovery_ignore(
 
     await deployment_reconciler.reconcile_one(
         dep,
-        deployments_by_config={},
         deployments_by_name={},
         volumes_by_name=NO_VOLUMES,
     )
@@ -392,7 +364,6 @@ async def test_drift_recovery_backoff_skips_recreate(
 
     await deployment_reconciler.reconcile_one(
         dep,
-        deployments_by_config={},
         deployments_by_name={},
         volumes_by_name=NO_VOLUMES,
     )
@@ -417,7 +388,6 @@ async def test_volume_mount_gating(
 
     await deployment_reconciler.reconcile_one(
         dep,
-        deployments_by_config={},
         deployments_by_name={},
         volumes_by_name={("default", "data"): vol},
     )
@@ -438,14 +408,12 @@ async def test_prerequisite_ready_through_reconciler(
     server = make_deployment("server")
     server.deployment_config = "server"
     cfg = make_deployment_config("server")
-    cfg.prerequisites = [Prerequisite(deployment_name="worker", condition="ready")]
+    server.prerequisites = [Prerequisite(deployment_name="worker", condition="ready")]
     deployment_reconciler.set_config_cache({("default", "server"): cfg})
     by_name = {("default", "worker"): worker}
-    by_config = {("default", "worker"): worker}
 
     await deployment_reconciler.reconcile_one(
         server,
-        deployments_by_config=by_config,
         deployments_by_name=by_name,
         volumes_by_name=NO_VOLUMES,
     )
@@ -472,16 +440,12 @@ async def test_drift_recovery_create_failure_stays_lost_and_backoffs(
 
     mock_backend.create_deployment = failing_create  # type: ignore[method-assign]
 
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
     assert dep.status == "LOST"
     assert "Will retry" in dep.status_message
     assert len(mock_backend.create_calls) == 1
 
-    await deployment_reconciler.reconcile_one(
-        dep, deployments_by_config={}, deployments_by_name={}, volumes_by_name=NO_VOLUMES
-    )
+    await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
     assert dep.status == "LOST"
     assert dep.status != "FAILED"
     assert len(mock_backend.create_calls) == 1
@@ -499,14 +463,12 @@ async def test_succeeded_prerequisite_in_index_allows_create(
     server = make_deployment("server")
     server.deployment_config = "server"
     cfg = make_deployment_config("server")
-    cfg.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
+    server.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
     deployment_reconciler.set_config_cache({("default", "server"): cfg})
     by_name = {("default", "puller"): puller}
-    by_config = {("default", "puller"): puller}
 
     await deployment_reconciler.reconcile_one(
         server,
-        deployments_by_config=by_config,
         deployments_by_name=by_name,
         volumes_by_name=NO_VOLUMES,
     )

--- a/plugins/nemo-deployments/tests/unit/reconciler/test_deployment_reconciler.py
+++ b/plugins/nemo-deployments/tests/unit/reconciler/test_deployment_reconciler.py
@@ -127,7 +127,7 @@ async def test_desired_stopped_deletes(
 
     await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
-    assert mock_backend.delete_calls == [("default", "dep1")]
+    assert mock_backend.deployment_delete_calls == [("default", "dep1")]
     mock_entities.delete.assert_awaited_once()
 
 
@@ -143,7 +143,7 @@ async def test_delete_proceeds_when_config_missing(
 
     await deployment_reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
-    assert mock_backend.delete_calls == [("default", "dep1")]
+    assert mock_backend.deployment_delete_calls == [("default", "dep1")]
     mock_entities.delete.assert_awaited_once()
 
 
@@ -286,7 +286,7 @@ async def test_orphan_cleanup_deletes_unknown(
 ) -> None:
     mock_backend.managed_names = ["default/orphan", "default/known"]
     await reconcile_orphans([mock_backend], {"default/known"})
-    assert mock_backend.delete_calls == [("default", "orphan")]
+    assert mock_backend.deployment_delete_calls == [("default", "orphan")]
 
 
 @pytest.mark.asyncio
@@ -295,7 +295,7 @@ async def test_orphan_cleanup_skips_invalid_ids(
 ) -> None:
     mock_backend.managed_names = ["default/valid", "/invalid", "ws/", "default/orphan"]
     await reconcile_orphans([mock_backend], {"default/valid"})
-    assert mock_backend.delete_calls == [("default", "orphan")]
+    assert mock_backend.deployment_delete_calls == [("default", "orphan")]
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-deployments/tests/unit/reconciler/test_prerequisite.py
+++ b/plugins/nemo-deployments/tests/unit/reconciler/test_prerequisite.py
@@ -55,6 +55,14 @@ def test_prerequisites_failed_propagation() -> None:
     assert "failed" in result.reason.lower()
 
 
+def test_prerequisites_invalid_ref_stays_unmet() -> None:
+    server = make_deployment("server")
+    server.prerequisites = [Prerequisite(deployment_name="/bad")]
+    result = prerequisites_met(server, deployments_by_name={})
+    assert result.met is False
+    assert "Invalid prerequisite ref" in result.reason
+
+
 def test_prerequisites_resolve_by_deployment_name_not_config() -> None:
     """Prerequisite deployment_name must match the Deployment entity name."""
     puller = make_deployment("puller-run-1")

--- a/plugins/nemo-deployments/tests/unit/reconciler/test_prerequisite.py
+++ b/plugins/nemo-deployments/tests/unit/reconciler/test_prerequisite.py
@@ -3,23 +3,21 @@
 
 from __future__ import annotations
 
-from helpers import make_deployment, make_deployment_config
+from helpers import make_deployment
 from nemo_deployments_plugin.entities import Prerequisite
 from nemo_deployments_plugin.reconciler.prerequisite import prerequisites_met
 
 
 def test_prerequisites_met_when_empty() -> None:
     dep = make_deployment()
-    cfg = make_deployment_config()
-    result = prerequisites_met(dep, cfg, deployments_by_config={}, deployments_by_name={})
+    result = prerequisites_met(dep, deployments_by_name={})
     assert result.met is True
 
 
 def test_prerequisites_waiting_for_missing() -> None:
     dep = make_deployment("server")
-    cfg = make_deployment_config("server")
-    cfg.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
-    result = prerequisites_met(dep, cfg, deployments_by_config={}, deployments_by_name={})
+    dep.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
+    result = prerequisites_met(dep, deployments_by_name={})
     assert result.met is False
     assert result.blocking_prerequisite == "puller"
     assert "Waiting" in result.reason
@@ -27,27 +25,22 @@ def test_prerequisites_waiting_for_missing() -> None:
 
 def test_prerequisites_succeeded_condition() -> None:
     puller = make_deployment("puller")
-    puller.deployment_config = "puller"
     puller.status = "SUCCEEDED"
     puller.exit_code = 0
     server = make_deployment("server")
-    cfg = make_deployment_config("server")
-    cfg.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
+    server.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
     by_name = {("default", "puller"): puller}
-    by_config = {("default", "puller"): puller}
-    result = prerequisites_met(server, cfg, deployments_by_config=by_config, deployments_by_name=by_name)
+    result = prerequisites_met(server, deployments_by_name=by_name)
     assert result.met is True
 
 
 def test_prerequisites_ready_condition() -> None:
-    dep = make_deployment("worker")
-    dep.status = "READY"
+    worker = make_deployment("worker")
+    worker.status = "READY"
     server = make_deployment("server")
-    cfg = make_deployment_config("server")
-    cfg.prerequisites = [Prerequisite(deployment_name="worker", condition="ready")]
-    by_name = {("default", "worker"): dep}
-    by_config = {("default", "worker"): dep}
-    result = prerequisites_met(server, cfg, deployments_by_config=by_config, deployments_by_name=by_name)
+    server.prerequisites = [Prerequisite(deployment_name="worker", condition="ready")]
+    by_name = {("default", "worker"): worker}
+    result = prerequisites_met(server, deployments_by_name=by_name)
     assert result.met is True
 
 
@@ -55,28 +48,23 @@ def test_prerequisites_failed_propagation() -> None:
     puller = make_deployment("puller")
     puller.status = "FAILED"
     server = make_deployment("server")
-    cfg = make_deployment_config("server")
-    cfg.prerequisites = [Prerequisite(deployment_name="puller")]
+    server.prerequisites = [Prerequisite(deployment_name="puller")]
     by_name = {("default", "puller"): puller}
-    by_config = {("default", "puller"): puller}
-    result = prerequisites_met(server, cfg, deployments_by_config=by_config, deployments_by_name=by_name)
+    result = prerequisites_met(server, deployments_by_name=by_name)
     assert result.met is False
     assert "failed" in result.reason.lower()
 
 
-def test_prerequisites_prefer_config_index_over_name_collision() -> None:
-    """deployment_name is a DeploymentConfig name; do not match unrelated deployment names."""
-    puller = make_deployment("puller")
-    puller.deployment_config = "puller"
+def test_prerequisites_resolve_by_deployment_name_not_config() -> None:
+    """Prerequisite deployment_name must match the Deployment entity name."""
+    puller = make_deployment("puller-run-1")
     puller.status = "SUCCEEDED"
     puller.exit_code = 0
     collision = make_deployment("puller")
-    collision.deployment_config = "other-config"
+    collision.deployment_config = "puller-run-1"
     collision.status = "PENDING"
     server = make_deployment("server")
-    cfg = make_deployment_config("server")
-    cfg.prerequisites = [Prerequisite(deployment_name="puller", condition="succeeded")]
-    by_name = {("default", "puller"): collision}
-    by_config = {("default", "puller"): puller}
-    result = prerequisites_met(server, cfg, deployments_by_config=by_config, deployments_by_name=by_name)
+    server.prerequisites = [Prerequisite(deployment_name="puller-run-1", condition="succeeded")]
+    by_name = {("default", "puller"): collision, ("default", "puller-run-1"): puller}
+    result = prerequisites_met(server, deployments_by_name=by_name)
     assert result.met is True

--- a/plugins/nemo-deployments/tests/unit/reconciler/test_volume_reconciler.py
+++ b/plugins/nemo-deployments/tests/unit/reconciler/test_volume_reconciler.py
@@ -41,3 +41,18 @@ async def test_volume_create_failure(
 
     assert vol.status == "FAILED"
     assert "docker unavailable" in vol.status_message
+
+
+@pytest.mark.asyncio
+async def test_deleting_volume_removes_backend_then_entity(
+    volume_reconciler: VolumeReconciler,
+    mock_backend: MockDeploymentBackend,
+    mock_entities: AsyncMock,
+) -> None:
+    vol = make_volume()
+    vol.status = "DELETING"
+
+    await volume_reconciler.reconcile_one(vol)
+
+    assert mock_backend.delete_calls == [("default", "vol1")]
+    mock_entities.delete.assert_awaited_once()

--- a/plugins/nemo-deployments/tests/unit/reconciler/test_volume_reconciler.py
+++ b/plugins/nemo-deployments/tests/unit/reconciler/test_volume_reconciler.py
@@ -54,5 +54,22 @@ async def test_deleting_volume_removes_backend_then_entity(
 
     await volume_reconciler.reconcile_one(vol)
 
-    assert mock_backend.delete_calls == [("default", "vol1")]
+    assert mock_backend.volume_delete_calls == [("default", "vol1")]
     mock_entities.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_deleting_volume_waits_for_executor(
+    volume_reconciler: VolumeReconciler,
+    mock_entities: AsyncMock,
+) -> None:
+    from nemo_deployments_plugin.backends.registry import ExecutorRegistry
+
+    empty_registry = ExecutorRegistry({}, default_executor=None)
+    reconciler = VolumeReconciler(mock_entities, empty_registry)
+    vol = make_volume()
+    vol.status = "DELETING"
+
+    await reconciler.reconcile_one(vol)
+
+    mock_entities.delete.assert_not_awaited()

--- a/plugins/nemo-deployments/tests/unit/test_api_deployment_configs.py
+++ b/plugins/nemo-deployments/tests/unit/test_api_deployment_configs.py
@@ -11,7 +11,6 @@ from fastapi.testclient import TestClient
 from helpers import list_response, make_deployment, make_deployment_config
 from nemo_deployments_plugin.api.v2 import deployment_configs as configs_module
 from nemo_deployments_plugin.api.v2.dependencies import get_entity_client
-from nemo_deployments_plugin.entities import Prerequisite
 from nemo_platform_plugin.entity_client import NemoEntityConflictError, NemoEntityNotFoundError
 
 
@@ -32,7 +31,6 @@ def client(mock_entity_client: AsyncMock) -> TestClient:
 
 
 def test_create_deployment_config_201(client: TestClient, mock_entity_client: AsyncMock) -> None:
-    mock_entity_client.list.return_value = list_response([])
     mock_entity_client.create.return_value = make_deployment_config("cfg1")
     resp = client.post(
         "/apis/deployments/v2/workspaces/default/deployment-configs",
@@ -40,19 +38,6 @@ def test_create_deployment_config_201(client: TestClient, mock_entity_client: As
     )
     assert resp.status_code == 201
     assert resp.json()["name"] == "cfg1"
-
-
-def test_create_deployment_config_cycle_400(client: TestClient, mock_entity_client: AsyncMock) -> None:
-    a = make_deployment_config("a")
-    b = make_deployment_config("b")
-    b.prerequisites = [Prerequisite(deployment_name="a")]
-    mock_entity_client.list.return_value = list_response([a, b])
-    resp = client.post(
-        "/apis/deployments/v2/workspaces/default/deployment-configs",
-        json={"name": "a", "prerequisites": [{"deployment_name": "b"}]},
-    )
-    assert resp.status_code == 400
-    assert "cycle" in resp.json()["detail"].lower()
 
 
 def test_get_deployment_config_404(client: TestClient, mock_entity_client: AsyncMock) -> None:
@@ -76,7 +61,6 @@ def test_delete_deployment_config_409_when_referenced(client: TestClient, mock_e
 
 
 def test_create_deployment_config_409(client: TestClient, mock_entity_client: AsyncMock) -> None:
-    mock_entity_client.list.return_value = list_response([])
     mock_entity_client.create.side_effect = NemoEntityConflictError("exists")
     resp = client.post(
         "/apis/deployments/v2/workspaces/default/deployment-configs",

--- a/plugins/nemo-deployments/tests/unit/test_api_deployments.py
+++ b/plugins/nemo-deployments/tests/unit/test_api_deployments.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 from helpers import list_response, make_deployment, make_deployment_config
 from nemo_deployments_plugin.api.v2 import deployments as deployments_module
 from nemo_deployments_plugin.api.v2.dependencies import get_entity_client
-from nemo_deployments_plugin.entities import DeploymentConfig
+from nemo_deployments_plugin.entities import DeploymentConfig, Prerequisite
 from nemo_platform_plugin.entity_client import NemoEntityConflictError, NemoEntityNotFoundError
 
 
@@ -42,6 +42,7 @@ def test_create_deployment_validates_config(client: TestClient, mock_entity_clie
 
 def test_create_deployment_201(client: TestClient, mock_entity_client: AsyncMock) -> None:
     mock_entity_client.get.return_value = make_deployment_config()
+    mock_entity_client.list.return_value = list_response([])
     mock_entity_client.create.return_value = make_deployment()
     resp = client.post(
         "/apis/deployments/v2/workspaces/default/deployments",
@@ -51,10 +52,29 @@ def test_create_deployment_201(client: TestClient, mock_entity_client: AsyncMock
     assert resp.json()["status"] == "PENDING"
 
 
+def test_create_deployment_cycle_400(client: TestClient, mock_entity_client: AsyncMock) -> None:
+    mock_entity_client.get.return_value = make_deployment_config()
+    a = make_deployment("a")
+    b = make_deployment("b")
+    b.prerequisites = [Prerequisite(deployment_name="a")]
+    mock_entity_client.list.return_value = list_response([a, b])
+    resp = client.post(
+        "/apis/deployments/v2/workspaces/default/deployments",
+        json={
+            "name": "a",
+            "deployment_config": "cfg1",
+            "prerequisites": [{"deployment_name": "b"}],
+        },
+    )
+    assert resp.status_code == 400
+    assert "cycle" in resp.json()["detail"].lower()
+
+
 def test_create_deployment_accepts_workspace_qualified_config_ref(
     client: TestClient, mock_entity_client: AsyncMock
 ) -> None:
     mock_entity_client.get.return_value = make_deployment_config("cfg1", workspace="other")
+    mock_entity_client.list.return_value = list_response([])
     mock_entity_client.create.return_value = make_deployment()
     resp = client.post(
         "/apis/deployments/v2/workspaces/default/deployments",

--- a/plugins/nemo-deployments/tests/unit/test_api_volumes.py
+++ b/plugins/nemo-deployments/tests/unit/test_api_volumes.py
@@ -52,9 +52,15 @@ def test_list_volumes_200(client: TestClient, mock_entity_client: AsyncMock) -> 
 
 
 def test_delete_volume_204(client: TestClient, mock_entity_client: AsyncMock) -> None:
+    volume = make_volume()
     mock_entity_client.list.return_value = list_response([])
+    mock_entity_client.get.return_value = volume
     resp = client.delete("/apis/deployments/v2/workspaces/default/volumes/vol1")
     assert resp.status_code == 204
+    mock_entity_client.update.assert_awaited_once()
+    updated = mock_entity_client.update.await_args.args[0]
+    assert updated.status == "DELETING"
+    mock_entity_client.delete.assert_not_awaited()
 
 
 def test_delete_volume_409_when_referenced(client: TestClient, mock_entity_client: AsyncMock) -> None:

--- a/plugins/nemo-deployments/tests/unit/test_entities.py
+++ b/plugins/nemo-deployments/tests/unit/test_entities.py
@@ -33,7 +33,7 @@ def test_volume_default_status_pending() -> None:
 def test_prerequisite_cycle_detected() -> None:
     with pytest.raises(PrerequisiteCycleError):
         detect_prerequisite_cycle(
-            config_name="c",
+            deployment_name="c",
             prerequisites=["a"],
             existing={"a": ["b"], "b": ["c"]},
         )

--- a/plugins/nemo-deployments/tests/unit/test_prerequisite_validation.py
+++ b/plugins/nemo-deployments/tests/unit/test_prerequisite_validation.py
@@ -4,12 +4,20 @@
 from __future__ import annotations
 
 import pytest
-from nemo_deployments_plugin.validation import PrerequisiteCycleError, detect_prerequisite_cycle
+from helpers import make_deployment
+from nemo_deployments_plugin.entities import Prerequisite
+from nemo_deployments_plugin.validation import (
+    PrerequisiteCycleError,
+    build_existing_prerequisite_map,
+    detect_prerequisite_cycle,
+    normalized_prerequisite_name,
+    prerequisite_names,
+)
 
 
 def test_linear_prerequisites_ok() -> None:
     detect_prerequisite_cycle(
-        config_name="c",
+        deployment_name="c",
         prerequisites=["b"],
         existing={"a": [], "b": ["a"]},
     )
@@ -18,7 +26,7 @@ def test_linear_prerequisites_ok() -> None:
 def test_self_cycle_rejected() -> None:
     with pytest.raises(PrerequisiteCycleError, match="cycle"):
         detect_prerequisite_cycle(
-            config_name="a",
+            deployment_name="a",
             prerequisites=["a"],
             existing={},
         )
@@ -27,7 +35,30 @@ def test_self_cycle_rejected() -> None:
 def test_three_node_cycle_rejected() -> None:
     with pytest.raises(PrerequisiteCycleError):
         detect_prerequisite_cycle(
-            config_name="a",
+            deployment_name="a",
             prerequisites=["c"],
             existing={"b": ["a"], "c": ["b"]},
         )
+
+
+def test_qualified_prerequisite_name_normalizes_to_bare_name() -> None:
+    assert normalized_prerequisite_name("default/foo", "default") == "foo"
+    assert normalized_prerequisite_name("foo", "default") == "foo"
+    assert normalized_prerequisite_name("other/foo", "default") == "other/foo"
+
+
+def test_cycle_detected_when_existing_uses_qualified_same_workspace_ref() -> None:
+    b = make_deployment("b")
+    b.prerequisites = [Prerequisite(deployment_name="default/a")]
+    existing = build_existing_prerequisite_map([b])
+    with pytest.raises(PrerequisiteCycleError):
+        detect_prerequisite_cycle(
+            deployment_name="a",
+            prerequisites=["b"],
+            existing=existing,
+        )
+
+
+def test_prerequisite_names_normalizes_for_create_validation() -> None:
+    names = prerequisite_names([Prerequisite(deployment_name="default/puller")], "default")
+    assert names == ["puller"]

--- a/plugins/nemo-deployments/tests/unit/test_prerequisite_validation.py
+++ b/plugins/nemo-deployments/tests/unit/test_prerequisite_validation.py
@@ -9,6 +9,7 @@ from nemo_deployments_plugin.entities import Prerequisite
 from nemo_deployments_plugin.validation import (
     PrerequisiteCycleError,
     build_existing_prerequisite_map,
+    deployment_graph_key,
     detect_prerequisite_cycle,
     normalized_prerequisite_name,
     prerequisite_names,
@@ -17,17 +18,17 @@ from nemo_deployments_plugin.validation import (
 
 def test_linear_prerequisites_ok() -> None:
     detect_prerequisite_cycle(
-        deployment_name="c",
-        prerequisites=["b"],
-        existing={"a": [], "b": ["a"]},
+        deployment_name="default/c",
+        prerequisites=["default/b"],
+        existing={"default/a": [], "default/b": ["default/a"]},
     )
 
 
 def test_self_cycle_rejected() -> None:
     with pytest.raises(PrerequisiteCycleError, match="cycle"):
         detect_prerequisite_cycle(
-            deployment_name="a",
-            prerequisites=["a"],
+            deployment_name="default/a",
+            prerequisites=["default/a"],
             existing={},
         )
 
@@ -35,15 +36,15 @@ def test_self_cycle_rejected() -> None:
 def test_three_node_cycle_rejected() -> None:
     with pytest.raises(PrerequisiteCycleError):
         detect_prerequisite_cycle(
-            deployment_name="a",
-            prerequisites=["c"],
-            existing={"b": ["a"], "c": ["b"]},
+            deployment_name="default/a",
+            prerequisites=["default/c"],
+            existing={"default/b": ["default/a"], "default/c": ["default/b"]},
         )
 
 
-def test_qualified_prerequisite_name_normalizes_to_bare_name() -> None:
-    assert normalized_prerequisite_name("default/foo", "default") == "foo"
-    assert normalized_prerequisite_name("foo", "default") == "foo"
+def test_qualified_prerequisite_name_uses_workspace_prefix() -> None:
+    assert normalized_prerequisite_name("default/foo", "default") == "default/foo"
+    assert normalized_prerequisite_name("foo", "default") == "default/foo"
     assert normalized_prerequisite_name("other/foo", "default") == "other/foo"
 
 
@@ -53,12 +54,12 @@ def test_cycle_detected_when_existing_uses_qualified_same_workspace_ref() -> Non
     existing = build_existing_prerequisite_map([b])
     with pytest.raises(PrerequisiteCycleError):
         detect_prerequisite_cycle(
-            deployment_name="a",
-            prerequisites=["b"],
+            deployment_name=deployment_graph_key("default", "a"),
+            prerequisites=[deployment_graph_key("default", "b")],
             existing=existing,
         )
 
 
 def test_prerequisite_names_normalizes_for_create_validation() -> None:
     names = prerequisite_names([Prerequisite(deployment_name="default/puller")], "default")
-    assert names == ["puller"]
+    assert names == ["default/puller"]


### PR DESCRIPTION
## Summary

Fast-follow to merged PR #315 (`AIRCORE-758`) implementing the four deferred items:

- **Prerequisites on Deployment** — moved from `DeploymentConfig` to `Deployment`; cycle validation runs on deployment create; controller loads terminal prerequisite deployments by name
- **Volume deletion reconciliation** — DELETE API marks volumes `DELETING`; reconciler deletes backend resource then entity
- **Terminal orphan grace TTL** — `terminal_orphan_grace_seconds` (default 3600) keeps `SUCCEEDED`/`FAILED` backend resources in orphan `known_ids` after terminal transition
- **Shutdown cancellation** — `NemoController.stop_requested()` wired through platform runner; `DeploymentsController` exits reconcile early between phases

Also includes pre-MR hardening: prerequisite ref normalization for cycle detection, skip orphan cleanup when terminal list fails, and conservative grace when `status_history` is missing.

**Breaking change:** `prerequisites` are no longer accepted on `DeploymentConfig` create; set them on each `Deployment` instead.

## Test plan

- [x] `pytest plugins/nemo-deployments/tests/unit` — 111 passed
- [x] `pytest packages/nmp_platform_runner/tests/test_plugin_adapter.py` — 6 passed
- [x] Pre-commit hooks (ruff, ty) pass on changed files
- [ ] `make refresh-openapi` in fully bootstrapped env (plugin OpenAPI manually updated at `plugins/nemo-deployments/openapi/openapi.yaml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployments now carry prerequisites (workspace-qualified names supported) and creation validates for prerequisite cycles.
  * Added cooperative shutdown so reconciliation can exit early when shutdown is requested.
  * Volume deletion is now staged via a `DELETING` status before entity removal.
  * Terminal deployments can be protected from orphan cleanup for a configurable grace period.
* **Bug Fixes**
  * Prerequisite evaluation/resolution now consistently uses deployment entities (not deployment-config identity).
  * Improved volume delete handling for not-found, already-gone, and conflict scenarios.
* **Documentation / API**
  * Updated NeMo Deployments documentation and OpenAPI schemas to match the new prerequisites model and `DELETING` status.
* **Tests**
  * Updated and added unit coverage for stop behavior, prerequisites, orphan cleanup, and deleting volumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->