### PR TITLE
feat(evaluator): agent-evaluation plugin job (run_local + submit)

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
@@ -44,7 +44,7 @@ class AgentOutput(BaseModel):
         default=None,
         description="User-visible final text produced by the agent, if any.",
     )
-    response: Any | None = Field(
+    response: dict[str, Any] | None = Field(
         default=None,
         description="Structured final response payload produced by the agent, if any.",
     )

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
@@ -15,7 +15,7 @@ from typing import Any, Protocol, runtime_checkable
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_evaluator_sdk.values import Agent, Model
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator, model_validator
 
 # Well-known evidence keys produced by ``standard_evidence_descriptors``. Harness
 # code may import these to tag evidence consistently; callers may still add
@@ -44,9 +44,10 @@ class AgentOutput(BaseModel):
         default=None,
         description="User-visible final text produced by the agent, if any.",
     )
-    response: dict[str, Any] | None = Field(
+    response: JsonValue | None = Field(
         default=None,
-        description="Structured final response payload produced by the agent, if any.",
+        description="Final response payload produced by the agent, if any. Any JSON value — a "
+        "structured object, or a raw JSON string/array for agents that don't return an object.",
     )
     metadata: dict[str, Any] = Field(
         default_factory=dict,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/agents.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/agents.py
@@ -29,7 +29,21 @@ class Agent(BaseModel):
 
     # TODO: Much of this is duplicated between agent and model. Once we have aligned on model defination.
     # the duplication can be removed by defining EndPoint class and reusing it across both model and agent.
-    model_config = ConfigDict(extra="forbid")
+    #
+    # ``allOf``/``if``/``then`` mirrors the ``_validate_generic_fields`` validator into the OpenAPI
+    # schema: a generic-format agent must carry ``body`` + ``response_path`` (the generic HTTP path
+    # needs them), so the contract rejects a ``url``-only generic agent rather than only failing later.
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "allOf": [
+                {
+                    "if": {"properties": {"format": {"const": "generic"}}},
+                    "then": {"required": ["body", "response_path"]},
+                }
+            ]
+        },
+    )
 
     url: str = Field(description="Base URL of the agent endpoint.")
     name: str = Field(description="Agent name / identifier.")

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, PrivateAttr, model_validator
 
 
 class FilesystemEntry(BaseModel):
@@ -293,7 +293,12 @@ class LocalFilesystemEvidence:
 class EvidenceDescriptor(BaseModel):
     """Descriptor for a candidate trace, source, or artifact."""
 
-    model_config = ConfigDict(extra="forbid")
+    # ``anyOf`` mirrors the ``_requires_ref_or_data`` validator into the OpenAPI schema, so a payload
+    # with neither ``ref`` nor ``data`` is rejected by the contract, not just at runtime.
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={"anyOf": [{"required": ["ref"]}, {"required": ["data"]}]},
+    )
 
     kind: str = Field(description="Evidence type, e.g. 'filesystem', 'trace', 'log_bundle', or 'review'.")
     ref: str | None = Field(
@@ -304,7 +309,7 @@ class EvidenceDescriptor(BaseModel):
         default=None,
         description="Parser hint for the evidence payload, e.g. 'atif' for normalized traces.",
     )
