### PR TITLE
feat(nemo-evaluator): add REST endpoints for metric catalog, schema, and sync evaluate

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
@@ -180,8 +180,7 @@ class BaseRAGASMetric(MetricBase):
                 "api_key": initial_api_key,
             }
             if judge_model.default_headers:
-                # Runtime headers (e.g. caller identity forwarded by the platform) must reach
-                # the judge client, or in-process evaluation silently drops the caller's identity.
+                # Forward runtime headers (e.g. caller identity) or the judge call drops them.
                 self._llm_model["default_headers"] = dict(judge_model.default_headers)
 
         embeddings_model = getattr(self, "embeddings_model", None)
@@ -305,9 +304,8 @@ class BaseRAGASMetric(MetricBase):
         chat_params: dict[str, Any] = {}
         if self._inference_params:
             chat_params.update(self._inference_params)
-        # Transport and auth (base_url, api_key, default_headers) come from the resolved model
-        # and must never be overridable by caller-supplied inference params — otherwise a
-        # request could redirect the judge call (SSRF) or replace forwarded caller identity.
+        # Applied last: transport/auth from the resolved model must win over inference params,
+        # else a request could redirect the judge call (SSRF) or replace the forwarded identity.
         chat_params.update(self._llm_model)
 
         # Filter out None values

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
@@ -302,9 +302,13 @@ class BaseRAGASMetric(MetricBase):
         if not self._llm_model:
             return None
 
-        chat_params: dict[str, Any] = {**self._llm_model}
+        chat_params: dict[str, Any] = {}
         if self._inference_params:
             chat_params.update(self._inference_params)
+        # Transport and auth (base_url, api_key, default_headers) come from the resolved model
+        # and must never be overridable by caller-supplied inference params — otherwise a
+        # request could redirect the judge call (SSRF) or replace forwarded caller identity.
+        chat_params.update(self._llm_model)
 
         # Filter out None values
         chat_params = {k: v for k, v in chat_params.items() if v is not None}

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/ragas/base.py
@@ -179,6 +179,10 @@ class BaseRAGASMetric(MetricBase):
                 "base_url": judge_model.url.replace("/completions", "").replace("/chat", ""),
                 "api_key": initial_api_key,
             }
+            if judge_model.default_headers:
+                # Runtime headers (e.g. caller identity forwarded by the platform) must reach
+                # the judge client, or in-process evaluation silently drops the caller's identity.
+                self._llm_model["default_headers"] = dict(judge_model.default_headers)
 
         embeddings_model = getattr(self, "embeddings_model", None)
         if isinstance(embeddings_model, Model):
@@ -198,6 +202,8 @@ class BaseRAGASMetric(MetricBase):
                 "api_key": initial_api_key,
                 "truncate": self._inference_params.get("truncate", "NONE"),
             }
+            if embeddings_model.default_headers:
+                self._embed_params["default_headers"] = dict(embeddings_model.default_headers)
 
     async def resolve_models(self, model_resolver: ModelResolver) -> None:
         """Resolve RAGAS model references before the metric is used for evaluation."""

--- a/packages/nemo_evaluator_sdk/tests/metrics/ragas/test_ragas_headers.py
+++ b/packages/nemo_evaluator_sdk/tests/metrics/ragas/test_ragas_headers.py
@@ -10,8 +10,10 @@ models; dropping them here silently strips the caller's identity from judge/embe
 from typing import Any, cast
 
 import httpx
-from nemo_evaluator_sdk.metrics.ragas import ResponseRelevancyMetric
+import pytest
+from nemo_evaluator_sdk.metrics.ragas import AnswerAccuracyMetric, ResponseRelevancyMetric
 from nemo_evaluator_sdk.values import Model
+from nemo_evaluator_sdk.values.params import InferenceParams
 
 CALLER_HEADERS = {"X-NMP-Principal-Id": "user@example.com"}
 
@@ -52,3 +54,40 @@ def test_default_headers_reach_judge_and_embeddings_clients() -> None:
     embeddings = metric._get_embeddings_client()
     assert embeddings is not None
     assert cast(Any, embeddings).embeddings.default_headers == CALLER_HEADERS
+
+
+def test_inference_extras_cannot_override_resolved_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A caller-supplied inference payload must not be able to redirect the judge call (SSRF) or
+    # replace the forwarded caller identity: transport/auth comes from the resolved model.
+    captured: dict[str, Any] = {}
+
+    class _FakeChatOpenAI:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("nemo_evaluator_sdk.metrics.ragas.base._get_langchain_chat_openai", lambda: _FakeChatOpenAI)
+    monkeypatch.setattr(
+        "nemo_evaluator_sdk.metrics.ragas.base.get_langchain_llm_wrapper_class", lambda: lambda judge: judge
+    )
+
+    metric = AnswerAccuracyMetric(
+        judge_model=Model(
+            name="gpt-4",
+            url="https://igw.local/v1/chat/completions",
+            default_headers=CALLER_HEADERS,
+        ),
+        inference=InferenceParams.model_validate(
+            {
+                "temperature": 0.5,
+                "base_url": "http://attacker.test/v1",
+                "default_headers": {"X-NMP-Principal-Id": "attacker"},
+            }
+        ),
+    )
+
+    metric._get_llm_judge(httpx.AsyncClient())
+
+    assert captured["base_url"] == "https://igw.local/v1"
+    assert captured["default_headers"] == CALLER_HEADERS
+    # Legitimate generation params still pass through.
+    assert captured["temperature"] == 0.5

