### PR TITLE
feat(experiments): Remove experiment summary field, description field remains

### DIFF
--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -10447,10 +10447,6 @@ components:
           title: Description
           description: Human-readable description.
           type: string
-        summary:
-          title: Summary
-          description: Human-authored summary of results.
-          type: string
       additionalProperties: false
       type: object
       required:
@@ -10492,9 +10488,6 @@ components:
           title: Metadata
         description:
           title: Description
-          type: string
-        summary:
-          title: Summary
           type: string
         created_at:
           title: Created At

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -10447,10 +10447,6 @@ components:
           title: Description
           description: Human-readable description.
           type: string
-        summary:
-          title: Summary
-          description: Human-authored summary of results.
-          type: string
       additionalProperties: false
       type: object
       required:
@@ -10492,9 +10488,6 @@ components:
           title: Metadata
         description:
           title: Description
-          type: string
-        summary:
-          title: Summary
           type: string
         created_at:
           title: Created At

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -10447,10 +10447,6 @@ components:
           title: Description
           description: Human-readable description.
           type: string
-        summary:
-          title: Summary
-          description: Human-authored summary of results.
-          type: string
       additionalProperties: false
       type: object
       required:
@@ -10492,9 +10488,6 @@ components:
           title: Metadata
         description:
           title: Description
-          type: string
-        summary:
-          title: Summary
           type: string
         created_at:
           title: Created At

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -10447,10 +10447,6 @@ components:
           title: Description
           description: Human-readable description.
           type: string
-        summary:
-          title: Summary
-          description: Human-authored summary of results.
-          type: string
       additionalProperties: false
       type: object
       required:
@@ -10492,9 +10488,6 @@ components:
           title: Metadata
         description:
           title: Description
-          type: string
-        summary:
-          title: Summary
           type: string
         created_at:
           title: Created At

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/experiments/experiments.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/experiments/experiments.py
@@ -88,7 +88,6 @@ class ExperimentsResource(SyncAPIResource):
         description: str | Omit = omit,
         metadata: Dict[str, object] | Omit = omit,
         source_link: str | Omit = omit,
-        summary: str | Omit = omit,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         exist_ok: bool = False,
@@ -115,8 +114,6 @@ class ExperimentsResource(SyncAPIResource):
           metadata: Free-form producer metadata.
 
           source_link: Optional URL for the source experiment.
-
-          summary: Human-authored summary of results.
 
 
           exist_ok: Do not raise an error if the resource already exists. Returns the existing resource.
@@ -146,7 +143,6 @@ class ExperimentsResource(SyncAPIResource):
                         "description": description,
                         "metadata": metadata,
                         "source_link": source_link,
-                        "summary": summary,
                     },
                     experiment_create_params.ExperimentCreateParams,
                 ),
@@ -210,7 +206,6 @@ class ExperimentsResource(SyncAPIResource):
         description: str | Omit = omit,
         metadata: Dict[str, object] | Omit = omit,
         source_link: str | Omit = omit,
-        summary: str | Omit = omit,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -236,8 +231,6 @@ class ExperimentsResource(SyncAPIResource):
           metadata: Free-form producer metadata.
 
           source_link: Optional URL for the source experiment.
-
-          summary: Human-authored summary of results.
 
           extra_headers: Send extra headers
 
@@ -268,7 +261,6 @@ class ExperimentsResource(SyncAPIResource):
                     "description": description,
                     "metadata": metadata,
                     "source_link": source_link,
-                    "summary": summary,
                 },
                 experiment_update_params.ExperimentUpdateParams,
             ),
@@ -504,7 +496,6 @@ class AsyncExperimentsResource(AsyncAPIResource):
         description: str | Omit = omit,
         metadata: Dict[str, object] | Omit = omit,
         source_link: str | Omit = omit,
-        summary: str | Omit = omit,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         exist_ok: bool = False,
@@ -531,8 +522,6 @@ class AsyncExperimentsResource(AsyncAPIResource):
           metadata: Free-form producer metadata.
 
           source_link: Optional URL for the source experiment.
-
-          summary: Human-authored summary of results.
 
 
           exist_ok: Do not raise an error if the resource already exists. Returns the existing resource.