-    data: Any | None = Field(
+    data: JsonValue | None = Field(
         default=None,
         description="Small inline evidence payload; at least one of ref or data must be set.",
     )

--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -515,6 +515,7 @@ nemo-switchyard = "nemo_switchyard.middleware:SwitchyardMiddleware"
 "auditor.audit" = "nemo_auditor.jobs.audit:AuditJob"
 "data-designer.create" = "nemo_data_designer_plugin.jobs.create:CreateJob"
 "evaluator.evaluate" = "nemo_evaluator.jobs.evaluate:EvaluateJob"
+"evaluator.agent-evaluate" = "nemo_evaluator.jobs.agent_evaluate:AgentEvalJob"
 
 # Generated from [tool.bundle-package]; do not edit this table by hand.
 [project.entry-points."nemo.sdk"]

--- a/packages/nmp_testing/src/nmp/testing/__init__.py
+++ b/packages/nmp_testing/src/nmp/testing/__init__.py
@@ -77,6 +77,7 @@ from .utils import (
     assert_exit_0,
     get_repo_root,
     grant_workspace_role,
+    igw_mock_provider_mode,
     run_nemo_local,
     short_unique_name,
     unique_email,
@@ -102,6 +103,7 @@ __all__ = [
     "as_user",
     "grant_workspace_role",
     "add_mock_provider",
+    "igw_mock_provider_mode",
     "MockProviderResponse",
     "wait_for_model_entity",
     # Task testing

--- a/packages/nmp_testing/src/nmp/testing/e2e/jobs.py
+++ b/packages/nmp_testing/src/nmp/testing/e2e/jobs.py
@@ -12,6 +12,7 @@ import time
 from collections.abc import Callable
 
 from nemo_platform import NeMoPlatform
+from nemo_platform.types.jobs.platform_job_response import PlatformJobResponse
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +90,7 @@ def wait_for_platform_job(
     image_pull_timeout: float = 600.0,
     poll_interval: float = 1.0,
     status_to_check: str = "",
-):
+) -> PlatformJobResponse:
     """Wait for a platform job to reach a terminal state.
 
     Uses the SDK's jobs API to poll for job status until it reaches
@@ -148,6 +149,8 @@ def wait_for_platform_job(
             error_parts.append(f"Failed to get job status: {detail_err}")
         raise TimeoutError("\n".join(error_parts)) from e
 
+    # poll_until_terminal calls get_status (which sets last_job) at least once before returning.
+    assert last_job is not None
     return last_job
 
 
@@ -218,6 +221,8 @@ def wait_for_job_completion(
             error_parts.append(f"Full job details: {job_response.json()}")
         raise TimeoutError("\n".join(error_parts)) from e
 
+    # poll_until_terminal calls get_status (which sets last_status) at least once before returning.
+    assert last_status is not None
     return last_status
 
 

--- a/packages/nmp_testing/src/nmp/testing/utils.py
+++ b/packages/nmp_testing/src/nmp/testing/utils.py
@@ -10,7 +10,8 @@ import subprocess
 import tempfile
 import time
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -362,6 +363,32 @@ def grant_workspace_role(
         roles=list(roles),
         wait_role_propagation=wait_role_propagation,
     )
+
+
+@contextmanager
+def igw_mock_provider_mode(prefix: str = "igw-mock-") -> Iterator[None]:
+    """Enable IGW mock-provider mode in *this* process for the duration of the ``with`` block.
+
+    Overrides ``InferenceGatewayConfig.mock_provider_prefix`` so :func:`add_mock_provider` can name
+    and resolve mock providers. Use this when driving a *real* platform subprocess (where
+    :func:`create_test_client` isn't in play) but the in-process config still has to recognize the
+    mock prefix.
+
+    Implemented as a ``Configuration`` override, which ``get_service_config`` honors ahead of the
+    env-derived config — so it works regardless of whether the IGW config was already read/cached
+    (an env var would lose that race) — and is scoped to the block, so it can't leak into unrelated
+    suites. The prior ``InferenceGatewayConfig`` override (if any) is restored on exit.
+    """
+    from nmp.common.config import Configuration
+    from nmp.core.inference_gateway.config import InferenceGatewayConfig
+
+    current = Configuration.get_service_config(InferenceGatewayConfig)
+    merged = InferenceGatewayConfig(**{**current.model_dump(), "mock_provider_prefix": prefix})
+    Configuration.set_overrides({InferenceGatewayConfig: merged})
+    try:
+        yield
+    finally:
+        Configuration.clear_override(InferenceGatewayConfig)
 
 
 def add_mock_provider(

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -45,6 +45,380 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/workspaces/{workspace}/agent-evaluate/jobs:
+    post:
+      tags:
+      - Evaluator Plugin Agent Eval Jobs Routes
+      summary: Create Job
+      operationId: create_job_apis_evaluator_v2_workspaces__workspace__agent_evaluate_jobs_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentEvaluateJobRequest'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentEvaluateJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Evaluator Plugin Agent Eval Jobs Routes
+      summary: List Jobs
+      operationId: list_jobs_apis_evaluator_v2_workspaces__workspace__agent_evaluate_jobs_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page number.
+          default: 1
+          title: Page
+        description: Page number.
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page size.
+          default: 10
+          title: Page Size
+        description: Page size.
+      - name: sort
+        in: query
+        required: false
+        schema:
+          allOf:
+          - $ref: '#/components/schemas/AgentEvaluateJobsSortField'
+          description: The field to sort by. To sort in decreasing order, use `-`
+            in front of the field name.
+          default: -created_at
+        description: The field to sort by. To sort in decreasing order, use `-` in
+          front of the field name.
+      - in: query
+        name: filter
+        style: deepObject
+        required: false
+        explode: true
+        schema:
+          $ref: '#/components/schemas/AgentEvaluateJobsListFilter'
+        description: Filter jobs on various criteria.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentEvaluateJobsPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/workspaces/{workspace}/agent-evaluate/jobs/{job}/results/{name}:
+    get:
+      tags:
+      - Evaluator Plugin Agent Eval Jobs Routes
+      summary: Get Job Result
+      operationId: get_job_result_apis_evaluator_v2_workspaces__workspace__agent_evaluate_jobs__job__results__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/workspaces/{workspace}/agent-evaluate/jobs/{job}/results/{name}/download:
+    get:
+      tags:
+      - Evaluator Plugin Agent Eval Jobs Routes
+      summary: Download Job Result
+      operationId: download_job_result_apis_evaluator_v2_workspaces__workspace__agent_evaluate_jobs__job__results__name__download_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Not Found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/workspaces/{workspace}/agent-evaluate/jobs/{name}:
+    get:
+      tags:
+      - Evaluator Plugin Agent Eval Jobs Routes
+      summary: Get Job
+      operationId: get_job_apis_evaluator_v2_workspaces__workspace__agent_evaluate_jobs__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentEvaluateJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Evaluator Plugin Agent Eval Jobs Routes
+      summary: Delete Job
+      operationId: delete_job_apis_evaluator_v2_workspaces__workspace__agent_evaluate_jobs__name__delete
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/workspaces/{workspace}/agent-evaluate/jobs/{name}/cancel:
+    post:
+      tags:
+      - Evaluator Plugin Agent Eval Jobs Routes
+      summary: Cancel Job
+      operationId: cancel_job_apis_evaluator_v2_workspaces__workspace__agent_evaluate_jobs__name__cancel_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentEvaluateJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/workspaces/{workspace}/agent-evaluate/jobs/{name}/logs:
+    get:
+      tags:
+      - Evaluator Plugin Agent Eval Jobs Routes
+      summary: Get Job Logs
+      operationId: get_job_logs_apis_evaluator_v2_workspaces__workspace__agent_evaluate_jobs__name__logs_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      - name: limit
+        in: query
+        required: false
+        schema:
+          title: Limit
+          type: integer
+      - name: page_cursor
+        in: query
+        required: false
+        schema:
+          title: Page Cursor
+          type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobLogPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/workspaces/{workspace}/agent-evaluate/jobs/{name}/results:
+    get:
+      tags:
+      - Evaluator Plugin Agent Eval Jobs Routes
+      summary: List Job Results
+      operationId: list_job_results_apis_evaluator_v2_workspaces__workspace__agent_evaluate_jobs__name__results_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobListResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/workspaces/{workspace}/agent-evaluate/jobs/{name}/status:
+    get:
+      tags:
+      - Evaluator Plugin Agent Eval Jobs Routes
+      summary: Get Job Status
+      operationId: get_job_status_apis_evaluator_v2_workspaces__workspace__agent_evaluate_jobs__name__status_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobStatusResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/evaluator/v2/workspaces/{workspace}/evaluate/jobs:
     post:
       tags:
@@ -605,6 +979,15 @@ paths:
 components:
   schemas:
     Agent:
+      allOf:
+      - if:
+          properties:
+            format:
+              const: generic
+        then:
+          required:
+          - body
+          - response_path
       properties:
         url:
           type: string
@@ -655,6 +1038,500 @@ components:
         \ HTTP POST with Jinja-templated body and\n  JSONPath extraction for response\
         \ and trajectory.\n- ``nemo_agent_toolkit``: NeMo Agent Toolkit SSE streaming\
         \ protocol\n  (``/generate/full?filter_steps=none``)."
+    AgentEvalInputSpec:
+      oneOf:
+      - required:
+        - target
+      - required:
+        - trials
+      properties:
+        target:
+          anyOf:
+          - $ref: '#/components/schemas/ModelTargetInput'
+          - $ref: '#/components/schemas/AgentTargetInput'
+          - $ref: '#/components/schemas/CodexRunnerTarget'
+          title: Target
+          description: 'What generates trials online: a Model or Agent endpoint, or
+            an agent runner (e.g. Codex CLI). Endpoint targets carry their own request
+            config (prompt template / inference params). Mutually exclusive with `trials`.'
+        trials:
+          title: Trials
+          description: Precomputed trials to score directly (offline eval), instead
+            of generating them from a `target`. Mutually exclusive with `target`.
+          items:
+            $ref: '#/components/schemas/AgentEvalTrialInput'
+          type: array
+        parallelism:
+          type: integer
+          minimum: 1.0
+          title: Parallelism
+          description: Maximum number of tasks scored concurrently.
+          default: 4
+        fail_fast:
+          type: boolean
+          title: Fail Fast
+          description: Stop the run on the first scoring failure when True.
+          default: false
+        benchmark:
+          additionalProperties: true
+          type: object
+          title: Benchmark
+          description: Benchmark metadata recorded with the run.
+        tasks:
+          items:
+            $ref: '#/components/schemas/AgentEvalTaskInput'
+          type: array
+          minItems: 1
+          title: Tasks
+          description: Tasks to evaluate; at least one is required.
+      additionalProperties: false
+      type: object
+      required:
+      - tasks
+      title: AgentEvalInputSpec
+      description: 'Submitter-facing agent-evaluation input: tasks whose metrics may
+        be inline or references.'
+    AgentEvalSpec:
+      oneOf:
+      - required:
+        - target
+      - required:
+        - trials
+      properties:
+        target:
+          anyOf:
+          - $ref: '#/components/schemas/ModelTargetOutput'
+          - $ref: '#/components/schemas/AgentTargetOutput'
+          - $ref: '#/components/schemas/CodexRunnerTarget'
+          title: Target
+          description: 'What generates trials online: a Model or Agent endpoint, or
+            an agent runner (e.g. Codex CLI). Endpoint targets carry their own request
+            config (prompt template / inference params). Mutually exclusive with `trials`.'
+        trials:
+          title: Trials
+          description: Precomputed trials to score directly (offline eval), instead
+            of generating them from a `target`. Mutually exclusive with `target`.
+          items:
+            $ref: '#/components/schemas/AgentEvalTrialOutput'
+          type: array
+        parallelism:
+          type: integer
+          minimum: 1.0
+          title: Parallelism
+          description: Maximum number of tasks scored concurrently.
+          default: 4
+        fail_fast:
+          type: boolean
+          title: Fail Fast
+          description: Stop the run on the first scoring failure when True.
+          default: false
+        benchmark:
+          additionalProperties: true
+          type: object
+          title: Benchmark
+          description: Benchmark metadata recorded with the run.
+        tasks:
+          items:
+            $ref: '#/components/schemas/AgentEvalTaskSpec'
+          type: array
+          minItems: 1
+          title: Tasks
+          description: Tasks to evaluate; at least one is required.
+      additionalProperties: false
+      type: object
+      required:
+      - tasks
+      title: AgentEvalSpec
+      description: 'Canonical agent-evaluation spec: tasks with all metric references
+        resolved to inline.'
+    AgentEvalTaskInput:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Stable task identifier, unique within the task collection.
+        intent:
+          type: string
+          title: Intent
+          description: Human-readable description of the desired agent behavior.
+        inputs:
+          additionalProperties: true
+          type: object
+          title: Inputs
+          description: What the agent receives or starts from (instruction, seed,
+            refs).
+        views:
+          additionalProperties:
+            $ref: '#/components/schemas/SemanticView'
+          type: object
+          title: Views
+          description: Optional reporting views mapping this task's metric outputs
+            into named semantic scores.
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+          description: Free-form metadata associated with the task.
+        metrics:
+          items:
+            anyOf:
+            - $ref: '#/components/schemas/MetricInline'
+            - $ref: '#/components/schemas/MetricRef'
+          type: array
+          title: Metrics
+          description: Metrics that score this task, inline and/or references to stored
+            metrics.
+      additionalProperties: false
+      type: object
+      required:
+      - id
+      - intent
+      - inputs
+      title: AgentEvalTaskInput
+      description: 'Submitter-facing task DTO: metrics may be inline bundles or stored-metric
+        references.'
+    AgentEvalTaskSpec:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Stable task identifier, unique within the task collection.
+        intent:
+          type: string
+          title: Intent
+          description: Human-readable description of the desired agent behavior.
+        inputs:
+          additionalProperties: true
+          type: object
+          title: Inputs
+          description: What the agent receives or starts from (instruction, seed,
+            refs).
+        views:
+          additionalProperties:
+            $ref: '#/components/schemas/SemanticView'
+          type: object
+          title: Views
+          description: Optional reporting views mapping this task's metric outputs
+            into named semantic scores.
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+          description: Free-form metadata associated with the task.
+        metrics:
+          items:
+            $ref: '#/components/schemas/MetricInline'
+          type: array
+          title: Metrics
+          description: Inline metric bundles that score this task; reconstructed to
+            runtime metrics at run time.
+      additionalProperties: false
+      type: object
+      required:
+      - id
+      - intent
+      - inputs
+      title: AgentEvalTaskSpec
+      description: 'Canonical task DTO: metrics fully resolved to inline bundles,
+        reconstructed at run time.'
+    AgentEvalTrialInput:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Stable identifier for this trial.
+        task_id:
+          type: string
+          title: Task Id
+          description: Identifier of the AgentEvalTask this trial was produced for.
+        status:
+          allOf:
+          - $ref: '#/components/schemas/AgentEvalTrialStatus'
+          description: Lifecycle status of the trial.
+        output:
+          allOf:
+          - $ref: '#/components/schemas/AgentOutput'
+          description: Final agent output captured for the trial; required when status
+            is completed.
+        evidence:
+          allOf:
+          - $ref: '#/components/schemas/CandidateEvidenceInput'
+          description: Named evidence descriptors (final state, traces, logs, ...)
+            captured for the trial.
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+          description: Free-form metadata associated with the trial.
+      additionalProperties: false
+      type: object
+      required:
+      - id
+      - task_id
+      - status
+      title: AgentEvalTrialInput
+      description: 'Durable trial artifact for one task: output, evidence, status,
+        and metadata.'
+    AgentEvalTrialOutput:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Stable identifier for this trial.
+        task_id:
+          type: string
+          title: Task Id
+          description: Identifier of the AgentEvalTask this trial was produced for.
+        status:
+          allOf:
+          - $ref: '#/components/schemas/AgentEvalTrialStatus'
+          description: Lifecycle status of the trial.
+        output:
+          allOf:
+          - $ref: '#/components/schemas/AgentOutput'
+          description: Final agent output captured for the trial; required when status
+            is completed.
+        evidence:
+          allOf:
+          - $ref: '#/components/schemas/CandidateEvidenceOutput'
+          description: Named evidence descriptors (final state, traces, logs, ...)
+            captured for the trial.
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+          description: Free-form metadata associated with the trial.
+      additionalProperties: false
+      type: object
+      required:
+      - id
+      - task_id
+      - status
+      title: AgentEvalTrialOutput
+      description: 'Durable trial artifact for one task: output, evidence, status,
+        and metadata.'
+    AgentEvalTrialStatus:
+      type: string
+      enum:
+      - completed
+      - failed
+      - partial
+      title: AgentEvalTrialStatus
+      description: 'Lifecycle status for a trial: completed, failed, or partial.'
+    AgentEvaluateJob:
+      properties:
+        id:
+          title: Id
+          type: string
+        name:
+          type: string
+          title: Name
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        workspace:
+          title: Workspace
+          type: string
+        created_at:
+          title: Created At
+          type: string
+          format: date-time
+        updated_at:
+          title: Updated At
+          type: string
+          format: date-time
+        spec:
+          $ref: '#/components/schemas/AgentEvalSpec'
+        status:
+          $ref: '#/components/schemas/PlatformJobStatus'
+        status_details:
+          title: Status Details
+          additionalProperties: true
+          type: object
+        error_details:
+          title: Error Details
+          additionalProperties: true
+          type: object
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - name
+      - spec
+      title: AgentEvaluateJob
+    AgentEvaluateJobRequest:
+      properties:
+        name:
+          title: Name
+          type: string
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        spec:
+          $ref: '#/components/schemas/AgentEvalInputSpec'
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - spec
+      title: AgentEvaluateJobRequest
+    AgentEvaluateJobsListFilter:
+      additionalProperties: false
+      properties:
+        created_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs created at 'gte' datetime or 'lte' datetime.
+        name:
+          anyOf:
+          - $ref: '#/components/schemas/StringFilter'
+          - type: string
+          description: Name of the job.
+          title: Name
+        workspace:
+          description: Workspace of the job.
+          title: Workspace
+          type: string
+        project:
+          description: Project containing the job.
+          title: Project
+          type: string
+        status:
+          allOf:
+          - $ref: '#/components/schemas/PlatformJobStatus'
+          description: The current status.
+        updated_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs updated at 'gte' datetime or 'lte' datetime.
+      title: AgentEvaluateJobsListFilter
+      type: object
+    AgentEvaluateJobsPage:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/AgentEvaluateJob'
+          type: array
+          title: Data
+        pagination:
+          allOf:
+          - $ref: '#/components/schemas/PaginationData'
+          description: Pagination information.
+        sort:
+          title: Sort
+          description: The field on which the results are sorted.
+          type: string
+        filter:
+          title: Filter
+          description: Filtering information.
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - data
+      title: AgentEvaluateJobsPage
+    AgentEvaluateJobsSortField:
+      type: string
+      enum:
+      - created_at
+      - -created_at
+      - updated_at
+      - -updated_at
+      title: AgentEvaluateJobsSortField
+    AgentOutput:
+      properties:
+        output_text:
+          title: Output Text
+          description: User-visible final text produced by the agent, if any.
+          type: string
+        response:
+          title: Response
+          description: Structured final response payload produced by the agent, if
+            any.
+          additionalProperties: true
+          type: object
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+          description: Free-form metadata associated with the agent output.
+      additionalProperties: false
+      type: object
+      title: AgentOutput
+      description: Captured final output from the evaluated agent, model, or imported
+        baseline for a trial.
+    AgentTargetInput:
+      properties:
+        kind:
+          type: string
+          const: agent
+          title: Kind
+          default: agent
+        agent:
+          allOf:
+          - $ref: '#/components/schemas/Agent'
+          description: The agent endpoint to generate trials against.
+        params:
+          allOf:
+          - $ref: '#/components/schemas/RunConfigOnline'
+          description: Optional online-inference parameters for trial generation.
+      additionalProperties: false
+      type: object
+      required:
+      - agent
+      title: AgentTargetInput
+      description: 'Generate trials by calling an Agent (generic HTTP) endpoint.
+
+
+        The agent shapes its own request via its ``body`` / ``response_path``, so
+        there is no separate
+
+        prompt template here.'
+    AgentTargetOutput:
+      properties:
+        kind:
+          type: string
+          const: agent
+          title: Kind
+          default: agent
+        agent:
+          allOf:
+          - $ref: '#/components/schemas/Agent'
+          description: The agent endpoint to generate trials against.
+        params:
+          allOf:
+          - $ref: '#/components/schemas/RunConfigOnline'
+          description: Optional online-inference parameters for trial generation.
+      additionalProperties: false
+      type: object
+      required:
+      - agent
+      title: AgentTargetOutput
+      description: 'Generate trials by calling an Agent (generic HTTP) endpoint.
+
+
+        The agent shapes its own request via its ``body`` / ``response_path``, so
+        there is no separate
+
+        prompt template here.'
     BundledMetricOutputSpec:
       properties:
         name:
@@ -674,6 +1551,42 @@ components:
       - value_json_schema
       title: BundledMetricOutputSpec
       description: JSON-safe projection of a runtime metric output spec.
+    CandidateEvidenceInput:
+      properties:
+        descriptors:
+          additionalProperties:
+            $ref: '#/components/schemas/EvidenceDescriptor'
+          type: object
+          title: Descriptors
+          description: Evidence descriptors keyed by name (e.g. 'final_state', 'trace',
+            'logs').
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+          description: Free-form metadata associated with the evidence collection.
+      additionalProperties: false
+      type: object
+      title: CandidateEvidenceInput
+      description: Named evidence descriptors attached to an AgentEvalAttempt.
+    CandidateEvidenceOutput:
+      properties:
+        descriptors:
+          additionalProperties:
+            $ref: '#/components/schemas/EvidenceDescriptor'
+          type: object
+          title: Descriptors
+          description: Evidence descriptors keyed by name (e.g. 'final_state', 'trace',
+            'logs').
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+          description: Free-form metadata associated with the evidence collection.
+      additionalProperties: false
+      type: object
+      title: CandidateEvidenceOutput
+      description: Named evidence descriptors attached to an AgentEvalAttempt.
     CloudpickleMetricPayload:
       properties:
         kind:
@@ -723,6 +1636,27 @@ components:
         polymorphically (typed as an abstract base), which renders as an opaque
 
         object in the spec; this concrete DTO documents the actual fields.'
+    CodexRunnerTarget:
+      properties:
+        kind:
+          type: string
+          const: codex
+          title: Kind
+          default: codex
+        model:
+          title: Model
+          description: Codex model to use (e.g. 'gpt-5.5'); CLI default when omitted.
+          type: string
+        timeout_s:
+          type: integer
+          minimum: 1.0
+          title: Timeout S
+          description: Per-task timeout for the Codex CLI, in seconds.
+          default: 600
+      additionalProperties: false
+      type: object
+      title: CodexRunnerTarget
+      description: Generate trials by driving the Codex CLI agent runner.
     DatetimeFilter:
       additionalProperties: false
       properties:
@@ -985,6 +1919,44 @@ components:
       title: EvaluateSpec
       description: Canonical SDK evaluation spec with platform model and metric references
         resolved.
+    EvidenceDescriptor:
+      anyOf:
+      - required:
+        - ref
+      - required:
+        - data
+      properties:
+        kind:
+          type: string
+          title: Kind
+          description: Evidence type, e.g. 'filesystem', 'trace', 'log_bundle', or
+            'review'.
+        ref:
+          title: Ref
+          description: Reference to externally stored evidence (e.g. a local path
+            or storage ref).
+          type: string
+        format:
+          title: Format
+          description: Parser hint for the evidence payload, e.g. 'atif' for normalized
+            traces.
+          type: string
+        data:
+          allOf:
+          - $ref: '#/components/schemas/JsonValue'
+          description: Small inline evidence payload; at least one of ref or data
+            must be set.
+        metadata:
+          additionalProperties: true
+          type: object
+          title: Metadata
+          description: Free-form metadata associated with the evidence descriptor.
+      additionalProperties: false
+      type: object
+      required:
+      - kind
+      title: EvidenceDescriptor
+      description: Descriptor for a candidate trace, source, or artifact.
     FieldMapping:
       properties:
         input:
@@ -1152,6 +2124,8 @@ components:
         so no code is shipped or executed on load. Used for platform-recognized
 
         built-in metric types.'
+    JsonValue:
+      title: JsonValue
     Metric:
       properties:
         id:
@@ -1411,6 +2385,72 @@ components:
       - name
       title: Model
       description: Model definition for use without persisting to the Models API.
+    ModelTargetInput:
+      properties:
+        kind:
+          type: string
+          const: model
+          title: Kind
+          default: model
+        model:
+          allOf:
+          - $ref: '#/components/schemas/Model'
+          description: The model endpoint to generate trials against.
+        prompt_template:
+          anyOf:
+          - type: string
+          - additionalProperties: true
+            type: object
+          title: Prompt Template
+          description: How each task maps to the chat/completion request. Defaults
+            to a single user message carrying the task prompt when omitted.
+        params:
+          allOf:
+          - $ref: '#/components/schemas/RunConfigOnlineModel'
+          description: Optional online-inference parameters for trial generation.
+      additionalProperties: false
+      type: object
+      required:
+      - model
+      title: ModelTargetInput
+      description: 'Generate trials by calling a Model (OpenAI-compatible) endpoint.
+
+
+        The prompt template *is* the request sent to the model, so it lives here with
+        the endpoint.'
+    ModelTargetOutput:
+      properties:
+        kind:
+          type: string
+          const: model
+          title: Kind
+          default: model
+        model:
+          allOf:
+          - $ref: '#/components/schemas/Model'
+          description: The model endpoint to generate trials against.
+        prompt_template:
+          anyOf:
+          - type: string
+          - additionalProperties: true
+            type: object
+          title: Prompt Template
+          description: How each task maps to the chat/completion request. Defaults
+            to a single user message carrying the task prompt when omitted.
+        params:
+          allOf:
+          - $ref: '#/components/schemas/RunConfigOnlineModel'
+          description: Optional online-inference parameters for trial generation.
+      additionalProperties: false
+      type: object
+      required:
+      - model
+      title: ModelTargetOutput
+      description: 'Generate trials by calling a Model (OpenAI-compatible) endpoint.
+
+
+        The prompt template *is* the request sent to the model, so it lives here with
+        the endpoint.'
     PaginationData:
       properties:
         page:
@@ -1817,6 +2857,40 @@ components:
       description: 'Reference to a platform secret or local environment variable.
         Format: ''secret_name'' (uses request workspace) or ''workspace/secret_name''
         (explicit workspace).'
+    SemanticReducer:
+      type: string
+      enum:
+      - single
+      - all
+      - any
+      - mean
+      - weighted_mean
+      title: SemanticReducer
+      description: Reduction strategy used to combine task-scoped view signals into
+        one score.
+    SemanticView:
+      properties:
+        reducer:
+          allOf:
+          - $ref: '#/components/schemas/SemanticReducer'
+          description: Strategy used to reduce this view's signals into a single task-level
+            score.
+        signals:
+          items:
+            $ref: '#/components/schemas/ViewSignal'
+          type: array
+          minItems: 1
+          title: Signals
+          description: Ordered metric outputs contributing to this view; at least
+            one is required.
+      additionalProperties: false
+      type: object
+      required:
+      - reducer
+      - signals
+      title: SemanticView
+      description: Task-scoped reporting view that maps a task's own metric outputs
+        into a named score.
     StringFilter:
       additionalProperties: false
       properties:
@@ -1869,3 +2943,26 @@ components:
       - msg
       - type
       title: ValidationError
+    ViewSignal:
+      properties:
+        metric:
+          type: string
+          title: Metric
+          description: Task-local metric type (metric.type) whose output feeds this
+            signal.
+        output:
+          type: string
+          title: Output
+          description: Name of the metric output, as declared by the metric's output_spec().
+        weight:
+          title: Weight
+          description: Relative weight for this signal when the view reducer is 'weighted_mean';
+            unused otherwise.
+          type: number
+      additionalProperties: false
+      type: object
+      required:
+      - metric
+      - output
+      title: ViewSignal
+      description: Task-scoped metric output that contributes to a semantic view.

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -1040,9 +1040,17 @@ components:
         \ protocol\n  (``/generate/full?filter_steps=none``)."
     AgentEvalInputSpec:
       oneOf:
-      - required:
+      - properties:
+          target:
+            not:
+              type: 'null'
+        required:
         - target
-      - required:
+      - properties:
+          trials:
+            not:
+              type: 'null'
+        required:
         - trials
       properties:
         target:
@@ -1061,11 +1069,13 @@ components:
           items:
             $ref: '#/components/schemas/AgentEvalTrialInput'
           type: array
-        parallelism:
+        max_concurrent_tasks:
           type: integer
           minimum: 1.0
-          title: Parallelism
-          description: Maximum number of tasks scored concurrently.
+          title: Max Concurrent Tasks
+          description: Maximum number of tasks evaluated concurrently. Distinct from
+            a target's `params.parallelism`, which bounds concurrent inference requests
+            *within* trial generation.
           default: 4
         fail_fast:
           type: boolean
@@ -1093,9 +1103,17 @@ components:
         be inline or references.'
     AgentEvalSpec:
       oneOf:
-      - required:
+      - properties:
+          target:
+            not:
+              type: 'null'
+        required:
         - target
-      - required:
+      - properties:
+          trials:
+            not:
+              type: 'null'
+        required:
         - trials
       properties:
         target:
@@ -1114,11 +1132,13 @@ components:
           items:
             $ref: '#/components/schemas/AgentEvalTrialOutput'
           type: array
-        parallelism:
+        max_concurrent_tasks:
           type: integer
           minimum: 1.0
-          title: Parallelism
-          description: Maximum number of tasks scored concurrently.
+          title: Max Concurrent Tasks
+          description: Maximum number of tasks evaluated concurrently. Distinct from
+            a target's `params.parallelism`, which bounds concurrent inference requests
+            *within* trial generation.
           default: 4
         fail_fast:
           type: boolean
@@ -1463,11 +1483,11 @@ components:
           description: User-visible final text produced by the agent, if any.
           type: string
         response:
-          title: Response
-          description: Structured final response payload produced by the agent, if
-            any.
-          additionalProperties: true
-          type: object
+          allOf:
+          - $ref: '#/components/schemas/JsonValue'
+          description: "Final response payload produced by the agent, if any. Any\
+            \ JSON value \u2014 a structured object, or a raw JSON string/array for\
+            \ agents that don't return an object."
         metadata:
           additionalProperties: true
           type: object

--- a/plugins/nemo-evaluator/pyproject.toml
+++ b/plugins/nemo-evaluator/pyproject.toml
@@ -24,6 +24,7 @@ evaluator = "nemo_evaluator.sdk.resources:evaluator_sdk_resources"
 
 [project.entry-points."nemo.jobs"]
 "evaluator.evaluate" = "nemo_evaluator.jobs.evaluate:EvaluateJob"
+"evaluator.agent-evaluate" = "nemo_evaluator.jobs.agent_evaluate:AgentEvalJob"
 
 [project.entry-points."nemo.skills"]
 evaluator = "nemo_evaluator.skills:get_skills_path"
@@ -42,16 +43,17 @@ packages = ["src/nemo_evaluator"]
 nemo-evaluator-sdk = { workspace = true }
 nemo-platform-plugin = { workspace = true }
 nemo-platform-sdk = { workspace = true }
+nmp-testing = { workspace = true }
 
 [dependency-groups]
-dev = ["pytest>=8.3.4", "pytest-asyncio>=0.25.3", "ruff>=0.11.8"]
+dev = ["pytest>=8.3.4", "pytest-asyncio>=0.25.3", "ruff>=0.11.8", "nmp-testing"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 pythonpath = ["src"]
 testpaths = ["tests"]
 markers = [
-    "integration: live service integration tests (opt-in; e.g. RUN_INTAKE_INTEGRATION=1)",
+    "integration: live service integration tests (opt-in; spin up a real platform — subprocess/docker backends — or gated by e.g. RUN_INTAKE_INTEGRATION=1); deselect with -m 'not integration'",
 ]
 
 # Opt this plugin into OpenAPI spec generation

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_compiler.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_compiler.py
@@ -26,6 +26,14 @@ from nemo_platform_plugin.jobs.image import get_qualified_image
 
 AGENT_EVAL_STEP_NAME = "agent-evaluate"
 
+#: Container wiring for the agent-evaluate step: the shared cpu-tasks image, run via ``python -m``.
+#: Constants (not inline literals) so the step definition and its tests share one source of truth.
+#: (Making these spec-configurable is a possible future enhancement — see PR #496 discussion — but
+#: they're fixed for the MVP.)
+AGENT_EVAL_IMAGE = "nmp-cpu-tasks"
+AGENT_EVAL_ENTRYPOINT = ["python", "-m"]
+AGENT_EVAL_COMMAND = ["nemo_evaluator.tasks.agent_evaluate"]
+
 
 def compile_agent_eval_job(spec: AgentEvalSpec, *, profile: str | None = None) -> PlatformJobSpec:
     """Compile a canonical agent-evaluation spec into a plugin-native platform job."""
@@ -55,9 +63,9 @@ def _agent_eval_step(spec: AgentEvalSpec, profile: str | None) -> PlatformJobSte
             profile=profile or "default",
             provider="cpu",
             container=ContainerSpec(
-                image=get_qualified_image("nmp-cpu-tasks"),
-                entrypoint=["python", "-m"],
-                command=["nemo_evaluator.tasks.agent_evaluate"],
+                image=get_qualified_image(AGENT_EVAL_IMAGE),
+                entrypoint=AGENT_EVAL_ENTRYPOINT,
+                command=AGENT_EVAL_COMMAND,
             ),
         ),
         config=spec.model_dump(mode="json"),

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_compiler.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_compiler.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plugin-native agent-evaluation job compiler.
+
+Parallels :mod:`nemo_evaluator.jobs.compiler` (row/model eval), emitting a single
+``cpu-tasks`` step that runs ``python -m nemo_evaluator.tasks.agent_evaluate`` in
+the platform task environment. Metric/endpoint secrets are surfaced as
+``from_secret`` environment variables; an agent *runner* target (e.g. Codex)
+carries no endpoint secret of its own.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from nemo_evaluator.jobs.agent_spec import AgentEvalSpec, AgentTarget, ModelTarget
+from nemo_evaluator.jobs.secret_env import build_task_environment
+from nemo_platform_plugin.jobs.api_factory import (
+    ContainerSpec,
+    CPUExecutionProviderSpec,
+    PlatformJobSpec,
+    PlatformJobStep,
+)
+from nemo_platform_plugin.jobs.image import get_qualified_image
+
+AGENT_EVAL_STEP_NAME = "agent-evaluate"
+
+
+def compile_agent_eval_job(spec: AgentEvalSpec, *, profile: str | None = None) -> PlatformJobSpec:
+    """Compile a canonical agent-evaluation spec into a plugin-native platform job."""
+    return PlatformJobSpec(steps=[_agent_eval_step(spec, profile)])
+
+
+def _secret_refs(spec: AgentEvalSpec) -> Iterator[tuple[str, str]]:
+    """Yield ``(env_name, secret_name)`` for each metric secret and the endpoint target's api key."""
+    for task in spec.tasks:
+        for bundle in task.metrics:
+            for env_name, secret_ref in bundle.secrets.items():
+                yield env_name, secret_ref.root
+
+    endpoint = None
+    if isinstance(spec.target, ModelTarget):
+        endpoint = spec.target.model
+    elif isinstance(spec.target, AgentTarget):
+        endpoint = spec.target.agent
+    if endpoint is not None and endpoint.api_key_secret is not None and endpoint.api_key_env:
+        yield endpoint.api_key_env, endpoint.api_key_secret.root
+
+
+def _agent_eval_step(spec: AgentEvalSpec, profile: str | None) -> PlatformJobStep:
+    return PlatformJobStep(
+        name=AGENT_EVAL_STEP_NAME,
+        executor=CPUExecutionProviderSpec(
+            profile=profile or "default",
+            provider="cpu",
+            container=ContainerSpec(
+                image=get_qualified_image("nmp-cpu-tasks"),
+                entrypoint=["python", "-m"],
+                command=["nemo_evaluator.tasks.agent_evaluate"],
+            ),
+        ),
+        config=spec.model_dump(mode="json"),
+        environment=build_task_environment(_secret_refs(spec)),
+    )

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDK-backed agent-evaluation job for the evaluator plugin.
+
+Runs :class:`AgentEvaluator` over a set of tasks against a Model/Agent endpoint
+or an agent runner (e.g. Codex CLI), producing an ``AgentEvalResult`` (trials +
+per-trial scores + summary). The row-based counterpart is
+:class:`~nemo_evaluator.jobs.evaluate.EvaluateJob`.
+
+Per-task metrics may be given inline or as references to stored metrics;
+references are resolved into inline metrics during ``to_spec`` via the shared
+:mod:`nemo_evaluator.jobs.metric_resolution` helper. The result bundle is
+persisted as job artifacts; persisting it to the platform (entity + fileset) is
+a follow-up.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.jobs.agent_compiler import compile_agent_eval_job
+from nemo_evaluator.jobs.agent_spec import (
+    AgentEvalInputSpec,
+    AgentEvalSpec,
+    AgentEvalTaskSpec,
+    AgentTarget,
+    CodexRunnerTarget,
+    ModelTarget,
+    Target,
+)
+from nemo_evaluator.jobs.metric_resolution import resolve_metrics_to_inline, to_runtime_bundle
+from nemo_evaluator.shared.metric_bundles.bundles import unbundle_metric
+from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
+from nemo_evaluator_sdk.agent_eval.persistence import persist_run
+from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
+from nemo_evaluator_sdk.agent_eval.runtimes.codex.runtime import CodexCliAgentRuntime
+from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTarget
+from nemo_evaluator_sdk.metrics.protocol import Metric
+from nemo_evaluator_sdk.values import RunConfigOnline, RunConfigOnlineModel
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.job import NemoJob
+from nemo_platform_plugin.job_context import JobContext
+from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
+from pydantic import BaseModel
+
+#: Job-result artifact names + the on-disk bundle directory.
+DEFAULT_RESULT_NAME = "agent-eval-results"
+SUMMARY_RESULT_NAME = "summary"
+AGENT_BUNDLE_DIR = "agent-eval"
+SUMMARY_FILE_NAME = "summary.json"
+
+#: Identity headers forwarded from the job's platform SDK to online inference so a platform-routed
+#: target authenticates as the job's principal (``get_task_sdk`` emits these). An explicit allowlist
+#: — not an ``X-NMP-*`` prefix match — so trace/metadata headers the SDK may add later never leak to
+#: a third-party model/agent endpoint. ``X-NMP-Principal-Id`` is the header the PDP authorizes on
+#: (verified against an auth-enabled platform); the rest carry the delegated on-behalf-of identity.
+_FORWARDED_IDENTITY_HEADERS = frozenset(
+    {
+        "X-NMP-Principal-Id",
+        "X-NMP-Principal-Email",
+        "X-NMP-Principal-Groups",
+        "X-NMP-Principal-On-Behalf-Of",
+        "X-NMP-Principal-On-Behalf-Of-Email",
+        "X-NMP-Principal-On-Behalf-Of-Groups",
+        "X-NMP-Internal",
+    }
+)
+
+
+@dataclass(frozen=True)
+class AgentEvalResultFiles:
+    """Filesystem layout for a persisted agent-eval bundle."""
+
+    bundle_dir: Path
+    summary: Path
+
+
+def _runtime_metric(metric: MetricInline) -> Metric:
+    """Reconstruct a runtime ``Metric`` from its inline bundle DTO."""
+    return unbundle_metric(to_runtime_bundle(metric))
+
+
+def _to_runtime_task(task: AgentEvalTaskSpec) -> AgentEvalTask:
+    """Reconstruct a runtime ``AgentEvalTask`` (live metrics) from its canonical DTO."""
+    return AgentEvalTask(
+        id=task.id,
+        intent=task.intent,
+        inputs=task.inputs,
+        metrics=[_runtime_metric(metric) for metric in task.metrics],
+        views=task.views,
+        metadata=task.metadata,
+    )
+
+
+class AgentEvalJob(NemoJob):
+    """Run agent evaluation (``AgentEvaluator``) over tasks against a Model/Agent endpoint or runner."""
+
+    name: ClassVar[str] = "agent-evaluate"
+    description: ClassVar[str] = "Run agent evaluation over tasks against a model, agent, or runner."
+    container: ClassVar[str] = "cpu-tasks"
+    input_spec_schema: ClassVar[type[BaseModel] | None] = AgentEvalInputSpec
+    spec_schema: ClassVar[type[BaseModel] | None] = AgentEvalSpec
+    job_collection_path: ClassVar[str | None] = "/agent-evaluate/jobs"
+
+    @classmethod
+    async def to_spec(
+        cls,
+        input_spec: BaseModel,
+        *,
+        workspace: str,
+        entity_client: object,
+        async_sdk: AsyncNeMoPlatform | NeMoPlatform | None,
+        is_local: bool,
+    ) -> BaseModel:
+        """Resolve each task's metric references into inline metrics for the canonical spec."""
+        del is_local
+        submit_spec = (
+            input_spec.model_copy(deep=True)
+            if isinstance(input_spec, AgentEvalInputSpec)
+            else AgentEvalInputSpec.model_validate_json(input_spec.model_dump_json())
+        )
+        resolved_tasks: list[AgentEvalTaskSpec] = []
+        for task in submit_spec.tasks:
+            metrics = await resolve_metrics_to_inline(
+                task.metrics,
+                workspace=workspace,
+                entity_client=entity_client,
+                async_sdk=async_sdk,
+            )
+            resolved_tasks.append(
+                AgentEvalTaskSpec(
+                    id=task.id,
+                    intent=task.intent,
+                    inputs=task.inputs,
+                    metrics=metrics,
+                    views=task.views,
+                    metadata=task.metadata,
+                )
+            )
+        return AgentEvalSpec(
+            tasks=resolved_tasks,
+            target=submit_spec.target,
+            trials=submit_spec.trials,
+            parallelism=submit_spec.parallelism,
+            fail_fast=submit_spec.fail_fast,
+            benchmark=submit_spec.benchmark,
+        )
+
+    @classmethod
+    async def compile(
+        cls,
+        *,
+        workspace: str,
+        spec: BaseModel,
+        entity_client: object,
+        job_name: str | None,
+        async_sdk: AsyncNeMoPlatform | None,
+        profile: str | None = None,
+        options: dict | None = None,
+    ) -> PlatformJobSpec:
+        """Compile the canonical spec into a plugin-native agent-evaluation job."""
+        del workspace, entity_client, job_name, async_sdk, options
+        canonical_spec = spec if isinstance(spec, AgentEvalSpec) else AgentEvalSpec.model_validate(spec.model_dump())
+        return compile_agent_eval_job(canonical_spec, profile=profile)
+
+    @staticmethod
+    def _build_evaluator(platform: NeMoPlatform | AsyncNeMoPlatform | None) -> AgentEvaluator:
+        """Construct the evaluator, forwarding the job's platform identity to online inference.
+
+        Online generation against a platform-routed Model/Agent target must act as the job's
+        principal, so the task SDK's identity headers (:data:`_FORWARDED_IDENTITY_HEADERS`, e.g.
+        the service principal id and on-behalf-of) are forwarded to the evaluator's inference client.
+        External-provider targets ignore these and authenticate via their own api key, so forwarding
+        the platform identity is safe (no bearer is forwarded, so the platform token never leaks to a
+        third-party endpoint). Isolated so tests can inject a fake inference seam.
+
+        ``platform`` is the SDK handle injected into ``run`` — a real ``NeMoPlatform`` in a submitted
+        job (built by ``get_task_sdk``, threading ``NMP_PRINCIPAL`` as on-behalf-of). It is ``None``
+        only for a platformless local run (e.g. offline ``run_local``), which has no identity to
+        forward.
+
+        NOTE: bearer-token auth for platform routes in an auth-enabled deployment is not yet
+        forwarded (the local/internal path relies on the ``X-NMP-*`` identity headers); see
+        AALGO-297 follow-ups.
+        """
+        identity_headers: dict[str, str] = {}
+        if platform is not None:
+            identity_headers = {
+                key: value
+                for key, value in platform.default_headers.items()
+                if key in _FORWARDED_IDENTITY_HEADERS and isinstance(value, str)
+            }
+        return AgentEvaluator(default_headers=identity_headers or None)
+
+    @staticmethod
+    def _resolve_target(
+        target: Target | None, ctx: JobContext
+    ) -> tuple[AgentEvalTarget | None, str | dict[str, Any] | None, RunConfigOnline | RunConfigOnlineModel | None]:
+        """Resolve a target spec to ``(runtime target, prompt_template, params)`` for the SDK run config.
+
+        Endpoint targets carry their own request config; a runner is instantiated to its runtime and
+        shapes its own request, so it contributes neither a prompt template nor inference params.
+        """
+        if isinstance(target, ModelTarget):
+            return target.model, target.prompt_template, target.params or RunConfigOnlineModel()
+        if isinstance(target, AgentTarget):
+            return target.agent, None, target.params or RunConfigOnline()
+        if isinstance(target, CodexRunnerTarget):
+            runtime = CodexCliAgentRuntime(
+                model=target.model,
+                timeout_s=target.timeout_s,
+                work_root=ctx.storage.persistent / "codex",
+            )
+            return runtime, None, None
+        return None, None, None
+
+    @staticmethod
+    def _write_result_files(result: AgentEvalResult, persistent_dir: Path) -> AgentEvalResultFiles:
+        """Persist the run bundle (trials/scores/tasks/summary) under the job's storage."""
+        bundle_dir = persistent_dir / AGENT_BUNDLE_DIR
+        persist_run(result, bundle_dir)
+        return AgentEvalResultFiles(bundle_dir=bundle_dir, summary=bundle_dir / SUMMARY_FILE_NAME)
+
+    def run(
+        self,
+        config: dict,
+        *,
+        ctx: JobContext,
+        sdk: NeMoPlatform | None = None,
+        async_sdk: AsyncNeMoPlatform | None = None,
+    ) -> dict:
+        """Run the agent evaluation locally and persist its result bundle as artifacts."""
+        spec = AgentEvalSpec.model_validate(config)
+        tasks = [_to_runtime_task(task) for task in spec.tasks]
+        target, prompt_template, params = self._resolve_target(spec.target, ctx)
+        run_config = AgentEvalRunConfig(
+            params=params,
+            prompt_template=prompt_template,
+            parallelism=spec.parallelism,
+            benchmark=spec.benchmark,
+            fail_fast=spec.fail_fast,
+            write_dashboard=False,
+        )
+        # `run` may be injected a sync `sdk` (submitted jobs, via get_task_sdk) and/or an
+        # `async_sdk`; forward whichever identity is present, preferring async when both are — the
+        # same precedence the SDK-backed dataset resolver uses.
+        evaluator = self._build_evaluator(async_sdk or sdk)
+        result = evaluator.run_sync(tasks=tasks, trials=spec.trials, target=target, config=run_config)
+
+        files = self._write_result_files(result, ctx.storage.persistent)
+        artifact = ctx.results.save(DEFAULT_RESULT_NAME, files.bundle_dir)
+        ctx.results.save(SUMMARY_RESULT_NAME, files.summary)
+
+        return {"status": "completed", "artifact": artifact.model_dump()}

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
@@ -10,9 +10,8 @@ per-trial scores + summary). The row-based counterpart is
 
 Per-task metrics may be given inline or as references to stored metrics;
 references are resolved into inline metrics during ``to_spec`` via the shared
-:mod:`nemo_evaluator.jobs.metric_resolution` helper. The result bundle is
-persisted as job artifacts; persisting it to the platform (entity + fileset) is
-a follow-up.
+:mod:`nemo_evaluator.jobs.metric_resolution` helper. The result bundle (trials +
+scores + summary) is persisted as job artifacts.
 """
 
 from __future__ import annotations
@@ -20,6 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar
+from urllib.parse import urlsplit
 
 from nemo_evaluator.api.schemas import MetricInline
 from nemo_evaluator.jobs.agent_compiler import compile_agent_eval_job
@@ -114,7 +114,7 @@ class AgentEvalJob(NemoJob):
         *,
         workspace: str,
         entity_client: object,
-        async_sdk: AsyncNeMoPlatform | NeMoPlatform | None,
+        async_sdk: AsyncNeMoPlatform | None,
         is_local: bool,
     ) -> BaseModel:
         """Resolve each task's metric references into inline metrics for the canonical spec."""
@@ -146,7 +146,7 @@ class AgentEvalJob(NemoJob):
             tasks=resolved_tasks,
             target=submit_spec.target,
             trials=submit_spec.trials,
-            parallelism=submit_spec.parallelism,
+            max_concurrent_tasks=submit_spec.max_concurrent_tasks,
             fail_fast=submit_spec.fail_fast,
             benchmark=submit_spec.benchmark,
         )
@@ -169,15 +169,40 @@ class AgentEvalJob(NemoJob):
         return compile_agent_eval_job(canonical_spec, profile=profile)
 
     @staticmethod
-    def _build_evaluator(platform: NeMoPlatform | AsyncNeMoPlatform | None) -> AgentEvaluator:
+    def _endpoint_url(target: Target | None) -> str | None:
+        """The HTTP endpoint a Model/Agent target generates against; ``None`` for a runner/offline."""
+        if isinstance(target, ModelTarget):
+            return str(target.model.url)
+        if isinstance(target, AgentTarget):
+            return str(target.agent.url)
+        return None
+
+    @staticmethod
+    def _is_platform_routed(url: str, platform: NeMoPlatform | AsyncNeMoPlatform) -> bool:
+        """True when *url* points at the platform itself (e.g. an IGW route under its base URL).
+
+        Compared by origin (host + port): the platform serves IGW under its own base URL, so a target
+        whose host matches is in-platform. A third-party endpoint the user configured does not match —
+        and must not receive the job's on-behalf-of identity (id/email/groups is PII).
+        """
+        target, base = urlsplit(url), urlsplit(str(platform.base_url))
+        return (target.hostname, target.port) == (base.hostname, base.port)
+
+    @staticmethod
+    def _build_evaluator(
+        platform: NeMoPlatform | AsyncNeMoPlatform | None, target: Target | None
+    ) -> AgentEvaluator:
         """Construct the evaluator, forwarding the job's platform identity to online inference.
 
-        Online generation against a platform-routed Model/Agent target must act as the job's
-        principal, so the task SDK's identity headers (:data:`_FORWARDED_IDENTITY_HEADERS`, e.g.
-        the service principal id and on-behalf-of) are forwarded to the evaluator's inference client.
-        External-provider targets ignore these and authenticate via their own api key, so forwarding
-        the platform identity is safe (no bearer is forwarded, so the platform token never leaks to a
-        third-party endpoint). Isolated so tests can inject a fake inference seam.
+        Online generation against a *platform-routed* Model/Agent target must act as the job's
+        principal, so the task SDK's identity headers (:data:`_FORWARDED_IDENTITY_HEADERS`, e.g. the
+        service principal id and on-behalf-of) are forwarded to the evaluator's inference client.
+
+        Forwarding is gated on the target being platform-routed (:meth:`_is_platform_routed`): a
+        third-party endpoint (or a runner with no HTTP endpoint) gets *no* identity headers, so the
+        delegated identity — which includes the user's email and group PII — never leaves the platform.
+        External providers authenticate via their own api key and don't need it anyway. Isolated so
+        tests can inject a fake inference seam.
 
         ``platform`` is the SDK handle injected into ``run`` — a real ``NeMoPlatform`` in a submitted
         job (built by ``get_task_sdk``, threading ``NMP_PRINCIPAL`` as on-behalf-of). It is ``None``
@@ -189,7 +214,8 @@ class AgentEvalJob(NemoJob):
         AALGO-297 follow-ups.
         """
         identity_headers: dict[str, str] = {}
-        if platform is not None:
+        url = AgentEvalJob._endpoint_url(target)
+        if platform is not None and url is not None and AgentEvalJob._is_platform_routed(url, platform):
             identity_headers = {
                 key: value
                 for key, value in platform.default_headers.items()
@@ -241,7 +267,7 @@ class AgentEvalJob(NemoJob):
         run_config = AgentEvalRunConfig(
             params=params,
             prompt_template=prompt_template,
-            parallelism=spec.parallelism,
+            parallelism=spec.max_concurrent_tasks,
             benchmark=spec.benchmark,
             fail_fast=spec.fail_fast,
             write_dashboard=False,
@@ -249,7 +275,7 @@ class AgentEvalJob(NemoJob):
         # `run` may be injected a sync `sdk` (submitted jobs, via get_task_sdk) and/or an
         # `async_sdk`; forward whichever identity is present, preferring async when both are — the
         # same precedence the SDK-backed dataset resolver uses.
-        evaluator = self._build_evaluator(async_sdk or sdk)
+        evaluator = self._build_evaluator(async_sdk or sdk, spec.target)
         result = evaluator.run_sync(tasks=tasks, trials=spec.trials, target=target, config=run_config)
 
         files = self._write_result_files(result, ctx.storage.persistent)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
@@ -189,9 +189,7 @@ class AgentEvalJob(NemoJob):
         return (target.hostname, target.port) == (base.hostname, base.port)
 
     @staticmethod
-    def _build_evaluator(
-        platform: NeMoPlatform | AsyncNeMoPlatform | None, target: Target | None
-    ) -> AgentEvaluator:
+    def _build_evaluator(platform: NeMoPlatform | AsyncNeMoPlatform | None, target: Target | None) -> AgentEvaluator:
         """Construct the evaluator, forwarding the job's platform identity to online inference.
 
         Online generation against a *platform-routed* Model/Agent target must act as the job's

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Spec and target models for the agent-evaluation job.
+
+These are the wire (submitter-facing) and canonical (resolved) DTOs that
+:class:`~nemo_evaluator.jobs.agent_evaluate.AgentEvalJob` validates and runs,
+plus the ``Target`` union describing what generates trials. They live in their
+own module so the job and its compiler can both depend on them without importing
+each other.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Self, TypeAlias
+
+# Imported for their registration side effects: each module registers its bundle
+# payload kind so MetricBundle payloads round-trip through validation.
+import nemo_evaluator.shared.metric_bundles.cloudpickle  # noqa: F401
+import nemo_evaluator.shared.metric_bundles.inline  # noqa: F401
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.jobs.metric_resolution import to_runtime_bundle, unresolved_model_refs
+from nemo_evaluator.metric_refs import MetricRefOrInline
+from nemo_evaluator.shared.metric_bundles.bundles import unbundle_metric
+from nemo_evaluator_sdk.agent_eval.tasks import SemanticView
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
+from nemo_evaluator_sdk.values import Agent, Model, RunConfigOnline, RunConfigOnlineModel
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelTarget(BaseModel):
+    """Generate trials by calling a Model (OpenAI-compatible) endpoint.
+
+    The prompt template *is* the request sent to the model, so it lives here with the endpoint.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["model"] = "model"
+    model: Model = Field(description="The model endpoint to generate trials against.")
+    prompt_template: str | dict[str, Any] | None = Field(
+        default=None,
+        description="How each task maps to the chat/completion request. Defaults to a single user "
+        "message carrying the task prompt when omitted.",
+    )
+    params: RunConfigOnlineModel | None = Field(
+        default=None, description="Optional online-inference parameters for trial generation."
+    )
+
+
+class AgentTarget(BaseModel):
+    """Generate trials by calling an Agent (generic HTTP) endpoint.
+
+    The agent shapes its own request via its ``body`` / ``response_path``, so there is no separate
+    prompt template here.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["agent"] = "agent"
+    agent: Agent = Field(description="The agent endpoint to generate trials against.")
+    params: RunConfigOnline | None = Field(
+        default=None, description="Optional online-inference parameters for trial generation."
+    )
+
+
+class CodexRunnerTarget(BaseModel):
+    """Generate trials by driving the Codex CLI agent runner."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["codex"] = "codex"
+    model: str | None = Field(
+        default=None, description="Codex model to use (e.g. 'gpt-5.5'); CLI default when omitted."
+    )
+    timeout_s: int = Field(default=600, ge=1, description="Per-task timeout for the Codex CLI, in seconds.")
+
+
+#: The agent-runner slot of the target union — the spec-side mirror of ``AgentTaskRunner``, resolved
+#: to a runtime at run time. One member today; widen to a ``kind``-union as more runners land.
+AgentRunnerTarget: TypeAlias = CodexRunnerTarget
+
+#: What generates trials: a Model or Agent endpoint, or an agent runner. ``kind``-discriminated, and
+#: the spec-level analog of the SDK's runtime ``AgentEvalTarget`` (Model | Agent | AgentTaskRunner).
+Target: TypeAlias = ModelTarget | AgentTarget | AgentRunnerTarget
+
+
+class _AgentEvalTaskCommon(BaseModel):
+    """Fields shared by the submitter and canonical task DTOs (everything but ``metrics``).
+
+    ``metrics`` differs between the two (refs allowed vs. fully resolved), so — as
+    with ``EvaluateInputSpec``/``EvaluateSpec`` — the variants are siblings that add
+    it, not a subtype pair (a mutable field can't be narrowed across inheritance).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(description="Stable task identifier, unique within the task collection.")
+    intent: str = Field(description="Human-readable description of the desired agent behavior.")
+    inputs: dict[str, Any] = Field(description="What the agent receives or starts from (instruction, seed, refs).")
+    views: dict[str, SemanticView] = Field(
+        default_factory=dict,
+        description="Optional reporting views mapping this task's metric outputs into named semantic scores.",
+    )
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Free-form metadata associated with the task.")
+
+
+class AgentEvalTaskInput(_AgentEvalTaskCommon):
+    """Submitter-facing task DTO: metrics may be inline bundles or stored-metric references."""
+
+    metrics: list[MetricRefOrInline] = Field(
+        default_factory=list,
+        description="Metrics that score this task, inline and/or references to stored metrics.",
+    )
+
+
+class AgentEvalTaskSpec(_AgentEvalTaskCommon):
+    """Canonical task DTO: metrics fully resolved to inline bundles, reconstructed at run time."""
+
+    metrics: list[MetricInline] = Field(
+        default_factory=list,
+        description="Inline metric bundles that score this task; reconstructed to runtime metrics at run time.",
+    )
+
+
+class _AgentEvalSpecCommon(BaseModel):
+    """Fields shared by the submitter input and canonical agent-eval specs (everything but ``tasks``)."""
+
+    # ``oneOf`` mirrors the ``_require_exactly_one_trial_source`` validator into the OpenAPI schema, so
+    # the generated contract (and clients) reject a target-less or both-supplied request instead of
+    # only discovering it via a 422 at runtime.
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={"oneOf": [{"required": ["target"]}, {"required": ["trials"]}]},
+    )
+
+    target: Target | None = Field(
+        default=None,
+        description="What generates trials online: a Model or Agent endpoint, or an agent runner (e.g. Codex "
+        "CLI). Endpoint targets carry their own request config (prompt template / inference params). "
+        "Mutually exclusive with `trials`.",
+    )
+    trials: list[AgentEvalTrial] | None = Field(
+        default=None,
+        description="Precomputed trials to score directly (offline eval), instead of generating them from a "
+        "`target`. Mutually exclusive with `target`.",
+    )
+    parallelism: int = Field(default=4, ge=1, description="Maximum number of tasks scored concurrently.")
+    fail_fast: bool = Field(default=False, description="Stop the run on the first scoring failure when True.")
+    benchmark: dict[str, Any] = Field(default_factory=dict, description="Benchmark metadata recorded with the run.")
+
+    @model_validator(mode="after")
+    def _require_exactly_one_trial_source(self) -> Self:
+        # The SDK evaluator requires exactly one of trials/target (one generates trials online, the
+        # other scores precomputed ones); enforce it at the spec boundary so a target-less or
+        # both-supplied spec is rejected at validation rather than failing inside the run.
+        if (self.target is None) == (self.trials is None):
+            raise ValueError(
+                "provide exactly one of `target` (generate trials online) or `trials` (score precomputed trials)"
+            )
+        return self
+
+
+class AgentEvalInputSpec(_AgentEvalSpecCommon):
+    """Submitter-facing agent-evaluation input: tasks whose metrics may be inline or references."""
+
+    tasks: list[AgentEvalTaskInput] = Field(min_length=1, description="Tasks to evaluate; at least one is required.")
+
+
+class AgentEvalSpec(_AgentEvalSpecCommon):
+    """Canonical agent-evaluation spec: tasks with all metric references resolved to inline."""
+
+    tasks: list[AgentEvalTaskSpec] = Field(min_length=1, description="Tasks to evaluate; at least one is required.")
+
+    @model_validator(mode="after")
+    def _reject_unresolved_metric_model_refs(self) -> Self:
+        for task in self.tasks:
+            unresolved = unresolved_model_refs([unbundle_metric(to_runtime_bundle(metric)) for metric in task.metrics])
+            if unresolved:
+                raise ValueError(
+                    f"AgentEvalSpec task {task.id!r} metric models must be resolved before run: "
+                    + ", ".join(unresolved)
+                )
+        return self

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
@@ -128,10 +128,17 @@ class _AgentEvalSpecCommon(BaseModel):
 
     # ``oneOf`` mirrors the ``_require_exactly_one_trial_source`` validator into the OpenAPI schema, so
     # the generated contract (and clients) reject a target-less or both-supplied request instead of
-    # only discovering it via a 422 at runtime.
+    # only discovering it via a 422 at runtime. Each branch also excludes an explicit ``null`` (the
+    # validator keys off non-null, not mere presence), so a request that sends ``"target": null``
+    # alongside ``trials`` is accepted by the schema exactly as the runtime accepts it.
     model_config = ConfigDict(
         extra="forbid",
-        json_schema_extra={"oneOf": [{"required": ["target"]}, {"required": ["trials"]}]},
+        json_schema_extra={
+            "oneOf": [
+                {"required": ["target"], "properties": {"target": {"not": {"type": "null"}}}},
+                {"required": ["trials"], "properties": {"trials": {"not": {"type": "null"}}}},
+            ]
+        },
     )
 
     target: Target | None = Field(
@@ -145,7 +152,12 @@ class _AgentEvalSpecCommon(BaseModel):
         description="Precomputed trials to score directly (offline eval), instead of generating them from a "
         "`target`. Mutually exclusive with `target`.",
     )
-    parallelism: int = Field(default=4, ge=1, description="Maximum number of tasks scored concurrently.")
+    max_concurrent_tasks: int = Field(
+        default=4,
+        ge=1,
+        description="Maximum number of tasks evaluated concurrently. Distinct from a target's "
+        "`params.parallelism`, which bounds concurrent inference requests *within* trial generation.",
+    )
     fail_fast: bool = Field(default=False, description="Stop the run on the first scoring failure when True.")
     benchmark: dict[str, Any] = Field(default_factory=dict, description="Benchmark metadata recorded with the run.")
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/compiler.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/compiler.py
@@ -5,24 +5,20 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 from nemo_evaluator.jobs.evaluate import EvaluateSpec
+from nemo_evaluator.jobs.secret_env import build_task_environment
 from nemo_evaluator_sdk.values import Agent, Model, RunConfig, RunConfigOnline, RunConfigOnlineModel
 from nemo_platform_plugin.jobs.api_factory import (
     ContainerSpec,
     CPUExecutionProviderSpec,
-    EnvironmentVariable,
-    EnvironmentVariableFromSecret,
     PlatformJobSpec,
     PlatformJobStep,
-)
-from nemo_platform_plugin.jobs.constants import (
-    DEFAULT_JOB_STORAGE_PATH,
-    PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
 )
 from nemo_platform_plugin.jobs.image import get_qualified_image
 
 EVALUATE_STEP_NAME = "evaluate"
-_RESERVED_SECRET_ENV_NAMES = frozenset({PERSISTENT_JOB_STORAGE_PATH_ENVVAR})
 
 
 def compile_evaluate_job(spec: EvaluateSpec, *, profile: str | None = None) -> PlatformJobSpec:
@@ -46,35 +42,14 @@ def _validate_evaluate_spec(spec: EvaluateSpec) -> None:
         raise TypeError("offline evaluation requires RunConfig")
 
 
-def _add_secret_ref(secret_refs: dict[str, str], env_name: str, secret_name: str) -> None:
-    if env_name in _RESERVED_SECRET_ENV_NAMES:
-        raise ValueError(f"{env_name!r} is reserved and cannot be sourced from secret refs")
-    existing = secret_refs.get(env_name)
-    if existing is not None and existing != secret_name:
-        raise ValueError(f"conflicting secret references for environment variable {env_name!r}")
-    secret_refs[env_name] = secret_name
-
-
-def _secret_environment(spec: EvaluateSpec) -> list[EnvironmentVariable]:
-    environment = [
-        EnvironmentVariable(
-            name=PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
-            value=DEFAULT_JOB_STORAGE_PATH,
-        )
-    ]
-    secret_refs: dict[str, str] = {}
+def _secret_refs(spec: EvaluateSpec) -> Iterator[tuple[str, str]]:
+    """Yield ``(env_name, secret_name)`` for each metric secret and the endpoint target's api key."""
     for bundle in spec.metrics:
         for env_name, secret_ref in bundle.secrets.items():
-            _add_secret_ref(secret_refs, env_name, secret_ref.root)
+            yield env_name, secret_ref.root
 
     if isinstance(spec.target, Model | Agent) and spec.target.api_key_secret is not None and spec.target.api_key_env:
-        _add_secret_ref(secret_refs, spec.target.api_key_env, spec.target.api_key_secret.root)
-
-    environment.extend(
-        EnvironmentVariable(name=env_name, from_secret=EnvironmentVariableFromSecret(name=secret_name))
-        for env_name, secret_name in sorted(secret_refs.items())
-    )
-    return environment
+        yield spec.target.api_key_env, spec.target.api_key_secret.root
 
 
 def _evaluate_step(spec: EvaluateSpec, profile: str | None) -> PlatformJobStep:
@@ -90,5 +65,5 @@ def _evaluate_step(spec: EvaluateSpec, profile: str | None) -> PlatformJobStep:
             ),
         ),
         config=spec.model_dump(mode="json"),
-        environment=_secret_environment(spec),
+        environment=build_task_environment(_secret_refs(spec)),
     )

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
@@ -214,7 +214,7 @@ class EvaluateJob(NemoJob):
         *,
         workspace: str,
         entity_client: object,
