### PR TITLE
feat(nemo-agents-plugin): add OpenClaw adapter to nemo-agents plugin

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -471,6 +471,7 @@ nat_claude_code_agent_adapter = "nat_claude_code_agent_adapter.register"
 nat_codex_agent_adapter = "nat_codex_agent_adapter.register"
 nat_cursor_agent_adapter = "nat_cursor_agent_adapter.register"
 nat_hermes_agent_adapter = "nat_hermes_agent_adapter.register"
+nat_openclaw_agent_adapter = "nat_openclaw_agent_adapter.register"
 nemo_agents_example_calculator = "calculator_agent.register"
 
 # Generated from [tool.bundle-package]; do not edit this table by hand.
@@ -601,7 +602,7 @@ garak-api = { source = "../../packages/garak_api/garakapi", module = "garakapi",
 switchyard-vendored = { source = "../../plugins/nemo-switchyard/vendor/switchyard/switchyard", module = "switchyard" }
 
 # Default first-party plugins
-nemo-agents-plugin = { source = "../../plugins/nemo-agents/src/nemo_agents_plugin", module = "nemo_agents_plugin", inherit = { "entry-points" = ["nemo.*", "nat.plugins", "nat.components"] }, force_include = { "../../vendor/claude_code_agent_adapter/src/nat_claude_code_agent_adapter" = "nat_claude_code_agent_adapter", "../../vendor/codex_agent_adapter/src/nat_codex_agent_adapter" = "nat_codex_agent_adapter", "../../vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter" = "nat_cursor_agent_adapter", "../../vendor/hermes_agent_adapter/src/nat_hermes_agent_adapter" = "nat_hermes_agent_adapter" } }
+nemo-agents-plugin = { source = "../../plugins/nemo-agents/src/nemo_agents_plugin", module = "nemo_agents_plugin", inherit = { "entry-points" = ["nemo.*", "nat.plugins", "nat.components"] }, force_include = { "../../vendor/claude_code_agent_adapter/src/nat_claude_code_agent_adapter" = "nat_claude_code_agent_adapter", "../../vendor/codex_agent_adapter/src/nat_codex_agent_adapter" = "nat_codex_agent_adapter", "../../vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter" = "nat_cursor_agent_adapter", "../../vendor/hermes_agent_adapter/src/nat_hermes_agent_adapter" = "nat_hermes_agent_adapter", "../../vendor/openclaw_agent_adapter/src/nat_openclaw_agent_adapter" = "nat_openclaw_agent_adapter" } }
 nemo-anonymizer-plugin = { source = "../../plugins/nemo-anonymizer/src/nemo_anonymizer_plugin", module = "nemo_anonymizer_plugin", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-auditor-plugin = { source = "../../plugins/nemo-auditor/src/nemo_auditor", module = "nemo_auditor", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-data-designer-plugin = { source = "../../plugins/nemo-data-designer/src/nemo_data_designer_plugin", module = "nemo_data_designer_plugin", inherit = { "entry-points" = ["nemo.*"] } }

--- a/plugins/nemo-agents/examples/openclaw-agent/README.md
+++ b/plugins/nemo-agents/examples/openclaw-agent/README.md
@@ -41,6 +41,26 @@ npm run --prefix "$NEMO_RELAY_ROOT" build --workspace=nemo-relay-openclaw
 openclaw plugins install --link "$NEMO_RELAY_ROOT/integrations/openclaw"
 ```
 
+Install the OpenClaw Codex plugin and authenticate it if you want the example to
+use OpenClaw's Codex app-server runtime:
+
+```bash
+openclaw plugins install @openclaw/codex
+openclaw models auth login --provider openai
+openclaw models status
+```
+
+Configure OpenClaw to use a Codex-backed model by default:
+
+```bash
+openclaw config set 'plugins.entries["codex"].enabled' true --strict-json
+openclaw config set 'agents.defaults.model.primary' openai/gpt-5.5
+openclaw config set 'agents.defaults.models["openai/gpt-5.5"].agentRuntime.id' codex
+openclaw config validate
+```
+
+The example config uses the OpenClaw default model configured above.
+
 Enable the `nemo-relay` plugin and choose an absolute ATIF output directory:
 
 ```bash

--- a/plugins/nemo-agents/examples/openclaw-agent/README.md
+++ b/plugins/nemo-agents/examples/openclaw-agent/README.md
@@ -1,0 +1,96 @@
+# OpenClaw Agent
+
+This example configures the vendored OpenClaw workflow adapter shipped with the
+`nemo-agents` plugin.
+
+The adapter is already packaged with `nemo-agents`; do not install a separate
+NAT OpenClaw adapter package.
+
+## Prerequisites
+
+Install the OpenClaw CLI and configure authentication in the same environment
+that will run `nemo`:
+
+```bash
+npm install -g openclaw@latest
+openclaw --version
+openclaw onboard
+openclaw doctor
+```
+
+The example config uses OpenClaw Gateway mode because Relay telemetry is
+provided by the NeMo Relay OpenClaw plugin running inside Gateway:
+
+```bash
+openclaw config set gateway.mode local
+openclaw config set gateway.bind loopback
+openclaw config set gateway.auth.mode token
+openclaw config set gateway.auth.token "$(openssl rand -hex 32)"
+openclaw config validate
+```
+
+Clone the NeMo Relay source locally, then build and link the OpenClaw plugin.
+This requires Node.js and npm in addition to the OpenClaw CLI:
+
+```bash
+git clone git@github.com:NVIDIA/NeMo-Relay.git
+export NEMO_RELAY_ROOT="$PWD/NeMo-Relay"
+npm install --prefix "$NEMO_RELAY_ROOT" --workspace=nemo-relay-node --workspace=nemo-relay-openclaw --ignore-scripts
+npm run --prefix "$NEMO_RELAY_ROOT" build --workspace=nemo-relay-node
+npm run --prefix "$NEMO_RELAY_ROOT" build --workspace=nemo-relay-openclaw
+openclaw plugins install --link "$NEMO_RELAY_ROOT/integrations/openclaw"
+```
+
+Enable the `nemo-relay` plugin and choose an absolute ATIF output directory:
+
+```bash
+export OPENCLAW_ATIF_DIR="$(pwd)/.tmp/nemo-relay-openclaw-atif"
+mkdir -p "$OPENCLAW_ATIF_DIR"
+openclaw config set 'plugins.entries["nemo-relay"].enabled' true --strict-json
+openclaw config set 'plugins.entries["nemo-relay"].hooks.allowConversationAccess' true --strict-json
+openclaw config set 'plugins.entries["nemo-relay"].config.plugins.components[0].kind' observability
+openclaw config set 'plugins.entries["nemo-relay"].config.plugins.components[0].config.atif.enabled' true --strict-json
+openclaw config set 'plugins.entries["nemo-relay"].config.plugins.components[0].config.atif.output_directory' "$OPENCLAW_ATIF_DIR"
+openclaw config validate
+```
+
+Start Gateway in a separate terminal and leave it running while the platform
+deployment invokes OpenClaw:
+
+```bash
+OPENCLAW_CODEX_APP_SERVER_MODE=guardian \
+OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY=on-request \
+OPENCLAW_CODEX_APP_SERVER_SANDBOX=workspace-write \
+openclaw gateway run
+```
+
+In the terminal that runs `nemo`, verify that Gateway loaded the plugin:
+
+```bash
+openclaw plugins inspect nemo-relay --runtime --json
+openclaw gateway call nemoRelay.status --json
+```
+
+## Run on NeMo Platform
+
+From the `nemo-platform` repository root, create and deploy the example agent:
+
+```bash
+nemo agents create \
+  --name openclaw-agent \
+  --agent-config plugins/nemo-agents/examples/openclaw-agent/openclaw-agent.yml
+
+nemo agents deploy --agent openclaw-agent
+```
+
+Invoke it with a read-only prompt first:
+
+```bash
+nemo agents invoke \
+  --agent openclaw-agent \
+  --input "Read pyproject.toml and say only the project name. Do not edit files."
+```
+
+The config uses `local: false` so OpenClaw runs through Gateway and the
+`nemo-relay` plugin can observe the agent run. If you only need a direct
+OpenClaw run without Relay telemetry, set `local: true`.

--- a/plugins/nemo-agents/examples/openclaw-agent/README.md
+++ b/plugins/nemo-agents/examples/openclaw-agent/README.md
@@ -12,7 +12,7 @@ Install the OpenClaw CLI and configure authentication in the same environment
 that will run `nemo`:
 
 ```bash
-npm install -g openclaw@latest
+npm install -g openclaw@2026.6.10
 openclaw --version
 openclaw onboard
 openclaw doctor
@@ -35,6 +35,7 @@ This requires Node.js and npm in addition to the OpenClaw CLI:
 ```bash
 git clone git@github.com:NVIDIA/NeMo-Relay.git
 export NEMO_RELAY_ROOT="$PWD/NeMo-Relay"
+git -C "$NEMO_RELAY_ROOT" checkout 19a537ddb045d853304f0f6a43dbc5346ad84233
 npm install --prefix "$NEMO_RELAY_ROOT" --workspace=nemo-relay-node --workspace=nemo-relay-openclaw --ignore-scripts
 npm run --prefix "$NEMO_RELAY_ROOT" build --workspace=nemo-relay-node
 npm run --prefix "$NEMO_RELAY_ROOT" build --workspace=nemo-relay-openclaw
@@ -45,7 +46,7 @@ Install the OpenClaw Codex plugin and authenticate it if you want the example to
 use OpenClaw's Codex app-server runtime:
 
 ```bash
-openclaw plugins install @openclaw/codex
+openclaw plugins install @openclaw/codex@2026.6.10
 openclaw models auth login --provider openai
 openclaw models status
 ```

--- a/plugins/nemo-agents/examples/openclaw-agent/openclaw-agent.yml
+++ b/plugins/nemo-agents/examples/openclaw-agent/openclaw-agent.yml
@@ -17,7 +17,7 @@ workflow:
   # Change this to the repository or workspace OpenClaw should operate in.
   working_directory: .
   agent_id: main
-  session_key: nemo-openclaw-agent
+  session_key: null
   local: false
   codex_app_server_mode: guardian
   codex_app_server_approval_policy: on-request

--- a/plugins/nemo-agents/examples/openclaw-agent/openclaw-agent.yml
+++ b/plugins/nemo-agents/examples/openclaw-agent/openclaw-agent.yml
@@ -1,0 +1,35 @@
+# openclaw-agent.yml
+#
+# An OpenClaw-backed NAT workflow for local coding tasks.
+#
+# Requires the openclaw CLI to be installed and configured. Relay telemetry is
+# provided by the NeMo Relay OpenClaw plugin loaded through OpenClaw Gateway.
+#
+# Platform-managed deployment:
+#   nemo agents create --name openclaw-agent --agent-config examples/openclaw-agent/openclaw-agent.yml
+#   nemo agents deploy --agent openclaw-agent
+#   nemo agents invoke --agent openclaw-agent \
+#       --input "Read pyproject.toml and say only the project name. Do not edit files."
+
+workflow:
+  _type: openclaw_agent
+  command: openclaw
+  # Change this to the repository or workspace OpenClaw should operate in.
+  working_directory: .
+  agent_id: main
+  session_key: nemo-openclaw-agent
+  local: false
+  codex_app_server_mode: guardian
+  codex_app_server_approval_policy: on-request
+  codex_app_server_sandbox: workspace-write
+  agent_timeout_seconds: 600
+  timeout_seconds: 660
+  max_output_chars: 12000
+
+general:
+  telemetry:
+    tracing:
+      nemo_trace:
+        _type: nemo_files
+        # workspace and agent_name are injected at deploy time
+        batch_size: 128

--- a/plugins/nemo-agents/pyproject.toml
+++ b/plugins/nemo-agents/pyproject.toml
@@ -54,6 +54,7 @@ nat_claude_code_agent_adapter = "nat_claude_code_agent_adapter.register"
 nat_codex_agent_adapter = "nat_codex_agent_adapter.register"
 nat_cursor_agent_adapter = "nat_cursor_agent_adapter.register"
 nat_hermes_agent_adapter = "nat_hermes_agent_adapter.register"
+nat_openclaw_agent_adapter = "nat_openclaw_agent_adapter.register"
 
 [project.optional-dependencies]
 container = [
@@ -79,6 +80,7 @@ packages = [
     "vendor/codex_agent_adapter/src/nat_codex_agent_adapter",
     "vendor/cursor_agent_adapter/src/nat_cursor_agent_adapter",
     "vendor/hermes_agent_adapter/src/nat_hermes_agent_adapter",
+    "vendor/openclaw_agent_adapter/src/nat_openclaw_agent_adapter",
 ]
 
 [tool.uv.sources]

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/validator.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/validator.py
@@ -20,6 +20,7 @@ _KNOWN_WORKFLOW_TYPES = frozenset(
         "codex_agent",
         "cursor_agent",
         "hermes_agent",
+        "openclaw_agent",
         "react_agent",
         "tool_calling_agent",
         "reasoning_agent",

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -612,6 +612,7 @@ class TestValidateAgentConfig:
             "codex_agent",
             "cursor_agent",
             "hermes_agent",
+            "openclaw_agent",
             "react_agent",
             "tool_calling_agent",
             "reasoning_agent",

--- a/plugins/nemo-agents/tests/unit/test_openclaw_adapter_packaging.py
+++ b/plugins/nemo-agents/tests/unit/test_openclaw_adapter_packaging.py
@@ -3,7 +3,7 @@
 
 """Unit tests for the vendored OpenClaw adapter packaging."""
 
-from importlib.metadata import entry_points
+from importlib.metadata import distribution
 from pathlib import Path
 
 import yaml
@@ -17,8 +17,8 @@ def test_openclaw_agent_workflow_type_registered() -> None:
 
 
 def test_openclaw_adapter_nat_components_entry_point_registered() -> None:
-    eps = entry_points(group="nat.components")
-    ep = next(ep for ep in eps if ep.name == "nat_openclaw_agent_adapter")
+    eps = distribution("nemo-agents-plugin").entry_points
+    ep = next(ep for ep in eps if ep.group == "nat.components" and ep.name == "nat_openclaw_agent_adapter")
     assert ep.value == "nat_openclaw_agent_adapter.register"
 
 

--- a/plugins/nemo-agents/tests/unit/test_openclaw_adapter_packaging.py
+++ b/plugins/nemo-agents/tests/unit/test_openclaw_adapter_packaging.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the vendored OpenClaw adapter packaging."""
+
+from importlib.metadata import entry_points
+from pathlib import Path
+
+import yaml
+from nat_openclaw_agent_adapter.register import OpenClawAgentWorkflowConfig
+
+_NEMO_AGENTS_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_openclaw_agent_workflow_type_registered() -> None:
+    assert OpenClawAgentWorkflowConfig.static_type() == "openclaw_agent"
+
+
+def test_openclaw_adapter_nat_components_entry_point_registered() -> None:
+    eps = entry_points(group="nat.components")
+    ep = next(ep for ep in eps if ep.name == "nat_openclaw_agent_adapter")
+    assert ep.value == "nat_openclaw_agent_adapter.register"
+
+
+def test_openclaw_example_config_validates_without_warnings() -> None:
+    from nemo_agents_plugin.container.validator import validate_agent_config
+
+    example = _NEMO_AGENTS_ROOT / "examples" / "openclaw-agent" / "openclaw-agent.yml"
+
+    data = yaml.safe_load(example.read_text(encoding="utf-8"))
+    assert data["workflow"]["_type"] == "openclaw_agent"
+    assert data["general"]["telemetry"]["tracing"]["nemo_trace"]["_type"] == "nemo_files"
+
+    result = validate_agent_config(example)
+    assert result.valid
+    assert result.errors == []
+    assert result.warnings == []

--- a/plugins/nemo-agents/vendor/openclaw_agent_adapter/README.md
+++ b/plugins/nemo-agents/vendor/openclaw_agent_adapter/README.md
@@ -1,0 +1,21 @@
+# Vendored OpenClaw agent adapter
+
+Snapshot of `examples/experimental/openclaw_agent_adapter` from
+[NVIDIA/NeMo-Agent-Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) at commit
+[`d2f1c9c77b91fa28547e1526b9fe8c4fb7a09725`](https://github.com/NVIDIA/NeMo-Agent-Toolkit/commit/d2f1c9c77b91fa28547e1526b9fe8c4fb7a09725).
+
+Copied upstream files:
+
+- `src/nat_openclaw_agent_adapter/`
+
+Generated files, example configs, data files, and local development artifacts
+from the upstream example are intentionally omitted, including `uv.lock`.
+
+The vendored adapter registers the NAT workflow type `_type: openclaw_agent`.
+Runtime use still requires the external `openclaw` command and the NeMo Relay
+OpenClaw plugin to be installed and configured in the environment that launches
+NAT.
+
+To refresh this snapshot, copy the same included files from the new upstream
+commit, preserve SPDX headers, and update this file with the new commit hash and
+summary.

--- a/plugins/nemo-agents/vendor/openclaw_agent_adapter/src/nat_openclaw_agent_adapter/__init__.py
+++ b/plugins/nemo-agents/vendor/openclaw_agent_adapter/src/nat_openclaw_agent_adapter/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/plugins/nemo-agents/vendor/openclaw_agent_adapter/src/nat_openclaw_agent_adapter/register.py
+++ b/plugins/nemo-agents/vendor/openclaw_agent_adapter/src/nat_openclaw_agent_adapter/register.py
@@ -1,0 +1,323 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import datetime
+import json
+import os
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import Any, Literal
+
+from nat.builder.builder import Builder
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.agent import AgentBaseConfig
+from nat.data_models.api_server import ChatRequest, ChatRequestOrMessage, ChatResponse, ChatResponseChunk, Usage
+from nat.data_models.component_ref import LLMRef
+from nat.utils.type_converter import GlobalTypeConverter
+from pydantic import Field
+
+CodexAppServerMode = Literal["guardian", "yolo"]
+CodexAppServerApprovalPolicy = Literal["on-request", "on-failure", "untrusted", "never"]
+CodexAppServerSandbox = Literal["read-only", "workspace-write", "danger-full-access"]
+
+
+class OpenClawAgentWorkflowConfig(AgentBaseConfig, name="openclaw_agent"):
+    """Configuration for the OpenClaw CLI workflow."""
+
+    llm_name: LLMRef | None = Field(
+        default=None,
+        description=(
+            "Optional NAT LLM reference. OpenClaw manages model selection through local config and `model`, "
+            "so this field is accepted for agent config consistency but is not used."
+        ),
+    )
+    description: str = Field(
+        default="OpenClaw CLI Agent Workflow", description="The description of this function's use."
+    )
+
+    command: str = Field(default="openclaw", description="OpenClaw CLI command or absolute path.")
+    working_directory: str = Field(default=".", description="Directory used as the OpenClaw subprocess cwd.")
+    agent_id: str = Field(default="main", description="OpenClaw agent id.")
+    session_key: str | None = Field(default="nat-openclaw", description="Optional durable OpenClaw session key.")
+    model: str | None = Field(default=None, description="Optional OpenClaw model reference.")
+    thinking: str | None = Field(default=None, description="Optional OpenClaw thinking level.")
+    local: bool = Field(default=False, description="Force embedded local execution instead of Gateway mode.")
+    agent_timeout_seconds: int = Field(default=600, gt=0, description="OpenClaw agent run timeout.")
+    codex_app_server_mode: CodexAppServerMode | None = Field(
+        default="guardian",
+        description=(
+            "Optional OpenClaw Codex app-server policy mode forwarded through OPENCLAW_CODEX_APP_SERVER_MODE."
+        ),
+    )
+    codex_app_server_approval_policy: CodexAppServerApprovalPolicy | None = Field(
+        default="on-request",
+        description=(
+            "Optional OpenClaw Codex app-server approval policy forwarded through "
+            "OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY."
+        ),
+    )
+    codex_app_server_sandbox: CodexAppServerSandbox | None = Field(
+        default="workspace-write",
+        description=("Optional OpenClaw Codex app-server sandbox forwarded through OPENCLAW_CODEX_APP_SERVER_SANDBOX."),
+    )
+
+    max_history: int | None = Field(default=15, ge=1, description="Maximum NAT chat messages to include in prompt.")
+    timeout_seconds: float = Field(default=660.0, gt=0, description="Overall OpenClaw CLI timeout.")
+    max_output_chars: int = Field(default=12000, gt=0, description="Maximum returned output characters.")
+
+
+def _clip(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + f"\n\n[truncated to {max_chars} characters]"
+
+
+def _nat_message_content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+            else:
+                text = getattr(block, "text", None)
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return str(content)
+
+
+def _role_to_text(role: Any) -> str:
+    return getattr(role, "value", str(role))
+
+
+def _build_prompt(message: ChatRequestOrMessage, config: OpenClawAgentWorkflowConfig) -> str:
+    if message.is_string:
+        return message.input_message or ""
+
+    chat_request = GlobalTypeConverter.get().convert(message, to_type=ChatRequest)
+    messages = chat_request.messages[-config.max_history :] if config.max_history else chat_request.messages
+
+    if len(messages) == 1 and _role_to_text(messages[0].role) == "user":
+        return _nat_message_content_to_text(messages[0].content)
+
+    prompt_parts = []
+    for chat_message in messages:
+        role = _role_to_text(chat_message.role)
+        content = _nat_message_content_to_text(chat_message.content)
+        prompt_parts.append(f"{role}: {content}")
+    return "\n\n".join(prompt_parts)
+
+
+def _usage_for(prompt: str, response: str) -> Usage:
+    prompt_tokens = len(prompt.split()) if prompt else 0
+    completion_tokens = len(response.split()) if response else 0
+    return Usage(
+        prompt_tokens=prompt_tokens, completion_tokens=completion_tokens, total_tokens=prompt_tokens + completion_tokens
+    )
+
+
+def _as_response(content: str, prompt: str, model: str | None) -> ChatResponse:
+    return ChatResponse.from_string(
+        content,
+        model=model or "openclaw-agent",
+        created=datetime.datetime.now(datetime.UTC),
+        usage=_usage_for(prompt, content),
+    )
+
+
+def _build_openclaw_command(config: OpenClawAgentWorkflowConfig, prompt: str) -> list[str]:
+    command = [
+        config.command,
+        "agent",
+        "--agent",
+        config.agent_id,
+        "--message",
+        prompt,
+        "--timeout",
+        str(config.agent_timeout_seconds),
+        "--json",
+    ]
+    if config.session_key:
+        command.extend(["--session-key", config.session_key])
+    if config.model:
+        command.extend(["--model", config.model])
+    if config.thinking:
+        command.extend(["--thinking", config.thinking])
+    if config.local:
+        command.append("--local")
+    return command
+
+
+def _add_gateway_path_context(prompt: str, cwd: Path, config: OpenClawAgentWorkflowConfig) -> str:
+    if config.local:
+        return prompt
+
+    return (
+        "The NeMo Agent Toolkit workflow launched OpenClaw from this directory:\n"
+        f"{cwd}\n\n"
+        "When the request mentions relative file paths, resolve them against that directory.\n\n"
+        f"User request:\n{prompt}"
+    )
+
+
+def _build_openclaw_env(config: OpenClawAgentWorkflowConfig) -> dict[str, str]:
+    env = os.environ.copy()
+    if config.codex_app_server_mode is not None:
+        env["OPENCLAW_CODEX_APP_SERVER_MODE"] = config.codex_app_server_mode
+    if config.codex_app_server_approval_policy is not None:
+        env["OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY"] = config.codex_app_server_approval_policy
+    if config.codex_app_server_sandbox is not None:
+        env["OPENCLAW_CODEX_APP_SERVER_SANDBOX"] = config.codex_app_server_sandbox
+    return env
+
+
+def _extract_text(value: Any, depth: int = 0) -> str:
+    if isinstance(value, str):
+        return value
+    if value is None or depth > 6:
+        return ""
+    if isinstance(value, list):
+        return "\n".join(part for item in value if (part := _extract_text(item, depth + 1)))
+    if not isinstance(value, dict):
+        return ""
+
+    for key in ["text", "message", "content", "response", "reply", "finalResponse", "final_response", "output"]:
+        text = _extract_text(value.get(key), depth + 1)
+        if text:
+            return text
+
+    for key in ["payloads", "result", "data"]:
+        text = _extract_text(value.get(key), depth + 1)
+        if text:
+            return text
+    return ""
+
+
+def _extract_openclaw_output(stdout: str, max_chars: int) -> str:
+    try:
+        result = json.loads(stdout)
+    except json.JSONDecodeError:
+        return _clip(stdout, max_chars)
+
+    text = _extract_text(result)
+    if not text:
+        text = json.dumps(result, indent=2, sort_keys=True)
+    return _clip(text, max_chars)
+
+
+def _diagnostic_hint(details: str) -> str:
+    if "approval_policy" in details and "Never" in details and "allowed set" in details:
+        return (
+            "\n\nHint: OpenClaw is using the Codex app-server harness with a full-access approval policy, but the "
+            "Codex cloud requirements for this account reject `Never`. Keep "
+            "`codex_app_server_mode: guardian`, `codex_app_server_approval_policy: on-request`, and "
+            "`codex_app_server_sandbox: workspace-write`, then use a fresh `session_key` if a previous OpenClaw "
+            "session was created with the rejected policy."
+        )
+    if "gateway closed" in details or "GatewayTransportError" in details:
+        return (
+            "\n\nHint: This Relay example uses OpenClaw Gateway mode so the `nemo-relay` plugin can observe the "
+            "run. Restart OpenClaw Gateway, verify `openclaw plugins inspect nemo-relay --runtime --json`, and "
+            "check `openclaw gateway call nemoRelay.status --json`. If you only need a direct OpenClaw run "
+            "without Relay telemetry, set `local: true`."
+        )
+    if "GatewayCredentialsRequiredError" in details or "gateway agent requires credentials" in details:
+        return (
+            "\n\nHint: This Relay example uses OpenClaw Gateway mode. Configure local Gateway auth before running "
+            "the workflow: set `gateway.mode: local`, `gateway.bind: loopback`, `gateway.auth.mode: token`, and "
+            "a `gateway.auth.token`, then restart OpenClaw Gateway."
+        )
+    if "timed out waiting for cloud requirements" in details:
+        return (
+            "\n\nHint: OpenClaw's Codex harness could not load cloud requirements. Run the workflow from the same "
+            "normal shell/user profile that can read and write `~/.openclaw`, verify `openclaw doctor`, and make "
+            "sure the selected OpenClaw/Codex model is available for the account."
+        )
+    return ""
+
+
+async def _run_openclaw_agent(prompt: str, config: OpenClawAgentWorkflowConfig) -> str:
+    cwd = Path(config.working_directory).resolve()
+    if not cwd.exists() or not cwd.is_dir():
+        raise RuntimeError(f"Invalid working_directory {config.working_directory!r}: {cwd} is not a directory.")
+
+    openclaw_prompt = _add_gateway_path_context(prompt, cwd, config)
+    command = _build_openclaw_command(config, openclaw_prompt)
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=str(cwd),
+            env=_build_openclaw_env(config),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as error:
+        raise RuntimeError(f"Could not find OpenClaw CLI command: {command[0]}") from error
+
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(process.communicate(), timeout=config.timeout_seconds)
+    except TimeoutError as error:
+        process.kill()
+        await process.wait()
+        raise RuntimeError(f"OpenClaw CLI timed out after {config.timeout_seconds} seconds") from error
+
+    stdout = stdout_bytes.decode(errors="replace").strip()
+    stderr = stderr_bytes.decode(errors="replace").strip()
+    if process.returncode:
+        details = "\n".join(part for part in [stderr, stdout] if part)
+        clipped_details = _clip(details, 4000)
+        raise RuntimeError(
+            f"OpenClaw CLI failed with exit code {process.returncode}: {clipped_details}{_diagnostic_hint(details)}"
+        )
+
+    return _extract_openclaw_output(stdout, config.max_output_chars)
+
+
+@register_function(config_type=OpenClawAgentWorkflowConfig)
+async def openclaw_agent(config: OpenClawAgentWorkflowConfig, _builder: Builder) -> AsyncGenerator[FunctionInfo, None]:
+    """Create the OpenClaw workflow function.
+
+    Args:
+        config: OpenClaw workflow configuration used to build subprocess commands and response handling.
+        _builder: Workflow builder supplied by NeMo Agent Toolkit. It is accepted for registry compatibility.
+
+    Returns:
+        An async generator that yields the FunctionInfo for normal and streaming OpenClaw responses.
+    """
+
+    async def _response_fn(chat_request_or_message: ChatRequestOrMessage) -> ChatResponse | str:
+        message = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequestOrMessage)
+        prompt = _build_prompt(message, config)
+        content = await _run_openclaw_agent(prompt=prompt, config=config)
+
+        if message.is_string:
+            return content
+        return _as_response(content, prompt=prompt, model=config.model)
+
+    async def _stream_fn(chat_request_or_message: ChatRequestOrMessage) -> AsyncGenerator[ChatResponseChunk]:
+        message = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequestOrMessage)
+        prompt = _build_prompt(message, config)
+        yield ChatResponseChunk.from_string(
+            await _run_openclaw_agent(prompt=prompt, config=config), model=config.model or "openclaw-agent"
+        )
+
+    yield FunctionInfo.create(single_fn=_response_fn, stream_fn=_stream_fn, description=config.description)


### PR DESCRIPTION
## Summary

Adds experimental OpenClaw agent support to `nemo-agents` by vendoring the NAT
OpenClaw adapter and wiring it into the plugin package, following the same
pattern used for the other experimental harness adapters.

This PR:

- Vendors the upstream OpenClaw adapter into `plugins/nemo-agents`
- Exposes the adapter through the `nat.components` entry point
- Recognizes `openclaw_agent` in nemo-agents config validation
- Adds an OpenClaw example config and README
- Adds tests for adapter registration and example config validation
- Records upstream provenance for the vendored OpenClaw adapter
- Documents the additional OpenClaw Codex plugin setup needed for the example
  Codex-backed flow

## Spike Update

The original spike only partially validated OpenClaw. At that point, OpenClaw
could register through NAT and Gateway could load the `nemo-relay` plugin, but
platform invocation had not been validated and the remaining uncertainty was
around OpenClaw's Gateway, model auth, session, and workspace behavior.

This PR improves on that result. OpenClaw was validated end-to-end through NeMo
Platform using a clean OpenClaw setup with Gateway, NeMo Relay, the official
`@openclaw/codex` plugin, and `openai/gpt-5.5` routed through the Codex harness.
Platform create, deploy, and invoke succeeded, and NeMo Relay wrote ATIF output
for the platform run.

OpenClaw is still operationally different from the other adapters: Gateway must
run separately, and provider/model auth, session state, and workspace behavior
are owned by OpenClaw rather than NAT or NeMo Platform.

## User Flow

Users install/use `nemo-agents` as usual, then provide a config with:

```yaml
workflow:
  _type: openclaw_agent
```

The included example is:

```text
plugins/nemo-agents/examples/openclaw-agent/openclaw-agent.yml
```

The OpenClaw adapter requires `openclaw` and an OpenClaw Gateway to be available
at runtime. Relay telemetry is provided by the NeMo Relay OpenClaw plugin loaded
inside Gateway.

For the documented Codex-backed OpenClaw flow, users also install and configure
the OpenClaw Codex plugin:

```bash
openclaw plugins install @openclaw/codex
openclaw models auth login --provider openai
openclaw config set 'plugins.entries["codex"].enabled' true --strict-json
openclaw config set 'agents.defaults.model.primary' openai/gpt-5.5
openclaw config set 'agents.defaults.models["openai/gpt-5.5"].agentRuntime.id' codex
```

The example README includes these setup details so users following the example
can get the same working path validated in the e2e test.

## Validation

Focused tests:

```bash
uv run --frozen pytest \
  plugins/nemo-agents/tests/unit/test_openclaw_adapter_packaging.py \
  plugins/nemo-agents/tests/unit/test_claude_code_adapter_packaging.py \
  plugins/nemo-agents/tests/unit/test_codex_adapter_packaging.py \
  plugins/nemo-agents/tests/unit/test_cursor_adapter_packaging.py \
  plugins/nemo-agents/tests/unit/test_container.py \
  -q
```

Result:

```text
110 passed, 1 warning
```

Additional checks:

```bash
tools/lint/lint-python-style.sh
uv run nemo agents package \
  --agent plugins/nemo-agents/examples/openclaw-agent/openclaw-agent.yml \
  --no-build \
  --output /tmp/nemo-openclaw-agent.Dockerfile
git diff --check
```

Manual platform smoke test:

- Created a clean OpenClaw setup with Gateway, NeMo Relay, `@openclaw/codex`,
  and `openai/gpt-5.5` routed through `agentRuntime.id: codex`
- `nemo agents create --name openclaw-codex-e2e --agent-config /tmp/openclaw-agent-codex-e2e.yml`
- `nemo agents deploy --agent openclaw-codex-e2e`
- `nemo agents invoke --agent openclaw-codex-e2e --input "Say exactly: openclaw-platform-codex-e2e-ok"`

Invoke returned:

```text
openclaw-platform-codex-e2e-ok
```

Relay status showed ATIF enabled, and the configured ATIF directory contained a
non-empty output file for the platform run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenClaw-backed `openclaw_agent` workflow adapter with a new NAT component entry point, bundled in published wheels.
* **Documentation**
  * Added an OpenClaw agent example README and an example configuration YAML, plus documentation for the vendored adapter snapshot.
* **Bug Fixes**
  * Recognize `openclaw_agent` during workflow validation to avoid “unknown workflow type” warnings.
* **Tests**
  * Added unit tests covering NAT entry-point registration, workflow/config validation, and successful loading of the example configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->