### PR TITLE
fix(auditor): use async SDK to rewrite IGW when necessary

### DIFF
--- a/plugins/nemo-auditor/src/nemo_auditor/jobs/audit.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/jobs/audit.py
@@ -17,6 +17,7 @@ and resume; local runs run to completion).
 
 from __future__ import annotations
 
+import asyncio
 import copy
 import json
 import logging
@@ -27,7 +28,7 @@ from typing import Annotated, ClassVar, TypeVar, cast
 
 import yaml
 from nemo_auditor.entities import AuditConfig, AuditTarget
-from nemo_platform import NeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform.resources.entities import AsyncEntitiesResource
 from nemo_platform_plugin.entities import parse_qualified_name
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
@@ -152,7 +153,11 @@ async def _resolve_ref(
         raise RuntimeError(f"{kind} '{ws}/{name}' not found in entity store") from exc
 
 
-def _rewrite_options_uris(options: dict, sdk: NeMoPlatform | None) -> None:
+def _rewrite_options_uris(
+    options: dict,
+    sdk: NeMoPlatform | None,
+    async_sdk: AsyncNeMoPlatform | None = None,
+) -> None:
     """Replace ``nmp_uri_spec`` sentinels in ``options`` with concrete ``uri`` values.
 
     Walks the options tree (BFS over dict values, non-dicts are skipped) and,
@@ -186,13 +191,23 @@ def _rewrite_options_uris(options: dict, sdk: NeMoPlatform | None) -> None:
             )
         if "uri" in node:
             raise ValueError("Cannot specify both 'uri' and 'nmp_uri_spec' in the same options block.")
-        if sdk is None:
+        if sdk is None and async_sdk is None:
             raise RuntimeError(
                 "nmp_uri_spec resolution requires a connected platform SDK; AuditJob.run was invoked without one."
             )
         try:
-            provider = sdk.inference.providers.retrieve(workspace=igw_ref["workspace"], name=igw_ref["provider"])
-            uri = sdk.models.get_provider_route_openai_url(provider)
+            if sdk is not None:
+                provider = sdk.inference.providers.retrieve(workspace=igw_ref["workspace"], name=igw_ref["provider"])
+                uri = sdk.models.get_provider_route_openai_url(provider)
+            else:
+                # async_sdk path: AuditJob.run() executes inside asyncio.to_thread(), so
+                # this worker thread has no running event loop — asyncio.run() is safe.
+                provider = asyncio.run(
+                    async_sdk.inference.providers.retrieve(  # type: ignore[union-attr]
+                        workspace=igw_ref["workspace"], name=igw_ref["provider"]
+                    )
+                )
+                uri = async_sdk.models.get_provider_route_openai_url(provider)  # type: ignore[union-attr]
         except Exception as exc:
             raise RuntimeError(
                 f"Failed to resolve inference gateway provider '{igw_ref['workspace']}/{igw_ref['provider']}': {exc}"
@@ -292,6 +307,7 @@ class AuditJob(NemoJob):
         *,
         ctx: JobContext,
         sdk: NeMoPlatform | None = None,
+        async_sdk: AsyncNeMoPlatform | None = None,
     ) -> dict:
         spec = AuditSpec.model_validate(config)
 
@@ -308,7 +324,7 @@ class AuditJob(NemoJob):
             # Deep-copy before rewriting so the validated AuditTarget on the spec
             # stays pristine; only the on-disk JSON we hand to garak is mutated.
             rewritten_options = copy.deepcopy(spec.target.options)
-            _rewrite_options_uris(rewritten_options, sdk)
+            _rewrite_options_uris(rewritten_options, sdk, async_sdk)
             target_opts_path = work_dir / "target_options.json"
             target_opts_path.write_text(json.dumps(rewritten_options))
 

--- a/plugins/nemo-auditor/tests/test_audit_job.py
+++ b/plugins/nemo-auditor/tests/test_audit_job.py
@@ -468,6 +468,35 @@ class TestRewriteOptionsUris:
         with pytest.raises(RuntimeError, match="requires a connected platform SDK"):
             _rewrite_options_uris(options, None)
 
+    def test_raises_when_both_sdk_and_async_sdk_are_none(self) -> None:
+        options = {
+            "nim": {
+                "nmp_uri_spec": {
+                    "inference_gateway": {"workspace": "default", "provider": "build"},
+                }
+            }
+        }
+        with pytest.raises(RuntimeError, match="requires a connected platform SDK"):
+            _rewrite_options_uris(options, None, async_sdk=None)
+
+    def test_resolves_nmp_uri_spec_via_async_sdk(self) -> None:
+        options = {
+            "nim": {
+                "max_tokens": 32,
+                "nmp_uri_spec": {
+                    "inference_gateway": {"workspace": "default", "provider": "nvidia-inference-api"},
+                },
+            }
+        }
+        async_sdk = MagicMock()
+        async_sdk.inference.providers.retrieve = AsyncMock(return_value=MagicMock())
+        async_sdk.models.get_provider_route_openai_url.return_value = "https://igw-async.example/v1"
+
+        _rewrite_options_uris(options, sdk=None, async_sdk=async_sdk)
+
+        assert options == {"nim": {"max_tokens": 32, "uri": "https://igw-async.example/v1"}}
+        async_sdk.inference.providers.retrieve.assert_called_once_with(workspace="default", name="nvidia-inference-api")
+
     def test_wraps_sdk_lookup_failure_in_runtimeerror(self) -> None:
         sdk = MagicMock()
         sdk.inference.providers.retrieve.side_effect = LookupError("no such provider")
@@ -532,6 +561,35 @@ class TestAuditJobIGW:
 
         on_disk = json.loads((ctx.storage.ephemeral / "target_options.json").read_text())
         assert on_disk == {"nim": {"max_tokens": 100}}
+
+    def test_run_resolves_nmp_uri_spec_via_async_sdk(self, tmp_path: Path, fake_garak_python: Path) -> None:
+        """async_sdk path: nmp_uri_spec is rewritten when sdk=None but async_sdk is provided."""
+        ctx = _make_ctx(tmp_path)
+        target = _make_target(
+            options={
+                "nim": {
+                    "max_tokens": 32,
+                    "nmp_uri_spec": {
+                        "inference_gateway": {"workspace": "default", "provider": "nvidia-inference-api"},
+                    },
+                }
+            }
+        )
+        spec = _make_spec_dict(target=target)
+
+        async_sdk = MagicMock()
+        async_sdk.inference.providers.retrieve = AsyncMock(return_value=MagicMock())
+        async_sdk.models.get_provider_route_openai_url.return_value = "https://igw-async.example/v1"
+
+        with patch("nemo_auditor.jobs.audit.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+            AuditJob().run(spec, ctx=ctx, sdk=None, async_sdk=async_sdk)
+
+        opts_path = ctx.storage.ephemeral / "target_options.json"
+        assert opts_path.exists()
+        on_disk = json.loads(opts_path.read_text())
+        assert on_disk == {"nim": {"max_tokens": 32, "uri": "https://igw-async.example/v1"}}
+        assert "nmp_uri_spec" in target.options["nim"]  # original spec untouched
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Existing Auditor URI rewrite code would fail if if using the async API to look up IGW URL. This uses the correct async SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving target URI sentinels using either a synchronous or asynchronous platform connection.
  * Audit runs can now accept an async platform interface and use it to rewrite target options before execution.

* **Bug Fixes**
  * Improved error handling when no platform connection is available, with a clearer failure message.
  * Added coverage to ensure resolved target settings are written correctly without altering the original validated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->