@@ -562,7 +551,6 @@ class AsyncExperimentsResource(AsyncAPIResource):
                         "description": description,
                         "metadata": metadata,
                         "source_link": source_link,
-                        "summary": summary,
                     },
                     experiment_create_params.ExperimentCreateParams,
                 ),
@@ -626,7 +614,6 @@ class AsyncExperimentsResource(AsyncAPIResource):
         description: str | Omit = omit,
         metadata: Dict[str, object] | Omit = omit,
         source_link: str | Omit = omit,
-        summary: str | Omit = omit,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -652,8 +639,6 @@ class AsyncExperimentsResource(AsyncAPIResource):
           metadata: Free-form producer metadata.
 
           source_link: Optional URL for the source experiment.
-
-          summary: Human-authored summary of results.
 
           extra_headers: Send extra headers
 
@@ -684,7 +669,6 @@ class AsyncExperimentsResource(AsyncAPIResource):
                     "description": description,
                     "metadata": metadata,
                     "source_link": source_link,
-                    "summary": summary,
                 },
                 experiment_update_params.ExperimentUpdateParams,
             ),

--- a/sdk/python/nemo-platform/src/nemo_platform/types/experiments/experiment_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/experiments/experiment_create_params.py
@@ -49,6 +49,3 @@ class ExperimentCreateParams(TypedDict, total=False):
 
     source_link: str
     """Optional URL for the source experiment."""
-
-    summary: str
-    """Human-authored summary of results."""

--- a/sdk/python/nemo-platform/src/nemo_platform/types/experiments/experiment_response.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/experiments/experiment_response.py
@@ -80,8 +80,6 @@ class ExperimentResponse(BaseModel):
 
     source_link: Optional[str] = None
 
-    summary: Optional[str] = None
-
     updated_at: Optional[datetime] = None
 
     if not PYDANTIC_V1:

--- a/sdk/python/nemo-platform/src/nemo_platform/types/experiments/experiment_update_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/experiments/experiment_update_params.py
@@ -51,6 +51,3 @@ class ExperimentUpdateParams(TypedDict, total=False):
 
     source_link: str
     """Optional URL for the source experiment."""
-
-    summary: str
-    """Human-authored summary of results."""

--- a/sdk/python/nemo-platform/src/nemo_platform/types/guardrail/log_adapter_config_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/guardrail/log_adapter_config_param.py
@@ -22,6 +22,10 @@ from typing_extensions import TypedDict
 __all__ = ["LogAdapterConfigParam"]
 
 
-class LogAdapterConfigParam(TypedDict, total=False, extra_items=object):  # type: ignore[call-arg]
+class LogAdapterConfigParam(  # type: ignore[call-arg]
+    TypedDict,
+    total=False,
+    extra_items=object,  # pyright: ignore[reportGeneralTypeIssues]
+):
     name: str
     """The name of the adapter."""

--- a/sdk/python/nemo-platform/src/nemo_platform/types/guardrail/model_parameters_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/guardrail/model_parameters_param.py
@@ -23,7 +23,11 @@ from typing_extensions import TypedDict
 __all__ = ["ModelParametersParam"]
 
 
-class ModelParametersParam(TypedDict, total=False, extra_items=object):  # type: ignore[call-arg]
+class ModelParametersParam(  # type: ignore[call-arg]
+    TypedDict,
+    total=False,
+    extra_items=object,  # pyright: ignore[reportGeneralTypeIssues]
+):
     """Parameters for configuring how to interact with a model in a guardrails config."""
 
     base_url: str

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/ingest/captured_chat_completions_request_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/ingest/captured_chat_completions_request_param.py
@@ -25,7 +25,11 @@ from .captured_chat_message_param import CapturedChatMessageParam
 __all__ = ["CapturedChatCompletionsRequestParam"]
 
 
-class CapturedChatCompletionsRequestParam(TypedDict, total=False, extra_items=object):  # type: ignore[call-arg]
+class CapturedChatCompletionsRequestParam(  # type: ignore[call-arg]
+    TypedDict,
+    total=False,
+    extra_items=object,  # pyright: ignore[reportGeneralTypeIssues]
+):
     """Flexible captured chat-completions request."""
 
     messages: Required[Iterable[CapturedChatMessageParam]]

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/ingest/captured_chat_completions_response_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/ingest/captured_chat_completions_response_param.py
@@ -23,7 +23,11 @@ from typing_extensions import TypedDict
 __all__ = ["CapturedChatCompletionsResponseParam"]
 
 
