### PR TITLE
feat(bootstrap): auto-install uv if missing using pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,14 @@ BOOTSTRAP_LOCAL_PLUGIN_DIRS ?=
 ensure-uv: ## Install uv if not present, using the version constraint from pyproject.toml.
 	@if ! command -v uv >/dev/null 2>&1; then \
 		uv_spec=$$(grep -E '"uv[>=<! ]' pyproject.toml | head -1 | sed 's/.*"\(uv[^"]*\)".*/\1/'); \
-		echo "uv not found — installing '$$uv_spec' via pip"; \
-		pip install "$$uv_spec"; \
+		echo "uv not found — installing '$$uv_spec'"; \
+		if pip install "$$uv_spec" 2>/dev/null; then :; \
+		elif pip install --break-system-packages "$$uv_spec" 2>/dev/null; then :; \
+		elif command -v pipx >/dev/null 2>&1 && pipx install "$$uv_spec" 2>/dev/null; then :; \
+		else \
+			echo "error: could not install uv — install it manually: https://docs.astral.sh/uv/getting-started/installation/"; \
+			exit 1; \
+		fi; \
 	fi
 
 .PHONY: bootstrap-python

--- a/Makefile
+++ b/Makefile
@@ -182,9 +182,16 @@ verify-python-version: ## Verify Python version and install if necessary
 # Optional escape hatch for local plugin packages that cannot participate in the
 # root uv workspace/lock. Leave empty for the normal monorepo bootstrap path.
 BOOTSTRAP_LOCAL_PLUGIN_DIRS ?=
+.PHONY: ensure-uv
+ensure-uv: ## Install uv if not present, using the version constraint from pyproject.toml.
+	@if ! command -v uv >/dev/null 2>&1; then \
+		uv_spec=$$(grep -E '"uv[>=<! ]' pyproject.toml | head -1 | sed 's/.*"\(uv[^"]*\)".*/\1/'); \
+		echo "uv not found — installing '$$uv_spec' via pip"; \
+		pip install "$$uv_spec"; \
+	fi
 
 .PHONY: bootstrap-python
-bootstrap-python: ## Bootstrap Python dependencies.
+bootstrap-python: ensure-uv ## Bootstrap Python dependencies.
 	@echo "~~~~~~"
 	@echo "installing python dependencies"
 	uv sync --frozen --all-packages


### PR DESCRIPTION
Adds an `ensure-uv` Makefile target that checks for `uv` and installs it via pip if absent, reading the required version spec directly from `pyproject.toml` so it stays in sync automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the Python bootstrap process to automatically ensure `uv` is available before setup continues.
  * If `uv` is missing, the build flow now installs a compatible version automatically, making local setup more reliable.
  * Updated the bootstrap target to run only after the `uv` availability check/installation step completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->