### PR TITLE
feat(studio): intake trace/span view tweaks

### DIFF
--- a/web/packages/studio/src/components/IntakeDetail/IntakeComponents/SpanFeedbackControls.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/IntakeComponents/SpanFeedbackControls.tsx
@@ -3,7 +3,7 @@
 
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { FeedbackAnnotationInputValue } from '@nemo/sdk/generated/platform/schema';
-import { Badge, Button, Divider, Flex, Tooltip } from '@nvidia/foundations-react-core';
+import { Button, Divider, Flex, Tooltip } from '@nvidia/foundations-react-core';
 import { useSpanAnnotationActions } from '@studio/components/IntakeDetail/IntakeComponents/useSpanAnnotationActions';
 import { NotebookPen, ThumbsDown, ThumbsUp } from 'lucide-react';
 import { type FC, type MouseEvent, useEffect } from 'react';
@@ -14,8 +14,8 @@ interface SpanFeedbackControlsProps {
   sessionId: string;
   /** Current feedback sentiment for the span, to highlight the active thumb. */
   activeFeedback?: FeedbackAnnotationInputValue;
-  /** Total annotations on the span, shown as a count badge beside the thumbs. */
-  annotationCount?: number;
+  /** Whether the span has any note annotations, to highlight the note icon. */
+  hasNotes?: boolean;
   /** Open the span and focus its annotations note field (handled by the parent). */
   onAddNote: () => void;
 }
