### PR TITLE
chore: bump automodel base to grab wandb upgrade

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -75,7 +75,7 @@ variable "BASE_TAG_PYTHON" {
 
 # Pin for nmp-automodel-base.
 variable "BASE_TAG_AUTOMODEL" {
-  default = "907446243676db5406e2a0421d1ac060ad1f1e14"
+  default = "f8239353044d71cbd53e209b60c0600ead484b58"
 }
 
 # The tag for base images if needed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default pinned base image reference to a newer commit/tag, so builds now use an updated prebuilt base by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->