### PR TITLE
feat(auth): authentik machine-identity reference + setup skill + docs

### DIFF
--- a/contrib/authentik/README.md
+++ b/contrib/authentik/README.md
@@ -1,0 +1,135 @@
+# Machine identity for NeMo Platform via authentik (optional reference)
+
+This is an optional reference, not part of the core platform. It stands up
+[authentik](https://goauthentik.io/) as an OIDC identity provider and shows how a
+**machine** (CI, an agent, a service) authenticates to NeMo Platform with its own
+credential, with access controlled by NeMo's existing RBAC.
+
+## Why this needs zero NeMo core changes
+
+NeMo already validates any OIDC token and authorizes it:
+
+- The middleware validates a `Authorization: Bearer <token>` JWT against the
+  configured issuer and builds `Principal(id=sub, email, groups)`
+  (`packages/nmp_common/src/nmp/common/auth/middleware.py`; `jwt.py` requires `sub`).
+- `authorize_request` forwards the principal's groups to the policy engine
+  (`packages/nmp_common/src/nmp/common/auth/client.py`), and the policy resolves
+  roles over the union of id, email, and groups
+  (`services/core/auth/src/nmp/core/auth/app/policies/common.rego`).
+
+A machine's client-credentials token goes through the same path. So: put the machine
+(a service account) in a group in your IdP, issue it tokens that carry the `groups`
+claim, and bind a NeMo role to that group. NeMo is not a token authority; authentik
+is.
+
+> Security: do NOT use the internal `X-NMP-Principal-Id: service:` header for customer
+> machines. That header is an unconditional trust path for internal services only, and
+> the edge/gateway must strip inbound `X-NMP-Principal-*` headers. Customer machines
+> authenticate via OIDC, as below.
+
+## 1. Bring up authentik
+
+```bash
+cp contrib/authentik/env.example contrib/authentik/.env   # set AUTHENTIK_SECRET_KEY
+docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml up -d
+```
+
+First start runs migrations (about a minute). The blueprint in `blueprints/nemo.yaml`
+is applied automatically: an RS256 OAuth2 provider, the `nemo` application
+(issuer `http://localhost:9000/application/o/nemo/`), groups `nemo-admins` and
+`nemo-editors`, and a service account `svc-nemo-ci` in `nemo-editors` with a
+non-expiring app-password token.
+
+Confirm discovery:
+
+```bash
+curl -s http://localhost:9000/application/o/nemo/.well-known/openid-configuration | jq .issuer
+```
+
+## 2. Get a machine token (client credentials)
+
+```bash
+curl -s -X POST http://localhost:9000/application/o/token/ \
+  -d grant_type=client_credentials \
+  -d client_id=nemo-platform \
+  -d client_secret=nemo-platform-secret-dev \
+  -d username=svc-nemo-ci \
+  -d password=svc-nemo-ci-token-secret-dev \
+  -d scope="openid email groups" | jq -r .access_token
+```
+
+Verify the token first (this is the load-bearing check). Decode the payload and
+confirm `sub` == `svc-nemo-ci`, `iss` == the configured issuer, and `groups` includes
+`nemo-editors`:
+
+```bash
+TOKEN=...   # from above
+echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '{sub, iss, aud, groups}'
+```
+
+## 3. Run NeMo against authentik
+
+```bash
+set -a && source packages/nmp_platform/config/local.env && set +a
+export NMP_BASE_URL=http://127.0.0.1:8080
+NMP_CONFIG_FILE_PATH=contrib/authentik/config/authentik.yaml \
+  nemo services run --services auth,entities,models --host 127.0.0.1 --port 8080
+```
+
+## 4. Demonstrate: respected, scoped, revocable
+
+Before any role binding, the machine is denied:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  http://127.0.0.1:8080/apis/models/v2/workspaces/default/models -H "Authorization: Bearer $TOKEN"
+# 403
+```
+
+Bind the `nemo-editors` group to a role (run as a service principal locally):
+
+```bash
+curl -s -X POST http://127.0.0.1:8080/apis/auth/v2/iam/role-bindings \
+  -H "X-NMP-Principal-Id: service:bootstrap" \
+  -H "Content-Type: application/json" \
+  -d '{"principal": "nemo-editors", "role": "Editor", "workspace": "default"}'
+```
+
+Now the machine is authorized:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  http://127.0.0.1:8080/apis/models/v2/workspaces/default/models -H "Authorization: Bearer $TOKEN"
+# 200
+```
+
+Revoke by removing the binding (or the SA's group in authentik), and the machine is
+denied again. Access is controlled entirely in NeMo via the group->role binding;
+identity and credential lifecycle live in authentik.
+
+## Tear down
+
+```bash
+docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml down -v
+```
+
+## What this does and does not do
+
+Does: federated machine auth with scoped, revocable access, validated by existing
+NeMo code, no core changes.
+
+Does not: add NeMo-native service accounts. The service account, its credential, and
+its lifecycle (create/rotate/revoke) live in authentik. NeMo only holds the role
+binding. This is intentional: NeMo federates identity rather than becoming a token
+authority.
+
+## Verified locally (2026-06-16)
+
+Run against this bundle (authentik 2024.x + NeMo from main, embedded PDP):
+
+- Machine token claims: `sub=svc-nemo-ci`, `iss=http://localhost:9000/application/o/nemo/`, `groups=["nemo-editors"]`, `alg=RS256`.
+- `GET /apis/models/v2/workspaces/default/models` with the token, before any binding: `403`.
+- After binding `nemo-editors -> Editor` in `default`: `200`.
+- After revoking the binding: `403`.
+
+NeMo respected, scoped, and revoked the machine identity with no core code changes.

--- a/contrib/authentik/blueprints/nemo.yaml
+++ b/contrib/authentik/blueprints/nemo.yaml
@@ -1,0 +1,122 @@
+# authentik blueprint: provision everything NeMo needs to use authentik as its
+# OIDC IdP, including a demo service account for MACHINE auth.
+#
+# authentik auto-applies blueprints mounted under /blueprints/custom on startup.
+# Idempotent: re-applying updates in place.
+#
+# Why these choices:
+# - sub_mode=user_username: the client-credentials token's `sub` is the readable
+#   service-account username (svc-nemo-ci), which is the principal you bind a NeMo
+#   role to. authentik otherwise defaults to a hashed subject.
+# - a custom "groups" scope mapping puts the user's groups (e.g. nemo-editors) into
+#   the token `groups` claim. NeMo maps groups -> roles, so this is how access is
+#   granted. (authentik has no built-in groups scope mapping.)
+# - self-signed signing key: tokens are RS256 JWTs that NeMo validates via JWKS.
+
+version: 1
+metadata:
+  name: nemo-platform-oidc
+  labels:
+    blueprints.goauthentik.io/description: "NeMo Platform OIDC provider + demo service account"
+
+entries:
+  # --- Custom scope mapping: emit the user's groups in a `groups` claim --------
+  - model: authentik_providers_oauth2.scopemapping
+    id: nemo-groups-scope
+    identifiers:
+      name: "NeMo groups"
+    attrs:
+      name: "NeMo groups"
+      scope_name: groups
+      description: "Group membership, used by NeMo to map groups to roles"
+      expression: |
+        return {"groups": [group.name for group in user.ak_groups.all()]}
+
+  # --- OAuth2 / OpenID provider ----------------------------------------------
+  - model: authentik_providers_oauth2.oauth2provider
+    id: nemo-provider
+    identifiers:
+      name: nemo-platform
+    attrs:
+      name: nemo-platform
+      client_type: confidential
+      client_id: nemo-platform
+      client_secret: nemo-platform-secret-dev
+      sub_mode: user_username
+      access_code_validity: "minutes=10"
+      include_claims_in_id_token: true
+      redirect_uris: []
+      authorization_flow:
+        !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow:
+        !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      signing_key:
+        !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+        - !KeyOf nemo-groups-scope
+
+  # --- Application bound to the provider --------------------------------------
+  - model: authentik_core.application
+    identifiers:
+      slug: nemo
+    attrs:
+      name: NeMo Platform
+      slug: nemo
+      provider: !KeyOf nemo-provider
+
+  # --- Groups that map to NeMo roles -----------------------------------------
+  - model: authentik_core.group
+    id: group-nemo-admins
+    identifiers:
+      name: nemo-admins
+    attrs:
+      name: nemo-admins
+  - model: authentik_core.group
+    id: group-nemo-editors
+    identifiers:
+      name: nemo-editors
+    attrs:
+      name: nemo-editors
+
+  # --- Demo service account (machine identity) -------------------------------
+  - model: authentik_core.user
+    id: svc-nemo-ci
+    identifiers:
+      username: svc-nemo-ci
+    attrs:
+      username: svc-nemo-ci
+      name: "NeMo CI service account"
+      type: service_account
+      path: service-accounts
+      groups:
+        - !KeyOf group-nemo-editors
+
+  # --- App-password token used as the client_credentials secret --------------
+  - model: authentik_core.token
+    identifiers:
+      identifier: svc-nemo-ci-token
+    attrs:
+      identifier: svc-nemo-ci-token
+      intent: app_password
+      user: !KeyOf svc-nemo-ci
+      key: svc-nemo-ci-token-secret-dev
+      expiring: false
+
+  # --- Enable OAuth device flow (needed for `nemo auth login` human SSO) ----
+  # Two things are required for `/device` to work:
+  # 1. flow_device_code: point the brand's device-code flow at the standard
+  #    authentication flow. Without it, /device has no flow.
+  # 2. default: true: the brand must be the default brand. authentik matches a
+  #    brand to the request Host; "localhost" matches no brand domain, so it uses
+  #    the in-memory fallback brand (which has NO device flow) and /device returns
+  #    404 after sign-in. Marking this brand default makes it serve every host,
+  #    including localhost, carrying the device-code flow with it.
+  - model: authentik_brands.brand
+    identifiers:
+      domain: authentik-default
+    attrs:
+      default: true
+      flow_device_code:
+        !Find [authentik_flows.flow, [slug, default-authentication-flow]]

--- a/contrib/authentik/config/authentik.yaml
+++ b/contrib/authentik/config/authentik.yaml
@@ -1,0 +1,90 @@
+# NeMo Platform config that uses authentik as the OIDC identity provider.
+# Mirrors packages/nmp_platform/config/local.yaml; only the `auth` block differs
+# (auth enabled, unsigned JWT off, OIDC pointed at the authentik bundle).
+# Re-sync with local.yaml if that file changes.
+#
+#   set -a && source packages/nmp_platform/config/local.env && set +a
+#   export NMP_BASE_URL=http://127.0.0.1:8080
+#   NMP_CONFIG_FILE_PATH=contrib/authentik/config/authentik.yaml \
+#     uv run nemo-platform run --host 127.0.0.1 --port 8080
+
+platform:
+  runtime: "docker"
+  base_url: "http://0.0.0.0:8080"
+
+service: {}
+
+auth:
+  enabled: true
+  allow_unsigned_jwt: false
+  policy_decision_point_provider: embedded
+  policy_decision_point_base_url: "http://localhost:8080"
+  policy_data_refresh_interval: 2
+  bundle_cache_seconds: 15
+  admin_email: "admin@example.com"
+  oidc:
+    enabled: true
+    # Issuer MUST equal the `iss` claim authentik puts in tokens (trailing slash
+    # included). Discovery is fetched at <issuer>/.well-known/openid-configuration.
+    issuer: "http://localhost:9000/application/o/nemo/"
+    client_id: "nemo-platform"
+    # authentik client-credentials tokens may not set `aud`; leave audience unset so
+    # issuer + signature are enforced (still secure). Set once you confirm the aud.
+    # audience: "nemo-platform"
+    subject_claim: "sub"
+    email_claim: "email"
+    groups_claim: "groups"
+    # `groups` scope is required so authentik emits the groups claim (via the
+    # "NeMo groups" scope mapping in blueprints/nemo.yaml). Without it the token
+    # carries no groups, so group->role authorization grants nothing and even
+    # `nemo workspaces list` returns empty for a real user. groups_claim above
+    # only says WHERE to read groups; this is what makes them get requested.
+    default_scopes: "openid profile email offline_access groups"
+
+entities: {}
+
+jobs:
+  executors:
+    - provider: subprocess
+      profile: default
+      backend: subprocess
+      config:
+        working_directory: /tmp/nmp-subprocess-jobs
+        cleanup_completed_jobs_immediately: false
+        ttl_seconds_before_active: 60
+        ttl_seconds_active: 3600
+        ttl_seconds_after_finished: 300
+  executor_defaults:
+    subprocess:
+      working_directory: /tmp/nmp-subprocess-jobs
+      cleanup_completed_jobs_immediately: false
+      ttl_seconds_before_active: 60
+      ttl_seconds_active: 3600
+      ttl_seconds_after_finished: 300
+
+evaluator:
+  recreate_existing_system_entities: True
+
+safe_synthesizer: {}
+
+models:
+  controller:
+    interval_seconds: 5
+    model_deployment_garbage_collection_ttl_seconds: 30
+    backends:
+      docker:
+        enabled: true
+
+inference_gateway: {}
+
+secrets:
+  allow_key_creation: true
+
+files:
+  default_storage_config:
+    type: local
+    path: ~/.local/share/nemo/files
+
+studio:
+  static_files_path: web/packages/studio/dist
+  sandbox_enabled: true

--- a/contrib/authentik/docker-compose.yml
+++ b/contrib/authentik/docker-compose.yml
@@ -1,0 +1,89 @@
+# Optional authentik identity provider for NeMo Platform (reference, not core).
+#
+# Stands up authentik (open-source OIDC IdP) so you can use "bring your own IdP"
+# with NeMo Platform, including MACHINE auth via the OAuth2 client-credentials
+# grant. NeMo already validates any OIDC token and authorizes via group->role
+# bindings, so this needs zero NeMo core changes.
+#
+# Bring up (explicit project name so other stacks are untouched):
+#   docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml up -d
+# Tear down (removes only what this stack created):
+#   docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml down -v
+#
+# See contrib/authentik/README.md for the full machine-auth walkthrough.
+
+x-authentik-env: &authentik-env
+  AUTHENTIK_REDIS__HOST: authentik-redis
+  AUTHENTIK_POSTGRESQL__HOST: authentik-postgres
+  AUTHENTIK_POSTGRESQL__USER: ${PG_USER:-authentik}
+  AUTHENTIK_POSTGRESQL__NAME: ${PG_DB:-authentik}
+  AUTHENTIK_POSTGRESQL__PASSWORD: ${PG_PASS:-authentik}
+  AUTHENTIK_SECRET_KEY: ${AUTHENTIK_SECRET_KEY:-change-me-dev-only}
+  # Dev only. Never use these defaults outside local testing.
+  AUTHENTIK_BOOTSTRAP_PASSWORD: ${AUTHENTIK_BOOTSTRAP_PASSWORD:-akadmin-dev}
+  AUTHENTIK_BOOTSTRAP_TOKEN: ${AUTHENTIK_BOOTSTRAP_TOKEN:-bootstrap-token-dev}
+
+services:
+  authentik-postgres:
+    image: docker.io/library/postgres:16-alpine
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    environment:
+      POSTGRES_USER: ${PG_USER:-authentik}
+      POSTGRES_DB: ${PG_DB:-authentik}
+      POSTGRES_PASSWORD: ${PG_PASS:-authentik}
+    volumes:
+      - authentik-pgdata:/var/lib/postgresql/data
+
+  authentik-redis:
+    image: docker.io/library/redis:7-alpine
+    restart: unless-stopped
+    command: --save 60 1 --loglevel warning
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - authentik-redisdata:/data
+
+  authentik-server:
+    image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2024.12}
+    restart: unless-stopped
+    command: server
+    environment: *authentik-env
+    ports:
+      # NeMo points oidc.issuer at http://localhost:9000/application/o/nemo/
+      - "9000:9000"
+    volumes:
+      # Blueprints mounted here are applied automatically on startup.
+      - ./blueprints:/blueprints/custom:ro
+      - authentik-media:/media
+    depends_on:
+      authentik-postgres:
+        condition: service_healthy
+      authentik-redis:
+        condition: service_healthy
+
+  authentik-worker:
+    image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2024.12}
+    restart: unless-stopped
+    command: worker
+    environment: *authentik-env
+    volumes:
+      - ./blueprints:/blueprints/custom:ro
+      - authentik-media:/media
+    depends_on:
+      authentik-postgres:
+        condition: service_healthy
+      authentik-redis:
+        condition: service_healthy
+
+volumes:
+  authentik-pgdata:
+  authentik-redisdata:
+  authentik-media:

