### PR TITLE
feat(studio): GroupExperiments sort based on metics

### DIFF
--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/MeanValueTooltipCell.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/MeanValueTooltipCell.tsx
@@ -31,14 +31,21 @@ export const MeanValueTooltipCell: FC<MeanValueTooltipCellProps> = ({
   count,
   runCount,
   children,
-}) => (
-  <Tooltip
-    slotContent={
-      <Text kind="body/regular/sm">{aggregateMetricTooltip(label, runNoun, count, runCount)}</Text>
-    }
-    className={tooltipClassName}
-    side="bottom"
-  >
-    <Text className="cursor-default border-b border-dotted border-brand">{children}</Text>
-  </Tooltip>
-);
+}) => {
+  if (count == null) {
+    return <Text>{children}</Text>;
+  }
+  return (
+    <Tooltip
+      slotContent={
+        <Text kind="body/regular/sm">
+          {aggregateMetricTooltip(label, runNoun, count, runCount)}
+        </Text>
+      }
+      className={tooltipClassName}
+      side="bottom"
+    >
+      <Text className="cursor-default border-b border-dotted border-brand">{children}</Text>
+    </Tooltip>
+  );
+};

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -10,8 +10,8 @@ import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataV
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { snakeCaseToTitleCase } from '@nemo/common/src/utils/formatters';
-import { getSortParamWithWhitelist } from '@nemo/common/src/utils/query';
 import { useGetExperimentGroup } from '@nemo/sdk/generated/platform/api';
 import type { ExperimentFilter } from '@nemo/sdk/generated/platform/schema';
 import { Button, Text, Tooltip } from '@nvidia/foundations-react-core';
@@ -22,6 +22,7 @@ import {
   type ListExperimentsSortParam,
   useExperimentGroupExperiments,
 } from '@studio/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments';
+import { useSortErrorRecovery } from '@studio/components/dataViews/ExperimentGroupDataView/useSortErrorRecovery';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { getExperimentDetailRoute } from '@studio/routes/utils';
 import { tooltipClassName } from '@studio/styles/common';
@@ -31,24 +32,31 @@ import { useNavigate } from 'react-router-dom';
 
 export type { ExperimentRow };
 
-const SORTABLE_FIELDS = ['name', 'created_at'] as const;
 const DEFAULT_SORT: ListExperimentsSortParam = '-created_at';
-const SORT_PARAMS = [
-  'name',
-  '-name',
-  'created_at',
-  '-created_at',
-] as const satisfies readonly ListExperimentsSortParam[];
-const SORT_PARAM_SET: ReadonlySet<string> = new Set(SORT_PARAMS);
 
