### PR TITLE
fix(evaluator): align RAGAS mode-qualified score names to declared output

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
@@ -69,6 +69,21 @@ RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME: dict[str, str] = {
 }
 
 
+def _strip_ragas_mode_suffix(name: str) -> str:
+    """Strip RAGAS's ``(mode=<mode>)`` suffix from a score name.
+
+    RAGAS keys mode-bearing metrics (e.g. ``NoiseSensitivity`` with mode
+    relevant/irrelevant, ``TopicAdherence`` with mode precision/recall/f1) as
+    ``"<name>(mode=<mode>)"`` (see ``ragas.evaluation``). The SDK declares the bare
+    metric-type name in ``output_spec``, so the suffix is removed before mapping the
+    RAGAS output name back to the declared SDK output name.
+    """
+    base, separator, remainder = name.partition("(mode=")
+    if separator and remainder.endswith(")"):
+        return base
+    return name
+
+
 # Lazy loaders for langchain classes (cached to avoid repeated imports)
 @cache
 def _get_langchain_chat_openai():
@@ -265,9 +280,10 @@ class BaseRAGASMetric(MetricBase):
         if not declared or not scores:
             return scores
 
-        translated_scores = {
-            RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME.get(name, name): value for name, value in scores.items()
-        }
+        translated_scores = {}
+        for name, value in scores.items():
+            base_name = _strip_ragas_mode_suffix(name)
+            translated_scores[RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME.get(base_name, base_name)] = value
         aligned = {
             name: scores[name] if name in scores else translated_scores[name]
             for name in declared

--- a/packages/nemo_evaluator_sdk/tests/metrics/ragas/test_ragas.py
+++ b/packages/nemo_evaluator_sdk/tests/metrics/ragas/test_ragas.py
@@ -195,6 +195,67 @@ def test_align_scores_does_not_guess_unknown_ragas_metric_name():
     assert aligned == {"unexpected_ragas_name": 0.75}
 
 
+@pytest.mark.parametrize(
+    "metric_factory,ragas_score_name,sdk_score_name",
+    [
+        # RAGAS keys mode-bearing metrics as "<name>(mode=<mode>)" (see ragas.evaluation).
+        # NoiseSensitivity defaults to mode="relevant"; the SDK declares the bare
+        # "noise_sensitivity" output, so the suffix must be stripped (NVBug 6369321).
+        (
+            lambda: NoiseSensitivityMetric(judge_model=MOCK_JUDGE_MODEL),
+            "noise_sensitivity(mode=relevant)",
+            MetricType.NOISE_SENSITIVITY.value,
+        ),
+        (
+            lambda: NoiseSensitivityMetric(judge_model=MOCK_JUDGE_MODEL),
+            "noise_sensitivity(mode=irrelevant)",
+            MetricType.NOISE_SENSITIVITY.value,
+        ),
+        # The same mode-suffixing applies to TopicAdherence (mode=precision/recall/f1).
+        (
+            lambda: TopicAdherenceMetric(metric_mode="f1", judge_model=MOCK_JUDGE_MODEL),
+            "topic_adherence(mode=f1)",
+            MetricType.TOPIC_ADHERENCE.value,
+        ),
+    ],
+)
+def test_align_scores_strips_ragas_mode_suffix(metric_factory, ragas_score_name, sdk_score_name):
+    metric = metric_factory()
+    aligned = metric._align_scores_to_output_spec({ragas_score_name: 0.75})
+    assert aligned == {sdk_score_name: 0.75}
+
+
+@pytest.mark.asyncio
+async def test_noise_sensitivity_metric_accepts_ragas_mode_qualified_score():
+    """Regression for NVBug 6369321.
+
+    RAGAS emits NoiseSensitivity scores under the mode-qualified key
+    ``noise_sensitivity(mode=relevant)``. The metric must align that to the declared
+    ``noise_sensitivity`` output instead of failing validation with
+    "Missing declared metric outputs: ['noise_sensitivity']".
+    """
+    metric = NoiseSensitivityMetric(judge_model=MOCK_JUDGE_MODEL)
+
+    mock_evaluate = MagicMock()
+    mock_evaluate.return_value.scores = [{"noise_sensitivity(mode=relevant)": 0.42}]
+    with patch("nemo_evaluator_sdk.metrics.ragas.base.get_evaluate_function", return_value=mock_evaluate):
+        result = await compute_scores(
+            metric,
+            {
+                "user_input": "What is the capital of France?",
+                "retrieved_contexts": [
+                    "Paris is the capital and largest city of France.",
+                    "Berlin is the capital of Germany.",
+                ],
+                "response": "The capital of France is Paris.",
+                "reference": "Paris is the capital of France.",
+            },
+            {},
+        )
+    assert isinstance(result, MetricResult)
+    assert _get_score_value(result, "noise_sensitivity") == 0.42
+
+
 def test_nan_scores_use_declared_output_spec_names():
     metric = ContextRelevanceMetric(judge_model=MOCK_JUDGE_MODEL)
     nan_scores = metric._nan_scores_for_metrics([])

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/ragas/base.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/ragas/base.py
@@ -69,6 +69,21 @@ RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME: dict[str, str] = {
 }
 
 
+def _strip_ragas_mode_suffix(name: str) -> str:
+    """Strip RAGAS's ``(mode=<mode>)`` suffix from a score name.
+
+    RAGAS keys mode-bearing metrics (e.g. ``NoiseSensitivity`` with mode
+    relevant/irrelevant, ``TopicAdherence`` with mode precision/recall/f1) as
+    ``"<name>(mode=<mode>)"`` (see ``ragas.evaluation``). The SDK declares the bare
+    metric-type name in ``output_spec``, so the suffix is removed before mapping the
+    RAGAS output name back to the declared SDK output name.
+    """
+    base, separator, remainder = name.partition("(mode=")
+    if separator and remainder.endswith(")"):
+        return base
+    return name
+
+
 # Lazy loaders for langchain classes (cached to avoid repeated imports)
 @cache
 def _get_langchain_chat_openai():
@@ -265,9 +280,10 @@ class BaseRAGASMetric(MetricBase):
         if not declared or not scores:
             return scores
 
-        translated_scores = {
-            RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME.get(name, name): value for name, value in scores.items()
-        }
+        translated_scores = {}
+        for name, value in scores.items():
+            base_name = _strip_ragas_mode_suffix(name)
+            translated_scores[RAGAS_OUTPUT_NAME_TO_SDK_OUTPUT_NAME.get(base_name, base_name)] = value
         aligned = {
             name: scores[name] if name in scores else translated_scores[name]
             for name in declared


### PR DESCRIPTION
## Summary

RAGAS keys mode-bearing metrics as `"<name>(mode=<mode>)"`, so `NoiseSensitivity` (default `mode="relevant"`) emits its score under `noise_sensitivity(mode=relevant)`. The SDK declares the bare `noise_sensitivity` output in `output_spec`, so `_align_scores_to_output_spec` couldn't map the suffixed key and validation failed with `Missing declared metric outputs: ['noise_sensitivity']` — breaking the documented `run()`/`submit()` Noise Sensitivity examples.

This strips the `(mode=...)` suffix before mapping RAGAS output names to declared SDK output names. The mode is fixed metric configuration (not a per-row result), so the score value is preserved while surfacing under the declared name. Also covers `TopicAdherence`'s precision/recall/f1 modes.

Follow-up (separate): surfacing the metric mode in results as provenance is deferred to its own output-contract enhancement.

NVBug: https://nvbugspro.nvidia.com/bug/6369321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of RAGAS metric names that include mode-qualified suffixes, so they now align correctly with the SDK’s declared output fields.
  * Fixed score alignment for metrics such as noise sensitivity and topic adherence when incoming scores contain a mode suffix.
* **Tests**
  * Added regression and parametrized coverage to confirm mode-qualified RAGAS scores are translated and returned correctly by score computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->