### PR TITLE
fix(docs): update switchyard github reference

### DIFF
--- a/plugins/nemo-switchyard/README.md
+++ b/plugins/nemo-switchyard/README.md
@@ -1,6 +1,6 @@
 # Switchyard Inference Middleware Plugin
 
-A NeMo Inference Middleware plugin wrapping [Switchyard](https://github.com/NVIDIA/switchyard) —
+A NeMo Inference Middleware plugin wrapping [Switchyard](https://github.com/NVIDIA-NeMo/Switchyard) —
 a protocol-agnostic request/response router for LLM backends.
 
 ## Features


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Switchyard reference link in the README to point to the current GitHub location.
  * No other documentation content was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->