### PR TITLE
feat(studio): OpenAPI Converter for TS Capabilities

### DIFF
--- a/web/packages/sdk/generateAll.ts
+++ b/web/packages/sdk/generateAll.ts
@@ -82,6 +82,7 @@ const computeInputHash = (): string => {
     path.join(ORVAL_DIR, 'format-generated.ts'),
     path.join(ORVAL_DIR, 'generateCustomFetcher.ts'),
     path.join(ORVAL_DIR, 'operationNameOverride.ts'),
+    path.join(ORVAL_DIR, 'generate-capabilities.ts'),
     path.join(__dirname, 'generateAll.ts'),
   ];
   for (const file of generatorSources) {
@@ -150,6 +151,8 @@ const main = async () => {
 
   try {
     execSync(concurrentlyCommand, { stdio: 'inherit' });
+    console.log('\n🧰 Generating LLM capability registry...');
+    execSync('pnpm run gen:capabilities', { stdio: 'inherit' });
     writeHash(currentHash);
     console.log('\n🎉 All type generation completed successfully!');
   } catch {

--- a/web/packages/sdk/orval/generate-capabilities.ts
+++ b/web/packages/sdk/orval/generate-capabilities.ts
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Generates an LLM-tool "capability registry" from the OpenAPI specs that drive
+ * `@nemo/sdk`. For every operation (path + method) it emits a serializable
+ * {@link CapabilityMeta} with a self-contained JSON Schema for its arguments.
+ *
+ * Output: `generated/capabilities/registry.ts` and `registry.json`.
+ *
+ * Run with: `pnpm gen:capabilities` (all services) or
+ * `pnpm gen:capabilities platform agents` (a subset).
+ *
+ * The runtime in `src/capabilities/` turns this registry into discoverable,
+ * invocable tools and into provider wire formats (Anthropic/OpenAI/MCP).
+ */
+import fs from 'fs';
+import path from 'path';
+import { parse as parseYaml } from 'yaml';
+import { serviceConfigs } from './constants';
+import type { CapabilityMeta, HttpMethod, JsonSchema } from '../src/capabilities/types';
+
+const HTTP_METHODS: readonly HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+const COMPONENT_SCHEMA_PREFIX = '#/components/schemas/';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+interface OpenApiSpec {
+  paths?: Record<string, unknown>;
+  components?: { schemas?: Record<string, unknown> };
+}
+
+interface OpenApiParameter {
+  name: string;
+  in: 'path' | 'query' | 'header' | 'cookie';
+  required?: boolean;
+  description?: string;
+  schema?: JsonSchema;
+}
+
+/**
+ * Recursively rewrites `#/components/schemas/X` references to local `#/$defs/X`
+ * references, recording every component name reached so the caller can bundle
+ * them. Returns a deep clone; the input is never mutated.
+ */
+const rewriteRefs = (node: unknown, needed: Set<string>): unknown => {
+  if (Array.isArray(node)) return node.map((item) => rewriteRefs(item, needed));
+  if (!isRecord(node)) return node;
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node)) {
+    // Rewrite both `$ref` values and discriminator `mapping` values, which are
+    // both whole-string pointers into the component schemas.
+    if (typeof value === 'string' && value.startsWith(COMPONENT_SCHEMA_PREFIX)) {
+      const name = value.slice(COMPONENT_SCHEMA_PREFIX.length);
+      needed.add(name);
+      result[key] = `#/$defs/${name}`;
+    } else {
+      result[key] = rewriteRefs(value, needed);
+    }
+  }
+  return result;
+};
+
+/**
+ * Walks the dependency graph of referenced component schemas and returns a
+ * `$defs` map containing every transitively-referenced schema (refs rewritten).
+ */
+const collectDefs = (
+  initial: Set<string>,
+  componentSchemas: Record<string, unknown>
+): Record<string, unknown> => {
+  const defs: Record<string, unknown> = {};
+  const queue = [...initial];
+  const seen = new Set<string>(initial);
+
+  while (queue.length > 0) {
+    const name = queue.shift() as string;
+    const schema = componentSchemas[name];
+    if (schema === undefined) {
+      console.warn(`  ⚠ referenced schema "${name}" not found in components.schemas`);
+      continue;
+    }
+    const moreNeeded = new Set<string>();
+    defs[name] = rewriteRefs(schema, moreNeeded);
+    for (const next of moreNeeded) {
+      if (!seen.has(next)) {
+        seen.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  return defs;
+};
+
+/** Merges a parameter's outer `description` into its schema for the LLM. */
+const paramSchema = (param: OpenApiParameter, needed: Set<string>): JsonSchema => {
+  const base = isRecord(param.schema) ? (rewriteRefs(param.schema, needed) as JsonSchema) : {};
+  if (param.description && base.description === undefined) {
+    return { ...base, description: param.description };
+  }
+  return base;
+};
+
+/** Extracts the `application/json` (or first available) request body schema. */
+const requestBodySchema = (
+  operation: Record<string, unknown>,
+  needed: Set<string>
+): { schema?: JsonSchema; required: boolean } => {
+  const body = operation.requestBody;
+  if (!isRecord(body)) return { required: false };
+  const content = isRecord(body.content) ? body.content : undefined;
+  if (!content) return { required: false };
+  const json = isRecord(content['application/json'])
+    ? (content['application/json'] as Record<string, unknown>)
+    : Object.values(content).find(isRecord);
+  const schema = json && isRecord(json.schema) ? (json.schema as JsonSchema) : undefined;
+  return {
+    schema: schema ? (rewriteRefs(schema, needed) as JsonSchema) : undefined,
+    required: body.required === true,
+  };
+};
+
+interface BuildResult {
+  meta: CapabilityMeta;
+}
+
+const buildCapability = (
+  service: string,
+  pathTemplate: string,
+  method: HttpMethod,
+  operation: Record<string, unknown>,
+  pathLevelParams: OpenApiParameter[],
+  componentSchemas: Record<string, unknown>,
+  usedNames: Set<string>
+): BuildResult => {
+  const needed = new Set<string>();
+
+  const opParams = Array.isArray(operation.parameters)
+    ? (operation.parameters as OpenApiParameter[])
+    : [];
+  // Operation-level params override path-level params of the same (name, in).
+  const paramKey = (p: OpenApiParameter) => `${p.in}:${p.name}`;
+  const merged = new Map<string, OpenApiParameter>();
+  for (const p of [...pathLevelParams, ...opParams]) {
+    if (isRecord(p) && typeof p.name === 'string') merged.set(paramKey(p), p);
+  }
+  const parameters = [...merged.values()];
+
+  const properties: Record<string, JsonSchema> = {};
+  const required: string[] = [];
+  const pathParams: string[] = [];
+  const queryParams: string[] = [];
+
+  for (const param of parameters) {
+    if (param.in === 'path') {
+      pathParams.push(param.name);
+      properties[param.name] = paramSchema(param, needed);
+      required.push(param.name);
+    } else if (param.in === 'query') {
+      queryParams.push(param.name);
+      properties[param.name] = paramSchema(param, needed);
+      if (param.required) required.push(param.name);
+    }
+  }
+
+  const { schema: bodySchema, required: bodyRequired } = requestBodySchema(operation, needed);
+  const hasBody = bodySchema !== undefined;
+  if (hasBody) {
+    properties.body = bodySchema as JsonSchema;
+    if (bodyRequired) required.push('body');
+  }
+
+  const defs = collectDefs(needed, componentSchemas);
+
+  const inputSchema: JsonSchema = {
+    type: 'object',
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+    ...(Object.keys(defs).length > 0 ? { $defs: defs } : {}),
+  };
+
+  const operationId = typeof operation.operationId === 'string' ? operation.operationId : undefined;
+  const baseName = operationId ?? `${method.toLowerCase()}_${pathTemplate}`.replace(/\W+/g, '_');
+  let name = baseName;
+  if (usedNames.has(name)) {
+    name = `${service}_${baseName}`;
+    let i = 2;
+    while (usedNames.has(name)) name = `${service}_${baseName}_${i++}`;
+  }
+  usedNames.add(name);
+
+  const tags = Array.isArray(operation.tags)
+    ? (operation.tags.filter((t) => typeof t === 'string') as string[])
+    : [];
+
+  const meta: CapabilityMeta = {
+    name,
+    service,
+    method,
+    path: pathTemplate,
+    summary: typeof operation.summary === 'string' ? operation.summary : undefined,
+    description: typeof operation.description === 'string' ? operation.description : undefined,
+    tags,
+    readOnly: method === 'GET',
+    pathParams,
+    queryParams,
+    hasBody,
+    bodyRequired: hasBody && bodyRequired,
+    inputSchema,
+  };
+
+  return { meta };
+};
+
+const buildServiceCapabilities = (
+  service: string,
+  spec: OpenApiSpec,
+  usedNames: Set<string>
+): CapabilityMeta[] => {
+  const componentSchemas = spec.components?.schemas ?? {};
+  const out: CapabilityMeta[] = [];
+
+  for (const [pathTemplate, pathItemRaw] of Object.entries(spec.paths ?? {})) {
+    if (!isRecord(pathItemRaw)) continue;
+    const pathLevelParams = Array.isArray(pathItemRaw.parameters)
+      ? (pathItemRaw.parameters as OpenApiParameter[])
+      : [];
+
+    for (const method of HTTP_METHODS) {
+      const operation = pathItemRaw[method.toLowerCase()];
+      if (!isRecord(operation)) continue;
+      const { meta } = buildCapability(
+        service,
+        pathTemplate,
+        method,
+        operation,
+        pathLevelParams,
+        componentSchemas,
+        usedNames
+      );
+      out.push(meta);
+    }
+  }
+  return out;
+};
+
+const HEADER = [
+  '// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.',
+  '// SPDX-License-Identifier: Apache-2.0',
+  '',
+  '// Generated by orval/generate-capabilities.ts. Do not edit manually.',
+  '',
+].join('\n');
+
+const main = (): void => {
+  const requested = process.argv.slice(2);
+  const services = requested.length > 0 ? requested : Object.keys(serviceConfigs);
+
+  const all: CapabilityMeta[] = [];
+  const usedNames = new Set<string>();
+
+  for (const service of services) {
+    const config = serviceConfigs[service as keyof typeof serviceConfigs];
+    if (!config) {
+      throw new Error(
+        `Unknown service "${service}". Known: ${Object.keys(serviceConfigs).join(', ')}`
+      );
+    }
+    const specPath = path.resolve(__dirname, config.url);
+    const spec = parseYaml(fs.readFileSync(specPath, 'utf8')) as OpenApiSpec;
+    const caps = buildServiceCapabilities(service, spec, usedNames);
+    console.log(`  ${service}: ${caps.length} operations`);
+    all.push(...caps);
+  }
+
+  all.sort((a, b) => a.name.localeCompare(b.name));
+
+  const outDir = path.resolve(__dirname, '../generated/capabilities');
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const ts =
+    HEADER +
+    `import type { CapabilityMeta } from '../../src/capabilities/types';\n\n` +
+    `export const capabilities: CapabilityMeta[] = ${JSON.stringify(all, null, 2)};\n`;
+  fs.writeFileSync(path.join(outDir, 'registry.ts'), ts);
+  fs.writeFileSync(path.join(outDir, 'registry.json'), JSON.stringify(all, null, 2) + '\n');
+
+  console.log(`✓ Wrote ${all.length} capabilities to ${path.relative(process.cwd(), outDir)}`);
+};
+
+main();

--- a/web/packages/sdk/package.json
+++ b/web/packages/sdk/package.json
@@ -8,6 +8,7 @@
     "gen": "tsx ./orval/generate.ts",
     "gen:all": "tsx ./generateAll.ts",
     "gen:all-force": "tsx ./generateAll.ts --force",
+    "gen:capabilities": "tsx ./orval/generate-capabilities.ts",
     "gen:agents": "tsx ./orval/generate.ts agents",
     "gen:agents-zod": "ORVAL_CLIENT=zod tsx ./orval/generate.ts agents",
     "gen:customizer": "tsx ./orval/generate.ts customizer",
@@ -38,14 +39,15 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@types/node": "catalog:",
     "@types/qs": "catalog:",
     "concurrently": "catalog:",
     "orval": "catalog:",
     "prettier": "catalog:",
-    "@types/node": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "yaml": "^2.8.3"
   }
 }

--- a/web/packages/sdk/src/capabilities/adapters/anthropic.ts
+++ b/web/packages/sdk/src/capabilities/adapters/anthropic.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Capability, JsonSchema } from '../types';
+
+/** Tool definition in the shape accepted by the Anthropic Messages API `tools` param. */
+export interface AnthropicTool {
+  readonly name: string;
+  readonly description: string;
+  readonly input_schema: JsonSchema;
+}
+
+/** Converts capabilities to Anthropic tool definitions. */
+export const toAnthropicTools = (capabilities: readonly Capability[]): AnthropicTool[] =>
+  capabilities.map((c) => ({
+    name: c.name,
+    description: c.description,
+    input_schema: c.inputSchema,
+  }));

--- a/web/packages/sdk/src/capabilities/adapters/mcp.ts
+++ b/web/packages/sdk/src/capabilities/adapters/mcp.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Capability, CapabilityContext, JsonSchema } from '../types';
+
+/** Tool descriptor in the Model Context Protocol `tools/list` shape. */
+export interface McpTool {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: JsonSchema;
+}
+
+/** MCP `tools/call` result content (text-only). */
+export interface McpCallResult {
+  readonly content: Array<{ readonly type: 'text'; readonly text: string }>;
+  readonly isError?: boolean;
+}
+
+/** Converts capabilities to MCP tool descriptors (for `tools/list`). */
+export const toMcpTools = (capabilities: readonly Capability[]): McpTool[] =>
+  capabilities.map((c) => ({
+    name: c.name,
+    description: c.description,
+    inputSchema: c.inputSchema,
+  }));
+
+/**
+ * Dispatches an MCP `tools/call` to the matching capability and returns an
+ * MCP-shaped result. Wire this into an MCP server's call handler; pair it with
+ * {@link toMcpTools} for the list handler.
+ */
+export const callMcpTool = async (
+  capabilities: readonly Capability[],
+  ctx: CapabilityContext,
+  name: string,
+  args: unknown
+): Promise<McpCallResult> => {
+  const capability = capabilities.find((c) => c.name === name);
+  if (!capability) {
+    return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
+  }
+  const result = await capability.execute(args, ctx);
+  return {
+    content: [{ type: 'text', text: result.content }],
+    isError: result.isError,
+  };
+};

