### PR TITLE
feat(deployments): fail stuck STARTING deployments after controller timeout (AIRCORE-861)

### DIFF
--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/config.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/config.py
@@ -41,6 +41,11 @@ class ControllerConfig(BaseModel):
             "orphan cleanup for this many seconds after the terminal status transition (0 disables)."
         ),
     )
+    starting_timeout_seconds: int = Field(
+        default=3600,
+        ge=0,
+        description="Max seconds in STARTING before FAILED (0 disables).",
+    )
 
     @model_validator(mode="after")
     def _validate_backoff(self) -> ControllerConfig:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/deployment_reconciler.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/reconciler/deployment_reconciler.py
@@ -143,6 +143,11 @@ class DeploymentReconciler:
             if status_update.status == "UNKNOWN":
                 await self._handle_unknown_status(deployment, status_update)
                 return
+            if status_update.status == "STARTING":
+                timeout_update = self._check_starting_timeout(deployment)
+                if timeout_update is not None:
+                    await self._update_deployment_status(deployment, timeout_update)
+                    return
             if status_update.status in ("READY", "SUCCEEDED"):
                 self._drift_cache.remove(deployment_id(deployment))
             await self._update_deployment_status(deployment, status_update)
@@ -323,6 +328,29 @@ class DeploymentReconciler:
             ),
         )
 
+    def _check_starting_timeout(self, deployment: Deployment) -> BackendStatusUpdate | None:
+        timeout = self._controller_config.starting_timeout_seconds
+        if timeout <= 0:
+            return None
+        starting_at = _starting_timestamp(deployment)
+        if starting_at is None:
+            return None
+        elapsed = (datetime.now(timezone.utc) - starting_at).total_seconds()
+        if elapsed < timeout:
+            return None
+        elapsed_int = int(elapsed)
+        return BackendStatusUpdate(
+            status="FAILED",
+            status_message=(
+                f"Deployment stuck in STARTING for {elapsed_int}s (timeout: {timeout}s). Readiness checks never passed."
+            ),
+            error_details={
+                "reason": "starting_timeout",
+                "elapsed_seconds": elapsed_int,
+                "timeout_seconds": timeout,
+            },
+        )
+
     async def _update_deployment_status_pending(self, deployment: Deployment, message: str) -> None:
         if deployment.status == "PENDING" and deployment.status_message == message:
             return
@@ -366,6 +394,15 @@ class DeploymentReconciler:
             await self._entities.update(deployment)
         except NemoEntityConflictError:
             raise