--- a/packages/nemo_evaluator_sdk/tests/metrics/ragas/test_ragas_headers.py
+++ b/packages/nemo_evaluator_sdk/tests/metrics/ragas/test_ragas_headers.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""RAGAS metrics must preserve runtime default headers when building provider clients.
+
+The platform forwards caller identity by stamping ``Model.default_headers`` onto resolved
+models; dropping them here silently strips the caller's identity from judge/embeddings calls.
+"""
+
+from typing import Any, cast
+
+import httpx
+from nemo_evaluator_sdk.metrics.ragas import ResponseRelevancyMetric
+from nemo_evaluator_sdk.values import Model
+
+CALLER_HEADERS = {"X-NMP-Principal-Id": "user@example.com"}
+
+
+def _metric_with_headers() -> ResponseRelevancyMetric:
+    return ResponseRelevancyMetric(
+        judge_model=Model(
+            name="gpt-4",
+            url="https://model.com/v1/chat/completions",
+            default_headers=CALLER_HEADERS,
+        ),
+        embeddings_model=Model(
+            name="embed",
+            url="https://model.com/v1/embeddings",
+            default_headers=CALLER_HEADERS,
+        ),
+    )
+
+
+def test_default_headers_reach_client_configuration() -> None:
+    metric = _metric_with_headers()
+
+    assert metric._llm_model is not None
+    assert metric._llm_model["default_headers"] == CALLER_HEADERS
+    assert metric._embed_params is not None
+    assert metric._embed_params["default_headers"] == CALLER_HEADERS
+
+
+def test_default_headers_reach_judge_and_embeddings_clients() -> None:
+    metric = _metric_with_headers()
+
+    llm_judge = metric._get_llm_judge(httpx.AsyncClient())
+    assert llm_judge is not None
+    # The wrapped client is typed as a generic BaseLanguageModel; the concrete ChatOpenAI
+    # carries default_headers.
+    assert cast(Any, llm_judge).langchain_llm.default_headers == CALLER_HEADERS
+
+    embeddings = metric._get_embeddings_client()
+    assert embeddings is not None
+    assert cast(Any, embeddings).embeddings.default_headers == CALLER_HEADERS

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -45,14 +45,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /apis/evaluator/v2/evaluate/schema:
+  /apis/evaluator/v2/evaluate/jobs/schema:
     get:
       tags:
       - Evaluator Plugin Catalog Routes
-      summary: Get Evaluate Input Schema
-      description: Return the JSON schema for the evaluate input spec (the `explain`
+      summary: Get Evaluate Job Input Schema
+      description: Return the JSON schema for the evaluate job input spec (the `explain`
         payload).
-      operationId: get_evaluate_schema_apis_evaluator_v2_evaluate_schema_get
+      operationId: get_evaluate_job_schema_apis_evaluator_v2_evaluate_jobs_schema_get
       responses:
         '200':
           description: JSON schema for the evaluate job input spec
@@ -61,8 +61,26 @@ paths:
               schema:
                 additionalProperties: true
                 type: object
-                title: Response Get Evaluate Schema Apis Evaluator V2 Evaluate Schema
-                  Get
+                title: Response Get Evaluate Job Schema Apis Evaluator V2 Evaluate
+                  Jobs Schema Get
+  /apis/evaluator/v2/evaluate/schema:
+    get:
+      tags:
+      - Evaluator Plugin Catalog Routes
+      summary: Get Synchronous Evaluate Request Schema
+      description: Return the JSON schema for the synchronous `POST .../evaluate`
+        request body.
+      operationId: get_evaluate_sync_schema_apis_evaluator_v2_evaluate_schema_get
+      responses:
+        '200':
+          description: JSON schema for the synchronous evaluate request body
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Get Evaluate Sync Schema Apis Evaluator V2 Evaluate
+                  Schema Get
   /apis/evaluator/v2/metric-types:
     get:
       tags:
@@ -77,14 +95,7 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties:
-                  items:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  type: array
-                type: object
-                title: Response List Metric Types Apis Evaluator V2 Metric Types Get
+                $ref: '#/components/schemas/MetricTypeList'
   /apis/evaluator/v2/metric-types/{metric_type}:
     get:
       tags:
@@ -3049,6 +3060,7 @@ components:
           items:
             $ref: '#/components/schemas/MetricInline'
           type: array
+          maxItems: 10
           minItems: 1
           title: Metrics
           description: Inline metrics to evaluate.
@@ -3698,6 +3710,35 @@ components:
       - -updated_at
       title: MetricSort
       description: Sort fields for metric queries.
+    MetricTypeEntry:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Metric type name, as accepted in metric definitions.
+        description:
+          type: string
+          title: Description
+          description: Human-readable description of the metric type.
+      type: object
+      required:
+      - name
+      - description
+      title: MetricTypeEntry
+      description: One built-in metric type in the catalog.
+    MetricTypeList:
+      properties:
+        metric_types:
+          items:
+            $ref: '#/components/schemas/MetricTypeEntry'
+          type: array
+          title: Metric Types
+          description: Available built-in metric types.
+      type: object
+      required:
+      - metric_types
+      title: MetricTypeList
+      description: Catalog of built-in metric types.
     MetricsPage:
       properties:
         data:

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -795,10 +795,22 @@ paths:
                   Post
         '422':
           description: Invalid request or unsupported metric/model
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateSyncError'
         '503':
           description: Synchronous evaluation capacity is full
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateSyncError'
         '504':
           description: Evaluation exceeded the synchronous time limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateSyncError'
   /apis/evaluator/v2/workspaces/{workspace}/evaluate/jobs:
     post:
       tags:
@@ -3054,6 +3066,17 @@ components:
       title: EvaluateSpec
       description: Canonical SDK evaluation spec with platform model and metric references
         resolved.
+    EvaluateSyncError:
+      properties:
+        detail:
+          type: string
+          title: Detail
+          description: Human-readable, actionable description of why the request failed.
+      type: object
+      required:
+      - detail
+      title: EvaluateSyncError
+      description: Error body for the synchronous evaluate route (422/503/504).
     EvaluateSyncRequest:
       properties:
         metrics:

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -45,6 +45,78 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/evaluate/schema:
+    get:
+      tags:
+      - Evaluator Plugin Catalog Routes
+      summary: Get Evaluate Input Schema
+      description: Return the JSON schema for the evaluate input spec (the `explain`
+        payload).
+      operationId: get_evaluate_schema_apis_evaluator_v2_evaluate_schema_get
+      responses:
+        '200':
+          description: JSON schema for the evaluate job input spec
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Get Evaluate Schema Apis Evaluator V2 Evaluate Schema
+                  Get
+  /apis/evaluator/v2/metric-types:
+    get:
+      tags:
+      - Evaluator Plugin Catalog Routes
+      summary: List Metric Types
+      description: List the built-in evaluator metric types (the same catalog the
+        CLI prints).
+      operationId: list_metric_types_apis_evaluator_v2_metric_types_get
+      responses:
+        '200':
+          description: Available built-in metric types and their descriptions
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  items:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  type: array
+                type: object
+                title: Response List Metric Types Apis Evaluator V2 Metric Types Get
+  /apis/evaluator/v2/metric-types/{metric_type}:
+    get:
+      tags:
+      - Evaluator Plugin Catalog Routes
+      summary: Get Metric Type Schema
+      description: Return the JSON schema for one built-in metric type.
+      operationId: get_metric_type_schema_apis_evaluator_v2_metric_types__metric_type__get
+      parameters:
+      - name: metric_type
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Metric Type
+      responses:
+        '200':
+          description: JSON schema for a single metric type
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Metric Type Schema Apis Evaluator V2 Metric Types  Metric
+                  Type  Get
+        '404':
+          description: Unknown metric type
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/evaluator/v2/workspaces/{workspace}/agent-eval-results:
     get:
       tags:
@@ -679,6 +751,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/evaluator/v2/workspaces/{workspace}/evaluate:
+    post:
+      tags:
+      - Evaluator Plugin Synchronous Evaluate Route
+      summary: Evaluate Synchronously
+      description: Run a bounded offline evaluation in-process and return the result.
+      operationId: evaluate_sync_apis_evaluator_v2_workspaces__workspace__evaluate_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvaluateSyncRequest'
+      responses:
+        '200':
+          description: The inline evaluation result (aggregate and row scores)
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/EvaluationResult'
+                - $ref: '#/components/schemas/BenchmarkEvaluationResult'
+                title: Response Evaluate Sync Apis Evaluator V2 Workspaces  Workspace  Evaluate
+                  Post
+        '422':
+          description: Invalid request or unsupported metric/model
+        '503':
+          description: Synchronous evaluation capacity is full
+        '504':
+          description: Evaluation exceeded the synchronous time limit
   /apis/evaluator/v2/workspaces/{workspace}/evaluate/jobs:
     post:
       tags:
@@ -2385,6 +2494,27 @@ components:
       - scores
       title: AggregatedMetricResult
       description: Result of aggregating metric scores with full statistics.
+    BenchmarkEvaluationResult:
+      properties:
+        row_scores:
+          items:
+            $ref: '#/components/schemas/RowScore'
+          type: array
+          title: Row Scores
+        aggregate_scores:
+          $ref: '#/components/schemas/AggregatedMetricResult'
+        per_metric:
+          additionalProperties:
+            $ref: '#/components/schemas/EvaluationResult'
+          type: object
+          title: Per Metric
+      type: object
+      required:
+      - row_scores
+      - aggregate_scores
+      - per_metric
+      title: BenchmarkEvaluationResult
+      description: Unified benchmark evaluation result.
     BundledMetricOutputSpec:
       properties:
         name:
@@ -2913,6 +3043,65 @@ components:
       title: EvaluateSpec
       description: Canonical SDK evaluation spec with platform model and metric references
         resolved.
+    EvaluateSyncRequest:
+      properties:
+        metrics:
+          items:
+            $ref: '#/components/schemas/MetricInline'
+          type: array
+          minItems: 1
+          title: Metrics
+          description: Inline metrics to evaluate.
+        dataset:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          maxItems: 10
+          minItems: 1
+          title: Dataset
+          description: Inline dataset rows to evaluate.
+        params:
+          allOf:
+          - $ref: '#/components/schemas/RunConfig'
+          description: Optional offline execution parameters.
+        field_mapping:
+          allOf:
+          - $ref: '#/components/schemas/FieldMapping'
+          description: Optional mapping from canonical evaluator fields to dataset
+            columns.
+      additionalProperties: false
+      type: object
+      required:
+      - metrics
+      - dataset
+      title: EvaluateSyncRequest
+      description: 'Bounded offline evaluation request: inline metrics over inline
+        rows, models by ModelRef.
+
+
+        See the handler for the inputs it rejects (online targets, inline models,
+        secrets, cloudpickle,
+
+        network metrics).'
+    EvaluationResult:
+      properties:
+        row_scores:
+          items:
+            $ref: '#/components/schemas/RowScore'
+          type: array
+          title: Row Scores
+          description: Row-level scores.
+        aggregate_scores:
+          allOf:
+          - $ref: '#/components/schemas/AggregatedMetricResult'
+          description: Aggregate score statistics.
+      type: object
+      required:
+      - row_scores
+      - aggregate_scores
+      title: EvaluationResult
+      description: Result object returned by SDK offline evaluation.
     EvidenceDescriptor:
       anyOf:
       - required:
@@ -3478,6 +3667,20 @@ components:
       type: object
       title: MetricMetadata
       description: User-facing metadata captured with a bundled metric.
+    MetricOutput:
+      properties:
+        name:
+          type: string
+          title: Name
+        value:
+          title: Value
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      - value
+      title: MetricOutput
+      description: One named value emitted by a metric.
     MetricRef:
       type: string
       pattern: ^[\w\-.]+(/[\w\-.]+)?$
@@ -4088,6 +4291,53 @@ components:
       - -updated_at
       title: ResultSort
       description: Sort fields for result queries (``-`` prefix sorts descending).
+    RowScore:
+      properties:
+        row_index:
+          title: Row Index
+          description: Stable row position used for result alignment.
+          type: integer
+          minimum: 0.0
+        item:
+          additionalProperties: true
+          type: object
+          title: Item
+          description: Input item metadata for the evaluated row.
+        sample:
+          additionalProperties: true
+          type: object
+          title: Sample
+          description: Sample output payload for the evaluated row.
+        metrics:
+          additionalProperties:
+            items:
+              $ref: '#/components/schemas/MetricOutput'
+            type: array
+          type: object
+          title: Metrics
+          description: Metric-level row outputs by metric key.
+        requests:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Requests
+          description: Request details captured during evaluation.
+        metric_errors:
+          title: Metric Errors
+          description: Full row-level error text keyed by metric for summary rendering.
+          additionalProperties:
+            type: string
+          type: object
+      additionalProperties: true
+      type: object
+      required:
+      - item
+      - sample
+      - metrics
+      - requests
+      title: RowScore
+      description: Normalized row-level score payload for metric/benchmark job results.
     RubricScoreStat:
       properties:
         label:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/catalog.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/catalog.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only metric-type catalog and evaluate-schema discovery routes (mirror the CLI)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, status
+from nemo_evaluator.authz import scope
+from nemo_evaluator.jobs.evaluate import EvaluateInputSpec
+from nemo_evaluator.metric_catalog import metric_type_entries, metric_type_schema
+from nemo_platform_plugin.authz import CallerKind, path_rule
+
+router = APIRouter()
+
+
+@router.get(
+    "/metric-types",
+    summary="List Metric Types",
+    response_description="Available built-in metric types and their descriptions",
+    status_code=status.HTTP_200_OK,
+)
+@scope.read
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
+async def list_metric_types() -> dict[str, list[dict[str, str]]]:
+    """List the built-in evaluator metric types (the same catalog the CLI prints)."""
+    return {"metric_types": metric_type_entries()}
+
+
+@router.get(
+    "/metric-types/{metric_type}",
+    summary="Get Metric Type Schema",
+    response_description="JSON schema for a single metric type",
+    status_code=status.HTTP_200_OK,
+    responses={status.HTTP_404_NOT_FOUND: {"description": "Unknown metric type"}},
+)
+@scope.read
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
+async def get_metric_type_schema(metric_type: str) -> dict[str, Any]:
+    """Return the JSON schema for one built-in metric type."""
+    schema = metric_type_schema(metric_type)
+    if schema is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown metric type: {metric_type}",
+        )
+    return schema
+
+
+@router.get(
+    "/evaluate/schema",
+    summary="Get Evaluate Input Schema",
+    response_description="JSON schema for the evaluate job input spec",
+    status_code=status.HTTP_200_OK,
+)
+@scope.read
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
+async def get_evaluate_schema() -> dict[str, Any]:
+    """Return the JSON schema for the evaluate input spec (the `explain` payload)."""
+    return EvaluateInputSpec.model_json_schema()

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/catalog.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/catalog.py
@@ -8,12 +8,27 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
+from nemo_evaluator.api.v2.evaluate import EvaluateSyncRequest
 from nemo_evaluator.authz import scope
 from nemo_evaluator.jobs.evaluate import EvaluateInputSpec
 from nemo_evaluator.metric_catalog import metric_type_entries, metric_type_schema
 from nemo_platform_plugin.authz import CallerKind, path_rule
+from pydantic import BaseModel, Field
 
 router = APIRouter()
+
+
+class MetricTypeEntry(BaseModel):
+    """One built-in metric type in the catalog."""
+
+    name: str = Field(description="Metric type name, as accepted in metric definitions.")
+    description: str = Field(description="Human-readable description of the metric type.")
+
+
+class MetricTypeList(BaseModel):
+    """Catalog of built-in metric types."""
+
+    metric_types: list[MetricTypeEntry] = Field(description="Available built-in metric types.")
 
 
 @router.get(
@@ -24,9 +39,9 @@ router = APIRouter()
 )
 @scope.read
 @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
-async def list_metric_types() -> dict[str, list[dict[str, str]]]:
+async def list_metric_types() -> MetricTypeList:
     """List the built-in evaluator metric types (the same catalog the CLI prints)."""
-    return {"metric_types": metric_type_entries()}
+    return MetricTypeList(metric_types=[MetricTypeEntry(**entry) for entry in metric_type_entries()])
 
 
 @router.get(
@@ -51,12 +66,25 @@ async def get_metric_type_schema(metric_type: str) -> dict[str, Any]:
 
 @router.get(
     "/evaluate/schema",
-    summary="Get Evaluate Input Schema",
+    summary="Get Synchronous Evaluate Request Schema",
+    response_description="JSON schema for the synchronous evaluate request body",
+    status_code=status.HTTP_200_OK,
+)
+@scope.read
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
+async def get_evaluate_sync_schema() -> dict[str, Any]:
+    """Return the JSON schema for the synchronous `POST .../evaluate` request body."""
+    return EvaluateSyncRequest.model_json_schema()
+
+
+@router.get(
+    "/evaluate/jobs/schema",
+    summary="Get Evaluate Job Input Schema",
     response_description="JSON schema for the evaluate job input spec",
     status_code=status.HTTP_200_OK,
 )
 @scope.read
 @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
-async def get_evaluate_schema() -> dict[str, Any]:
-    """Return the JSON schema for the evaluate input spec (the `explain` payload)."""
+async def get_evaluate_job_schema() -> dict[str, Any]:
+    """Return the JSON schema for the evaluate job input spec (the `explain` payload)."""
     return EvaluateInputSpec.model_json_schema()

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/evaluate.py
@@ -10,29 +10,35 @@ models by platform ModelRef only. Heavier or untrusted work goes through `/evalu
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import functools
 import logging
-from concurrent.futures import ThreadPoolExecutor
-from typing import Annotated, Any
+import threading
+from typing import Annotated, Any, Callable, cast
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from nemo_evaluator.api.schemas import MetricInline
 from nemo_evaluator.authz import scope
-from nemo_evaluator.jobs.evaluate import run_evaluation, to_runtime_bundle
+from nemo_evaluator.jobs.evaluate import EvaluationArtifactResult, run_evaluation, to_runtime_bundle
 from nemo_evaluator.resolvers import PlatformModelResolver
 from nemo_evaluator.shared.metric_bundles.bundles import unbundle_metric
+from nemo_evaluator_sdk import inference as sdk_inference
 from nemo_evaluator_sdk.enums import MetricType
 from nemo_evaluator_sdk.execution.config import resolve_params
 from nemo_evaluator_sdk.execution.values import EvaluationError
-from nemo_evaluator_sdk.metrics.protocol import MetricWithModels
+from nemo_evaluator_sdk.inference import InferenceFn
+from nemo_evaluator_sdk.metrics.protocol import Metric, MetricWithModels
+from nemo_evaluator_sdk.metrics.ragas.base import BaseRAGASMetric
 from nemo_evaluator_sdk.values import FieldMapping, Model, RunConfig
 from nemo_evaluator_sdk.values.models import ModelRef
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult
+from nemo_evaluator_sdk.values.params import InferenceParams
 from nemo_evaluator_sdk.values.results import EvaluationResult
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.authz import CallerKind, PermissionSet, path_rule, perm
 from nemo_platform_plugin.dependencies import get_sdk_client
 from nemo_platform_plugin.sdk_provider import get_forwarding_headers
+from openai import AsyncOpenAI
 from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
@@ -45,14 +51,22 @@ class EvaluateSyncPerms(PermissionSet, namespace="evaluator.evaluate"):
 
 
 MAX_SYNC_ROWS = 10
+MAX_SYNC_METRICS = 10
 SYNC_EVALUATE_TIMEOUT_SECONDS = 60.0
 
-# Dedicated bounded pool so a stuck (uncancellable) sync eval can't starve the main request pool.
 _SYNC_EVAL_MAX_WORKERS = 4
-_SYNC_EVAL_EXECUTOR = ThreadPoolExecutor(max_workers=_SYNC_EVAL_MAX_WORKERS, thread_name_prefix="evaluator-sync")
+# A timed-out (detached) worker keeps its slot until its bounded inference calls finish, so
+# retries are capped low to keep worst-case slot occupancy near the request timeout.
+_SYNC_WORKER_MAX_RETRIES = 1
 
-# Metric types that call a user-supplied URL during evaluation (SSRF surface).
+# Metric types that call a user-supplied URL during evaluation (SSRF surface). Belt on top of
+# the inline-payload allow-list below for metric types whose payload is inline but whose
+# runtime behavior is network-bound.
 _NETWORK_BACKED_METRIC_TYPES = frozenset({MetricType.REMOTE.value, MetricType.NEMO_AGENT_TOOLKIT_REMOTE.value})
+
+# In-flight bound for sync evals. Thread-safe: released from the worker future's done callback,
+# which runs on the worker thread — it must not depend on any event loop still being alive.
+_SYNC_SLOTS = threading.BoundedSemaphore(_SYNC_EVAL_MAX_WORKERS)
 
 router = APIRouter()
 
@@ -70,29 +84,87 @@ class _ForwardedHeaderModelResolver:
         return model.with_default_headers(self._headers)
 
 
-class _SlotCounter:
-    """In-flight counter for sync-eval backpressure; mutated only on the event-loop thread."""
-
-    def __init__(self, limit: int) -> None:
-        self._limit = limit
-        self._in_flight = 0
-
-    def try_acquire(self) -> bool:
-        if self._in_flight >= self._limit:
-            return False
-        self._in_flight += 1
+def _has_inline_model(value: object) -> bool:
+    """True if an inline Model (vs a platform ModelRef) appears anywhere in a metric's fields."""
+    if isinstance(value, Model):
         return True
+    if isinstance(value, BaseModel):
+        return any(_has_inline_model(field_value) for field_value in vars(value).values())
+    if isinstance(value, dict):
+        return any(_has_inline_model(item) for item in value.values())
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return any(_has_inline_model(item) for item in value)
+    return False
 
-    def release(self) -> None:
-        self._in_flight = max(0, self._in_flight - 1)
+
+def _bounded_inference_fn(budget_seconds: float) -> InferenceFn:
+    """Inference fn that caps per-request timeout and retries at the sync budget."""
+
+    async def _fn(
+        model: Model,
+        request: dict,
+        max_retries: int | None = None,
+        *,
+        client: AsyncOpenAI | None = None,
+        api_key: str | None = None,
+        default_headers: dict | None = None,
+        timeout: float | None = None,
+    ) -> dict:
+        # Attribute access (not an imported symbol) so injected/patched inference fns still apply.
+        return await sdk_inference.make_inference_request(
+            model,
+            request,
+            min(max_retries if max_retries is not None else _SYNC_WORKER_MAX_RETRIES, _SYNC_WORKER_MAX_RETRIES),
+            client=client,
+            api_key=api_key,
+            default_headers=default_headers,
+            timeout=timeout if timeout is not None else budget_seconds,
+        )
+
+    return _fn
 
 
-_SYNC_SLOTS = _SlotCounter(_SYNC_EVAL_MAX_WORKERS)
+def _bound_worker_inference(metrics: list[Metric], budget_seconds: float) -> None:
+    """Bound each metric's model calls so a detached (timed-out) worker frees its slot quickly.
+
+    Without this, judge calls fall back to client-default timeouts (up to 600s per attempt),
+    letting one slow upstream hold a sync slot far beyond the request timeout.
+    """
+    for metric in metrics:
+        set_inference_fn = getattr(metric, "set_inference_fn", None)
+        if callable(set_inference_fn):
+            set_inference_fn(_bounded_inference_fn(budget_seconds))
+        if isinstance(metric, BaseRAGASMetric):
+            # RAGAS builds its judge client from `inference` extras (ChatOpenAI kwargs);
+            # respect explicit user settings, only fill the gaps. InferenceParams allows
+            # extra fields, so assignment lands in __pydantic_extra__ and survives dumps.
+            inference = getattr(metric, "inference", None)
+            if isinstance(inference, InferenceParams):
+                extras = cast(Any, inference)
+                if getattr(extras, "request_timeout", None) is None:
+                    extras.request_timeout = budget_seconds
+                if getattr(extras, "max_retries", None) is None:
+                    extras.max_retries = _SYNC_WORKER_MAX_RETRIES
 
 
-def _has_inline_model(metric: object) -> bool:
-    """True if any top-level metric field is an inline Model (vs a platform ModelRef)."""
-    return any(isinstance(value, Model) for value in vars(metric).values())
+def _submit_sync_evaluation(run: Callable[[], EvaluationArtifactResult]) -> concurrent.futures.Future:
+    """Run an evaluation on a dedicated daemon thread and return a Future for its result.
+
+    Daemon threads (unlike ThreadPoolExecutor workers) can't block interpreter shutdown if an
+    uncancellable eval is stuck on a network call when the process receives SIGTERM.
+    """
+    future: concurrent.futures.Future = concurrent.futures.Future()
+
+    def _worker() -> None:
+        if not future.set_running_or_notify_cancel():
+            return
+        try:
+            future.set_result(run())
+        except BaseException as exc:  # noqa: BLE001 — the future is the error channel
+            future.set_exception(exc)
+
+    threading.Thread(target=_worker, name="evaluator-sync", daemon=True).start()
+    return future
 
 
 class EvaluateSyncRequest(BaseModel):
@@ -104,7 +176,10 @@ class EvaluateSyncRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    metrics: Annotated[list[MetricInline], Field(min_length=1, description="Inline metrics to evaluate.")]
+    metrics: Annotated[
+        list[MetricInline],
+        Field(min_length=1, max_length=MAX_SYNC_METRICS, description="Inline metrics to evaluate."),
+    ]
     dataset: Annotated[
         list[dict[str, Any]],
         Field(min_length=1, max_length=MAX_SYNC_ROWS, description="Inline dataset rows to evaluate."),
@@ -137,12 +212,14 @@ async def evaluate_sync(
     del workspace  # route is workspace-scoped for authz only
 
     for metric in request.metrics:
-        if metric.payload.kind == "cloudpickle":
+        # Allow-list: only the inline payload kind may execute in the API process, so any
+        # future payload kind fails closed instead of slipping past a cloudpickle deny-check.
+        if metric.payload.kind != "inline":
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=(
-                    "Synchronous evaluation supports inline (built-in) metrics only. "
-                    "Submit cloudpickle metric bundles as a durable job via /evaluate/jobs."
+                    f"Synchronous evaluation supports inline (built-in) metrics only, "
+                    f"not '{metric.payload.kind}' payloads. Submit them as a durable job via /evaluate/jobs."
                 ),
             )
         if metric.metric_type in _NETWORK_BACKED_METRIC_TYPES:
@@ -162,6 +239,8 @@ async def evaluate_sync(
                 ),
             )
 