--- a/web/packages/sdk/src/capabilities/adapters/openai.ts
+++ b/web/packages/sdk/src/capabilities/adapters/openai.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Capability, JsonSchema } from '../types';
+
+/** Tool definition in the OpenAI chat-completions `tools` (function-calling) shape. */
+export interface OpenAITool {
+  readonly type: 'function';
+  readonly function: {
+    readonly name: string;
+    readonly description: string;
+    readonly parameters: JsonSchema;
+  };
+}
+
+/** Converts capabilities to OpenAI function-calling tool definitions. */
+export const toOpenAITools = (capabilities: readonly Capability[]): OpenAITool[] =>
+  capabilities.map((c) => ({
+    type: 'function',
+    function: {
+      name: c.name,
+      description: c.description,
+      parameters: c.inputSchema,
+    },
+  }));

--- a/web/packages/sdk/src/capabilities/capabilities.test.ts
+++ b/web/packages/sdk/src/capabilities/capabilities.test.ts
@@ -127,6 +127,17 @@ describe('searchCapabilities', () => {
   it('returns nothing when not every term matches', () => {
     expect(searchCapabilities(registry, 'models nonexistentterm')).toHaveLength(0);
   });
+
+  it('caps results at a positive integer limit', () => {
+    expect(searchCapabilities(registry, 'models', { limit: 1 })).toHaveLength(1);
+  });
+
+  it('ignores non-positive or non-integer limits instead of dropping results', () => {
+    const all = searchCapabilities(registry, 'models');
+    for (const limit of [0, -1, 1.5, NaN]) {
+      expect(searchCapabilities(registry, 'models', { limit })).toHaveLength(all.length);
+    }
+  });
 });
 
 describe('gateway', () => {

--- a/web/packages/sdk/src/capabilities/capabilities.test.ts
+++ b/web/packages/sdk/src/capabilities/capabilities.test.ts
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { toAnthropicTools } from './adapters/anthropic';
+import { callMcpTool, toMcpTools } from './adapters/mcp';
+import { toOpenAITools } from './adapters/openai';
+import { createGateway } from './gateway';
+import { invokeCapability } from './invoke';
+import { searchCapabilities } from './registry';
+import type { CapabilityContext, CapabilityMeta, FetchRequest } from './types';
+
+const listModels: CapabilityMeta = {
+  name: 'models_list',
+  service: 'platform',
+  method: 'GET',
+  path: '/apis/models/v2/workspaces/{workspace}/models',
+  summary: 'List models',
+  description: 'List all model entities in a workspace.',
+  tags: ['Models'],
+  readOnly: true,
+  pathParams: ['workspace'],
+  queryParams: ['page', 'page_size'],
+  hasBody: false,
+  bodyRequired: false,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      workspace: { type: 'string' },
+      page: { type: 'integer' },
+      page_size: { type: 'integer' },
+    },
+    required: ['workspace'],
+  },
+};
+
+const createModel: CapabilityMeta = {
+  name: 'models_create',
+  service: 'platform',
+  method: 'POST',
+  path: '/apis/models/v2/workspaces/{workspace}/models',
+  summary: 'Create model',
+  description: 'Create a new model entity.',
+  tags: ['Models'],
+  readOnly: false,
+  pathParams: ['workspace'],
+  queryParams: [],
+  hasBody: true,
+  bodyRequired: true,
+  inputSchema: {
+    type: 'object',
+    properties: { workspace: { type: 'string' }, body: { type: 'object' } },
+    required: ['workspace', 'body'],
+  },
+};
+
+const registry: CapabilityMeta[] = [listModels, createModel];
+
+const makeContext = (
+  impl?: (req: FetchRequest) => unknown
+): {
+  ctx: CapabilityContext;
+  calls: FetchRequest[];
+} => {
+  const calls: FetchRequest[] = [];
+  const fetcher = vi.fn(async (req: FetchRequest) => {
+    calls.push(req);
+    return impl ? impl(req) : { ok: true };
+  });
+  return {
+    ctx: { fetchers: { platform: fetcher as never }, workspace: 'default' },
+    calls,
+  };
+};
+
+describe('invokeCapability', () => {
+  it('substitutes path params, splits query params, and omits body for GET', async () => {
+    const { ctx, calls } = makeContext();
+    await invokeCapability(listModels, { workspace: 'ws1', page: 2 }, ctx);
+    expect(calls[0]).toMatchObject({
+      url: '/apis/models/v2/workspaces/ws1/models',
+      method: 'GET',
+      params: { page: 2 },
+    });
+    expect(calls[0].data).toBeUndefined();
+  });
+
+  it('falls back to ctx.workspace when the workspace path param is omitted', async () => {
+    const { ctx, calls } = makeContext();
+    await invokeCapability(listModels, { page: 1 }, ctx);
+    expect(calls[0].url).toBe('/apis/models/v2/workspaces/default/models');
+  });
+
+  it('sends the body for write operations', async () => {
+    const { ctx, calls } = makeContext();
+    await invokeCapability(createModel, { workspace: 'ws1', body: { name: 'm' } }, ctx);
+    expect(calls[0]).toMatchObject({ method: 'POST', data: { name: 'm' } });
+  });
+
+  it('throws when a required path param is missing and no fallback exists', async () => {
+    const fetcher = vi.fn(async () => ({}));
+    const ctx: CapabilityContext = { fetchers: { platform: fetcher as never } };
+    await expect(invokeCapability(createModel, { body: {} }, ctx)).rejects.toThrow(
+      /Missing required path parameter "workspace"/
+    );
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('throws when no fetcher is registered for the service', async () => {
+    await expect(
+      invokeCapability(listModels, { workspace: 'ws1' }, { fetchers: {} })
+    ).rejects.toThrow(/No fetcher registered for service "platform"/);
+  });
+});
+
+describe('searchCapabilities', () => {
+  it('finds operations by keyword and ranks name/path hits first', () => {
+    const results = searchCapabilities(registry, 'models');
+    expect(results.map((r) => r.name)).toContain('models_list');
+    expect(results.map((r) => r.name)).toContain('models_create');
+  });
+
+  it('filters by readOnly', () => {
+    const results = searchCapabilities(registry, 'models', { readOnly: false });
+    expect(results.map((r) => r.name)).toEqual(['models_create']);
+  });
+
+  it('returns nothing when not every term matches', () => {
+    expect(searchCapabilities(registry, 'models nonexistentterm')).toHaveLength(0);
+  });
+});
+
+describe('gateway', () => {
+  const gateway = createGateway(registry);
+  const get = (name: string) => gateway.find((c) => c.name === name)!;
+
+  it('exposes exactly the four gateway tools with correct confirmation flags', () => {
+    expect(gateway.map((c) => c.name)).toEqual([
+      'search_capabilities',
+      'describe_capability',
+      'read_capability',
+      'run_capability',
+    ]);
+    expect(get('run_capability').requiresConfirmation).toBe(true);
+    expect(get('read_capability').requiresConfirmation).toBe(false);
+  });
+
+  it('search_capabilities returns matching operations', async () => {
+    const { ctx } = makeContext();
+    const res = await get('search_capabilities').execute({ query: 'models' }, ctx);
+    const payload = JSON.parse(res.content) as { count: number };
+    expect(payload.count).toBe(2);
+  });
+
+  it('describe_capability returns the input schema', async () => {
+    const { ctx } = makeContext();
+    const res = await get('describe_capability').execute({ name: 'models_create' }, ctx);
+    const payload = JSON.parse(res.content) as { method: string; inputSchema: unknown };
+    expect(payload.method).toBe('POST');
+    expect(payload.inputSchema).toEqual(createModel.inputSchema);
+  });
+
+  it('read_capability invokes a GET and returns its result', async () => {
+    const { ctx, calls } = makeContext(() => ({ data: [{ id: '1' }] }));
+    const res = await get('read_capability').execute(
+      { name: 'models_list', args: { workspace: 'ws1' } },
+      ctx
+    );
+    expect(calls[0].method).toBe('GET');
+    expect(JSON.parse(res.content)).toEqual({ data: [{ id: '1' }] });
+  });
+
+  it('read_capability refuses a mutating operation', async () => {
+    const { ctx, calls } = makeContext();
+    const res = await get('read_capability').execute({ name: 'models_create' }, ctx);
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/Use run_capability/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('run_capability refuses a read-only operation', async () => {
+    const { ctx } = makeContext();
+    const res = await get('run_capability').execute({ name: 'models_list' }, ctx);
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/Use read_capability/);
+  });
+
+  it('run_capability executes a write and surfaces fetcher errors', async () => {
+    const { ctx } = makeContext(() => {
+      throw new Error('boom');
+    });
+    const res = await get('run_capability').execute(
+      { name: 'models_create', args: { workspace: 'ws1', body: {} } },
+      ctx
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/models_create failed: boom/);
+  });
+
+  it('reports unknown operations', async () => {
+    const { ctx } = makeContext();
+    const res = await get('describe_capability').execute({ name: 'nope' }, ctx);
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatch(/Unknown operation/);
+  });
+});
+
+describe('adapters', () => {
+  const gateway = createGateway(registry);
+
+  it('toAnthropicTools maps name/description/input_schema', () => {
+    const tools = toAnthropicTools(gateway);
+    expect(tools[0]).toMatchObject({ name: 'search_capabilities' });
+    expect(tools[0].input_schema).toBeDefined();
+  });
+
+  it('toOpenAITools wraps in the function shape', () => {
+    const tools = toOpenAITools(gateway);
+    expect(tools[0].type).toBe('function');
+    expect(tools[0].function.name).toBe('search_capabilities');
+    expect(tools[0].function.parameters).toBeDefined();
+  });
+
+  it('toMcpTools and callMcpTool dispatch by name', async () => {
+    const tools = toMcpTools(gateway);
+    expect(tools.map((t) => t.name)).toContain('describe_capability');
+
+    const { ctx } = makeContext();
+    const result = await callMcpTool(gateway, ctx, 'search_capabilities', { query: 'models' });
+    expect(result.content[0].type).toBe('text');
+    expect(result.isError).toBeFalsy();
+
+    const unknown = await callMcpTool(gateway, ctx, 'does_not_exist', {});
+    expect(unknown.isError).toBe(true);
+  });
+});

--- a/web/packages/sdk/src/capabilities/fetchers.ts
+++ b/web/packages/sdk/src/capabilities/fetchers.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Binds each service's generated `customFetch` (axios client with OIDC auth and
+ * base-URL resolution) to a {@link Fetcher} keyed by service name. This is the
+ * only file in the capabilities runtime that depends on the generated clients,
+ * keeping the rest of the module decoupled and unit-testable.
+ */
+import { customFetch as agentsFetch } from '../../generated/fetchers/agents';
+import { customFetch as dataDesignerFetch } from '../../generated/fetchers/data-designer';
+import { customFetch as evaluatorFetch } from '../../generated/fetchers/evaluator';
+import { customFetch as platformFetch } from '../../generated/fetchers/platform';
+import { customFetch as safeSynthesizerFetch } from '../../generated/fetchers/safe-synthesizer';
+import type { Fetcher } from './types';
+
+/** Service name → generated axios fetcher. Keys match `CapabilityMeta.service`. */
+export const defaultFetchers: Partial<Record<string, Fetcher>> = {
+  platform: platformFetch,
+  'data-designer': dataDesignerFetch,
+  agents: agentsFetch,
+  'safe-synthesizer': safeSynthesizerFetch,
+  evaluator: evaluatorFetch,
+};

--- a/web/packages/sdk/src/capabilities/gateway.ts
+++ b/web/packages/sdk/src/capabilities/gateway.ts
@@ -85,7 +85,8 @@ export const createGateway = (capabilities: readonly CapabilityMeta[]): Capabili
       const query = asString(args.query);
       if (!query) return err('Invalid arguments: "query" is required.');
       const results = searchCapabilities(capabilities, query, {
-        limit: typeof args.limit === 'number' ? args.limit : undefined,
+        limit:
+          typeof args.limit === 'number' && args.limit >= 1 ? Math.floor(args.limit) : undefined,
         service: asString(args.service),
         readOnly: typeof args.readOnly === 'boolean' ? args.readOnly : undefined,
       });

--- a/web/packages/sdk/src/capabilities/gateway.ts
+++ b/web/packages/sdk/src/capabilities/gateway.ts
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { invokeCapability } from './invoke';
+import { getCapability, indexByName, searchCapabilities } from './registry';
+import type { Capability, CapabilityContext, CapabilityMeta, JsonSchema } from './types';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+const ok = (payload: unknown) => ({ content: JSON.stringify(payload) });
+const err = (message: string) => ({ content: message, isError: true });
+
+const stringifyResult = (value: unknown): string => {
+  if (value === undefined) return 'OK (no content)';
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+};
+
+const SEARCH_SCHEMA: JsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    query: {
+      type: 'string',
+      description: 'Keywords to match against operation names, paths, summaries, and tags.',
+    },
+    service: {
+      type: 'string',
+      description: 'Optional: restrict to one service spec (e.g. platform, agents, evaluator).',
+    },
+    readOnly: {
+      type: 'boolean',
+      description: 'Optional: true for read-only (GET) operations, false for mutating ones.',
+    },
+    limit: { type: 'integer', description: 'Max results (default 25).', minimum: 1 },
+  },
+  required: ['query'],
+};
+
+const NAME_SCHEMA: JsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    name: { type: 'string', description: 'The exact operation name from search_capabilities.' },
+    args: {
+      type: 'object',
+      description:
+        'Arguments object. Provide path and query parameters as top-level keys, and the request payload under "body". Call describe_capability first to get the exact schema.',
+    },
+  },
+  required: ['name'],
+};
+
+const DESCRIBE_SCHEMA: JsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    name: { type: 'string', description: 'The exact operation name from search_capabilities.' },
+  },
+  required: ['name'],
+};
+
+/**
+ * Builds the gateway: a small, fixed set of capabilities that let an LLM
+ * navigate and call the entire NeMo Platform API without holding hundreds of
+ * tool definitions in context. The flow is search → describe → read/run.
+ */
+export const createGateway = (capabilities: readonly CapabilityMeta[]): Capability[] => {
+  const index = indexByName(capabilities);
+  const resolve = (name: string) => index.get(name) ?? getCapability(capabilities, name);
+
+  const searchCapability: Capability = {
+    name: 'search_capabilities',
+    description:
+      'Search the NeMo Platform API for operations by keyword. Returns a ranked list of operation names with their method, path, and summary. Use this first to find the right operation, then describe_capability for its arguments.',
+    inputSchema: SEARCH_SCHEMA,
+    readOnly: true,
+    requiresConfirmation: false,
+    execute: async (args) => {
+      if (!isRecord(args)) return err('Invalid arguments: expected an object.');
+      const query = asString(args.query);
+      if (!query) return err('Invalid arguments: "query" is required.');
+      const results = searchCapabilities(capabilities, query, {
+        limit: typeof args.limit === 'number' ? args.limit : undefined,
+        service: asString(args.service),
+        readOnly: typeof args.readOnly === 'boolean' ? args.readOnly : undefined,
+      });
+      return ok({ count: results.length, results });
+    },
+  };
+
+  const describeCapability: Capability = {
+    name: 'describe_capability',
+    description:
+      'Get the full definition of a single API operation by name: its HTTP method, path, whether it is read-only, and a JSON Schema for its arguments (path/query parameters and request body). Call this before read_capability or run_capability.',
+    inputSchema: DESCRIBE_SCHEMA,
+    readOnly: true,
+    requiresConfirmation: false,
+    execute: async (args) => {
+      if (!isRecord(args)) return err('Invalid arguments: expected an object.');
+      const name = asString(args.name);
+      if (!name) return err('Invalid arguments: "name" is required.');
+      const meta = resolve(name);
+      if (!meta) return err(`Unknown operation "${name}". Use search_capabilities to find one.`);
+      return ok({
+        name: meta.name,
+        service: meta.service,
+        method: meta.method,
+        path: meta.path,
+        summary: meta.summary,
+        description: meta.description,
+        readOnly: meta.readOnly,
+        inputSchema: meta.inputSchema,
+      });
+    },
+  };
+
+  const runOperation = async (args: unknown, ctx: CapabilityContext, mode: 'read' | 'run') => {
+    if (!isRecord(args)) return err('Invalid arguments: expected an object.');
+    const name = asString(args.name);
+    if (!name) return err('Invalid arguments: "name" is required.');
+    const meta = resolve(name);
+    if (!meta) return err(`Unknown operation "${name}". Use search_capabilities to find one.`);
+
+    if (mode === 'read' && !meta.readOnly) {
+      return err(`"${name}" mutates state (${meta.method}). Use run_capability instead.`);
+    }
+    if (mode === 'run' && meta.readOnly) {
+      return err(`"${name}" is read-only (${meta.method}). Use read_capability instead.`);
+    }
+
+    try {
+      const result = await invokeCapability(meta, args.args, ctx);
+      return { content: stringifyResult(result) };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return err(`${name} failed: ${message}`);
+    }
+  };
+
+  const readCapability: Capability = {
+    name: 'read_capability',
+    description:
+      'Execute a read-only (GET) API operation and return its response. Provide the operation "name" and an "args" object as described by describe_capability.',
+    inputSchema: NAME_SCHEMA,
+    readOnly: true,
+    requiresConfirmation: false,
+    execute: (args, ctx) => runOperation(args, ctx, 'read'),
+  };
+
+  const runCapability: Capability = {
+    name: 'run_capability',
+    description:
+      'Execute a state-changing (POST/PUT/PATCH/DELETE) API operation. This creates, updates, or deletes resources, so it should be confirmed with the user first. Provide the operation "name" and an "args" object as described by describe_capability.',
+    inputSchema: NAME_SCHEMA,
+    readOnly: false,
+    requiresConfirmation: true,
+    execute: (args, ctx) => runOperation(args, ctx, 'run'),
+  };
+
+  return [searchCapability, describeCapability, readCapability, runCapability];
+};