-        async_sdk: AsyncNeMoPlatform | NeMoPlatform | None,
+        async_sdk: AsyncNeMoPlatform | None,
         is_local: bool,
     ) -> BaseModel:
         """Resolve submitter-facing model and metric references into the canonical evaluation spec."""

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,18 +16,16 @@ import nemo_evaluator.shared.metric_bundles.cloudpickle  # noqa: F401
 import nemo_evaluator.shared.metric_bundles.inline  # noqa: F401
 from nemo_evaluator.api.schemas import MetricInline
 from nemo_evaluator.filesets import FilesetRef, download_dataset, download_dataset_sync
-from nemo_evaluator.metric_refs import MetricRef, resolve_metric_specs
-from nemo_evaluator.resolvers import PlatformModelResolver
-from nemo_evaluator.shared.metric_bundles.bundles import (
-    MetricBundle,
-    bundle_metric,
-    metric_bundle_packager_for_payload,
-    unbundle_metric,
+from nemo_evaluator.jobs.metric_resolution import (
+    resolve_metrics_to_inline,
+    to_runtime_bundle,
+    unresolved_model_refs,
 )
+from nemo_evaluator.metric_refs import MetricRefOrInline
+from nemo_evaluator.shared.metric_bundles.bundles import unbundle_metric
 from nemo_evaluator_sdk import Evaluator
 from nemo_evaluator_sdk.execution.config import resolve_params
 from nemo_evaluator_sdk.execution.metric_execution import run_sync
-from nemo_evaluator_sdk.metrics.protocol import Metric, MetricWithModels
 from nemo_evaluator_sdk.values import (
     Agent,
     FieldMapping,
@@ -46,7 +43,7 @@ from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 TargetSpec = Model | Agent
-MetricSpec: TypeAlias = Annotated[list[MetricInline | MetricRef], Field(min_length=1)]
+MetricSpec: TypeAlias = Annotated[list[MetricRefOrInline], Field(min_length=1)]
 # Canonical spec carries inline metrics only (refs resolved) — still the wire DTO,
 # so the runtime MetricBundle never surfaces as a public schema.
 ResolvedMetricSpec: TypeAlias = Annotated[list[MetricInline], Field(min_length=1)]
@@ -72,32 +69,6 @@ class EvaluationResultFiles:
     aggregate_scores: Path
     row_scores: Path
     artifacts_dir: Path
-
-
-def _unresolved_model_refs(metrics: list[Metric]) -> list[str]:
-    refs = [
-        model_ref.root
-        for item in metrics
-        if isinstance(item, MetricWithModels)
-        for model_ref in item.model_refs().values()
-    ]
-    return sorted(refs)
-
-
-def _bundle_resolved_metric(metric: Metric, source_bundle: MetricBundle) -> MetricBundle:
-    packager = metric_bundle_packager_for_payload(source_bundle.payload)
-    resolved_bundle = bundle_metric(metric, packager)
-    return resolved_bundle.model_copy(update={"metadata": source_bundle.metadata})
-
-
-def _to_inline(bundle: MetricBundle) -> MetricInline:
-    """Project a runtime bundle onto the wire DTO (JSON round-trip keeps base64 consistent)."""
-    return MetricInline.model_validate_json(bundle.model_dump_json())
-
-
-def _to_runtime_bundle(metric: MetricInline) -> MetricBundle:
-    """Reconstruct the runtime bundle from a wire DTO for execution."""
-    return MetricBundle.model_validate_json(metric.model_dump_json())
 
 
 def _resolve_run_dataset(
@@ -175,9 +146,7 @@ class EvaluateSpec(_EvaluateSpecCommon):
 
     @model_validator(mode="after")
     def reject_unresolved_metric_model_refs(self) -> Self:
-        unresolved_refs = _unresolved_model_refs(
-            [unbundle_metric(_to_runtime_bundle(metric)) for metric in self.metrics]
-        )
+        unresolved_refs = unresolved_model_refs([unbundle_metric(to_runtime_bundle(metric)) for metric in self.metrics])
         if unresolved_refs:
             raise ValueError(
                 "EvaluateSpec metric models must be resolved before compile/run: " + ", ".join(unresolved_refs)
@@ -203,7 +172,7 @@ class EvaluateJob(NemoJob):
         spec: BaseModel,
         entity_client: object,
         job_name: str | None,
-        async_sdk: object,
+        async_sdk: AsyncNeMoPlatform | None,
         profile: str | None = None,
         options: dict | None = None,
     ) -> PlatformJobSpec:
@@ -255,34 +224,16 @@ class EvaluateJob(NemoJob):
             if isinstance(input_spec, EvaluateInputSpec)
             else EvaluateInputSpec.model_validate_json(input_spec.model_dump_json())
         )
-        resolved_async_sdk = async_sdk if isinstance(async_sdk, AsyncNeMoPlatform) else None
-        resolved_metrics = await resolve_metric_specs(
+        metrics = await resolve_metrics_to_inline(
             submit_spec.metrics,
             workspace=workspace,
             entity_client=entity_client,
-            async_sdk=resolved_async_sdk,
+            async_sdk=async_sdk,
         )
-        metrics = [unbundle_metric(bundle) for bundle in resolved_metrics]
-        params = resolve_params(submit_spec.params, submit_spec.target)
-        final_bundles = resolved_metrics
-        unresolved_refs = _unresolved_model_refs(metrics)
-        if unresolved_refs:
-            if async_sdk is None:
-                raise ValueError(
-                    "ModelRef metrics require `async_sdk` for spec resolution: " + ", ".join(unresolved_refs)
-                )
-            resolver = PlatformModelResolver(async_sdk)
-            await asyncio.gather(
-                *(metric.resolve_models(resolver) for metric in metrics if isinstance(metric, MetricWithModels))
-            )
-            final_bundles = [
-                _bundle_resolved_metric(metric, bundle)
-                for metric, bundle in zip(metrics, resolved_metrics, strict=True)
-            ]
         return EvaluateSpec(
-            metrics=[_to_inline(bundle) for bundle in final_bundles],
+            metrics=metrics,
             dataset=submit_spec.dataset,
-            params=params,
+            params=resolve_params(submit_spec.params, submit_spec.target),
             target=submit_spec.target,
             prompt_template=submit_spec.prompt_template,
             field_mapping=submit_spec.field_mapping,
@@ -300,7 +251,7 @@ class EvaluateJob(NemoJob):
         spec = EvaluateSpec.model_validate(config)
         evaluator = Evaluator()
         params = resolve_params(spec.params, spec.target)
-        metrics = [unbundle_metric(_to_runtime_bundle(metric)) for metric in spec.metrics]
+        metrics = [unbundle_metric(to_runtime_bundle(metric)) for metric in spec.metrics]
         dataset = _resolve_run_dataset(
             spec.dataset,
             ctx=ctx,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/metric_resolution.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/metric_resolution.py
@@ -16,7 +16,7 @@ import asyncio
 
 from nemo_evaluator.api.schemas import MetricInline
 from nemo_evaluator.metric_refs import MetricRefOrInline, resolve_metric_specs
-from nemo_evaluator.resolvers import ModelResolverSdk, PlatformModelResolver
+from nemo_evaluator.resolvers import ModelResolverSDK, PlatformModelResolver
 from nemo_evaluator.shared.metric_bundles.bundles import (
     MetricBundle,
     bundle_metric,
@@ -76,7 +76,7 @@ async def resolve_metrics_to_inline(
       else (``None`` or the sync client) is narrowed to ``None`` and rejected with a clear error when
       a stored ``MetricRef`` is actually present — never awaited blindly.
     * **Model-ref resolution** duck-types the client (``PlatformModelResolver`` tolerates sync or
-      async via ``_maybe_await``), so it accepts anything conforming to ``ModelResolverSdk``; a
+      async via ``_maybe_await``), so it accepts anything conforming to ``ModelResolverSDK``; a
       non-conforming or absent client is rejected up front rather than failing deep in resolution.
     """
     files_sdk = async_sdk if isinstance(async_sdk, AsyncNeMoPlatform) else None
@@ -90,7 +90,7 @@ async def resolve_metrics_to_inline(
     final_bundles = resolved_bundles
     unresolved = unresolved_model_refs(runtime_metrics)
     if unresolved:
-        if not isinstance(async_sdk, ModelResolverSdk):
+        if not isinstance(async_sdk, ModelResolverSDK):
             raise ValueError(
                 "ModelRef metrics require a platform connection (models + inference) to resolve: "
                 + ", ".join(unresolved)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/metric_resolution.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/metric_resolution.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared metric-reference resolution for evaluator jobs.
+
+Both ``EvaluateJob`` (row/model eval) and ``AgentEvalJob`` accept metrics as a
+mix of inline bundles and references to stored metrics. During ``to_spec`` those
+must be resolved into canonical inline metrics — stored refs loaded from the
+entity store, and any model references carried by ``MetricWithModels`` resolved
+through the platform. This module is the one place that logic lives.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.metric_refs import MetricRefOrInline, resolve_metric_specs
+from nemo_evaluator.resolvers import ModelResolverSdk, PlatformModelResolver
+from nemo_evaluator.shared.metric_bundles.bundles import (
+    MetricBundle,
+    bundle_metric,
+    metric_bundle_packager_for_payload,
+    unbundle_metric,
+)
+from nemo_evaluator_sdk.metrics.protocol import Metric, MetricWithModels
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+
+
+def unresolved_model_refs(metrics: list[Metric]) -> list[str]:
+    """Return the sorted model references still unresolved across the given metrics."""
+    refs = [
+        model_ref.root
+        for item in metrics
+        if isinstance(item, MetricWithModels)
+        for model_ref in item.model_refs().values()
+    ]
+    return sorted(refs)
+
+
+def to_inline(bundle: MetricBundle) -> MetricInline:
+    """Project a runtime bundle onto the wire DTO (JSON round-trip keeps base64 consistent)."""
+    return MetricInline.model_validate_json(bundle.model_dump_json())
+
+
+def to_runtime_bundle(metric: MetricInline) -> MetricBundle:
+    """Reconstruct the runtime bundle from a wire DTO for execution."""
+    return MetricBundle.model_validate_json(metric.model_dump_json())
+
+
+def _bundle_resolved_metric(metric: Metric, source_bundle: MetricBundle) -> MetricBundle:
+    packager = metric_bundle_packager_for_payload(source_bundle.payload)
+    resolved_bundle = bundle_metric(metric, packager)
+    return resolved_bundle.model_copy(update={"metadata": source_bundle.metadata})
+
+
+async def resolve_metrics_to_inline(
+    metrics: list[MetricRefOrInline],
+    *,
+    workspace: str,
+    entity_client: object,
+    async_sdk: AsyncNeMoPlatform | NeMoPlatform | None,
+) -> list[MetricInline]:
+    """Resolve a wire metric list (inline + stored refs) into canonical inline metrics.
+
+    Stored references are loaded from the entity store; any ``MetricWithModels``
+    model references are resolved through the platform. Raises if a model
+    reference is present without a usable ``async_sdk`` connection.
+
+    ``async_sdk`` accepts either client because the call sites differ: submit forwards a real
+    ``AsyncNeMoPlatform``, while local execution forwards the *sync* ``NeMoPlatform``. The two
+    resolution concerns then have *different* client requirements:
+
+    * **Stored-ref loading** awaits real platform file I/O (``resolve_metric_ref`` → ``load_bundle``
+      → ``await sdk.files._download_file``), so it needs a genuine ``AsyncNeMoPlatform``. Anything
+      else (``None`` or the sync client) is narrowed to ``None`` and rejected with a clear error when
+      a stored ``MetricRef`` is actually present — never awaited blindly.
+    * **Model-ref resolution** duck-types the client (``PlatformModelResolver`` tolerates sync or
+      async via ``_maybe_await``), so it accepts anything conforming to ``ModelResolverSdk``; a
+      non-conforming or absent client is rejected up front rather than failing deep in resolution.
+    """
+    files_sdk = async_sdk if isinstance(async_sdk, AsyncNeMoPlatform) else None
+    resolved_bundles = await resolve_metric_specs(
+        metrics,
+        workspace=workspace,
+        entity_client=entity_client,
+        async_sdk=files_sdk,
+    )
+    runtime_metrics = [unbundle_metric(bundle) for bundle in resolved_bundles]
+    final_bundles = resolved_bundles
+    unresolved = unresolved_model_refs(runtime_metrics)
+    if unresolved:
+        if not isinstance(async_sdk, ModelResolverSdk):
+            raise ValueError(
+                "ModelRef metrics require a platform connection (models + inference) to resolve: "
+                + ", ".join(unresolved)
+            )
+        resolver = PlatformModelResolver(async_sdk)
+        await asyncio.gather(
+            *(metric.resolve_models(resolver) for metric in runtime_metrics if isinstance(metric, MetricWithModels))
+        )
+        final_bundles = [
+            _bundle_resolved_metric(metric, bundle)
+            for metric, bundle in zip(runtime_metrics, resolved_bundles, strict=True)
+        ]
+    return [to_inline(bundle) for bundle in final_bundles]

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/secret_env.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/secret_env.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared task-environment construction for evaluator plugin job compilers.
+
+Both ``compile_evaluate_job`` and ``compile_agent_eval_job`` turn a spec's metric/endpoint secret
+references into ``from_secret`` task environment variables. The per-job code differs only in *how*
+it walks its own schema to collect ``(env_name, secret_name)`` pairs; the assembly — the
+persistent-storage path, the reserved-name guard, and conflict detection — is identical and lives
+here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from nemo_platform_plugin.jobs.api_factory import EnvironmentVariable, EnvironmentVariableFromSecret
+from nemo_platform_plugin.jobs.constants import DEFAULT_JOB_STORAGE_PATH, PERSISTENT_JOB_STORAGE_PATH_ENVVAR
+
+#: Env names a job sets itself, so they cannot be sourced from a secret ref.
+RESERVED_SECRET_ENV_NAMES = frozenset({PERSISTENT_JOB_STORAGE_PATH_ENVVAR})
+
+
+def build_task_environment(secret_refs: Iterable[tuple[str, str]]) -> list[EnvironmentVariable]:
+    """Build a task's environment: the persistent-storage path plus ``from_secret`` variables.
+
+    ``secret_refs`` yields ``(env_name, secret_name)`` pairs. Raises if a pair targets a reserved
+    env name, or if two pairs map the same env name to different secrets.
+    """
+    environment = [EnvironmentVariable(name=PERSISTENT_JOB_STORAGE_PATH_ENVVAR, value=DEFAULT_JOB_STORAGE_PATH)]
+    resolved: dict[str, str] = {}
+    for env_name, secret_name in secret_refs:
+        if env_name in RESERVED_SECRET_ENV_NAMES:
+            raise ValueError(f"{env_name!r} is reserved and cannot be sourced from secret refs")
+        existing = resolved.get(env_name)
+        if existing is not None and existing != secret_name:
+            raise ValueError(f"conflicting secret references for environment variable {env_name!r}")
+        resolved[env_name] = secret_name
+
+    environment.extend(
+        EnvironmentVariable(name=env_name, from_secret=EnvironmentVariableFromSecret(name=secret_name))
+        for env_name, secret_name in sorted(resolved.items())
+    )
+    return environment

--- a/plugins/nemo-evaluator/src/nemo_evaluator/metric_refs.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/metric_refs.py
@@ -12,7 +12,7 @@ converted, so the canonical job spec and execution path only ever see runtime
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypeAlias
 
 from nemo_evaluator.api.schemas import MetricInline
 from nemo_evaluator.entities import MetricBundleEntity
@@ -35,6 +35,10 @@ class MetricRef(RootModel[str]):
         pattern=_METRIC_REF_PATTERN,
         description="Reference to a stored metric (format: workspace/metric-name, or metric-name in the job workspace).",
     )
+
+
+#: A wire metric is either an inline bundle DTO or a reference to a stored metric.
+MetricRefOrInline: TypeAlias = MetricInline | MetricRef
 
 
 def parse_metric_ref(root: str, default_workspace: str) -> tuple[str, str]:
@@ -75,7 +79,7 @@ async def resolve_metric_ref(
 
 
 async def resolve_metric_specs(
-    metrics: list[MetricInline | MetricRef],
+    metrics: list[MetricRefOrInline],
     *,
     workspace: str,
     entity_client: Any,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/resolvers.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/resolvers.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import inspect
 import logging
 from collections.abc import Awaitable
-from typing import Protocol, TypeVar, cast
+from typing import Protocol, TypeVar, cast, runtime_checkable
 
 from nemo_evaluator_sdk.enums import ModelFormat
 from nemo_evaluator_sdk.values.models import Model, ModelRef
@@ -54,8 +54,14 @@ class _InferenceResource(Protocol):
     providers: _ProvidersResource
 
 
-class _PlatformSDK(Protocol):
-    """Minimal platform SDK surface used by this resolver."""
+@runtime_checkable
+class ModelResolverSdk(Protocol):
+    """Minimal platform SDK surface used by model-reference resolution.
+
+    Runtime-checkable so callers can confirm conformance and raise a clear error instead of failing
+    deep in resolution. The resolver tolerates sync or async clients (see ``_maybe_await``), so this
+    only asserts the presence of the ``models`` / ``inference`` resources, not their await-ness.
+    """
 
     models: _ModelsResource
     inference: _InferenceResource
@@ -69,7 +75,7 @@ async def _maybe_await(value: _T | Awaitable[_T]) -> _T:
 
 
 async def _resolve_provider_host_url(
-    sdk: _PlatformSDK,
+    sdk: ModelResolverSdk,
     model_entity: PlatformModelEntity,
 ) -> str | None:
     """Resolve the direct provider host URL from a model entity's first provider."""
@@ -100,7 +106,7 @@ class PlatformModelResolver:
 
     def __init__(self, sdk: object) -> None:
         """Store the platform SDK used for model lookup."""
-        self._sdk = cast(_PlatformSDK, sdk)
+        self._sdk = cast(ModelResolverSdk, sdk)
 
     async def resolve_model(self, model_ref: ModelRef) -> Model:
         """Resolve ``workspace/name`` to an SDK Model routed through inference gateway."""

--- a/plugins/nemo-evaluator/src/nemo_evaluator/resolvers.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/resolvers.py
@@ -55,7 +55,7 @@ class _InferenceResource(Protocol):
 
 
 @runtime_checkable
-class ModelResolverSdk(Protocol):
+class ModelResolverSDK(Protocol):
     """Minimal platform SDK surface used by model-reference resolution.
 
     Runtime-checkable so callers can confirm conformance and raise a clear error instead of failing
@@ -75,7 +75,7 @@ async def _maybe_await(value: _T | Awaitable[_T]) -> _T:
 
 
 async def _resolve_provider_host_url(
-    sdk: ModelResolverSdk,
+    sdk: ModelResolverSDK,
     model_entity: PlatformModelEntity,
 ) -> str | None:
     """Resolve the direct provider host URL from a model entity's first provider."""
@@ -106,7 +106,7 @@ class PlatformModelResolver:
 
     def __init__(self, sdk: object) -> None:
         """Store the platform SDK used for model lookup."""
-        self._sdk = cast(ModelResolverSdk, sdk)
+        self._sdk = cast(ModelResolverSDK, sdk)
 
     async def resolve_model(self, model_ref: ModelRef) -> Model:
         """Resolve ``workspace/name`` to an SDK Model routed through inference gateway."""

--- a/plugins/nemo-evaluator/src/nemo_evaluator/service.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/service.py
@@ -10,6 +10,7 @@ from typing import ClassVar
 from fastapi import APIRouter
 from nemo_evaluator.api.v2 import metrics as metrics_routes
 from nemo_evaluator.core import say_hello
+from nemo_evaluator.jobs.agent_evaluate import AgentEvalJob
 from nemo_evaluator.jobs.evaluate import EvaluateJob
 from nemo_evaluator.schema import HelloResponse
 from nemo_platform_plugin.authz import (
@@ -71,6 +72,11 @@ class EvaluatorPluginService(NemoService):
                 collection_suffix="/evaluate/jobs",
                 permission_prefix=f"{cls.name}.jobs",
             ),
+            authz_for_workspace_job_collection(
+                api_area=cls.name,
+                collection_suffix="/agent-evaluate/jobs",
+                permission_prefix=f"{cls.name}.jobs",
+            ),
             _authz_for_metrics_collection(
                 api_area=cls.name,
                 permission_prefix=f"{cls.name}.metrics",
@@ -80,6 +86,7 @@ class EvaluatorPluginService(NemoService):
     def get_routers(self) -> list[RouterSpec]:
         router = APIRouter()
         jobs_router = add_job_routes(EvaluateJob)
+        agent_jobs_router = add_job_routes(AgentEvalJob)
 
         @router.get("/healthz")
         async def healthz() -> dict[str, object]:
@@ -87,7 +94,7 @@ class EvaluatorPluginService(NemoService):
                 "plugin": self.name,
                 "status": "ok",
                 "mode": "sdk-backed-job-scaffold",
-                "jobs": ["evaluator.evaluate"],
+                "jobs": ["evaluator.evaluate", "evaluator.agent-evaluate"],
             }
 
         return [
@@ -109,6 +116,13 @@ class EvaluatorPluginService(NemoService):
                 router=jobs_router,
                 tag="Evaluator Plugin Jobs Routes",
                 description="Evaluator plugin jobs routes.",
+                prefix="/v2/workspaces/{workspace}",
+            ),
+            RouterSpec(
+                # POST /apis/evaluator/v2/workspaces/{workspace}/agent-evaluate/jobs.
+                router=agent_jobs_router,
+                tag="Evaluator Plugin Agent Eval Jobs Routes",
+                description="Evaluator plugin agent-evaluation job routes.",
                 prefix="/v2/workspaces/{workspace}",
             ),
             RouterSpec(

--- a/plugins/nemo-evaluator/src/nemo_evaluator/tasks/agent_evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/tasks/agent_evaluate.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Container entrypoint for the evaluator plugin's agent-evaluation job."""
+
+from __future__ import annotations
+
+import sys
+
+from nemo_evaluator.jobs.agent_evaluate import AgentEvalJob
+from nemo_evaluator.tasks.runner import run_task_main
+
+
+def main() -> int:
+    """Build the task SDK and dispatch to the agent-evaluation job."""
+    return run_task_main(AgentEvalJob, service_name="evaluator")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/nemo-evaluator/src/nemo_evaluator/tasks/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/tasks/evaluate.py
@@ -5,39 +5,15 @@
 
 from __future__ import annotations
 
-import logging
-import signal
 import sys
-from enum import IntEnum
-from types import FrameType
 
 from nemo_evaluator.jobs.evaluate import EvaluateJob
-from nemo_platform_plugin.sdk_provider import get_task_sdk
-from nemo_platform_plugin.tasks.dispatcher import run_task
-
-logger = logging.getLogger(__name__)
-
-
-class EvaluateTaskExitCode(IntEnum):
-    """Evaluator task setup exit codes."""
-
-    SDK_INITIALIZATION_FAILED = 2
-
-
-def _shutdown_handler(signum: int, frame: FrameType | None) -> None:
-    logger.warning("Received shutdown signal (%d). Exiting.", signum)
-    raise SystemExit(128 + signum)
+from nemo_evaluator.tasks.runner import run_task_main
 
 
 def main() -> int:
     """Build the task SDK and dispatch to the evaluator plugin job."""
-    signal.signal(signal.SIGTERM, _shutdown_handler)
-    try:
-        sdk = get_task_sdk("evaluator")
-    except Exception:
-        logger.exception("Failed to build task SDK for evaluator")
-        return EvaluateTaskExitCode.SDK_INITIALIZATION_FAILED
-    return run_task(EvaluateJob, sdk=sdk)
+    return run_task_main(EvaluateJob, service_name="evaluator")
 
 
 if __name__ == "__main__":

--- a/plugins/nemo-evaluator/src/nemo_evaluator/tasks/runner.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/tasks/runner.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared container/subprocess task entrypoint for evaluator plugin jobs.
+
+Each job's ``tasks/<job>.py`` is a thin ``python -m`` target that calls :func:`run_task_main` with
+its job class. The lifecycle — SIGTERM handling, building the task SDK, and dispatching to the job
+— is identical across jobs and lives here.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+from types import FrameType
+
+from nemo_platform_plugin.job import NemoJob
+from nemo_platform_plugin.sdk_provider import get_task_sdk
+from nemo_platform_plugin.tasks.dispatcher import run_task
+
+logger = logging.getLogger(__name__)
+
+#: Process exit code when the task SDK can't be built (setup failure, before the job runs).
+SDK_INITIALIZATION_EXIT_CODE = 2
+
+
+def _shutdown_handler(signum: int, frame: FrameType | None) -> None:
+    logger.warning("Received shutdown signal (%d). Exiting.", signum)
+    raise SystemExit(128 + signum)
+
+
+def run_task_main(job_cls: type[NemoJob], *, service_name: str) -> int:
+    """Build the task SDK and dispatch to ``job_cls``; return a process exit code.
+
+    Returns :data:`SDK_INITIALIZATION_EXIT_CODE` if the task SDK can't be built.
+    """
+    signal.signal(signal.SIGTERM, _shutdown_handler)
+    try:
+        sdk = get_task_sdk(service_name)
+    except Exception:
+        logger.exception("Failed to build task SDK for %s", service_name)
+        return SDK_INITIALIZATION_EXIT_CODE
+    return run_task(job_cls, sdk=sdk)

--- a/plugins/nemo-evaluator/tests/integration/conftest.py
+++ b/plugins/nemo-evaluator/tests/integration/conftest.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared harness + fixtures for evaluator-plugin integration tests.
+
+``running_platform`` is the one place the ``nemo services run`` lifecycle (launch on a chosen
+port, wait for readiness, tear down) lives, so each suite contributes a thin session-scoped
+fixture rather than re-rolling the boilerplate. Each platform binds its own port so independent
+suites can coexist in a single test session (e.g. the agent-eval submit platform here vs. the
+intake/publish platform on its own port).
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import time
+import urllib.request
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import pytest
+import yaml
+from nmp.testing import igw_mock_provider_mode
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+#: IGW mock-provider prefix, and the env var the in-process IGW config reads it from. Applied to
+#: *this* (test) process via the ``_igw_mock_prefix`` fixture (not at import) so it never leaks into
+#: unrelated unit suites that merely collect this conftest; passed to the platform subprocess via
+#: each fixture's ``env_overrides``.
+MOCK_PROVIDER_PREFIX = "igw-mock-"
+MOCK_PROVIDER_PREFIX_ENVVAR = "NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX"
+
+#: Base URL (and therefore port) for the agent-eval subprocess-backend platform. Distinct from
+#: other integration platforms so both can run in the same session without a port clash.
+AGENT_PLATFORM_BASE_URL = os.environ.get("NMP_AGENT_BASE_URL", "http://localhost:8090")
+
+#: Base URL for the docker-backend platform — its own port so it can coexist with the subprocess one.
+AGENT_DOCKER_PLATFORM_BASE_URL = os.environ.get("NMP_AGENT_DOCKER_BASE_URL", "http://localhost:8091")
+
+#: Base URL for the auth-enabled subprocess platform (own port, coexists with the others).
+AGENT_AUTH_PLATFORM_BASE_URL = os.environ.get("NMP_AGENT_AUTH_BASE_URL", "http://localhost:8092")
+
+
+def _docker_available() -> bool:
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=10).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _wait_for_ready(base_url: str, *, timeout: float, process: subprocess.Popen[bytes]) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"platform at {base_url} exited early (code {process.returncode}) before ready")
+        try:
+            with urllib.request.urlopen(f"{base_url}/health/ready", timeout=2) as response:  # noqa: S310
+                if response.status == 200:
+                    return
+        except OSError:
+            pass
+        time.sleep(2)
+    raise RuntimeError(f"platform at {base_url} not ready within {timeout}s")
+
+
+def _port_in_use(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1)
+        return sock.connect_ex((host, port)) == 0
+
+
+@contextmanager
+def running_platform(
+    *,
+    run_args: list[str],
+    base_url: str,
+    env_overrides: dict[str, str] | None = None,
+    ready_timeout: float = 180.0,
+) -> Iterator[str]:
+    """Run ``nemo services run`` bound to ``base_url``'s port, yield the URL, then tear it down.
+
+    Fails loudly if the port is already taken: a stray platform would otherwise quietly serve the
+    tests, masking whatever services/config they actually depend on.
+    """
+    split = urlsplit(base_url)
+    host, port = split.hostname or "localhost", split.port
+    if port is None:
+        raise ValueError(f"base_url must include an explicit port: {base_url!r}")
+    if _port_in_use(host, port):
+        raise RuntimeError(f"{host}:{port} is already in use; stop other platform instances before running these tests")
+
+    process = subprocess.Popen(
+        ["uv", "run", "nemo", "services", "run", *run_args, "--port", str(port)],
+        cwd=REPO_ROOT,
+        env={**os.environ, "NMP_BASE_URL": base_url, **(env_overrides or {})},
+    )
+    try:
+        _wait_for_ready(base_url, timeout=ready_timeout, process=process)
+        yield base_url
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+
+@pytest.fixture(autouse=True)
+def _igw_mock_prefix() -> Iterator[None]:
+    """Configure the IGW mock-provider prefix in the *test* process for each integration test, so
+    ``add_mock_provider`` can prefix and register mock providers.
+
+    Function-scoped + autouse so it applies only to these integration tests — never the unit suite
+    that merely collects this conftest (which would break the inference-gateway ``is_mock_provider``
+    tests), and never another integration suite. Uses a config override via ``igw_mock_provider_mode``
+    (an ``nmp.testing`` helper — a plugin must not import ``nmp-common`` directly) rather than an env
+    var: the override is honored ahead of the cached/env config, so it works regardless of when the
+    IGW config was first read, whereas a whole-repo run can read and cache that config before any
+    plugin-local hook fires. The platform *subprocess* gets the same prefix via each fixture's
+    ``env_overrides``.
+    """
+    with igw_mock_provider_mode(MOCK_PROVIDER_PREFIX):
+        yield
+
+
+def _materialize_subprocess_config(work_root: Path, *, base_url: str, auth_enabled: bool = False) -> Path:
+    """Write a self-contained subprocess-backend platform config under ``work_root``.
+
+    Owned here rather than borrowed from ``e2e/configs`` (legacy, not run in CI). It pins
+    ``platform.runtime: none`` with an explicit subprocess jobs executor and ABSOLUTE storage paths:
+    the jobs service writes each step config under ``working_directory`` while the task subprocess
+    resolves the same path against a different CWD, so a relative dir would make the task miss its
+    config. Absolute paths keep the step-config path agreeing across both processes.
+
+    ``auth_enabled`` turns on the PDP so the auth-forwarding test can prove a submitted task's
+    ``X-NMP-*`` service-principal identity actually authenticates its IGW inference.
+    """
+    jobs_work_dir = str(work_root / "subprocess-jobs")
+    subprocess_executor_config = {
+        "working_directory": jobs_work_dir,
+        "cleanup_completed_jobs_immediately": False,
+        "ttl_seconds_before_active": 60,
+        "ttl_seconds_active": 3600,
+        "ttl_seconds_after_finished": 300,
+    }
+    config = {
+        "platform": {"runtime": "none", "base_url": base_url},
+        "auth": {"enabled": auth_enabled, "allow_unsigned_jwt": True},
+        "jobs": {
+            "executors": [
+                {
+                    "provider": "subprocess",
+                    "profile": "default",
+                    "backend": "subprocess",
+                    "config": subprocess_executor_config,
+                }
+            ],
+            "executor_defaults": {"subprocess": subprocess_executor_config},
+        },
+        "secrets": {"allow_key_creation": True},
+        "files": {"default_storage_config": {"type": "local", "path": str(work_root / "files")}},
+    }
+    config_path = work_root / "subprocess-platform.yaml"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    return config_path
+
+
+@pytest.fixture(scope="session")
+def subprocess_platform(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Session-scoped platform with the subprocess jobs backend + IGW mock-provider mode.
+
+    Subprocess backend: the compiled task runs as a host process, so a Codex *runner* target finds
+    the host's codex CLI + ChatGPT login. IGW mock mode (``NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX``)
+    lets Model/Agent-target tests register a mock provider returning a canned response — no real model
+    or key. Codex-dependent tests gate themselves with ``@requires_codex``; this fixture does not, so
+    Model/Agent tests (which need only the running IGW) can use it without codex installed.
+    """
+    config_path = _materialize_subprocess_config(tmp_path_factory.mktemp("platform"), base_url=AGENT_PLATFORM_BASE_URL)
+    with running_platform(
+        run_args=["--service-group", "all", "--controller-group", "all"],
+        base_url=AGENT_PLATFORM_BASE_URL,
+        env_overrides={
+            "NMP_CONFIG_FILE_PATH": str(config_path),
+            MOCK_PROVIDER_PREFIX_ENVVAR: MOCK_PROVIDER_PREFIX,
+        },
+    ) as base_url:
+        yield base_url
+
+
+@pytest.fixture(scope="session")
+def auth_subprocess_platform(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Session-scoped subprocess-backend platform with ``auth.enabled`` and IGW mock mode.
+
+    Used to prove that a submitted job's forwarded ``X-NMP-*`` service-principal identity
+    authenticates its online IGW inference under auth (no bearer). Test-side calls authenticate as an
+    internal service principal (which the default PDP policy grants full permissions).
+    """
+    config_path = _materialize_subprocess_config(
+        tmp_path_factory.mktemp("auth-platform"), base_url=AGENT_AUTH_PLATFORM_BASE_URL, auth_enabled=True
+    )
+    with running_platform(
+        run_args=["--service-group", "all", "--controller-group", "all"],
+        base_url=AGENT_AUTH_PLATFORM_BASE_URL,
+        env_overrides={
+            "NMP_CONFIG_FILE_PATH": str(config_path),
+            MOCK_PROVIDER_PREFIX_ENVVAR: MOCK_PROVIDER_PREFIX,
+        },
+    ) as base_url:
+        yield base_url
+
+
+def _materialize_docker_config(work_root: Path, *, base_url: str) -> Path:
+    """Write a docker-backend platform config: ``cpu/default`` routes to the docker jobs backend.
+
+    Critically registers NO subprocess executor: the jobs API's
+    ``translate_cpu_container_steps_to_subprocess`` reroutes ``cpu/default`` container steps to the
+    host subprocess backend whenever one is registered there, which would make a "docker" test
+    silently run on subprocess. ``platform.runtime: docker`` + a ``cpu/default`` docker executor
+    keeps the agent-eval step on the docker backend. The jobs-launcher binary is optional (the
+    backend falls back to the container's own entrypoint when it's absent), so it isn't built here.
+    """
+    docker_executor_config = {
+        "launcher_tool_path": str(REPO_ROOT / "services/core/jobs/jobs-launcher/jobs-launcher"),
+        "cleanup_completed_jobs_immediately": False,
+        "ttl_seconds_before_active": 60,
+        "ttl_seconds_active": 3600,
+        "ttl_seconds_after_finished": 300,
+    }
+    config = {
+        "platform": {"runtime": "docker", "base_url": base_url},
+        "auth": {"enabled": False, "allow_unsigned_jwt": True},
+        "jobs": {
+            "executors": [
+                {"provider": "cpu", "profile": "default", "backend": "docker", "config": docker_executor_config},
+            ],
+            "executor_defaults": {"docker": docker_executor_config},
+        },
+        "secrets": {"allow_key_creation": True},
+        "files": {"default_storage_config": {"type": "local", "path": str(work_root / "files")}},
+    }
+    config_path = work_root / "docker-platform.yaml"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    return config_path
+
+
+@pytest.fixture(scope="session")
+def docker_platform(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Session-scoped platform with the docker jobs backend (for the docker-backend submit test).
+
+    Gates on a reachable Docker daemon only — codex runs *inside* the task container, not on the
+    host, so host codex is irrelevant here. The agent-eval step runs in the ``cpu-tasks`` image;
+    runner targets aren't expected to succeed there yet (the image carries no codex CLI/auth — see
+    AALGO-301), which is why the test using this fixture is marked xfail.
+    """
+    if not _docker_available():
+        pytest.skip("docker daemon not available")
+    config_path = _materialize_docker_config(
+        tmp_path_factory.mktemp("docker-platform"), base_url=AGENT_DOCKER_PLATFORM_BASE_URL
+    )
+    with running_platform(
+        run_args=["--service-group", "all", "--controller-group", "all"],
+        base_url=AGENT_DOCKER_PLATFORM_BASE_URL,
+        env_overrides={"NMP_CONFIG_FILE_PATH": str(config_path)},
+    ) as base_url:
+        yield base_url

--- a/plugins/nemo-evaluator/tests/integration/test_agent_evaluate_job.py
+++ b/plugins/nemo-evaluator/tests/integration/test_agent_evaluate_job.py
@@ -1,0 +1,447 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for the agent-evaluation job (AALGO-297).
+
+These exercise the job against *real* execution seams, across the dimensions that
+matter for this work:
+
+* target type — a Codex *runner*, plus Model and Agent endpoint targets pointed at an
+  IGW mock provider (canned response, so no real model or key);
+* metric form — an inline metric bundle, plus a stored ``MetricRef`` resolved against
+  the live entity store;
+* execution mode — in-process ``run_local`` and service-side ``submit`` on both the
+  subprocess and docker backends, against the session ``subprocess_platform`` /
+  ``docker_platform`` fixtures in ``conftest.py``. (Docker submit is xfail today — the
+  cpu-tasks image predates this work; tracked in AALGO-301.)
+
+Marked ``integration`` (auto-applied to ``/integration/`` paths). Codex-dependent tests
+gate on ``@requires_codex`` (skip when the ``codex`` CLI is absent, needs a logged-in
+ChatGPT account); Model/Agent tests need only the running platform's IGW.
+
+Run directly::
+
+    uv run pytest plugins/nemo-evaluator/tests/integration/test_agent_evaluate_job.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import uuid
+from pathlib import Path
+
+import cloudpickle
+import httpx
+import pytest
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.jobs.agent_evaluate import AgentEvalJob
+from nemo_evaluator.jobs.agent_spec import (
+    AgentEvalInputSpec,
+    AgentEvalTaskInput,
+    AgentTarget,
+    CodexRunnerTarget,
+    ModelTarget,
+)
+from nemo_evaluator.metric_refs import MetricRef
+from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
+from nemo_evaluator_sdk.enums import AgentFormat, ModelFormat
+from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
+from nemo_evaluator_sdk.values import Agent, Model, RunConfigOnline, RunConfigOnlineModel
+from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.scheduler import NemoJobScheduler
+from nmp.testing import add_mock_provider
+from nmp.testing.e2e import wait_for_platform_job
+
+#: Opt-in: these tests spin real ``nemo services`` platforms (subprocess/docker/auth) and some need
+#: a local ``codex`` CLI + login, so they're kept out of the standard CI integration job. Run them
+#: locally (or on demand) with ``RUN_AGENT_EVAL_INTEGRATION=1``.
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_AGENT_EVAL_INTEGRATION"),
+        reason="opt-in; set RUN_AGENT_EVAL_INTEGRATION=1 to run (spins real nemo services platforms)",
+    ),
+]
+
+#: Codex model the runner drives. ChatGPT-account dependent; gpt-5.5 is known-good.
+CODEX_MODEL = "gpt-5.5"
+
+WORKSPACE = "default"
+
+#: Headers a job's task SDK carries (mirrors ``get_task_sdk``): an internal service principal the
+#: default PDP policy grants full permissions. Authenticates test-side calls against the
+#: auth-enabled platform without standing up OIDC.
+SERVICE_PRINCIPAL_HEADERS = {"X-NMP-Principal-Id": "service:evaluator", "X-NMP-Internal": "true"}
+
+
+def _codex_available() -> bool:
+    return shutil.which("codex") is not None
+
+
+requires_codex = pytest.mark.skipif(not _codex_available(), reason="codex CLI not on PATH")
+
+
+# Pickle metrics defined in this test module BY VALUE so the cloudpickle bundle embeds the class
+# itself — the submit-backend task runs in a subprocess that can't import this test module, and a
+# by-reference pickle would fail to hydrate there.
+cloudpickle.register_pickle_by_value(sys.modules[__name__])
+
+
+class _OutputContainsMetric:
+    """Custom metric: scores 1.0 iff the trial's output contains the expected token (case-insensitive).
+
+    Validates what the agent actually produced — unlike a built-in clean-exit signal — and exercises
+    the inline user-defined-metric path end to end (bundled, shipped in the spec, hydrated at run time).
+    """
+
+    def __init__(self, expected: str) -> None:
+        self.expected = expected
+
+    @property
+    def type(self) -> str:
+        return "output-contains"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.boolean("contains")]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:  # noqa: A002
+        text = input.candidate.output_text or ""
+        return MetricResult(outputs=[MetricOutput(name="contains", value=self.expected.lower() in text.lower())])
+
+
+def _output_contains_metric(expected: str) -> MetricInline:
+    """An inline, user-defined metric that validates the agent's output text."""
+    bundle = bundle_metric(_OutputContainsMetric(expected), CloudpickleMetricBundlePackager())
+    return MetricInline.model_validate(bundle.model_dump(mode="json"))
+
+
+def _bundle_dir(run_result: dict) -> Path:
+    """The persisted run bundle directory (trials/scores/summary) from a run_local result."""
+    return Path(run_result["artifact"]["artifact_url"].removeprefix("file://"))
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _chat_completion(content: str) -> dict:
+    """An OpenAI ``chat.completion`` response body whose assistant message is ``content``."""
+    return {
+        "id": "chatcmpl-mock",
+        "object": "chat.completion",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": content}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _igw_chat_url(base_url: str, model_entity: str) -> str:
+    """OpenAI-compatible chat URL for a model entity routed through the platform's IGW."""
+    return f"{base_url}/apis/inference-gateway/v2/workspaces/{WORKSPACE}/model/{model_entity}/-/v1/chat/completions"
+
+
+def _unique(prefix: str) -> str:
+    """A unique entity name, so a rerun (e.g. pytest-rerunfailures) doesn't 409 on an existing one."""
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.mark.timeout(300)
+def test_run_local_model_target_scores_a_real_trial(subprocess_platform: str) -> None:
+    # dim 1 (Model endpoint target): generate a trial against an IGW mock provider that returns
+    # "DONE" (no real model/key), then score the trial output with the inline metric.
+    sdk = NeMoPlatform(base_url=subprocess_platform, max_retries=2)
+    sdk.workspaces.create(name=WORKSPACE, exist_ok=True)
+    model_name = _unique("model-judge")
+    add_mock_provider(sdk, workspace=WORKSPACE, name=model_name, mock_response_body=_chat_completion("DONE"))
+
+    input_spec = AgentEvalInputSpec(
+        tasks=[
+            AgentEvalTaskInput(
+                id="ask",
+                intent="Obtain a one-word reply from the model.",
+                inputs={"prompt": "Reply with the single word DONE and nothing else."},
+                metrics=[_output_contains_metric("DONE")],
+            )
+        ],
+        target=ModelTarget(
+            model=Model(
+                url=_igw_chat_url(subprocess_platform, model_name), name=model_name, format=ModelFormat.OPEN_AI
+            ),
+            prompt_template={"messages": [{"role": "user", "content": "{{item.prompt}}"}]},
+            params=RunConfigOnlineModel(),
+        ),
+    )
+
+    result = NemoJobScheduler().run_local(AgentEvalJob, input_spec.model_dump(mode="json"))
+
+    assert result["status"] == "completed"
+    bundle = _bundle_dir(result)
+    trials = _read_jsonl(bundle / "trials.jsonl")
+    assert trials[0]["output"]["output_text"] == "DONE"
+    scores = _read_jsonl(bundle / "scores.jsonl")
+    assert scores[0]["outputs"][0]["value"] in (True, 1.0)
+
+
+@pytest.mark.timeout(300)
+def test_run_local_agent_target_scores_a_real_trial(subprocess_platform: str) -> None:
+    # dim 1 (Agent endpoint target): a generic-HTTP agent posts to an IGW mock provider returning
+    # "DONE"; response_path extracts the assistant content, then the inline metric scores it.
+    sdk = NeMoPlatform(base_url=subprocess_platform, max_retries=2)
+    sdk.workspaces.create(name=WORKSPACE, exist_ok=True)
+    agent_name = _unique("agent-judge")
+    add_mock_provider(sdk, workspace=WORKSPACE, name=agent_name, mock_response_body=_chat_completion("DONE"))
+
+    agent = Agent(
+        url=_igw_chat_url(subprocess_platform, agent_name),
+        name=agent_name,
+        format=AgentFormat.GENERIC,
+        body={"model": agent_name, "messages": [{"role": "user", "content": "Reply with DONE."}]},
+        response_path="$.choices[0].message.content",
+    )
+    input_spec = AgentEvalInputSpec(
+        tasks=[
+            AgentEvalTaskInput(
+                id="ask",
+                intent="Obtain a one-word reply from the agent.",
+                inputs={"prompt": "Reply with the single word DONE and nothing else."},
+                metrics=[_output_contains_metric("DONE")],
+            )
+        ],
+        target=AgentTarget(agent=agent, params=RunConfigOnline()),
+    )
+
+    result = NemoJobScheduler().run_local(AgentEvalJob, input_spec.model_dump(mode="json"))
+
+    assert result["status"] == "completed"
+    bundle = _bundle_dir(result)
+    trials = _read_jsonl(bundle / "trials.jsonl")
+    assert trials[0]["output"]["output_text"] == "DONE"
+    scores = _read_jsonl(bundle / "scores.jsonl")
+    assert scores[0]["outputs"][0]["value"] in (True, 1.0)
+
+
+@requires_codex
+@pytest.mark.timeout(300)
+def test_run_local_codex_runner_scores_a_real_trial() -> None:
+    # One real Codex run covering dim 1 (runner) x dim 2 (inline metric) x dim 3 (run): the CLI
+    # produces a trial and a user-defined inline metric scores its output. (Every task must declare
+    # >=1 metric — the SDK evaluator rejects a metric-less task — so this is the minimal real run.)
+    input_spec = AgentEvalInputSpec(
+        tasks=[
+            AgentEvalTaskInput(
+                id="say-done",
+                intent="Agent follows a trivial instruction and exits cleanly.",
+                inputs={"instruction": "Reply with the single word DONE and nothing else."},
+                metrics=[_output_contains_metric("DONE")],
+            )
+        ],
+        target=CodexRunnerTarget(model=CODEX_MODEL),
+    )
+
+    result = NemoJobScheduler().run_local(AgentEvalJob, input_spec.model_dump(mode="json"))
+
+    assert result["status"] == "completed"
+    bundle = _bundle_dir(result)
+
+    trials = _read_jsonl(bundle / "trials.jsonl")
+    assert len(trials) == 1
+    assert trials[0]["task_id"] == "say-done"
+    assert trials[0]["status"] == "completed"
+
+    scores = _read_jsonl(bundle / "scores.jsonl")
+    assert [score["metric_type"] for score in scores] == ["output-contains"]
+    assert scores[0]["trial_id"] == trials[0]["id"]
+    # The custom metric actually validated the agent's output (it replied "DONE").
+    output = scores[0]["outputs"][0]
+    assert output["name"] == "contains"
+    assert output["value"] in (True, 1.0)
+
+
+# --- submit: service-side execution -----------------------------------------
+
+
+def _offline_trials_input_spec() -> dict:
+    """Submitter-facing spec: one precomputed trial scored offline by one inline metric.
+
+    No target — so no online generation, no codex, no IGW. Runs entirely inside the task container,
+    isolating the docker-backend-wiring + entrypoint condition (rather than also depending on a codex
+    CLI/auth the image doesn't carry)."""
+    return AgentEvalInputSpec(
+        tasks=[
+            AgentEvalTaskInput(
+                id="say-done",
+                intent="Agent follows a trivial instruction and exits cleanly.",
+                inputs={"instruction": "Reply with the single word DONE and nothing else."},
+                metrics=[_output_contains_metric("DONE")],
+            )
+        ],
+        trials=[
+            AgentEvalTrial(
+                id="t-1",
+                task_id="say-done",
+                status=AgentEvalTrialStatus.COMPLETED,
+                output=AgentOutput(output_text="DONE"),
+            )
+        ],
+    ).model_dump(mode="json")
+
+
+def _codex_eval_input_spec() -> dict:
+    """Submitter-facing spec: one Codex-runner task scored by one inline metric."""
+    return AgentEvalInputSpec(
+        tasks=[
+            AgentEvalTaskInput(
+                id="say-done",
+                intent="Agent follows a trivial instruction and exits cleanly.",
+                inputs={"instruction": "Reply with the single word DONE and nothing else."},
+                metrics=[_output_contains_metric("DONE")],
+            )
+        ],
+        target=CodexRunnerTarget(model=CODEX_MODEL),
+    ).model_dump(mode="json")
+
+
+@requires_codex
+@pytest.mark.timeout(600)
+def test_submit_to_subprocess_backend_runs_agent_eval(subprocess_platform: str) -> None:
+    # dim 3 (submit) x dim 4 (subprocess backend): submit through the plugin route; the jobs service
+    # compiles + runs the task as a host subprocess (which has codex), to completion.
+    client = NeMoPlatform(base_url=subprocess_platform, max_retries=2)
+    client.workspaces.create(name=WORKSPACE, exist_ok=True)
+
+    response = NemoJobScheduler().submit_remote(
+        AgentEvalJob,
+        _codex_eval_input_spec(),
+        base_url=subprocess_platform,
+        workspace=WORKSPACE,
+        profile="default",
+    )
+    job_name = response.get("name") or response.get("id")
+    assert job_name, f"submit response carried no job name/id: {response}"
+
+    job = wait_for_platform_job(client, job_name, WORKSPACE, timeout=480)
+    assert job.status == "completed", f"job {job_name} ended {job.status!r}: {getattr(job, 'status_details', None)}"
+
+
+@requires_codex
+@pytest.mark.timeout(600)
+def test_submit_with_stored_metric_ref_resolves_and_scores(subprocess_platform: str) -> None:
+    # dim 2 (stored MetricRef): store a metric in the platform, reference it by name, and submit.
+    # The server-side to_spec must resolve the ref against the live entity store + files service
+    # (not an inline bundle) before the job runs.
+    client = NeMoPlatform(base_url=subprocess_platform, max_retries=2)
+    client.workspaces.create(name=WORKSPACE, exist_ok=True)
+
+    metric_name = _unique("done-contains")
+    stored = _output_contains_metric("DONE")
+    create = httpx.post(
+        f"{subprocess_platform}/apis/evaluator/v2/workspaces/{WORKSPACE}/metrics/{metric_name}",
+        content=stored.model_dump_json(),
+        headers={"content-type": "application/json"},
+        timeout=30,
+    )
+    assert create.status_code in (200, 201), f"metric create failed: {create.status_code} {create.text}"
+
+    spec = AgentEvalInputSpec(
+        tasks=[
+            AgentEvalTaskInput(
+                id="say-done",
+                intent="Agent follows a trivial instruction and exits cleanly.",
+                inputs={"instruction": "Reply with the single word DONE and nothing else."},
+                metrics=[MetricRef(f"{WORKSPACE}/{metric_name}")],
+            )
+        ],
+        target=CodexRunnerTarget(model=CODEX_MODEL),
+    ).model_dump(mode="json")
+
+    response = NemoJobScheduler().submit_remote(
+        AgentEvalJob, spec, base_url=subprocess_platform, workspace=WORKSPACE, profile="default"
+    )
+    job_name = response.get("name") or response.get("id")
+    assert job_name, f"submit response carried no job name/id: {response}"
+
+    job = wait_for_platform_job(client, job_name, WORKSPACE, timeout=480)
+    assert job.status == "completed", f"job {job_name} ended {job.status!r}: {getattr(job, 'status_details', None)}"
+
+
+@pytest.mark.timeout(420)
+def test_submit_model_target_under_auth_forwards_identity_to_igw(auth_subprocess_platform: str) -> None:
+    # dim 1 (Model target) x dim 3 (submit) under auth.enabled: the submitted task's get_task_sdk
+    # identity (X-NMP-Principal-Id: service:evaluator) must be forwarded to the evaluator's IGW
+    # inference client (AgentEvalJob._build_evaluator) — otherwise the IGW returns 401 and the job
+    # fails. A clean completion proves the forwarded service-principal headers authenticate online
+    # inference under auth, with no bearer. (Probed directly too: service headers -> 200, none -> 401.)
+    # No codex: the target is an IGW mock provider, so this runs without the runner toolchain.
+    sdk = NeMoPlatform(base_url=auth_subprocess_platform, default_headers=SERVICE_PRINCIPAL_HEADERS, max_retries=2)
+    sdk.workspaces.create(name=WORKSPACE, exist_ok=True)
+    model_name = _unique("auth-model")
+    add_mock_provider(sdk, workspace=WORKSPACE, name=model_name, mock_response_body=_chat_completion("DONE"))
+
+    spec = AgentEvalInputSpec(
+        tasks=[
+            AgentEvalTaskInput(
+                id="ask",
+                intent="Obtain a one-word reply from the model.",
+                inputs={"prompt": "Reply with the single word DONE and nothing else."},
+                metrics=[_output_contains_metric("DONE")],
+            )
+        ],
+        target=ModelTarget(
+            model=Model(
+                url=_igw_chat_url(auth_subprocess_platform, model_name), name=model_name, format=ModelFormat.OPEN_AI
+            ),
+            prompt_template={"messages": [{"role": "user", "content": "{{item.prompt}}"}]},
+            params=RunConfigOnlineModel(),
+        ),
+    ).model_dump(mode="json")
+
+    response = NemoJobScheduler().submit_remote(
+        AgentEvalJob,
+        spec,
+        base_url=auth_subprocess_platform,
+        workspace=WORKSPACE,
+        profile="default",
+        headers=SERVICE_PRINCIPAL_HEADERS,
+    )
+    job_name = response.get("name") or response.get("id")
+    assert job_name, f"submit response carried no job name/id: {response}"
+
+    job = wait_for_platform_job(sdk, job_name, WORKSPACE, timeout=360)
+    assert job.status == "completed", f"job {job_name} ended {job.status!r}: {getattr(job, 'status_details', None)}"
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.xfail(
+    reason="agent-eval can't run under the docker backend until the cpu-tasks image is rebuilt with "
+    "this work: the published image predates the nemo_evaluator.tasks.agent_evaluate entrypoint "
+    "(container exits with ModuleNotFoundError). This submits an offline trials spec (no online "
+    "generation, no codex, no IGW), so the stale image is the only remaining failure cause — the "
+    "xfail flips the moment the image ships the entrypoint. Tracked in AALGO-301.",
+    strict=False,
+)
+def test_submit_to_docker_backend_runs_agent_eval(docker_platform: str) -> None:
+    # dim 4 (docker backend): the platform routes cpu/default to the docker backend (no subprocess
+    # executor is registered, so the step isn't rerouted), so the agent-eval task runs in the
+    # cpu-tasks container. Verified to genuinely reach the docker backend (it creates a container
+    # from the cpu-tasks image); it fails today because that image predates this work — hence xfail.
+    # An offline trials spec keeps the task self-contained in-container, so this isolates the
+    # backend-wiring + entrypoint condition rather than also depending on a codex CLI/auth.
+    client = NeMoPlatform(base_url=docker_platform, max_retries=2)
+    client.workspaces.create(name=WORKSPACE, exist_ok=True)
+
+    response = NemoJobScheduler().submit_remote(
+        AgentEvalJob,
+        _offline_trials_input_spec(),
+        base_url=docker_platform,
+        workspace=WORKSPACE,
+        profile="default",
+    )
+    job_name = response.get("name") or response.get("id")
+    assert job_name, f"submit response carried no job name/id: {response}"
+
+    job = wait_for_platform_job(client, job_name, WORKSPACE, timeout=480)
+    assert job.status == "completed"

--- a/plugins/nemo-evaluator/tests/test_agent_evaluate.py
+++ b/plugins/nemo-evaluator/tests/test_agent_evaluate.py
@@ -1,0 +1,468 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the agent-evaluation job (AALGO-297)."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.jobs.agent_evaluate import (
+    AGENT_BUNDLE_DIR,
+    DEFAULT_RESULT_NAME,
+    SUMMARY_RESULT_NAME,
+    AgentEvalJob,
+    _to_runtime_task,
+)
+from nemo_evaluator.jobs.agent_spec import (
+    AgentEvalInputSpec,
+    AgentEvalSpec,
+    AgentEvalTaskInput,
+    AgentEvalTaskSpec,
+    AgentTarget,
+    CodexRunnerTarget,
+    ModelTarget,
+    Target,
+)
+from nemo_evaluator.metric_refs import MetricRef
+from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator.tasks.agent_evaluate import main as agent_eval_task_main
+from nemo_evaluator.tasks.runner import SDK_INITIALIZATION_EXIT_CODE
+from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSummary
+from nemo_evaluator_sdk.agent_eval.runtimes.codex.runtime import CodexCliAgentRuntime
+from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+from nemo_evaluator_sdk.agent_eval.trials import (
+    AgentEvalTarget,
+    AgentEvalTrial,
+    AgentEvalTrialStatus,
+    AgentOutput,
+)
+from nemo_evaluator_sdk.enums import AgentFormat
+from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
+from nemo_evaluator_sdk.values import Agent, Model, RunConfigOnline, RunConfigOnlineModel, SecretRef
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform.types.jobs.platform_job_spec import PlatformJobSpec
+from nemo_platform_plugin.job_context import JobContext, StoragePaths
+from nemo_platform_plugin.job_results import LocalJobResults
+from nemo_platform_plugin.jobs.constants import PERSISTENT_JOB_STORAGE_PATH_ENVVAR
+from nemo_platform_plugin.scheduler import NemoJobScheduler
+from pytest_mock import MockerFixture
+
+
+def _inline_metric() -> MetricInline:
+    bundle = bundle_metric(
+        ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.model_output}}"),
+        CloudpickleMetricBundlePackager(),
+    )
+    return MetricInline.model_validate(bundle.model_dump(mode="json"))
+
+
+def _task_spec() -> AgentEvalTaskSpec:
+    return AgentEvalTaskSpec(
+        id="task-1",
+        intent="Answer the question.",
+        inputs={"prompt": "What is 2+2?"},
+        metrics=[_inline_metric()],
+    )
+
+
+def _job_context(tmp_path: Path) -> JobContext:
+    storage = StoragePaths(ephemeral=tmp_path / "ephemeral", persistent=tmp_path / "persistent")
+    storage.ephemeral.mkdir()
+    storage.persistent.mkdir()
+    return JobContext(
+        workspace="dev",
+        storage=storage,
+        results=LocalJobResults(root=storage.persistent / "results"),
+    )
+
+
+class _FakeEvaluator:
+    """Stand-in for AgentEvaluator: records the tasks it was handed and returns canned trials."""
+
+    def __init__(self) -> None:
+        self.received_tasks: list[AgentEvalTask] = []
+        self.received_trials: list[AgentEvalTrial] | None = None
+        self.received_target: AgentEvalTarget | None = None
+        self.received_config: AgentEvalRunConfig | None = None
+
+    def run_sync(
+        self,
+        *,
+        tasks: Sequence[AgentEvalTask],
+        trials: Sequence[AgentEvalTrial] | None = None,
+        target: AgentEvalTarget | None = None,
+        config: AgentEvalRunConfig | None = None,
+    ) -> AgentEvalResult:
+        self.received_tasks = list(tasks)
+        self.received_trials = list(trials) if trials is not None else None
+        self.received_target = target
+        self.received_config = config
+        generated_trials = [
+            AgentEvalTrial(
+                id=f"{task.id}:trial",
+                task_id=task.id,
+                status=AgentEvalTrialStatus.COMPLETED,
+                output=AgentOutput(output_text="4"),
+            )
+            for task in tasks
+        ]
+        return AgentEvalResult(
+            run_id="run-1", tasks=list(tasks), trials=generated_trials, scores=[], summary=AgentEvalSummary()
+        )
+
+
+def test_to_runtime_task_reconstructs_runtime_metric_instances() -> None:
+    task = _to_runtime_task(_task_spec())
+    assert isinstance(task, AgentEvalTask)
+    assert task.id == "task-1"
+    assert len(task.metrics) == 1
+    assert isinstance(task.metrics[0], ExactMatchMetric)
+
+
+def test_agent_eval_job_reconstructs_tasks_and_persists_bundle(tmp_path: Path, mocker: MockerFixture) -> None:
+    fake = _FakeEvaluator()
+    mocker.patch.object(AgentEvalJob, "_build_evaluator", return_value=fake)
+    ctx = _job_context(tmp_path)
+
+    spec = AgentEvalSpec(tasks=[_task_spec()], target=CodexRunnerTarget(model="gpt-5.5"))
+    result = AgentEvalJob().run(spec.model_dump(), ctx=ctx)
+
+    # The job reconstructed runtime tasks (bundled metric round-tripped) before handing off.
+    assert [task.id for task in fake.received_tasks] == ["task-1"]
+    assert isinstance(fake.received_tasks[0].metrics[0], ExactMatchMetric)
+
+    # The run bundle is persisted under job storage and registered as artifacts.
+    assert result["status"] == "completed"
+    bundle = ctx.storage.persistent / AGENT_BUNDLE_DIR
+    assert (bundle / "trials.jsonl").exists()
+    assert (bundle / "scores.jsonl").exists()
+    assert (bundle / "summary.json").exists()
+    assert (ctx.storage.persistent / "results" / DEFAULT_RESULT_NAME).exists()
+    assert (ctx.storage.persistent / "results" / SUMMARY_RESULT_NAME).exists()
+    assert result["artifact"]["name"] == DEFAULT_RESULT_NAME
+
+
+def test_agent_eval_spec_requires_at_least_one_task() -> None:
+    with pytest.raises(ValueError, match="at least 1 item|too_short|min_length"):
+        AgentEvalSpec(tasks=[])
+
+
+def _agent() -> Agent:
+    return Agent(
+        url="http://agent.test",
+        name="test-agent",
+        format=AgentFormat.GENERIC,
+        body={"question": "{{item.prompt}}"},
+        response_path="$.answer",
+    )
+
+
+def test_resolve_target_builds_codex_runtime_from_runner_target(tmp_path: Path) -> None:
+    ctx = _job_context(tmp_path)
+    target, prompt_template, params = AgentEvalJob._resolve_target(CodexRunnerTarget(model="gpt-5.5"), ctx)
+    # A runner shapes its own request, so it contributes no prompt template or inference params.
+    assert isinstance(target, CodexCliAgentRuntime)
+    assert prompt_template is None
+    assert params is None
+
+
+def test_resolve_target_unpacks_model_target_request_config(tmp_path: Path) -> None:
+    ctx = _job_context(tmp_path)
+    model = Model(url="http://model.test/v1/chat/completions", name="m")
+    target, prompt_template, params = AgentEvalJob._resolve_target(
+        ModelTarget(model=model, prompt_template="{{item.prompt}}", params=RunConfigOnlineModel()), ctx
+    )
+    assert target is model
+    assert prompt_template == "{{item.prompt}}"
+    assert isinstance(params, RunConfigOnlineModel)
+
+
+def test_resolve_target_agent_carries_no_prompt_template(tmp_path: Path) -> None:
+    ctx = _job_context(tmp_path)
+    agent = _agent()
+    target, prompt_template, params = AgentEvalJob._resolve_target(AgentTarget(agent=agent), ctx)
+    # The agent shapes its own request via body/response_path — no separate prompt template.
+    assert target is agent
+    assert prompt_template is None
+    assert isinstance(params, RunConfigOnline)
+
+
+def test_resolve_target_resolves_none_to_no_target(tmp_path: Path) -> None:
+    ctx = _job_context(tmp_path)
+    assert AgentEvalJob._resolve_target(None, ctx) == (None, None, None)
+
+
+def test_runner_target_is_accepted(tmp_path: Path) -> None:
+    spec = AgentEvalSpec(tasks=[_task_spec()], target=CodexRunnerTarget(model="gpt-5.5"))
+    assert isinstance(spec.target, CodexRunnerTarget)
+
+
+@pytest.mark.parametrize("sdk_cls", [NeMoPlatform, AsyncNeMoPlatform])
+def test_build_evaluator_forwards_platform_identity_headers(
+    sdk_cls: type[NeMoPlatform | AsyncNeMoPlatform],
+) -> None:
+    """Online inference must act as the job's principal, so the injected SDK's identity headers are
+    forwarded to the evaluator. Forwarding is an explicit allowlist: the service principal id and
+    on-behalf-of go through, but Stainless/transport noise and other ``X-NMP-*`` (e.g. trace) headers
+    do not — so no bearer or internal metadata leaks to a third-party endpoint. A submitted job is
+    injected the sync ``NeMoPlatform``; ``run_local`` may inject the async counterpart."""
+    sdk = sdk_cls(
+        base_url="http://platform",
+        default_headers={
+            "X-NMP-Principal-Id": "service:evaluator",
+            "X-NMP-Principal-On-Behalf-Of": "user-1",
+            "X-NMP-Internal": "true",
+            "X-NMP-Trace-Id": "must-not-forward",  # non-identity X-NMP-* must be dropped
+            "Authorization": "Bearer super-secret",  # bearer must never reach a third-party endpoint
+        },
+    )
+
+    evaluator = AgentEvalJob._build_evaluator(sdk)
+
+    assert evaluator.default_headers == {
+        "X-NMP-Principal-Id": "service:evaluator",
+        "X-NMP-Principal-On-Behalf-Of": "user-1",
+        "X-NMP-Internal": "true",
+    }
+
+
+def test_build_evaluator_without_platform_forwards_no_headers() -> None:
+    assert AgentEvalJob._build_evaluator(None).default_headers is None
+
+
+def test_input_spec_accepts_stored_metric_reference() -> None:
+    spec = AgentEvalInputSpec(
+        tasks=[AgentEvalTaskInput(id="task-1", intent="Answer.", inputs={}, metrics=[MetricRef("stored-metric")])],
+        target=CodexRunnerTarget(model="gpt-5.5"),
+    )
+    assert isinstance(spec.tasks[0].metrics[0], MetricRef)
+
+
+async def test_to_spec_resolves_inline_task_metrics_without_a_platform() -> None:
+    # Inline metrics need no entity client/SDK; refs would, but none are used here.
+    input_spec = AgentEvalInputSpec(
+        tasks=[
+            AgentEvalTaskInput(
+                id="task-1",
+                intent="Answer the question.",
+                inputs={"prompt": "What is 2+2?"},
+                metrics=[_inline_metric()],
+            )
+        ],
+        target=CodexRunnerTarget(model="gpt-5.5"),
+    )
+
+    spec = await AgentEvalJob.to_spec(input_spec, workspace="dev", entity_client=None, async_sdk=None, is_local=True)
+
+    assert isinstance(spec, AgentEvalSpec)
+    assert len(spec.tasks) == 1
+    assert isinstance(spec.tasks[0].metrics[0], MetricInline)
+    # Canonical metrics reconstruct to runtime instances.
+    assert isinstance(_to_runtime_task(spec.tasks[0]).metrics[0], ExactMatchMetric)
+
+
+async def test_to_spec_requires_platform_to_resolve_a_metric_reference() -> None:
+    # A stored MetricRef can only be loaded with an entity store + SDK; without one, to_spec must
+    # fail loudly rather than silently drop the metric.
+    input_spec = AgentEvalInputSpec(
+        tasks=[AgentEvalTaskInput(id="task-1", intent="Answer.", inputs={}, metrics=[MetricRef("stored-metric")])],
+        target=CodexRunnerTarget(model="gpt-5.5"),
+    )
+    with pytest.raises(ValueError, match="platform connection"):
+        await AgentEvalJob.to_spec(input_spec, workspace="dev", entity_client=None, async_sdk=None, is_local=True)
+
+
+# --- compile: the submit/service-side path ----------------------------------
+
+
+def _assert_agent_eval_step_entrypoint(job_spec: PlatformJobSpec) -> None:
+    step = job_spec.steps[0]
+    container = cast(Any, step.executor).container
+    assert container.entrypoint == ["python", "-m"]
+    assert container.command == ["nemo_evaluator.tasks.agent_evaluate"]
+
+
+@pytest.mark.parametrize(
+    ("target", "expected_kind", "expected_endpoint_name"),
+    [
+        (CodexRunnerTarget(model="gpt-5.5"), "codex", None),
+        (
+            ModelTarget(
+                model=Model(url="http://model.test/v1/chat/completions", name="test-model"),
+                params=RunConfigOnlineModel(),
+            ),
+            "model",
+            "test-model",
+        ),
+        (AgentTarget(agent=_agent(), params=RunConfigOnline()), "agent", "test-agent"),
+    ],
+)
+async def test_compile_produces_cpu_task_step_carrying_each_target(
+    target: Target,
+    expected_kind: str,
+    expected_endpoint_name: str | None,
+) -> None:
+    spec = AgentEvalSpec(tasks=[_task_spec()], target=target)
+
+    compiled = await AgentEvalJob.compile(
+        workspace="default", spec=spec, entity_client=object(), job_name=None, async_sdk=None
+    )
+
+    job_spec = PlatformJobSpec.model_validate(compiled)
+    assert len(job_spec.steps) == 1
+    step = job_spec.steps[0]
+    assert step.name == "agent-evaluate"
+    _assert_agent_eval_step_entrypoint(job_spec)
+    config = cast(dict[str, Any], step.config)
+    assert len(config["tasks"]) == 1
+    assert config["target"]["kind"] == expected_kind
+    if expected_endpoint_name is not None:
+        endpoint = config["target"].get("model") or config["target"].get("agent")
+        assert endpoint["name"] == expected_endpoint_name
+
+
+async def test_compile_injects_target_api_key_secret() -> None:
+    spec = AgentEvalSpec(
+        tasks=[_task_spec()],
+        target=ModelTarget(
+            model=Model(
+                url="https://integrate.api.nvidia.com/v1/chat/completions",
+                name="nvidia/model",
+                api_key_secret=SecretRef(root="NVIDIA_API_KEY"),
+            ),
+            params=RunConfigOnlineModel(),
+        ),
+    )
+
+    compiled = await AgentEvalJob.compile(
+        workspace="default", spec=spec, entity_client=object(), job_name=None, async_sdk=None
+    )
+
+    step = PlatformJobSpec.model_validate(compiled).steps[0]
+    secrets = {env.name: env.from_secret.name for env in step.environment or [] if env.from_secret}
+    assert secrets == {"NVIDIA_API_KEY": "NVIDIA_API_KEY"}
+
+
+async def test_compile_rejects_reserved_secret_env_name() -> None:
+    spec = AgentEvalSpec(
+        tasks=[_task_spec()],
+        target=ModelTarget(
+            model=Model(
+                url="https://integrate.api.nvidia.com/v1/chat/completions",
+                name="nvidia/model",
+                api_key_secret=SecretRef(root=PERSISTENT_JOB_STORAGE_PATH_ENVVAR),
+            ),
+            params=RunConfigOnlineModel(),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="reserved"):
+        await AgentEvalJob.compile(
+            workspace="default", spec=spec, entity_client=object(), job_name=None, async_sdk=None
+        )
+
+
+# --- run_local: the in-process run path, across target types ----------------
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        ModelTarget(
+            model=Model(url="http://model.test/v1/chat/completions", name="test-model"), params=RunConfigOnlineModel()
+        ),
+        AgentTarget(agent=_agent(), params=RunConfigOnline()),
+        CodexRunnerTarget(model="gpt-5.5"),
+    ],
+)
+def test_run_local_executes_each_target_type(target: Target, mocker: MockerFixture) -> None:
+    # run_local drives the full validate -> to_spec -> run path. The evaluator is faked so the target
+    # is threaded (a runner resolved to its runtime, an endpoint passed through) without real inference.
+    fake = _FakeEvaluator()
+    mocker.patch.object(AgentEvalJob, "_build_evaluator", return_value=fake)
+    input_spec = AgentEvalInputSpec(
+        tasks=[
+            AgentEvalTaskInput(
+                id="task-1", intent="Answer.", inputs={"prompt": "What is 2+2?"}, metrics=[_inline_metric()]
+            )
+        ],
+        target=target,
+    )
+
+    result = NemoJobScheduler().run_local(AgentEvalJob, input_spec.model_dump(mode="json"))
+
+    assert result["status"] == "completed"
+    assert result["artifact"]["name"] == DEFAULT_RESULT_NAME
+    assert [task.id for task in fake.received_tasks] == ["task-1"]
+    assert fake.received_trials is None  # online generation, not precomputed
+    if isinstance(target, CodexRunnerTarget):
+        assert isinstance(fake.received_target, CodexCliAgentRuntime)
+    elif isinstance(target, ModelTarget):
+        assert getattr(fake.received_target, "name", None) == target.model.name
+    else:
+        assert getattr(fake.received_target, "name", None) == target.agent.name
+
+
+def test_run_local_scores_precomputed_trials_offline(mocker: MockerFixture) -> None:
+    # Offline eval: precomputed trials are scored directly, with no target / no generation.
+    fake = _FakeEvaluator()
+    mocker.patch.object(AgentEvalJob, "_build_evaluator", return_value=fake)
+    precomputed = [
+        AgentEvalTrial(
+            id="t-1", task_id="task-1", status=AgentEvalTrialStatus.COMPLETED, output=AgentOutput(output_text="4")
+        )
+    ]
+    input_spec = AgentEvalInputSpec(
+        tasks=[AgentEvalTaskInput(id="task-1", intent="Answer.", inputs={}, metrics=[_inline_metric()])],
+        trials=precomputed,
+    )
+
+    result = NemoJobScheduler().run_local(AgentEvalJob, input_spec.model_dump(mode="json"))
+
+    assert result["status"] == "completed"
+    assert fake.received_target is None
+    assert [trial.id for trial in fake.received_trials or []] == ["t-1"]
+
+
+def test_spec_requires_exactly_one_of_target_or_trials() -> None:
+    trial = AgentEvalTrial(
+        id="t-1", task_id="task-1", status=AgentEvalTrialStatus.COMPLETED, output=AgentOutput(output_text="4")
+    )
+    with pytest.raises(ValueError, match="exactly one"):
+        AgentEvalSpec(tasks=[_task_spec()])  # neither target nor trials
+    with pytest.raises(ValueError, match="exactly one"):
+        AgentEvalSpec(tasks=[_task_spec()], target=CodexRunnerTarget(model="gpt-5.5"), trials=[trial])  # both
+
+
+# --- container task entrypoint ----------------------------------------------
+
+
+class TestAgentEvalTask:
+    """Coverage for the compiled container/subprocess task entrypoint."""
+
+    def test_main_dispatches_agent_eval_job_with_task_sdk(self, mocker: MockerFixture) -> None:
+        sdk = object()
+        get_task_sdk = mocker.patch("nemo_evaluator.tasks.runner.get_task_sdk", return_value=sdk)
+        run_task = mocker.patch("nemo_evaluator.tasks.runner.run_task", return_value=0)
+
+        exit_code = agent_eval_task_main()
+
+        assert exit_code == 0
+        get_task_sdk.assert_called_once_with("evaluator")
+        run_task.assert_called_once_with(AgentEvalJob, sdk=sdk)
+
+    def test_main_returns_setup_exit_code_when_task_sdk_fails(self, mocker: MockerFixture) -> None:
+        get_task_sdk = mocker.patch("nemo_evaluator.tasks.runner.get_task_sdk", side_effect=RuntimeError("boom"))
+        run_task = mocker.patch("nemo_evaluator.tasks.runner.run_task")
+
+        exit_code = agent_eval_task_main()
+
+        assert exit_code == SDK_INITIALIZATION_EXIT_CODE
+        get_task_sdk.assert_called_once_with("evaluator")
+        run_task.assert_not_called()

--- a/plugins/nemo-evaluator/tests/test_agent_evaluate.py
+++ b/plugins/nemo-evaluator/tests/test_agent_evaluate.py
@@ -203,37 +203,67 @@ def test_runner_target_is_accepted(tmp_path: Path) -> None:
     assert isinstance(spec.target, CodexRunnerTarget)
 
 
-@pytest.mark.parametrize("sdk_cls", [NeMoPlatform, AsyncNeMoPlatform])
-def test_build_evaluator_forwards_platform_identity_headers(
-    sdk_cls: type[NeMoPlatform | AsyncNeMoPlatform],
-) -> None:
-    """Online inference must act as the job's principal, so the injected SDK's identity headers are
-    forwarded to the evaluator. Forwarding is an explicit allowlist: the service principal id and
-    on-behalf-of go through, but Stainless/transport noise and other ``X-NMP-*`` (e.g. trace) headers
-    do not — so no bearer or internal metadata leaks to a third-party endpoint. A submitted job is
-    injected the sync ``NeMoPlatform``; ``run_local`` may inject the async counterpart."""
-    sdk = sdk_cls(
+def _sdk_with_identity(sdk_cls: type[NeMoPlatform | AsyncNeMoPlatform]) -> NeMoPlatform | AsyncNeMoPlatform:
+    return sdk_cls(
         base_url="http://platform",
         default_headers={
             "X-NMP-Principal-Id": "service:evaluator",
             "X-NMP-Principal-On-Behalf-Of": "user-1",
+            "X-NMP-Principal-On-Behalf-Of-Email": "user@corp.test",  # PII — must stay in-platform
             "X-NMP-Internal": "true",
             "X-NMP-Trace-Id": "must-not-forward",  # non-identity X-NMP-* must be dropped
-            "Authorization": "Bearer super-secret",  # bearer must never reach a third-party endpoint
+            "Authorization": "Bearer super-secret",  # bearer must never reach any endpoint
         },
     )
 
-    evaluator = AgentEvalJob._build_evaluator(sdk)
+
+def _model_target(url: str) -> ModelTarget:
+    return ModelTarget(model=Model(url=url, name="m"))
+
+
+@pytest.mark.parametrize("sdk_cls", [NeMoPlatform, AsyncNeMoPlatform])
+def test_build_evaluator_forwards_identity_headers_to_platform_routed_target(
+    sdk_cls: type[NeMoPlatform | AsyncNeMoPlatform],
+) -> None:
+    """A platform-routed target (same host as the SDK base URL, e.g. an IGW route) must act as the
+    job's principal, so identity headers are forwarded. Forwarding is an explicit allowlist: the
+    service principal id and on-behalf-of go through, but transport noise and other ``X-NMP-*`` (e.g.
+    trace) headers and the bearer do not."""
+    sdk = _sdk_with_identity(sdk_cls)
+    target = _model_target("http://platform/apis/inference-gateway/v2/workspaces/default/model/m/-/v1/chat/completions")
+
+    evaluator = AgentEvalJob._build_evaluator(sdk, target)
 
     assert evaluator.default_headers == {
         "X-NMP-Principal-Id": "service:evaluator",
         "X-NMP-Principal-On-Behalf-Of": "user-1",
+        "X-NMP-Principal-On-Behalf-Of-Email": "user@corp.test",
         "X-NMP-Internal": "true",
     }
 
 
+@pytest.mark.parametrize("sdk_cls", [NeMoPlatform, AsyncNeMoPlatform])
+def test_build_evaluator_sends_no_identity_to_third_party_target(
+    sdk_cls: type[NeMoPlatform | AsyncNeMoPlatform],
+) -> None:
+    """A third-party target the user configured must receive no on-behalf-of identity — that would
+    leak the delegated user's id/email/groups PII to an external host (it authenticates via its own
+    api key anyway)."""
+    sdk = _sdk_with_identity(sdk_cls)
+    target = _model_target("https://api.openai.com/v1/chat/completions")
+
+    assert AgentEvalJob._build_evaluator(sdk, target).default_headers is None
+
+
+def test_build_evaluator_runner_target_forwards_no_headers() -> None:
+    # A runner (Codex CLI) has no platform HTTP endpoint, so there's no identity to forward.
+    sdk = _sdk_with_identity(NeMoPlatform)
+    assert AgentEvalJob._build_evaluator(sdk, CodexRunnerTarget(model="gpt-5.5")).default_headers is None
+
+
 def test_build_evaluator_without_platform_forwards_no_headers() -> None:
-    assert AgentEvalJob._build_evaluator(None).default_headers is None
+    target = _model_target("http://platform/apis/inference-gateway/v2/workspaces/default/model/m/-/v1/chat/completions")
+    assert AgentEvalJob._build_evaluator(None, target).default_headers is None
 
 
 def test_input_spec_accepts_stored_metric_reference() -> None:

--- a/plugins/nemo-evaluator/tests/test_evaluate_job.py
+++ b/plugins/nemo-evaluator/tests/test_evaluate_job.py
@@ -36,8 +36,8 @@ from nemo_evaluator.shared.metric_bundles.bundles import (
     unbundle_metric,
 )
 from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
-from nemo_evaluator.tasks.evaluate import EvaluateTaskExitCode
 from nemo_evaluator.tasks.evaluate import main as evaluate_task_main
+from nemo_evaluator.tasks.runner import SDK_INITIALIZATION_EXIT_CODE
 from nemo_evaluator_sdk.enums import AgentFormat
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
 from nemo_evaluator_sdk.metrics.f1 import F1Metric
@@ -672,7 +672,7 @@ async def test_evaluate_job_compile_produces_cpu_task_step() -> None:
         spec=spec,
         entity_client=object(),
         job_name=None,
-        async_sdk=object(),
+        async_sdk=None,
     )
     job_spec = PlatformJobSpec.model_validate(compiled)
     assert len(job_spec.steps) == 1
@@ -722,7 +722,7 @@ async def test_evaluate_job_to_spec_resolves_bundled_metric_model_refs_before_co
         spec=canonical,
         entity_client=object(),
         job_name=None,
-        async_sdk=object(),
+        async_sdk=None,
     )
 
     job_spec = PlatformJobSpec.model_validate(compiled)
@@ -784,7 +784,7 @@ async def test_evaluate_job_compile_produces_online_model_job() -> None:
         spec=spec,
         entity_client=object(),
         job_name=None,
-        async_sdk=object(),
+        async_sdk=None,
     )
 
     job_spec = PlatformJobSpec.model_validate(compiled)
@@ -811,7 +811,7 @@ async def test_evaluate_job_compile_normalizes_generic_online_model_params() -> 
         spec=spec,
         entity_client=object(),
         job_name=None,
-        async_sdk=object(),
+        async_sdk=None,
     )
 
     job_spec = PlatformJobSpec.model_validate(compiled)