+
+
+def _starting_timestamp(deployment: Deployment) -> datetime | None:
+    for event in reversed(deployment.status_history):
+        if event.status == "STARTING" and event.timestamp:
+            return datetime.fromisoformat(event.timestamp)
+    if deployment.status_history and deployment.status_history[0].timestamp:
+        return datetime.fromisoformat(deployment.status_history[0].timestamp)
+    return None
 
 
 def _prerequisite_failed(

--- a/plugins/nemo-deployments/tests/unit/reconciler/test_deployment_reconciler.py
+++ b/plugins/nemo-deployments/tests/unit/reconciler/test_deployment_reconciler.py
@@ -1,20 +1,73 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import AsyncMock
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from helpers import make_deployment, make_deployment_config
 from nemo_deployments_plugin.backends.base import BackendStatusUpdate
 from nemo_deployments_plugin.backends.registry import ExecutorRegistry
 from nemo_deployments_plugin.config import ControllerConfig
-from nemo_deployments_plugin.entities import Prerequisite, Volume
+from nemo_deployments_plugin.entities import Deployment, Prerequisite, StatusEvent, Volume
 from nemo_deployments_plugin.reconciler.deployment_reconciler import DeploymentReconciler
 from nemo_deployments_plugin.reconciler.orphan_cleanup import reconcile_orphans
 from nemo_platform_plugin.entity_client import NemoEntityConflictError, NemoEntityNotFoundError
 from reconciler.conftest import MockDeploymentBackend
 
 NO_VOLUMES: dict[tuple[str, str], Volume] = {}
+
+NOW = datetime(2026, 6, 30, 12, 0, 0, tzinfo=timezone.utc)
+STARTING_TIMEOUT_SECONDS = 60
+
+
+@pytest.fixture
+def patch_reconciler_now():
+    with patch(
+        "nemo_deployments_plugin.reconciler.deployment_reconciler.datetime",
+        wraps=datetime,
+    ) as mock_dt:
+        mock_dt.now.return_value = NOW
+        yield
+
+
+def _starting_timeout_reconciler(
+    mock_entities: AsyncMock,
+    mock_backend: MockDeploymentBackend,
+    *,
+    starting_timeout_seconds: int = STARTING_TIMEOUT_SECONDS,
+) -> DeploymentReconciler:
+    return DeploymentReconciler(
+        mock_entities,
+        ExecutorRegistry({"default": mock_backend}, default_executor="default"),
+        ControllerConfig(
+            drift_recovery_max_attempts=3,
+            drift_recovery_initial_delay_seconds=1,
+            drift_recovery_max_delay_seconds=10,
+            starting_timeout_seconds=starting_timeout_seconds,
+        ),
+    )
+
+
+def _deployment_stuck_starting(*, elapsed_seconds: int) -> Deployment:
+    starting_at = NOW - timedelta(seconds=elapsed_seconds)
+    dep = make_deployment()
+    dep.status = "STARTING"
+    dep.status_history = [
+        StatusEvent(status="STARTING", message="created", timestamp=starting_at.isoformat()),
+    ]
+    return dep
+
+
+async def _reconcile_stuck_starting(
+    reconciler: DeploymentReconciler,
+    mock_backend: MockDeploymentBackend,
+    dep: Deployment,
+) -> None:
+    cfg = make_deployment_config()
+    reconciler.set_config_cache({("default", "cfg1"): cfg})
+    mock_backend.read_status_result = BackendStatusUpdate(status="STARTING", status_message="waiting")
+    await reconciler.reconcile_one(dep, deployments_by_name={}, volumes_by_name=NO_VOLUMES)
 
 
 @pytest.mark.asyncio
@@ -164,6 +217,100 @@ async def test_on_failure_succeeded_terminal(
 
     assert dep.status == "SUCCEEDED"
     assert dep.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_starting_timeout_fails_at_boundary(
+    mock_entities: AsyncMock,
+    mock_backend: MockDeploymentBackend,
+    patch_reconciler_now,
+) -> None:
+    reconciler = _starting_timeout_reconciler(mock_entities, mock_backend)
+    dep = _deployment_stuck_starting(elapsed_seconds=STARTING_TIMEOUT_SECONDS)
+
+    await _reconcile_stuck_starting(reconciler, mock_backend, dep)
+
+    assert dep.status == "FAILED"
+    assert "stuck in STARTING" in dep.status_message
+    assert dep.error_details is not None
+    assert dep.error_details["reason"] == "starting_timeout"
+    assert dep.error_details["elapsed_seconds"] == STARTING_TIMEOUT_SECONDS
+    assert dep.error_details["timeout_seconds"] == STARTING_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_starting_timeout_before_boundary_stays_starting(
+    mock_entities: AsyncMock,
+    mock_backend: MockDeploymentBackend,
+    patch_reconciler_now,
+) -> None:
+    reconciler = _starting_timeout_reconciler(mock_entities, mock_backend)
+    dep = _deployment_stuck_starting(elapsed_seconds=STARTING_TIMEOUT_SECONDS - 1)
+
+    await _reconcile_stuck_starting(reconciler, mock_backend, dep)
+
+    assert dep.status == "STARTING"
+    assert dep.error_details is None
+
+
+@pytest.mark.asyncio
+async def test_starting_timeout_disabled_when_zero(
+    mock_entities: AsyncMock,
+    mock_backend: MockDeploymentBackend,
+    patch_reconciler_now,
+) -> None:
+    reconciler = _starting_timeout_reconciler(mock_entities, mock_backend, starting_timeout_seconds=0)
+    dep = _deployment_stuck_starting(elapsed_seconds=7200)
+
+    await _reconcile_stuck_starting(reconciler, mock_backend, dep)
+
+    assert dep.status == "STARTING"
+    assert dep.error_details is None
+
+
+@pytest.mark.asyncio
+async def test_starting_timeout_uses_latest_starting_episode(
+    mock_entities: AsyncMock,
+    mock_backend: MockDeploymentBackend,
+    patch_reconciler_now,
+) -> None:
+    """After drift recovery, elapsed time should reset from the latest STARTING entry."""
+    reconciler = _starting_timeout_reconciler(mock_entities, mock_backend)
+    dep = make_deployment()
+    dep.status = "STARTING"
+    old_starting = NOW - timedelta(hours=2)
+    recent_starting = NOW - timedelta(seconds=30)
+    dep.status_history = [
+        StatusEvent(status="STARTING", message="created", timestamp=old_starting.isoformat()),
+        StatusEvent(status="READY", message="healthy", timestamp=(NOW - timedelta(hours=1)).isoformat()),
+        StatusEvent(status="LOST", message="backend lost", timestamp=(NOW - timedelta(minutes=45)).isoformat()),
+        StatusEvent(status="STARTING", message="recovering", timestamp=recent_starting.isoformat()),
+    ]
+
+    await _reconcile_stuck_starting(reconciler, mock_backend, dep)
+
+    assert dep.status == "STARTING"
+    assert dep.error_details is None
+
+
+@pytest.mark.asyncio
+async def test_starting_timeout_falls_back_to_first_history_entry(
+    mock_entities: AsyncMock,
+    mock_backend: MockDeploymentBackend,
+    patch_reconciler_now,
+) -> None:
+    reconciler = _starting_timeout_reconciler(mock_entities, mock_backend)
+    dep = make_deployment()
+    dep.status = "STARTING"
+    dep.status_history = [
+        StatusEvent(status="PENDING", message="waiting", timestamp=(NOW - timedelta(seconds=60)).isoformat()),
+    ]
+
+    await _reconcile_stuck_starting(reconciler, mock_backend, dep)
+
+    assert dep.status == "FAILED"
+    assert dep.error_details is not None
+    assert dep.error_details["reason"] == "starting_timeout"
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-deployments/tests/unit/test_config.py
+++ b/plugins/nemo-deployments/tests/unit/test_config.py
@@ -10,6 +10,7 @@ def test_controller_config_defaults() -> None:
     assert cfg.controller.interval_seconds == 5
     assert cfg.controller.drift_recovery_max_attempts == 5
     assert cfg.controller.orphan_cleanup_interval_seconds == 30
+    assert cfg.controller.starting_timeout_seconds == 3600
 
 
 def test_controller_config_custom_orphan_interval() -> None:
@@ -30,3 +31,8 @@ def test_controller_config_rejects_inverted_backoff() -> None:
 def test_controller_config_allows_zero_orphan_interval_to_disable() -> None:
     cfg = ControllerConfig(orphan_cleanup_interval_seconds=0)
     assert cfg.orphan_cleanup_interval_seconds == 0
+
+
+def test_controller_config_allows_zero_starting_timeout_to_disable() -> None:
+    cfg = ControllerConfig(starting_timeout_seconds=0)
+    assert cfg.starting_timeout_seconds == 0


### PR DESCRIPTION
## Summary

- Add `starting_timeout_seconds` to deployments `ControllerConfig` (default 3600s; `0` disables).
- In the deployment reconciler, when the backend reports `STARTING`, compute elapsed time from the latest `STARTING` entry in `status_history` (fallback: first history entry) and transition to `FAILED` with `error_details.reason = "starting_timeout"` when the timeout is exceeded.
- Unit tests cover boundary, before-boundary, disabled timeout, drift-recovery episode reset, and history fallback.

**Recommended merge order:** This should land before starting **AIRCORE-757** so deployments stuck in `STARTING` fail with a clear timeout instead of polling indefinitely during that work.

## Test plan

- [x] `uv run --frozen pytest plugins/nemo-deployments/tests/unit/reconciler/test_deployment_reconciler.py -v`
- [x] `uv run --frozen pytest plugins/nemo-deployments/tests/unit/test_config.py -v`
- [x] Pre-commit hooks pass on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for deployments that remain in the `STARTING` state too long.
  * Deployments now automatically fail when this timeout is reached, with details included in the status.

* **Bug Fixes**
  * Improved how the app determines when a deployment entered `STARTING`, including recovery scenarios and fallback behavior.
  * Kept timeout handling disabled when the setting is set to `0`.

* **Tests**
  * Added coverage for default and disabled timeout settings, plus timeout boundary and status-history cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->