--- a/web/packages/sdk/src/capabilities/index.ts
+++ b/web/packages/sdk/src/capabilities/index.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * NeMo Platform API capabilities for LLM tool use.
+ *
+ * The generated registry (`generated/capabilities/registry.ts`) describes every
+ * API operation. The gateway exposes a handful of capabilities — search,
+ * describe, read, run — that let an agent navigate and invoke the whole API
+ * without holding hundreds of tool definitions in context. Adapters convert
+ * capabilities to Anthropic, OpenAI, or MCP wire formats.
+ *
+ * Quick start:
+ * ```ts
+ * import { nemoGateway, toAnthropicTools, defaultFetchers } from '@nemo/sdk/src/capabilities';
+ *
+ * const tools = toAnthropicTools(nemoGateway);                 // pass to the Messages API
+ * const ctx = { fetchers: defaultFetchers, workspace: 'default' };
+ * // when the model calls a tool:
+ * const cap = nemoGateway.find((c) => c.name === toolUse.name)!;
+ * const result = await cap.execute(toolUse.input, ctx);
+ * ```
+ */
+import { capabilities } from '../../generated/capabilities/registry';
+import { createGateway } from './gateway';
+
+export * from './types';
+export * from './registry';
+export * from './invoke';
+export * from './gateway';
+export * from './fetchers';
+export * from './adapters/anthropic';
+export * from './adapters/openai';
+export * from './adapters/mcp';
+
+/** The full generated registry of API operations. */
+export { capabilities };
+
+/** The ready-to-use gateway capabilities (search/describe/read/run). */
+export const nemoGateway = createGateway(capabilities);