@@ -841,7 +841,7 @@ async def test_evaluate_job_compile_produces_online_agent_job() -> None:
         spec=spec,
         entity_client=object(),
         job_name=None,
-        async_sdk=object(),
+        async_sdk=None,
     )
 
     job_spec = PlatformJobSpec.model_validate(compiled)
@@ -891,7 +891,7 @@ async def test_evaluate_job_compile_injects_metric_and_target_secrets() -> None:
         spec=spec,
         entity_client=object(),
         job_name=None,
-        async_sdk=object(),
+        async_sdk=None,
     )
 
     step = PlatformJobSpec.model_validate(compiled).steps[0]
@@ -923,7 +923,7 @@ async def test_evaluate_job_compile_rejects_secret_reserved_env_names() -> None:
             spec=spec,
             entity_client=object(),
             job_name=None,
-            async_sdk=object(),
+            async_sdk=None,
         )
 
 
@@ -1057,7 +1057,7 @@ class TestEvaluateJobCompile:
             spec=EquivalentSpec.model_validate(_exact_match_spec()),
             entity_client=object(),
             job_name=None,
-            async_sdk=object(),
+            async_sdk=None,
         )
 
         job_spec = PlatformJobSpec.model_validate(compiled)
@@ -1084,7 +1084,7 @@ class TestEvaluateJobCompile:
             spec=spec,
             entity_client=object(),
             job_name=None,