--- a/contrib/authentik/env.example
+++ b/contrib/authentik/env.example
@@ -1,0 +1,21 @@
+# Copy to contrib/authentik/.env and adjust. Dev defaults only; never ship these.
+#   cp contrib/authentik/.env.example contrib/authentik/.env
+
+# authentik image tag (pin a real release).
+AUTHENTIK_TAG=2024.12
+
+# Generate with: openssl rand -base64 48
+AUTHENTIK_SECRET_KEY=change-me-dev-only
+
+# Bootstrap admin (user: akadmin) + an API token for scripting.
+AUTHENTIK_BOOTSTRAP_PASSWORD=akadmin-dev
+AUTHENTIK_BOOTSTRAP_TOKEN=bootstrap-token-dev
+
+# Postgres for authentik (separate from NeMo's own DB).
+PG_USER=authentik
+PG_DB=authentik
+PG_PASS=authentik
+
+# OAuth client NeMo uses; must match config/authentik.yaml and the blueprint.
+NEMO_OIDC_CLIENT_ID=nemo-platform
+NEMO_OIDC_CLIENT_SECRET=nemo-platform-secret-dev

--- a/docs/auth/authentication/machine-identity.mdx
+++ b/docs/auth/authentication/machine-identity.mdx
@@ -1,0 +1,116 @@
+---
+title: "Machine Identity (Bring Your Own IdP)"
+description: ""
+---
+A non-human caller (CI pipeline, agent, or service) authenticates to NeMo Platform with its own IdP-issued credential, and NeMo's existing RBAC controls what it can reach. No NeMo core change is required. The machine is treated like any other principal: it presents a token, the platform validates it, builds a principal, and resolves roles.
+
+NeMo Platform is not a token authority. Your IdP issues and revokes the machine's credential; the platform only holds the role binding that grants access.
+
+**Prerequisites**: OIDC must be configured on the platform. See [OIDC Setup](/documentation/access-control/authentication/oidc-setup). Familiarity with [Managing Access](/documentation/access-control/authorization/managing-access) helps for the binding step.
+
+## Why This Works Without Code Changes
+
+NeMo Platform validates any OIDC access token the same way, whether it came from a human's device-flow login or a machine's OAuth2 client-credentials grant. The bearer path in the auth middleware validates the JWT (signature, issuer, audience, expiry) and builds a principal from the token claims: `sub` becomes the principal ID, `email` the email, `groups` the group list. The `sub` claim is required.
+
+Authorization then resolves roles over the union of the principal's ID, email, and groups. The auth client forwards the principal's groups to the policy decision point (PDP); the policy engine collects all applicable principals (ID, email, each group) and checks role bindings against every one of them. A role bound to a group therefore applies to any principal carrying that group, human or machine.
+
+A machine's client-credentials token rides the identical path. Put the machine in a group in your IdP, issue it tokens that carry the `groups` claim, bind a NeMo role to that group, and the platform authorizes the machine exactly as it would a person in the same group.
+
+<Note>
+
+Automatic group-to-role mapping is not yet implemented. The group arrives in the token and reaches the PDP, but you still create the role binding explicitly (bind to the group, or to the machine's stable `sub`). See [Managing Access](/documentation/access-control/authorization/managing-access).
+
+</Note>
+## The Pattern
+
+Five steps, all standard OIDC. None of them touch NeMo Platform source.
+
+1. **Create a service account in your IdP.** This is the machine's identity. It owns the credential and its lifecycle (create, rotate, revoke).
+2. **Put the service account in a group** (for example `nemo-editors`). The group is how you will grant access without re-binding every individual machine.
+3. **Issue client-credentials tokens** for the service account. Configure the IdP so these tokens carry a stable `sub` and the `groups` claim. The `sub` should be durable across rotations so a binding to it survives credential changes.
+4. **Bind a NeMo role to the group** (or to the `sub`) in the target workspace. This is the only state the platform holds about the machine.
+5. **Call NeMo Platform APIs with the token** in the `Authorization: Bearer <token>` header. The platform validates, builds the principal, resolves the group's role, and authorizes.
+
+Binding to the group is the common case: add or remove machines by changing IdP group membership, and the NeMo binding stays put. Bind to the `sub` when you want one specific machine to have access independent of any group.
+
+<Warning>
+
+Do not use the internal `X-NMP-Principal-Id: service:` header for customer machines. That header is an unconditional trust path reserved for internal platform services; a request carrying `service:<name>` is auto-authorized with access to all workspaces by the policy's unconditional service bypass. Customer machines must authenticate via OIDC, as described here.
+
+This is why the edge matters: the gateway must strip inbound `X-NMP-Principal-*` headers from external requests so a client cannot forge a `service:` (or any other) identity. See [Security Model](/documentation/access-control/security-model#service-principals) and [Gateway Integration](/documentation/access-control/deployment/gateway-integration).
+
+</Warning>
+## Worked Example: authentik
+
+[authentik](https://goauthentik.io/) is an open-source IdP, and the repo ships a runnable reference bundle at `contrib/authentik/`. It is an optional reference, not part of the core platform. The bundle contains:
+
+- `docker-compose.yml` to bring up authentik locally
+- `blueprints/nemo.yaml`, which provisions an RS256 OAuth2 provider, the `nemo` application, the groups `nemo-admins` and `nemo-editors`, and a service account `svc-nemo-ci` placed in `nemo-editors` with a token
+- `config/authentik.yaml`, the matching NeMo Platform OIDC config
+- `env.example` and a `README.md` with the full walkthrough
+
+The bundle's `README.md` is the source of truth for exact commands and current values. The steps below summarize the flow so you can see how the pattern maps onto a real IdP.
+
+### Bring up authentik and the provider
+
+Start authentik with the bundled compose file; the blueprint provisions the provider, application, groups, and the `svc-nemo-ci` service account on first start.
+
+```bash
+cp contrib/authentik/env.example contrib/authentik/.env   # set AUTHENTIK_SECRET_KEY
+docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml up -d
+```
+
+Confirm the discovery document is served at the provider's issuer URL before going further.
+
+### Get a machine token
+
+Request a token for the service account with the client-credentials grant, then inspect it. The check that matters: the decoded payload's `sub` is the service account, `iss` matches the configured issuer, and `groups` includes the group you intend to bind (`nemo-editors`).
+
+```bash
+echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '{sub, iss, aud, groups}'
+```
+
+If those claims are wrong, fix the IdP before touching NeMo Platform. The platform authorizes on what the token says.
+
+### Point NeMo at authentik
+
+Run NeMo Platform with the bundle's OIDC config so it validates tokens against authentik:
+
+```bash
+NMP_CONFIG_FILE_PATH=contrib/authentik/config/authentik.yaml \
+  nemo services run --services auth,entities,models --host 127.0.0.1 --port 8080
+```
+
+## Validate: Denied, Bound, Allowed, Revoked
+
+This is the procedure to confirm the machine is authorized by NeMo's RBAC and nothing else. Run it against a protected endpoint. The expected behavior at each step is noted; treat these as what you should observe, not a recorded run.
+
+1. **Before any binding, the machine is denied.** Call a protected endpoint with the machine's token. Expect `403`: the principal is authenticated but has no role.
+
+   ```bash
+   curl -s -o /dev/null -w '%{http_code}\n' \
+     http://127.0.0.1:8080/apis/<a-protected-endpoint> -H "Authorization: Bearer $TOKEN"
+   ```
+
+2. **Bind the group to a role.** An admin grants the `nemo-editors` group the `Editor` role in the target workspace through the normal authenticated members API. Use a NeMo Admin user's credentials for this call. (The bundle's local README uses a bootstrap service header to do this on a single-node dev box; that path is for local bootstrap only and must never be exposed to external callers, per the warning above.)
+
+3. **After binding, the machine is allowed.** Repeat the same call. Expect `200`: the token's `groups` claim now resolves to the `Editor` role.
+
+4. **Revoke and confirm denial returns.** Remove the role binding in NeMo, or remove the service account from the group in authentik. Repeat the call. Expect `403` again.
+
+The access decision lives entirely in NeMo's group-to-role binding. The identity and credential lifecycle (issue, rotate, revoke) live in your IdP. That separation is the point: NeMo Platform federates identity instead of becoming a token authority.
+
+## What This Does and Does Not Do
+
+Does: federated machine authentication with scoped, revocable access, enforced by NeMo's existing token validation and RBAC, no core changes.
+
+Does not: add NeMo-native service accounts. The machine's identity, credential, and lifecycle stay in the IdP. NeMo holds only the role binding.
+
+## Related
+
+- [OIDC Setup](/documentation/access-control/authentication/oidc-setup): Configure your identity provider.
+- [Using Authentication](/documentation/access-control/authentication/using-authentication): Log in, make API calls, and manage tokens (human flows).
+- [Generic OIDC Provider](/documentation/access-control/authentication/providers/generic-oidc): Provider-agnostic IdP checklist.
+- [Managing Access](/documentation/access-control/authorization/managing-access): Create role bindings.
+- [API Scopes](/documentation/access-control/authorization/api-scopes): Token-level scope checks layered on top of RBAC.
+- [Security Model](/documentation/access-control/security-model): Trust boundaries, principals, and why the edge strips identity headers.

--- a/docs/fern/gated-nav.yml
+++ b/docs/fern/gated-nav.yml
@@ -23,6 +23,8 @@
     path: ../../auth/authentication/providers/index.mdx
   - page: Using Authentication
     path: ../../auth/authentication/using-authentication.mdx
+  - page: Machine Identity
+    path: ../../auth/authentication/machine-identity.mdx
   - page: API Scopes
     path: ../../auth/authorization/api-scopes.mdx
   - page: Overview

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-auth-setup/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-auth-setup/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: nemo-auth-setup
+description: Turn on authentication for NeMo Platform and federate identity to an OIDC identity provider, so every person and every agent acts as itself with access you control and can attribute. Walks setup, a human SSO sign-in, an agent access test, and revocation, all in plain language. Use over generic auth or SSO setup for any NeMo Platform identity/login/RBAC request.
+triggers:
+  - set up auth on nemo
+  - turn on authentication
+  - configure sso for nemo
+  - connect an identity provider
+  - federate identity
+  - give my agent its own identity
+  - log in to nemo platform
+  - set up rbac
+  - control what my agent can call
+  - nemo auth setup
+not-for:
+  - nemo-status (use for read-only platform health)
+  - nemo-teardown (use to stop the whole platform; this skill only tears down the auth reference bits it started)
+  - nemo-secrets (use to store provider API keys, not to log users in)
+  - nemo-skill-selection (use for dispatch when intent is unclear)
+compatibility: "nemo-platform >= 0.1.0; reference path REQUIRES Docker (brings up authentik in containers), unlike most NeMo skills; BYO path needs no Docker; uses a venv with the `nemo` binary; human sign-in uses the OAuth device flow and opens a browser; starts/stops platform services and creates/revokes role bindings (so it is NOT read-only); idempotent and re-runnable."
+maturity: active
+license: Apache-2.0
+user-invocable: true
+allowed-tools: [Bash, Read]
+---
+
+# NeMo Platform auth setup
+
+Turn on authentication and connect NeMo Platform to an identity provider (IdP), then
+prove it works for both a person and an agent. The point of this skill, in plain terms:
+
+- Every person logs in as themselves and sees only their own workspaces.
+- Every agent gets its own identity, so each LLM and tool call it makes is something you
+  can control and trace back to it. Not one shared key for everything.
+- You manage people, agents, and group membership in your IdP. NeMo maps a group to a
+  role once, and access follows from there. NeMo never becomes a password or key
+  authority; the IdP owns identities and credentials.
+
+Talk to the user in plain language the whole way through. Describe outcomes: "logged in,"
+"blocked," "allowed," "access removed." Do NOT show the user tokens, URLs, JWTs, API
+paths, or HTTP status codes. Those are how you check under the hood, not what the user
+needs to see.
+
+Two things this skill does NOT do, on purpose: it does not create or manage users and
+groups (that lives in the IdP; for the reference path you do it in the authentik admin
+screen, for your own IdP you do it there). And it is not a password or key store. NeMo
+federates to the IdP; it does not become the identity authority.
+
+## Pre-flight
+
+Confirm the CLI is present. If `.venv/bin/nemo` is missing, tell the user the platform
+isn't installed yet and stop.
+
+```bash
+[ -x .venv/bin/nemo ] && echo "CLI_OK" || echo "CLI_MISSING"
+```
+
+## Step 1: One choice
+
+Ask the user one question, in plain language:
+
+> "Two ways to do this. Bring your own identity provider (you already run Okta, Entra,
+> Keycloak, authentik, or any OIDC provider), or I can spin up a reference one for you
+> (authentik, in Docker) so you can see the whole thing work end to end. Which do you
+> want?"
+
+- Reference provider, go to **Step 2R**.
+- Bring your own, go to **Step 2B**.
+
+Do not ask anything else yet. Everything else you can set up or confirm yourself.
+
+## Step 2R: Reference path (authentik)
+
+The repo ships a self-contained authentik bundle under `contrib/authentik/`: an OIDC
+provider with device-flow sign-in enabled, two groups (`nemo-admins`, `nemo-editors`),
+and a demo agent identity (`svc-nemo-ci`, a CI/service account) that belongs to
+`nemo-editors`. You bring it up, point NeMo at it, and both a human and the agent can
+sign in.
+
+### 2R.1 Bring up the identity provider
+
+Tell the user: "Starting the reference identity provider. First run pulls images and
+applies the setup, about a minute."
+
+```bash
+# A local-only secret for the dev IdP. Generated fresh, never committed (.env is gitignored).
+if [ ! -f contrib/authentik/.env ]; then
+  SECRET=$(openssl rand -base64 48)
+  sed "s|^AUTHENTIK_SECRET_KEY=.*|AUTHENTIK_SECRET_KEY=${SECRET}|" \
+    contrib/authentik/env.example > contrib/authentik/.env
+fi
+docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml up -d
+
+# Wait until the provider is fully up and its setup has applied.
+for i in $(seq 1 48); do
+  READY=$(curl -s --max-time 3 \
+    http://localhost:9000/application/o/nemo/.well-known/openid-configuration 2>/dev/null \
+    | python3 -c "import sys,json;print(json.load(sys.stdin).get('issuer',''))" 2>/dev/null)
+  [ "$READY" = "http://localhost:9000/application/o/nemo/" ] && { echo "IDP_READY"; break; }
+  sleep 5
+done
+[ "$READY" = "http://localhost:9000/application/o/nemo/" ] || echo "IDP_NOT_READY"
+```
+
+If `IDP_NOT_READY`, see "If verification fails." When ready, tell the user: "The identity
+provider is up."
+
+Then point the admin at it, in plain language. This is the admin setup step (distinct from
+the end-user narration); the URL and admin login are exactly what they need here:
+
+> "The identity provider is running at http://localhost:9000. To manage people and groups,
+> open http://localhost:9000/if/admin/ and sign in as the bootstrap admin, user `akadmin`.
+> Its password is the `AUTHENTIK_BOOTSTRAP_PASSWORD` value in `contrib/authentik/.env` (a
+> local dev secret; I won't print it here). In there you create and manage users and groups,
+> and put people in `nemo-admins` or `nemo-editors`. NeMo maps those groups to roles; it
+> never holds the users or their passwords."
+
+Do not echo the password value. Point to the env var and file; the admin reads it there.
+
+### 2R.2 Point NeMo at it (auth on)
+
+The NeMo config that turns auth on and points at this provider already exists at
+`contrib/authentik/config/authentik.yaml`. Start the platform with it. `nemo services
+start` runs in the background and returns once the platform is ready.
+
+```bash
+mkdir -p "$HOME/.local/share/nemo" "$HOME/.local/state/nmp"
+set -a && source packages/nmp_platform/config/local.env && set +a
+export NMP_BASE_URL=http://127.0.0.1:8080
+.venv/bin/nemo services start --services auth,entities,models \
+  --config contrib/authentik/config/authentik.yaml --host 127.0.0.1 --port 8080
+curl -sS --max-time 5 http://127.0.0.1:8080/health/ready -o /dev/null -w "%{http_code}\n"
+```
+
+`200` means NeMo is up with authentication on. Tell the user: "NeMo is running with
+authentication on, connected to the identity provider. People and agents now sign in as
+themselves."
+
+Go to **Step 3** (agent) or **Step 4** (human); do them in whichever order suits the
+conversation.
+
+## Step 2B: Bring-your-own path
+
+Collect three things from the user, in plain language. Don't ask for anything you can
+infer.
+
+1. "What's the address of your identity provider?" (its OIDC issuer URL)
+2. "What's the application/client ID you registered for NeMo?"
+3. "Which claim in your tokens carries group membership?" (default `groups`) and "which
+   carries the user's email?" (default `email`)
+
+Reuse the reference config shape and swap in their values. Write the result to the data
+directory (outside the repo, so nothing provider-specific gets committed):
+
+```bash
+ISSUER="<from user>"; CLIENT_ID="<from user>"
+GROUPS_CLAIM="<from user, default groups>"; EMAIL_CLAIM="<from user, default email>"
+BYO_CONFIG="$HOME/.local/share/nemo/byo-oidc.yaml"; mkdir -p "$(dirname "$BYO_CONFIG")"
+
+python3 - "$ISSUER" "$CLIENT_ID" "$GROUPS_CLAIM" "$EMAIL_CLAIM" > "$BYO_CONFIG" <<'PY'
+import sys, re
+issuer, client_id, groups_claim, email_claim = sys.argv[1:5]
+s = open("contrib/authentik/config/authentik.yaml").read()
+s = re.sub(r'(?m)^(\s*issuer:).*',       rf'\1 "{issuer}"',       s, count=1)
+s = re.sub(r'(?m)^(\s*client_id:).*',    rf'\1 "{client_id}"',    s, count=1)
+s = re.sub(r'(?m)^(\s*groups_claim:).*', rf'\1 "{groups_claim}"', s, count=1)
+s = re.sub(r'(?m)^(\s*email_claim:).*',  rf'\1 "{email_claim}"',  s, count=1)
+sys.stdout.write(s)
+PY
+
+curl -s --max-time 5 "${ISSUER%/}/.well-known/openid-configuration" -o /dev/null -w "%{http_code}\n"
+```
+
+A `200` from discovery means the issuer is reachable. Then start NeMo with auth on:
+
+```bash
+mkdir -p "$HOME/.local/share/nemo" "$HOME/.local/state/nmp"
+set -a && source packages/nmp_platform/config/local.env && set +a
+export NMP_BASE_URL=http://127.0.0.1:8080
+.venv/bin/nemo services start --services auth,entities,models \
+  --config "$HOME/.local/share/nemo/byo-oidc.yaml" --host 127.0.0.1 --port 8080
+```
+
+Tell the user NeMo is connected to their provider. For the tests below, substitute their
+own group names for `nemo-editors`, and have a real person from their IdP do the Step 4
+sign-in. The mechanism is identical to the reference path.
+
+## Step 3: Agent identity, controlled and attributable
+
+Show three states for an agent: blocked, then mapped to a role and allowed, then access
+removed. Under the hood you check an ordinary platform call (listing the models in a
+workspace). Run the whole check as ONE block; it fetches its own token and helper so it
+does not depend on any earlier step. Never read the codes out to the user.
+
+```bash
+NMP=http://127.0.0.1:8080
+MODELS_URL="$NMP/apis/models/v2/workspaces/default/models"
+ADMIN_HDR="X-NMP-Principal-Id: service:bootstrap"   # local bootstrap admin for binding
+PRINCIPAL="nemo-editors"; WORKSPACE="default"; ROLE="Editor"
+BINDING=$(python3 -c "import hashlib;print('rb-'+hashlib.sha256('${PRINCIPAL}:${WORKSPACE}:${ROLE}'.encode()).hexdigest()[:24])")
+agent_token(){ curl -s -X POST http://localhost:9000/application/o/token/ \
+  -d grant_type=client_credentials -d client_id=nemo-platform \
+  -d client_secret=nemo-platform-secret-dev -d username=svc-nemo-ci \
+  -d password=svc-nemo-ci-token-secret-dev -d scope="openid email groups" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null; }
+access(){ curl -s -o /dev/null -w '%{http_code}' "$MODELS_URL" -H "Authorization: Bearer $(agent_token)"; }
+
+# Clean slate: drop any leftover mapping (also clears a soft-deleted tombstone).
+curl -s -o /dev/null -X DELETE -H "$ADMIN_HDR" \
+  "$NMP/apis/entities/v2/workspaces/${WORKSPACE}/entities/role_binding/$BINDING"; sleep 2
+echo "BLOCKED_BEFORE $(access)"   # expect 403
+
+# Map the group to a role.
+curl -s -o /dev/null -X POST -H "$ADMIN_HDR" -H "Content-Type: application/json" \
+  "$NMP/apis/auth/v2/iam/role-bindings" \
+  -d "{\"principal\":\"${PRINCIPAL}\",\"role\":\"${ROLE}\",\"workspace\":\"${WORKSPACE}\"}"; sleep 2
+echo "ALLOWED $(access)"          # expect 200
+```
+
+Narrate, one beat at a time:
+
+- `BLOCKED_BEFORE 403`: "The agent has its own identity and can prove who it is, but it
+  has no permissions yet, so when it tried to list the models it was turned away.
+  Authenticated is not the same as authorized."
+- `ALLOWED 200`: "I mapped the agent's group (`nemo-editors`) to the `Editor` role in the
+  `default` workspace. The same request goes through now, and every call it makes is
+  attributable to its own identity, not a shared key."
+
+### Two ways to cut access
+
+Show both levers explicitly. Lever 1 is on the NeMo side, lever 2 is in the IdP.
+
+```bash
+# Lever 1: remove the NeMo role mapping. Immediate.
+curl -s -o /dev/null -X DELETE -H "$ADMIN_HDR" \
+  "$NMP/apis/auth/v2/iam/role-bindings/$BINDING"; sleep 2
+echo "LEVER1_NEMO_UNBIND $(access)"     # expect 403
+
+# Put it back so we can show the other lever.
+curl -s -o /dev/null -X DELETE -H "$ADMIN_HDR" \
+  "$NMP/apis/entities/v2/workspaces/${WORKSPACE}/entities/role_binding/$BINDING"
+curl -s -o /dev/null -X POST -H "$ADMIN_HDR" -H "Content-Type: application/json" \
+  "$NMP/apis/auth/v2/iam/role-bindings" \
+  -d "{\"principal\":\"${PRINCIPAL}\",\"role\":\"${ROLE}\",\"workspace\":\"${WORKSPACE}\"}"; sleep 2
+echo "REGRANTED $(access)"              # expect 200
+
+# Lever 2: remove the agent from the group IN THE IdP (reference path).
+# A fresh token then carries no group, so NeMo denies. (Existing tokens keep their
+# claims until they expire; an agent that re-authenticates per run is denied at once.)
+AK=http://localhost:9000/api/v3; AKTOK="Authorization: Bearer bootstrap-token-dev"
+GRP=$(curl -s -H "$AKTOK" "$AK/core/groups/?search=nemo-editors" | python3 -c "import sys,json;print(json.load(sys.stdin)['results'][0]['pk'])")
+USR=$(curl -s -H "$AKTOK" "$AK/core/users/?search=svc-nemo-ci" | python3 -c "import sys,json;print(json.load(sys.stdin)['results'][0]['pk'])")
+curl -s -o /dev/null -X POST -H "$AKTOK" -H "Content-Type: application/json" "$AK/core/groups/$GRP/remove_user/" -d "{\"pk\": $USR}"; sleep 2
+echo "LEVER2_IDP_REMOVE $(access)"      # expect 403
+# Restore membership (leaves the demo re-runnable).
+curl -s -o /dev/null -X POST -H "$AKTOK" -H "Content-Type: application/json" "$AK/core/groups/$GRP/add_user/" -d "{\"pk\": $USR}"
+```
+
+Narrate:
+
+- `LEVER1_NEMO_UNBIND 403`: "First lever, on the NeMo side: I removed the role mapping.
+  The agent is locked out immediately."
+- `LEVER2_IDP_REMOVE 403`: "Second lever, in the IdP: I removed the agent from the group
+  in authentik. I never touched NeMo. Its next sign-in carries no group, so NeMo denies
+  it. You manage access where your people and agents already live."
+
+## Step 4: Human sign-in and workspace isolation
+
+A person signs into NeMo through the IdP and sees only their own workspaces. This is a
+real browser sign-in, so the user does it; you set the stage and confirm the result.
+
+For the reference path, an admin would have created the person and put them in a group in
+the authentik screen (this skill does not create users). Assume a person exists and their
+group is mapped to a role in one workspace. Tell the user:
+
+> "Sign in as yourself: run `nemo auth login --base-url http://127.0.0.1:8080`. A browser
+> opens to the identity provider. Log in there, then come back."
+
+```bash
+# The user runs this; it opens a browser to the IdP and waits for sign-in.
+.venv/bin/nemo auth login --base-url http://127.0.0.1:8080 --scope "openid email groups profile offline_access"
+```
+
+Once the CLI reports the person is logged in, show isolation. This runs as the signed-in
+person (their session is in the CLI context):
+
+```bash
+.venv/bin/nemo workspaces list
+```
+
+Narrate: "You're signed in as yourself, and you see only the workspaces you have a role
+in, not everyone else's. Same identity model as the agent: a person logs in once, and
+NeMo shows them exactly what they're entitled to, nothing more." If the list is empty,
+the person's group isn't mapped to a role in any workspace yet; map it (Step 3's grant,
+using their group) and re-run.
+
+## Step 5: Tear down (only what this skill started)
+
+Offer this when the user is done. This skill tears down only the auth reference bits it
+brought up; it does not wipe the whole platform (that's `nemo-teardown`).
+
+```bash
+.venv/bin/nemo auth logout >/dev/null 2>&1 || true   # clear the local sign-in
+.venv/bin/nemo services stop --force || true          # stop NeMo
+docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml down -v
+```
+
+Verify nothing is left:
+
+```bash
+docker ps -a --format '{{.Names}}' | grep -q authentik && echo "IDP_STILL_PRESENT" || echo "idp gone"
+docker volume ls --format '{{.Name}}' | grep -q "nemo-authentik_" && echo "IDP_VOLUMES_REMAIN" || echo "idp volumes gone"
+lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 && echo "NEMO_STILL_UP" || echo "nemo stopped"
+```
+
+Tell the user: "Cleaned up. The identity provider and its data are gone, and NeMo is
+stopped." For wiping the rest of the platform data, route to `nemo-teardown`.
+
+## Verification
+
+The skill verifies itself as it goes; surface failures, don't hide them:
+
+- IdP ready: discovery returns the expected issuer (`IDP_READY`).
+- NeMo up with auth on: `/health/ready` returns `200`.
+- Agent test: `BLOCKED_BEFORE 403`, `ALLOWED 200`, `LEVER1_NEMO_UNBIND 403`,
+  `REGRANTED 200`, `LEVER2_IDP_REMOVE 403`.
+- Human test: `nemo auth login` reports the person is logged in, and `nemo workspaces
+  list` shows only their workspaces, not all of them.
+- Teardown clean: no authentik containers, no authentik volumes, nothing on :8080.
+
+## If verification fails
+
+| Symptom | Cause | Recovery |
+|---|---|---|
+| `IDP_NOT_READY` after the wait loop | First-run image pull + setup still going, or Docker isn't running | Confirm Docker is up; re-run the wait loop. First start can exceed a minute on a cold pull. Check `docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml ps`. |
+| `/health/ready` not `200` after start | NeMo didn't come up; usually the auth policy bundle, a port in use, or a stale instance lock | Tail `.venv/bin/nemo services logs -n 100`. If `:8080` is held, `lsof -iTCP:8080 -sTCP:LISTEN`; clear a stale lock with `nemo services stop --force`. |
+| `BLOCKED_BEFORE` not `403` | Auth isn't on, or a leftover mapping is still active | Confirm the config used was `contrib/authentik/config/authentik.yaml`. The block deletes any leftover binding first; re-run it. |
+| `ALLOWED`/`REGRANTED` not `200` | Mapping didn't propagate, or the create hit a leftover tombstone | The create waits for propagation; give it a couple seconds and re-check. The clean-slate delete clears a tombstone a previous revoke left behind. |
+| `LEVER2_IDP_REMOVE` not `403` | The check reused a cached token that still has the group | Lever 2 only affects NEW tokens. The `access` helper fetches a fresh token each call, so re-run after the membership change propagates (a couple seconds). |
+| `nemo auth login` errors saving the session | Missing `--base-url` | Re-run with `--base-url http://127.0.0.1:8080` so the CLI persists the session into a context. |
+| `nemo workspaces list` is empty for the person | Their group isn't mapped to a role in any workspace | Map their group to a role (Step 3's grant, substituting their group), then re-run. |
+
+## Gotchas
+
+- **Authenticated is not authorized.** A valid identity with no role binding is correctly
+  blocked. That is the headline of the first agent state, not a failure.
+- **Never expose the plumbing to the user.** No tokens, URLs, JWT fields, API paths, or
+  HTTP codes in what you say. Translate every check into an outcome.
+- **NeMo is not the identity authority, and this skill does not manage users.** People,
+  agents, credentials, and group membership live in the IdP. For the reference path, an
+  admin creates and manages them in the authentik screen; NeMo only holds the group->role
+  mapping.
+- **Two revoke levers, two scopes.** Removing the NeMo role mapping is immediate and
+  affects that workspace. Removing someone from a group in the IdP affects everywhere that
+  group grants access, and it applies to their next sign-in (existing tokens keep their
+  claims until they expire). Say which one you used.
+- **Human sign-in is a real browser flow.** `nemo auth login` uses the device flow and
+  needs `--base-url` to persist the session. The person logs in themselves; you cannot do
+  it for them. The reference IdP has device sign-in enabled out of the box.
+- **The mapping is by group and deterministic.** A binding's internal name comes from
+  `principal:workspace:role`, so re-binding the same group/role/workspace reuses the same
+  name. Revoke is a soft delete that leaves that name reserved; the agent block hard-
+  deletes by name first so the test is repeatable.
+- **The `service:bootstrap` admin header is local-only.** It is the local bootstrap admin
+  used to create the role binding during setup. Never use a `service:` principal header
+  for a real customer machine, and the edge must strip inbound `X-NMP-Principal-*`
+  headers. Customer agents and people authenticate via OIDC.
+- **Reference path needs Docker; BYO doesn't.** Most NeMo skills don't need Docker. This
+  one does for the reference IdP. Offer the BYO path if Docker isn't available.
+- **Teardown is scoped.** This skill stops NeMo and removes the authentik reference only.
+  Route to `nemo-teardown` to wipe platform data, the venv, or local agent files.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-auth-setup/tests.json
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-auth-setup/tests.json
@@ -1,0 +1,65 @@
+{
+  "skill": "nemo-auth-setup",
+  "tests": [
+    {
+      "type": "explicit",
+      "prompt": "Use nemo-auth-setup to turn on authentication for the platform.",
+      "expected_skill": "nemo-auth-setup"
+    },
+    {
+      "type": "explicit",
+      "prompt": "Run the nemo-auth-setup skill and spin up the reference identity provider.",
+      "expected_skill": "nemo-auth-setup"
+    },
+    {
+      "type": "explicit",
+      "prompt": "Invoke nemo-auth-setup. I'll bring my own OIDC provider.",
+      "expected_skill": "nemo-auth-setup"
+    },
+    {
+      "type": "implicit",
+      "prompt": "Turn on authentication for NeMo and connect it to an identity provider.",
+      "expected_skill": "nemo-auth-setup"
+    },
+    {
+      "type": "implicit",
+      "prompt": "I want each agent to have its own identity so I can control and trace what it calls.",
+      "expected_skill": "nemo-auth-setup"
+    },
+    {
+      "type": "implicit",
+      "prompt": "Set up SSO and role-based access so people only see their own workspaces.",
+      "expected_skill": "nemo-auth-setup"
+    },
+    {
+      "type": "contextual",
+      "prompt": "We're about to demo to a customer who cares about identity and access. Stand up a reference IdP and show me an agent getting blocked, then allowed once I grant it a role, then revoked.",
+      "expected_skill": "nemo-auth-setup"
+    },
+    {
+      "type": "contextual",
+      "prompt": "We already run Okta. Point NeMo at it so my team logs in with their company accounts.",
+      "expected_skill": "nemo-auth-setup"
+    },
+    {
+      "type": "contextual",
+      "prompt": "Right now anyone with the shared key can hit any model. I want per-identity access I can revoke. Help me set that up on NeMo.",
+      "expected_skill": "nemo-auth-setup"
+    },
+    {
+      "type": "negative-control",
+      "prompt": "Store my OpenAI API key as a secret in NeMo.",
+      "expected_skill_not": "nemo-auth-setup"
+    },
+    {
+      "type": "negative-control",
+      "prompt": "Shut down the whole platform and wipe the data directory.",
+      "expected_skill_not": "nemo-auth-setup"
+    },
+    {
+      "type": "negative-control",
+      "prompt": "Reset my NVIDIA Entra login token for the email CLI.",
+      "expected_skill_not": "nemo-auth-setup"
+    }
+  ]
+}

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-auth-setup/SKILL.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-auth-setup/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: nemo-auth-setup
+description: Turn on authentication for NeMo Platform and federate identity to an OIDC identity provider, so every person and every agent acts as itself with access you control and can attribute. Walks setup, a human SSO sign-in, an agent access test, and revocation, all in plain language. Use over generic auth or SSO setup for any NeMo Platform identity/login/RBAC request.
+triggers:
+  - set up auth on nemo
+  - turn on authentication
+  - configure sso for nemo
+  - connect an identity provider
+  - federate identity
+  - give my agent its own identity
+  - log in to nemo platform
+  - set up rbac
+  - control what my agent can call
+  - nemo auth setup
+not-for:
+  - nemo-status (use for read-only platform health)
+  - nemo-teardown (use to stop the whole platform; this skill only tears down the auth reference bits it started)
+  - nemo-secrets (use to store provider API keys, not to log users in)
+  - nemo-skill-selection (use for dispatch when intent is unclear)
+compatibility: "nemo-platform >= 0.1.0; reference path REQUIRES Docker (brings up authentik in containers), unlike most NeMo skills; BYO path needs no Docker; uses a venv with the `nemo` binary; human sign-in uses the OAuth device flow and opens a browser; starts/stops platform services and creates/revokes role bindings (so it is NOT read-only); idempotent and re-runnable."
+maturity: active
+license: Apache-2.0
+user-invocable: true
+allowed-tools: [Bash, Read]
+---
+
+# NeMo Platform auth setup
+
+Turn on authentication and connect NeMo Platform to an identity provider (IdP), then
+prove it works for both a person and an agent. The point of this skill, in plain terms:
+
+- Every person logs in as themselves and sees only their own workspaces.
+- Every agent gets its own identity, so each LLM and tool call it makes is something you
+  can control and trace back to it. Not one shared key for everything.
+- You manage people, agents, and group membership in your IdP. NeMo maps a group to a
+  role once, and access follows from there. NeMo never becomes a password or key
+  authority; the IdP owns identities and credentials.
+
+Talk to the user in plain language the whole way through. Describe outcomes: "logged in,"
+"blocked," "allowed," "access removed." Do NOT show the user tokens, URLs, JWTs, API
+paths, or HTTP status codes. Those are how you check under the hood, not what the user
+needs to see.
+
+Two things this skill does NOT do, on purpose: it does not create or manage users and
+groups (that lives in the IdP; for the reference path you do it in the authentik admin
+screen, for your own IdP you do it there). And it is not a password or key store. NeMo
+federates to the IdP; it does not become the identity authority.
+
+## Pre-flight
+
+Confirm the CLI is present. If `.venv/bin/nemo` is missing, tell the user the platform
+isn't installed yet and stop.
+
+```bash
+[ -x .venv/bin/nemo ] && echo "CLI_OK" || echo "CLI_MISSING"
+```
+
+## Step 1: One choice
+
+Ask the user one question, in plain language:
+
+> "Two ways to do this. Bring your own identity provider (you already run Okta, Entra,
+> Keycloak, authentik, or any OIDC provider), or I can spin up a reference one for you
+> (authentik, in Docker) so you can see the whole thing work end to end. Which do you
+> want?"
+
+- Reference provider, go to **Step 2R**.
+- Bring your own, go to **Step 2B**.
+
+Do not ask anything else yet. Everything else you can set up or confirm yourself.
+
+## Step 2R: Reference path (authentik)
+
+The repo ships a self-contained authentik bundle under `contrib/authentik/`: an OIDC
+provider with device-flow sign-in enabled, two groups (`nemo-admins`, `nemo-editors`),
+and a demo agent identity (`svc-nemo-ci`, a CI/service account) that belongs to
+`nemo-editors`. You bring it up, point NeMo at it, and both a human and the agent can
+sign in.
+
+### 2R.1 Bring up the identity provider
+
+Tell the user: "Starting the reference identity provider. First run pulls images and
+applies the setup, about a minute."
+
+```bash
+# A local-only secret for the dev IdP. Generated fresh, never committed (.env is gitignored).
+if [ ! -f contrib/authentik/.env ]; then
+  SECRET=$(openssl rand -base64 48)
+  sed "s|^AUTHENTIK_SECRET_KEY=.*|AUTHENTIK_SECRET_KEY=${SECRET}|" \
+    contrib/authentik/env.example > contrib/authentik/.env
+fi
+docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml up -d
+
+# Wait until the provider is fully up and its setup has applied.
+for i in $(seq 1 48); do
+  READY=$(curl -s --max-time 3 \
+    http://localhost:9000/application/o/nemo/.well-known/openid-configuration 2>/dev/null \
+    | python3 -c "import sys,json;print(json.load(sys.stdin).get('issuer',''))" 2>/dev/null)
+  [ "$READY" = "http://localhost:9000/application/o/nemo/" ] && { echo "IDP_READY"; break; }
+  sleep 5
+done
+[ "$READY" = "http://localhost:9000/application/o/nemo/" ] || echo "IDP_NOT_READY"
+```
+
+If `IDP_NOT_READY`, see "If verification fails." When ready, tell the user: "The identity
+provider is up."
+
+Then point the admin at it, in plain language. This is the admin setup step (distinct from
+the end-user narration); the URL and admin login are exactly what they need here:
+
+> "The identity provider is running at http://localhost:9000. To manage people and groups,
+> open http://localhost:9000/if/admin/ and sign in as the bootstrap admin, user `akadmin`.
+> Its password is the `AUTHENTIK_BOOTSTRAP_PASSWORD` value in `contrib/authentik/.env` (a
+> local dev secret; I won't print it here). In there you create and manage users and groups,
+> and put people in `nemo-admins` or `nemo-editors`. NeMo maps those groups to roles; it
+> never holds the users or their passwords."
+
+Do not echo the password value. Point to the env var and file; the admin reads it there.
+
+### 2R.2 Point NeMo at it (auth on)
+
+The NeMo config that turns auth on and points at this provider already exists at
+`contrib/authentik/config/authentik.yaml`. Start the platform with it. `nemo services
+start` runs in the background and returns once the platform is ready.
+
+```bash
+mkdir -p "$HOME/.local/share/nemo" "$HOME/.local/state/nmp"
+set -a && source packages/nmp_platform/config/local.env && set +a
+export NMP_BASE_URL=http://127.0.0.1:8080
+.venv/bin/nemo services start --services auth,entities,models \
+  --config contrib/authentik/config/authentik.yaml --host 127.0.0.1 --port 8080
+curl -sS --max-time 5 http://127.0.0.1:8080/health/ready -o /dev/null -w "%{http_code}\n"
+```
+
+`200` means NeMo is up with authentication on. Tell the user: "NeMo is running with
+authentication on, connected to the identity provider. People and agents now sign in as
+themselves."
+
+Go to **Step 3** (agent) or **Step 4** (human); do them in whichever order suits the
+conversation.
+
+## Step 2B: Bring-your-own path
+
+Collect three things from the user, in plain language. Don't ask for anything you can
+infer.
+
+1. "What's the address of your identity provider?" (its OIDC issuer URL)
+2. "What's the application/client ID you registered for NeMo?"
+3. "Which claim in your tokens carries group membership?" (default `groups`) and "which
+   carries the user's email?" (default `email`)
+
+Reuse the reference config shape and swap in their values. Write the result to the data
+directory (outside the repo, so nothing provider-specific gets committed):
+
+```bash
+ISSUER="<from user>"; CLIENT_ID="<from user>"
+GROUPS_CLAIM="<from user, default groups>"; EMAIL_CLAIM="<from user, default email>"
+BYO_CONFIG="$HOME/.local/share/nemo/byo-oidc.yaml"; mkdir -p "$(dirname "$BYO_CONFIG")"
+
+python3 - "$ISSUER" "$CLIENT_ID" "$GROUPS_CLAIM" "$EMAIL_CLAIM" > "$BYO_CONFIG" <<'PY'
+import sys, re
+issuer, client_id, groups_claim, email_claim = sys.argv[1:5]
+s = open("contrib/authentik/config/authentik.yaml").read()
+s = re.sub(r'(?m)^(\s*issuer:).*',       rf'\1 "{issuer}"',       s, count=1)
+s = re.sub(r'(?m)^(\s*client_id:).*',    rf'\1 "{client_id}"',    s, count=1)
+s = re.sub(r'(?m)^(\s*groups_claim:).*', rf'\1 "{groups_claim}"', s, count=1)
+s = re.sub(r'(?m)^(\s*email_claim:).*',  rf'\1 "{email_claim}"',  s, count=1)
+sys.stdout.write(s)
+PY
+
+curl -s --max-time 5 "${ISSUER%/}/.well-known/openid-configuration" -o /dev/null -w "%{http_code}\n"
+```
+
+A `200` from discovery means the issuer is reachable. Then start NeMo with auth on:
+
+```bash
+mkdir -p "$HOME/.local/share/nemo" "$HOME/.local/state/nmp"
+set -a && source packages/nmp_platform/config/local.env && set +a
+export NMP_BASE_URL=http://127.0.0.1:8080
+.venv/bin/nemo services start --services auth,entities,models \
+  --config "$HOME/.local/share/nemo/byo-oidc.yaml" --host 127.0.0.1 --port 8080
+```
+
+Tell the user NeMo is connected to their provider. For the tests below, substitute their
+own group names for `nemo-editors`, and have a real person from their IdP do the Step 4
+sign-in. The mechanism is identical to the reference path.
+
+## Step 3: Agent identity, controlled and attributable
+
+Show three states for an agent: blocked, then mapped to a role and allowed, then access
+removed. Under the hood you check an ordinary platform call (listing the models in a
+workspace). Run the whole check as ONE block; it fetches its own token and helper so it
+does not depend on any earlier step. Never read the codes out to the user.
+
+```bash
+NMP=http://127.0.0.1:8080
+MODELS_URL="$NMP/apis/models/v2/workspaces/default/models"
+ADMIN_HDR="X-NMP-Principal-Id: service:bootstrap"   # local bootstrap admin for binding
+PRINCIPAL="nemo-editors"; WORKSPACE="default"; ROLE="Editor"
+BINDING=$(python3 -c "import hashlib;print('rb-'+hashlib.sha256('${PRINCIPAL}:${WORKSPACE}:${ROLE}'.encode()).hexdigest()[:24])")
+agent_token(){ curl -s -X POST http://localhost:9000/application/o/token/ \
+  -d grant_type=client_credentials -d client_id=nemo-platform \
+  -d client_secret=nemo-platform-secret-dev -d username=svc-nemo-ci \
+  -d password=svc-nemo-ci-token-secret-dev -d scope="openid email groups" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null; }
+access(){ curl -s -o /dev/null -w '%{http_code}' "$MODELS_URL" -H "Authorization: Bearer $(agent_token)"; }
+
+# Clean slate: drop any leftover mapping (also clears a soft-deleted tombstone).
+curl -s -o /dev/null -X DELETE -H "$ADMIN_HDR" \
+  "$NMP/apis/entities/v2/workspaces/${WORKSPACE}/entities/role_binding/$BINDING"; sleep 2
+echo "BLOCKED_BEFORE $(access)"   # expect 403
+
+# Map the group to a role.
+curl -s -o /dev/null -X POST -H "$ADMIN_HDR" -H "Content-Type: application/json" \
+  "$NMP/apis/auth/v2/iam/role-bindings" \
+  -d "{\"principal\":\"${PRINCIPAL}\",\"role\":\"${ROLE}\",\"workspace\":\"${WORKSPACE}\"}"; sleep 2
+echo "ALLOWED $(access)"          # expect 200
+```
+
+Narrate, one beat at a time:
+
+- `BLOCKED_BEFORE 403`: "The agent has its own identity and can prove who it is, but it
+  has no permissions yet, so when it tried to list the models it was turned away.
+  Authenticated is not the same as authorized."
+- `ALLOWED 200`: "I mapped the agent's group (`nemo-editors`) to the `Editor` role in the
+  `default` workspace. The same request goes through now, and every call it makes is
+  attributable to its own identity, not a shared key."
+
+### Two ways to cut access
+
+Show both levers explicitly. Lever 1 is on the NeMo side, lever 2 is in the IdP.
+
+```bash
+# Lever 1: remove the NeMo role mapping. Immediate.
+curl -s -o /dev/null -X DELETE -H "$ADMIN_HDR" \
+  "$NMP/apis/auth/v2/iam/role-bindings/$BINDING"; sleep 2
+echo "LEVER1_NEMO_UNBIND $(access)"     # expect 403
+
+# Put it back so we can show the other lever.
+curl -s -o /dev/null -X DELETE -H "$ADMIN_HDR" \
+  "$NMP/apis/entities/v2/workspaces/${WORKSPACE}/entities/role_binding/$BINDING"
+curl -s -o /dev/null -X POST -H "$ADMIN_HDR" -H "Content-Type: application/json" \
+  "$NMP/apis/auth/v2/iam/role-bindings" \
+  -d "{\"principal\":\"${PRINCIPAL}\",\"role\":\"${ROLE}\",\"workspace\":\"${WORKSPACE}\"}"; sleep 2
+echo "REGRANTED $(access)"              # expect 200
+
+# Lever 2: remove the agent from the group IN THE IdP (reference path).
+# A fresh token then carries no group, so NeMo denies. (Existing tokens keep their
+# claims until they expire; an agent that re-authenticates per run is denied at once.)
+AK=http://localhost:9000/api/v3; AKTOK="Authorization: Bearer bootstrap-token-dev"
+GRP=$(curl -s -H "$AKTOK" "$AK/core/groups/?search=nemo-editors" | python3 -c "import sys,json;print(json.load(sys.stdin)['results'][0]['pk'])")
+USR=$(curl -s -H "$AKTOK" "$AK/core/users/?search=svc-nemo-ci" | python3 -c "import sys,json;print(json.load(sys.stdin)['results'][0]['pk'])")
+curl -s -o /dev/null -X POST -H "$AKTOK" -H "Content-Type: application/json" "$AK/core/groups/$GRP/remove_user/" -d "{\"pk\": $USR}"; sleep 2
+echo "LEVER2_IDP_REMOVE $(access)"      # expect 403
+# Restore membership (leaves the demo re-runnable).
+curl -s -o /dev/null -X POST -H "$AKTOK" -H "Content-Type: application/json" "$AK/core/groups/$GRP/add_user/" -d "{\"pk\": $USR}"
+```
+
+Narrate:
+
+- `LEVER1_NEMO_UNBIND 403`: "First lever, on the NeMo side: I removed the role mapping.
+  The agent is locked out immediately."
+- `LEVER2_IDP_REMOVE 403`: "Second lever, in the IdP: I removed the agent from the group
+  in authentik. I never touched NeMo. Its next sign-in carries no group, so NeMo denies
+  it. You manage access where your people and agents already live."
+
+## Step 4: Human sign-in and workspace isolation
+
+A person signs into NeMo through the IdP and sees only their own workspaces. This is a
+real browser sign-in, so the user does it; you set the stage and confirm the result.
+
+For the reference path, an admin would have created the person and put them in a group in
+the authentik screen (this skill does not create users). Assume a person exists and their
+group is mapped to a role in one workspace. Tell the user:
+
+> "Sign in as yourself: run `nemo auth login --base-url http://127.0.0.1:8080`. A browser
+> opens to the identity provider. Log in there, then come back."
+
+```bash
+# The user runs this; it opens a browser to the IdP and waits for sign-in.
+.venv/bin/nemo auth login --base-url http://127.0.0.1:8080 --scope "openid email groups profile offline_access"
+```
+
+Once the CLI reports the person is logged in, show isolation. This runs as the signed-in
+person (their session is in the CLI context):
+
+```bash
+.venv/bin/nemo workspaces list
+```
+
+Narrate: "You're signed in as yourself, and you see only the workspaces you have a role
+in, not everyone else's. Same identity model as the agent: a person logs in once, and
+NeMo shows them exactly what they're entitled to, nothing more." If the list is empty,
+the person's group isn't mapped to a role in any workspace yet; map it (Step 3's grant,
+using their group) and re-run.
+
+## Step 5: Tear down (only what this skill started)
+
+Offer this when the user is done. This skill tears down only the auth reference bits it
+brought up; it does not wipe the whole platform (that's `nemo-teardown`).
+
+```bash
+.venv/bin/nemo auth logout >/dev/null 2>&1 || true   # clear the local sign-in
+.venv/bin/nemo services stop --force || true          # stop NeMo
+docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml down -v
+```
+
+Verify nothing is left:
+
+```bash
+docker ps -a --format '{{.Names}}' | grep -q authentik && echo "IDP_STILL_PRESENT" || echo "idp gone"
+docker volume ls --format '{{.Name}}' | grep -q "nemo-authentik_" && echo "IDP_VOLUMES_REMAIN" || echo "idp volumes gone"
+lsof -iTCP:8080 -sTCP:LISTEN >/dev/null 2>&1 && echo "NEMO_STILL_UP" || echo "nemo stopped"
+```
+
+Tell the user: "Cleaned up. The identity provider and its data are gone, and NeMo is
+stopped." For wiping the rest of the platform data, route to `nemo-teardown`.
+
+## Verification
+
+The skill verifies itself as it goes; surface failures, don't hide them:
+
+- IdP ready: discovery returns the expected issuer (`IDP_READY`).
+- NeMo up with auth on: `/health/ready` returns `200`.
+- Agent test: `BLOCKED_BEFORE 403`, `ALLOWED 200`, `LEVER1_NEMO_UNBIND 403`,
+  `REGRANTED 200`, `LEVER2_IDP_REMOVE 403`.
+- Human test: `nemo auth login` reports the person is logged in, and `nemo workspaces
+  list` shows only their workspaces, not all of them.
+- Teardown clean: no authentik containers, no authentik volumes, nothing on :8080.
+
+## If verification fails
+
+| Symptom | Cause | Recovery |
+|---|---|---|
+| `IDP_NOT_READY` after the wait loop | First-run image pull + setup still going, or Docker isn't running | Confirm Docker is up; re-run the wait loop. First start can exceed a minute on a cold pull. Check `docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml ps`. |
+| `/health/ready` not `200` after start | NeMo didn't come up; usually the auth policy bundle, a port in use, or a stale instance lock | Tail `.venv/bin/nemo services logs -n 100`. If `:8080` is held, `lsof -iTCP:8080 -sTCP:LISTEN`; clear a stale lock with `nemo services stop --force`. |
+| `BLOCKED_BEFORE` not `403` | Auth isn't on, or a leftover mapping is still active | Confirm the config used was `contrib/authentik/config/authentik.yaml`. The block deletes any leftover binding first; re-run it. |
+| `ALLOWED`/`REGRANTED` not `200` | Mapping didn't propagate, or the create hit a leftover tombstone | The create waits for propagation; give it a couple seconds and re-check. The clean-slate delete clears a tombstone a previous revoke left behind. |
+| `LEVER2_IDP_REMOVE` not `403` | The check reused a cached token that still has the group | Lever 2 only affects NEW tokens. The `access` helper fetches a fresh token each call, so re-run after the membership change propagates (a couple seconds). |
+| `nemo auth login` errors saving the session | Missing `--base-url` | Re-run with `--base-url http://127.0.0.1:8080` so the CLI persists the session into a context. |
+| `nemo workspaces list` is empty for the person | Their group isn't mapped to a role in any workspace | Map their group to a role (Step 3's grant, substituting their group), then re-run. |
+
+## Gotchas
+
+- **Authenticated is not authorized.** A valid identity with no role binding is correctly
+  blocked. That is the headline of the first agent state, not a failure.
+- **Never expose the plumbing to the user.** No tokens, URLs, JWT fields, API paths, or
+  HTTP codes in what you say. Translate every check into an outcome.
+- **NeMo is not the identity authority, and this skill does not manage users.** People,
+  agents, credentials, and group membership live in the IdP. For the reference path, an
+  admin creates and manages them in the authentik screen; NeMo only holds the group->role
+  mapping.
+- **Two revoke levers, two scopes.** Removing the NeMo role mapping is immediate and
+  affects that workspace. Removing someone from a group in the IdP affects everywhere that
+  group grants access, and it applies to their next sign-in (existing tokens keep their
+  claims until they expire). Say which one you used.
+- **Human sign-in is a real browser flow.** `nemo auth login` uses the device flow and
+  needs `--base-url` to persist the session. The person logs in themselves; you cannot do
+  it for them. The reference IdP has device sign-in enabled out of the box.
+- **The mapping is by group and deterministic.** A binding's internal name comes from
+  `principal:workspace:role`, so re-binding the same group/role/workspace reuses the same
+  name. Revoke is a soft delete that leaves that name reserved; the agent block hard-
+  deletes by name first so the test is repeatable.
+- **The `service:bootstrap` admin header is local-only.** It is the local bootstrap admin
+  used to create the role binding during setup. Never use a `service:` principal header
+  for a real customer machine, and the edge must strip inbound `X-NMP-Principal-*`
+  headers. Customer agents and people authenticate via OIDC.
+- **Reference path needs Docker; BYO doesn't.** Most NeMo skills don't need Docker. This
+  one does for the reference IdP. Offer the BYO path if Docker isn't available.
+- **Teardown is scoped.** This skill stops NeMo and removes the authentik reference only.
+  Route to `nemo-teardown` to wipe platform data, the venv, or local agent files.

--- a/services/core/auth/tests/test_machine_group_authz.py
+++ b/services/core/auth/tests/test_machine_group_authz.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Group-based authorization for a MACHINE principal.
+
+Proves that a machine principal (service-account-style id, no email) is
+authorized via group -> role, exactly how an OIDC client-credentials token from
+authentik would be handled:
+
+  * principal id looks like a service account ("svc-nemo-ci")
+  * no email
+  * carries groups ["nemo-editors"]
+
+A role binding mapping the GROUP "nemo-editors" -> Editor in workspace "default"
+must grant access; without that binding the same principal is denied.
+
+The role binding flows through the real bundle-build path
+(``_build_authorization_data_internal``), which is what turns a stored
+RoleBindingEntity whose ``principal`` is a group name into
+``authz.principals["nemo-editors"].workspaces["default"] = ["Editor"]``. The
+embedded WASM PDP then treats each entry of ``principal_groups`` as an
+applicable principal (see ``policies/common.rego: get_applicable_principals``).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from nmp.core.auth.app.bundle import _build_authorization_data_internal
+from nmp.core.auth.app.embedded_pdp import evaluate, set_policy_data
+
+# Machine principal: service-account-style id, NO email, group membership only.
+# The id deliberately has no "service:" prefix, so it does NOT hit the
+# service-principal bypass — authorization must come purely from the group.
+MACHINE_PRINCIPAL_ID = "svc-nemo-ci"
+MACHINE_GROUP = "nemo-editors"
+WORKSPACE = "default"
+
+# Editor-only endpoint: POST /apis/models/v2/workspaces/{workspace}/models
+# requires the "models.create" permission, which Editor has and Viewer does not.
+EDITOR_ONLY_REQUEST = {
+    "principal_id": MACHINE_PRINCIPAL_ID,
+    # No principal_email — mirrors a client-credentials machine token.
+    "principal_groups": [MACHINE_GROUP],
+    "method": "POST",
+    "path": f"/apis/models/v2/workspaces/{WORKSPACE}/models",
+}
+
+
+@pytest.fixture(autouse=True)
+def reset_policy():
+    """Reset the PDP policy singleton between tests."""
+    import nmp.core.auth.app.embedded_pdp.engine as pe
+
+    pe._policy = None
+    pe._policy_data = {}
+    yield
+    pe._policy = None
+    pe._policy_data = {}
+
+
+def _entities_client_with_group_binding():
+    """Mock entity client returning one active group->Editor role binding.
+
+    The build loop in ``_build_authorization_data_internal`` only reads
+    ``.principal``, ``.workspace``, ``.role`` and ``.revoked_at`` off each
+    binding, so a SimpleNamespace is sufficient and avoids RoleBindingEntity
+    required-field coupling.
+    """
+    binding = SimpleNamespace(
+        principal=MACHINE_GROUP,  # binding is on the GROUP, not the machine id
+        workspace=WORKSPACE,
+        role="Editor",
+        revoked_at=None,
+    )
+    page = SimpleNamespace(data=[binding])
+    client = SimpleNamespace(list=AsyncMock(return_value=page))
+    return client
+
+
+@pytest.mark.asyncio
+async def test_machine_principal_allowed_via_group_binding():
+    """ALLOW: group binding nemo-editors -> Editor grants the machine access."""
+    data = await _build_authorization_data_internal(
+        entities_client=_entities_client_with_group_binding()  # type: ignore[arg-type]
+    )
+
+    # The group binding became a group-keyed principal entry.
+    assert data["authz"]["principals"][MACHINE_GROUP]["workspaces"][WORKSPACE] == ["Editor"]
+    # The machine id itself was never granted anything directly.
+    assert MACHINE_PRINCIPAL_ID not in data["authz"]["principals"]
+
+    set_policy_data(data)
+    result = evaluate("allow", EDITOR_ONLY_REQUEST)
+    assert result["allowed"] is True
+
+
+@pytest.mark.asyncio
+async def test_machine_principal_denied_without_group_binding():
+    """DENY: no role binding -> the same machine principal is rejected."""
+    data = await _build_authorization_data_internal(entities_client=None)
+
+    # No binding means no group-keyed principal entry.
+    assert MACHINE_GROUP not in data["authz"]["principals"]
+    assert MACHINE_PRINCIPAL_ID not in data["authz"]["principals"]
+
+    set_policy_data(data)
+    result = evaluate("allow", EDITOR_ONLY_REQUEST)
+    assert result["allowed"] is False
+
+
+@pytest.mark.asyncio
+async def test_machine_principal_has_editor_permission_via_group():
+    """has_permissions entrypoint: the group grants the Editor-only permission."""
+    data = await _build_authorization_data_internal(
+        entities_client=_entities_client_with_group_binding()  # type: ignore[arg-type]
+    )
+    set_policy_data(data)
+
+    result = evaluate(
+        "has_permissions",
+        {
+            "principal_id": MACHINE_PRINCIPAL_ID,
+            "principal_groups": [MACHINE_GROUP],
+            "workspace": WORKSPACE,
+            "permissions": ["models.create"],  # Editor-only (not in Viewer)
+        },
+    )
+    assert result["allowed"] is True

--- a/services/intake/src/nmp/intake/spans/ingest/otlp.py
+++ b/services/intake/src/nmp/intake/spans/ingest/otlp.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from nmp.common.auth import AuthClient, get_auth_client
 from nmp.intake.config import IntakeConfig
 from nmp.intake.spans.api.dependencies import SpansServiceDep, require_workspace_access
 from nmp.intake.spans.domain import (
@@ -21,6 +22,10 @@ from pydantic import BaseModel, Field
 
 router = APIRouter(dependencies=[Depends(require_workspace_access)])
 API_TAG = "Ingest"
+
+# Attribute key on each ingested span recording the authenticated caller (the
+# agent or user whose token posted the spans). Queryable via span attribute filters.
+CALLER_PRINCIPAL_ATTRIBUTE = "nmp.caller_principal"
 
 # Ordered by precedence. Keep direct input.value/output.value first so existing
 # OpenInference/LangChain payloads continue to win over framework-specific fallbacks.
@@ -59,6 +64,7 @@ async def ingest_otlp_traces(
     workspace: str,
     request: Request,
     service: SpansServiceDep,
+    auth_client: AuthClient = Depends(get_auth_client),
     content_type: str = Header(default="application/octet-stream"),
     content_length: int | None = Header(default=None),
 ) -> IngestResponse:
@@ -78,6 +84,7 @@ async def ingest_otlp_traces(
     body = await _read_limited_body(request, max_bytes=max_bytes)
     export_request = _parse_export_request(body)
     ingested_at = utc_now()
+    caller_principal = _resolve_caller_principal(auth_client)
     spans: list[IntakeSpan] = []
     errors: list[str] = []
 
@@ -97,6 +104,7 @@ async def ingest_otlp_traces(
                         resource_attributes=resource_attributes,
                         scope_data=scope_data,
                         ingested_at=ingested_at,
+                        caller_principal=caller_principal,
                     )
                 except (OverflowError, OSError, TypeError, ValueError) as exc:
                     span_hex = bytes(getattr(span, "span_id", b"")).hex() or "<missing>"
@@ -143,6 +151,14 @@ def _otlp_max_body_bytes(request: Request) -> int:
     return cfg.otlp_max_body_bytes
 
 
+def _resolve_caller_principal(auth_client: AuthClient) -> str:
+    """Identity of the authenticated caller posting these spans, empty if auth is off."""
+    if not getattr(auth_client, "auth_enabled", False):
+        return ""
+    principal_id = getattr(getattr(auth_client, "principal", None), "id", None)
+    return principal_id or ""
+
+
 def _span_to_domain(
     *,
     workspace: str,
@@ -150,6 +166,7 @@ def _span_to_domain(
     resource_attributes: dict[str, Any],
     scope_data: dict[str, Any],
     ingested_at: datetime,
+    caller_principal: str = "",
 ) -> IntakeSpan:
     trace_id = _required_otlp_id(span.trace_id, field_name="trace_id")
     trace_id_hex = trace_id.hex()
@@ -185,6 +202,9 @@ def _span_to_domain(
         attribute_bags.put_json("otel.events", events)
     if any(value is not None for value in scope_data.values()):
         attribute_bags.put_json("otel.scope", scope_data)
+
+    if caller_principal:
+        attribute_bags.string[CALLER_PRINCIPAL_ATTRIBUTE] = caller_principal
 
     # TODO: After the POC lands, switch non-openinference/non-gen_ai spans from UNKNOWN rows to hard drops.
     span_domain = IntakeSpan(

--- a/services/intake/tests/test_otlp_caller_principal.py
+++ b/services/intake/tests/test_otlp_caller_principal.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AIRCORE-800 first cut: the authenticated caller is stamped onto ingested spans.
+
+Proves attribution at ingest: every span records which agent/user posted it, so you
+can later answer "which agent made which calls" by filtering on this attribute.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from nmp.intake.spans.ingest.otlp import (
+    CALLER_PRINCIPAL_ATTRIBUTE,
+    _resolve_caller_principal,
+    _span_to_domain,
+)
+from opentelemetry.proto.trace.v1.trace_pb2 import Span
+
+
+def _otlp_span() -> Span:
+    return Span(trace_id=b"\x01" * 16, span_id=b"\x02" * 8, name="llm-call")
+
+
+def test_caller_principal_stamped_on_span():
+    dom = _span_to_domain(
+        workspace="default",
+        span=_otlp_span(),
+        resource_attributes={},
+        scope_data={},
+        ingested_at=datetime.now(timezone.utc),
+        caller_principal="svc-nemo-ci",
+    )
+    assert dom.attributes_string[CALLER_PRINCIPAL_ATTRIBUTE] == "svc-nemo-ci"
+
+
+def test_no_caller_attribute_when_absent():
+    dom = _span_to_domain(
+        workspace="default",
+        span=_otlp_span(),
+        resource_attributes={},
+        scope_data={},
+        ingested_at=datetime.now(timezone.utc),
+        caller_principal="",
+    )
+    assert CALLER_PRINCIPAL_ATTRIBUTE not in dom.attributes_string
+
+
+def test_resolve_caller_principal():
+    on = SimpleNamespace(auth_enabled=True, principal=SimpleNamespace(id="svc-nemo-ci"))
+    off = SimpleNamespace(auth_enabled=False, principal=SimpleNamespace(id="ignored"))
+    assert _resolve_caller_principal(on) == "svc-nemo-ci"
+    assert _resolve_caller_principal(off) == ""


### PR DESCRIPTION
# Auth: authentik machine-identity reference + setup skill + docs

## Summary

Adds an optional [authentik](https://goauthentik.io/) IdP reference under `contrib/authentik/` that shows how a **machine** (CI, an agent, a service) authenticates to NeMo Platform with its own OIDC credential, with access controlled by NeMo's existing RBAC. Plus a conversational setup skill, a docs page, and an end-to-end authz test.

The headline: **the machine-identity path needs zero NeMo core changes.** A client-credentials token validates through the same auth middleware as a human token, and a group to role to workspace binding grants scoped, revocable access. The reference kit and the new authz test prove it end to end.

## How a teammate reproduces it

From a NeMo Platform checkout (full runbook in `contrib/authentik/README.md`):

1. **Bring up authentik:** `docker compose -p nemo-authentik -f contrib/authentik/docker-compose.yml up -d`. The blueprint provisions an OIDC provider, a `groups` scope mapping, the `nemo` application, the `nemo-admins`/`nemo-editors` groups, and a `svc-nemo-ci` service account.
2. **Get a machine token** via the client-credentials grant, and verify its claims (`sub`, `iss`, `groups`).
3. **Run NeMo against authentik** with the bundle's OIDC config.
4. **Demonstrate respected, scoped, revocable access:** the machine is denied (403) before any binding, allowed (200) after binding `nemo-editors` to a role, and denied again after the binding (or the group membership) is removed.

For the conversational version, the `nemo-auth-setup` skill walks an operator through both the reference path and bring-your-own-IdP, plus agent identity and both revoke levers.

## NeMo Platform changes (what the demo actually needed)

* **Core platform: nothing.** The machine-identity flow works on existing middleware and RBAC. That is the point of the reference, and `services/core/auth/tests/test_machine_group_authz.py` locks it in.
* **One additive product change, in this PR:** stamp the authenticated caller on ingested spans at the OTLP ingest point (`services/intake/.../otlp.py`), so traces can record who made the call. This is the **first cut of AIRCORE-800**; it does not touch the authorization model. The trace-record column and the "who" filter are follow-ups under that ticket. Happy to split this commit into its own PR if reviewers prefer.
* **Reference IdP config, not core:** the `groups` scope mapping, `brand default: true` (without it `/device` returns 404 on `localhost`), and `groups` in default scopes all live in `contrib/authentik/`. They are authentik-side settings the reference needs, not platform changes.
* **A bug we hit, already fixed upstream:** `nemo auth logout` was a silent no-op on the branch we forked from. Main has since reworked the credential update path to downgrade to a `NoAuthUser` on logout, so it is fixed. Nothing for it here.

## Tickets filed from this work

Epic and children (AIRE Core / Platform Core):

* **AIRCORE-802** (epic): Authentication & Authorization (RBAC) for NeMo Platform. Documents the verified-in-code model (workspace is the only tenancy boundary; group to role to workspace bindings; API keys are workspace-level) and the gaps vs the 26.02 PRD.
* **AIRCORE-803**: Gate workspace creation + `workspaceCreator` role (P0).
* **AIRCORE-804**: Add/confirm a workspace-level Admin role (manage members, visibility).
* **AIRCORE-805**: Workspace visibility (public/private) + public auto-Viewer.
* **AIRCORE-806**: Friendly RBAC CLI/SDK verbs (`nemo workspace add-member`, `iam grant-role`).
* **AIRCORE-807**: Platform governance read APIs (cross-workspace visibility, P1).
* **AIRCORE-808**: NeMo Studio login + member-management UI (stretch).
* **AIRCORE-809**: `nemo auth login`: print a ready-to-click device-flow link (the demo worked around this).
* **AIRCORE-856**: Add an authorization-code + PKCE login with a localhost callback, so NeMo can serve a branded, in-tab sign-in confirmation that works with any IdP. This replaces the removed success-page hack (see below).

Related: **AIRCORE-800** (trace attribution; first cut is in this PR), AIRCORE-753, AIRCORE-771, AIRCORE-222.

## What is intentionally not here

* **The branded CLI success page** (`success_page.html` + the `_open_branded_success_page` hook) was removed. With the device flow there is no redirect URI, so the user lands on the IdP's own page and NeMo cannot control that tab; the hack opened a second tab in the system browser and never showed in the flow. The correct fix is auth-code + PKCE with a localhost callback, tracked as **AIRCORE-856**.
* **Demo-only local settings** (`.claude/settings.json` sandbox tweaks and `CLAUDE.md` agent guidance) are excluded.

## Reviewer notes

* The `nemo-auth-setup` skill invokes the CLI as `.venv/bin/nemo` (it assumes a source-checkout venv and checks for it in pre-flight). Flagging in case the shipped skill should call plain `nemo` instead.
* `env.example` and the blueprint use only dev-only placeholders (`*-dev`, `change-me-dev-only`), with `openssl rand` guidance for the real secret key. No real secrets.

## Verification

* `contrib/authentik/README.md` records a local end-to-end run (machine token claims; 403 before binding; 200 after `nemo-editors -> Editor`; 403 after revoke).
* `services/core/auth/tests/test_machine_group_authz.py` covers the group to role authz path.
* `services/intake/tests/test_otlp_caller_principal.py` covers the span-attribution change.