-class CapturedChatCompletionsResponseParam(TypedDict, total=False, extra_items=object):  # type: ignore[call-arg]
+class CapturedChatCompletionsResponseParam(  # type: ignore[call-arg]
+    TypedDict,
+    total=False,
+    extra_items=object,  # pyright: ignore[reportGeneralTypeIssues]
+):
     """Flexible captured chat-completions response."""
 
     choices: Iterable[Dict[str, object]]

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/ingest/captured_chat_message_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/ingest/captured_chat_message_param.py
@@ -24,7 +24,11 @@ from .chat_message_role import ChatMessageRole
 __all__ = ["CapturedChatMessageParam"]
 
 
-class CapturedChatMessageParam(TypedDict, total=False, extra_items=object):  # type: ignore[call-arg]
+class CapturedChatMessageParam(  # type: ignore[call-arg]
+    TypedDict,
+    total=False,
+    extra_items=object,  # pyright: ignore[reportGeneralTypeIssues]
+):
     """
     A flexible message model that requires a valid role field but allows provider-specific fields.
     """

--- a/sdk/python/nemo-platform/src/nemo_platform/types/shared_params/inference_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/shared_params/inference_params.py
@@ -24,7 +24,11 @@ from ..._types import SequenceNotStr
 __all__ = ["InferenceParams"]
 
 
