### PR TITLE
chore: remove ffmpeg related deps from automodel base

### DIFF
--- a/docker/Dockerfile.nmp-automodel-base
+++ b/docker/Dockerfile.nmp-automodel-base
@@ -115,6 +115,7 @@ COPY --from=nmp-automodel-base-builder /opt/venv /opt/venv
 COPY --from=nmp-automodel-base-builder /opt/Automodel /opt/Automodel
 # Builder pins uv 0.9.14 but does not ship it in the venv layer; PyTorch base may ship 0.10.x.
 COPY --from=ghcr.io/astral-sh/uv:0.9.14 /uv /bin/uv
+COPY docker/scripts/automodel-cve-cleanup.sh /bin/
 
 # Stale copies under NGC system site-packages (verified on nvcr.io/nvidia/pytorch:26.05-py3).
 # CVE scanners read dist-packages even when --system-site-packages resolves imports from /opt/venv.
@@ -142,6 +143,8 @@ RUN rm -rf \
     /usr/local/lib/python3.12/dist-packages/mlflow \
     /usr/local/lib/python3.12/dist-packages/mlflow-*.dist-info \
     /usr/local/lib/python3.12/dist-packages/mlflow_skinny-*.dist-info
+
+RUN bash /bin/automodel-cve-cleanup.sh
 
 ENV VIRTUAL_ENV=/opt/venv \
     UV_PROJECT_ENVIRONMENT=/opt/venv \

--- a/docker/automodel/README.md
+++ b/docker/automodel/README.md
@@ -85,6 +85,11 @@ Override registry: `export WHEELS_REGISTRY=...` and `export IMAGE_REGISTRY=...` 
 |-------|---------|
 | `3d98f6e3.diff` | Drop `decord` + `imageio-ffmpeg` (old bundled ffmpeg); use `torchcodec` for VLM video (`FORCE_QWENVL_VIDEO_READER=torchcodec`) |
 
+`docker/scripts/automodel-cve-cleanup.sh` runs in the published base image and removes
+unused PyAV/OpenCV packages plus their vendored FFmpeg libraries. Platform Automodel
+jobs use text/retrieval fine-tuning paths; VLM/diffusion media helpers that require
+`av` or `cv2` are intentionally not available in these runtime images.
+
 **Tasks image:** `uv sync --package nmp-automodel --no-dev --inexact` from the minimal workspace. CPU steps only need platform SDK glue; upgrading ancillary packages here does not affect training.
 
 **Training image:** Do **not** use `uv sync` — it upgrades `transformers` and breaks `PreTrainedModel`. Use **`uv pip install -e`** with **`--overrides no_override_requirements.txt`**, then `uv pip install --no-deps -e /opt/Automodel` to re-pin `nemo_automodel` from the base clone (not PyPI).

--- a/docker/scripts/automodel-cve-cleanup.sh
+++ b/docker/scripts/automodel-cve-cleanup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Automodel's platform task/training images do not use the VLM/diffusion media
+# paths that need PyAV or OpenCV. Those wheels vendor FFmpeg shared libraries
+# under av.libs/opencv_python_headless.libs, which are scanned independently.
+# Remove the full packages instead of deleting only .so files; the extension
+# modules link against those libraries and would fail to import anyway.
+for site_packages in /opt/venv/lib/python*/site-packages /usr/local/lib/python*/dist-packages; do
+    if [ -d "${site_packages}" ]; then
+        rm -rf \
+            "${site_packages}"/av \
+            "${site_packages}"/av-*.dist-info \
+            "${site_packages}"/av.libs \
+            "${site_packages}"/cv2 \
+            "${site_packages}"/opencv_python-*.dist-info \
+            "${site_packages}"/opencv_python.libs \
+            "${site_packages}"/opencv_python_headless-*.dist-info \
+            "${site_packages}"/opencv_python_headless.libs
+    fi
+done

--- a/tests/smoke_gpu/test_customizer_automodel.py
+++ b/tests/smoke_gpu/test_customizer_automodel.py
@@ -16,6 +16,10 @@ Two failure classes are caught at .so load time, before any GPU device is touche
                          the one installed (ABI mismatch)
 """
 
+import sys
+from importlib.util import find_spec
+from pathlib import Path
+
 import pytest
 
 
@@ -47,6 +51,22 @@ def test_causal_conv1d_importable():
 @pytest.mark.smoke_nmp_automodel_training
 def test_bitsandbytes_importable():
     import bitsandbytes  # noqa: F401
+
+
+@pytest.mark.smoke_nmp_automodel_tasks
+@pytest.mark.smoke_nmp_automodel_training
+@pytest.mark.parametrize("module", ["av", "cv2"])
+def test_unused_media_packages_removed(module: str):
+    assert find_spec(module) is None
+
+
+@pytest.mark.smoke_nmp_automodel_tasks
+@pytest.mark.smoke_nmp_automodel_training
+@pytest.mark.parametrize("directory", ["av.libs", "opencv_python.libs", "opencv_python_headless.libs"])
+def test_unused_media_shared_libraries_removed(directory: str):
+    for entry in sys.path:
+        if entry.endswith(("site-packages", "dist-packages")):
+            assert not (Path(entry) / directory).exists()
 
 
 @pytest.mark.smoke_nmp_automodel_tasks


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated cleanup step during image build to remove unused media-related Python packages and bundled libraries from the base image.
  * Runtime images no longer include `av`/`cv2`-dependent media helpers.

* **Bug Fixes**
  * Reduced the chance of shipping stale or vulnerable package artifacts in published images.

* **Tests**
  * Added smoke checks to verify the unwanted media packages and shared libraries are not present in the final environment.

* **Documentation**
  * Updated build notes to describe the cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->