### PR TITLE
fix(docs): use IGW providers consistent with docs and defaults

### DIFF
--- a/docs/auditor/sdk-resources.mdx
+++ b/docs/auditor/sdk-resources.mdx
@@ -115,11 +115,11 @@ target = auditor.targets.create(
     workspace="default",
     name="llama-31-8b",
     type="nim.NVOpenAIChat",
-    model="meta/llama-3.1-8b-instruct",
+    model="nvidia/meta/llama-3.1-8b-instruct",
     options={
         "nim": {
             "nmp_uri_spec": {
-                "inference_gateway": {"workspace": "default", "provider": "nvidia-build"},
+                "inference_gateway": {"workspace": "default", "provider": "nvidia-inference-api"},
             },
         },
     },

--- a/docs/auditor/targets/index.mdx
+++ b/docs/auditor/targets/index.mdx
@@ -24,18 +24,27 @@ See [Target Schema](/documentation/vulnerability-scanning/targets/schema) for th
 Audit a NIM (or any OpenAI-compatible chat endpoint) routed through a NeMo Platform provider:
 
 ```python
+# List providers registered in your deployment and pick one.
+providers = client.inference.providers.list(workspace="default")
+for provider in providers["data"]:
+    print(provider["name"], provider.get("host_url"))
+```
+
+Use a `provider` name from this output in the target below. The model identifier format depends on the provider — check the provider's API documentation or served-model list if unsure.
+
+```python
 target = client.auditor.targets.create(
     workspace="default",
     name="llama-31-8b",
     type="nim.NVOpenAIChat",
-    model="meta/llama-3.1-8b-instruct",
+    model="nvidia/meta/llama-3.1-8b-instruct",
     options={
         "nim": {
             "max_tokens": 1024,
             "nmp_uri_spec": {
                 "inference_gateway": {
                     "workspace": "default",
-                    "provider": "nvidia-build",
+                    "provider": "nvidia-inference-api",
                 },
             },
         },
@@ -110,12 +119,12 @@ updated = client.auditor.targets.update(
     workspace="default",
     name="llama-31-8b",
     type="nim.NVOpenAIChat",
-    model="meta/llama-3.3-70b-instruct",
+    model="nvidia/meta/llama-3.3-70b-instruct",
     options={
         "nim": {
             "max_tokens": 2048,
             "nmp_uri_spec": {
-                "inference_gateway": {"workspace": "default", "provider": "nvidia-build"},
+                "inference_gateway": {"workspace": "default", "provider": "nvidia-inference-api"},
             },
         },
     },

--- a/docs/auditor/targets/inference-gateway.mdx
+++ b/docs/auditor/targets/inference-gateway.mdx
@@ -35,21 +35,21 @@ Both `workspace` and `provider` are required. Other keys inside `nmp_uri_spec` a
 
 ## Worked Example
 
-Audit a NIM endpoint registered as the `nvidia-build` provider in the `default` workspace:
+Audit a NIM endpoint registered as the `nvidia-inference-api` provider in the `default` workspace:
 
 ```python
 target = client.auditor.targets.create(
     workspace="default",
     name="llama-31-8b",
     type="nim.NVOpenAIChat",
-    model="meta/llama-3.1-8b-instruct",
+    model="nvidia/meta/llama-3.1-8b-instruct",
     options={
         "nim": {
             "max_tokens": 1024,
             "nmp_uri_spec": {
                 "inference_gateway": {
                     "workspace": "default",
-                    "provider": "nvidia-build",
+                    "provider": "nvidia-inference-api",
                 },
             },
         },

--- a/docs/auditor/tutorials/run-audit-locally.mdx
+++ b/docs/auditor/tutorials/run-audit-locally.mdx
@@ -23,7 +23,7 @@ This tutorial takes approximately **10 minutes** to complete, plus however long 
 
 - Install and start NeMo Platform using the [Setup guide](/documentation/get-started).
 - Install garak in a Python virtual environment so the plugin can shell out to it. By default the plugin invokes `~/.auditor/.venv/bin/python -m garak`. Override the interpreter path with `NEMO_AUDITOR_GARAK_PYTHON` if your install lives elsewhere.
-- Configure at least one Inference Gateway provider — this tutorial uses a provider named `nvidia-build` that routes to NVIDIA Build models, but any chat-completion-compatible provider works. See [Inference Gateway](/documentation/vulnerability-scanning/targets/inference-gateway) for details on the `nmp_uri_spec` block used below.
+- Configure at least one Inference Gateway provider — this tutorial uses the `nvidia-inference-api` provider that is included in a default local setup, but any chat-completion-compatible provider works. Step 3 shows how to list the providers registered in your deployment. See [Inference Gateway](/documentation/vulnerability-scanning/targets/inference-gateway) for details on the `nmp_uri_spec` block used below.
 
 ---
 
@@ -90,21 +90,31 @@ For the full set of options on each sub-block, see [Configuration Schema](/docum
 
 ## 3. Create an Audit Target
 
-Define the model under test. This example uses garak's `nim.NVOpenAIChat` generator pointed at a provider registered in the Inference Gateway:
+First, list the providers registered in your deployment so you can pick one that exists:
+
+```python
+providers = client.inference.providers.list(workspace="default")
+for provider in providers["data"]:
+    print(provider["name"], provider.get("host_url"))
+```
+
+Use a `provider` name from this output in the target below. The model identifier format depends on the provider — check the provider's API documentation or served-model list if unsure.
+
+Define the model under test. This example uses garak's `nim.NVOpenAIChat` generator pointed at the `nvidia-inference-api` provider registered in a default local setup:
 
 ```python
 target = auditor.targets.create(
     workspace="default",
     name="llama-31-8b",
     type="nim.NVOpenAIChat",
-    model="meta/llama-3.1-8b-instruct",
+    model="nvidia/meta/llama-3.1-8b-instruct",
     options={
         "nim": {
             "max_tokens": 1024,
             "nmp_uri_spec": {
                 "inference_gateway": {
                     "workspace": "default",
-                    "provider": "nvidia-build",
+                    "provider": "nvidia-inference-api",
                 },
             },
         },


### PR DESCRIPTION
Documentation previously used IGW providers that were not consistent with the rest of docs, out of box defaults, and nvidia build backend identifiers. Updated to use more consistent examples and added example to show how to find local list of providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated auditor examples and tutorials to reflect the current inference gateway provider name.
  * Revised sample model identifiers and configuration values across target setup, update, and worked-example docs.
  * Added guidance to list available inference providers before selecting one in setup steps.
  * Clarified local audit tutorial prerequisites and target-creation instructions with the latest provider details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->