+    # Validation phase: everything here failed because of the request contents, so 422 carries
+    # the underlying message (model ref not found, malformed metric, bad params, ...).
     try:
         runtime_metrics = [unbundle_metric(to_runtime_bundle(metric)) for metric in request.metrics]
 
@@ -176,6 +255,8 @@ async def evaluate_sync(
                     ),
                 )
 
+        _bound_worker_inference(runtime_metrics, SYNC_EVALUATE_TIMEOUT_SECONDS)
+
         # Resolve refs as the caller (forward request-scoped headers); skip when no metric uses a model.
         metrics_with_models = [m for m in runtime_metrics if isinstance(m, MetricWithModels)]
         if metrics_with_models:
@@ -185,14 +266,22 @@ async def evaluate_sync(
             await asyncio.gather(*(m.resolve_models(resolver) for m in metrics_with_models))
 
         params = resolve_params(request.params, None)
+    except HTTPException:
+        raise
+    except (TypeError, ValueError, EvaluationError) as exc:
+        logger.warning("Synchronous evaluation request was invalid", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Evaluation request was invalid: {exc}",
+        ) from exc
 
-        if not _SYNC_SLOTS.try_acquire():
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Synchronous evaluation capacity is full; retry shortly or submit a durable job via /evaluate/jobs.",
-            )
-        loop = asyncio.get_running_loop()
-        future = _SYNC_EVAL_EXECUTOR.submit(
+    if not _SYNC_SLOTS.acquire(blocking=False):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Synchronous evaluation capacity is full; retry shortly or submit a durable job via /evaluate/jobs.",
+        )
+    try:
+        future = _submit_sync_evaluation(
             functools.partial(
                 run_evaluation,
                 metrics=runtime_metrics,
@@ -203,14 +292,20 @@ async def evaluate_sync(
                 field_mapping=request.field_mapping,
             )
         )
-        # Free the slot only on true completion, so an orphaned (timed-out) run can't oversubscribe.
-        future.add_done_callback(lambda _f: loop.call_soon_threadsafe(_SYNC_SLOTS.release))
-        result = await asyncio.wait_for(asyncio.wrap_future(future), timeout=SYNC_EVALUATE_TIMEOUT_SECONDS)
-    except HTTPException:
+    except BaseException:
+        _SYNC_SLOTS.release()
         raise
-    except asyncio.TimeoutError:
+    # Free the slot only on true completion, so an orphaned (timed-out) run can't oversubscribe.
+    future.add_done_callback(lambda _f: _SYNC_SLOTS.release())
+
+    # asyncio.wait (not wait_for) so a TimeoutError raised inside the worker can't be mistaken
+    # for the sync budget expiring: not-done is the only timeout signal.
+    wrapped = asyncio.wrap_future(future)
+    done, _ = await asyncio.wait({wrapped}, timeout=SYNC_EVALUATE_TIMEOUT_SECONDS)
+    if not done:
         logger.warning(
-            "Synchronous evaluation exceeded %.0fs; worker may still be running.", SYNC_EVALUATE_TIMEOUT_SECONDS
+            "Synchronous evaluation exceeded %.0fs; worker keeps its slot until its bounded inference calls finish.",
+            SYNC_EVALUATE_TIMEOUT_SECONDS,
         )
         raise HTTPException(
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,
@@ -219,14 +314,17 @@ async def evaluate_sync(
                 "Submit as a durable job via /evaluate/jobs instead."
             ),
         )
-    except (TypeError, ValueError, EvaluationError):
-        logger.warning("Synchronous evaluation could not be completed", exc_info=True)
+
+    try:
+        return wrapped.result()
+    except EvaluationError as exc:
+        # Evaluation-level failures (missing dataset columns, judge output mismatch, ...) are
+        # actionable by the caller; internal TypeError/ValueError bugs stay 500s below.
+        logger.warning("Synchronous evaluation failed", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Evaluation request was invalid or could not be completed.",
-        )
+            detail=f"Evaluation failed: {exc}",
+        ) from exc
     except Exception:
         logger.exception("Synchronous evaluation failed")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")
-
-    return result

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/evaluate.py
@@ -55,17 +55,13 @@ MAX_SYNC_METRICS = 10
 SYNC_EVALUATE_TIMEOUT_SECONDS = 60.0
 
 _SYNC_EVAL_MAX_WORKERS = 4
-# A timed-out (detached) worker keeps its slot until its bounded inference calls finish, so
-# retries are capped low to keep worst-case slot occupancy near the request timeout.
+# Capped low so a detached (timed-out) worker's slot occupancy stays near the request timeout.
 _SYNC_WORKER_MAX_RETRIES = 1
 
-# Metric types that call a user-supplied URL during evaluation (SSRF surface). Belt on top of
-# the inline-payload allow-list below for metric types whose payload is inline but whose
-# runtime behavior is network-bound.
+# Metric types that call a user-supplied URL during evaluation (SSRF surface).
 _NETWORK_BACKED_METRIC_TYPES = frozenset({MetricType.REMOTE.value, MetricType.NEMO_AGENT_TOOLKIT_REMOTE.value})
 
-# In-flight bound for sync evals. Thread-safe: released from the worker future's done callback,
-# which runs on the worker thread — it must not depend on any event loop still being alive.
+# Released from the worker's done callback (worker thread), so it can't depend on any event loop.
 _SYNC_SLOTS = threading.BoundedSemaphore(_SYNC_EVAL_MAX_WORKERS)
 
 router = APIRouter()
@@ -110,7 +106,7 @@ def _bounded_inference_fn(budget_seconds: float) -> InferenceFn:
         default_headers: dict | None = None,
         timeout: float | None = None,
     ) -> dict:
-        # Attribute access (not an imported symbol) so injected/patched inference fns still apply.
+        # Attribute access (not a bound import) so a patched make_inference_request still applies.
         return await sdk_inference.make_inference_request(
             model,
             request,
@@ -124,19 +120,13 @@ def _bounded_inference_fn(budget_seconds: float) -> InferenceFn:
     return _fn
 
 
-# RAGAS builds its judge ChatOpenAI client from `inference` (extra="allow"), so a caller could
-# smuggle transport/auth kwargs (base_url, default_headers, api_key, ...) that redirect the judge
-# call or replace the forwarded caller identity. On the sync path only these generation params
-# survive; transport/auth is forced from the resolved model.
+# RAGAS builds its judge ChatOpenAI client from `inference` (extra="allow"); only these
+# generation params survive the sync path, so a caller can't smuggle transport/auth kwargs.
 _ALLOWED_RAGAS_INFERENCE_KEYS = frozenset({"temperature", "max_tokens", "max_completion_tokens", "top_p", "stop"})
 
 
 def _bound_worker_inference(metrics: list[Metric], budget_seconds: float) -> None:
-    """Bound each metric's model calls so a detached (timed-out) worker frees its slot quickly.
-
-    Without this, judge calls fall back to client-default timeouts (up to 600s per attempt),
-    letting one slow upstream hold a sync slot far beyond the request timeout.
-    """
+    """Cap each metric's model calls at the sync budget so a detached worker frees its slot fast."""
     for metric in metrics:
         set_inference_fn = getattr(metric, "set_inference_fn", None)
         if callable(set_inference_fn):
@@ -146,12 +136,7 @@ def _bound_worker_inference(metrics: list[Metric], budget_seconds: float) -> Non
 
 
 def _sanitize_ragas_inference(metric: BaseRAGASMetric, budget_seconds: float) -> None:
-    """Strip RAGAS inference down to safe generation params and clamp its timeout/retries.
-
-    Drops any transport/auth kwargs a caller supplied (they must come from the resolved model),
-    and clamps request_timeout/max_retries into the sync budget so an explicit 3600s/99-retry
-    request can't keep its worker slot occupied for hours after the 60s HTTP response.
-    """
+    """Drop caller transport/auth kwargs (forced from the resolved model) and clamp timeout/retries."""
     inference = getattr(metric, "inference", None)
     if not isinstance(inference, InferenceParams):
         return
@@ -166,18 +151,13 @@ def _sanitize_ragas_inference(metric: BaseRAGASMetric, budget_seconds: float) ->
         min(existing_retries, _SYNC_WORKER_MAX_RETRIES) if existing_retries is not None else _SYNC_WORKER_MAX_RETRIES
     )
 
-    # Reassigned before resolve_models() re-runs _configure_models(), so the sanitized params are
-    # what RAGAS uses to build its client. (inference lives on the RAGAS judge-config mixin, not
-    # on the BaseRAGASMetric base, so set it dynamically.)
+    # Set dynamically: inference lives on the RAGAS judge-config mixin, not the base. Applied
+    # before resolve_models() re-runs _configure_models(), so RAGAS builds its client from these.
     setattr(metric, "inference", InferenceParams(**safe))
 
 
 def _submit_sync_evaluation(run: Callable[[], EvaluationArtifactResult]) -> concurrent.futures.Future:
-    """Run an evaluation on a dedicated daemon thread and return a Future for its result.
-
-    Daemon threads (unlike ThreadPoolExecutor workers) can't block interpreter shutdown if an
-    uncancellable eval is stuck on a network call when the process receives SIGTERM.
-    """
+    """Run on a daemon thread (returns a Future) so a stuck eval can't block SIGTERM shutdown."""
     future: concurrent.futures.Future = concurrent.futures.Future()
 
     def _worker() -> None:
@@ -252,8 +232,7 @@ async def evaluate_sync(
     del workspace  # route is workspace-scoped for authz only
 
     for metric in request.metrics:
-        # Allow-list: only the inline payload kind may execute in the API process, so any
-        # future payload kind fails closed instead of slipping past a cloudpickle deny-check.
+        # Allow-list, not deny-list: any future payload kind fails closed.
         if metric.payload.kind != "inline":
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -279,12 +258,11 @@ async def evaluate_sync(
                 ),
             )
 
-    # Cheap request-shape validation — no slot held, no remote calls. 422 carries the underlying
-    # message (malformed metric, bad params, ...).
+    # Cheap request-shape validation — no slot held, no remote calls.
     try:
         runtime_metrics = [unbundle_metric(to_runtime_bundle(metric)) for metric in request.metrics]
 
