### PR TITLE
feat(nemo-agents-plugin): add cursor adapter to nemo-agents plugin

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -468,6 +468,7 @@ nmp = "nemo_platform.cli.app:cli"
 # Generated from [tool.bundle-package]; do not edit this table by hand.
 [project.entry-points."nat.components"]
 nat_codex_agent_adapter = "nat_codex_agent_adapter.register"
+nat_cursor_agent_adapter = "nat_cursor_agent_adapter.register"
 nemo_agents_example_calculator = "calculator_agent.register"
 
 # Generated from [tool.bundle-package]; do not edit this table by hand.
@@ -598,7 +599,7 @@ garak-api = { source = "../../packages/garak_api/garakapi", module = "garakapi",
 switchyard-vendored = { source = "../../plugins/nemo-switchyard/vendor/switchyard/switchyard", module = "switchyard" }
 
 # Default first-party plugins
-nemo-agents-plugin = { source = "../../plugins/nemo-agents/src/nemo_agents_plugin", module = "nemo_agents_plugin", inherit = { "entry-points" = ["nemo.*", "nat.plugins", "nat.components"] }, force_include = { "../../vendor/codex_agent_adapter/src/nat_codex_agent_adapter" = "nat_codex_agent_adapter" } }
+nemo-agents-plugin = { source = "../../plugins/nemo-agents/src/nemo_agents_plugin", module = "nemo_agents_plugin", inherit = { "entry-points" = ["nemo.*", "nat.plugins", "nat.components"] }, force_include = { "../../vendor/codex_agent_adapter/src/nat_codex_agent_adapter" = "nat_codex_agent_adapter", "../../vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter" = "nat_cursor_agent_adapter" } }
 nemo-anonymizer-plugin = { source = "../../plugins/nemo-anonymizer/src/nemo_anonymizer_plugin", module = "nemo_anonymizer_plugin", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-auditor-plugin = { source = "../../plugins/nemo-auditor/src/nemo_auditor", module = "nemo_auditor", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-data-designer-plugin = { source = "../../plugins/nemo-data-designer/src/nemo_data_designer_plugin", module = "nemo_data_designer_plugin", inherit = { "entry-points" = ["nemo.*"] } }

--- a/plugins/nemo-agents/examples/cursor-agent/README.md
+++ b/plugins/nemo-agents/examples/cursor-agent/README.md
@@ -1,0 +1,52 @@
+# Cursor Agent
+
+This example configures the vendored Cursor workflow adapter shipped with the
+`nemo-agents` plugin.
+
+The adapter is already packaged with `nemo-agents`; do not install a separate
+NAT Cursor adapter package.
+
+## Prerequisites
+
+Install the Cursor Agent CLI and configure authentication in the same
+environment that will run `nemo`:
+
+```bash
+curl https://cursor.com/install -fsS | bash
+cursor-agent login
+cursor-agent status
+```
+
+For non-interactive environments, set `CURSOR_API_KEY` before starting `nemo`.
+
+Install the NeMo Relay CLI so `nemo-relay` is available on `PATH`:
+
+```bash
+git clone git@github.com:NVIDIA/NeMo-Relay.git
+export NEMO_RELAY_ROOT="$PWD/NeMo-Relay"
+cargo install --path "$NEMO_RELAY_ROOT/crates/cli" --root "${VIRTUAL_ENV:-.venv}" --locked
+nemo-relay --help
+```
+
+## Run on NeMo Platform
+
+From the `nemo-platform` repository root, create and deploy the example agent:
+
+```bash
+nemo agents create \
+  --name cursor-agent \
+  --agent-config plugins/nemo-agents/examples/cursor-agent/cursor-agent.yml
+
+nemo agents deploy --agent cursor-agent
+```
+
+Invoke it with a read-only prompt first:
+
+```bash
+nemo agents invoke \
+  --agent cursor-agent \
+  --input "Read pyproject.toml and say only the project name. Do not edit files."
+```
+
+The config uses `mode: plan` by default. It also sets `trust_workspace: true`
+because Cursor Agent requires workspace trust for headless `--print` runs.

--- a/plugins/nemo-agents/examples/cursor-agent/README.md
+++ b/plugins/nemo-agents/examples/cursor-agent/README.md
@@ -19,7 +19,11 @@ cursor-agent status
 
 For non-interactive environments, set `CURSOR_API_KEY` before starting `nemo`.
 
-Install the NeMo Relay CLI so `nemo-relay` is available on `PATH`:
+Install Rust so `cargo` is available on `PATH`, then install the NeMo Relay CLI.
+The `cargo install` command below writes `nemo-relay` into the active virtual
+environment when `VIRTUAL_ENV` is set, or into `.venv` otherwise. After
+activating that environment, `nemo-relay --help` should resolve on `PATH` for
+the smoke test:
 
 ```bash
 git clone git@github.com:NVIDIA/NeMo-Relay.git

--- a/plugins/nemo-agents/examples/cursor-agent/cursor-agent.yml
+++ b/plugins/nemo-agents/examples/cursor-agent/cursor-agent.yml
@@ -1,0 +1,32 @@
+# cursor-agent.yml
+#
+# A Cursor-backed NAT workflow for local coding tasks.
+#
+# Requires the cursor-agent and nemo-relay CLIs to be installed and available on
+# PATH, with Cursor authentication already configured.
+#
+# Platform-managed deployment:
+#   nemo agents create --name cursor-agent --agent-config examples/cursor-agent/cursor-agent.yml
+#   nemo agents deploy --agent cursor-agent
+#   nemo agents invoke --agent cursor-agent \
+#       --input "Read pyproject.toml and say only the project name. Do not edit files."
+
+workflow:
+  _type: cursor_agent
+  command: cursor-agent
+  # Change this to the repository or workspace Cursor should operate in.
+  working_directory: .
+  mode: plan
+  sandbox: disabled
+  trust_workspace: true
+  timeout_seconds: 300
+  max_output_chars: 12000
+  relay_atof_output_dir: ./.tmp/nemo-relay-cursor-atof
+
+general:
+  telemetry:
+    tracing:
+      nemo_trace:
+        _type: nemo_files
+        # workspace and agent_name are injected at deploy time
+        batch_size: 128

--- a/plugins/nemo-agents/pyproject.toml
+++ b/plugins/nemo-agents/pyproject.toml
@@ -51,6 +51,7 @@ nemo_agents_files_telemetry = "nemo_agents_plugin.telemetry.files_service_export
 # NeMo Agent Toolkit — register vendored workflow adapters (see nat.components)
 [project.entry-points."nat.components"]
 nat_codex_agent_adapter = "nat_codex_agent_adapter.register"
+nat_cursor_agent_adapter = "nat_cursor_agent_adapter.register"
 
 [project.optional-dependencies]
 container = [
@@ -73,6 +74,7 @@ build-backend = "hatchling.build"
 packages = [
     "src/nemo_agents_plugin",
     "vendor/codex_agent_adapter/src/nat_codex_agent_adapter",
+    "vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter",
 ]
 
 [tool.uv.sources]

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/validator.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/validator.py
@@ -17,6 +17,7 @@ import yaml
 _KNOWN_WORKFLOW_TYPES = frozenset(
     {
         "codex_agent",
+        "cursor_agent",
         "react_agent",
         "tool_calling_agent",
         "reasoning_agent",

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -607,7 +607,14 @@ class TestValidateAgentConfig:
     def test_known_workflow_types_pass(self, tmp_path: Path) -> None:
         from nemo_agents_plugin.container.validator import validate_agent_config
 
-        for wf_type in ("codex_agent", "react_agent", "tool_calling_agent", "reasoning_agent", "rewoo_agent"):
+        for wf_type in (
+            "codex_agent",
+            "cursor_agent",
+            "react_agent",
+            "tool_calling_agent",
+            "reasoning_agent",
+            "rewoo_agent",
+        ):
             p = tmp_path / f"{wf_type}.yaml"
             p.write_text(f"workflow:\n  _type: {wf_type}\n")
             result = validate_agent_config(p)

--- a/plugins/nemo-agents/tests/unit/test_cursor_adapter_packaging.py
+++ b/plugins/nemo-agents/tests/unit/test_cursor_adapter_packaging.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the vendored Cursor adapter packaging."""
+
+from importlib.metadata import entry_points
+from pathlib import Path
+
+import yaml
+from nat_cursor_agent_adapter.register import CursorAgentWorkflowConfig
+
+_NEMO_AGENTS_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_cursor_agent_workflow_type_registered() -> None:
+    assert CursorAgentWorkflowConfig._typed_model_name == "cursor_agent"
+
+
+def test_cursor_adapter_nat_components_entry_point_registered() -> None:
+    eps = entry_points(group="nat.components")
+    ep = next(ep for ep in eps if ep.name == "nat_cursor_agent_adapter")
+    assert ep.value == "nat_cursor_agent_adapter.register"
+
+
+def test_cursor_example_config_validates_without_warnings() -> None:
+    from nemo_agents_plugin.container.validator import validate_agent_config
+
+    example = _NEMO_AGENTS_ROOT / "examples" / "cursor-agent" / "cursor-agent.yml"
+
+    data = yaml.safe_load(example.read_text(encoding="utf-8"))
+    assert data["workflow"]["_type"] == "cursor_agent"
+    assert data["general"]["telemetry"]["tracing"]["nemo_trace"]["_type"] == "nemo_files"
+
+    result = validate_agent_config(example)
+    assert result.valid
+    assert result.errors == []
+    assert result.warnings == []

--- a/plugins/nemo-agents/tests/unit/test_cursor_adapter_packaging.py
+++ b/plugins/nemo-agents/tests/unit/test_cursor_adapter_packaging.py
@@ -13,7 +13,7 @@ _NEMO_AGENTS_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_cursor_agent_workflow_type_registered() -> None:
-    assert CursorAgentWorkflowConfig._typed_model_name == "cursor_agent"
+    assert CursorAgentWorkflowConfig.static_type() == "cursor_agent"
 
 
 def test_cursor_adapter_nat_components_entry_point_registered() -> None:

--- a/plugins/nemo-agents/vendor/cursor_agent_adapter/README.md
+++ b/plugins/nemo-agents/vendor/cursor_agent_adapter/README.md
@@ -1,0 +1,20 @@
+# Vendored Cursor agent adapter
+
+Snapshot of `examples/experimental/cursor_agent_adapter` from
+[NVIDIA/NeMo-Agent-Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) at commit
+[`ffa626e512e0b9bdb973f3ebe4f4122272092499`](https://github.com/NVIDIA/NeMo-Agent-Toolkit/commit/ffa626e512e0b9bdb973f3ebe4f4122272092499).
+
+Copied upstream files:
+
+- `src/nat_cursor_agent_adapter/`
+
+Generated files, example configs, data files, and local development artifacts
+from the upstream example are intentionally omitted, including `uv.lock`.
+
+The vendored adapter registers the NAT workflow type `_type: cursor_agent`.
+Runtime use still requires external `cursor-agent` and `nemo-relay` commands to
+be installed and configured in the environment that launches NAT.
+
+To refresh this snapshot, copy the same included files from the new upstream
+commit, preserve SPDX headers, and update this file with the new commit hash and
+summary.

--- a/plugins/nemo-agents/vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter/__init__.py
+++ b/plugins/nemo-agents/vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/plugins/nemo-agents/vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter/register.py
+++ b/plugins/nemo-agents/vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter/register.py
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Register the experimental Cursor Agent adapter with NVIDIA NeMo Agent Toolkit."""
+
+import asyncio
+import datetime
+import json
+import shlex
+import tempfile
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import Any, Literal
+
+from nat.builder.builder import Builder
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.agent import AgentBaseConfig
+from nat.data_models.api_server import ChatRequest, ChatRequestOrMessage, ChatResponse, ChatResponseChunk, Usage
+from nat.data_models.component_ref import LLMRef
+from nat.experimental.relay_telemetry_bridge import inject_atof_jsonl
+from nat.utils.type_converter import GlobalTypeConverter
+from pydantic import Field
+
+CursorMode = Literal["plan", "ask"]
+SandboxMode = Literal["enabled", "disabled"]
+
+
+class CursorAgentWorkflowConfig(AgentBaseConfig, name="cursor_agent"):
+    """Configuration for the Cursor Agent CLI workflow."""
+
+    llm_name: LLMRef | None = Field(
+        default=None,
+        description=(
+            "Optional NAT LLM reference. Cursor Agent manages model selection through `model`, so this "
+            "field is accepted for agent config consistency but is not used."
+        ),
+    )
+    description: str = Field(default="Cursor Agent CLI Workflow", description="The description of this function's use.")
+
+    command: str = Field(default="cursor-agent", description="Cursor Agent CLI command or absolute path.")
+    command_args: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Additional arguments inserted after `command` and before Cursor Agent non-interactive query arguments."
+        ),
+    )
+    working_directory: str = Field(default=".", description="Directory used as the Cursor Agent workspace.")
+    mode: CursorMode | None = Field(default="plan", description="Cursor Agent execution mode.")
+    model: str | None = Field(default=None, description="Optional Cursor Agent model name.")
+    sandbox: SandboxMode | None = Field(default=None, description="Optional Cursor Agent sandbox setting.")
+    trust_workspace: bool = Field(
+        default=False,
+        description=("Pass `--trust` for non-interactive runs after the workspace has been reviewed and trusted."),
+    )
+    max_history: int | None = Field(default=15, ge=1, description="Maximum NAT chat messages to include in prompt.")
+    timeout_seconds: float = Field(default=120.0, gt=0, description="Overall Cursor Agent CLI timeout.")
+    max_output_chars: int = Field(default=12000, gt=0, description="Maximum returned output characters.")
+    relay_command: str = Field(default="nemo-relay", description="NeMo Relay CLI command or absolute path.")
+    relay_atof_output_dir: str | None = Field(
+        default=None,
+        description=(
+            "Optional directory where Relay ATOF JSONL should be persisted. If unset, the adapter uses a "
+            "temporary directory and removes it after importing telemetry."
+        ),
+    )
+    relay_patch_restore_hooks: bool = Field(
+        default=True,
+        description=(
+            "Allow NeMo Relay to temporarily merge Cursor hook entries into project `.cursor/hooks.json` "
+            "and restore the original file after the run."
+        ),
+    )
+
+
+def _clip(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + f"\n\n[truncated to {max_chars} characters]"
+
+
+def _nat_message_content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+            else:
+                text = getattr(block, "text", None)
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return str(content)
+
+
+def _role_to_text(role: Any) -> str:
+    return getattr(role, "value", str(role))
+
+
+def _build_prompt(message: ChatRequestOrMessage, config: CursorAgentWorkflowConfig) -> str:
+    if message.is_string:
+        return message.input_message or ""
+
+    chat_request = GlobalTypeConverter.get().convert(message, to_type=ChatRequest)
+    messages = chat_request.messages[-config.max_history :] if config.max_history else chat_request.messages
+
+    if len(messages) == 1 and _role_to_text(messages[0].role) == "user":
+        return _nat_message_content_to_text(messages[0].content)
+
+    prompt_parts = []
+    for chat_message in messages:
+        role = _role_to_text(chat_message.role)
+        content = _nat_message_content_to_text(chat_message.content)
+        prompt_parts.append(f"{role}: {content}")
+    return "\n\n".join(prompt_parts)
+
+
+def _usage_for(prompt: str, response: str) -> Usage:
+    prompt_tokens = len(prompt.split()) if prompt else 0
+    completion_tokens = len(response.split()) if response else 0
+    return Usage(
+        prompt_tokens=prompt_tokens, completion_tokens=completion_tokens, total_tokens=prompt_tokens + completion_tokens
+    )
+
+
+def _as_response(content: str, prompt: str, model: str | None) -> ChatResponse:
+    return ChatResponse.from_string(
+        content,
+        model=model or "cursor-agent",
+        created=datetime.datetime.now(datetime.UTC),
+        usage=_usage_for(prompt, content),
+    )
+
+
+def _build_cursor_args(config: CursorAgentWorkflowConfig, prompt: str) -> list[str]:
+    command = [
+        "--print",
+        "--output-format",
+        "text",
+        "--workspace",
+        str(Path(config.working_directory).resolve()),
+    ]
+    if config.mode:
+        command.extend(["--mode", config.mode])
+    if config.sandbox:
+        command.extend(["--sandbox", config.sandbox])
+    if config.trust_workspace:
+        command.append("--trust")
+    if config.model:
+        command.extend(["--model", config.model])
+    command.append(prompt)
+    return command
+
+
+def _write_relay_config(config: CursorAgentWorkflowConfig, path: Path) -> None:
+    cursor_command = shlex.join([config.command, *config.command_args])
+    path.write_text(
+        "[agents.cursor]\n"
+        f"command = {json.dumps(cursor_command)}\n"
+        f"patch_restore_hooks = {str(config.relay_patch_restore_hooks).lower()}\n"
+    )
+
+
+def _relay_plugin_config(atof_dir: Path) -> str:
+    return json.dumps(
+        {
+            "version": 1,
+            "components": [
+                {
+                    "kind": "observability",
+                    "enabled": True,
+                    "config": {
+                        "atof": {
+                            "enabled": True,
+                            "output_directory": str(atof_dir),
+                            "filename": "events.jsonl",
+                            "mode": "overwrite",
+                        }
+                    },
+                }
+            ],
+        }
+    )
+
+
+def _build_relay_command(
+    config: CursorAgentWorkflowConfig, prompt: str, relay_config_path: Path, atof_dir: Path
+) -> list[str]:
+    return [
+        config.relay_command,
+        "run",
+        "--agent",
+        "cursor",
+        "--config",
+        str(relay_config_path),
+        "--plugin-config",
+        _relay_plugin_config(atof_dir),
+        "--",
+        *_build_cursor_args(config, prompt),
+    ]
+
+
+def _inject_relay_events(atof_path: Path) -> None:
+    if atof_path.exists():
+        inject_atof_jsonl(atof_path)
+
+
+def _cursor_auth_hint(command_name: str) -> str:
+    return (
+        f"Cursor Agent CLI is not authenticated. Run `{command_name} login` and "
+        f"`{command_name} status` from the same shell that runs `nat`, or export `CURSOR_API_KEY` before "
+        "starting the workflow. Cursor app login may not be visible to the standalone agent CLI."
+    )
+
+
+def _cursor_trust_hint() -> str:
+    return (
+        "Cursor Agent CLI needs workspace trust for headless `--print` runs. Review the workspace, then set "
+        "`trust_workspace: true` in the workflow config or run Cursor Agent interactively once to trust it."
+    )
+
+
+def _cursor_sandbox_hint() -> str:
+    return (
+        "Cursor Agent sandboxing is not available on this system. Keep `mode: plan` for read-only planning and "
+        "set `sandbox: disabled`, or omit `sandbox` to use the local Cursor Agent default."
+    )
+
+
+async def _run_cursor_agent(prompt: str, config: CursorAgentWorkflowConfig) -> str:
+    cwd = Path(config.working_directory).resolve()
+    relay_temp_dir = tempfile.TemporaryDirectory(prefix="nat-cursor-relay-")
+    relay_root = Path(relay_temp_dir.name)
+    relay_config_path = relay_root / "config.toml"
+    relay_atof_dir = (
+        Path(config.relay_atof_output_dir).resolve() if config.relay_atof_output_dir else relay_root / "atof"
+    )
+    relay_atof_dir.mkdir(parents=True, exist_ok=True)
+    _write_relay_config(config, relay_config_path)
+    relay_atof_path = relay_atof_dir / "events.jsonl"
+    command = _build_relay_command(config, prompt, relay_config_path, relay_atof_dir)
+    if not cwd.exists() or not cwd.is_dir():
+        relay_temp_dir.cleanup()
+        raise RuntimeError(f"Invalid working_directory {config.working_directory!r}: {cwd} is not a directory.")
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *command, cwd=str(cwd), stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+    except FileNotFoundError as error:
+        relay_temp_dir.cleanup()
+        raise RuntimeError(
+            f"Could not find NeMo Relay CLI command: {command[0]}. Install NeMo Relay as `nemo-relay` or set "
+            "`relay_command` in the workflow config. Also install Cursor Agent as `cursor-agent` or set `command` / "
+            "`command_args` in the workflow config."
+        ) from error
+
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(process.communicate(), timeout=config.timeout_seconds)
+    except TimeoutError as error:
+        process.kill()
+        await process.wait()
+        try:
+            _inject_relay_events(relay_atof_path)
+        finally:
+            relay_temp_dir.cleanup()
+        raise RuntimeError(f"Cursor Agent CLI timed out after {config.timeout_seconds} seconds") from error
+
+    stdout = stdout_bytes.decode(errors="replace").strip()
+    stderr = stderr_bytes.decode(errors="replace").strip()
+    try:
+        _inject_relay_events(relay_atof_path)
+    finally:
+        relay_temp_dir.cleanup()
+
+    if process.returncode:
+        details = "\n".join(part for part in [stderr, stdout] if part)
+        if "Authentication required" in details or "CURSOR_API_KEY" in details:
+            details = f"{details}\n\n{_cursor_auth_hint(config.command)}"
+        if "Workspace Trust Required" in details:
+            details = f"{details}\n\n{_cursor_trust_hint()}"
+        if "Sandbox mode is enabled but not available" in details:
+            details = f"{details}\n\n{_cursor_sandbox_hint()}"
+        raise RuntimeError(f"Cursor Agent CLI failed with exit code {process.returncode}: {_clip(details, 4000)}")
+
+    return _clip(stdout, config.max_output_chars)
+
+
+@register_function(config_type=CursorAgentWorkflowConfig)
+async def cursor_agent(config: CursorAgentWorkflowConfig, _builder: Builder) -> AsyncGenerator[FunctionInfo, None]:
+    """Create a Cursor Agent workflow function for NVIDIA NeMo Agent Toolkit.
+
+    Args:
+        config: Cursor Agent workflow configuration from the NeMo Agent Toolkit config system.
+        _builder: Toolkit builder supplied during workflow construction.
+
+    Yields:
+        FunctionInfo containing single-response and streaming handlers that invoke Cursor Agent through NeMo Relay.
+    """
+
+    async def _response_fn(chat_request_or_message: ChatRequestOrMessage) -> ChatResponse | str:
+        message = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequestOrMessage)
+        prompt = _build_prompt(message, config)
+        content = await _run_cursor_agent(prompt=prompt, config=config)
+
+        if message.is_string:
+            return content
+        return _as_response(content, prompt=prompt, model=config.model)
+
+    async def _stream_fn(chat_request_or_message: ChatRequestOrMessage) -> AsyncGenerator[ChatResponseChunk]:
+        message = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequestOrMessage)
+        prompt = _build_prompt(message, config)
+        yield ChatResponseChunk.from_string(
+            await _run_cursor_agent(prompt=prompt, config=config), model=config.model or "cursor-agent"
+        )
+
+    yield FunctionInfo.create(single_fn=_response_fn, stream_fn=_stream_fn, description=config.description)


### PR DESCRIPTION
## Summary

Adds experimental Cursor agent support to `nemo-agents` by vendoring the NAT
Cursor adapter and wiring it into the plugin package, following the same pattern
used for the Codex adapter.

This PR:

- Vendors the upstream Cursor adapter into `plugins/nemo-agents`
- Exposes the adapter through the `nat.components` entry point
- Recognizes `cursor_agent` in nemo-agents config validation
- Adds a Cursor example config and README
- Adds tests for adapter registration and example config validation
- Records upstream provenance for the vendored Cursor adapter, matching the
  Codex vendoring approach

## User Flow

Users install/use `nemo-agents` as usual, then provide a config with:

```yaml
workflow:
  _type: cursor_agent
```

The included example is:

```text
plugins/nemo-agents/examples/cursor-agent/cursor-agent.yml
```

The Cursor adapter requires `cursor-agent` and `nemo-relay` to be installed on
`PATH`. Relay is used internally by the adapter to run Cursor Agent and bridge
Cursor events into NAT telemetry.

The example config uses:

```yaml
workflow:
  _type: cursor_agent
  command: cursor-agent
  working_directory: .
  mode: plan
  sandbox: disabled
  trust_workspace: true
```

## Validation

Focused tests:

```bash
uv run --frozen pytest plugins/nemo-agents/tests/unit/test_cursor_adapter_packaging.py plugins/nemo-agents/tests/unit/test_codex_adapter_packaging.py plugins/nemo-agents/tests/unit/test_container.py -q
```

Result:

```text
104 passed, 1 warning
```

Additional checks:

```bash
tools/lint/lint-python-style.sh
uv run nemo agents package --agent plugins/nemo-agents/examples/cursor-agent/cursor-agent.yml --no-build --output /tmp/nemo-cursor-agent.Dockerfile
git diff --check
```

Manual smoke tests:

- `nemo agents create --name cursor-agent --agent-config plugins/nemo-agents/examples/cursor-agent/cursor-agent.yml`
- `nemo agents deploy --agent cursor-agent`
- `nemo agents invoke --agent cursor-agent --input "Read pyproject.toml and say only the project name. Do not edit files."`

Invoke returned:

```text
nemoplatform
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new Cursor-backed agent workflow.
  * Added a ready-to-use example configuration and setup guide for running it on NeMo Platform.
  * Bundled the Cursor adapter and exposed it via a new NAT component entry point.

* **Bug Fixes**
  * Updated workflow configuration validation to recognize the new Cursor workflow type.

* **Tests**
  * Added unit tests covering the workflow type, the new component entry point, and validation of the provided example configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->