-            async_sdk=object(),
+            async_sdk=None,
         )
 
         config = cast(dict[str, Any], PlatformJobSpec.model_validate(compiled).steps[0].config)
@@ -1126,7 +1126,7 @@ class TestEvaluateJobCompile:
                 spec=spec,
                 entity_client=object(),
                 job_name=None,
-                async_sdk=object(),
+                async_sdk=None,
             )
 
     @pytest.mark.parametrize(
@@ -1174,7 +1174,7 @@ class TestEvaluateJobCompile:
             spec=EvaluateSpec.model_validate({**_exact_match_spec(), "dataset": dataset}),
             entity_client=object(),
             job_name=None,
-            async_sdk=object(),
+            async_sdk=None,
         )
 
         job_spec = PlatformJobSpec.model_validate(compiled)
@@ -1361,8 +1361,8 @@ class TestEvaluateTask:
 
     def test_main_dispatches_evaluate_job_with_task_sdk(self, mocker: MockerFixture) -> None:
         sdk = object()
-        get_task_sdk = mocker.patch("nemo_evaluator.tasks.evaluate.get_task_sdk", return_value=sdk)
-        run_task = mocker.patch("nemo_evaluator.tasks.evaluate.run_task", return_value=0)
+        get_task_sdk = mocker.patch("nemo_evaluator.tasks.runner.get_task_sdk", return_value=sdk)
+        run_task = mocker.patch("nemo_evaluator.tasks.runner.run_task", return_value=0)
 
         exit_code = evaluate_task_main()
 