-        # An inline model's URL/secret would SSRF/exfiltrate from the API process; require a ModelRef.
+        # Inline models carry an arbitrary URL/secret (SSRF); require a ModelRef.
         for runtime_metric in runtime_metrics:
             if _has_inline_model(runtime_metric):
                 raise HTTPException(
@@ -305,8 +283,7 @@ async def evaluate_sync(
             detail=f"Evaluation request was invalid: {exc}",
         ) from exc
 
-    # Reserve capacity before any downstream fan-out: model resolution hits remote model/provider
-    # lookups, so backpressure must gate it — otherwise requests fan out unbounded while full.
+    # Reserve capacity before model resolution so backpressure gates its remote lookups.
     if not _SYNC_SLOTS.acquire(blocking=False):
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -318,7 +295,7 @@ async def evaluate_sync(
         try:
             _bound_worker_inference(runtime_metrics, SYNC_EVALUATE_TIMEOUT_SECONDS)
 
-            # Resolve refs as the caller (forward request-scoped headers); skip when no metric uses a model.
+            # Resolve refs as the caller (forward request-scoped headers).
             metrics_with_models = [m for m in runtime_metrics if isinstance(m, MetricWithModels)]
             if metrics_with_models:
                 resolver = _ForwardedHeaderModelResolver(
@@ -343,18 +320,17 @@ async def evaluate_sync(
                 field_mapping=request.field_mapping,
             )
         )
-        # Ownership of the slot passes to the future's done callback; the finally must not
-        # also release it. Set before registering the callback: an already-finished worker
-        # runs the callback inline, and a double release trips BoundedSemaphore.
+        # Slot ownership passes to the done callback (fires on true completion, so a timed-out
+        # run can't oversubscribe). Clear slot_held first: an already-done future runs the
+        # callback inline, and a double release trips BoundedSemaphore.
         slot_held = False
-        # Free the slot only on true completion, so an orphaned (timed-out) run can't oversubscribe.
         future.add_done_callback(lambda _f: _SYNC_SLOTS.release())
     finally:
         if slot_held:
             _SYNC_SLOTS.release()
 
-    # asyncio.wait (not wait_for) so a TimeoutError raised inside the worker can't be mistaken
-    # for the sync budget expiring: not-done is the only timeout signal.
+    # asyncio.wait (not wait_for): not-done is the only timeout signal, so a worker-raised
+    # TimeoutError isn't mistaken for the sync budget expiring.
     wrapped = asyncio.wrap_future(future)
     done, _ = await asyncio.wait({wrapped}, timeout=SYNC_EVALUATE_TIMEOUT_SECONDS)
     if not done:
@@ -373,8 +349,7 @@ async def evaluate_sync(
     try:
         return wrapped.result()
     except EvaluationError as exc:
-        # Evaluation-level failures (missing dataset columns, judge output mismatch, ...) are
-        # actionable by the caller; internal TypeError/ValueError bugs stay 500s below.
+        # Caller-actionable; internal TypeError/ValueError bugs stay 500s below.
         logger.warning("Synchronous evaluation failed", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/evaluate.py
@@ -14,7 +14,7 @@ import concurrent.futures
 import functools
 import logging
 import threading
-from typing import Annotated, Any, Callable, cast
+from typing import Annotated, Any, Callable
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from nemo_evaluator.api.schemas import MetricInline
@@ -124,6 +124,13 @@ def _bounded_inference_fn(budget_seconds: float) -> InferenceFn:
     return _fn
 
 
+# RAGAS builds its judge ChatOpenAI client from `inference` (extra="allow"), so a caller could
+# smuggle transport/auth kwargs (base_url, default_headers, api_key, ...) that redirect the judge
+# call or replace the forwarded caller identity. On the sync path only these generation params
+# survive; transport/auth is forced from the resolved model.
+_ALLOWED_RAGAS_INFERENCE_KEYS = frozenset({"temperature", "max_tokens", "max_completion_tokens", "top_p", "stop"})
+
+
 def _bound_worker_inference(metrics: list[Metric], budget_seconds: float) -> None:
     """Bound each metric's model calls so a detached (timed-out) worker frees its slot quickly.
 
@@ -135,16 +142,34 @@ def _bound_worker_inference(metrics: list[Metric], budget_seconds: float) -> Non
         if callable(set_inference_fn):
             set_inference_fn(_bounded_inference_fn(budget_seconds))
         if isinstance(metric, BaseRAGASMetric):
-            # RAGAS builds its judge client from `inference` extras (ChatOpenAI kwargs);
-            # respect explicit user settings, only fill the gaps. InferenceParams allows
-            # extra fields, so assignment lands in __pydantic_extra__ and survives dumps.
-            inference = getattr(metric, "inference", None)
-            if isinstance(inference, InferenceParams):
-                extras = cast(Any, inference)
-                if getattr(extras, "request_timeout", None) is None:
-                    extras.request_timeout = budget_seconds
-                if getattr(extras, "max_retries", None) is None:
-                    extras.max_retries = _SYNC_WORKER_MAX_RETRIES
+            _sanitize_ragas_inference(metric, budget_seconds)
+
+
+def _sanitize_ragas_inference(metric: BaseRAGASMetric, budget_seconds: float) -> None:
+    """Strip RAGAS inference down to safe generation params and clamp its timeout/retries.
+
+    Drops any transport/auth kwargs a caller supplied (they must come from the resolved model),
+    and clamps request_timeout/max_retries into the sync budget so an explicit 3600s/99-retry
+    request can't keep its worker slot occupied for hours after the 60s HTTP response.
+    """
+    inference = getattr(metric, "inference", None)
+    if not isinstance(inference, InferenceParams):
+        return
+
+    dumped = inference.model_dump(exclude_none=True)
+    safe = {key: value for key, value in dumped.items() if key in _ALLOWED_RAGAS_INFERENCE_KEYS}
+
+    existing_timeout = dumped.get("request_timeout")
+    safe["request_timeout"] = min(existing_timeout, budget_seconds) if existing_timeout else budget_seconds
+    existing_retries = dumped.get("max_retries")
+    safe["max_retries"] = (
+        min(existing_retries, _SYNC_WORKER_MAX_RETRIES) if existing_retries is not None else _SYNC_WORKER_MAX_RETRIES
+    )
+
+    # Reassigned before resolve_models() re-runs _configure_models(), so the sanitized params are
+    # what RAGAS uses to build its client. (inference lives on the RAGAS judge-config mixin, not
+    # on the BaseRAGASMetric base, so set it dynamically.)
+    setattr(metric, "inference", InferenceParams(**safe))
 
 
 def _submit_sync_evaluation(run: Callable[[], EvaluationArtifactResult]) -> concurrent.futures.Future:
@@ -165,6 +190,12 @@ def _submit_sync_evaluation(run: Callable[[], EvaluationArtifactResult]) -> conc
 
     threading.Thread(target=_worker, name="evaluator-sync", daemon=True).start()
     return future
+
+
+class EvaluateSyncError(BaseModel):
+    """Error body for the synchronous evaluate route (422/503/504)."""
+
+    detail: str = Field(description="Human-readable, actionable description of why the request failed.")
 
 
 class EvaluateSyncRequest(BaseModel):
@@ -196,9 +227,18 @@ class EvaluateSyncRequest(BaseModel):
     response_description="The inline evaluation result (aggregate and row scores)",
     status_code=status.HTTP_200_OK,
     responses={
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid request or unsupported metric/model"},
-        status.HTTP_503_SERVICE_UNAVAILABLE: {"description": "Synchronous evaluation capacity is full"},
-        status.HTTP_504_GATEWAY_TIMEOUT: {"description": "Evaluation exceeded the synchronous time limit"},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+            "model": EvaluateSyncError,
+            "description": "Invalid request or unsupported metric/model",
+        },
+        status.HTTP_503_SERVICE_UNAVAILABLE: {
+            "model": EvaluateSyncError,
+            "description": "Synchronous evaluation capacity is full",
+        },
+        status.HTTP_504_GATEWAY_TIMEOUT: {
+            "model": EvaluateSyncError,
+            "description": "Evaluation exceeded the synchronous time limit",
+        },
     },
 )
 @scope.write
@@ -239,8 +279,8 @@ async def evaluate_sync(
                 ),
             )
 
-    # Validation phase: everything here failed because of the request contents, so 422 carries
-    # the underlying message (model ref not found, malformed metric, bad params, ...).
+    # Cheap request-shape validation — no slot held, no remote calls. 422 carries the underlying
+    # message (malformed metric, bad params, ...).
     try:
         runtime_metrics = [unbundle_metric(to_runtime_bundle(metric)) for metric in request.metrics]
 
@@ -255,16 +295,6 @@ async def evaluate_sync(
                     ),
                 )
 
-        _bound_worker_inference(runtime_metrics, SYNC_EVALUATE_TIMEOUT_SECONDS)
-
-        # Resolve refs as the caller (forward request-scoped headers); skip when no metric uses a model.
-        metrics_with_models = [m for m in runtime_metrics if isinstance(m, MetricWithModels)]
-        if metrics_with_models:
-            resolver = _ForwardedHeaderModelResolver(
-                PlatformModelResolver(async_sdk), get_forwarding_headers(async_sdk)
-            )
-            await asyncio.gather(*(m.resolve_models(resolver) for m in metrics_with_models))
-
         params = resolve_params(request.params, None)
     except HTTPException:
         raise
@@ -275,12 +305,33 @@ async def evaluate_sync(
             detail=f"Evaluation request was invalid: {exc}",
         ) from exc
 
+    # Reserve capacity before any downstream fan-out: model resolution hits remote model/provider
+    # lookups, so backpressure must gate it — otherwise requests fan out unbounded while full.
     if not _SYNC_SLOTS.acquire(blocking=False):
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Synchronous evaluation capacity is full; retry shortly or submit a durable job via /evaluate/jobs.",
         )
+
+    slot_held = True
     try:
+        try:
+            _bound_worker_inference(runtime_metrics, SYNC_EVALUATE_TIMEOUT_SECONDS)
+
+            # Resolve refs as the caller (forward request-scoped headers); skip when no metric uses a model.
+            metrics_with_models = [m for m in runtime_metrics if isinstance(m, MetricWithModels)]
+            if metrics_with_models:
+                resolver = _ForwardedHeaderModelResolver(
+                    PlatformModelResolver(async_sdk), get_forwarding_headers(async_sdk)
+                )
+                await asyncio.gather(*(m.resolve_models(resolver) for m in metrics_with_models))
+        except (TypeError, ValueError, EvaluationError) as exc:
+            logger.warning("Synchronous evaluation request was invalid", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Evaluation request was invalid: {exc}",
+            ) from exc
+
         future = _submit_sync_evaluation(
             functools.partial(
                 run_evaluation,
@@ -292,11 +343,15 @@ async def evaluate_sync(
                 field_mapping=request.field_mapping,
             )
         )
-    except BaseException:
-        _SYNC_SLOTS.release()
-        raise
-    # Free the slot only on true completion, so an orphaned (timed-out) run can't oversubscribe.
-    future.add_done_callback(lambda _f: _SYNC_SLOTS.release())
+        # Ownership of the slot passes to the future's done callback; the finally must not
+        # also release it. Set before registering the callback: an already-finished worker
+        # runs the callback inline, and a double release trips BoundedSemaphore.
+        slot_held = False
+        # Free the slot only on true completion, so an orphaned (timed-out) run can't oversubscribe.
+        future.add_done_callback(lambda _f: _SYNC_SLOTS.release())
+    finally:
+        if slot_held:
+            _SYNC_SLOTS.release()
 
     # asyncio.wait (not wait_for) so a TimeoutError raised inside the worker can't be mistaken
     # for the sync budget expiring: not-done is the only timeout signal.

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/evaluate.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Synchronous evaluate route — the HTTP equivalent of `nemo evaluator evaluate run`.
+
+Scoped to what is safe in the long-lived API process: offline, inline metrics over inline rows,
+models by platform ModelRef only. Heavier or untrusted work goes through `/evaluate/jobs`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.authz import scope
+from nemo_evaluator.jobs.evaluate import run_evaluation, to_runtime_bundle
+from nemo_evaluator.resolvers import PlatformModelResolver
+from nemo_evaluator.shared.metric_bundles.bundles import unbundle_metric
+from nemo_evaluator_sdk.enums import MetricType
+from nemo_evaluator_sdk.execution.config import resolve_params
+from nemo_evaluator_sdk.execution.values import EvaluationError
+from nemo_evaluator_sdk.metrics.protocol import MetricWithModels
+from nemo_evaluator_sdk.values import FieldMapping, Model, RunConfig
+from nemo_evaluator_sdk.values.models import ModelRef
+from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult
+from nemo_evaluator_sdk.values.results import EvaluationResult
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.authz import CallerKind, PermissionSet, path_rule, perm
+from nemo_platform_plugin.dependencies import get_sdk_client
+from nemo_platform_plugin.sdk_provider import get_forwarding_headers
+from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
+
+
+class EvaluateSyncPerms(PermissionSet, namespace="evaluator.evaluate"):
+    """Permission for the synchronous evaluate execution route."""
+
+    EXEC = perm("Execute synchronous evaluator evaluations")
+
+
+MAX_SYNC_ROWS = 10
+SYNC_EVALUATE_TIMEOUT_SECONDS = 60.0
+
+# Dedicated bounded pool so a stuck (uncancellable) sync eval can't starve the main request pool.
+_SYNC_EVAL_MAX_WORKERS = 4
+_SYNC_EVAL_EXECUTOR = ThreadPoolExecutor(max_workers=_SYNC_EVAL_MAX_WORKERS, thread_name_prefix="evaluator-sync")
+
+# Metric types that call a user-supplied URL during evaluation (SSRF surface).
+_NETWORK_BACKED_METRIC_TYPES = frozenset({MetricType.REMOTE.value, MetricType.NEMO_AGENT_TOOLKIT_REMOTE.value})
+
+router = APIRouter()
+
+
+class _ForwardedHeaderModelResolver:
+    """Resolve a ModelRef to its IGW Model, stamping the caller's request-scoped headers on it so
+    the in-process call runs as the caller with no secret."""
+
+    def __init__(self, inner: PlatformModelResolver, headers: dict[str, str]) -> None:
+        self._inner = inner
+        self._headers = headers
+
+    async def resolve_model(self, model_ref: ModelRef) -> Model:
+        model = await self._inner.resolve_model(model_ref)
+        return model.with_default_headers(self._headers)
+
+
+class _SlotCounter:
+    """In-flight counter for sync-eval backpressure; mutated only on the event-loop thread."""
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._in_flight = 0
+
+    def try_acquire(self) -> bool:
+        if self._in_flight >= self._limit:
+            return False
+        self._in_flight += 1
+        return True
+
+    def release(self) -> None:
+        self._in_flight = max(0, self._in_flight - 1)
+
+
+_SYNC_SLOTS = _SlotCounter(_SYNC_EVAL_MAX_WORKERS)
+
+
+def _has_inline_model(metric: object) -> bool:
+    """True if any top-level metric field is an inline Model (vs a platform ModelRef)."""
+    return any(isinstance(value, Model) for value in vars(metric).values())
+
+
+class EvaluateSyncRequest(BaseModel):
+    """Bounded offline evaluation request: inline metrics over inline rows, models by ModelRef.
+
+    See the handler for the inputs it rejects (online targets, inline models, secrets, cloudpickle,
+    network metrics).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    metrics: Annotated[list[MetricInline], Field(min_length=1, description="Inline metrics to evaluate.")]
+    dataset: Annotated[
+        list[dict[str, Any]],
+        Field(min_length=1, max_length=MAX_SYNC_ROWS, description="Inline dataset rows to evaluate."),
+    ]
+    params: RunConfig | None = Field(default=None, description="Optional offline execution parameters.")
+    field_mapping: FieldMapping | None = Field(
+        default=None, description="Optional mapping from canonical evaluator fields to dataset columns."
+    )
+
+
+@router.post(
+    "/evaluate",
+    summary="Evaluate Synchronously",
+    response_description="The inline evaluation result (aggregate and row scores)",
+    status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid request or unsupported metric/model"},
+        status.HTTP_503_SERVICE_UNAVAILABLE: {"description": "Synchronous evaluation capacity is full"},
+        status.HTTP_504_GATEWAY_TIMEOUT: {"description": "Evaluation exceeded the synchronous time limit"},
+    },
+)
+@scope.write
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[EvaluateSyncPerms.EXEC])
+async def evaluate_sync(
+    workspace: str,
+    request: EvaluateSyncRequest,
+    async_sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
+) -> EvaluationResult | BenchmarkEvaluationResult:
+    """Run a bounded offline evaluation in-process and return the result."""
+    del workspace  # route is workspace-scoped for authz only
+
+    for metric in request.metrics:
+        if metric.payload.kind == "cloudpickle":
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "Synchronous evaluation supports inline (built-in) metrics only. "
+                    "Submit cloudpickle metric bundles as a durable job via /evaluate/jobs."
+                ),
+            )
+        if metric.metric_type in _NETWORK_BACKED_METRIC_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"Metric type '{metric.metric_type}' calls an external endpoint and is not "
+                    "allowed on the synchronous path. Submit it as a durable job via /evaluate/jobs."
+                ),
+            )
+        if metric.secrets:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "Metrics with secret references are not allowed on the synchronous path. "
+                    "Reference a platform-registered model (workspace/model) or submit a durable job."
+                ),
+            )
+
+    try:
+        runtime_metrics = [unbundle_metric(to_runtime_bundle(metric)) for metric in request.metrics]
+
+        # An inline model's URL/secret would SSRF/exfiltrate from the API process; require a ModelRef.
+        for runtime_metric in runtime_metrics:
+            if _has_inline_model(runtime_metric):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        "Metric models must be platform references (workspace/model). Inline model "
+                        "definitions are not allowed on the synchronous path; submit a durable job."
+                    ),
+                )
+
+        # Resolve refs as the caller (forward request-scoped headers); skip when no metric uses a model.
+        metrics_with_models = [m for m in runtime_metrics if isinstance(m, MetricWithModels)]
+        if metrics_with_models:
+            resolver = _ForwardedHeaderModelResolver(
+                PlatformModelResolver(async_sdk), get_forwarding_headers(async_sdk)
+            )
+            await asyncio.gather(*(m.resolve_models(resolver) for m in metrics_with_models))
+
+        params = resolve_params(request.params, None)
+
+        if not _SYNC_SLOTS.try_acquire():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Synchronous evaluation capacity is full; retry shortly or submit a durable job via /evaluate/jobs.",
+            )
+        loop = asyncio.get_running_loop()
+        future = _SYNC_EVAL_EXECUTOR.submit(
+            functools.partial(
+                run_evaluation,
+                metrics=runtime_metrics,
+                dataset=request.dataset,
+                params=params,
+                target=None,
+                prompt_template=None,
+                field_mapping=request.field_mapping,
+            )
+        )
+        # Free the slot only on true completion, so an orphaned (timed-out) run can't oversubscribe.
+        future.add_done_callback(lambda _f: loop.call_soon_threadsafe(_SYNC_SLOTS.release))
+        result = await asyncio.wait_for(asyncio.wrap_future(future), timeout=SYNC_EVALUATE_TIMEOUT_SECONDS)
+    except HTTPException:
+        raise
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Synchronous evaluation exceeded %.0fs; worker may still be running.", SYNC_EVALUATE_TIMEOUT_SECONDS
+        )
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail=(
+                f"Synchronous evaluation exceeded {SYNC_EVALUATE_TIMEOUT_SECONDS:.0f}s. "
+                "Submit as a durable job via /evaluate/jobs instead."
+            ),
+        )
+    except (TypeError, ValueError, EvaluationError):
+        logger.warning("Synchronous evaluation could not be completed", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Evaluation request was invalid or could not be completed.",
+        )
+    except Exception:
+        logger.exception("Synchronous evaluation failed")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")
+
+    return result

--- a/plugins/nemo-evaluator/src/nemo_evaluator/cli.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/cli.py
@@ -5,76 +5,12 @@
 
 from __future__ import annotations
 
-import inspect
 import json
-from enum import Enum
-from types import UnionType
-from typing import Annotated, Any, ClassVar, Union, get_args, get_origin
+from typing import Any, ClassVar
 
 import typer
-from nemo_evaluator_sdk.metrics.types import MetricVariants
-from nemo_evaluator_sdk.values.metrics import _RAGASBase
+from nemo_evaluator.metric_catalog import metric_type_entries, metric_type_models
 from nemo_platform_plugin.cli import NemoCLI
