### PR TITLE
chore: remove ffmpeg via opencv from nss task image

### DIFF
--- a/docker/scripts/cve-cleanup.sh
+++ b/docker/scripts/cve-cleanup.sh
@@ -8,9 +8,21 @@ set -e
 # overlayfs whiteouts that also hide the hard-linked venv files (e.g.
 # typing_extensions, pydantic), breaking imports at runtime.
 
-# Remove unused bundled ffmpeg binaries with their own vulnerability surface.
+# Remove unused OpenCV wheels. vLLM declares opencv-python-headless for video
+# paths, but the Safe Synthesizer task image does not use cv2. The upstream
+# wheel bundles FFmpeg as libav*/libsw*.so files, so deleting only ffmpeg-named
+# binaries does not remove the scanner finding.
 for venv in /app/.venv /opt/venv; do
     if [ -d "${venv}" ]; then
+        if [ -x "${venv}/bin/python" ]; then
+            uv pip uninstall --python "${venv}/bin/python" \
+                opencv-contrib-python \
+                opencv-contrib-python-headless \
+                opencv-python \
+                opencv-python-headless
+        fi
+
+        # Fallback for other packages that ship standalone ffmpeg binaries.
         find "${venv}" -type f \( -name ffmpeg -o -name 'ffmpeg-*' \) -delete
     fi
 done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced unnecessary bundled media and vision packages from application environments, helping lower image size and avoid conflicts at runtime.
  - Kept the existing cleanup of bundled FFmpeg binaries as a fallback for packages that still include them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->