--- a/web/packages/sdk/src/capabilities/invoke.ts
+++ b/web/packages/sdk/src/capabilities/invoke.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CapabilityContext, CapabilityMeta, Fetcher } from './types';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const resolveFetcher = (meta: CapabilityMeta, ctx: CapabilityContext): Fetcher => {
+  const fetcher = ctx.fetchers[meta.service] ?? ctx.defaultFetcher;
+  if (!fetcher) {
+    throw new Error(
+      `No fetcher registered for service "${meta.service}". Provide ctx.fetchers["${meta.service}"] or ctx.defaultFetcher.`
+    );
+  }
+  return fetcher;
+};
+
+/**
+ * Invokes an API operation described by {@link CapabilityMeta}.
+ *
+ * Path parameters are substituted into the path template, query parameters are
+ * collected into `params`, and the `body` argument (if any) becomes the request
+ * payload. A `{workspace}` path param falls back to `ctx.workspace` when the
+ * caller omits it. The actual HTTP call is delegated to the per-service fetcher,
+ * so this function never depends on the generated client directly.
+ */
+export const invokeCapability = async <T = unknown>(
+  meta: CapabilityMeta,
+  args: unknown,
+  ctx: CapabilityContext
+): Promise<T> => {
+  const input: Record<string, unknown> = isRecord(args) ? args : {};
+
+  let url = meta.path;
+  for (const name of meta.pathParams) {
+    let value = input[name];
+    if ((value === undefined || value === null) && name === 'workspace' && ctx.workspace) {
+      value = ctx.workspace;
+    }
+    if (value === undefined || value === null) {
+      throw new Error(`Missing required path parameter "${name}" for ${meta.name}.`);
+    }
+    url = url.replace(`{${name}}`, encodeURIComponent(String(value)));
+  }
+
+  const params: Record<string, unknown> = {};
+  for (const name of meta.queryParams) {
+    if (input[name] !== undefined) {
+      params[name] = input[name];
+    }
+  }
+
+  const data = meta.hasBody ? input.body : undefined;
+  if (meta.hasBody && meta.bodyRequired && data === undefined) {
+    throw new Error(`Missing required request body ("body") for ${meta.name}.`);
+  }
+
+  const fetcher = resolveFetcher(meta, ctx);
+  return fetcher<T>({
+    url,
+    method: meta.method,
+    params: Object.keys(params).length > 0 ? params : undefined,
+    data,
+    signal: ctx.signal,
+  });
+};