-from pydantic import BaseModel
-
-
-def _unwrap_metric_model_classes(type_hint: object) -> list[type[BaseModel]]:
-    """Return Pydantic model classes from an annotated metric union."""
-    origin = get_origin(type_hint)
-    if origin is Annotated:
-        return _unwrap_metric_model_classes(get_args(type_hint)[0])
-    if origin in {Union, UnionType}:
-        model_classes: list[type[BaseModel]] = []
-        for union_member in get_args(type_hint):
-            model_classes.extend(_unwrap_metric_model_classes(union_member))
-        return model_classes
-    if isinstance(type_hint, type) and issubclass(type_hint, BaseModel):
-        return [type_hint]
-    return []
-
-
-def _json_value(value: object) -> object:
-    if isinstance(value, Enum):
-        return value.value
-    return value
-
-
-def _metric_type_values(model_cls: type[BaseModel]) -> list[str]:
-    type_field = model_cls.model_fields["type"]
-    annotation_args = get_args(type_field.annotation)
-    if annotation_args:
-        return [str(_json_value(value)) for value in annotation_args]
-    return [str(_json_value(type_field.default))]
-
-
-def _metric_type_models() -> dict[str, type[BaseModel]]:
-    metric_types: dict[str, type[BaseModel]] = {}
-    for model_cls in _unwrap_metric_model_classes(MetricVariants):
-        for metric_type in _metric_type_values(model_cls):
-            existing = metric_types.get(metric_type)
-            if existing is not None and existing is not model_cls:
-                raise ValueError(
-                    f"Duplicate metric type '{metric_type}' mapped to both {existing.__name__} and {model_cls.__name__}"
-                )
-            metric_types[metric_type] = model_cls
-    return dict(sorted(metric_types.items()))
-
-
-def _is_ragas_metric(model_cls: type[BaseModel]) -> bool:
-    return issubclass(model_cls, _RAGASBase)
-
-
-def _metric_type_entries() -> list[dict[str, str]]:
-    return [
-        {
-            "name": metric_type,
-            "description": inspect.getdoc(model_cls) or "",
-        }
-        for metric_type, model_cls in sorted(
-            _metric_type_models().items(),
-            key=lambda item: (_is_ragas_metric(item[1]), item[0]),
-        )
-    ]
 
 
 def _echo_json(payload: Any) -> None:
@@ -113,10 +49,10 @@ class EvaluatorPluginCLI(NemoCLI):
         ) -> None:
             """Print available evaluator metric names or a metric JSON schema."""
             if metric_types_name is None:
-                _echo_json({"metric_types": _metric_type_entries()})
+                _echo_json({"metric_types": metric_type_entries()})
                 return
 
-            metric_types_map = _metric_type_models()
+            metric_types_map = metric_type_models()
             model_cls = metric_types_map.get(metric_types_name)
             if model_cls is None:
                 typer.echo(

--- a/plugins/nemo-evaluator/src/nemo_evaluator/docs/index.md
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/docs/index.md
@@ -21,7 +21,8 @@ All routes are under `/apis/evaluator`. Several map directly to CLI commands so 
 |---|---|---|
 | `GET /v2/metric-types` | List built-in metric types and descriptions | `nemo evaluator metric-types` |
 | `GET /v2/metric-types/{metric_type}` | JSON schema for one metric type | `nemo evaluator metric-types <name>` |
-| `GET /v2/evaluate/schema` | JSON schema for the evaluate input spec | `nemo evaluator evaluate explain` |
+| `GET /v2/evaluate/schema` | JSON schema for the **synchronous** evaluate request body | — |
+| `GET /v2/evaluate/jobs/schema` | JSON schema for the evaluate **job** input spec | `nemo evaluator evaluate explain` |
 | `POST /v2/workspaces/{workspace}/evaluate` | Run a bounded evaluation **synchronously** and return the result inline | `nemo evaluator evaluate run` |
 | `POST /v2/workspaces/{workspace}/evaluate/jobs` (+ lifecycle) | Submit a durable evaluation job | `nemo evaluator evaluate submit` |
 | `GET/POST/DELETE /v2/workspaces/{workspace}/metrics[/{name}]` | Stored-metric CRUD (create/list/get/delete; immutable) | — |
@@ -32,7 +33,8 @@ All routes are under `/apis/evaluator`. Several map directly to CLI commands so 
 is deliberately bounded to what is safe there (anything else goes to the durable `/evaluate/jobs`
 API, which runs in an isolated container). It returns `422` for:
 
-- **Cloudpickle metric bundles** — arbitrary code is never unpickled in the API process.
+- **Non-inline metric payloads** (allow-list on `payload.kind == "inline"`) — arbitrary code
+  (e.g. cloudpickle) is never executed in the API process, and future payload kinds fail closed.
 - **Network (remote) metric types** (`remote`, `nemo-agent-toolkit-remote`) — they call a
   user-supplied URL (SSRF).
 - **Metrics with secret references** — the in-process backend resolves secrets from the API
@@ -45,13 +47,15 @@ API, which runs in an isolated container). It returns `422` for:
 - **Online targets** — generation against a model/agent target is not supported here; submit a job.
 
 So **LLM-judge and other model-backed metrics are supported** as long as their models are
-`ModelRef`s. The dataset must be **inline rows** (no `FilesetRef`), capped at `MAX_SYNC_ROWS` (10).
+`ModelRef`s. The dataset must be **inline rows** (no `FilesetRef`), capped at `MAX_SYNC_ROWS` (10),
+and the metrics list is capped at `MAX_SYNC_METRICS` (10).
 
-Execution runs on a dedicated bounded thread pool (`_SYNC_EVAL_MAX_WORKERS`, 4) under a wall-clock
-timeout (`SYNC_EVALUATE_TIMEOUT_SECONDS`, 60s) → `504` on expiry. When all slots are busy the
-endpoint returns `503` rather than queueing (a blocking SDK call can't be cancelled, so a
-timed-out evaluation keeps holding its slot until the underlying call actually returns). For
-anything heavier, use the durable job API.
+Execution runs on bounded daemon worker threads (`_SYNC_EVAL_MAX_WORKERS`, 4 concurrent slots)
+under a wall-clock timeout (`SYNC_EVALUATE_TIMEOUT_SECONDS`, 60s) → `504` on expiry. When all
+slots are busy the endpoint returns `503` rather than queueing. A timed-out evaluation keeps
+holding its slot until its underlying calls return, but each metric's model calls are bounded to
+the same 60s budget (with retries capped at 1), so worst-case slot occupancy stays near the
+request timeout. For anything heavier, use the durable job API.
 
 Authz: read routes require `evaluator:read`; the synchronous evaluate route requires the
 `evaluator.evaluate.exec` permission (`evaluator:write`).

--- a/plugins/nemo-evaluator/src/nemo_evaluator/docs/index.md
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/docs/index.md
@@ -7,11 +7,54 @@ The evaluator plugin is a first-party for evaluator functionality. It keeps the 
 | Surface | Entry point | Current behavior |
 |---|---|---|
 | CLI | `nemo.cli:evaluator` | Adds `nemo evaluator info` and hosts evaluator job commands. |
-| Service | `nemo.services:evaluator` | `jobs`, `healthz` paths. |
+| Service | `nemo.services:evaluator` | `evaluate/jobs` lifecycle, `metrics` CRUD, the read-only metric-type catalog + `evaluate/schema`, the synchronous `evaluate` route, and `healthz`. |
 | SDK | `nemo.sdk:evaluator` | Adds `client.evaluator.plugin_status() and run(), submit() interfaces`. |
 | Job | `nemo.jobs:evaluator.evaluate` | Backs local `run` through in-process execution and `submit` through durable platform job submission. |
 | Docs | `nemo.docs:evaluator` | Publishes this reference page. |
 | Skills | `nemo.skills:evaluator` | Publishes the evaluator plugin development skill. |
+
+## REST API
+
+All routes are under `/apis/evaluator`. Several map directly to CLI commands so non-Python clients (e.g. Studio) can reach the same functionality.
+
+| Method + path | Purpose | CLI equivalent |
+|---|---|---|
+| `GET /v2/metric-types` | List built-in metric types and descriptions | `nemo evaluator metric-types` |
+| `GET /v2/metric-types/{metric_type}` | JSON schema for one metric type | `nemo evaluator metric-types <name>` |
+| `GET /v2/evaluate/schema` | JSON schema for the evaluate input spec | `nemo evaluator evaluate explain` |
+| `POST /v2/workspaces/{workspace}/evaluate` | Run a bounded evaluation **synchronously** and return the result inline | `nemo evaluator evaluate run` |
+| `POST /v2/workspaces/{workspace}/evaluate/jobs` (+ lifecycle) | Submit a durable evaluation job | `nemo evaluator evaluate submit` |
+| `GET/POST/DELETE /v2/workspaces/{workspace}/metrics[/{name}]` | Stored-metric CRUD (create/list/get/delete; immutable) | — |
+
+### Synchronous evaluate constraints
+
+`POST .../evaluate` is the "test a metric" path. It runs **in the long-lived API process**, so it
+is deliberately bounded to what is safe there (anything else goes to the durable `/evaluate/jobs`
+API, which runs in an isolated container). It returns `422` for:
+
+- **Cloudpickle metric bundles** — arbitrary code is never unpickled in the API process.
+- **Network (remote) metric types** (`remote`, `nemo-agent-toolkit-remote`) — they call a
+  user-supplied URL (SSRF).
+- **Metrics with secret references** — the in-process backend resolves secrets from the API
+  process environment, so request-supplied secrets are refused (exfiltration guard).
+- **Inline model definitions** — any model a metric uses (e.g. an LLM-judge's judge model) must
+  be a platform **`ModelRef`** (`workspace/model`). Refs resolve to the inference gateway with no
+  secret, and the in-process call carries the **caller's** request-scoped headers (principal +
+  trace), so it runs as the caller — not an elevated service principal — and leaks no secret.
+  Inline models carry an arbitrary URL and are rejected.
+- **Online targets** — generation against a model/agent target is not supported here; submit a job.
+
+So **LLM-judge and other model-backed metrics are supported** as long as their models are
+`ModelRef`s. The dataset must be **inline rows** (no `FilesetRef`), capped at `MAX_SYNC_ROWS` (10).
+
+Execution runs on a dedicated bounded thread pool (`_SYNC_EVAL_MAX_WORKERS`, 4) under a wall-clock
+timeout (`SYNC_EVALUATE_TIMEOUT_SECONDS`, 60s) → `504` on expiry. When all slots are busy the
+endpoint returns `503` rather than queueing (a blocking SDK call can't be cancelled, so a
+timed-out evaluation keeps holding its slot until the underlying call actually returns). For
+anything heavier, use the durable job API.
+
+Authz: read routes require `evaluator:read`; the synchronous evaluate route requires the
+`evaluator.evaluate.exec` permission (`evaluator:write`).
 
 ## Current Job
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
@@ -28,6 +28,7 @@ from nemo_evaluator.shared.metric_bundles.bundles import unbundle_metric
 from nemo_evaluator_sdk import Evaluator
 from nemo_evaluator_sdk.execution.config import resolve_params
 from nemo_evaluator_sdk.execution.metric_execution import run_sync
+from nemo_evaluator_sdk.metrics.protocol import Metric
 from nemo_evaluator_sdk.values import (
     Agent,
     AgentBase,
@@ -103,6 +104,59 @@ def _resolve_run_dataset(
             destination=destination,
         )
     raise ValueError("FilesetRef datasets require an SDK client for local evaluator job execution.")
+
+
+def run_evaluation(
+    *,
+    metrics: list[Metric],
+    dataset: InlineDataset | Path,
+    params: RunConfig | RunConfigOnline | RunConfigOnlineModel,
+    target: TargetSpec | None,
+    prompt_template: str | dict[str, Any] | None,
+    field_mapping: FieldMapping | None,
+) -> EvaluationArtifactResult:
+    """Dispatch resolved metrics to the SDK evaluator by target type (offline/model/agent).
+
+    Shared by the job and the sync route; ``params`` must already be resolved.
+    """
+    if not metrics:
+        raise ValueError("run_evaluation requires at least one metric")
+    evaluator = Evaluator()
+    runtime_metrics = metrics if len(metrics) > 1 else metrics[0]
+    if isinstance(target, Model):
+        if not isinstance(params, RunConfigOnlineModel):
+            raise TypeError("model target requires RunConfigOnlineModel")
+        return evaluator.run_sync(
+            metrics=runtime_metrics,
+            dataset=dataset,
+            config=params,
+            target=target,
+            field_mapping=field_mapping,
+            prompt_template=prompt_template,
+        )
+    if isinstance(target, AgentBase):
+        if type(params) is not RunConfigOnline:
+            raise TypeError("agent target requires RunConfigOnline")
+        if prompt_template is None:
+            raise ValueError("agent target requires prompt_template")
+        return evaluator.run_sync(
+            metrics=runtime_metrics,
+            dataset=dataset,
+            config=params,
+            target=target,
+            field_mapping=field_mapping,
+            prompt_template=prompt_template,
+        )
+    if type(params) is not RunConfig:
+        raise TypeError("offline evaluation requires RunConfig")
+    return evaluator.run_sync(
+        metrics=runtime_metrics,
+        dataset=dataset,
+        config=params,
+        target=None,
+        field_mapping=field_mapping,
+        prompt_template=None,
+    )
 
 
 class _EvaluateSpecCommon(BaseModel):
@@ -254,7 +308,6 @@ class EvaluateJob(NemoJob):
     ) -> dict:
         """Run the evaluator job locally and persist its result artifact."""
         spec = EvaluateSpec.model_validate(config)
-        evaluator = Evaluator()
         params = resolve_params(spec.params, spec.target)
         metrics = [unbundle_metric(to_runtime_bundle(metric)) for metric in spec.metrics]
         dataset = _resolve_run_dataset(
@@ -263,42 +316,14 @@ class EvaluateJob(NemoJob):
             sdk=sdk,
             async_sdk=async_sdk,
         )
