### PR TITLE
feat(studio): add column selector to intake traces table (ASE-385)

### DIFF
--- a/web/packages/studio/src/components/IntakeLists/IntakeSpansTable.tsx
+++ b/web/packages/studio/src/components/IntakeLists/IntakeSpansTable.tsx
@@ -98,7 +98,7 @@ const SpanNameCell: FC<SpanNameCellProps> = ({ span, depth, showHierarchy }) => 
 
 export interface IntakeSpansTableProps {
   workspace?: string;
-  filterTogglePortalTargetId?: string;
+  slotEndPortalTargetId?: string;
   fixedFilter?: SpanFilter;
   mode?: ListSpansMode;
   defaultSort?: { id: string; desc: boolean };
@@ -115,7 +115,7 @@ export interface IntakeSpansTableProps {
 
 export const IntakeSpansTable: FC<IntakeSpansTableProps> = ({
   workspace: workspaceProp,
-  filterTogglePortalTargetId,
+  slotEndPortalTargetId,
   fixedFilter,
   mode = 'summary',
   defaultSort = { id: 'started_at', desc: true },
@@ -311,7 +311,7 @@ export const IntakeSpansTable: FC<IntakeSpansTableProps> = ({
     <IntakeTelemetryDataView<SpanTableRow>
       dataViewState={dataViewState}
       makeColumns={makeColumns}
-      filterTogglePortalTargetId={filterTogglePortalTargetId}
+      slotEndPortalTargetId={slotEndPortalTargetId}
       onRowClick={handleRowClick}
       attributes={{
         DataViewRoot: {

--- a/web/packages/studio/src/components/IntakeLists/IntakeTelemetryDataView.tsx
+++ b/web/packages/studio/src/components/IntakeLists/IntakeTelemetryDataView.tsx
@@ -63,9 +63,7 @@ const IntakeTelemetryToolbar = <DataType,>({
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
-    setPortalTarget(
-      slotEndPortalTargetId ? document.getElementById(slotEndPortalTargetId) : null
-    );
+    setPortalTarget(slotEndPortalTargetId ? document.getElementById(slotEndPortalTargetId) : null);
   }, [slotEndPortalTargetId]);
 
   const filterToggle = hasFilterableColumns ? (
@@ -80,7 +78,13 @@ const IntakeTelemetryToolbar = <DataType,>({
   return (
     <>
       {shouldPortalToggle && portalTarget
-        ? createPortal(<>{filterToggle}{slotEnd}</>, portalTarget)
+        ? createPortal(
+            <>
+              {filterToggle}
+              {slotEnd}
+            </>,
+            portalTarget
+          )
         : null}
       {rendersToolbar && (
         <DataView.Toolbar

--- a/web/packages/studio/src/components/IntakeLists/IntakeTelemetryDataView.tsx
+++ b/web/packages/studio/src/components/IntakeLists/IntakeTelemetryDataView.tsx
@@ -40,7 +40,7 @@ interface IntakeTelemetryToolbarProps<DataType = unknown> {
   searchField?: string;
   showFilters: boolean;
   onToggleFilters: () => void;
-  filterTogglePortalTargetId?: string;
+  slotEndPortalTargetId?: string;
   renderBulkActions?: (props: {
     selectedRows: DataType[];
     table: DataView.TanstackTable.Table<DataType>;
@@ -53,7 +53,7 @@ const IntakeTelemetryToolbar = <DataType,>({
   searchField,
   showFilters,
   onToggleFilters,
-  filterTogglePortalTargetId,
+  slotEndPortalTargetId,
   renderBulkActions,
   searchBarProps,
   slotEnd,
@@ -64,23 +64,23 @@ const IntakeTelemetryToolbar = <DataType,>({
 
   useEffect(() => {
     setPortalTarget(
-      filterTogglePortalTargetId ? document.getElementById(filterTogglePortalTargetId) : null
+      slotEndPortalTargetId ? document.getElementById(slotEndPortalTargetId) : null
     );
-  }, [filterTogglePortalTargetId]);
+  }, [slotEndPortalTargetId]);
 
   const filterToggle = hasFilterableColumns ? (
     <FilterPanelToggle showFilters={showFilters} onToggle={onToggleFilters} />
   ) : null;
-  const shouldPortalToggle = Boolean(filterTogglePortalTargetId);
-  const rendersInlineToggle = Boolean(!filterTogglePortalTargetId && filterToggle);
+  const shouldPortalToggle = Boolean(slotEndPortalTargetId);
+  const rendersInlineToggle = Boolean(!slotEndPortalTargetId && filterToggle);
   const rendersToolbar = Boolean(
-    searchField || slotEnd || rendersInlineToggle || renderBulkActions
+    searchField || (!shouldPortalToggle && slotEnd) || rendersInlineToggle || renderBulkActions
   );
 
   return (
     <>
-      {shouldPortalToggle && portalTarget && filterToggle
-        ? createPortal(filterToggle, portalTarget)
+      {shouldPortalToggle && portalTarget
+        ? createPortal(<>{filterToggle}{slotEnd}</>, portalTarget)
         : null}
       {rendersToolbar && (
         <DataView.Toolbar
@@ -103,7 +103,7 @@ const IntakeTelemetryToolbar = <DataType,>({
               {...searchBarProps}
             />
           )}
-          {slotEnd}
+          {!shouldPortalToggle && slotEnd}
           {rendersInlineToggle ? filterToggle : null}
         </DataView.Toolbar>
       )}
@@ -124,7 +124,7 @@ export interface IntakeTelemetryDataViewProps<DataType> {
   }) => ReactNode;
   children?: ReactNode;
   toolbarSlotEnd?: ReactNode;
-  filterTogglePortalTargetId?: string;
+  slotEndPortalTargetId?: string;
   scrollContainerRef?: RefObject<HTMLDivElement | null>;
   attributes?: {
     DataViewRoot?: Omit<
@@ -148,7 +148,7 @@ export const IntakeTelemetryDataView = <DataType,>({
   scrollContainerRef,
   searchField,
   toolbarSlotEnd,
-  filterTogglePortalTargetId,
+  slotEndPortalTargetId,
 }: IntakeTelemetryDataViewProps<DataType>) => {
   const [showFilters, setShowFilters] = useState(false);
   const toggleFilters = useMemo(() => () => setShowFilters((prev) => !prev), []);
@@ -208,7 +208,7 @@ export const IntakeTelemetryDataView = <DataType,>({
           searchField={searchField}
           showFilters={showFilters}
           onToggleFilters={toggleFilters}
-          filterTogglePortalTargetId={filterTogglePortalTargetId}
+          slotEndPortalTargetId={slotEndPortalTargetId}
           renderBulkActions={renderBulkActions}
           searchBarProps={attributes?.DataViewSearchBar}
           slotEnd={toolbarSlotEnd}

--- a/web/packages/studio/src/components/IntakeLists/IntakeTracesTable.tsx
+++ b/web/packages/studio/src/components/IntakeLists/IntakeTracesTable.tsx
@@ -11,7 +11,6 @@ import { getSortParamWithWhitelist } from '@nemo/common/src/utils/query';
 import { useListTraces } from '@nemo/sdk/generated/platform/api';
 import type { Trace, TraceFilter, TraceSortField } from '@nemo/sdk/generated/platform/schema';
 import { Badge, Button } from '@nvidia/foundations-react-core';
-import { Columns3 } from 'lucide-react';
 import { getErrorMessage } from '@studio/api/common/utils';
 import { IntakeTelemetryDataView } from '@studio/components/IntakeLists/IntakeTelemetryDataView';
 import { useWorkspaceFromPathIfExists } from '@studio/hooks/useWorkspaceFromPath';
@@ -23,6 +22,7 @@ import {
   getTraceDisplayName,
 } from '@studio/util/intakeTelemetry';
 import { keepPreviousData } from '@tanstack/react-query';
+import { Columns3 } from 'lucide-react';
 import type { ComponentProps, FC, ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -167,7 +167,11 @@ export const IntakeTracesTable: FC<IntakeTracesTableProps> = ({
       makeColumns={makeColumns}
       slotEndPortalTargetId={slotEndPortalTargetId}
       toolbarSlotEnd={
-        <EditColumnsMenu kind="secondary" showChevron={false} slotContent={<div aria-hidden className="h-0 w-[230px]" />}>
+        <EditColumnsMenu
+          kind="secondary"
+          showChevron={false}
+          slotContent={<div aria-hidden className="h-0 w-[230px]" />}
+        >
           <>
             <Columns3 />
             <span className="hide-mobile">Columns</span>

--- a/web/packages/studio/src/components/IntakeLists/IntakeTracesTable.tsx
+++ b/web/packages/studio/src/components/IntakeLists/IntakeTracesTable.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { dateTimeFilter } from '@nemo/common/src/components/DataView/dateTimeFilter';
+import { EditColumnsMenu } from '@nemo/common/src/components/DataView/internal';
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
@@ -10,6 +11,7 @@ import { getSortParamWithWhitelist } from '@nemo/common/src/utils/query';
 import { useListTraces } from '@nemo/sdk/generated/platform/api';
 import type { Trace, TraceFilter, TraceSortField } from '@nemo/sdk/generated/platform/schema';
 import { Badge, Button } from '@nvidia/foundations-react-core';
+import { Columns3 } from 'lucide-react';
 import { getErrorMessage } from '@studio/api/common/utils';
 import { IntakeTelemetryDataView } from '@studio/components/IntakeLists/IntakeTelemetryDataView';
 import { useWorkspaceFromPathIfExists } from '@studio/hooks/useWorkspaceFromPath';
@@ -26,14 +28,14 @@ import { useNavigate } from 'react-router-dom';
 
 export interface IntakeTracesTableProps {
   workspace?: string;
-  filterTogglePortalTargetId?: string;
+  slotEndPortalTargetId?: string;
   emptyStateActions?: ReactNode;
   noResultsActions?: ReactNode;
 }
 
 export const IntakeTracesTable: FC<IntakeTracesTableProps> = ({
   workspace: workspaceProp,
-  filterTogglePortalTargetId,
+  slotEndPortalTargetId,
   emptyStateActions,
   noResultsActions,
 }) => {
@@ -163,7 +165,15 @@ export const IntakeTracesTable: FC<IntakeTracesTableProps> = ({
     <IntakeTelemetryDataView<Trace>
       dataViewState={dataViewState}
       makeColumns={makeColumns}
-      filterTogglePortalTargetId={filterTogglePortalTargetId}
+      slotEndPortalTargetId={slotEndPortalTargetId}
+      toolbarSlotEnd={
+        <EditColumnsMenu kind="secondary" showChevron={false} slotContent={<div aria-hidden className="h-0 w-[230px]" />}>
+          <>
+            <Columns3 />
+            <span className="hide-mobile">Columns</span>
+          </>
+        </EditColumnsMenu>
+      }
       onRowClick={(trace) => navigate(getIntakeTraceRoute(requestWorkspace, trace.id))}
       attributes={{
         DataViewRoot: {

--- a/web/packages/studio/src/routes/IntakeLayout/index.tsx
+++ b/web/packages/studio/src/routes/IntakeLayout/index.tsx
@@ -68,7 +68,7 @@ export const IntakeLayout: FC = () => {
           />
           <div
             id={INTAKE_FILTER_ACTION_TARGET_ID}
-            className="flex shrink-0 items-center justify-end"
+            className="flex shrink-0 items-center justify-end gap-density-xl"
           />
         </div>
         <Suspense fallback={<Loading description="Loading..." />}>

--- a/web/packages/studio/src/routes/groups/intakeRoutes.tsx
+++ b/web/packages/studio/src/routes/groups/intakeRoutes.tsx
@@ -16,7 +16,7 @@ const IntakeTracesTableRoute = lazy(() =>
   import('@studio/components/IntakeLists/IntakeTracesTable').then(({ IntakeTracesTable }) => {
     const IntakeTracesTableRouteComponent: FC = () => (
       <Stack className="flex-1 min-h-0">
-        <IntakeTracesTable filterTogglePortalTargetId={INTAKE_FILTER_ACTION_TARGET_ID} />
+        <IntakeTracesTable slotEndPortalTargetId={INTAKE_FILTER_ACTION_TARGET_ID} />
       </Stack>
     );
 
@@ -27,7 +27,7 @@ const IntakeSpansTableRoute = lazy(() =>
   import('@studio/components/IntakeLists/IntakeSpansTable').then(({ IntakeSpansTable }) => {
     const IntakeSpansTableRouteComponent: FC = () => (
       <Stack className="flex-1 min-h-0">
-        <IntakeSpansTable filterTogglePortalTargetId={INTAKE_FILTER_ACTION_TARGET_ID} />
+        <IntakeSpansTable slotEndPortalTargetId={INTAKE_FILTER_ACTION_TARGET_ID} />
       </Stack>
     );
 


### PR DESCRIPTION
Closes #ASE-385

https://github.com/user-attachments/assets/baee116f-887c-415f-b08d-e3a6830ada17

# Summary

The Intake traces list had no way to hide columns, unlike the experiment group and test cases tables which already have column visibility controls. This adds the same `EditColumnsMenu` (Columns button) to the Intake traces table, appearing in the tab row alongside the existing Filters button: `| [Traces] [Spans] ___ | Filters | Columns |`.

The Filters button was already being portaled from inside `IntakeTelemetryDataView` up to the tab row in `IntakeLayout` via a DOM portal. Extended that mechanism so `toolbarSlotEnd` is portaled alongside the filter toggle, rather than rendering in a separate toolbar row. Also renamed `filterTogglePortalTargetId` → `slotEndPortalTargetId` on `IntakeTelemetryDataView` and its callsites — the prop describes where content goes, not what content it carries.

# Test plan
- [ ] Navigate to `/workspaces/{workspace}/intake/traces`
- [ ] Confirm `| Filters | Columns |` buttons appear to the right of the Traces/Spans tabs on the same row
- [ ] Open Columns menu and toggle a column off — confirm it disappears from the table
- [ ] Toggle it back on — confirm it reappears
- [ ] Confirm the Spans tab (`/intake/spans`) is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new table action area for intake traces, including an inline “Columns” control.
  * Updated intake spans and telemetry views to support a new end-of-slot placement for toolbar content.

* **Improvements**
  * Adjusted header spacing in the intake layout for better alignment and readability.
  * Unified the action target used by intake routes to support the updated toolbar placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->