-const isListExperimentsSortParam = (sort: string): sort is ListExperimentsSortParam =>
-  SORT_PARAM_SET.has(sort);
+// Maps sortable static column ids to their API sort fields.
+const STATIC_SORT_FIELD_MAP: Readonly<Record<string, string>> = {
+  name: 'name',
+  created_at: 'created_at',
+  cost_usd: 'cost_usd.mean',
+  latency_ms: 'latency_ms.mean',
+  run_count: 'run_count',
+};
 
 const getExperimentSortParam = (
-  sortingState: Parameters<typeof getSortParamWithWhitelist>[0]
+  sortingState: { id: string; desc: boolean }[]
 ): ListExperimentsSortParam => {
-  const sort = getSortParamWithWhitelist(sortingState, SORTABLE_FIELDS, DEFAULT_SORT);
-  return isListExperimentsSortParam(sort) ? sort : DEFAULT_SORT;
+  const [first] = sortingState;
+  if (!first) return DEFAULT_SORT;
+  let field = STATIC_SORT_FIELD_MAP[first.id];
+  if (!field) {
+    // Evaluator columns use id `evaluator-<name>` so the API field can be derived without
+    // a separate lookup into evaluatorNames (which would create a circular dependency).
+    const evaluatorMatch = first.id.match(/^evaluator-(.+)$/);
+    if (evaluatorMatch) field = `evaluators.${evaluatorMatch[1]}.mean`;
+  }
+  if (!field) return DEFAULT_SORT;
+  return `${first.desc ? '-' : ''}${field}`;
 };
 
 interface ExperimentGroupDataViewProps {
@@ -71,6 +79,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
 }) => {
   const workspace = useWorkspaceFromPath();
   const navigate = useNavigate();
+  const toast = useToast();
   const {
     data: group,
     isLoading: isGroupLoading,
@@ -96,6 +105,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
     totalCount,
     error,
     isLoading,
+    isSuccess,
   } = useExperimentGroupExperiments({
     workspace,
     experimentGroupId,
@@ -104,6 +114,17 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
     page,
     pageSize,
     sort: sortParam,
+  });
+
+  // A metric sort (cost, latency, evaluator score) can fail with 413/503/400. Recover by toasting
+  // and reverting the sort indicator to the last good sort instead of replacing the table with an
+  // error; `isRecoverableSortError` lets us skip the page-level error for that case.
+  const isRecoverableSortError = useSortErrorRecovery({
+    error,
+    isSuccess,
+    sortingState: dataViewState.sorting.state,
+    setSorting: dataViewState.sorting.set,
+    onError: toast.error,
   });
 
   // One score column per evaluator: the union of evaluator names across the loaded rows,
@@ -254,18 +275,19 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
           }
         )
       ),