-class InferenceParams(TypedDict, total=False, extra_items=object):  # type: ignore[call-arg]
+class InferenceParams(  # type: ignore[call-arg]
+    TypedDict,
+    total=False,
+    extra_items=object,  # pyright: ignore[reportGeneralTypeIssues]
+):
     """Parameters for model inference.
 
     Extra fields can be supplied for additional options applied to the inference request directly. Fields not supported by the model may cause inference errors during evaluation.

--- a/sdk/python/nemo-platform/tests/api_resources/test_experiments.py
+++ b/sdk/python/nemo-platform/tests/api_resources/test_experiments.py
@@ -59,7 +59,6 @@ class TestExperiments:
             description="description",
             metadata={"foo": "bar"},
             source_link="https://example.com",
-            summary="summary",
         )
         assert_matches_type(ExperimentResponse, experiment, path=["response"])
 
@@ -183,7 +182,6 @@ class TestExperiments:
             description="description",
             metadata={"foo": "bar"},
             source_link="https://example.com",
-            summary="summary",
         )
         assert_matches_type(ExperimentResponse, experiment, path=["response"])
 
@@ -497,7 +495,6 @@ class TestAsyncExperiments:
             description="description",
             metadata={"foo": "bar"},
             source_link="https://example.com",
-            summary="summary",
         )
         assert_matches_type(ExperimentResponse, experiment, path=["response"])
 
@@ -621,7 +618,6 @@ class TestAsyncExperiments:
             description="description",
             metadata={"foo": "bar"},
             source_link="https://example.com",
-            summary="summary",
         )
         assert_matches_type(ExperimentResponse, experiment, path=["response"])
 

--- a/services/intake/scripts/spans/seed_experiments_demo.py
+++ b/services/intake/scripts/spans/seed_experiments_demo.py
@@ -57,7 +57,6 @@ DEFAULT_WORKSPACE = "default"
 class ExperimentSpec:
     name: str
     description: str
-    summary: str | None = None
     agent_name: str = "sample-agent"
     agent_version: str = "1.0.0"
     # Optional: sessions cycle through these instead of the scalar above, so a single
@@ -99,7 +98,6 @@ DEMO_GROUPS: list[GroupSpec] = [
             ExperimentSpec(
                 name="reranker-main-baseline",
                 description="Pre-reranker baseline on the production prompt.",
-                summary="Baseline. Solid grounding but answers are verbose.",
                 agent_name="codex-cli",
                 agent_version="1.2.3",
                 model_name="openai/gpt-4o-mini",
@@ -126,7 +124,6 @@ DEMO_GROUPS: list[GroupSpec] = [
             ExperimentSpec(
                 name="reranker-tightened-prompt",
                 description="Cross-encoder reranker + tightened system prompt.",
-                summary="Best so far. Refusal rate down, citations up.",
                 agent_name="codex-cli",
                 agent_version="1.2.3",
                 model_name="openai/gpt-4o-mini",
@@ -153,7 +150,6 @@ DEMO_GROUPS: list[GroupSpec] = [
             ExperimentSpec(
                 name="reranker-no-reranker",
                 description="Ablation: prompt change without the reranker.",
-                summary="Prompt change helps but the reranker is doing real work.",
                 agent_name="codex-cli",
                 agent_version="1.2.3",
                 model_name="openai/gpt-4o-mini",
@@ -190,7 +186,6 @@ DEMO_GROUPS: list[GroupSpec] = [
             ExperimentSpec(
                 name="tb2-claude-code-opus",
                 description="claude-code @ 0.125 with opus.",
-                summary="Strongest accuracy, highest cost.",
                 agent_name="claude-code",
                 agent_version="0.125.0",
                 model_name="anthropic/claude-opus-4-7",
@@ -252,7 +247,6 @@ DEMO_GROUPS: list[GroupSpec] = [
             ExperimentSpec(
                 name="claude-code-on-support",
                 description="claude-code on customer-support v2.",
-                summary="claude-code dominates short-horizon support flows.",
                 agent_name="claude-code",
                 agent_version="0.125.0",
                 model_name="anthropic/claude-opus-4-7",
@@ -444,8 +438,6 @@ def _experiment_body(spec: ExperimentSpec, group_id: str) -> dict[str, Any]:
             **spec.metadata,
         },
     }
-    if spec.summary:
-        body["summary"] = spec.summary
     if spec.source_link:
         body["source_link"] = spec.source_link
     return body

--- a/services/intake/src/nmp/intake/api/v2/experiments/endpoints.py
+++ b/services/intake/src/nmp/intake/api/v2/experiments/endpoints.py
@@ -319,7 +319,6 @@ async def create_experiment(
         source_link=body.source_link,
         metadata=body.metadata,
         description=body.description,
-        summary=body.summary,
     )
     try:
         created = await entity_client.create(entity)
@@ -454,7 +453,7 @@ async def get_experiment(
 
 # Identity and the dataset it was run against are fixed for the life of an
 # Experiment (see the ingest invariants); changing them means it's a different
-# Experiment. PUT may only edit group membership, source link, summary, description, metadata.
+# Experiment. PUT may only edit group membership, source link, description, metadata.
 _IMMUTABLE_EXPERIMENT_FIELDS = ("name", "dataset_name", "dataset_version")
 
 
@@ -499,7 +498,6 @@ async def update_experiment(
     existing.source_link = body.source_link
     existing.metadata = body.metadata
     existing.description = body.description
-    existing.summary = body.summary
     updated = await entity_client.update(existing)
     response = ExperimentResponse.from_entity(updated)
     await _hydrate_rollups(workspace=workspace, responses=[response], rollup_repository=rollup_repository)

--- a/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
+++ b/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
@@ -42,7 +42,6 @@ class ExperimentRequest(BaseModel):
     source_link: AnyUrl | None = Field(default=None, description="Optional URL for the source experiment.")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Free-form producer metadata.")
     description: str | None = Field(default=None, description="Human-readable description.")
-    summary: str | None = Field(default=None, description="Human-authored summary of results.")
 
 
 class ExperimentGroupResponse(BaseModel):
@@ -97,7 +96,6 @@ class ExperimentResponse(BaseModel):
     source_link: AnyUrl | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
     description: str | None = None
-    summary: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
     pinned_at: datetime | None = Field(
@@ -145,7 +143,6 @@ class ExperimentResponse(BaseModel):
             source_link=entity.source_link,
             metadata=entity.metadata,
             description=entity.description,
-            summary=entity.summary,
             created_at=entity.created_at,
             updated_at=entity.updated_at,
             pinned_at=entity.pinned_at,

--- a/services/intake/src/nmp/intake/entities/experiments.py
+++ b/services/intake/src/nmp/intake/entities/experiments.py
@@ -60,7 +60,6 @@ class Experiment(EntityBase):
     )
 
     description: str | None = Field(default=None, description="Human-readable description of the experiment.")
-    summary: str | None = Field(default=None, description="Human-authored summary of results.")
 
     is_deleted: bool = Field(
         default=False,

--- a/services/intake/tests/integration/test_experiments_crud.py
+++ b/services/intake/tests/integration/test_experiments_crud.py
@@ -80,12 +80,12 @@ def test_experiment_update_moves_between_groups_and_edits(client: TestClient) ->
     group_b = client.post(GROUPS, json={"name": "grp-b"}).json()
     client.post(EXPERIMENTS, json=_experiment_body(name="exp-a", experiment_group_id=group_a["id"]))
 
-    # Move the experiment from group_a to group_b and edit its summary.
-    body = _experiment_body(name="exp-a", experiment_group_id=group_b["id"], summary="looks good")
+    # Move the experiment from group_a to group_b and edit its description.
+    body = _experiment_body(name="exp-a", experiment_group_id=group_b["id"], description="looks good")
     updated = client.put(f"{EXPERIMENTS}/exp-a", json=body)
     assert updated.status_code == 200, updated.text
     assert updated.json()["experiment_group_id"] == group_b["id"]
-    assert updated.json()["summary"] == "looks good"
+    assert updated.json()["description"] == "looks good"
 
 
 def test_experiment_update_rejects_immutable_change(client: TestClient) -> None:

--- a/web/packages/sdk/generated/agents/schema/DeploymentLogsResponse.ts
+++ b/web/packages/sdk/generated/agents/schema/DeploymentLogsResponse.ts
@@ -6,7 +6,7 @@
  * Do not edit manually.
  * agents (plugin)
  */
-import type { LogLine } from './LogLine';
+import type { LogLine } from './LogLine.ts';
 
 /**
  * Response body for ``GET /deployments/{name}/logs``.

--- a/web/packages/sdk/generated/agents/schema/DeploymentLogsResponse.ts
+++ b/web/packages/sdk/generated/agents/schema/DeploymentLogsResponse.ts
@@ -6,7 +6,7 @@
  * Do not edit manually.
  * agents (plugin)
  */
-import type { LogLine } from './LogLine.ts';
+import type { LogLine } from './LogLine';
 
 /**
  * Response body for ``GET /deployments/{name}/logs``.

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -166,16 +166,16 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
         meta: { title: false },
         size: 300,
         cell: ({ row }) => {
-          const { name, summary } = row.original;
-          if (!summary) return <Text>{name}</Text>;
+          const { name, description } = row.original;
+          if (!description) return <Text>{name}</Text>;
           return (
             <Tooltip
               slotContent={
                 <div className="flex flex-col gap-1">
                   <Text kind="label/regular/sm" className="text-secondary">
-                    Summary
+                    Description
                   </Text>
-                  <Text kind="body/regular/sm">{summary}</Text>
+                  <Text kind="body/regular/sm">{description}</Text>
                 </div>
               }
               className={tooltipClassName}

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -35,7 +35,11 @@ export const ExperimentDetailRoute: FC = () => {
   return (
     <AccessibleTitle title={experimentName}>
       <Stack className="h-full overflow-auto" gap="density-2xl" padding="density-2xl">
-        <PageHeader className="p-0" slotHeading={experimentName} />
+        <PageHeader
+          className="p-0"
+          slotHeading={experimentName}
+          slotDescription={experiment?.description || undefined}
+        />
         <ExperimentDetailMetrics experimentName={experimentName} />
         <div className="flex flex-col gap-4 border-t border-base pt-4">
           <div className="flex items-center gap-3">


### PR DESCRIPTION
We had both `description` and `summary` fields on the Experiment entity. This was a redundant oversight. Reducing to just `description`. Summary was previously surfaced in the UI (description was not), swapped this out to surface description in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experiment details and lists now show a **description** field instead of **summary** (including tooltips and page header context when available).

* **Bug Fixes**
  * Updated experiment create/edit flows to persist and return the correct text field consistently.
  * Demo experiment data and related screens now use the same description-based wording.
  * Experiment update behavior and API responses were aligned so the displayed text matches what was entered.
  * Updated integration coverage to validate **description** updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->