-        runtime_metrics = metrics if len(metrics) > 1 else metrics[0]
-        if isinstance(spec.target, Model):
-            if not isinstance(params, RunConfigOnlineModel):
-                raise TypeError("model target requires RunConfigOnlineModel")
-            result = evaluator.run_sync(
-                metrics=runtime_metrics,
-                dataset=dataset,
-                config=params,
-                target=spec.target,
-                field_mapping=spec.field_mapping,
-                prompt_template=spec.prompt_template,
-            )
-        elif isinstance(spec.target, AgentBase):
-            if type(params) is not RunConfigOnline:
-                raise TypeError("agent target requires RunConfigOnline")
-            if spec.prompt_template is None:
-                raise ValueError("agent target requires prompt_template")
-            result = evaluator.run_sync(
-                metrics=runtime_metrics,
-                dataset=dataset,
-                config=params,
-                target=spec.target,
-                field_mapping=spec.field_mapping,
-                prompt_template=spec.prompt_template,
-            )
-        else:
-            if type(params) is not RunConfig:
-                raise TypeError("offline evaluation requires RunConfig")
-            result = evaluator.run_sync(
-                metrics=runtime_metrics,
-                dataset=dataset,
-                config=params,
-                target=None,
-                field_mapping=spec.field_mapping,
-                prompt_template=None,
-            )
+        result = run_evaluation(
+            metrics=metrics,
+            dataset=dataset,
+            params=params,
+            target=spec.target,
+            prompt_template=spec.prompt_template,
+            field_mapping=spec.field_mapping,
+        )
         result_files = self._write_result_files(result, ctx.storage.persistent)
         artifact = ctx.results.save(DEFAULT_RESULT_NAME, result_files.full_result)
         ctx.results.save(AGGREGATE_SCORES_RESULT_NAME, result_files.aggregate_scores)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/metric_catalog.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/metric_catalog.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Built-in metric type catalog (`MetricVariants`), shared by the CLI and the REST routes."""
+
+from __future__ import annotations
+
+import inspect
+from enum import Enum
+from types import UnionType
+from typing import Annotated, Any, Union, get_args, get_origin
+
+from nemo_evaluator_sdk.metrics.types import MetricVariants
+from nemo_evaluator_sdk.values.metrics import _RAGASBase
+from pydantic import BaseModel
+
+
+def _unwrap_metric_model_classes(type_hint: object) -> list[type[BaseModel]]:
+    """Return Pydantic model classes from an annotated metric union."""
+    origin = get_origin(type_hint)
+    if origin is Annotated:
+        return _unwrap_metric_model_classes(get_args(type_hint)[0])
+    if origin in {Union, UnionType}:
+        model_classes: list[type[BaseModel]] = []
+        for union_member in get_args(type_hint):
+            model_classes.extend(_unwrap_metric_model_classes(union_member))
+        return model_classes
+    if isinstance(type_hint, type) and issubclass(type_hint, BaseModel):
+        return [type_hint]
+    return []
+
+
+def _json_value(value: object) -> object:
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _metric_type_values(model_cls: type[BaseModel]) -> list[str]:
+    type_field = model_cls.model_fields["type"]
+    annotation_args = get_args(type_field.annotation)
+    if annotation_args:
+        return [str(_json_value(value)) for value in annotation_args]
+    return [str(_json_value(type_field.default))]
+
+
+def _is_ragas_metric(model_cls: type[BaseModel]) -> bool:
+    return issubclass(model_cls, _RAGASBase)
+
+
+def metric_type_models() -> dict[str, type[BaseModel]]:
+    """Map each built-in metric type name to its Pydantic config model class."""
+    metric_types: dict[str, type[BaseModel]] = {}
+    for model_cls in _unwrap_metric_model_classes(MetricVariants):
+        for metric_type in _metric_type_values(model_cls):
+            existing = metric_types.get(metric_type)
+            if existing is not None and existing is not model_cls:
+                raise ValueError(
+                    f"Duplicate metric type '{metric_type}' mapped to both {existing.__name__} and {model_cls.__name__}"
+                )
+            metric_types[metric_type] = model_cls
+    return dict(sorted(metric_types.items()))
+
+
+def metric_type_entries() -> list[dict[str, str]]:
+    """List `{name, description}` for every built-in metric type (RAGAS sorted last)."""
+    return [
+        {
+            "name": metric_type,
+            "description": inspect.getdoc(model_cls) or "",
+        }
+        for metric_type, model_cls in sorted(
+            metric_type_models().items(),
+            key=lambda item: (_is_ragas_metric(item[1]), item[0]),
+        )
+    ]
+
+
+def metric_type_schema(metric_type: str) -> dict[str, Any] | None:
+    """Return the JSON schema for a metric type, or None if the type is unknown."""
+    model_cls = metric_type_models().get(metric_type)
+    if model_cls is None:
+        return None
+    return model_cls.model_json_schema()

--- a/plugins/nemo-evaluator/src/nemo_evaluator/service.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/service.py
@@ -39,10 +39,8 @@ class EvaluatorPluginService(NemoService):
     """Service surface for the evaluator plugin."""
 
     name: ClassVar[str] = "evaluator"
-    # NOTE: models and inference-gateway are intentionally NOT startup dependencies even though
-    # the sync evaluate route uses them: declaring them would block evaluator startup (up to 120s
-    # per dependency) whenever either is deployed-but-unhealthy. The sync route degrades at
-    # request time instead (model resolution fails with an actionable 422).
+    # models/inference-gateway are deliberately excluded: as startup deps they'd block boot (up to
+    # 120s each) when unhealthy. The sync evaluate route degrades at request time with a 422 instead.
     dependencies: ClassVar[list[str]] = ["nemo-evaluator-sdk", "entities", "files"]
 
     def get_routers(self) -> list[RouterSpec]:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/service.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/service.py
@@ -39,7 +39,11 @@ class EvaluatorPluginService(NemoService):
     """Service surface for the evaluator plugin."""
 
     name: ClassVar[str] = "evaluator"
-    dependencies: ClassVar[list[str]] = ["nemo-evaluator-sdk", "entities", "files", "models", "inference-gateway"]
+    # NOTE: models and inference-gateway are intentionally NOT startup dependencies even though
+    # the sync evaluate route uses them: declaring them would block evaluator startup (up to 120s
+    # per dependency) whenever either is deployed-but-unhealthy. The sync route degrades at
+    # request time instead (model resolution fails with an actionable 422).
+    dependencies: ClassVar[list[str]] = ["nemo-evaluator-sdk", "entities", "files"]
 
     def get_routers(self) -> list[RouterSpec]:
         router = APIRouter()

--- a/plugins/nemo-evaluator/src/nemo_evaluator/service.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/service.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from typing import ClassVar
 
 from fastapi import APIRouter
+from nemo_evaluator.api.v2 import catalog as catalog_routes
+from nemo_evaluator.api.v2 import evaluate as evaluate_routes
 from nemo_evaluator.api.v2 import metrics as metrics_routes
 from nemo_evaluator.api.v2 import results as results_routes
 from nemo_evaluator.api.v2 import tasks as tasks_routes
@@ -37,7 +39,7 @@ class EvaluatorPluginService(NemoService):
     """Service surface for the evaluator plugin."""
 
     name: ClassVar[str] = "evaluator"
-    dependencies: ClassVar[list[str]] = ["nemo-evaluator-sdk", "entities", "files"]
+    dependencies: ClassVar[list[str]] = ["nemo-evaluator-sdk", "entities", "files", "models", "inference-gateway"]
 
     def get_routers(self) -> list[RouterSpec]:
         router = APIRouter()
@@ -115,6 +117,20 @@ class EvaluatorPluginService(NemoService):
                 router=tasksets_routes.router,
                 tag="Evaluator Plugin Tasksets Routes",
                 description="Stored taskset CRUD routes.",
+                prefix="/v2/workspaces/{workspace}",
+            ),
+            RouterSpec(
+                # GET /apis/evaluator/v2/metric-types and /apis/evaluator/v2/evaluate/schema.
+                router=catalog_routes.router,
+                tag="Evaluator Plugin Catalog Routes",
+                description="Metric-type catalog and evaluate input-schema discovery routes.",
+                prefix="/v2",
+            ),
+            RouterSpec(
+                # POST /apis/evaluator/v2/workspaces/{workspace}/evaluate (synchronous).
+                router=evaluate_routes.router,
+                tag="Evaluator Plugin Synchronous Evaluate Route",
+                description="Synchronous, bounded evaluation that returns the result inline.",
                 prefix="/v2/workspaces/{workspace}",
             ),
         ]

--- a/plugins/nemo-evaluator/tests/api/v2/test_catalog_routes.py
+++ b/plugins/nemo-evaluator/tests/api/v2/test_catalog_routes.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""HTTP route-level tests for the read-only /metric-types and /evaluate/schema routes.
+"""HTTP route-level tests for the read-only /metric-types and evaluate-schema routes.
 
 Asserts the REST surface is sourced from the same `metric_catalog` helpers the
 CLI uses (single source of truth) and that schemas match the Pydantic models.
@@ -13,6 +13,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from nemo_evaluator.api.v2 import catalog as catalog_routes
+from nemo_evaluator.api.v2.evaluate import EvaluateSyncRequest
 from nemo_evaluator.jobs.evaluate import EvaluateInputSpec
 from nemo_evaluator.metric_catalog import metric_type_entries, metric_type_models
 
@@ -48,7 +49,24 @@ def test_get_metric_type_schema_unknown_returns_404(client: TestClient) -> None:
     assert resp.status_code == 404
 
 
-def test_get_evaluate_schema_matches_model(client: TestClient) -> None:
+def test_list_metric_types_response_is_typed() -> None:
+    # The OpenAPI schema must expose the envelope (metric_types with name/description
+    # entries) so generated SDK clients get typed accessors, not a free-form map.
+    app = FastAPI()
+    app.include_router(catalog_routes.router, prefix="/v2")
+    schema = app.openapi()["paths"]["/v2/metric-types"]["get"]["responses"]["200"]
+    response_ref = schema["content"]["application/json"]["schema"]["$ref"]
+    assert response_ref.endswith("/MetricTypeList")
+
+
+def test_get_evaluate_schema_matches_sync_request_model(client: TestClient) -> None:
+    # /evaluate/schema sits beside POST .../evaluate, so it must describe that route's body.
     resp = client.get("/v2/evaluate/schema")
+    assert resp.status_code == 200
+    assert resp.json() == EvaluateSyncRequest.model_json_schema()
+
+
+def test_get_evaluate_jobs_schema_matches_job_input_spec(client: TestClient) -> None:
+    resp = client.get("/v2/evaluate/jobs/schema")
     assert resp.status_code == 200
     assert resp.json() == EvaluateInputSpec.model_json_schema()

--- a/plugins/nemo-evaluator/tests/api/v2/test_catalog_routes.py
+++ b/plugins/nemo-evaluator/tests/api/v2/test_catalog_routes.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""HTTP route-level tests for the read-only /metric-types and /evaluate/schema routes.
+
+Asserts the REST surface is sourced from the same `metric_catalog` helpers the
+CLI uses (single source of truth) and that schemas match the Pydantic models.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from nemo_evaluator.api.v2 import catalog as catalog_routes
+from nemo_evaluator.jobs.evaluate import EvaluateInputSpec
+from nemo_evaluator.metric_catalog import metric_type_entries, metric_type_models
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    # Mirror production mounting: catalog routes are workspace-independent at /v2.
+    app.include_router(catalog_routes.router, prefix="/v2")
+    return TestClient(app)
+
+
+def test_list_metric_types_matches_catalog(client: TestClient) -> None:
+    resp = client.get("/v2/metric-types")
+    assert resp.status_code == 200
+    # Single source of truth: REST output is exactly the shared catalog helper,
+    # which is the same function the `nemo evaluator metric-types` CLI prints.
+    assert resp.json() == {"metric_types": metric_type_entries()}
+
+
+def test_get_metric_type_schema_matches_model(client: TestClient) -> None:
+    # Pick a known built-in metric type from the catalog rather than hardcoding.
+    metric_type, model_cls = next(iter(metric_type_models().items()))
+
+    resp = client.get(f"/v2/metric-types/{metric_type}")
+
+    assert resp.status_code == 200
+    assert resp.json() == model_cls.model_json_schema()
+
+
+def test_get_metric_type_schema_unknown_returns_404(client: TestClient) -> None:
+    resp = client.get("/v2/metric-types/not-a-real-metric")
+    assert resp.status_code == 404
+
+
+def test_get_evaluate_schema_matches_model(client: TestClient) -> None:
+    resp = client.get("/v2/evaluate/schema")
+    assert resp.status_code == 200
+    assert resp.json() == EvaluateInputSpec.model_json_schema()

--- a/plugins/nemo-evaluator/tests/api/v2/test_evaluate_sync_route.py
+++ b/plugins/nemo-evaluator/tests/api/v2/test_evaluate_sync_route.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""HTTP route-level tests for the synchronous POST /evaluate endpoint.
+
+Covers the happy-path offline evaluation plus the security/limit guards: cloudpickle metrics,
+network (remote) metrics, secret-bearing metrics, inline (non-ModelRef) models, FilesetRef
+datasets, and over-cap inline datasets are all rejected with 422.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.api.v2 import evaluate as evaluate_routes
+from nemo_evaluator.resolvers import PlatformModelResolver
+from nemo_evaluator.shared.metric_bundles.bundles import MetricBundlePackager, bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator.shared.metric_bundles.inline import InlineMetricBundlePackager
+from nemo_evaluator_sdk.enums import ModelFormat
+from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
+from nemo_evaluator_sdk.metrics.llm_judge import LLMJudgeMetric
+from nemo_evaluator_sdk.values import Model
+from nemo_evaluator_sdk.values.models import ModelRef
+from nemo_evaluator_sdk.values.scores import JSONScoreParser, RangeScore
+from nemo_platform_plugin.dependencies import get_sdk_client
+from pytest_mock import MockerFixture
+
+_BASE = "/v2/workspaces/default/evaluate"
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(evaluate_routes.router, prefix="/v2/workspaces/{workspace}")
+    # Offline built-in metrics never touch the SDK client.
+    app.dependency_overrides[get_sdk_client] = lambda: None
+    return TestClient(app)
+
+
+def _metric_body(packager: MetricBundlePackager) -> dict:
+    metric = ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.output}}")
+    bundle = bundle_metric(metric, packager)
+    return MetricInline.model_validate_json(bundle.model_dump_json()).model_dump(mode="json")
+
+
+def _llm_judge_inline_model_body() -> dict:
+    """An LLM-judge metric whose judge model is an inline Model (not a ModelRef)."""
+    metric = LLMJudgeMetric(
+        model=Model(url="http://example.test/v1/chat/completions", name="judge"),
+        scores=[
+            RangeScore(
+                name="quality",
+                description="quality score",
+                minimum=0,
+                maximum=4,
+                parser=JSONScoreParser(json_path="quality"),
+            )
+        ],
+        prompt_template={"messages": [{"role": "user", "content": "{{item.input}}"}]},
+    )
+    bundle = bundle_metric(metric, InlineMetricBundlePackager())
+    return MetricInline.model_validate_json(bundle.model_dump_json()).model_dump(mode="json")
+
+
+def test_sync_evaluate_offline_returns_scores(client: TestClient) -> None:
+    body = {
+        "metrics": [_metric_body(InlineMetricBundlePackager())],
+        "dataset": [
+            {"expected": "yes", "output": "yes"},
+            {"expected": "yes", "output": "no"},
+        ],
+    }
+
+    resp = client.post(_BASE, json=body)
+
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert "aggregate_scores" in payload
+    assert len(payload["row_scores"]) == 2
+
+
+def test_sync_evaluate_rejects_cloudpickle_metric(client: TestClient) -> None:
+    body = {
+        "metrics": [_metric_body(CloudpickleMetricBundlePackager())],
+        "dataset": [{"expected": "yes", "output": "yes"}],
+    }
+
+    resp = client.post(_BASE, json=body)
+
+    assert resp.status_code == 422
+
+
+def test_sync_evaluate_rejects_network_backed_metric(client: TestClient) -> None:
+    # Network-backed metrics call a user-supplied URL (SSRF surface) — rejected.
+    body_metric = _metric_body(InlineMetricBundlePackager())
+    body_metric["metric_type"] = "remote"
+    body = {
+        "metrics": [body_metric],
+        "dataset": [{"expected": "yes", "output": "yes"}],
+    }
+
+    resp = client.post(_BASE, json=body)
+
+    assert resp.status_code == 422
+
+
+def test_sync_evaluate_rejects_metric_with_secrets(client: TestClient) -> None:
+    # Secret references would be resolved from the API-process env — exfil vector, rejected.
+    body_metric = _metric_body(InlineMetricBundlePackager())
+    body_metric["secrets"] = {"api_key": "NVIDIA_API_KEY"}
+    body = {
+        "metrics": [body_metric],
+        "dataset": [{"expected": "yes", "output": "yes"}],
+    }
+
+    resp = client.post(_BASE, json=body)
+
+    assert resp.status_code == 422
+
+
+def test_sync_evaluate_rejects_inline_model(client: TestClient) -> None:
+    # Inline models carry an arbitrary URL (SSRF) — only platform ModelRefs allowed.
+    body = {
+        "metrics": [_llm_judge_inline_model_body()],
+        "dataset": [{"input": "hi", "output": "hello"}],
+    }
+
+    resp = client.post(_BASE, json=body)
+
+    assert resp.status_code == 422
+
+
+def test_sync_evaluate_llm_judge_modelref_forwards_caller_headers(client: TestClient, mocker: MockerFixture) -> None:
+    # LLM-judge with a ModelRef judge: the resolved model reaches inference with the caller's headers.
+    class _CallerSdk:
+        _custom_headers = {"X-NMP-Principal-Id": "user@example.com"}
+
+    client.app.dependency_overrides[get_sdk_client] = _CallerSdk
+
+    mocker.patch.object(
+        PlatformModelResolver,
+        "resolve_model",
+        new=mocker.AsyncMock(
+            return_value=Model(
+                url="http://igw.local/v1/chat/completions", name="resolved-judge", format=ModelFormat.OPEN_AI
+            )
+        ),
+    )
+
+    captured: dict = {}
+
+    async def _fake_inference(model: Model, request: dict, max_retries: int | None = 3, **kwargs: object) -> dict:
+        captured["headers"] = dict(model.default_headers or {})
+        return {"choices": [{"message": {"content": '{"quality": 3}'}}]}
+
+    mocker.patch("nemo_evaluator_sdk.inference.make_inference_request", new=_fake_inference)
+
+    metric = LLMJudgeMetric(
+        model=ModelRef(root="default/judge"),
+        scores=[RangeScore(name="quality", minimum=0, maximum=4, parser=JSONScoreParser(json_path="quality"))],
+        prompt_template={"messages": [{"role": "user", "content": "{{item.input}}"}]},
+    )
+    bundle = bundle_metric(metric, InlineMetricBundlePackager())
+    body_metric = MetricInline.model_validate_json(bundle.model_dump_json()).model_dump(mode="json")
+    body = {"metrics": [body_metric], "dataset": [{"input": "hi", "output": "hello"}]}
+
+    resp = client.post(_BASE, json=body)
+
+    assert resp.status_code == 200, resp.text
+    # The resolved judge model reached the inference call carrying the caller's principal header.
+    assert captured["headers"] == {"X-NMP-Principal-Id": "user@example.com"}
+    assert len(resp.json()["row_scores"]) == 1
+
+
+def test_sync_evaluate_rejects_fileset_ref_dataset(client: TestClient) -> None:
+    body = {
+        "metrics": [_metric_body(InlineMetricBundlePackager())],
+        "dataset": "default/my-fileset",  # not inline rows
+    }
+
+    resp = client.post(_BASE, json=body)
+
+    assert resp.status_code == 422
+
+
+def test_sync_evaluate_rejects_over_cap_dataset(client: TestClient) -> None:
+    body = {
+        "metrics": [_metric_body(InlineMetricBundlePackager())],
+        "dataset": [{"expected": "a", "output": "a"} for _ in range(11)],
+    }
+
+    resp = client.post(_BASE, json=body)
+
+    assert resp.status_code == 422

