### PR TITLE
feat(nemo-agents-plugin): add hermes adapter to nemo-agents plugin

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -470,6 +470,7 @@ nmp = "nemo_platform.cli.app:cli"
 nat_claude_code_agent_adapter = "nat_claude_code_agent_adapter.register"
 nat_codex_agent_adapter = "nat_codex_agent_adapter.register"
 nat_cursor_agent_adapter = "nat_cursor_agent_adapter.register"
+nat_hermes_agent_adapter = "nat_hermes_agent_adapter.register"
 nemo_agents_example_calculator = "calculator_agent.register"
 
 # Generated from [tool.bundle-package]; do not edit this table by hand.
@@ -600,7 +601,7 @@ garak-api = { source = "../../packages/garak_api/garakapi", module = "garakapi",
 switchyard-vendored = { source = "../../plugins/nemo-switchyard/vendor/switchyard/switchyard", module = "switchyard" }
 
 # Default first-party plugins
-nemo-agents-plugin = { source = "../../plugins/nemo-agents/src/nemo_agents_plugin", module = "nemo_agents_plugin", inherit = { "entry-points" = ["nemo.*", "nat.plugins", "nat.components"] }, force_include = { "../../vendor/claude_code_agent_adapter/src/nat_claude_code_agent_adapter" = "nat_claude_code_agent_adapter", "../../vendor/codex_agent_adapter/src/nat_codex_agent_adapter" = "nat_codex_agent_adapter", "../../vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter" = "nat_cursor_agent_adapter" } }
+nemo-agents-plugin = { source = "../../plugins/nemo-agents/src/nemo_agents_plugin", module = "nemo_agents_plugin", inherit = { "entry-points" = ["nemo.*", "nat.plugins", "nat.components"] }, force_include = { "../../vendor/claude_code_agent_adapter/src/nat_claude_code_agent_adapter" = "nat_claude_code_agent_adapter", "../../vendor/codex_agent_adapter/src/nat_codex_agent_adapter" = "nat_codex_agent_adapter", "../../vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter" = "nat_cursor_agent_adapter", "../../vendor/hermes_agent_adapter/src/nat_hermes_agent_adapter" = "nat_hermes_agent_adapter" } }
 nemo-anonymizer-plugin = { source = "../../plugins/nemo-anonymizer/src/nemo_anonymizer_plugin", module = "nemo_anonymizer_plugin", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-auditor-plugin = { source = "../../plugins/nemo-auditor/src/nemo_auditor", module = "nemo_auditor", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-data-designer-plugin = { source = "../../plugins/nemo-data-designer/src/nemo_data_designer_plugin", module = "nemo_data_designer_plugin", inherit = { "entry-points" = ["nemo.*"] } }

--- a/plugins/nemo-agents/examples/claude-code-agent/README.md
+++ b/plugins/nemo-agents/examples/claude-code-agent/README.md
@@ -19,15 +19,16 @@ claude auth status
 ```
 
 Install Rust so `cargo` is available on `PATH`, then install the NeMo Relay CLI.
-The `cargo install` command below writes `nemo-relay` into the active virtual
-environment when `VIRTUAL_ENV` is set, or into `.venv` otherwise. After
-activating that environment, `nemo-relay --help` should resolve on `PATH` for
-the smoke test:
+If `VIRTUAL_ENV` is set, the commands below install into that environment;
+otherwise they install into a local `.nemo-relay` directory. The `PATH` export
+makes the installed `nemo-relay` binary available for the smoke test:
 
 ```bash
 git clone git@github.com:NVIDIA/NeMo-Relay.git
 export NEMO_RELAY_ROOT="$PWD/NeMo-Relay"
-cargo install --path "$NEMO_RELAY_ROOT/crates/cli" --root "${VIRTUAL_ENV:-.venv}" --locked
+export NEMO_RELAY_INSTALL_ROOT="${VIRTUAL_ENV:-$PWD/.nemo-relay}"
+cargo install --path "$NEMO_RELAY_ROOT/crates/cli" --root "$NEMO_RELAY_INSTALL_ROOT" --locked
+export PATH="$NEMO_RELAY_INSTALL_ROOT/bin:$PATH"
 nemo-relay --help
 ```
 

--- a/plugins/nemo-agents/examples/codex-agent/README.md
+++ b/plugins/nemo-agents/examples/codex-agent/README.md
@@ -17,12 +17,17 @@ codex login
 codex login status
 ```
 
-Install the NeMo Relay CLI so `nemo-relay` is available on `PATH`:
+Install Rust so `cargo` is available on `PATH`, then install the NeMo Relay CLI.
+If `VIRTUAL_ENV` is set, the commands below install into that environment;
+otherwise they install into a local `.nemo-relay` directory. The `PATH` export
+makes the installed `nemo-relay` binary available for the smoke test:
 
 ```bash
 git clone git@github.com:NVIDIA/NeMo-Relay.git
 export NEMO_RELAY_ROOT="$PWD/NeMo-Relay"
-cargo install --path "$NEMO_RELAY_ROOT/crates/cli" --root "${VIRTUAL_ENV:-.venv}" --locked
+export NEMO_RELAY_INSTALL_ROOT="${VIRTUAL_ENV:-$PWD/.nemo-relay}"
+cargo install --path "$NEMO_RELAY_ROOT/crates/cli" --root "$NEMO_RELAY_INSTALL_ROOT" --locked
+export PATH="$NEMO_RELAY_INSTALL_ROOT/bin:$PATH"
 nemo-relay --help
 ```
 

--- a/plugins/nemo-agents/examples/cursor-agent/README.md
+++ b/plugins/nemo-agents/examples/cursor-agent/README.md
@@ -20,15 +20,16 @@ cursor-agent status
 For non-interactive environments, set `CURSOR_API_KEY` before starting `nemo`.
 
 Install Rust so `cargo` is available on `PATH`, then install the NeMo Relay CLI.
-The `cargo install` command below writes `nemo-relay` into the active virtual
-environment when `VIRTUAL_ENV` is set, or into `.venv` otherwise. After
-activating that environment, `nemo-relay --help` should resolve on `PATH` for
-the smoke test:
+If `VIRTUAL_ENV` is set, the commands below install into that environment;
+otherwise they install into a local `.nemo-relay` directory. The `PATH` export
+makes the installed `nemo-relay` binary available for the smoke test:
 
 ```bash
 git clone git@github.com:NVIDIA/NeMo-Relay.git
 export NEMO_RELAY_ROOT="$PWD/NeMo-Relay"
-cargo install --path "$NEMO_RELAY_ROOT/crates/cli" --root "${VIRTUAL_ENV:-.venv}" --locked
+export NEMO_RELAY_INSTALL_ROOT="${VIRTUAL_ENV:-$PWD/.nemo-relay}"
+cargo install --path "$NEMO_RELAY_ROOT/crates/cli" --root "$NEMO_RELAY_INSTALL_ROOT" --locked
+export PATH="$NEMO_RELAY_INSTALL_ROOT/bin:$PATH"
 nemo-relay --help
 ```
 

--- a/plugins/nemo-agents/examples/hermes-agent/README.md
+++ b/plugins/nemo-agents/examples/hermes-agent/README.md
@@ -1,0 +1,56 @@
+# Hermes Agent
+
+This example configures the vendored Hermes workflow adapter shipped with the
+`nemo-agents` plugin.
+
+The adapter is already packaged with `nemo-agents`; do not install a separate
+NAT Hermes adapter package.
+
+## Prerequisites
+
+Install and configure Hermes Agent in the same environment that will run
+`nemo`. The workflow config launches Hermes with `uvx`, so a global `hermes`
+executable is not required:
+
+```bash
+uvx --from hermes-agent hermes setup
+uvx --from hermes-agent hermes auth
+uvx --from hermes-agent hermes model
+uvx --from hermes-agent hermes status
+```
+
+Install Rust so `cargo` is available on `PATH`, then install the NeMo Relay CLI.
+The `cargo install` command below writes `nemo-relay` into the active virtual
+environment when `VIRTUAL_ENV` is set, or into `.venv` otherwise. After
+activating that environment, `nemo-relay --help` should resolve on `PATH` for
+the smoke test:
+
+```bash
+git clone git@github.com:NVIDIA/NeMo-Relay.git
+export NEMO_RELAY_ROOT="$PWD/NeMo-Relay"
+cargo install --path "$NEMO_RELAY_ROOT/crates/cli" --root "${VIRTUAL_ENV:-.venv}" --locked
+nemo-relay --help
+```
+
+## Run on NeMo Platform
+
+From the `nemo-platform` repository root, create and deploy the example agent:
+
+```bash
+nemo agents create \
+  --name hermes-agent \
+  --agent-config plugins/nemo-agents/examples/hermes-agent/hermes-agent.yml
+
+nemo agents deploy --agent hermes-agent
+```
+
+Invoke it with a read-only prompt first:
+
+```bash
+nemo agents invoke \
+  --agent hermes-agent \
+  --input "Read pyproject.toml and say only the project name. Do not edit files."
+```
+
+`uvx --from hermes-agent hermes status` should show a concrete model and an
+authenticated provider before a live model-backed workflow run.

--- a/plugins/nemo-agents/examples/hermes-agent/README.md
+++ b/plugins/nemo-agents/examples/hermes-agent/README.md
@@ -20,15 +20,16 @@ uvx --from hermes-agent hermes status
 ```
 
 Install Rust so `cargo` is available on `PATH`, then install the NeMo Relay CLI.
-The `cargo install` command below writes `nemo-relay` into the active virtual
-environment when `VIRTUAL_ENV` is set, or into `.venv` otherwise. After
-activating that environment, `nemo-relay --help` should resolve on `PATH` for
-the smoke test:
+If `VIRTUAL_ENV` is set, the commands below install into that environment;
+otherwise they install into a local `.nemo-relay` directory. The `PATH` export
+makes the installed `nemo-relay` binary available for the smoke test:
 
 ```bash
 git clone git@github.com:NVIDIA/NeMo-Relay.git
 export NEMO_RELAY_ROOT="$PWD/NeMo-Relay"
-cargo install --path "$NEMO_RELAY_ROOT/crates/cli" --root "${VIRTUAL_ENV:-.venv}" --locked
+export NEMO_RELAY_INSTALL_ROOT="${VIRTUAL_ENV:-$PWD/.nemo-relay}"
+cargo install --path "$NEMO_RELAY_ROOT/crates/cli" --root "$NEMO_RELAY_INSTALL_ROOT" --locked
+export PATH="$NEMO_RELAY_INSTALL_ROOT/bin:$PATH"
 nemo-relay --help
 ```
 

--- a/plugins/nemo-agents/examples/hermes-agent/hermes-agent.yml
+++ b/plugins/nemo-agents/examples/hermes-agent/hermes-agent.yml
@@ -1,0 +1,30 @@
+# hermes-agent.yml
+#
+# A Hermes-backed NAT workflow for local coding tasks.
+#
+# Requires uvx and nemo-relay to be installed and available on PATH, with Hermes
+# Agent authentication/model configuration already set up.
+#
+# Platform-managed deployment:
+#   nemo agents create --name hermes-agent --agent-config examples/hermes-agent/hermes-agent.yml
+#   nemo agents deploy --agent hermes-agent
+#   nemo agents invoke --agent hermes-agent \
+#       --input "Read pyproject.toml and say only the project name. Do not edit files."
+
+workflow:
+  _type: hermes_agent
+  command: uvx
+  command_args: ["--from", "hermes-agent", "hermes"]
+  # Change this to the repository or workspace Hermes should operate in.
+  working_directory: .
+  timeout_seconds: 300
+  max_output_chars: 12000
+  relay_atof_output_dir: ./.tmp/nemo-relay-hermes-atof
+
+general:
+  telemetry:
+    tracing:
+      nemo_trace:
+        _type: nemo_files
+        # workspace and agent_name are injected at deploy time
+        batch_size: 128

--- a/plugins/nemo-agents/pyproject.toml
+++ b/plugins/nemo-agents/pyproject.toml
@@ -53,6 +53,7 @@ nemo_agents_files_telemetry = "nemo_agents_plugin.telemetry.files_service_export
 nat_claude_code_agent_adapter = "nat_claude_code_agent_adapter.register"
 nat_codex_agent_adapter = "nat_codex_agent_adapter.register"
 nat_cursor_agent_adapter = "nat_cursor_agent_adapter.register"
+nat_hermes_agent_adapter = "nat_hermes_agent_adapter.register"
 
 [project.optional-dependencies]
 container = [
@@ -77,6 +78,7 @@ packages = [
     "vendor/claude_code_agent_adapter/src/nat_claude_code_agent_adapter",
     "vendor/codex_agent_adapter/src/nat_codex_agent_adapter",
     "vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter",
+    "vendor/hermes_agent_adapter/src/nat_hermes_agent_adapter",
 ]
 
 [tool.uv.sources]

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/validator.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/validator.py
@@ -19,6 +19,7 @@ _KNOWN_WORKFLOW_TYPES = frozenset(
         "claude_code_agent",
         "codex_agent",
         "cursor_agent",
+        "hermes_agent",
         "react_agent",
         "tool_calling_agent",
         "reasoning_agent",

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -611,6 +611,7 @@ class TestValidateAgentConfig:
             "claude_code_agent",
             "codex_agent",
             "cursor_agent",
+            "hermes_agent",
             "react_agent",
             "tool_calling_agent",
             "reasoning_agent",

--- a/plugins/nemo-agents/tests/unit/test_hermes_adapter_packaging.py
+++ b/plugins/nemo-agents/tests/unit/test_hermes_adapter_packaging.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the vendored Hermes adapter packaging."""
+
+from importlib.metadata import entry_points
+from pathlib import Path
+
+import yaml
+from nat_hermes_agent_adapter.register import HermesAgentWorkflowConfig
+
+_NEMO_AGENTS_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_hermes_agent_workflow_type_registered() -> None:
+    assert HermesAgentWorkflowConfig.static_type() == "hermes_agent"
+
+
+def test_hermes_adapter_nat_components_entry_point_registered() -> None:
+    eps = entry_points(group="nat.components")
+    ep = next(ep for ep in eps if ep.name == "nat_hermes_agent_adapter")
+    assert ep.value == "nat_hermes_agent_adapter.register"
+
+
+def test_hermes_example_config_validates_without_warnings() -> None:
+    from nemo_agents_plugin.container.validator import validate_agent_config
+
+    example = _NEMO_AGENTS_ROOT / "examples" / "hermes-agent" / "hermes-agent.yml"
+
+    data = yaml.safe_load(example.read_text(encoding="utf-8"))
+    assert data["workflow"]["_type"] == "hermes_agent"
+    assert data["general"]["telemetry"]["tracing"]["nemo_trace"]["_type"] == "nemo_files"
+
+    result = validate_agent_config(example)
+    assert result.valid
+    assert result.errors == []
+    assert result.warnings == []

--- a/plugins/nemo-agents/vendor/hermes_agent_adapter/README.md
+++ b/plugins/nemo-agents/vendor/hermes_agent_adapter/README.md
@@ -1,0 +1,21 @@
+# Vendored Hermes agent adapter
+
+Snapshot of `examples/experimental/hermes_agent_adapter` from
+[NVIDIA/NeMo-Agent-Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) at commit
+[`d2f1c9c77b91fa28547e1526b9fe8c4fb7a09725`](https://github.com/NVIDIA/NeMo-Agent-Toolkit/commit/d2f1c9c77b91fa28547e1526b9fe8c4fb7a09725).
+
+Copied upstream files:
+
+- `src/nat_hermes_agent_adapter/`
+
+Generated files, example configs, data files, and local development artifacts
+from the upstream example are intentionally omitted, including `uv.lock`.
+
+The vendored adapter registers the NAT workflow type `_type: hermes_agent`.
+Runtime use still requires external `uvx` and `nemo-relay` commands to be
+installed and configured in the environment that launches NAT. The default
+config uses `uvx --from hermes-agent hermes` to run Hermes Agent.
+
+To refresh this snapshot, copy the same included files from the new upstream
+commit, preserve SPDX headers, and update this file with the new commit hash and
+summary.

--- a/plugins/nemo-agents/vendor/hermes_agent_adapter/src/nat_hermes_agent_adapter/__init__.py
+++ b/plugins/nemo-agents/vendor/hermes_agent_adapter/src/nat_hermes_agent_adapter/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/plugins/nemo-agents/vendor/hermes_agent_adapter/src/nat_hermes_agent_adapter/register.py
+++ b/plugins/nemo-agents/vendor/hermes_agent_adapter/src/nat_hermes_agent_adapter/register.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Register the experimental Hermes adapter with NVIDIA NeMo Agent Toolkit."""
+
+import asyncio
+import datetime
+import json
+import shlex
+import tempfile
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import Any
+
+from nat.builder.builder import Builder
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.agent import AgentBaseConfig
+from nat.data_models.api_server import ChatRequest, ChatRequestOrMessage, ChatResponse, ChatResponseChunk, Usage
+from nat.data_models.component_ref import LLMRef
+from nat.experimental.relay_telemetry_bridge import inject_atof_jsonl
+from nat.utils.type_converter import GlobalTypeConverter
+from pydantic import Field
+
+
+class HermesAgentWorkflowConfig(AgentBaseConfig, name="hermes_agent"):
+    """Configuration for the Hermes Agent CLI workflow."""
+
+    llm_name: LLMRef | None = Field(
+        default=None,
+        description=(
+            "Optional NAT LLM reference. Hermes manages provider/model selection through local config, "
+            "`provider`, and `model`, so this field is accepted for agent config consistency but is not "
+            "used."
+        ),
+    )
+    description: str = Field(default="Hermes Agent CLI Workflow", description="The description of this function's use.")
+
+    command: str = Field(default="hermes", description="Hermes CLI command or absolute path.")
+    command_args: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Additional arguments inserted after `command` and before Hermes "
+            "non-interactive query arguments. Useful for launchers such as "
+            "`uvx`."
+        ),
+    )
+    working_directory: str = Field(default=".", description="Directory used as the Hermes subprocess cwd.")
+    provider: str | None = Field(default=None, description="Optional Hermes provider override.")
+    model: str | None = Field(default=None, description="Optional Hermes model override.")
+    max_history: int | None = Field(default=15, ge=1, description="Maximum NAT chat messages to include in prompt.")
+    timeout_seconds: float = Field(default=300.0, gt=0, description="Overall Hermes CLI timeout.")
+    max_output_chars: int = Field(default=12000, gt=0, description="Maximum returned output characters.")
+    error_on_empty_output: bool = Field(
+        default=True, description=("Raise an error when Hermes exits successfully but does not print a final response.")
+    )
+    relay_command: str = Field(default="nemo-relay", description="NeMo Relay CLI command or absolute path.")
+    relay_atof_output_dir: str | None = Field(
+        default=None,
+        description=(
+            "Optional directory where Relay ATOF JSONL should be persisted. If unset, the adapter uses a "
+            "temporary directory and removes it after importing telemetry."
+        ),
+    )
+
+
+def _clip(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + f"\n\n[truncated to {max_chars} characters]"
+
+
+def _nat_message_content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+            else:
+                text = getattr(block, "text", None)
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return str(content)
+
+
+def _role_to_text(role: Any) -> str:
+    return getattr(role, "value", str(role))
+
+
+def _build_prompt(message: ChatRequestOrMessage, config: HermesAgentWorkflowConfig) -> str:
+    if message.is_string:
+        return message.input_message or ""
+
+    chat_request = GlobalTypeConverter.get().convert(message, to_type=ChatRequest)
+    messages = chat_request.messages[-config.max_history :] if config.max_history else chat_request.messages
+
+    if len(messages) == 1 and _role_to_text(messages[0].role) == "user":
+        return _nat_message_content_to_text(messages[0].content)
+
+    prompt_parts = []
+    for chat_message in messages:
+        role = _role_to_text(chat_message.role)
+        content = _nat_message_content_to_text(chat_message.content)
+        prompt_parts.append(f"{role}: {content}")
+    return "\n\n".join(prompt_parts)
+
+
+def _usage_for(prompt: str, response: str) -> Usage:
+    prompt_tokens = len(prompt.split()) if prompt else 0
+    completion_tokens = len(response.split()) if response else 0
+    return Usage(
+        prompt_tokens=prompt_tokens, completion_tokens=completion_tokens, total_tokens=prompt_tokens + completion_tokens
+    )
+
+
+def _as_response(content: str, prompt: str, model: str | None) -> ChatResponse:
+    return ChatResponse.from_string(
+        content,
+        model=model or "hermes-agent",
+        created=datetime.datetime.now(datetime.UTC),
+        usage=_usage_for(prompt, content),
+    )
+
+
+def _build_hermes_args(config: HermesAgentWorkflowConfig, prompt: str) -> list[str]:
+    command = ["chat", "-q", prompt, "-Q"]
+    if config.provider:
+        command.extend(["--provider", config.provider])
+    if config.model:
+        command.extend(["--model", config.model])
+    return command
+
+
+def _write_relay_config(config: HermesAgentWorkflowConfig, path: Path) -> None:
+    hermes_command = shlex.join([config.command, *config.command_args])
+    path.write_text(f"[agents.hermes]\ncommand = {json.dumps(hermes_command)}\n")
+
+
+def _relay_plugin_config(atof_dir: Path) -> str:
+    return json.dumps(
+        {
+            "version": 1,
+            "components": [
+                {
+                    "kind": "observability",
+                    "enabled": True,
+                    "config": {
+                        "atof": {
+                            "enabled": True,
+                            "output_directory": str(atof_dir),
+                            "filename": "events.jsonl",
+                            "mode": "overwrite",
+                        }
+                    },
+                }
+            ],
+        }
+    )
+
+
+def _build_relay_command(
+    config: HermesAgentWorkflowConfig, prompt: str, relay_config_path: Path, atof_dir: Path
+) -> list[str]:
+    return [
+        config.relay_command,
+        "run",
+        "--agent",
+        "hermes",
+        "--config",
+        str(relay_config_path),
+        "--plugin-config",
+        _relay_plugin_config(atof_dir),
+        "--",
+        *_build_hermes_args(config, prompt),
+    ]
+
+
+def _diagnose_empty_output(command: list[str]) -> str:
+    launcher = " ".join(command[:4])
+    return (
+        "Hermes CLI exited successfully but printed no final response text. Run "
+        '`uvx --from hermes-agent hermes chat -q "Say hello in one sentence." -Q`; it should print either a '
+        "model response or a provider/authentication error. If it shows `Model: (not set)`, missing credentials, "
+        "or a provider error such as `model does not exist`, run `uvx --from hermes-agent hermes model`, "
+        "`uvx --from hermes-agent hermes auth`, or `uvx --from hermes-agent hermes setup`, then retry. If you "
+        f"use a specific provider, set both `provider` and `model` in this workflow config. Launcher prefix: "
+        f"{launcher}"
+    )
+
+
+def _clean_hermes_output(stdout: str) -> str:
+    lines = stdout.splitlines()
+    while lines and lines[-1].strip().startswith("session_id:"):
+        lines.pop()
+    return "\n".join(lines).strip()
+
+
+def _inject_relay_events(atof_path: Path) -> None:
+    if atof_path.exists():
+        inject_atof_jsonl(atof_path)
+
+
+async def _run_hermes_agent(prompt: str, config: HermesAgentWorkflowConfig) -> str:
+    cwd = Path(config.working_directory).resolve()
+    relay_temp_dir = tempfile.TemporaryDirectory(prefix="nat-hermes-relay-")
+    relay_root = Path(relay_temp_dir.name)
+    relay_config_path = relay_root / "config.toml"
+    relay_atof_dir = (
+        Path(config.relay_atof_output_dir).resolve() if config.relay_atof_output_dir else relay_root / "atof"
+    )
+    relay_atof_dir.mkdir(parents=True, exist_ok=True)
+    _write_relay_config(config, relay_config_path)
+    relay_atof_path = relay_atof_dir / "events.jsonl"
+    command = _build_relay_command(config, prompt, relay_config_path, relay_atof_dir)
+    if not cwd.exists() or not cwd.is_dir():
+        relay_temp_dir.cleanup()
+        raise RuntimeError(f"Invalid working_directory {config.working_directory!r}: {cwd} is not a directory.")
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *command, cwd=str(cwd), stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+    except FileNotFoundError as error:
+        relay_temp_dir.cleanup()
+        raise RuntimeError(
+            f"Could not find NeMo Relay CLI command: {command[0]}. Install NeMo Relay as `nemo-relay` or set "
+            "`relay_command` in the workflow config. Also install uv/uvx for the configured Hermes launcher, or set "
+            "`command` / `command_args` in the workflow config."
+        ) from error
+
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(process.communicate(), timeout=config.timeout_seconds)
+    except TimeoutError as error:
+        process.kill()
+        await process.wait()
+        try:
+            _inject_relay_events(relay_atof_path)
+        finally:
+            relay_temp_dir.cleanup()
+        raise RuntimeError(f"Hermes CLI timed out after {config.timeout_seconds} seconds") from error
+
+    stdout = _clean_hermes_output(stdout_bytes.decode(errors="replace").strip())
+    stderr = stderr_bytes.decode(errors="replace").strip()
+    try:
+        _inject_relay_events(relay_atof_path)
+    finally:
+        relay_temp_dir.cleanup()
+
+    if process.returncode:
+        details = "\n".join(part for part in [stderr, stdout] if part)
+        raise RuntimeError(f"Hermes CLI failed with exit code {process.returncode}: {_clip(details, 4000)}")
+
+    if not stdout:
+        if stderr:
+            raise RuntimeError(f"Hermes CLI produced no stdout. Stderr: {_clip(stderr, 4000)}")
+        if config.error_on_empty_output:
+            raise RuntimeError(_diagnose_empty_output(command))
+
+    return _clip(stdout, config.max_output_chars)
+
+
+@register_function(config_type=HermesAgentWorkflowConfig)
+async def hermes_agent(config: HermesAgentWorkflowConfig, _builder: Builder) -> AsyncGenerator[FunctionInfo, None]:
+    """Create a Hermes workflow function for NVIDIA NeMo Agent Toolkit.
+
+    Args:
+        config: Hermes workflow configuration from the NeMo Agent Toolkit config system.
+        _builder: Toolkit builder supplied during workflow construction.
+
+    Yields:
+        FunctionInfo containing single-response and streaming handlers that invoke Hermes through NeMo Relay.
+    """
+
+    async def _response_fn(chat_request_or_message: ChatRequestOrMessage) -> ChatResponse | str:
+        message = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequestOrMessage)
+        prompt = _build_prompt(message, config)
+        content = await _run_hermes_agent(prompt=prompt, config=config)
+
+        if message.is_string:
+            return content
+        return _as_response(content, prompt=prompt, model=config.model)
+
+    async def _stream_fn(chat_request_or_message: ChatRequestOrMessage) -> AsyncGenerator[ChatResponseChunk]:
+        message = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequestOrMessage)
+        prompt = _build_prompt(message, config)
+        yield ChatResponseChunk.from_string(
+            await _run_hermes_agent(prompt=prompt, config=config), model=config.model or "hermes-agent"
+        )
+
+    yield FunctionInfo.create(single_fn=_response_fn, stream_fn=_stream_fn, description=config.description)


### PR DESCRIPTION
## Summary

Adds experimental Hermes agent support to `nemo-agents` by vendoring the NAT
Hermes adapter and wiring it into the plugin package, following the same pattern
used for the Codex, Cursor, and Claude Code adapters.

This PR:

- Vendors the upstream Hermes adapter into `plugins/nemo-agents`
- Exposes the adapter through the `nat.components` entry point
- Recognizes `hermes_agent` in nemo-agents config validation
- Adds a Hermes example config and README
- Adds tests for adapter registration and example config validation
- Records upstream provenance for the vendored Hermes adapter, matching the
  existing vendoring approach

## User Flow

Users install/use `nemo-agents` as usual, then provide a config with:

```yaml
workflow:
  _type: hermes_agent
```

The included example is:

```text
plugins/nemo-agents/examples/hermes-agent/hermes-agent.yml
```

The Hermes adapter requires `uvx` and `nemo-relay` to be installed on `PATH`,
with Hermes Agent authentication/model configuration already set up. Relay is
used internally by the adapter to run Hermes and bridge Hermes events into NAT
telemetry.

The example config uses:

```yaml
workflow:
  _type: hermes_agent
  command: uvx
  command_args: ["--from", "hermes-agent", "hermes"]
  working_directory: .
```

## Model Passthrough Note

The spike called out that Hermes owns provider/model configuration outside of
NAT's normal `llms:` primitive. That concern is still valid: the Hermes adapter
does not use `llm_name` to resolve a NAT LLM.

There is, however, a practical passthrough path. The adapter accepts
Hermes-specific `provider` and `model` fields and forwards them to the Hermes
CLI as `--provider` and `--model`.

For example:

```yaml
workflow:
  _type: hermes_agent
  command: uvx
  command_args: ["--from", "hermes-agent", "hermes"]
  working_directory: .
  provider: nvidia_nim
  model: nvidia/nvidia-nemotron-nano-9b-v2
```

If those fields are omitted, Hermes falls back to its own local auth/model
configuration. So platform/NAT model capabilities still cannot be attached
uniformly through the standard NAT `llms:` path, but users can override the
Hermes provider/model through adapter-level passthrough fields.

## Validation

Focused tests:

```bash
uv run --frozen pytest plugins/nemo-agents/tests/unit/test_hermes_adapter_packaging.py plugins/nemo-agents/tests/unit/test_claude_code_adapter_packaging.py plugins/nemo-agents/tests/unit/test_codex_adapter_packaging.py plugins/nemo-agents/tests/unit/test_cursor_adapter_packaging.py plugins/nemo-agents/tests/unit/test_container.py -q
```

Result:

```text
110 passed, 1 warning
```

Additional checks:

```bash
tools/lint/lint-python-style.sh
uv run nemo agents package --agent plugins/nemo-agents/examples/hermes-agent/hermes-agent.yml --no-build --output /tmp/nemo-hermes-agent.Dockerfile
git diff --check
```

Manual smoke tests:

- `uvx --from hermes-agent hermes setup`
- `uvx --from hermes-agent hermes auth`
- `uvx --from hermes-agent hermes model`
- `uvx --from hermes-agent hermes status`
- `nemo agents create --name hermes-agent --agent-config plugins/nemo-agents/examples/hermes-agent/hermes-agent.yml`
- `nemo agents deploy --agent hermes-agent`
- `nemo agents invoke --agent hermes-agent --input "Read pyproject.toml and say only the project name. Do not edit files."`

Invoke returned:

```text
The project name in pyproject.toml is **nemoplatform**.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new Hermes-backed workflow type (`hermes_agent`) for agent runs.
  * Added a ready-to-use Hermes example configuration and run/deploy documentation.
  * Packaged the Hermes adapter so it’s included with the plugin and available via the plugin component entry point.
* **Bug Fixes**
  * Updated configuration validation to recognize `hermes_agent`, preventing “unknown type” warnings.
* **Documentation**
  * Refreshed prerequisites in multiple agent examples to improve NeMo Relay installation and smoke-test `PATH` behavior.
* **Tests**
  * Added unit tests covering workflow type registration, config loading, and packaging for the Hermes adapter and example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->