### PR TITLE
fix(studio): enforce single-select without callback and apply attributes prop

### DIFF
--- a/web/packages/studio/src/components/DatasetsTable/index.tsx
+++ b/web/packages/studio/src/components/DatasetsTable/index.tsx
@@ -40,6 +40,7 @@ export const DatasetsTable: FC<DatasetsTableProps> = ({
   getDatasetRoute,
   renderRowActions,
   purposeFilter,
+  attributes,
 }) => {
   const {
     workspace,
@@ -128,6 +129,7 @@ export const DatasetsTable: FC<DatasetsTableProps> = ({
             : undefined
         }
         attributes={{
+          ...attributes,
           DataViewSearchBar: {
             placeholder: 'Search filesets...',
           },

--- a/web/packages/studio/src/components/DatasetsTable/useDatasetsTable.ts
+++ b/web/packages/studio/src/components/DatasetsTable/useDatasetsTable.ts
@@ -116,8 +116,6 @@ export function useDatasetsTable({
     if (selection === prevSelectionRef.current) return;
     prevSelectionRef.current = selection;
 
-    if (!onDatasetsSelected) return;
-
     // For single selection, keep only the most recently selected row
     const selectedIds = Object.keys(selection).filter((id) => selection[id]);
     if (selectionType === 'single' && selectedIds.length > 1) {
@@ -125,6 +123,8 @@ export function useDatasetsTable({
       dataViewState.rowSelection.set({ [lastSelected]: true });
       return; // The set above will re-trigger this effect with the corrected state
     }
+
+    if (!onDatasetsSelected) return;
 
     const selectedDatasets = datasets.filter((d) => selection[d.id]);
     onDatasetsSelected(selectedDatasets);


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs in `DatasetsTable` (logic moved verbatim from `main` during ASTD-229 decomposition):

### Bug 1: Single-select bypassed when no callback
- **File**: `useDatasetsTable.ts` (~line 112)
- **Issue**: The selection effect checks `if (!onDatasetsSelected) return;` BEFORE the single-select normalization. With `selectionType === 'single'` and no `onDatasetsSelected`, multiple rows can stay selected.
- **Fix**: Moved single-select normalization logic before the early return.

### Bug 2: `attributes` prop declared but never applied
- **File**: `DatasetsTable/index.tsx` (lines 32-43 / 130-174)
- **Issue**: `DatasetsTableProps.attributes` is part of the public API but is never merged into the DataView config, so external `DataViewRoot`/`DataViewContent` overrides are silently ignored.
- **Fix**: Spread `attributes` prop into `StudioDataView`'s attributes.

### Testing
- All 29 existing tests pass
- Type checking passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dataset tables can now accept additional view attributes, allowing callers to customize or extend table display behavior.

* **Bug Fixes**
  * Row selection handling now works more consistently when no selection callback is provided, while preserving single-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->