--- a/web/packages/sdk/src/capabilities/registry.ts
+++ b/web/packages/sdk/src/capabilities/registry.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CapabilityMeta } from './types';
+
+/** A lightweight summary returned by search, cheap for an LLM to scan. */
+export interface CapabilitySummary {
+  readonly name: string;
+  readonly service: string;
+  readonly method: string;
+  readonly path: string;
+  readonly summary: string;
+  readonly readOnly: boolean;
+}
+
+export interface SearchOptions {
+  /** Max results to return. Defaults to 25. */
+  readonly limit?: number;
+  /** Restrict to a single service spec. */
+  readonly service?: string;
+  /** Restrict to read-only (true) or mutating (false) operations. */
+  readonly readOnly?: boolean;
+}
+
+const toSummary = (meta: CapabilityMeta): CapabilitySummary => ({
+  name: meta.name,
+  service: meta.service,
+  method: meta.method,
+  path: meta.path,
+  summary: meta.summary ?? meta.description ?? '',
+  readOnly: meta.readOnly,
+});
+
+/** Builds an O(1) name → metadata index over a registry. */
+export const indexByName = (
+  capabilities: readonly CapabilityMeta[]
+): ReadonlyMap<string, CapabilityMeta> => new Map(capabilities.map((c) => [c.name, c]));
+
+export const getCapability = (
+  capabilities: readonly CapabilityMeta[],
+  name: string
+): CapabilityMeta | undefined => capabilities.find((c) => c.name === name);
+
+const haystack = (meta: CapabilityMeta): string =>
+  [meta.name, meta.path, meta.summary, meta.description, meta.service, ...meta.tags]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+/**
+ * Ranked keyword search over the registry. Every whitespace-separated term in
+ * `query` must appear somewhere in the operation's name/path/summary/tags. Results
+ * are scored by how many terms hit the name or path (the strongest signals) so the
+ * most relevant operations surface first.
+ */
+export const searchCapabilities = (
+  capabilities: readonly CapabilityMeta[],
+  query: string,
+  options: SearchOptions = {}
+): CapabilitySummary[] => {
+  const { limit = 25, service, readOnly } = options;
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+
+  const scored: Array<{ meta: CapabilityMeta; score: number }> = [];
+  for (const meta of capabilities) {
+    if (service && meta.service !== service) continue;
+    if (readOnly !== undefined && meta.readOnly !== readOnly) continue;
+
+    const hay = haystack(meta);
+    if (!terms.every((t) => hay.includes(t))) continue;
+
+    const nameOrPath = `${meta.name} ${meta.path}`.toLowerCase();
+    const score = terms.reduce((acc, t) => acc + (nameOrPath.includes(t) ? 1 : 0), 0);
+    scored.push({ meta, score });
+  }
+
+  scored.sort((a, b) => b.score - a.score || a.meta.name.localeCompare(b.meta.name));
+  return scored.slice(0, limit).map(({ meta }) => toSummary(meta));
+};