@@ -1372,13 +1372,13 @@ class TestEvaluateTask:
 
     def test_main_returns_setup_exit_code_when_task_sdk_fails(self, mocker: MockerFixture) -> None:
         get_task_sdk = mocker.patch(
-            "nemo_evaluator.tasks.evaluate.get_task_sdk",
+            "nemo_evaluator.tasks.runner.get_task_sdk",
             side_effect=RuntimeError("boom"),
         )
-        run_task = mocker.patch("nemo_evaluator.tasks.evaluate.run_task")
+        run_task = mocker.patch("nemo_evaluator.tasks.runner.run_task")
 
         exit_code = evaluate_task_main()
 
-        assert exit_code == EvaluateTaskExitCode.SDK_INITIALIZATION_FAILED
+        assert exit_code == SDK_INITIALIZATION_EXIT_CODE
         get_task_sdk.assert_called_once_with("evaluator")
         run_task.assert_not_called()

--- a/plugins/nemo-evaluator/tests/test_service.py
+++ b/plugins/nemo-evaluator/tests/test_service.py
@@ -37,7 +37,7 @@ def test_service_health_route_mounts_with_valid_prefix() -> None:
         "plugin": "evaluator",
         "status": "ok",
         "mode": "sdk-backed-job-scaffold",
-        "jobs": ["evaluator.evaluate"],
+        "jobs": ["evaluator.evaluate", "evaluator.agent-evaluate"],
     }
 
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/trials.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/trials.py
@@ -15,7 +15,7 @@ from typing import Any, Protocol, runtime_checkable
 from nemo_platform.beta.evaluator.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_platform.beta.evaluator.values import Agent, Model
 from nemo_platform.beta.evaluator.values.evidence import CandidateEvidence, EvidenceDescriptor
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator, model_validator
 
 # Well-known evidence keys produced by ``standard_evidence_descriptors``. Harness
 # code may import these to tag evidence consistently; callers may still add