@@ -32,7 +32,7 @@ export const SpanFeedbackControls: FC<SpanFeedbackControlsProps> = ({
   spanId,
   sessionId,
   activeFeedback,
-  annotationCount,
+  hasNotes,
   onAddNote,
 }) => {
   const { submitFeedback, isMutating, error, clearError } = useSpanAnnotationActions(
@@ -65,13 +65,6 @@ export const SpanFeedbackControls: FC<SpanFeedbackControlsProps> = ({
       {/* Separate the span metadata (tokens/cost/duration) from the annotation
           controls. */}
       <Divider orientation="vertical" className="mr-density-xs h-4 self-center" />
-      {annotationCount !== undefined && annotationCount > 0 && (
-        <Tooltip slotContent="Number of annotations" side="top">
-          <Badge color="gray" kind="solid" aria-label={`${annotationCount} annotations`}>
-            {annotationCount}
-          </Badge>
-        </Tooltip>
-      )}
       <Tooltip slotContent="Positive feedback" side="top">
         <Button
           type="button"
@@ -108,15 +101,20 @@ export const SpanFeedbackControls: FC<SpanFeedbackControlsProps> = ({
           />
         </Button>
       </Tooltip>
-      <Tooltip slotContent="Add note" side="top">
+      <Tooltip slotContent={hasNotes ? 'Notes added' : 'Add note'} side="top">
         <Button
           type="button"
           size="tiny"
           kind="tertiary"
-          aria-label="Add note"
+          aria-label={hasNotes ? 'Add note (this span has notes)' : 'Add note'}
           onClick={withoutToggle(onAddNote)}
         >
-          <NotebookPen size={14} aria-hidden />
+          {/* Tinted to match the Guardrail kind accent (var --text-color-accent-yellow). */}
+          <NotebookPen
+            size={14}
+            aria-hidden
+            className={hasNotes ? 'text-[color:var(--text-color-accent-yellow)]' : undefined}
+          />
         </Button>
       </Tooltip>
     </Flex>

--- a/web/packages/studio/src/components/IntakeDetail/README.md
+++ b/web/packages/studio/src/components/IntakeDetail/README.md
@@ -7,6 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 
 Trace and span detail UI: trajectory explorer, per-span bodies, kind templates, and shared atoms. List views (traces/spans tables) live in `IntakeLists/`.
 
+Span templates provide specialized view for each known KIND template, with a fallback for unknown kinds. To review the output of these templates, run the seed script at:
+services/intake/scripts/spans/seed_span_type_showcase.py.
+
 ## Architecture
 
 ```mermaid
@@ -56,7 +59,7 @@ flowchart TB
 | Layer                           | Role                                                                                                                       |
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | **Routes**                      | Thin wrappers; resolve workspace + id, set breadcrumbs. `IntakeTraceDetailContent` is exported for experiment trace reuse. |
-| **IntakeTraceDetailView**       | Page header, trace summary header, span explorer, trace-level Metadata / Experiment Context accordions, raw JSON debug.    |
+| **IntakeTraceDetailView**       | Page header, trace summary header, span explorer, trace-level Attributes / Experiment Context accordions, raw JSON debug.  |
 | **TraceSpanAccordions**         | Fetches spans (`detailed`) and trace annotations; Tree/List toggle; expand/collapse toolbar; row headers + feedback.       |
 | **SpanTreeView / SpanListView** | Layout shells for tree vs list modes; shared row chrome (`SpanTriggerLabel`, `SpanTriggerMeta`, `SpanFeedbackControls`).   |
 | **TraceSpanAccordionContent**   | Lazy `useGetSpan` when a span body is shown; merges list summary with full detail via `mergeSpanDetails`.                  |

--- a/web/packages/studio/src/components/IntakeDetail/SpanMetadataAccordions.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/SpanMetadataAccordions.tsx
@@ -99,7 +99,7 @@ const SECTIONS: Record<
   llm: { value: 'span-llm', label: 'Usage', Body: UsageSection },
   input: { value: 'span-input', label: 'Input', Body: InputSection },
   output: { value: 'span-output', label: 'Output', Body: OutputSection },
-  metadata: { value: 'span-summary', label: 'Metadata', Body: MetadataSection },
+  metadata: { value: 'span-summary', label: 'Attributes', Body: MetadataSection },
   annotations: { value: 'span-annotations', label: 'Annotations', Body: AnnotationsSection },
 };
 
@@ -109,15 +109,14 @@ const sectionLabel = (label: string): ReactNode => (
   </Text>
 );
 
-// The Annotations section trigger shows a count badge to the right of its label.
+// The Annotations section trigger shows the annotation count as a badge to the
+// right of its label — always, including zero.
 const annotationsSectionLabel = (label: string, count: number | undefined): ReactNode => (
   <Flex align="center" gap="density-sm" className="min-w-0">
     <Text kind="body/semibold/sm">{label}</Text>
-    {count !== undefined && count > 0 && (
-      <Badge color="gray" kind="solid">
-        {count}
-      </Badge>
-    )}
+    <Badge color="gray" kind="solid">
+      {count ?? 0}
+    </Badge>
   </Flex>
 );
 

--- a/web/packages/studio/src/components/IntakeDetail/TraceDetailView.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/TraceDetailView.tsx
@@ -112,7 +112,7 @@ export const IntakeTraceDetailView: FC<IntakeTraceDetailViewProps> = ({
           items={[
             {
               value: TRACE_SUMMARY_SECTION,
-              slotLabel: <Text kind="body/semibold/sm">Metadata</Text>,
+              slotLabel: <Text kind="body/semibold/sm">Attributes</Text>,
               slotContent: (
                 <Stack className="min-w-0">
                   <KeyValueRows entries={summaryEntries} />

--- a/web/packages/studio/src/components/IntakeDetail/TraceSpanAccordions.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/TraceSpanAccordions.tsx
@@ -94,6 +94,12 @@ export const TraceSpanAccordions: FC<TraceSpanAccordionsProps> = ({ workspace, t
     () => spanRows.find((span) => span.span_id === activeSpanId) ?? spanRows[0],
     [spanRows, activeSpanId]
   );
+  // The trace's own error lives on its root span (the trace status derives from
+  // it); used to decide whether to surface a trace-level error banner.
+  const rootSpan = useMemo(
+    () => spanRows.find((span) => span.span_id === trace.root_span_id) ?? spanRows[0],
+    [spanRows, trace.root_span_id]
+  );
 
   // One query for the whole trace's annotations (rather than per row) so each
   // header can show its feedback sentiment and annotation count. Sorted
@@ -104,17 +110,19 @@ export const TraceSpanAccordions: FC<TraceSpanAccordionsProps> = ({ workspace, t
     sort: AnnotationSortField['-created_at'],
     filter: { session_id: trace.session_id },
   });
-  const { feedbackBySpan, annotationCountBySpan } = useMemo(() => {
+  const { feedbackBySpan, annotationCountBySpan, notesBySpan } = useMemo(() => {
     const feedback = new Map<string, FeedbackAnnotationInputValue>();
     const counts = new Map<string, number>();
+    const notes = new Set<string>();
     for (const annotation of annotationsResponse?.data ?? []) {
       if (!annotation.span_id) continue;
       counts.set(annotation.span_id, (counts.get(annotation.span_id) ?? 0) + 1);
+      if (annotation.kind === 'note') notes.add(annotation.span_id);
       if (annotation.kind === 'feedback' && !feedback.has(annotation.span_id)) {
         feedback.set(annotation.span_id, annotation.value);
       }
     }
-    return { feedbackBySpan: feedback, annotationCountBySpan: counts };
+    return { feedbackBySpan: feedback, annotationCountBySpan: counts, notesBySpan: notes };
   }, [annotationsResponse]);
 
   const handleSelectSpan = useCallback((spanId: string) => {
@@ -176,17 +184,15 @@ export const TraceSpanAccordions: FC<TraceSpanAccordionsProps> = ({ workspace, t
     trace.span_count !== null &&
     trace.span_count > TRACE_SPANS_PAGE_SIZE;
 
-  const banner =
-    trace.status === SpanStatus.error ? (
-      <IntakeErrorBanner
-        heading="Error"
-        message={
-          trace.error_count
-            ? `${trace.error_count} error span${trace.error_count === 1 ? '' : 's'} in this trace.`
-            : 'This trace ended with an error.'
-        }
-      />
-    ) : null;
+  // Only surface a trace-level error banner when the trace itself has an error
+  // message (carried on its root span). A child-span error alone no longer
+  // raises a banner here — it shows on that span's own detail instead.
+  const banner = rootSpan?.error_message?.trim() ? (
+    <IntakeErrorBanner
+      heading={rootSpan.error_type?.trim() || 'Error'}
+      message={rootSpan.error_message}
+    />
+  ) : null;
 
   if (error) {
     return <ErrorMessage message={getErrorMessage(error)} />;
@@ -263,6 +269,7 @@ export const TraceSpanAccordions: FC<TraceSpanAccordionsProps> = ({ workspace, t
           annotationCount={
             selectedSpan ? annotationCountBySpan.get(selectedSpan.span_id) : undefined
           }
+          hasNotes={selectedSpan ? notesBySpan.has(selectedSpan.span_id) : false}
           focusNoteNonce={
             selectedSpan ? noteFocusNonce(noteRequest, selectedSpan.span_id) : undefined
           }
@@ -277,6 +284,7 @@ export const TraceSpanAccordions: FC<TraceSpanAccordionsProps> = ({ workspace, t
           banner={banner}
           feedbackBySpan={feedbackBySpan}
           annotationCountBySpan={annotationCountBySpan}
+          notesBySpan={notesBySpan}
           noteRequest={noteRequest}
           onAddNote={handleAddNote}
         />

--- a/web/packages/studio/src/components/IntakeDetail/TraceSpanListView.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/TraceSpanListView.tsx
@@ -24,6 +24,7 @@ interface SpanListViewProps {
   banner: ReactNode;
   feedbackBySpan: Map<string, FeedbackAnnotationInputValue>;
   annotationCountBySpan: Map<string, number>;
+  notesBySpan: ReadonlySet<string>;
   noteRequest: NoteRequest;
   onAddNote: (spanId: string) => void;
 }
@@ -37,6 +38,7 @@ export const SpanListView: FC<SpanListViewProps> = ({
   banner,
   feedbackBySpan,
   annotationCountBySpan,
+  notesBySpan,
   noteRequest,
   onAddNote,
 }) => (
@@ -59,7 +61,7 @@ export const SpanListView: FC<SpanListViewProps> = ({
                 spanId={span.span_id}
                 sessionId={span.session_id}
                 activeFeedback={feedbackBySpan.get(span.span_id)}
-                annotationCount={annotationCountBySpan.get(span.span_id)}
+                hasNotes={notesBySpan.has(span.span_id)}
                 onAddNote={() => onAddNote(span.span_id)}
               />
             </>

--- a/web/packages/studio/src/components/IntakeDetail/TraceSpanTreeView.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/TraceSpanTreeView.tsx
@@ -25,6 +25,7 @@ interface SpanTreeViewProps {
   collapseToken: number;
   activeFeedback?: FeedbackAnnotationInputValue;
   annotationCount?: number;
+  hasNotes?: boolean;
   focusNoteNonce?: number;
   onAddNote: () => void;
 }
@@ -44,6 +45,7 @@ export const SpanTreeView: FC<SpanTreeViewProps> = ({
   collapseToken,
   activeFeedback,
   annotationCount,
+  hasNotes,
   focusNoteNonce,
   onAddNote,
 }) => (
@@ -82,7 +84,7 @@ export const SpanTreeView: FC<SpanTreeViewProps> = ({
                   spanId={selectedSpan.span_id}
                   sessionId={selectedSpan.session_id}
                   activeFeedback={activeFeedback}
-                  annotationCount={annotationCount}
+                  hasNotes={hasNotes}
                   onAddNote={onAddNote}
                 />
               </span>


### PR DESCRIPTION
## Summary
Follow-up UX tweaks to the intake trace & span detail views (PR #460).

- **Annotations header**: always render the annotation count as a badge, including `0`.
- **Span row header**: removed the annotation count badge; the note icon now gets a highlight (Guardrail-kind accent, `--text-color-accent-yellow`) when the span has note annotations, with matching tooltip/aria.
- **Metadata → Attributes**: renamed the Metadata accordion to "Attributes" in both span and trace views (internal section ids unchanged).
- **Trace-level error banner**: only shown when the trace itself has an error message (sourced from the root span, which defines the trace status). Removed the "N error span in this trace" count warning — child-span errors still surface on their own span detail.
- **Docs**: README note pointing at the span-type showcase seed script.

## Testing
- `pnpm --filter nemo-studio-ui typecheck` — passes
- `pnpm --filter nemo-studio-ui test src/components/IntakeDetail` — 29/29
- ESLint + Prettier clean on changed files

## Note
The `Trace` API type has no `error_message`/`error_type` field, so the trace-level banner reads them from the root span (which the trace's status derives from). If `Trace` is meant to carry its own error message, that's an SDK/OpenAPI gap to address separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated span feedback controls to better reflect when notes have been added, including clearer tooltip text, button labeling, and icon state.
  * Renamed several accordion sections from “Metadata” to “Attributes” for clearer wording.
  * Annotation badges now display consistently, including a visible zero state when no annotations are present.

* **Documentation**
  * Improved Intake Detail docs with clearer guidance on span templates and updated terminology for trace details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->