--- a/web/packages/sdk/src/capabilities/registry.ts
+++ b/web/packages/sdk/src/capabilities/registry.ts
@@ -58,7 +58,8 @@ export const searchCapabilities = (
   query: string,
   options: SearchOptions = {}
 ): CapabilitySummary[] => {
-  const { limit = 25, service, readOnly } = options;
+  const { limit, service, readOnly } = options;
+  const safeLimit = limit && Number.isInteger(limit) && limit > 0 ? Math.floor(limit) : 25;
   const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
 
   const scored: Array<{ meta: CapabilityMeta; score: number }> = [];
@@ -75,5 +76,5 @@ export const searchCapabilities = (
   }
 
   scored.sort((a, b) => b.score - a.score || a.meta.name.localeCompare(b.meta.name));
-  return scored.slice(0, limit).map(({ meta }) => toSummary(meta));
+  return scored.slice(0, safeLimit).map(({ meta }) => toSummary(meta));
 };

--- a/web/packages/sdk/src/capabilities/types.ts
+++ b/web/packages/sdk/src/capabilities/types.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Framework-agnostic capability model for the NeMo Platform API.
+ *
+ * A "capability" is a single API operation (one path + method) described in a
+ * way an LLM agent can discover and invoke through tool use. The metadata in
+ * {@link CapabilityMeta} is produced by `orval/generate-capabilities.ts` from the
+ * same OpenAPI specs that drive the rest of `@nemo/sdk`; the runtime in this
+ * module turns that metadata into invocable tools and into the wire formats of
+ * specific LLM providers (Anthropic, OpenAI) and MCP via the adapters.
+ */
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+/**
+ * A JSON Schema fragment. OpenAPI 3.1 schemas are JSON Schema 2020-12, which is
+ * also what the Anthropic/OpenAI tool `input_schema`/`parameters` fields accept,
+ * so we pass these through largely unchanged. References are bundled into a local
+ * `$defs` block by the generator so every schema is self-contained.
+ */
+export type JsonSchema = Record<string, unknown>;
+
+/** Generated, serializable description of a single API operation. */
+export interface CapabilityMeta {
+  /** Stable, unique identifier used as the tool/operation name. */
+  readonly name: string;
+  /** Owning service spec, e.g. `platform`, `agents`, `evaluator`. */
+  readonly service: string;
+  readonly method: HttpMethod;
+  /** Path template, e.g. `/apis/models/v2/workspaces/{workspace}/models`. */
+  readonly path: string;
+  readonly summary?: string;
+  readonly description?: string;
+  readonly tags: readonly string[];
+  /** True for safe, side-effect-free operations (GET). */
+  readonly readOnly: boolean;
+  /** Names of `{...}` path parameters, in declaration order. */
+  readonly pathParams: readonly string[];
+  /** Names of query parameters. */
+  readonly queryParams: readonly string[];
+  readonly hasBody: boolean;
+  readonly bodyRequired: boolean;
+  /**
+   * Self-contained JSON Schema describing the full argument object: every path
+   * and query parameter as a top-level property, plus a `body` property when the
+   * operation takes a request body. Referenced component schemas live under
+   * `$defs`.
+   */
+  readonly inputSchema: JsonSchema;
+}
+
+/** Result returned by a capability's `execute`, shaped for an LLM tool message. */
+export interface ToolResult {
+  readonly content: string;
+  readonly isError?: boolean;
+}
+
+/** Minimal request shape shared with the generated `customFetch` per service. */
+export interface FetchRequest {
+  readonly url: string;
+  readonly method: string;
+  readonly params?: Record<string, unknown>;
+  readonly data?: unknown;
+  readonly signal?: AbortSignal;
+}
+
+/** A function that performs an HTTP request and resolves the response body. */
+export type Fetcher = <T>(request: FetchRequest) => Promise<T>;
+
+/**
+ * Execution context threaded through every capability call. Fetchers are
+ * injected (rather than imported) so the core stays decoupled from the generated
+ * axios clients and is trivially testable.
+ */
+export interface CapabilityContext {
+  /** Per-service fetchers, keyed by {@link CapabilityMeta.service}. */
+  readonly fetchers: Partial<Record<string, Fetcher>>;
+  /** Fallback fetcher used when no service-specific one is registered. */
+  readonly defaultFetcher?: Fetcher;
+  /** Auto-filled into a `{workspace}` path param when the caller omits it. */
+  readonly workspace?: string;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * A neutral, invocable tool. The gateway exposes a handful of these
+ * (search/describe/read/run); adapters convert them to provider wire formats.
+ */
+export interface Capability {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: JsonSchema;
+  readonly readOnly: boolean;
+  /** Hint to the caller that this tool mutates state and should be confirmed. */
+  readonly requiresConfirmation: boolean;
+  execute(args: unknown, ctx: CapabilityContext): Promise<ToolResult>;
+}

--- a/web/packages/sdk/tsconfig.json
+++ b/web/packages/sdk/tsconfig.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
-    "types": ["vite/client", "node"]
+    "types": ["vitest/globals", "vite/client", "node"]
   },
   "include": ["src/**/*.ts", "generated/*/api.ts", "generated/*/schema/**/*.ts"]
 }