--- a/plugins/nemo-evaluator/tests/api/v2/test_evaluate_sync_route.py
+++ b/plugins/nemo-evaluator/tests/api/v2/test_evaluate_sync_route.py
@@ -3,12 +3,17 @@
 
 """HTTP route-level tests for the synchronous POST /evaluate endpoint.
 
-Covers the happy-path offline evaluation plus the security/limit guards: cloudpickle metrics,
-network (remote) metrics, secret-bearing metrics, inline (non-ModelRef) models, FilesetRef
-datasets, and over-cap inline datasets are all rejected with 422.
+Covers the happy-path offline evaluation, the security/limit guards (non-inline payloads,
+network metrics, secret-bearing metrics, inline models, FilesetRef datasets, row/metric caps),
+and the capacity machinery: 503 backpressure, 504 timeout, and slot release on true completion
+even when the submitting request's event loop is gone (TestClient uses a loop per request).
 """
 
 from __future__ import annotations
+
+import threading
+import time
+from typing import Any
 
 import pytest
 from fastapi import FastAPI
@@ -20,11 +25,13 @@ from nemo_evaluator.shared.metric_bundles.bundles import MetricBundlePackager, b
 from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
 from nemo_evaluator.shared.metric_bundles.inline import InlineMetricBundlePackager
 from nemo_evaluator_sdk.enums import ModelFormat
+from nemo_evaluator_sdk.execution.values import EvaluationError
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
 from nemo_evaluator_sdk.metrics.llm_judge import LLMJudgeMetric
+from nemo_evaluator_sdk.metrics.remote import RemoteMetric
 from nemo_evaluator_sdk.values import Model
 from nemo_evaluator_sdk.values.models import ModelRef
-from nemo_evaluator_sdk.values.scores import JSONScoreParser, RangeScore
+from nemo_evaluator_sdk.values.scores import JSONScoreParser, RangeScore, RemoteScore
 from nemo_platform_plugin.dependencies import get_sdk_client
 from pytest_mock import MockerFixture
 
@@ -38,6 +45,12 @@ def client() -> TestClient:
     # Offline built-in metrics never touch the SDK client.
     app.dependency_overrides[get_sdk_client] = lambda: None
     return TestClient(app)
