### PR TITLE
fix(studio): tooltip for mean metric columns

### DIFF
--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/MeanValueTooltipCell.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/MeanValueTooltipCell.tsx
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Text, Tooltip } from '@nvidia/foundations-react-core';
+import { tooltipClassName } from '@studio/styles/common';
+import { type FC, type ReactNode } from 'react';
+
+/**
+ * Builds the hover explanation for an aggregated metric cell — which statistic is shown, over how
+ * many runs it was computed (N), and how many runs exist in total (M). N is the metric's own
+ * `count` (how many runs contributed a value); M is the experiment's `run_count`. The shape is
+ * identical for every evaluator and for cost/latency, so the only per-metric inputs are the label
+ * and the run noun — nothing producer-specific.
+ *
+ * @example "Mean Accuracy over 8 scored runs (of 10 total)."
+ */
+const aggregateMetricTooltip = (
+  label: string,
+  runNoun: string,
+  count: number | null | undefined,
+  runCount: number | null | undefined
+): string => {
+  const contributing = count ?? 0;
+  const total = runCount ?? 0;
+  const noun = contributing === 1 ? runNoun : `${runNoun}s`;
+  return `Mean ${label} over ${contributing} ${noun} (of ${total} total).`;
+};
+
+interface MeanValueTooltipCellProps {
+  /** Human-readable metric name, e.g. an evaluator title or "cost". */
+  label: string;
+  /** Singular noun for one contributing run — "scored run" for evaluators, "run" for cost/latency. */
+  runNoun: string;
+  /** How many runs contributed a value to this metric's aggregate (N). */
+  count: number | null | undefined;
+  /** Total runs in the experiment (M). */
+  runCount: number | null | undefined;
+  /** The formatted metric value to display. */
+  children: ReactNode;
+}
+
+/**
+ * A metric value with a hover tooltip explaining how it was aggregated and over how many runs. The
+ * dotted underline marks the value as hoverable, matching the Name column's affordance.
+ */
+export const MeanValueTooltipCell: FC<MeanValueTooltipCellProps> = ({
+  label,
+  runNoun,
+  count,
+  runCount,
+  children,
+}) => (
+  <Tooltip
+    slotContent={
+      <Text kind="body/regular/sm">{aggregateMetricTooltip(label, runNoun, count, runCount)}</Text>
+    }
+    className={tooltipClassName}
+    side="bottom"
+  >
+    <Text className="cursor-default border-b border-dotted border-brand">{children}</Text>
+  </Tooltip>
+);

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/MeanValueTooltipCell.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/MeanValueTooltipCell.tsx
@@ -5,15 +5,6 @@ import { Text, Tooltip } from '@nvidia/foundations-react-core';
 import { tooltipClassName } from '@studio/styles/common';
 import { type FC, type ReactNode } from 'react';
 
-/**
- * Builds the hover explanation for an aggregated metric cell — which statistic is shown, over how
- * many runs it was computed (N), and how many runs exist in total (M). N is the metric's own
- * `count` (how many runs contributed a value); M is the experiment's `run_count`. The shape is
- * identical for every evaluator and for cost/latency, so the only per-metric inputs are the label
- * and the run noun — nothing producer-specific.
- *
- * @example "Mean Accuracy over 8 scored runs (of 10 total)."
- */
 const aggregateMetricTooltip = (
   label: string,
   runNoun: string,
@@ -27,22 +18,13 @@ const aggregateMetricTooltip = (
 };
 
 interface MeanValueTooltipCellProps {
-  /** Human-readable metric name, e.g. an evaluator title or "cost". */
   label: string;
-  /** Singular noun for one contributing run — "scored run" for evaluators, "run" for cost/latency. */
   runNoun: string;
-  /** How many runs contributed a value to this metric's aggregate (N). */
   count: number | null | undefined;
-  /** Total runs in the experiment (M). */
   runCount: number | null | undefined;
-  /** The formatted metric value to display. */
   children: ReactNode;
 }
 
-/**
- * A metric value with a hover tooltip explaining how it was aggregated and over how many runs. The
- * dotted underline marks the value as hoverable, matching the Name column's affordance.
- */
 export const MeanValueTooltipCell: FC<MeanValueTooltipCellProps> = ({
   label,
   runNoun,

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -16,6 +16,7 @@ import { useGetExperimentGroup } from '@nemo/sdk/generated/platform/api';
 import type { ExperimentFilter } from '@nemo/sdk/generated/platform/schema';
 import { Button, Text, Tooltip } from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/dataViews/ExperimentGroupDataView/Empty';
+import { MeanValueTooltipCell } from '@studio/components/dataViews/ExperimentGroupDataView/MeanValueTooltipCell';
 import {
   type ExperimentRow,
   type ListExperimentsSortParam,
@@ -258,28 +259,59 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
           id: `score-${index}`,
           header: `Avg ${snakeCaseToTitleCase(name)}`,
           enableSorting: false,
+          meta: { title: false },
           size: 140,
-          cell: ({ getValue }) => (
-            <Text>{formatEvaluatorScore(getValue<number | undefined>())}</Text>
-          ),
+          cell: ({ row }) => {
+            const score = row.original.aggregate_scores?.[name];
+            return (
+              <MeanValueTooltipCell
+                label={snakeCaseToTitleCase(name)}
+                runNoun="scored run"
+                count={score?.count}
+                runCount={row.original.run_count}
+              >
+                {formatEvaluatorScore(score?.mean)}
+              </MeanValueTooltipCell>
+            );
+          },
         })
       ),
       accessor((original) => original.cost_usd?.mean, {
         id: 'cost_usd',
         header: 'Avg Cost',
         enableSorting: false,
+        meta: { title: false },
         cell: ({ row }) => {
-          const mean = row.original.cost_usd?.mean;
-          return <Text>{mean != null ? `$${mean.toFixed(3)}` : '-'}</Text>;
+          const { cost_usd, run_count } = row.original;
+          return (
+            <MeanValueTooltipCell
+              label="cost"
+              runNoun="run"
+              count={cost_usd?.count}
+              runCount={run_count}
+            >
+              {cost_usd?.mean != null ? `$${cost_usd.mean.toFixed(3)}` : '-'}
+            </MeanValueTooltipCell>
+          );
         },
       }),
       accessor((original) => original.latency_ms?.mean, {
         id: 'latency_ms',
         header: 'Avg Latency',
+        meta: { title: false },
         enableSorting: false,
         cell: ({ row }) => {
-          const mean = row.original.latency_ms?.mean;
-          return <Text>{mean != null ? `${Math.round(mean)} ms` : '-'}</Text>;
+          const { latency_ms, run_count } = row.original;
+          return (
+            <MeanValueTooltipCell
+              label="latency"
+              runNoun="run"
+              count={latency_ms?.count}
+              runCount={run_count}
+            >
+              {latency_ms?.mean != null ? `${Math.round(latency_ms.mean)} ms` : '-'}
+            </MeanValueTooltipCell>
+          );
         },
       }),
       accessor((original) => original.run_count, {


### PR DESCRIPTION

https://github.com/user-attachments/assets/2dcc948e-06ab-49db-a1c1-ba1dfdc59562



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hover tooltips to aggregate metric values (evaluator averages, average cost, and average latency) in experiment group tables.
  * Tooltip text now summarizes the mean value and how many runs it represents.

* **Bug Fixes**
  * Improved handling of missing metrics by showing `-` when values aren’t available.
  * Tooltip wording is more consistent when run counts are missing (treated as zero) and properly pluralizes run nouns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->