@@ -44,9 +44,10 @@ class AgentOutput(BaseModel):
         default=None,
         description="User-visible final text produced by the agent, if any.",
     )
-    response: dict[str, Any] | None = Field(
+    response: JsonValue | None = Field(
         default=None,
-        description="Structured final response payload produced by the agent, if any.",
+        description="Final response payload produced by the agent, if any. Any JSON value — a "
+        "structured object, or a raw JSON string/array for agents that don't return an object.",
     )
     metadata: dict[str, Any] = Field(
         default_factory=dict,

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/trials.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/trials.py
@@ -44,7 +44,7 @@ class AgentOutput(BaseModel):
         default=None,
         description="User-visible final text produced by the agent, if any.",
     )
-    response: Any | None = Field(
+    response: dict[str, Any] | None = Field(
         default=None,
         description="Structured final response payload produced by the agent, if any.",
     )

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/agents.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/agents.py
@@ -29,7 +29,21 @@ class Agent(BaseModel):
 
     # TODO: Much of this is duplicated between agent and model. Once we have aligned on model defination.
     # the duplication can be removed by defining EndPoint class and reusing it across both model and agent.
-    model_config = ConfigDict(extra="forbid")
+    #
+    # ``allOf``/``if``/``then`` mirrors the ``_validate_generic_fields`` validator into the OpenAPI
+    # schema: a generic-format agent must carry ``body`` + ``response_path`` (the generic HTTP path
+    # needs them), so the contract rejects a ``url``-only generic agent rather than only failing later.
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "allOf": [
+                {
+                    "if": {"properties": {"format": {"const": "generic"}}},
+                    "then": {"required": ["body", "response_path"]},
+                }
+            ]
+        },
+    )
 
     url: str = Field(description="Base URL of the agent endpoint.")
     name: str = Field(description="Agent name / identifier.")

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, PrivateAttr, model_validator
 
 
 class FilesystemEntry(BaseModel):