+
+
+@pytest.fixture
+def fresh_slots(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate slot state so capacity tests can't poison each other via the module global."""
+    monkeypatch.setattr(evaluate_routes, "_SYNC_SLOTS", threading.BoundedSemaphore(1))
 
 
 def _metric_body(packager: MetricBundlePackager) -> dict:
@@ -94,9 +107,16 @@ def test_sync_evaluate_rejects_cloudpickle_metric(client: TestClient) -> None:
 
 
 def test_sync_evaluate_rejects_network_backed_metric(client: TestClient) -> None:
-    # Network-backed metrics call a user-supplied URL (SSRF surface) — rejected.
-    body_metric = _metric_body(InlineMetricBundlePackager())
-    body_metric["metric_type"] = "remote"
+    # Network-backed metrics call a user-supplied URL (SSRF surface) — rejected. Built from a
+    # real, self-consistent RemoteMetric bundle so this pins the route's network-type guard
+    # itself, not the bundle-consistency backstop a mutated metric_type would trip instead.
+    metric = RemoteMetric(
+        url="http://attacker.test/score",
+        body={"input": "{{item.expected}}"},
+        scores=[RemoteScore(name="score")],
+    )
+    bundle = bundle_metric(metric, InlineMetricBundlePackager())
+    body_metric = MetricInline.model_validate_json(bundle.model_dump_json()).model_dump(mode="json")
     body = {
         "metrics": [body_metric],
         "dataset": [{"expected": "yes", "output": "yes"}],
@@ -105,6 +125,7 @@ def test_sync_evaluate_rejects_network_backed_metric(client: TestClient) -> None
     resp = client.post(_BASE, json=body)
 
     assert resp.status_code == 422
+    assert "external endpoint" in resp.json()["detail"]
 
 
 def test_sync_evaluate_rejects_metric_with_secrets(client: TestClient) -> None:
@@ -195,3 +216,147 @@ def test_sync_evaluate_rejects_over_cap_dataset(client: TestClient) -> None:
     resp = client.post(_BASE, json=body)
 
     assert resp.status_code == 422
+
+
+def test_sync_evaluate_rejects_over_cap_metrics(client: TestClient) -> None:
+    metric_body = _metric_body(InlineMetricBundlePackager())
+    body = {
+        "metrics": [metric_body for _ in range(evaluate_routes.MAX_SYNC_METRICS + 1)],
+        "dataset": [{"expected": "yes", "output": "yes"}],
+    }
+
+    resp = client.post(_BASE, json=body)
+
+    assert resp.status_code == 422
+
+
+def test_sync_evaluate_unknown_model_ref_returns_actionable_422(client: TestClient, mocker: MockerFixture) -> None:
+    # Resolution failures are caller errors; the 422 must carry the resolver's message.
+    class _CallerSdk:
+        _custom_headers = {"X-NMP-Principal-Id": "user@example.com"}
+
+    client.app.dependency_overrides[get_sdk_client] = _CallerSdk
+    mocker.patch.object(
+        PlatformModelResolver,
+        "resolve_model",
+        new=mocker.AsyncMock(side_effect=ValueError("Model reference 'default/judge' not found.")),
+    )
+    metric = LLMJudgeMetric(
+        model=ModelRef(root="default/judge"),
+        scores=[RangeScore(name="quality", minimum=0, maximum=4, parser=JSONScoreParser(json_path="quality"))],
+        prompt_template={"messages": [{"role": "user", "content": "{{item.input}}"}]},
+    )
+    bundle = bundle_metric(metric, InlineMetricBundlePackager())
+    body_metric = MetricInline.model_validate_json(bundle.model_dump_json()).model_dump(mode="json")
+
+    resp = client.post(_BASE, json={"metrics": [body_metric], "dataset": [{"input": "hi"}]})
+
+    assert resp.status_code == 422
+    assert "default/judge" in resp.json()["detail"]
+
+
+def test_sync_evaluate_worker_evaluation_error_returns_422_with_detail(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _failing_run(**kwargs: object) -> object:
+        raise EvaluationError(0, "dataset is missing required column 'expected'")
+
+    monkeypatch.setattr(evaluate_routes, "run_evaluation", _failing_run)
+    body = {
+        "metrics": [_metric_body(InlineMetricBundlePackager())],
+        "dataset": [{"expected": "yes", "output": "yes"}],
+    }
+
+    resp = client.post(_BASE, json=body)
+
+    assert resp.status_code == 422
+    assert "missing required column" in resp.json()["detail"]
+
+
+def test_sync_evaluate_worker_internal_bug_returns_500(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A TypeError raised while executing is an internal bug, not a caller error: it must be a
+    # 500 (visible to error-rate alerting), not a client-blaming 422.
+    def _buggy_run(**kwargs: object) -> object:
+        raise TypeError("'NoneType' object is not subscriptable")
+
+    monkeypatch.setattr(evaluate_routes, "run_evaluation", _buggy_run)
+    body = {
+        "metrics": [_metric_body(InlineMetricBundlePackager())],
+        "dataset": [{"expected": "yes", "output": "yes"}],
+    }
+
+    resp = client.post(_BASE, json=body)
+
+    assert resp.status_code == 500
+
+
+def test_bound_worker_inference_caps_judge_and_ragas_call_time() -> None:
+    # A detached worker's slot occupancy is bounded by its inference calls: judge metrics get a
+    # wrapped inference fn, RAGAS metrics get request_timeout/max_retries inference extras.
+    from nemo_evaluator_sdk.metrics.ragas import AnswerAccuracyMetric
+
+    judge = LLMJudgeMetric(
+        model=ModelRef(root="default/judge"),
+        scores=[RangeScore(name="quality", minimum=0, maximum=4, parser=JSONScoreParser(json_path="quality"))],
+        prompt_template={"messages": [{"role": "user", "content": "{{item.input}}"}]},
+    )
+    ragas = AnswerAccuracyMetric(judge_model=ModelRef(root="default/judge"))
+
+    evaluate_routes._bound_worker_inference([judge, ragas], budget_seconds=60.0)
+
+    assert judge._inference_fn is not None
+    ragas_inference = ragas.inference.model_dump()
+    assert ragas_inference["request_timeout"] == 60.0
+    assert ragas_inference["max_retries"] == evaluate_routes._SYNC_WORKER_MAX_RETRIES
+
+
+def test_sync_evaluate_backpressure_timeout_and_slot_release(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, fresh_slots: None
+) -> None:
+    """One request through the full capacity lifecycle: 504 on timeout, 503 while the orphaned
+    worker holds its slot, then release on true completion.
+
+    TestClient runs each request on a fresh event loop, so this also pins that slot release
+    must not depend on the submitting request's loop still being alive (regression: a
+    loop-coupled release leaked the slot permanently and 503'd the endpoint until restart).
+    """
+    monkeypatch.setattr(evaluate_routes, "SYNC_EVALUATE_TIMEOUT_SECONDS", 0.2)
+    gate = threading.Event()
+    worker_is_daemon: list[bool] = []
+    real_run_evaluation = evaluate_routes.run_evaluation
+
+    def _gated_run(**kwargs: Any) -> object:
+        worker_is_daemon.append(threading.current_thread().daemon)
+        assert gate.wait(timeout=10), "test gate was never opened"
+        return real_run_evaluation(**kwargs)
+
+    monkeypatch.setattr(evaluate_routes, "run_evaluation", _gated_run)
+    body = {
+        "metrics": [_metric_body(InlineMetricBundlePackager())],
+        "dataset": [{"expected": "yes", "output": "yes"}],
+    }
+
+    # 1. The eval outlives the sync budget: 504, worker detaches but keeps its slot.
+    resp = client.post(_BASE, json=body)
+    assert resp.status_code == 504
+
+    # 2. The orphaned worker still holds the only slot: immediate 503, no queueing.
+    resp = client.post(_BASE, json=body)
+    assert resp.status_code == 503
+
+    # 3. The worker finishes; its done callback must release the slot even though the
+    #    request loop that submitted it is long gone.
+    gate.set()
+    deadline = time.monotonic() + 5
+    while True:
+        resp = client.post(_BASE, json=body)
+        if resp.status_code == 200:
+            break
+        # 503 while the slot is still held; 504 possible if a probe itself outruns the
+        # shortened budget on a slow machine — both mean "keep polling".
+        assert resp.status_code in (503, 504), resp.text
+        assert time.monotonic() < deadline, "slot was never released after worker completion"
+        time.sleep(0.05)
+
+    # Sync workers must be daemon threads so a stuck eval can't block process shutdown.
+    assert worker_is_daemon and all(worker_is_daemon)

--- a/plugins/nemo-evaluator/tests/api/v2/test_evaluate_sync_route.py
+++ b/plugins/nemo-evaluator/tests/api/v2/test_evaluate_sync_route.py
@@ -352,12 +352,9 @@ def test_sync_evaluate_error_responses_are_typed_in_openapi() -> None:
 def test_sync_evaluate_backpressure_timeout_and_slot_release(
     client: TestClient, monkeypatch: pytest.MonkeyPatch, fresh_slots: None
 ) -> None:
-    """One request through the full capacity lifecycle: 504 on timeout, 503 while the orphaned
-    worker holds its slot, then release on true completion.
-
-    TestClient runs each request on a fresh event loop, so this also pins that slot release
-    must not depend on the submitting request's loop still being alive (regression: a
-    loop-coupled release leaked the slot permanently and 503'd the endpoint until restart).
+    """Full capacity lifecycle: 504 on timeout, 503 while the orphaned worker holds its slot,
+    release on completion. TestClient's per-request loop also pins that release can't depend on
+    the submitting loop (regression: a loop-coupled release leaked the slot until restart).
     """
     monkeypatch.setattr(evaluate_routes, "SYNC_EVALUATE_TIMEOUT_SECONDS", 0.2)
     gate = threading.Event()

--- a/plugins/nemo-evaluator/tests/api/v2/test_evaluate_sync_route.py
+++ b/plugins/nemo-evaluator/tests/api/v2/test_evaluate_sync_route.py
@@ -310,6 +310,45 @@ def test_bound_worker_inference_caps_judge_and_ragas_call_time() -> None:
     assert ragas_inference["max_retries"] == evaluate_routes._SYNC_WORKER_MAX_RETRIES
 
 
+def test_bound_worker_inference_clamps_and_strips_ragas_transport() -> None:
+    # Explicit oversized timeout/retries are clamped to the budget, and caller-supplied
+    # transport/auth extras (SSRF / identity-forgery vector) are dropped from RAGAS inference.
+    from nemo_evaluator_sdk.metrics.ragas import AnswerAccuracyMetric
+    from nemo_evaluator_sdk.values.params import InferenceParams
+
+    ragas = AnswerAccuracyMetric(
+        judge_model=ModelRef(root="default/judge"),
+        inference=InferenceParams.model_validate(
+            {
+                "request_timeout": 3600,
+                "max_retries": 99,
+                "temperature": 0.3,
+                "base_url": "http://attacker.test/v1",
+                "default_headers": {"X-NMP-Principal-Id": "attacker"},
+            }
+        ),
+    )
+
+    evaluate_routes._bound_worker_inference([ragas], budget_seconds=60.0)
+
+    dumped = ragas.inference.model_dump()
+    assert dumped["request_timeout"] == 60.0
+    assert dumped["max_retries"] == evaluate_routes._SYNC_WORKER_MAX_RETRIES
+    assert dumped["temperature"] == 0.3
+    assert "base_url" not in dumped
+    assert "default_headers" not in dumped
+
+
+def test_sync_evaluate_error_responses_are_typed_in_openapi() -> None:
+    # 422/503/504 bodies must carry a schema so generated clients get typed error detail.
+    app = FastAPI()
+    app.include_router(evaluate_routes.router, prefix="/v2/workspaces/{workspace}")
+    responses = app.openapi()["paths"]["/v2/workspaces/{workspace}/evaluate"]["post"]["responses"]
+    for code in ("422", "503", "504"):
+        ref = responses[code]["content"]["application/json"]["schema"]["$ref"]
+        assert ref.endswith("/EvaluateSyncError")
+
+
 def test_sync_evaluate_backpressure_timeout_and_slot_release(
     client: TestClient, monkeypatch: pytest.MonkeyPatch, fresh_slots: None
 ) -> None:

--- a/plugins/nemo-evaluator/tests/test_evaluate_job.py
+++ b/plugins/nemo-evaluator/tests/test_evaluate_job.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Literal, cast
 
-import nemo_evaluator.cli as evaluator_cli
+import nemo_evaluator.metric_catalog as evaluator_metric_catalog
 import pytest
 from nemo_evaluator.cli import EvaluatorPluginCLI
 from nemo_evaluator.filesets import FilesetRef
@@ -25,6 +25,7 @@ from nemo_evaluator.jobs.evaluate import (
     EvaluateInputSpec,
     EvaluateJob,
     EvaluateSpec,
+    to_runtime_bundle,
 )
 from nemo_evaluator.resolvers import PlatformModelResolver, _parse_required_workspace_name
 from nemo_evaluator.shared.metric_bundles.bundles import (
@@ -38,7 +39,7 @@ from nemo_evaluator.shared.metric_bundles.bundles import (
 from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
 from nemo_evaluator.tasks.evaluate import main as evaluate_task_main
 from nemo_evaluator.tasks.runner import SDK_INITIALIZATION_EXIT_CODE
-from nemo_evaluator_sdk.enums import AgentFormat
+from nemo_evaluator_sdk.enums import AgentFormat, ModelFormat
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
 from nemo_evaluator_sdk.metrics.f1 import F1Metric
 from nemo_evaluator_sdk.metrics.llm_judge import LLMJudgeMetric
@@ -170,7 +171,7 @@ def _generated_llm_as_judge_spec() -> dict[str, Any]:
                         url="https://integrate.api.nvidia.com/v1/chat/completions",
                         name="nvidia/nemotron-3-super-120b-a12b",
                         api_key_secret=SecretRef(root="NVIDIA_API_KEY"),
-                        format="nim",
+                        format=ModelFormat.NVIDIA_NIM,
                     ),
                     scores=[
                         RangeScore(
@@ -555,7 +556,7 @@ def test_cli_metric_types_rejects_duplicate_metric_type_keys(mocker: MockerFixtu
         type: Literal["duplicate-metric"] = "duplicate-metric"
 
     mocker.patch.object(
-        evaluator_cli,
+        evaluator_metric_catalog,
         "_unwrap_metric_model_classes",
         return_value=[FirstMetric, SecondMetric],
     )
@@ -564,7 +565,7 @@ def test_cli_metric_types_rejects_duplicate_metric_type_keys(mocker: MockerFixtu
         ValueError,
         match="Duplicate metric type 'duplicate-metric' mapped to both FirstMetric and SecondMetric",
     ):
-        evaluator_cli._metric_type_models()
+        evaluator_metric_catalog.metric_type_models()
 
 
 def test_cli_metric_types_reports_json_schema_for_named_metric_types() -> None:
@@ -727,7 +728,7 @@ async def test_evaluate_job_to_spec_resolves_bundled_metric_model_refs_before_co
         is_local=False,
     )
     assert isinstance(canonical, EvaluateSpec)
-    canonical_metric = unbundle_metric(canonical.metrics[0])
+    canonical_metric = unbundle_metric(to_runtime_bundle(canonical.metrics[0]))
     assert isinstance(canonical_metric, LLMJudgeMetric)
     assert isinstance(canonical_metric.model, Model)
     assert canonical_metric.model.name == "judge"
@@ -781,7 +782,7 @@ async def test_evaluate_job_to_spec_preserves_metric_without_model_refs() -> Non
     )
 
     assert isinstance(canonical, EvaluateSpec)
-    metric = unbundle_metric(canonical.metrics[0])
+    metric = unbundle_metric(to_runtime_bundle(canonical.metrics[0]))
     assert isinstance(metric, LLMJudgeMetric)
     assert metric.prompt_template is None
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/ragas/base.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/ragas/base.py
@@ -179,6 +179,9 @@ class BaseRAGASMetric(MetricBase):
                 "base_url": judge_model.url.replace("/completions", "").replace("/chat", ""),
                 "api_key": initial_api_key,
             }
+            if judge_model.default_headers:
+                # Forward runtime headers (e.g. caller identity) or the judge call drops them.
+                self._llm_model["default_headers"] = dict(judge_model.default_headers)
 
         embeddings_model = getattr(self, "embeddings_model", None)
         if isinstance(embeddings_model, Model):
@@ -198,6 +201,8 @@ class BaseRAGASMetric(MetricBase):
                 "api_key": initial_api_key,
                 "truncate": self._inference_params.get("truncate", "NONE"),
             }
+            if embeddings_model.default_headers:
+                self._embed_params["default_headers"] = dict(embeddings_model.default_headers)
 
     async def resolve_models(self, model_resolver: ModelResolver) -> None:
         """Resolve RAGAS model references before the metric is used for evaluation."""
@@ -296,9 +301,12 @@ class BaseRAGASMetric(MetricBase):
         if not self._llm_model:
             return None
 
-        chat_params: dict[str, Any] = {**self._llm_model}
+        chat_params: dict[str, Any] = {}
         if self._inference_params:
             chat_params.update(self._inference_params)
+        # Applied last: transport/auth from the resolved model must win over inference params,
+        # else a request could redirect the judge call (SSRF) or replace the forwarded identity.
+        chat_params.update(self._llm_model)
 
         # Filter out None values
         chat_params = {k: v for k, v in chat_params.items() if v is not None}

--- a/skills/nemo-evaluator-plugin/SKILL.md
+++ b/skills/nemo-evaluator-plugin/SKILL.md
@@ -138,7 +138,8 @@ See examples of using the plugin SDK interface in [plugin_sdk_examples.py](./ass
 The CLI metric-discovery and evaluate commands have HTTP equivalents under `/apis/evaluator`, for non-Python clients:
 
 - `GET /v2/metric-types` and `GET /v2/metric-types/{metric_type}` — mirror `nemo evaluator metric-types [<name>]`.
-- `GET /v2/evaluate/schema` — mirrors `nemo evaluator evaluate explain`.
+- `GET /v2/evaluate/schema` — JSON schema for the synchronous `POST .../evaluate` request body (`EvaluateSyncRequest`).
+- `GET /v2/evaluate/jobs/schema` — JSON schema for the durable-job input spec; mirrors `nemo evaluator evaluate explain`.
 - `POST /v2/workspaces/{workspace}/evaluate` — synchronous evaluation (mirrors `nemo evaluator evaluate run`). Inline built-in metrics + inline rows only (cloudpickle bundles and FilesetRef datasets are rejected; submit those as a durable job).
 - `POST /v2/workspaces/{workspace}/evaluate/jobs` — durable jobs (mirrors `nemo evaluator evaluate submit`).
 

--- a/skills/nemo-evaluator-plugin/SKILL.md
+++ b/skills/nemo-evaluator-plugin/SKILL.md
@@ -133,6 +133,15 @@ status = platform_client.evaluator.plugin_status()
 
 See examples of using the plugin SDK interface in [plugin_sdk_examples.py](./assets/examples/plugin_sdk_examples.py).
 
+## REST API
+
+The CLI metric-discovery and evaluate commands have HTTP equivalents under `/apis/evaluator`, for non-Python clients:
+
+- `GET /v2/metric-types` and `GET /v2/metric-types/{metric_type}` — mirror `nemo evaluator metric-types [<name>]`.
+- `GET /v2/evaluate/schema` — mirrors `nemo evaluator evaluate explain`.
+- `POST /v2/workspaces/{workspace}/evaluate` — synchronous evaluation (mirrors `nemo evaluator evaluate run`). Inline built-in metrics + inline rows only (cloudpickle bundles and FilesetRef datasets are rejected; submit those as a durable job).
+- `POST /v2/workspaces/{workspace}/evaluate/jobs` — durable jobs (mirrors `nemo evaluator evaluate submit`).
+
 ## Security
 Make sure not to print any secrets to stdout since this can be collected as logs
 


### PR DESCRIPTION
## Summary

Brings the `nemo-evaluator` plugin's **REST surface to parity with its CLI**. After the
legacy evaluator service was removed and replaced by the plugin, several CLI capabilities had
no HTTP equivalent — so a UI or any non-Python client couldn't reach them. This adds those
endpoints, with a synchronous evaluate route that is carefully bounded to what is safe inside
the long-lived API process.

| New endpoint | Purpose | CLI equivalent |
|---|---|---|
| `GET /v2/metric-types` | List built-in metric types + descriptions | `nemo evaluator metric-types` |
| `GET /v2/metric-types/{metric_type}` | JSON schema for one metric type | `nemo evaluator metric-types <name>` |
| `GET /v2/evaluate/schema` | Schema for the **synchronous** evaluate request body | — |
| `GET /v2/evaluate/jobs/schema` | Schema for the durable-job input spec | `nemo evaluator evaluate explain` |
| `POST /v2/workspaces/{workspace}/evaluate` | **Synchronous** bounded evaluation, result inline | `nemo evaluator evaluate run` |

## Changes

- **`metric_catalog.py`** (new) — metric-type introspection moves out of `cli.py` so the CLI
  and the new REST routes share one source of truth.
- **`jobs/evaluate.py`** — factored the `Evaluator().run_sync` target dispatch out of
  `EvaluateJob.run` into a reusable `run_evaluation(...)` (behavior-preserving), shared by the
  job and the sync route.
- **`api/v2/catalog.py`** (new) — read-only discovery routes, mounted at `/v2`. Typed
  `MetricTypeList`/`MetricTypeEntry` response envelope so generated clients get typed accessors.
- **`api/v2/evaluate.py`** (new) — the synchronous evaluate route (see hardening below).
- **`service.py`** — registers the routers and authz (`evaluator.metric_types` read scopes;
  new `evaluator.evaluate.exec` write permission).
- **`metrics/ragas/base.py`** — RAGAS judge/embeddings clients now carry the resolved model's
  `default_headers` (so run-as-caller identity forwarding works for the RAGAS family), and the
  resolved model's transport/auth is authoritative over caller-supplied inference params.
- Regenerated `plugins/nemo-evaluator/openapi/openapi.yaml`; documented the endpoints in the
  plugin reference and the `nemo-evaluator-plugin` skill.

## Security / limits on the synchronous endpoint

It executes the SDK evaluator inside the long-lived API process, so it is deliberately bounded.
Rejected with `422`:

- **Non-inline metric payloads** — enforced as an allow-list (`payload.kind == "inline"`), so
  cloudpickle bundles and any future payload kind fail closed; arbitrary code is never executed
  in the API process. Ship those as a durable job.
- **Network-backed metric types** (`remote`, `nemo-agent-toolkit-remote`) — they call a
  user-supplied URL (SSRF surface).
- **Metrics with secret references** — resolving request-supplied secrets from the API-process
  environment would be an exfiltration vector.
- **Inline model definitions** — any model a metric uses must be a platform `ModelRef`
  (`workspace/model`), scanned recursively; inline models carry an arbitrary URL (SSRF). Refs
  resolve to the inference gateway with no secret, and the in-process call carries the
  **caller's** request-scoped headers, so it runs as the caller (not an elevated service
  principal). For RAGAS, caller-supplied `inference` params are reduced to a generation-param
  allow-list so they can't override the resolved model's transport/auth.
- **Online targets** and **`FilesetRef` datasets** — submit those as a job.

Capacity and lifecycle:

- Inline dataset rows only, capped at `MAX_SYNC_ROWS` (10); metrics list capped at
  `MAX_SYNC_METRICS` (10).
- Bounded concurrency via a thread-safe semaphore (`_SYNC_EVAL_MAX_WORKERS`, 4). At capacity the
  endpoint returns `503` immediately (no queueing); the slot is reserved before model resolution
  so backpressure gates downstream lookups.
- Runs on **daemon worker threads** so a stuck eval can't block process shutdown (SIGTERM), and
  under a **60s wall-clock timeout** → `504`. Each metric's model calls are bounded to the same
  budget (retries capped), so a detached worker frees its slot near the timeout rather than
  holding it for the upstream's full default timeout.
- `422`/`503`/`504` responses carry a typed `EvaluateSyncError` body with actionable detail.

`models` and `inference-gateway` are intentionally **not** evaluator startup dependencies (they
would block startup when deployed-but-unhealthy); the sync route degrades at request time with an
actionable `422` instead.

## Testing

- **`tests/api/v2/test_catalog_routes.py`** — catalog/schema parity, 404, typed response
  envelope, and the job-vs-sync schema split.
- **`tests/api/v2/test_evaluate_sync_route.py`** — happy-path offline eval; all guard rejections
  (SSRF guard pinned with a real `RemoteMetric` bundle, not a mutated type); the full capacity
  lifecycle (503 backpressure, 504 timeout, slot release across event loops, daemon workers);
  metrics cap; actionable-422 and worker-bug-500 error mapping; RAGAS transport strip + timeout
  clamp; typed error bodies.
- **`packages/nemo_evaluator_sdk/tests/metrics/ragas/test_ragas_headers.py`** (new) — RAGAS
  forwards caller headers to judge/embeddings clients, and caller `inference` params cannot
  override the resolved model's transport/identity.
- `pytest plugins/nemo-evaluator/tests/` → **470 passed** (integration deselected); relevant SDK
  RAGAS tests pass; `ruff` + `ty` clean.

## Notes

- The web SDK (`gen:evaluator`) regenerates cleanly; its output is gitignored, so no diff here.
- The `SKILL.md` edit makes `skill.oms.sig` stale — run `/nvskills-ci` so the signing bot
  refreshes it (required by branch protection before merge).
- Stainless is out of scope: the platform spec has no `/apis/evaluator/*` paths; the plugin owns
  its SDK and surfaces to web clients via orval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new evaluator API for discovering metric types and fetching request schemas.
  * Introduced a synchronous evaluation endpoint for quick, in-process runs.
  * Expanded documentation with REST API coverage and command-to-endpoint mapping.

* **Bug Fixes**
  * Preserved caller-provided request headers across model and embedding configuration.
  * Improved how evaluation settings are combined so resolved model settings take precedence.
  * Added stricter validation, better timeout handling, and clearer error responses for synchronous evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->