-      ...evaluatorNames.map((name, index) =>
-        accessor((original) => original.aggregate_scores?.[name]?.mean, {
-          id: `score-${index}`,
-          header: `Avg ${snakeCaseToTitleCase(name)}`,
-          enableSorting: false,
+      ...evaluatorNames.map((name) => {
+        const title = snakeCaseToTitleCase(name);
+        return accessor((original) => original.aggregate_scores?.[name]?.mean, {
+          id: `evaluator-${name}`,
+          header: `Avg ${title}`,
+          enableSorting: true,
           meta: { title: false },
           size: 140,
           cell: ({ row }) => {
             const score = row.original.aggregate_scores?.[name];
             return (
               <MeanValueTooltipCell
-                label={snakeCaseToTitleCase(name)}
+                label={title}
                 runNoun="scored run"
                 count={score?.count}
                 runCount={row.original.run_count}
@@ -274,12 +296,12 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
               </MeanValueTooltipCell>
             );
           },
-        })
-      ),
+        });
+      }),
       accessor((original) => original.cost_usd?.mean, {
         id: 'cost_usd',
         header: 'Avg Cost',
-        enableSorting: false,
+        enableSorting: true,
         meta: { title: false },
         cell: ({ row }) => {
           const { cost_usd, run_count } = row.original;
@@ -299,7 +321,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
         id: 'latency_ms',
         header: 'Avg Latency',
         meta: { title: false },
-        enableSorting: false,
+        enableSorting: true,
         cell: ({ row }) => {
           const { latency_ms, run_count } = row.original;
           return (
@@ -317,7 +339,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
       accessor((original) => original.run_count, {
         id: 'run_count',
         header: 'Run Count',
-        enableSorting: false,
+        enableSorting: true,
         cell: ({ row }) => <Text>{String(row.original.run_count ?? 0)}</Text>,
       }),
       accessor('created_at', {
@@ -350,7 +372,9 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
     return <ErrorMessage message="Failed to load experiment group." />;
   }
 
-  if (error) {
+  // A recoverable sort error is handled by useSortErrorRecovery (toast + revert), and the table keeps
+  // showing the last good page — so don't replace it with the full-page error for that case.
+  if (error && !isRecoverableSortError) {
     return <ErrorMessage message="Failed to load experiments." />;
   }
 

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.test.ts
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.test.ts
@@ -39,12 +39,13 @@ const pin = (name: string): Row => ({ id: name, name, pinned_at: '2026-01-01T00:
 const unp = (name: string): Row => ({ id: name, name, pinned_at: null });
 
 // Minimal stand-in for the SDK query result; the hook only reads `data`, `pagination.total_results`,
-// and the loading/fetching/error flags.
+// and the loading/fetching/success/error flags.
 const queryResult = (rows: Row[], total: number) =>
   ({
     data: { data: rows, pagination: { total_results: total } },
     isLoading: false,
     isFetching: false,
+    isSuccess: true,
     error: null,
   }) as unknown as ReturnType<typeof useListExperiments>;
 
@@ -160,6 +161,32 @@ describe('useExperimentGroupExperiments', () => {
     const { result } = renderHook(() => useExperimentGroupExperiments(baseParams));
 
     expect(result.current.isLoading).toBe(false);
+  });
+
+  it('reports isSuccess from the unpinned (sortable) query, not the pinned one', () => {
+    // Pinned has loaded; the unpinned query (which carries the sort) is still fetching its sort.
+    mockUseListExperiments.mockImplementation(((_workspace, params) =>
+      (params?.filter as { is_pinned?: boolean } | undefined)?.is_pinned
+        ? queryResult([pin('p')], 1)
+        : ({
+            data: undefined,
+            isLoading: false,
+            isFetching: true,
+            isSuccess: false,
+            error: null,
+          } as unknown as ReturnType<typeof useListExperiments>)) as typeof useListExperiments);
+
+    const { result } = renderHook(() => useExperimentGroupExperiments(baseParams));
+
+    expect(result.current.isSuccess).toBe(false);
+  });
+
+  it('reports isSuccess once the unpinned query has loaded the current sort', () => {
+    mockLists({ rows: [pin('p')], total: 1 }, { rows: [unp('u')], total: 1 });
+
+    const { result } = renderHook(() => useExperimentGroupExperiments(baseParams));
+
+    expect(result.current.isSuccess).toBe(true);
   });
 
   it('scopes pin/unpin invalidation to this group, not the whole workspace', () => {

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.test.ts
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.test.ts
@@ -189,6 +189,26 @@ describe('useExperimentGroupExperiments', () => {
     expect(result.current.isSuccess).toBe(true);
   });
 
+  it('does not report isSuccess while a new sort is in flight and the previous page is shown as placeholder', () => {
+    // The `keepPreviousData` window: status 'success' but isPlaceholderData true. isSuccess must stay
+    // false, else sort-error recovery banks the about-to-fail sort and the next 413/503 isn't recovered.
+    mockUseListExperiments.mockImplementation(((_workspace, params) =>
+      (params?.filter as { is_pinned?: boolean } | undefined)?.is_pinned
+        ? queryResult([pin('p')], 1)
+        : ({
+            data: { data: [unp('u')], pagination: { total_results: 1 } },
+            isLoading: false,
+            isFetching: true,
+            isSuccess: true,
+            isPlaceholderData: true,
+            error: null,
+          } as unknown as ReturnType<typeof useListExperiments>)) as typeof useListExperiments);
+
+    const { result } = renderHook(() => useExperimentGroupExperiments(baseParams));
+
+    expect(result.current.isSuccess).toBe(false);
+  });
+
   it('scopes pin/unpin invalidation to this group, not the whole workspace', () => {
     mockLists({ rows: [], total: 0 }, { rows: [], total: 0 });
 

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.ts
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.ts
@@ -121,6 +121,7 @@ export function useExperimentGroupExperiments({
     isLoading: isUnpinnedLoading,
     isFetching: isUnpinnedFetching,
     isSuccess: isUnpinnedSuccess,
+    isPlaceholderData: isUnpinnedPlaceholder,
     error: unpinnedError,
   } = useListExperiments(
     workspace,
@@ -203,9 +204,9 @@ export function useExperimentGroupExperiments({
   // both lists have loaded once, rather than clearing as soon as the faster query returns.
   const isLoading = isPinnedLoading || isUnpinnedLoading;
   const isFetching = isPinnedFetching || isUnpinnedFetching;
-  // Only the unpinned query carries the caller's (potentially metric-backed) sort; the pinned query
-  // always sorts by `-pinned_at`. So sort-error recovery keys off the unpinned query's success.
-  const isSuccess = isUnpinnedSuccess;
+  // Sort-error recovery keys off the unpinned (sort-carrying) query. Exclude placeholder data so
+  // `keepPreviousData`'s in-flight 'success' doesn't bank an about-to-fail sort as the last good one.
+  const isSuccess = isUnpinnedSuccess && !isUnpinnedPlaceholder;
 
   return { rows, togglePin, totalCount, error, isLoading, isFetching, isSuccess };
 }

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.ts
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useExperimentGroupExperiments.ts
@@ -60,6 +60,12 @@ export interface ExperimentGroupExperiments {
   isLoading: boolean;
   /** True when either query is fetching */
   isFetching: boolean;
+  /**
+   * True once the sortable (unpinned) page has loaded successfully for the current sort. Tracks the
+   * current sort key specifically — it stays false while a new sort is in flight or has errored — so
+   * callers can record the last good sort for sort-error recovery.
+   */
+  isSuccess: boolean;
 }
 
 /**
@@ -114,6 +120,7 @@ export function useExperimentGroupExperiments({
     data: unpinnedResponse,
     isLoading: isUnpinnedLoading,
     isFetching: isUnpinnedFetching,
+    isSuccess: isUnpinnedSuccess,
     error: unpinnedError,
   } = useListExperiments(
     workspace,
@@ -196,6 +203,9 @@ export function useExperimentGroupExperiments({
   // both lists have loaded once, rather than clearing as soon as the faster query returns.
   const isLoading = isPinnedLoading || isUnpinnedLoading;
   const isFetching = isPinnedFetching || isUnpinnedFetching;
+  // Only the unpinned query carries the caller's (potentially metric-backed) sort; the pinned query
+  // always sorts by `-pinned_at`. So sort-error recovery keys off the unpinned query's success.
+  const isSuccess = isUnpinnedSuccess;
 
-  return { rows, togglePin, totalCount, error, isLoading, isFetching };
+  return { rows, togglePin, totalCount, error, isLoading, isFetching, isSuccess };
 }

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useSortErrorRecovery.test.ts
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useSortErrorRecovery.test.ts
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ListExperimentsQueryError } from '@nemo/sdk/generated/platform/api';
+import {
+  SORT_ERROR_MESSAGES,
+  type SortingState,
+  useSortErrorRecovery,
+  type UseSortErrorRecoveryParams,
+} from '@studio/components/dataViews/ExperimentGroupDataView/useSortErrorRecovery';
+import { renderHook } from '@testing-library/react';
+
+const sort = (id: string, desc = false): SortingState => [{ id, desc }];
+// Minimal Axios-shaped error: the hook only reads `response.status`.
+const httpError = (status: number): ListExperimentsQueryError =>
+  ({ response: { status } }) as unknown as ListExperimentsQueryError;
+
+const CREATED_AT = sort('created_at', true);
+const LATENCY = sort('latency_ms');
+const COST = sort('cost_usd');
+
+const setup = (overrides: Partial<UseSortErrorRecoveryParams> = {}) => {
+  const setSorting = vi.fn();
+  const onError = vi.fn();
+  const initialProps: UseSortErrorRecoveryParams = {
+    error: null,
+    isSuccess: true,
+    sortingState: CREATED_AT,
+    setSorting,
+    onError,
+    ...overrides,
+  };
+  const { result, rerender } = renderHook(
+    (props: UseSortErrorRecoveryParams) => useSortErrorRecovery(props),
+    { initialProps }
+  );
+  return { result, rerender, setSorting, onError, initialProps };
+};
+
+describe('useSortErrorRecovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([413, 503, 400] as const)(
+    'toasts and reverts the sort when a newly applied sort fails with %i',
+    (status) => {
+      const { result, rerender, setSorting, onError, initialProps } = setup();
+
+      // User applies a metric sort; it is in flight (not yet successful).
+      rerender({ ...initialProps, isSuccess: false, sortingState: LATENCY });
+      // The metric sort request errors.
+      rerender({
+        ...initialProps,
+        error: httpError(status),
+        isSuccess: false,
+        sortingState: LATENCY,
+      });
+
+      expect(result.current).toBe(true);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(SORT_ERROR_MESSAGES[status]);
+      // Reverts the indicator to the last sort that loaded successfully.
+      expect(setSorting).toHaveBeenCalledWith(CREATED_AT);
+    }
+  );
+
+  it('does not recover from a non-sort error status (e.g. 500)', () => {
+    const { result, rerender, setSorting, onError, initialProps } = setup();
+
+    rerender({ ...initialProps, isSuccess: false, sortingState: LATENCY });
+    rerender({ ...initialProps, error: httpError(500), isSuccess: false, sortingState: LATENCY });
+
+    expect(result.current).toBe(false);
+    expect(onError).not.toHaveBeenCalled();
+    expect(setSorting).not.toHaveBeenCalled();
+  });
+
+  it('does not recover when the error is on the already-good sort (e.g. initial load), to avoid a loop', () => {
+    // Never reached a success: last good sort is the initial sort, and the error is on that same sort.
+    const { result, setSorting, onError, rerender, initialProps } = setup({ isSuccess: false });
+
+    rerender({
+      ...initialProps,
+      error: httpError(503),
+      isSuccess: false,
+      sortingState: CREATED_AT,
+    });
+
+    expect(result.current).toBe(false);
+    expect(onError).not.toHaveBeenCalled();
+    expect(setSorting).not.toHaveBeenCalled();
+  });
+
+  it('reverts to the most recent good sort, not the original', () => {
+    const { rerender, setSorting, initialProps } = setup();
+
+    // A second sort loads successfully, becoming the new last-good sort...
+    rerender({ ...initialProps, isSuccess: true, sortingState: LATENCY });
+    // ...then a third sort is applied and fails.
+    rerender({ ...initialProps, isSuccess: false, sortingState: COST });
+    rerender({ ...initialProps, error: httpError(413), isSuccess: false, sortingState: COST });
+
+    expect(setSorting).toHaveBeenCalledWith(LATENCY);
+  });
+
+  it('handles each error episode once even if other inputs change', () => {
+    const { rerender, onError, initialProps } = setup();
+    const error = httpError(413);
+
+    rerender({ ...initialProps, isSuccess: false, sortingState: LATENCY });
+    rerender({ ...initialProps, error, isSuccess: false, sortingState: LATENCY });
+    // Same error object, still on the failed sort, but a new onError reference re-runs the effect.
+    const newOnError = vi.fn();
+    rerender({
+      ...initialProps,
+      error,
+      isSuccess: false,
+      sortingState: LATENCY,
+      onError: newOnError,
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(newOnError).not.toHaveBeenCalled();
+  });
+
+  it('handles a fresh error after the previous one cleared', () => {
+    const { rerender, onError, setSorting, initialProps } = setup();
+
+    // First failed sort → handled.
+    rerender({ ...initialProps, isSuccess: false, sortingState: LATENCY });
+    rerender({ ...initialProps, error: httpError(413), isSuccess: false, sortingState: LATENCY });
+    // Revert applied + refetch on the good sort succeeds (error clears).
+    rerender({ ...initialProps, error: null, isSuccess: true, sortingState: CREATED_AT });
+    // A new sort fails again → handled again.
+    rerender({ ...initialProps, isSuccess: false, sortingState: COST });
+    rerender({ ...initialProps, error: httpError(503), isSuccess: false, sortingState: COST });
+
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenNthCalledWith(1, SORT_ERROR_MESSAGES[413]);
+    expect(onError).toHaveBeenNthCalledWith(2, SORT_ERROR_MESSAGES[503]);
+    expect(setSorting).toHaveBeenLastCalledWith(CREATED_AT);
+  });
+});

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useSortErrorRecovery.ts
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/useSortErrorRecovery.ts
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TanstackTable } from '@nemo/common/src/components/DataView/internal';
+import type { ListExperimentsQueryError } from '@nemo/sdk/generated/platform/api';
+import { useEffect, useRef } from 'react';
+
+/** The table's sorting state — at most one active column for this single-sort table. */
+export type SortingState = TanstackTable.SortingState;
+
+/**
+ * HTTP statuses a metrics-backed experiment sort can fail with, mapped to a user-facing message.
+ * Sorting by a mean metric (cost, latency, evaluator score) is served from the metrics store, which
+ * can reject the request in ways an ordinary column sort never would:
+ * - 413: the group has more experiments than can be sorted in one request — narrow the filter.
+ * - 503: the metrics store is temporarily unavailable.
+ * - 400: unsupported sort field — guarded against by the column whitelist, handled defensively.
+ */
+export const SORT_ERROR_MESSAGES: Readonly<Record<number, string>> = {
+  413: 'Too many experiments to sort by this metric. Narrow your filter and try again.',
+  503: 'Sorting is temporarily unavailable while metrics load. Please try again shortly.',
+  400: 'This column can’t be sorted.',
+};
+
+const isSameSort = (a: SortingState, b: SortingState): boolean =>
+  a[0]?.id === b[0]?.id && (a[0]?.desc ?? false) === (b[0]?.desc ?? false);
+
+export interface UseSortErrorRecoveryParams {
+  error: ListExperimentsQueryError | null;
+  isSuccess: boolean;
+  sortingState: SortingState;
+  setSorting: (next: SortingState) => void;
+  onError: (message: string) => void;
+}
+
+/**
+ * Recovers from a failed metric sort rather than leaving the table broken. When the current sort
+ * triggers a recoverable error (see {@link SORT_ERROR_MESSAGES}), this surfaces a toast and reverts
+ * the sort indicator to the last sort that loaded successfully. The displayed rows stay consistent
+ * with the indicator because the previous page is kept (`keepPreviousData`) while a sort is in
+ * flight or errored, so the revert is seamless.
+ *
+ * @returns whether the current error is a recoverable sort error, so the caller can suppress its
+ *   page-level error UI for this case (the toast + revert handle it instead).
+ */
+export const useSortErrorRecovery = ({
+  error,
+  isSuccess,
+  sortingState,
+  setSorting,
+  onError,
+}: UseSortErrorRecoveryParams): boolean => {
+  const lastGoodSortRef = useRef<SortingState>(sortingState);
+  useEffect(() => {
+    if (isSuccess) lastGoodSortRef.current = sortingState;
+  }, [isSuccess, sortingState]);
+
+  const status = error?.response?.status;
+  const message = status != null ? SORT_ERROR_MESSAGES[status] : undefined;
+  const isRecoverableSortError =
+    message != null && !isSameSort(sortingState, lastGoodSortRef.current);
+
+  const handledErrorRef = useRef<ListExperimentsQueryError | null>(null);
+  useEffect(() => {
+    if (!error) {
+      handledErrorRef.current = null;
+      return;
+    }
+    if (!isRecoverableSortError || handledErrorRef.current === error || message == null) return;
+    handledErrorRef.current = error;
+    onError(message);
+    setSorting(lastGoodSortRef.current);
+  }, [error, isRecoverableSortError, message, onError, setSorting]);
+
+  return isRecoverableSortError;
+};


### PR DESCRIPTION

https://github.com/user-attachments/assets/440db4f1-de86-4d41-992c-cd8de1ab5439



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the experiment table’s sorting with additional sortable metric columns and evaluator score columns.
  * Improved recovery for recoverable sort failures, automatically restoring the last working sort and surfacing a clearer error message.

* **Bug Fixes**
  * Prevented full-page error states when a recoverable sorting issue occurs (sorting UI reverts instead).
  * Tooltip content is now only shown when a value is available, avoiding empty/incorrect tooltip displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->