@@ -293,7 +293,12 @@ class LocalFilesystemEvidence:
 class EvidenceDescriptor(BaseModel):
     """Descriptor for a candidate trace, source, or artifact."""
 
-    model_config = ConfigDict(extra="forbid")
+    # ``anyOf`` mirrors the ``_requires_ref_or_data`` validator into the OpenAPI schema, so a payload
+    # with neither ``ref`` nor ``data`` is rejected by the contract, not just at runtime.
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={"anyOf": [{"required": ["ref"]}, {"required": ["data"]}]},
+    )
 
     kind: str = Field(description="Evidence type, e.g. 'filesystem', 'trace', 'log_bundle', or 'review'.")
     ref: str | None = Field(
@@ -304,7 +309,7 @@ class EvidenceDescriptor(BaseModel):
         default=None,
         description="Parser hint for the evidence payload, e.g. 'atif' for normalized traces.",
     )
-    data: Any | None = Field(
+    data: JsonValue | None = Field(
         default=None,
         description="Small inline evidence payload; at least one of ref or data must be set.",
     )

--- a/uv.lock
+++ b/uv.lock
@@ -4363,6 +4363,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "nmp-testing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pytest-asyncio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "ruff", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -4380,6 +4381,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "nmp-testing", editable = "packages/nmp_testing" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "ruff", specifier = ">=0.11.8" },


### PR DESCRIPTION
## What

Adds **`AgentEvalJob`** — a plugin-native job that runs the agent-eval SDK (`AgentEvaluator`) over a taskset against a **model, agent, or agent runner**, either locally (`run_local`) or submitted to a backend (subprocess / docker / k8s). This is the [AALGO-297](https://linear.app/) "agent evaluation as a plugin job" work.

## Design notes

- **Target model is kind-discriminated:** `ModelTarget | AgentTarget | AgentRunnerTarget` (`CodexRunnerTarget` today), unioned as `Target`. The prompt lives where it belongs — on the model target — rather than as a job-level `prompt_template`. A spec must provide **exactly one** trial source: an online `target`, or precomputed `trials` for an offline eval.
- **Online inference forwards the job's platform identity** (the task SDK's `X-NMP-*` headers — including `X-NMP-Principal-Id: service:evaluator`) to the evaluator, so a platform-routed target acts as the job's principal. No bearer is forwarded, so the platform token never leaks to a third-party endpoint. **Verified against an auth-enabled platform: these service-principal headers are sufficient** (the PDP grants `service:*` full permissions) — no bearer is needed. Identity propagation happens at run time (the on-behalf-of principal only exists when the task runs), and rides a generic `default_headers` seam, so the evaluator SDK stays platform-agnostic.

## Shared plumbing extracted

- `tasks/runner.py` — one container entrypoint (SIGTERM handling, task SDK build, dispatch) shared by both evaluator jobs; per-job modules are thin `python -m` targets.
- `secret_env.py` — `build_task_environment()` for metric/endpoint secrets.
- `metric_resolution.py` — stored-ref + model-ref resolution shared by both jobs. Stored refs need a real `AsyncNeMoPlatform`; model resolution duck-types sync/async clients via a `runtime_checkable` `ModelResolverSdk` protocol.

## Testing

Unit: full evaluator suite green (352 passed). Integration matrix (real platform fixtures):

| Test | Result |
|---|---|
| `run_local` model / agent (IGW mock) / codex (real) | ✅ pass |
| submit → subprocess backend | ✅ pass |
| submit with a stored `MetricRef` | ✅ pass |
| **submit Model target under `auth.enabled` → IGW** (forwarded identity authenticates online inference end-to-end) | ✅ pass |
| submit → docker backend | ⚠️ xfail (until the `cpu-tasks` image ships the task module) |

Auth-sufficiency probed directly too: a call to the IGW model route with the service-principal headers returns **200**, the same call with no auth returns **401** — so the forwarding is both necessary and sufficient under auth.

`nmp-testing` is now an explicit evaluator dev dependency.

## Follow-ups (Monday)

- SDK / OpenAPI regen for the new `/agent-evaluate/jobs` routes.
- AALGO-301 (container/runner image), AALGO-302 (`intent` leak into the agent prompt).
- 3 pre-existing `ty` diagnostics in `test_evaluate_job.py` (`format="nim"` literal, `unbundle_metric(MetricInline)`) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **agent-evaluate** job with model, agent, and Codex runner targets, including plugin-native compilation and local/platform execution.
  * Exposed new **job API routes** and a **nemo.jobs** entry point, plus a dedicated **OpenAPI** contract for agent-evaluation jobs.

* **Bug Fixes**
  * Strengthened job-completion polling with safety assertions.
  * Improved secret-backed task environment construction and identity header forwarding, and tightened evaluator/spec validation.

* **Tests**
  * Expanded unit and integration coverage (inline/stored metrics, auth, Codex, and docker backends).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