--- a/web/packages/sdk/vitest.config.ts
+++ b/web/packages/sdk/vitest.config.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -523,6 +523,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.10.6)(jsdom@29.0.2)(msw@2.13.3(@types/node@24.12.0)(typescript@6.0.2))(vite@8.0.16(@types/node@24.12.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
   packages/storybook:
     dependencies:


### PR DESCRIPTION
This PR adds a new script for generating capabilities and some gateway tool definitions (search, describe, read and run) to help with consuming said capabilities. 

The idea here, is an agent/model will inveitably want to interact with nemo platform through the API. There already exists nemo skills that describe CLI commands which work well but only for CLI based AIs. In Studio, a web UI based app, we would want an agent to be able to interact with the platform similar to how a user would through publicly available web based APIs. This isn't meant as a replacement for the CLI skills but rather a new tool for web based interaction of agents and nemo platform. Since this is auto generated from the openapi yaml, it is the clearest connection from what is available on the API. 

example capability
```
{
    "name": "access_secret_apis_secrets_v2_workspaces__workspace__secrets__name__access_get",
    "service": "platform",
    "method": "GET",
    "path": "/apis/secrets/v2/workspaces/{workspace}/secrets/{name}/access",
    "summary": "Access Secret",
    "description": "Access the value of a secret.",
    "tags": [
      "Secrets"
    ],
    "readOnly": true,
    "pathParams": [
      "name",
      "workspace"
    ],
    "queryParams": [],
    "hasBody": false,
    "bodyRequired": false,
    "inputSchema": {
      "type": "object",
      "properties": {
        "name": {
          "type": "string",
          "title": "Name"
        },
        "workspace": {
          "type": "string",
          "title": "Workspace"
        }
      },
      "required": [
        "name",
        "workspace"
      ]
    }
  }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an SDK capabilities system to discover, describe, and run API operations via a ready-to-use gateway and bundled registry.
  * Introduced tool export support for OpenAI, Anthropic, and MCP-compatible formats.
  * Added capability metadata generation from service OpenAPI specs to keep the registry in sync.
* **Bug Fixes**
  * Improved capability regeneration by expanding cache invalidation coverage and running capability generation during the generation pipeline.
* **Tests**
  * Added unit tests covering capability search, invocation, gateway behavior, and adapter conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->