### PR TITLE
fix(deployments): hash k8s-safe names from workspace/name identity (AIRCORE-860)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,8 @@ PYTEST_WORKERS ?= auto
 PYTEST_MAX_WORKERS ?= 16
 PYTEST_CMD := env PYTHONWARNINGS="ignore::UserWarning:pytest_only.version" uv run --frozen \
 	pytest \
-	-n $(PYTEST_WORKERS) --maxprocesses=$(PYTEST_MAX_WORKERS) --dist loadscope --timeout=120 $(PYTEST_VERBOSITY) $(PYTEST_EXTRA)
+	-n $(PYTEST_WORKERS) --maxprocesses=$(PYTEST_MAX_WORKERS) --max-worker-restart=2 \
+	--dist loadscope --timeout=120 $(PYTEST_VERBOSITY) $(PYTEST_EXTRA)
 
 PYTEST_CI_OPTS := --cov=src --cov=packages \
 	--junitxml=report.xml \

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/k8s_naming.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/k8s_naming.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Kubernetes DNS-safe resource naming shared by platform services and plugins.
+
+Plugins cannot depend on ``nmp_common``; this module lives in ``nemo_platform_plugin``
+so deployments, models, and other plugins share one hashing/normalization contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Literal
+
+DNS_LABEL_MAX_LENGTH = 63
+DNS_SUBDOMAIN_MAX_LENGTH = 253
+HASH_SUFFIX_LENGTH = 8
+
+
+def workspace_name_identity(workspace: str, name: str) -> str:
+    """Canonical ``workspace/name`` identity used as ``hash_input`` for resource names."""
+    return f"{workspace}/{name}"
+
+
+def k8s_safe_name(
+    base_name: str,
+    max_length: int = DNS_LABEL_MAX_LENGTH,
+    suffix: str = "",
+    name_type: Literal["label", "dns_subdomain"] = "label",
+    hash_input: str | None = None,
+    *,
+    include_hash: bool = True,
+) -> str:
+    """Generate a Kubernetes-compliant name with a mandatory hash suffix.
+
+    Normalizes ``base_name`` for display, truncates when needed, then returns
+    ``{normalized}-{hash8}{suffix}``. The hash is SHA-256 of ``hash_input`` when
+    provided, otherwise ``base_name``. Callers representing a workspace/name pair
+    should pass ``hash_input=workspace_name_identity(workspace, name)`` so the hash
+    reflects the unambiguous identity rather than a join-ambiguous prefix.
+    """
+    hash_source = hash_input if hash_input is not None else base_name
+    hash_suffix = hashlib.sha256(hash_source.encode()).hexdigest()[:HASH_SUFFIX_LENGTH]
+
+    normalized = base_name.lower()
+
+    if name_type == "label":
+        normalized = re.sub(r"[^a-z0-9-]", "-", normalized)
+        normalized = re.sub(r"-+", "-", normalized)
+        if normalized and not normalized[0].isalpha():
+            normalized = f"x{normalized}"
+    else:  # dns_subdomain
+        normalized = re.sub(r"[^a-z0-9.-]", "-", normalized)
+        normalized = re.sub(r"[.]+", ".", normalized).strip(".")
+        labels = []
+        for label in normalized.split("."):
+            label = re.sub(r"-+", "-", label).strip("-")
+            labels.append(label or "x")
+        normalized = ".".join(labels)
+        normalized = normalized.lstrip("-.")
+        if not normalized or not normalized[0].isalnum():
+            normalized = f"x{normalized}"
+
+    normalized = normalized.rstrip("-.")
+    if not normalized or not normalized[-1].isalnum():
+        normalized = "x" if not normalized else normalized.rstrip("-.")
+        if not normalized:
+            normalized = "x"
+
+    if not include_hash:
+        if len(normalized) + len(suffix) <= max_length:
+            return f"{normalized}{suffix}"
+
+        max_base_len = max_length - len(suffix)
+        if max_base_len < 1:
+            max_base_len = 1
+        truncated = normalized[:max_base_len].rstrip("-.")
+        if not truncated or not truncated[-1].isalnum():
+            while truncated and not truncated[-1].isalnum():
+                truncated = truncated[:-1]
+            if not truncated:
+                truncated = "x"
+        return f"{truncated}{suffix}"
+
+    reserved = HASH_SUFFIX_LENGTH + 1 + len(suffix)
+    if len(normalized) + reserved > max_length:
+        max_base_len = max_length - reserved
+        if max_base_len < 1:
+            max_base_len = max(1, max_length - HASH_SUFFIX_LENGTH - len(suffix))
+
+        truncated = normalized[:max_base_len]
+        truncated = truncated.rstrip("-.")
+        if not truncated or not truncated[-1].isalnum():
+            while truncated and not truncated[-1].isalnum():
+                truncated = truncated[:-1]
+            if not truncated:
+                # Input was all invalid chars, or truncation left no usable base
+                # (e.g. max_length only fits hash + suffix).
+                truncated = "x"
+        normalized = truncated
+
+    result = f"{normalized}-{hash_suffix}{suffix}"
+
+    if len(result) > max_length:
+        excess = len(result) - max_length
+        normalized = normalized[: len(normalized) - excess].rstrip("-.")
+        if not normalized:
+            # Rare second-pass trim when hash+suffix still exceed max_length.
+            normalized = "x"
+        result = f"{normalized}-{hash_suffix}{suffix}"
+
+    return result

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/k8s_naming.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/k8s_naming.py
@@ -7,8 +7,6 @@ Plugins cannot depend on ``nmp_common``; this module lives in ``nemo_platform_pl
 so deployments, models, and other plugins share one hashing/normalization contract.
 """
 
-from __future__ import annotations
-
 import hashlib
 import re
 from typing import Literal
@@ -40,6 +38,12 @@ def k8s_safe_name(
     should pass ``hash_input=workspace_name_identity(workspace, name)`` so the hash
     reflects the unambiguous identity rather than a join-ambiguous prefix.
     """
+    min_required_length = 1 + len(suffix)
+    if include_hash:
+        min_required_length += 1 + HASH_SUFFIX_LENGTH
+    if min_required_length > max_length:
+        raise ValueError("max_length is too small for base name, hash, and suffix")
+
     hash_source = hash_input if hash_input is not None else base_name
     hash_suffix = hashlib.sha256(hash_source.encode()).hexdigest()[:HASH_SUFFIX_LENGTH]
 

--- a/packages/nemo_platform_plugin/tests/test_k8s_naming.py
+++ b/packages/nemo_platform_plugin/tests/test_k8s_naming.py
@@ -4,6 +4,7 @@
 import hashlib
 import re
 
+import pytest
 from nemo_platform_plugin.k8s_naming import k8s_safe_name, workspace_name_identity
 
 _HASH8 = re.compile(r"-[0-9a-f]{8}$")
@@ -31,3 +32,8 @@ def test_k8s_safe_name_hash_input_differs_from_joined_base() -> None:
     name_a = k8s_safe_name(base, hash_input=workspace_name_identity("foo", "bar-baz"))
     name_b = k8s_safe_name(base, hash_input=workspace_name_identity("foo-bar", "baz"))
     assert name_a != name_b
+
+
+def test_k8s_safe_name_rejects_suffix_too_long_for_max_length() -> None:
+    with pytest.raises(ValueError, match="max_length is too small"):
+        k8s_safe_name("base", max_length=10, suffix="-" * 10)

--- a/packages/nemo_platform_plugin/tests/test_k8s_naming.py
+++ b/packages/nemo_platform_plugin/tests/test_k8s_naming.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import re
+
+from nemo_platform_plugin.k8s_naming import k8s_safe_name, workspace_name_identity
+
+_HASH8 = re.compile(r"-[0-9a-f]{8}$")
+_DNS_LABEL = re.compile(r"^[a-z](?:[a-z0-9-]*[a-z0-9])?$")
+
+
+def _base_hash(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()[:8]
+
+
+def test_k8s_safe_name_always_includes_hash_suffix() -> None:
+    name = k8s_safe_name("short-name")
+    assert _HASH8.search(name)
+    assert name == k8s_safe_name("short-name")
+
+
+def test_k8s_safe_name_empty_base_uses_fallback_prefix() -> None:
+    name = k8s_safe_name("")
+    assert name.startswith("x-")
+    assert len(name) <= 63
+
+
+def test_k8s_safe_name_hash_input_differs_from_joined_base() -> None:
+    base = "dep-foo-bar-baz"
+    name_a = k8s_safe_name(base, hash_input=workspace_name_identity("foo", "bar-baz"))
+    name_b = k8s_safe_name(base, hash_input=workspace_name_identity("foo-bar", "baz"))
+    assert name_a != name_b

--- a/plugins/nemo-deployments/README.md
+++ b/plugins/nemo-deployments/README.md
@@ -46,3 +46,11 @@ deployments:
 
 Entity-level `backend_config.docker` accepts only deployment-specific overrides such
 as `network`.
+
+## Docker resource naming
+
+Docker container and volume names use a readable prefix plus a deterministic
+8-character hash suffix. The hash is computed from ``{workspace}/{name}``, not
+from the hyphen-joined string, so pairs like ``foo``/``bar-baz`` and
+``foo-bar``/``baz`` cannot collide. Orphan cleanup matches identity labels, not
+names alone; existing containers keep their old names after upgrade.

--- a/plugins/nemo-deployments/README.md
+++ b/plugins/nemo-deployments/README.md
@@ -52,5 +52,7 @@ as `network`.
 Docker container and volume names use a readable prefix plus a deterministic
 8-character hash suffix. The hash is computed from ``{workspace}/{name}``, not
 from the hyphen-joined string, so pairs like ``foo``/``bar-baz`` and
-``foo-bar``/``baz`` cannot collide. Orphan cleanup matches identity labels, not
-names alone; existing containers keep their old names after upgrade.
+``foo-bar``/``baz`` cannot collide. Naming logic is shared via
+``nemo_platform_plugin.k8s_naming`` (same module used by the models service).
+Orphan cleanup matches identity labels, not names alone; existing containers
+keep their old names after upgrade.

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/labels.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/labels.py
@@ -9,17 +9,15 @@ Resource names are derived from a human-readable prefix plus a deterministic
 pairs like ``("foo", "bar-baz")`` and ``("foo-bar", "baz")`` produce distinct
 names even when their joined prefixes collide.
 
-Orphan cleanup and idempotency rely on identity labels, not container names
-alone. Existing containers keep their pre-change names after upgrade; only new
-deployments receive hashed names.
+Naming logic is shared via ``nemo_platform_plugin.k8s_naming`` (plugins cannot
+import ``nmp_common``). Orphan cleanup and idempotency rely on identity labels,
+not container names alone.
 """
 
 from __future__ import annotations
 
-import hashlib
-import re
-
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
+from nemo_platform_plugin.k8s_naming import k8s_safe_name, workspace_name_identity
 
 MANAGED_BY_KEY = "managed-by"
 DEPLOYMENT_WORKSPACE_LABEL = "nemo.nvidia.com/deployment-workspace"
@@ -29,43 +27,10 @@ CONFIG_NAME_LABEL = "nemo.nvidia.com/deployment-config"
 VOLUME_WORKSPACE_LABEL = "nemo.nvidia.com/volume-workspace"
 VOLUME_NAME_LABEL = "nemo.nvidia.com/volume-name"
 
-_HASH_SUFFIX_LENGTH = 8
-
-
-def k8s_safe_name(
-    base_name: str,
-    *,
-    max_length: int = 63,
-    suffix: str = "",
-    hash_input: str | None = None,
-) -> str:
-    """Generate a DNS-label-safe name (RFC 1035) with a mandatory hash suffix.
-
-    Normalizes ``base_name`` for display, truncates when needed, then returns
-    ``{normalized}-{hash8}{suffix}``. The hash is SHA-256 of ``hash_input`` when
-    provided, otherwise ``base_name``. Callers that represent a workspace/name
-    pair should pass ``hash_input=deployment_key(workspace, name)`` so the hash
-    reflects the unambiguous identity rather than the join-ambiguous prefix.
-    """
-    hash_source = hash_input if hash_input is not None else base_name
-    hash_suffix = hashlib.sha256(hash_source.encode()).hexdigest()[:_HASH_SUFFIX_LENGTH]
-    normalized = re.sub(r"[^a-z0-9-]", "-", base_name.lower())
-    normalized = re.sub(r"[-]+", "-", normalized)
-    if normalized and not normalized[0].isalpha():
-        normalized = f"x{normalized}"
-    normalized = normalized.rstrip("-")
-
-    reserved = len(suffix) + len(hash_suffix) + 1
-    if len(normalized) + reserved > max_length:
-        normalized = normalized[: max_length - reserved].rstrip("-")
-    if not normalized:
-        normalized = "x"
-    return f"{normalized}-{hash_suffix}{suffix}"
-
 
 def deployment_key(workspace: str, name: str) -> str:
     """Return the canonical identity string used for hashing and label keys."""
-    return f"{workspace}/{name}"
+    return workspace_name_identity(workspace, name)
 
 
 def container_name(workspace: str, deployment_name: str) -> str:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/labels.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/labels.py
@@ -14,8 +14,6 @@ import ``nmp_common``). Orphan cleanup and idempotency rely on identity labels,
 not container names alone.
 """
 
-from __future__ import annotations
-
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
 from nemo_platform_plugin.k8s_naming import k8s_safe_name, workspace_name_identity
 

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/labels.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/labels.py
@@ -1,7 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Docker resource naming and identity labels for orphan cleanup."""
+"""Docker resource naming and identity labels for orphan cleanup.
+
+Resource names are derived from a human-readable prefix plus a deterministic
+8-character hash. The hash is computed from ``{workspace}/{name}`` (see
+``deployment_key``), not from the hyphen-joined display string, so ambiguous
+pairs like ``("foo", "bar-baz")`` and ``("foo-bar", "baz")`` produce distinct
+names even when their joined prefixes collide.
+
+Orphan cleanup and idempotency rely on identity labels, not container names
+alone. Existing containers keep their pre-change names after upgrade; only new
+deployments receive hashed names.
+"""
 
 from __future__ import annotations
 
@@ -18,10 +29,26 @@ CONFIG_NAME_LABEL = "nemo.nvidia.com/deployment-config"
 VOLUME_WORKSPACE_LABEL = "nemo.nvidia.com/volume-workspace"
 VOLUME_NAME_LABEL = "nemo.nvidia.com/volume-name"
 
+_HASH_SUFFIX_LENGTH = 8
 
-def k8s_safe_name(base_name: str, *, max_length: int = 63, suffix: str = "") -> str:
-    """Generate a DNS-label-safe name (RFC 1035) from arbitrary input."""
-    hash_suffix = hashlib.sha256(base_name.encode()).hexdigest()[:8]
+
+def k8s_safe_name(
+    base_name: str,
+    *,
+    max_length: int = 63,
+    suffix: str = "",
+    hash_input: str | None = None,
+) -> str:
+    """Generate a DNS-label-safe name (RFC 1035) with a mandatory hash suffix.
+
+    Normalizes ``base_name`` for display, truncates when needed, then returns
+    ``{normalized}-{hash8}{suffix}``. The hash is SHA-256 of ``hash_input`` when
+    provided, otherwise ``base_name``. Callers that represent a workspace/name
+    pair should pass ``hash_input=deployment_key(workspace, name)`` so the hash
+    reflects the unambiguous identity rather than the join-ambiguous prefix.
+    """
+    hash_source = hash_input if hash_input is not None else base_name
+    hash_suffix = hashlib.sha256(hash_source.encode()).hexdigest()[:_HASH_SUFFIX_LENGTH]
     normalized = re.sub(r"[^a-z0-9-]", "-", base_name.lower())
     normalized = re.sub(r"[-]+", "-", normalized)
     if normalized and not normalized[0].isalpha():
@@ -30,24 +57,31 @@ def k8s_safe_name(base_name: str, *, max_length: int = 63, suffix: str = "") -> 
 
     reserved = len(suffix) + len(hash_suffix) + 1
     if len(normalized) + reserved > max_length:
-        trim = max_length - reserved
-        normalized = normalized[:trim].rstrip("-")
-        normalized = f"{normalized}-{hash_suffix}{suffix}"
-    elif suffix:
-        normalized = f"{normalized}{suffix}"
-    return normalized
-
-
-def container_name(workspace: str, deployment_name: str) -> str:
-    return k8s_safe_name(f"dep-{workspace}-{deployment_name}")
-
-
-def docker_volume_name(workspace: str, volume_name: str) -> str:
-    return k8s_safe_name(f"dep-vol-{workspace}-{volume_name}")
+        normalized = normalized[: max_length - reserved].rstrip("-")
+    if not normalized:
+        normalized = "x"
+    return f"{normalized}-{hash_suffix}{suffix}"
 
 
 def deployment_key(workspace: str, name: str) -> str:
+    """Return the canonical identity string used for hashing and label keys."""
     return f"{workspace}/{name}"
+
+
+def container_name(workspace: str, deployment_name: str) -> str:
+    """Docker container name for a deployment (``dep-`` prefix, hashed identity)."""
+    return k8s_safe_name(
+        f"dep-{workspace}-{deployment_name}",
+        hash_input=deployment_key(workspace, deployment_name),
+    )
+
+
+def docker_volume_name(workspace: str, volume_name: str) -> str:
+    """Docker volume name for a deployment volume (``dep-vol-`` prefix, hashed identity)."""
+    return k8s_safe_name(
+        f"dep-vol-{workspace}-{volume_name}",
+        hash_input=deployment_key(workspace, volume_name),
+    )
 
 
 BACKOFF_LIMIT_LABEL = "nemo.nvidia.com/backoff-limit"

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_labels.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_labels.py
@@ -20,12 +20,12 @@ from nemo_deployments_plugin.backends.docker.labels import (
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
 
 _HASH8 = re.compile(r"-[0-9a-f]{8}$")
+_DNS_LABEL = re.compile(r"^[a-z](?:[a-z0-9-]*[a-z0-9])?$")
 
 
 def _assert_dns_label_safe(name: str) -> None:
     assert len(name) <= 63
-    assert name[0].isalpha()
-    assert name[-1].isalnum()
+    assert _DNS_LABEL.fullmatch(name)
     assert _HASH8.search(name)
 
 
@@ -55,6 +55,8 @@ def test_docker_volume_name_ambiguous_workspace_name_pairs_differ() -> None:
     assert name_a != name_b
     assert name_a.startswith("dep-vol-")
     assert name_b.startswith("dep-vol-")
+    _assert_dns_label_safe(name_a)
+    _assert_dns_label_safe(name_b)
 
 
 def test_k8s_safe_name_empty_base_uses_fallback_prefix() -> None:

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_labels.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_labels.py
@@ -15,9 +15,9 @@ from nemo_deployments_plugin.backends.docker.labels import (
     container_name,
     deployment_identity_labels,
     docker_volume_name,
-    k8s_safe_name,
 )
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
+from nemo_platform_plugin.k8s_naming import k8s_safe_name
 
 _HASH8 = re.compile(r"-[0-9a-f]{8}$")
 _DNS_LABEL = re.compile(r"^[a-z](?:[a-z0-9-]*[a-z0-9])?$")

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_labels.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_labels.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import re
+
 from nemo_deployments_plugin.backends.docker.labels import (
     CONFIG_NAME_LABEL,
     DEPLOYMENT_NAME_LABEL,
@@ -13,13 +15,51 @@ from nemo_deployments_plugin.backends.docker.labels import (
     container_name,
     deployment_identity_labels,
     docker_volume_name,
+    k8s_safe_name,
 )
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
+
+_HASH8 = re.compile(r"-[0-9a-f]{8}$")
+
+
+def _assert_dns_label_safe(name: str) -> None:
+    assert len(name) <= 63
+    assert name[0].isalpha()
+    assert name[-1].isalnum()
+    assert _HASH8.search(name)
 
 
 def test_container_name_is_dns_safe() -> None:
     name = container_name("my-workspace", "my.deployment")
     assert name.startswith("dep-")
+    _assert_dns_label_safe(name)
+
+
+def test_k8s_safe_name_always_includes_hash_suffix() -> None:
+    name = k8s_safe_name("short-name")
+    assert _HASH8.search(name)
+    assert name == k8s_safe_name("short-name")
+
+
+def test_container_name_ambiguous_workspace_name_pairs_differ() -> None:
+    name_a = container_name("foo", "bar-baz")
+    name_b = container_name("foo-bar", "baz")
+    assert name_a != name_b
+    _assert_dns_label_safe(name_a)
+    _assert_dns_label_safe(name_b)
+
+
+def test_docker_volume_name_ambiguous_workspace_name_pairs_differ() -> None:
+    name_a = docker_volume_name("foo", "bar-baz")
+    name_b = docker_volume_name("foo-bar", "baz")
+    assert name_a != name_b
+    assert name_a.startswith("dep-vol-")
+    assert name_b.startswith("dep-vol-")
+
+
+def test_k8s_safe_name_empty_base_uses_fallback_prefix() -> None:
+    name = k8s_safe_name("")
+    assert name.startswith("x-")
     assert len(name) <= 63
 
 

--- a/services/core/inference-gateway/tests/integration/test_inference.py
+++ b/services/core/inference-gateway/tests/integration/test_inference.py
@@ -24,6 +24,7 @@ from nemo_platform.types.inference.model_provider import ModelProvider
 from nemo_platform.types.inference.virtual_model import VirtualModel as SDKVirtualModel
 from nmp.core.inference_gateway.api.dependencies import global_virtual_model_cache
 from nmp.core.inference_gateway.api.model_cache import ModelCache, ModelProviderInfo
+from nmp.core.models.app.utils import get_docker_container_name, get_docker_volume_name
 from nmp.core.models.controllers.models_controller import ModelsController
 from tenacity import retry, stop_after_delay, wait_fixed
 
@@ -245,11 +246,11 @@ def test_igw_routes_to_deployed_mock_nim(
     test_uuid = uuid.uuid4().hex[:8]
     config_name = f"test-igw-e2e-{test_uuid}"
     deployment_name = f"test-igw-e2e-{test_uuid}"
-    container_name = f"md-{DEFAULT_WORKSPACE}-{deployment_name}"
+    container_name = get_docker_container_name(DEFAULT_WORKSPACE, deployment_name)
 
     # Register for cleanup
     ctx.register_container(container_name)
-    ctx.register_volume(f"nim-cache-{DEFAULT_WORKSPACE}-{deployment_name}")
+    ctx.register_volume(get_docker_volume_name(DEFAULT_WORKSPACE, deployment_name))
 
     # === Phase 1: Create deployment config and deployment ===
     config, deployment = _create_deployment_with_config(sdk, config_name, deployment_name, mock_nim_image)
@@ -410,10 +411,10 @@ def test_igw_cache_removes_deleted_deployment_provider(
     test_uuid = uuid.uuid4().hex[:8]
     config_name = f"test-igw-delete-{test_uuid}"
     deployment_name = f"test-igw-delete-{test_uuid}"
-    container_name = f"md-{DEFAULT_WORKSPACE}-{deployment_name}"
+    container_name = get_docker_container_name(DEFAULT_WORKSPACE, deployment_name)
 
     ctx.register_container(container_name)
-    ctx.register_volume(f"nim-cache-{DEFAULT_WORKSPACE}-{deployment_name}")
+    ctx.register_volume(get_docker_volume_name(DEFAULT_WORKSPACE, deployment_name))
 
     # Create deployment
     config, deployment = _create_deployment_with_config(sdk, config_name, deployment_name, mock_nim_image)

--- a/services/core/inference-gateway/tests/integration/test_middleware_pipeline.py
+++ b/services/core/inference-gateway/tests/integration/test_middleware_pipeline.py
@@ -49,6 +49,7 @@ from nmp.core.inference_gateway.api.middleware_registry import (
 )
 from nmp.core.inference_gateway.api.model_cache import ModelProviderInfo
 from nmp.core.inference_gateway.api.virtual_model_cache import VirtualModelCache
+from nmp.core.models.app.utils import get_docker_container_name, get_docker_volume_name
 from tenacity import retry, stop_after_delay, wait_fixed
 
 DEFAULT_WORKSPACE = "default"
@@ -393,10 +394,10 @@ def test_middleware_request_and_response_mutation_through_backend(
     vm_name = f"test-mw-alias-{test_uuid}"
     router_key = f"test-router-{test_uuid}"
     marker_key = f"test-marker-{test_uuid}"
-    container_name = f"md-{DEFAULT_WORKSPACE}-{deployment_name}"
+    container_name = get_docker_container_name(DEFAULT_WORKSPACE, deployment_name)
 
     ctx.register_container(container_name)
-    ctx.register_volume(f"nim-cache-{DEFAULT_WORKSPACE}-{deployment_name}")
+    ctx.register_volume(get_docker_volume_name(DEFAULT_WORKSPACE, deployment_name))
 
     # ---- Phase 1: Deploy mock NIM ----------------------------------------
     image_name, image_tag = mock_nim_image.rsplit(":", 1)
@@ -515,10 +516,10 @@ def test_model_endpoint_request_and_response_mutation_through_backend(
     vm_name = f"test-mep-alias-{test_uuid}"
     router_key = f"test-mep-router-{test_uuid}"
     marker_key = f"test-mep-marker-{test_uuid}"
-    container_name = f"md-{DEFAULT_WORKSPACE}-{deployment_name}"
+    container_name = get_docker_container_name(DEFAULT_WORKSPACE, deployment_name)
 
     ctx.register_container(container_name)
-    ctx.register_volume(f"nim-cache-{DEFAULT_WORKSPACE}-{deployment_name}")
+    ctx.register_volume(get_docker_volume_name(DEFAULT_WORKSPACE, deployment_name))
 
     # ---- Phase 1: Deploy mock NIM ----------------------------------------
     image_name, image_tag = mock_nim_image.rsplit(":", 1)
@@ -634,10 +635,10 @@ def test_model_endpoint_non_model_body_mutation_regression(
     vm_name = f"test-mep-reg-alias-{test_uuid}"
     router_key = f"test-mep-reg-router-{test_uuid}"
     echo_key = f"test-mep-reg-echo-{test_uuid}"
-    container_name = f"md-{DEFAULT_WORKSPACE}-{deployment_name}"
+    container_name = get_docker_container_name(DEFAULT_WORKSPACE, deployment_name)
 
     ctx.register_container(container_name)
-    ctx.register_volume(f"nim-cache-{DEFAULT_WORKSPACE}-{deployment_name}")
+    ctx.register_volume(get_docker_volume_name(DEFAULT_WORKSPACE, deployment_name))
 
     # ---- Phase 1: Deploy mock NIM ----------------------------------------
     image_name, image_tag = mock_nim_image.rsplit(":", 1)

--- a/services/core/models/src/nmp/core/models/app/utils.py
+++ b/services/core/models/src/nmp/core/models/app/utils.py
@@ -7,12 +7,19 @@ import hashlib
 import re
 from enum import Enum
 from logging import getLogger
-from typing import Generic, List, Literal, Optional, TypeVar
+from typing import Generic, List, Optional, TypeVar
 
 from nemo_platform.types.inference.model_deployment import ModelDeployment
 from nemo_platform.types.inference.model_deployment_config import ModelDeploymentConfig
 from nemo_platform.types.inference.model_provider import ModelProvider
 from nemo_platform.types.models import ModelEntity
+from nemo_platform_plugin.k8s_naming import (
+    DNS_LABEL_MAX_LENGTH,
+    DNS_SUBDOMAIN_MAX_LENGTH,
+    HASH_SUFFIX_LENGTH,
+    k8s_safe_name,
+    workspace_name_identity,
+)
 from nmp.common.api.common import PaginationData
 from nmp.common.entities.constants import NAME_PATTERN as ENTITY_NAME_PATTERN
 from pydantic import BaseModel
@@ -260,147 +267,14 @@ def normalize_model_entity_name(model_name: str) -> str:
     return normalized
 
 
-_HASH_SUFFIX_LENGTH = 8
 _LORA_SIDECAR_SUFFIX = "-sidecar"
 # Primary Docker container names must leave room for an optional LoRA sidecar suffix.
-_DOCKER_CONTAINER_NAME_MAX_LENGTH = 63 - len(_LORA_SIDECAR_SUFFIX)
+_DOCKER_CONTAINER_NAME_MAX_LENGTH = DNS_LABEL_MAX_LENGTH - len(_LORA_SIDECAR_SUFFIX)
 
-
-def _workspace_name_identity(workspace: str, name: str) -> str:
-    """Canonical ``workspace/name`` identity used as ``hash_input`` for resource names."""
-    return f"{workspace}/{name}"
-
-
-def _get_k8s_safe_name(
-    base_name: str,
-    max_length: int = 63,
-    suffix: str = "",
-    name_type: Literal["label", "dns_subdomain"] = "label",
-    hash_input: str | None = None,
-    *,
-    include_hash: bool = True,
-) -> str:
-    """
-    Generate a Kubernetes-compliant name from a base name.
-
-    This function is deterministic - the same input will always produce the same output.
-    It follows a logical order:
-    1. Generate deterministic hash from hash_input (or base_name when omitted)
-    2. Normalize characters to K8s-compatible format
-    3. Truncate if needed to fit max_length with hash and suffix
-    4. Always append an 8-char hash suffix for uniqueness
-
-    Handles both RFC 1035 DNS labels (for Services, Pods, etc.) and RFC 1123 DNS subdomains (for Secrets).
-
-    DNS Label Rules (RFC 1035):
-    - Max 63 characters
-    - Only lowercase alphanumeric and hyphens
-    - Must start with a letter
-    - Must end with alphanumeric
-    - Regex: [a-z]([-a-z0-9]*[a-z0-9])?
-
-    DNS Subdomain Rules (RFC 1123):
-    - Max 253 characters
-    - Lowercase alphanumeric, hyphens, and dots
-    - Must start with alphanumeric
-    - Must end with alphanumeric
-
-    Args:
-        base_name: The original name to convert
-        max_length: Maximum length for the K8s resource (63 for labels, 253 for DNS subdomains)
-        suffix: Optional suffix to append (e.g., "-pvc", "-hf-token")
-        name_type: Type of K8s name - "label" for RFC 1035, "dns_subdomain" for RFC 1123
-        hash_input: Optional distinct identity for hashing (defaults to base_name).
-            Resource builders pass ``workspace/name`` so ambiguous hyphen joins
-            (e.g. ``foo`` + ``bar-baz`` vs ``foo-bar`` + ``baz``) hash differently.
-        include_hash: When False, append ``suffix`` only without a second hash.
-            Used when deriving init/sidecar names from an already-hashed base.
-
-    Returns:
-        A Kubernetes-compliant name that fits within max_length
-
-    Examples:
-        >>> _get_k8s_safe_name("test-deployment", max_length=63, suffix="")
-        'test-deployment-5f363e0a'
-
-        >>> _get_k8s_safe_name("llama-3.2-1b", max_length=63, name_type="label")
-        'llama-3-2-1b-...'
-
-        >>> _get_k8s_safe_name("a" * 100, max_length=63, suffix="-pvc")
-        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-5f363e0a-pvc'
-    """
-    hash_source = hash_input if hash_input is not None else base_name
-    hash_suffix = hashlib.sha256(hash_source.encode()).hexdigest()[:_HASH_SUFFIX_LENGTH]
-
-    # Normalize characters to K8s-compatible format
-    normalized = base_name.lower()
-
-    # For DNS labels (Services, Pods, etc.), replace dots and invalid chars with hyphens
-    # For DNS subdomains (Secrets), dots are allowed
-    if name_type == "label":
-        normalized = re.sub(r"[^a-z0-9-]", "-", normalized)
-        normalized = re.sub(r"-+", "-", normalized)
-        if normalized and not normalized[0].isalpha():
-            normalized = f"x{normalized}"
-    else:  # dns_subdomain
-        normalized = re.sub(r"[^a-z0-9.-]", "-", normalized)
-        normalized = re.sub(r"[.]+", ".", normalized).strip(".")
-        labels = []
-        for label in normalized.split("."):
-            label = re.sub(r"-+", "-", label).strip("-")
-            labels.append(label or "x")
-        normalized = ".".join(labels)
-        normalized = normalized.lstrip("-.")
-        if not normalized or not normalized[0].isalnum():
-            normalized = f"x{normalized}"
-
-    normalized = normalized.rstrip("-.")
-    if not normalized or not normalized[-1].isalnum():
-        normalized = "x" if not normalized else normalized.rstrip("-.")
-        if not normalized:
-            normalized = "x"
-
-    if not include_hash:
-        if len(normalized) + len(suffix) <= max_length:
-            return f"{normalized}{suffix}"
-
-        max_base_len = max_length - len(suffix)
-        if max_base_len < 1:
-            max_base_len = 1
-        truncated = normalized[:max_base_len].rstrip("-.")
-        if not truncated or not truncated[-1].isalnum():
-            while truncated and not truncated[-1].isalnum():
-                truncated = truncated[:-1]
-            if not truncated:
-                truncated = "x"
-        return f"{truncated}{suffix}"
-
-    hash_len = _HASH_SUFFIX_LENGTH
-    reserved = hash_len + 1 + len(suffix)
-    if len(normalized) + reserved > max_length:
-        max_base_len = max_length - reserved
-        if max_base_len < 1:
-            max_base_len = max(1, max_length - hash_len - len(suffix))
-
-        truncated = normalized[:max_base_len]
-        truncated = truncated.rstrip("-.")
-        if not truncated or not truncated[-1].isalnum():
-            while truncated and not truncated[-1].isalnum():
-                truncated = truncated[:-1]
-            if not truncated:
-                truncated = "x"
-        normalized = truncated
-
-    result = f"{normalized}-{hash_suffix}{suffix}"
-
-    if len(result) > max_length:
-        excess = len(result) - max_length
-        normalized = normalized[: len(normalized) - excess].rstrip("-.")
-        if not normalized:
-            normalized = "x"
-        result = f"{normalized}-{hash_suffix}{suffix}"
-
-    return result
+# Backward-compatible aliases for models service call sites and tests.
+_HASH_SUFFIX_LENGTH = HASH_SUFFIX_LENGTH
+_get_k8s_safe_name = k8s_safe_name
+_workspace_name_identity = workspace_name_identity
 
 
 def get_docker_container_name(workspace: str, name: str) -> str:
@@ -419,7 +293,16 @@ def get_docker_volume_name(workspace: str, name: str) -> str:
     label_name = f"nim-cache-{workspace}-{name}"
     return _get_k8s_safe_name(
         label_name,
-        max_length=63,
+        name_type="label",
+        hash_input=_workspace_name_identity(workspace, name),
+    )
+
+
+def get_docker_puller_container_name(workspace: str, name: str) -> str:
+    """Docker SFT/model puller container name."""
+    label_name = f"md-puller-{workspace}-{name}"
+    return _get_k8s_safe_name(
+        label_name,
         name_type="label",
         hash_input=_workspace_name_identity(workspace, name),
     )
@@ -430,7 +313,6 @@ def get_docker_plugin_puller_container_name(workspace: str, name: str) -> str:
     label_name = f"md-plugin-{workspace}-{name}"
     return _get_k8s_safe_name(
         label_name,
-        max_length=63,
         name_type="label",
         hash_input=_workspace_name_identity(workspace, name),
     )
@@ -463,7 +345,6 @@ def get_deployment_resource_name(workspace: str, name: str) -> str:
     identity = _workspace_name_identity(workspace, name)
     return _get_k8s_safe_name(
         base,
-        max_length=63,
         suffix="",
         name_type="label",
         hash_input=identity,
@@ -537,7 +418,7 @@ def get_deployment_secret_name(workspace: str, name: str, prefix: str = "md", su
     identity = _workspace_name_identity(workspace, name)
     return _get_k8s_safe_name(
         base,
-        max_length=253,
+        max_length=DNS_SUBDOMAIN_MAX_LENGTH,
         suffix=suffix,
         name_type="dns_subdomain",
         hash_input=identity,

--- a/services/core/models/src/nmp/core/models/app/utils.py
+++ b/services/core/models/src/nmp/core/models/app/utils.py
@@ -339,17 +339,17 @@ def _get_k8s_safe_name(
     # For DNS subdomains (Secrets), dots are allowed
     if name_type == "label":
         normalized = re.sub(r"[^a-z0-9-]", "-", normalized)
-    else:  # dns_subdomain
-        normalized = re.sub(r"[^a-z0-9.-]", "-", normalized)
-
-    normalized = re.sub(r"[-]+", "-", normalized)
-    if name_type == "dns_subdomain":
-        normalized = re.sub(r"[.]+", ".", normalized)
-
-    if name_type == "label":
+        normalized = re.sub(r"-+", "-", normalized)
         if normalized and not normalized[0].isalpha():
             normalized = f"x{normalized}"
-    else:
+    else:  # dns_subdomain
+        normalized = re.sub(r"[^a-z0-9.-]", "-", normalized)
+        normalized = re.sub(r"[.]+", ".", normalized).strip(".")
+        labels = []
+        for label in normalized.split("."):
+            label = re.sub(r"-+", "-", label).strip("-")
+            labels.append(label or "x")
+        normalized = ".".join(labels)
         normalized = normalized.lstrip("-.")
         if not normalized or not normalized[0].isalnum():
             normalized = f"x{normalized}"
@@ -401,6 +401,39 @@ def _get_k8s_safe_name(
         result = f"{normalized}-{hash_suffix}{suffix}"
 
     return result
+
+
+def get_docker_container_name(workspace: str, name: str) -> str:
+    """Docker NIM container name (capped at 55 chars to leave room for ``-sidecar``)."""
+    label_name = f"md-{workspace}-{name}"
+    return _get_k8s_safe_name(
+        label_name,
+        max_length=_DOCKER_CONTAINER_NAME_MAX_LENGTH,
+        name_type="label",
+        hash_input=_workspace_name_identity(workspace, name),
+    )
+
+
+def get_docker_volume_name(workspace: str, name: str) -> str:
+    """Docker model-cache volume name for a deployment."""
+    label_name = f"nim-cache-{workspace}-{name}"
+    return _get_k8s_safe_name(
+        label_name,
+        max_length=63,
+        name_type="label",
+        hash_input=_workspace_name_identity(workspace, name),
+    )
+
+
+def get_docker_plugin_puller_container_name(workspace: str, name: str) -> str:
+    """Docker plugin fileset puller container name."""
+    label_name = f"md-plugin-{workspace}-{name}"
+    return _get_k8s_safe_name(
+        label_name,
+        max_length=63,
+        name_type="label",
+        hash_input=_workspace_name_identity(workspace, name),
+    )
 
 
 def get_deployment_resource_name(workspace: str, name: str) -> str:

--- a/services/core/models/src/nmp/core/models/app/utils.py
+++ b/services/core/models/src/nmp/core/models/app/utils.py
@@ -260,21 +260,35 @@ def normalize_model_entity_name(model_name: str) -> str:
     return normalized
 
 
+_HASH_SUFFIX_LENGTH = 8
+_LORA_SIDECAR_SUFFIX = "-sidecar"
+# Primary Docker container names must leave room for an optional LoRA sidecar suffix.
+_DOCKER_CONTAINER_NAME_MAX_LENGTH = 63 - len(_LORA_SIDECAR_SUFFIX)
+
+
+def _workspace_name_identity(workspace: str, name: str) -> str:
+    """Canonical ``workspace/name`` identity used as ``hash_input`` for resource names."""
+    return f"{workspace}/{name}"
+
+
 def _get_k8s_safe_name(
     base_name: str,
     max_length: int = 63,
     suffix: str = "",
     name_type: Literal["label", "dns_subdomain"] = "label",
+    hash_input: str | None = None,
+    *,
+    include_hash: bool = True,
 ) -> str:
     """
     Generate a Kubernetes-compliant name from a base name.
 
     This function is deterministic - the same input will always produce the same output.
     It follows a logical order:
-    1. Generate deterministic hash (for uniqueness if truncation is needed)
+    1. Generate deterministic hash from hash_input (or base_name when omitted)
     2. Normalize characters to K8s-compatible format
-    3. Check length requirements (considering user-provided suffix)
-    4. Apply truncation with hash suffix only if necessary
+    3. Truncate if needed to fit max_length with hash and suffix
+    4. Always append an 8-char hash suffix for uniqueness
 
     Handles both RFC 1035 DNS labels (for Services, Pods, etc.) and RFC 1123 DNS subdomains (for Secrets).
 
@@ -296,105 +310,95 @@ def _get_k8s_safe_name(
         max_length: Maximum length for the K8s resource (63 for labels, 253 for DNS subdomains)
         suffix: Optional suffix to append (e.g., "-pvc", "-hf-token")
         name_type: Type of K8s name - "label" for RFC 1035, "dns_subdomain" for RFC 1123
+        hash_input: Optional distinct identity for hashing (defaults to base_name).
+            Resource builders pass ``workspace/name`` so ambiguous hyphen joins
+            (e.g. ``foo`` + ``bar-baz`` vs ``foo-bar`` + ``baz``) hash differently.
+        include_hash: When False, append ``suffix`` only without a second hash.
+            Used when deriving init/sidecar names from an already-hashed base.
 
     Returns:
         A Kubernetes-compliant name that fits within max_length
 
     Examples:
         >>> _get_k8s_safe_name("test-deployment", max_length=63, suffix="")
-        'test-deployment'
+        'test-deployment-5f363e0a'
 
         >>> _get_k8s_safe_name("llama-3.2-1b", max_length=63, name_type="label")
-        'llama-3-2-1b'
-
-        >>> _get_k8s_safe_name("my.secret.name", max_length=253, name_type="dns_subdomain")
-        'my.secret.name'
+        'llama-3-2-1b-...'
 
         >>> _get_k8s_safe_name("a" * 100, max_length=63, suffix="-pvc")
         'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-5f363e0a-pvc'
     """
-    # Step 1: Generate deterministic hash first (before any normalization)
-    # This ensures the same input always produces the same hash
-    hash_suffix = hashlib.sha256(base_name.encode()).hexdigest()[:8]
+    hash_source = hash_input if hash_input is not None else base_name
+    hash_suffix = hashlib.sha256(hash_source.encode()).hexdigest()[:_HASH_SUFFIX_LENGTH]
 
-    # Step 2: Normalize characters to K8s-compatible format
+    # Normalize characters to K8s-compatible format
     normalized = base_name.lower()
 
     # For DNS labels (Services, Pods, etc.), replace dots and invalid chars with hyphens
     # For DNS subdomains (Secrets), dots are allowed
     if name_type == "label":
-        # Replace any character that's not alphanumeric or hyphen with hyphen
         normalized = re.sub(r"[^a-z0-9-]", "-", normalized)
     else:  # dns_subdomain
-        # Replace any character that's not alphanumeric, hyphen, or dot with hyphen
         normalized = re.sub(r"[^a-z0-9.-]", "-", normalized)
 
-    # Remove consecutive hyphens/dots
     normalized = re.sub(r"[-]+", "-", normalized)
     if name_type == "dns_subdomain":
         normalized = re.sub(r"[.]+", ".", normalized)
 
-    # Ensure it starts correctly based on type
     if name_type == "label":
-        # Must start with a letter for RFC 1035
         if normalized and not normalized[0].isalpha():
-            # Prepend 'x' if it starts with digit or hyphen
             normalized = f"x{normalized}"
-    else:  # dns_subdomain
-        # Must start with alphanumeric for RFC 1123
+    else:
         normalized = normalized.lstrip("-.")
         if not normalized or not normalized[0].isalnum():
             normalized = f"x{normalized}"
 
-    # Ensure it ends with alphanumeric (both types)
     normalized = normalized.rstrip("-.")
     if not normalized or not normalized[-1].isalnum():
-        # If we've stripped everything, use 'x' as fallback
         normalized = "x" if not normalized else normalized.rstrip("-.")
         if not normalized:
             normalized = "x"
 
-    # Step 3: Analyze length with user-provided suffix
-    suffix_len = len(suffix)
-    total_length = len(normalized) + suffix_len
+    if not include_hash:
+        if len(normalized) + len(suffix) <= max_length:
+            return f"{normalized}{suffix}"
 
-    # If it fits, return it without modification
-    if total_length <= max_length:
-        return f"{normalized}{suffix}"
+        max_base_len = max_length - len(suffix)
+        if max_base_len < 1:
+            max_base_len = 1
+        truncated = normalized[:max_base_len].rstrip("-.")
+        if not truncated or not truncated[-1].isalnum():
+            while truncated and not truncated[-1].isalnum():
+                truncated = truncated[:-1]
+            if not truncated:
+                truncated = "x"
+        return f"{truncated}{suffix}"
 
-    # Step 4: Only apply truncation with hash if necessary
-    hash_len = 8
-    # Format: {truncated}-{hash}{suffix}
-    # Need room for: truncated + '-' + hash + suffix
-    max_base_len = max_length - hash_len - 1 - suffix_len
+    hash_len = _HASH_SUFFIX_LENGTH
+    reserved = hash_len + 1 + len(suffix)
+    if len(normalized) + reserved > max_length:
+        max_base_len = max_length - reserved
+        if max_base_len < 1:
+            max_base_len = max(1, max_length - hash_len - len(suffix))
 
-    if max_base_len < 1:
-        # Edge case: suffix is very long, just fit what we can
-        max_base_len = max(1, max_length - hash_len - suffix_len)
+        truncated = normalized[:max_base_len]
+        truncated = truncated.rstrip("-.")
+        if not truncated or not truncated[-1].isalnum():
+            while truncated and not truncated[-1].isalnum():
+                truncated = truncated[:-1]
+            if not truncated:
+                truncated = "x"
+        normalized = truncated
 
-    truncated = normalized[:max_base_len]
+    result = f"{normalized}-{hash_suffix}{suffix}"
 
-    # Ensure truncated part ends with alphanumeric
-    truncated = truncated.rstrip("-.")
-    if not truncated or not truncated[-1].isalnum():
-        # Keep going back until we find an alphanumeric char
-        while truncated and not truncated[-1].isalnum():
-            truncated = truncated[:-1]
-        if not truncated:
-            # If nothing left, use first char if valid, else 'x'
-            truncated = "x"
-
-    result = f"{truncated}-{hash_suffix}{suffix}"
-
-    # Final safety check: ensure we didn't exceed max_length
     if len(result) > max_length:
-        # Shouldn't happen, but be defensive
-        # Trim from the truncated part, not from hash or suffix
         excess = len(result) - max_length
-        truncated = truncated[: len(truncated) - excess].rstrip("-.")
-        if not truncated:
-            truncated = "x"
-        result = f"{truncated}-{hash_suffix}{suffix}"
+        normalized = normalized[: len(normalized) - excess].rstrip("-.")
+        if not normalized:
+            normalized = "x"
+        result = f"{normalized}-{hash_suffix}{suffix}"
 
     return result
 
@@ -404,7 +408,9 @@ def get_deployment_resource_name(workspace: str, name: str) -> str:
     Generate K8s resource name for ModelDeployment resources (NIMService/PVC).
 
     This is used for NIMService and standalone PVC resources which must follow
-    RFC 1035 DNS label rules (63 char limit).
+    RFC 1035 DNS label rules (63 char limit). The returned name is
+    ``md-{workspace}-{name}-{hash8}`` where the hash is derived from
+    ``workspace/name``, not the hyphen-joined prefix alone.
 
     For NIMCache resources, use `get_nimcache_resource_name` instead, which
     reserves 4 characters for the `-job` suffix appended by k8s-nim-operator.
@@ -418,10 +424,17 @@ def get_deployment_resource_name(workspace: str, name: str) -> str:
 
     Example:
         >>> get_deployment_resource_name("default", "llama-3.2-1b")
-        'md-default-llama-3-2-1b'
+        'md-default-llama-3-2-1b-<hash8>'
     """
     base = f"md-{workspace}-{name}"
-    return _get_k8s_safe_name(base, max_length=63, suffix="", name_type="label")
+    identity = _workspace_name_identity(workspace, name)
+    return _get_k8s_safe_name(
+        base,
+        max_length=63,
+        suffix="",
+        name_type="label",
+        hash_input=identity,
+    )
 
 
 def get_nimcache_resource_name(workspace: str, name: str) -> str:
@@ -436,11 +449,10 @@ def get_nimcache_resource_name(workspace: str, name: str) -> str:
         Job.batch "<nimcache-name>-job" is invalid:
           metadata.labels: Invalid value: "...": must be no more than 63 characters
 
-    The same `_get_k8s_safe_name` logic is used, so names that are already
-    ≤ 59 characters are returned unchanged and names that exceed the limit are
-    deterministically truncated with an 8-char hash suffix — ensuring GET/LIST/
-    DELETE operations on the same (workspace, name) pair always resolve to the
-    same NIMCache resource name.
+    The same `_get_k8s_safe_name` logic is used, so names always include an
+    8-char hash suffix. Names that exceed the 59-char limit are deterministically
+    truncated before the hash — ensuring GET/LIST/DELETE operations on the same
+    (workspace, name) pair always resolve to the same NIMCache resource name.
 
     Args:
         workspace: The deployment workspace
@@ -451,17 +463,26 @@ def get_nimcache_resource_name(workspace: str, name: str) -> str:
 
     Example:
         >>> get_nimcache_resource_name("default", "llama-3.2-1b")
-        'md-default-llama-3-2-1b'
+        'md-default-llama-3-2-1b-<hash8>'
     """
     base = f"md-{workspace}-{name}"
-    return _get_k8s_safe_name(base, max_length=59, suffix="", name_type="label")
+    identity = _workspace_name_identity(workspace, name)
+    return _get_k8s_safe_name(
+        base,
+        max_length=59,
+        suffix="",
+        name_type="label",
+        hash_input=identity,
+    )
 
 
 def get_deployment_secret_name(workspace: str, name: str, prefix: str = "md", suffix: str = "") -> str:
     """
     Generate K8s Secret name with configurable prefix and suffix.
 
-    Secrets use RFC 1123 DNS subdomain rules (253 char limit).
+    Secrets use RFC 1123 DNS subdomain rules (253 char limit). The hash is
+    derived from ``workspace/name``; the caller suffix (e.g. ``-hf-token``)
+    is appended after the hash: ``{base}-{hash8}{suffix}``.
 
     Args:
         workspace: The workspace
@@ -474,10 +495,17 @@ def get_deployment_secret_name(workspace: str, name: str, prefix: str = "md", su
 
     Examples:
         >>> get_deployment_secret_name("default", "test", prefix="md", suffix="-hf-token")
-        'md-default-test-hf-token'
+        'md-default-test-<hash8>-hf-token'
 
         >>> get_deployment_secret_name("default", "test", prefix="model-provider", suffix="-api-key")
-        'model-provider-default-test-api-key'
+        'model-provider-default-test-<hash8>-api-key'
     """
     base = f"{prefix}-{workspace}-{name}"
-    return _get_k8s_safe_name(base, max_length=253, suffix=suffix, name_type="dns_subdomain")
+    identity = _workspace_name_identity(workspace, name)
+    return _get_k8s_safe_name(
+        base,
+        max_length=253,
+        suffix=suffix,
+        name_type="dns_subdomain",
+        hash_input=identity,
+    )

--- a/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
@@ -34,7 +34,12 @@ from nmp.common.docker.gpu_pool import DockerGPUPool, GPUAllocationError
 from nmp.common.sdk_factory import get_sdk_on_behalf_of
 from nmp.core.models.app import ModelWeightsType, get_model_weights_type, is_multi_llm_image, parse_model_name_revision
 from nmp.core.models.app.constants import MODEL_MANAGED_BY_LABEL, MODEL_MANAGED_BY_MODELS_CONTROLLER
-from nmp.core.models.app.utils import _DOCKER_CONTAINER_NAME_MAX_LENGTH, _get_k8s_safe_name
+from nmp.core.models.app.utils import (
+    _get_k8s_safe_name,
+    get_docker_container_name,
+    get_docker_plugin_puller_container_name,
+    get_docker_volume_name,
+)
 from nmp.core.models.controllers.backends import generic_compiler, vllm_compiler
 from nmp.core.models.controllers.backends.backends import DeploymentStatusUpdate
 from nmp.core.models.controllers.backends.common import deployment_config_view
@@ -242,23 +247,11 @@ class DockerDeploymentCreationReconciler:
 
     def get_container_name(self, workspace: str, name: str) -> str:
         """Primary NIM container name; capped at 55 chars to leave room for ``-sidecar``."""
-        label_name = f"md-{workspace}-{name}"
-        return _get_k8s_safe_name(
-            label_name,
-            max_length=_DOCKER_CONTAINER_NAME_MAX_LENGTH,
-            name_type="label",
-            hash_input=self.get_deployment_key(workspace, name),
-        )
+        return get_docker_container_name(workspace, name)
 
     def get_volume_name(self, workspace: str, name: str) -> str:
         """Model cache volume name (hashed ``workspace/name`` identity)."""
-        label_name = f"nim-cache-{workspace}-{name}"
-        return _get_k8s_safe_name(
-            label_name,
-            max_length=63,
-            name_type="label",
-            hash_input=self.get_deployment_key(workspace, name),
-        )
+        return get_docker_volume_name(workspace, name)
 
     def get_puller_container_name(self, workspace: str, name: str) -> str:
         """SFT/model puller container name (hashed ``workspace/name`` identity)."""
@@ -269,6 +262,10 @@ class DockerDeploymentCreationReconciler:
             name_type="label",
             hash_input=self.get_deployment_key(workspace, name),
         )
+
+    def get_plugin_puller_container_name(self, workspace: str, name: str) -> str:
+        """Tool-call plugin fileset puller container name."""
+        return get_docker_plugin_puller_container_name(workspace, name)
 
     def get_deployment_key(self, workspace: str, name: str) -> str:
         return f"{workspace}/{name}"
@@ -1334,13 +1331,7 @@ class DockerDeploymentCreationReconciler:
         Returns ``(container_path_to_py_file, None)`` on success,
         or ``(None, error_message)`` on failure.
         """
-        container_name = f"md-plugin-{deployment.workspace}-{deployment.name}"
-        container_name = _get_k8s_safe_name(
-            container_name,
-            max_length=63,
-            name_type="label",
-            hash_input=self.get_deployment_key(deployment.workspace, deployment.name),
-        )
+        container_name = self.get_plugin_puller_container_name(deployment.workspace, deployment.name)
         puller_image = self._backend_config.huggingface_model_puller
         target_path = f"/model-store/{target_subdir}"
 

--- a/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
@@ -34,7 +34,7 @@ from nmp.common.docker.gpu_pool import DockerGPUPool, GPUAllocationError
 from nmp.common.sdk_factory import get_sdk_on_behalf_of
 from nmp.core.models.app import ModelWeightsType, get_model_weights_type, is_multi_llm_image, parse_model_name_revision
 from nmp.core.models.app.constants import MODEL_MANAGED_BY_LABEL, MODEL_MANAGED_BY_MODELS_CONTROLLER
-from nmp.core.models.app.utils import _get_k8s_safe_name
+from nmp.core.models.app.utils import _DOCKER_CONTAINER_NAME_MAX_LENGTH, _get_k8s_safe_name
 from nmp.core.models.controllers.backends import generic_compiler, vllm_compiler
 from nmp.core.models.controllers.backends.backends import DeploymentStatusUpdate
 from nmp.core.models.controllers.backends.common import deployment_config_view
@@ -241,16 +241,34 @@ class DockerDeploymentCreationReconciler:
     # ======================================================================
 
     def get_container_name(self, workspace: str, name: str) -> str:
+        """Primary NIM container name; capped at 55 chars to leave room for ``-sidecar``."""
         label_name = f"md-{workspace}-{name}"
-        return _get_k8s_safe_name(label_name, max_length=63, name_type="label")
+        return _get_k8s_safe_name(
+            label_name,
+            max_length=_DOCKER_CONTAINER_NAME_MAX_LENGTH,
+            name_type="label",
+            hash_input=self.get_deployment_key(workspace, name),
+        )
 
     def get_volume_name(self, workspace: str, name: str) -> str:
+        """Model cache volume name (hashed ``workspace/name`` identity)."""
         label_name = f"nim-cache-{workspace}-{name}"
-        return _get_k8s_safe_name(label_name, max_length=63, name_type="label")
+        return _get_k8s_safe_name(
+            label_name,
+            max_length=63,
+            name_type="label",
+            hash_input=self.get_deployment_key(workspace, name),
+        )
 
     def get_puller_container_name(self, workspace: str, name: str) -> str:
+        """SFT/model puller container name (hashed ``workspace/name`` identity)."""
         label_name = f"md-puller-{workspace}-{name}"
-        return _get_k8s_safe_name(label_name, max_length=63, name_type="label")
+        return _get_k8s_safe_name(
+            label_name,
+            max_length=63,
+            name_type="label",
+            hash_input=self.get_deployment_key(workspace, name),
+        )
 
     def get_deployment_key(self, workspace: str, name: str) -> str:
         return f"{workspace}/{name}"
@@ -1317,7 +1335,12 @@ class DockerDeploymentCreationReconciler:
         or ``(None, error_message)`` on failure.
         """
         container_name = f"md-plugin-{deployment.workspace}-{deployment.name}"
-        container_name = _get_k8s_safe_name(container_name, max_length=63, name_type="label")
+        container_name = _get_k8s_safe_name(
+            container_name,
+            max_length=63,
+            name_type="label",
+            hash_input=self.get_deployment_key(deployment.workspace, deployment.name),
+        )
         puller_image = self._backend_config.huggingface_model_puller
         target_path = f"/model-store/{target_subdir}"
 

--- a/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
@@ -35,9 +35,9 @@ from nmp.common.sdk_factory import get_sdk_on_behalf_of
 from nmp.core.models.app import ModelWeightsType, get_model_weights_type, is_multi_llm_image, parse_model_name_revision
 from nmp.core.models.app.constants import MODEL_MANAGED_BY_LABEL, MODEL_MANAGED_BY_MODELS_CONTROLLER
 from nmp.core.models.app.utils import (
-    _get_k8s_safe_name,
     get_docker_container_name,
     get_docker_plugin_puller_container_name,
+    get_docker_puller_container_name,
     get_docker_volume_name,
 )
 from nmp.core.models.controllers.backends import generic_compiler, vllm_compiler
@@ -255,13 +255,7 @@ class DockerDeploymentCreationReconciler:
 
     def get_puller_container_name(self, workspace: str, name: str) -> str:
         """SFT/model puller container name (hashed ``workspace/name`` identity)."""
-        label_name = f"md-puller-{workspace}-{name}"
-        return _get_k8s_safe_name(
-            label_name,
-            max_length=63,
-            name_type="label",
-            hash_input=self.get_deployment_key(workspace, name),
-        )
+        return get_docker_puller_container_name(workspace, name)
 
     def get_plugin_puller_container_name(self, workspace: str, name: str) -> str:
         """Tool-call plugin fileset puller container name."""

--- a/services/core/models/src/nmp/core/models/controllers/backends/k8s_nim_operator/nimservice_compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/k8s_nim_operator/nimservice_compiler.py
@@ -13,7 +13,7 @@ from nemo_platform.types.models.model_entity import ModelEntity
 from nmp.common.config import get_platform_config
 from nmp.core.models.app import is_multi_llm_image, parse_model_name_revision
 from nmp.core.models.app.constants import MODEL_MANAGED_BY_LABEL, MODEL_MANAGED_BY_MODELS_CONTROLLER
-from nmp.core.models.app.utils import _get_k8s_safe_name
+from nmp.core.models.app.utils import _get_k8s_safe_name, get_docker_plugin_puller_container_name
 from nmp.core.models.controllers.backends.common import DeploymentConfigView, deployment_config_view
 from nmp.core.models.controllers.backends.k8s_nim_operator.config import K8sNimOperatorConfig
 from nmp.core.models.controllers.backends.k8s_nim_operator.types.nimcache import (
@@ -216,13 +216,7 @@ def _generate_tool_plugin_container(
 
     if plugin_fileset:
         logger.info(f"Pulling tool_call_plugin fileset '{plugin_fileset}' for {deployment.workspace}/{deployment.name}")
-        container_name = f"md-plugin-{deployment.workspace}-{deployment.name}"
-        container_name = _get_k8s_safe_name(
-            container_name,
-            max_length=63,
-            name_type="label",
-            hash_input=f"{deployment.workspace}/{deployment.name}",
-        )
+        container_name = get_docker_plugin_puller_container_name(deployment.workspace, deployment.name)
         if not huggingface_model_puller:
             logger.warning(
                 "tool_call_plugin is configured but huggingface_model_puller image is unavailable; "

--- a/services/core/models/src/nmp/core/models/controllers/backends/k8s_nim_operator/nimservice_compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/k8s_nim_operator/nimservice_compiler.py
@@ -217,7 +217,12 @@ def _generate_tool_plugin_container(
     if plugin_fileset:
         logger.info(f"Pulling tool_call_plugin fileset '{plugin_fileset}' for {deployment.workspace}/{deployment.name}")
         container_name = f"md-plugin-{deployment.workspace}-{deployment.name}"
-        container_name = _get_k8s_safe_name(container_name, max_length=63, name_type="label")
+        container_name = _get_k8s_safe_name(
+            container_name,
+            max_length=63,
+            name_type="label",
+            hash_input=f"{deployment.workspace}/{deployment.name}",
+        )
         if not huggingface_model_puller:
             logger.warning(
                 "tool_call_plugin is configured but huggingface_model_puller image is unavailable; "
@@ -241,7 +246,9 @@ def _generate_tool_plugin_container(
 
         return [
             ContainerSpec(
-                name=_get_k8s_safe_name(container_name, max_length=63, suffix="-prepare", name_type="label"),
+                name=_get_k8s_safe_name(
+                    container_name, max_length=63, suffix="-prepare", name_type="label", include_hash=False
+                ),
                 image=Image(
                     repository=backend_config.busybox_image,
                     tag=backend_config.busybox_image_tag,
@@ -255,7 +262,9 @@ def _generate_tool_plugin_container(
                 ],
             ),
             ContainerSpec(
-                name=_get_k8s_safe_name(container_name, max_length=63, suffix="-pull", name_type="label"),
+                name=_get_k8s_safe_name(
+                    container_name, max_length=63, suffix="-pull", name_type="label", include_hash=False
+                ),
                 image=Image(
                     repository=puller_repo,
                     tag=puller_tag,
@@ -273,7 +282,9 @@ def _generate_tool_plugin_container(
                 ],
             ),
             ContainerSpec(
-                name=_get_k8s_safe_name(container_name, max_length=63, suffix="-finalize", name_type="label"),
+                name=_get_k8s_safe_name(
+                    container_name, max_length=63, suffix="-finalize", name_type="label", include_hash=False
+                ),
                 image=Image(
                     repository=backend_config.busybox_image,
                     tag=backend_config.busybox_image_tag,
@@ -360,7 +371,9 @@ def compile_nimservice(
     if nim_config.lora_enabled:
         sidecar_containers = [
             ContainerSpec(
-                name=_get_k8s_safe_name(resource_name, max_length=63, suffix="-lora-sidecar", name_type="label"),
+                name=_get_k8s_safe_name(
+                    resource_name, max_length=63, suffix="-lora-sidecar", name_type="label", include_hash=False
+                ),
                 image=Image(
                     repository=f"{platform_config.image_registry}/{backend_config.lora_sidecar_image_name}",
                     tag=platform_config.image_tag,

--- a/services/core/models/tests/integration/test_models_controller.py
+++ b/services/core/models/tests/integration/test_models_controller.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from docker.errors import NotFound
 from nemo_platform import NotFoundError
+from nmp.core.models.app.utils import get_docker_container_name, get_docker_volume_name
 from nmp.core.models.controllers.backends.backends import DeploymentStatusUpdate
 from nmp.core.models.controllers.backends.docker import DockerServiceBackend
 from nmp.core.models.controllers.backends.registry import BackendRegistry
@@ -496,11 +497,13 @@ def test_docker_deployment_lifecycle(controller_with_docker, docker_client):
     test_uuid = uuid.uuid4().hex[:8]
     config_name = f"test-docker-lifecycle-{test_uuid}"
     deployment_name = f"test-docker-lifecycle-{test_uuid}"
-    container_name = f"md-default-{deployment_name}"
+    workspace = "default"
+    container_name = get_docker_container_name(workspace, deployment_name)
+    volume_name = get_docker_volume_name(workspace, deployment_name)
 
     # Register container for cleanup
     ctx.register_container(container_name)
-    ctx.register_volume(f"nim-cache-default-{deployment_name}")
+    ctx.register_volume(volume_name)
 
     # === Phase 1: Create config and deployment ===
     # Parse image name and tag - use rsplit to handle registry URLs with port numbers

--- a/services/core/models/tests/unit/common/test_utils.py
+++ b/services/core/models/tests/unit/common/test_utils.py
@@ -3,6 +3,8 @@
 
 """Unit tests for common utilities."""
 
+import hashlib
+import re
 from datetime import datetime
 
 import pytest
@@ -882,35 +884,51 @@ def test_normalize_model_entity_name_digit_leading_long_truncates():
 # Tests for Kubernetes-safe name generation
 # ============================================================================
 
+_HASH8 = re.compile(r"-[0-9a-f]{8}(?:-[a-z0-9-]+)?$")
 
-def test_k8s_safe_name_simple_unchanged():
-    """Test that a simple valid name passes through unchanged."""
+
+def _identity_hash(workspace: str, name: str) -> str:
+    return hashlib.sha256(f"{workspace}/{name}".encode()).hexdigest()[:8]
+
+
+def _base_hash(base_name: str) -> str:
+    return hashlib.sha256(base_name.encode()).hexdigest()[:8]
+
+
+def _assert_label_with_hash(name: str, *, prefix: str | None = None) -> None:
+    assert len(name) <= 63
+    assert name[0].isalpha()
+    assert name[-1].isalnum()
+    assert _HASH8.search(name)
+    if prefix is not None:
+        assert name.startswith(prefix)
+
+
+def test_k8s_safe_name_always_includes_hash_suffix():
+    """Test that a simple valid name always includes a hash suffix."""
     result = _get_k8s_safe_name("test-deployment", max_length=63, name_type="label")
-    assert result == "test-deployment"
+    assert result == f"test-deployment-{_base_hash('test-deployment')}"
 
 
 def test_k8s_safe_name_dots_replaced_in_labels():
     """Test that dots are replaced with hyphens for DNS labels (RFC 1035)."""
-    # This fixes the user's reported issue: llama-3.2-1b should become llama-3-2-1b
     result = _get_k8s_safe_name("llama-3.2-1b", max_length=63, name_type="label")
-    assert result == "llama-3-2-1b"
+    assert result == f"llama-3-2-1b-{_base_hash('llama-3.2-1b')}"
     assert "." not in result
 
 
 def test_k8s_safe_name_dots_preserved_in_dns_subdomain():
     """Test that dots are preserved for DNS subdomains (RFC 1123)."""
     result = _get_k8s_safe_name("my.secret.name", max_length=253, name_type="dns_subdomain")
-    assert result == "my.secret.name"
+    assert result == f"my.secret.name-{_base_hash('my.secret.name')}"
 
 
 def test_k8s_safe_name_starts_with_letter_for_labels():
     """Test that labels must start with a letter (RFC 1035)."""
-    # Starts with digit - should prepend 'x'
     result = _get_k8s_safe_name("123-deployment", max_length=63, name_type="label")
     assert result[0].isalpha()
-    assert result == "x123-deployment"
+    assert result == f"x123-deployment-{_base_hash('123-deployment')}"
 
-    # Starts with hyphen - should prepend 'x'
     result = _get_k8s_safe_name("-deployment", max_length=63, name_type="label")
     assert result[0].isalpha()
 
@@ -919,13 +937,13 @@ def test_k8s_safe_name_ends_with_alphanumeric():
     """Test that names must end with alphanumeric."""
     result = _get_k8s_safe_name("deployment-", max_length=63, name_type="label")
     assert result[-1].isalnum()
-    assert result == "deployment"
+    assert result == f"deployment-{_base_hash('deployment-')}"
 
 
 def test_k8s_safe_name_lowercase_conversion():
     """Test that names are converted to lowercase."""
     result = _get_k8s_safe_name("MyDeployment", max_length=63, name_type="label")
-    assert result == "mydeployment"
+    assert result == f"mydeployment-{_base_hash('MyDeployment')}"
     assert result.islower()
 
 
@@ -958,19 +976,52 @@ def test_k8s_safe_name_deterministic():
     assert result1 == result2
 
 
+def test_k8s_safe_name_hash_input_differs_from_joined_base():
+    """Distinct workspace/name identities produce different hashes for the same joined base."""
+    base = "dep-foo-bar-baz"
+    name_a = _get_k8s_safe_name(base, hash_input="foo/bar-baz")
+    name_b = _get_k8s_safe_name(base, hash_input="foo-bar/baz")
+    assert name_a != name_b
+
+
+def test_plugin_puller_name_ambiguous_workspace_name_pairs_differ():
+    """Plugin puller container names use workspace/name identity, not joined hyphens alone."""
+    base = "md-plugin-foo-bar-baz"
+    name_a = _get_k8s_safe_name(base, hash_input="foo/bar-baz")
+    name_b = _get_k8s_safe_name(base, hash_input="foo-bar/baz")
+    assert name_a != name_b
+
+
+def test_get_deployment_secret_name_ambiguous_workspace_name_pairs_differ():
+    """Secret names must not collide on ambiguous workspace/name pairs."""
+    name_a = get_deployment_secret_name("foo", "bar-baz", prefix="md", suffix="-hf-token")
+    name_b = get_deployment_secret_name("foo-bar", "baz", prefix="md", suffix="-hf-token")
+    assert name_a != name_b
+    assert name_a.endswith("-hf-token")
+    assert name_b.endswith("-hf-token")
+
+
 def test_get_deployment_resource_name_simple():
     """Test simple deployment resource name."""
     result = get_deployment_resource_name("default", "test-deployment")
-    assert result == "md-default-test-deployment"
+    assert result == f"md-default-test-deployment-{_identity_hash('default', 'test-deployment')}"
     assert len(result) <= 63
+
+
+def test_get_deployment_resource_name_ambiguous_workspace_name_pairs_differ():
+    """Regression: hyphen-joined workspace/name pairs must not collide."""
+    name_a = get_deployment_resource_name("foo", "bar-baz")
+    name_b = get_deployment_resource_name("foo-bar", "baz")
+    assert name_a != name_b
+    _assert_label_with_hash(name_a, prefix="md-")
+    _assert_label_with_hash(name_b, prefix="md-")
 
 
 def test_get_deployment_resource_name_dots_replaced():
     """Test that dots in deployment name are replaced (DNS-1035 compliance)."""
-    # This is the exact issue from the user's error message
     result = get_deployment_resource_name("ben-test", "llama-3.2-1b-deployment")
     assert "." not in result
-    assert result == "md-ben-test-llama-3-2-1b-deployment"
+    assert result == f"md-ben-test-llama-3-2-1b-deployment-{_identity_hash('ben-test', 'llama-3.2-1b-deployment')}"
     assert len(result) <= 63
 
 
@@ -989,14 +1040,14 @@ def test_get_deployment_resource_name_long_names():
 def test_get_deployment_secret_name_simple():
     """Test simple secret name generation."""
     result = get_deployment_secret_name("default", "test", prefix="md", suffix="-hf-token")
-    assert result == "md-default-test-hf-token"
+    assert result == f"md-default-test-{_identity_hash('default', 'test')}-hf-token"
     assert len(result) <= 253
 
 
 def test_get_deployment_secret_name_provider():
     """Test provider secret name generation."""
     result = get_deployment_secret_name("default", "test", prefix="model-provider", suffix="-api-key")
-    assert result == "model-provider-default-test-api-key"
+    assert result == f"model-provider-default-test-{_identity_hash('default', 'test')}-api-key"
     assert len(result) <= 253
 
 
@@ -1043,8 +1094,8 @@ def test_real_invalid_k8s_name_issue():
     assert all(c.isalnum() or c == "-" for c in result)
     assert result.islower()
 
-    # Expected output
-    assert result == "md-ben-test-llama-3-2-1b-deployment"
+    # Expected output includes hash from unambiguous workspace/name identity
+    assert result == f"md-ben-test-llama-3-2-1b-deployment-{_identity_hash('ben-test', 'llama-3.2-1b-deployment')}"
 
 
 def test_maximum_length_deployment_resources():
@@ -1072,9 +1123,9 @@ def test_maximum_length_deployment_resources():
 
 
 def test_get_nimcache_resource_name_simple():
-    """Short names are unchanged and also valid for get_deployment_resource_name."""
+    """Short names include hash suffix and stay within the 59-char NIMCache limit."""
     result = get_nimcache_resource_name("default", "test-deployment")
-    assert result == "md-default-test-deployment"
+    assert result == f"md-default-test-deployment-{_identity_hash('default', 'test-deployment')}"
     assert len(result) <= 59
 
 
@@ -1082,7 +1133,7 @@ def test_get_nimcache_resource_name_dots_replaced():
     """Dots are replaced with hyphens (DNS-1035 compliance)."""
     result = get_nimcache_resource_name("ben-test", "llama-3.2-1b-deployment")
     assert "." not in result
-    assert result == "md-ben-test-llama-3-2-1b-deployment"
+    assert result == f"md-ben-test-llama-3-2-1b-deployment-{_identity_hash('ben-test', 'llama-3.2-1b-deployment')}"
     assert len(result) <= 59
 
 
@@ -1189,7 +1240,7 @@ def test_nimcache_and_nimservice_names_may_differ_for_long_inputs():
 def test_get_deployment_secret_name_hft_suffix():
     """Test secret name with -hft suffix (used for HuggingFace token secrets)."""
     result = get_deployment_secret_name("default", "my-deployment", prefix="md", suffix="-hft")
-    assert result == "md-default-my-deployment-hft"
+    assert result == f"md-default-my-deployment-{_identity_hash('default', 'my-deployment')}-hft"
     assert len(result) <= 253
 
 

--- a/services/core/models/tests/unit/common/test_utils.py
+++ b/services/core/models/tests/unit/common/test_utils.py
@@ -923,6 +923,14 @@ def test_k8s_safe_name_dots_preserved_in_dns_subdomain():
     assert result == f"my.secret.name-{_base_hash('my.secret.name')}"
 
 
+def test_k8s_safe_name_dns_subdomain_sanitizes_invalid_label_chars():
+    """Invalid characters within dot-delimited labels are sanitized per label."""
+    result = _get_k8s_safe_name("my..secret!.name", max_length=253, name_type="dns_subdomain")
+    assert "!" not in result
+    assert result.startswith("my.secret.name-")
+    assert result.endswith(f"-{_base_hash('my..secret!.name')}")
+
+
 def test_k8s_safe_name_starts_with_letter_for_labels():
     """Test that labels must start with a letter (RFC 1035)."""
     result = _get_k8s_safe_name("123-deployment", max_length=63, name_type="label")

--- a/services/core/models/tests/unit/controllers/test_docker_backend.py
+++ b/services/core/models/tests/unit/controllers/test_docker_backend.py
@@ -12,6 +12,11 @@ from docker.errors import ImageNotFound, NotFound
 from nmp.common.config import PlatformConfig
 from nmp.core.models.app import ModelWeightsType
 from nmp.core.models.app.constants import MODEL_MANAGED_BY_LABEL, MODEL_MANAGED_BY_MODELS_CONTROLLER
+from nmp.core.models.app.utils import (
+    get_docker_container_name,
+    get_docker_plugin_puller_container_name,
+    get_docker_volume_name,
+)
 from nmp.core.models.controllers.backends.backends import DeploymentStatusUpdate
 from nmp.core.models.controllers.backends.docker import DockerServiceBackend
 from nmp.core.models.controllers.backends.docker.creation_reconciler import (
@@ -341,6 +346,7 @@ def sample_resource_names(docker_backend, sample_deployment):
         "volume": volume,
         "scratch_volume": f"{volume}-scratch",
         "puller": reconciler.get_puller_container_name(ws, name),
+        "plugin": reconciler.get_plugin_puller_container_name(ws, name),
         "sidecar": f"{container}-sidecar",
         "host_url": f"http://{container}:8000",
     }
@@ -942,6 +948,8 @@ def test_docker_backend_container_naming(docker_backend, sample_deployment, samp
     """Test container naming convention."""
     container_name = docker_backend._reconciler.get_container_name(sample_deployment.workspace, sample_deployment.name)
     assert container_name == sample_resource_names["container"]
+    assert container_name == get_docker_container_name("default", "test-deployment")
+    assert container_name == "md-default-test-deployment-a47830f1"
     assert container_name.startswith("md-default-test-deployment-")
     assert len(f"{container_name}-sidecar") <= 63
 
@@ -950,6 +958,8 @@ def test_docker_backend_volume_naming(docker_backend, sample_deployment, sample_
     """Test volume naming convention."""
     volume_name = docker_backend._reconciler.get_volume_name(sample_deployment.workspace, sample_deployment.name)
     assert volume_name == sample_resource_names["volume"]
+    assert volume_name == get_docker_volume_name("default", "test-deployment")
+    assert volume_name == "nim-cache-default-test-deployment-a47830f1"
     assert volume_name.startswith("nim-cache-default-test-deployment-")
 
 
@@ -966,6 +976,17 @@ def test_docker_backend_puller_container_naming(docker_backend, sample_deploymen
     )
     assert puller_name == sample_resource_names["puller"]
     assert puller_name.startswith("md-puller-default-test-deployment-")
+
+
+def test_docker_backend_plugin_puller_container_naming(docker_backend, sample_deployment, sample_resource_names):
+    """Test plugin puller container naming convention."""
+    plugin_name = docker_backend._reconciler.get_plugin_puller_container_name(
+        sample_deployment.workspace, sample_deployment.name
+    )
+    assert plugin_name == sample_resource_names["plugin"]
+    assert plugin_name == get_docker_plugin_puller_container_name("default", "test-deployment")
+    assert plugin_name == "md-plugin-default-test-deployment-a47830f1"
+    assert plugin_name.startswith("md-plugin-default-test-deployment-")
 
 
 # =============================================================================
@@ -3598,6 +3619,7 @@ async def test_plugin_puller_success(docker_backend, sample_deployment, mock_doc
         if c.kwargs.get("labels", {}).get("nmp.nvidia.com/container-type") == "plugin-puller"
     ]
     assert len(plugin_puller_calls) == 1
+    assert plugin_puller_calls[0].kwargs["name"] == sample_resource_names["plugin"]
     assert plugin_puller_calls[0].kwargs["entrypoint"] == ["hf"]
     assert plugin_puller_calls[0].kwargs["command"][0] == "download"
 
@@ -3629,6 +3651,14 @@ async def test_plugin_puller_no_py_files(docker_backend, sample_deployment, mock
     assert plugin_path is None
     assert "no .py files" in error
 
+    plugin_puller_calls = [
+        c
+        for c in mock_docker_client.containers.run.call_args_list
+        if c.kwargs.get("labels", {}).get("nmp.nvidia.com/container-type") == "plugin-puller"
+    ]
+    assert len(plugin_puller_calls) == 1
+    assert plugin_puller_calls[0].kwargs["name"] == sample_resource_names["plugin"]
+
 
 @pytest.mark.asyncio
 async def test_plugin_puller_multiple_py_files(
@@ -3659,6 +3689,14 @@ async def test_plugin_puller_multiple_py_files(
     assert plugin_path is None
     assert "2 .py files" in error
 
+    plugin_puller_calls = [
+        c
+        for c in mock_docker_client.containers.run.call_args_list
+        if c.kwargs.get("labels", {}).get("nmp.nvidia.com/container-type") == "plugin-puller"
+    ]
+    assert len(plugin_puller_calls) == 1
+    assert plugin_puller_calls[0].kwargs["name"] == sample_resource_names["plugin"]
+
 
 @pytest.mark.asyncio
 async def test_plugin_puller_container_fails(
@@ -3688,6 +3726,14 @@ async def test_plugin_puller_container_fails(
     assert plugin_path is None
     assert error is not None
     assert "exit code 1" in error.lower() or "failed" in error.lower()
+
+    plugin_puller_calls = [
+        c
+        for c in mock_docker_client.containers.run.call_args_list
+        if c.kwargs.get("labels", {}).get("nmp.nvidia.com/container-type") == "plugin-puller"
+    ]
+    assert len(plugin_puller_calls) == 1
+    assert plugin_puller_calls[0].kwargs["name"] == sample_resource_names["plugin"]
 
 
 # ============================================================================

--- a/services/core/models/tests/unit/controllers/test_docker_backend.py
+++ b/services/core/models/tests/unit/controllers/test_docker_backend.py
@@ -329,9 +329,26 @@ def sample_config():
     return config
 
 
+@pytest.fixture
+def sample_resource_names(docker_backend, sample_deployment):
+    """Computed Docker resource names for the default sample deployment."""
+    reconciler = docker_backend._reconciler
+    ws, name = sample_deployment.workspace, sample_deployment.name
+    container = reconciler.get_container_name(ws, name)
+    volume = reconciler.get_volume_name(ws, name)
+    return {
+        "container": container,
+        "volume": volume,
+        "scratch_volume": f"{volume}-scratch",
+        "puller": reconciler.get_puller_container_name(ws, name),
+        "sidecar": f"{container}-sidecar",
+        "host_url": f"http://{container}:8000",
+    }
+
+
 @pytest.mark.asyncio
 async def test_docker_backend_create_model_deployment(
-    docker_backend, sample_deployment, sample_config, mock_docker_client
+    docker_backend, sample_deployment, sample_config, mock_docker_client, sample_resource_names
 ):
     """Test creating a model deployment with Docker backend."""
     # Setup mock container
@@ -364,20 +381,20 @@ async def test_docker_backend_create_model_deployment(
     assert status_update is not None
     assert status_update.status == "PENDING"
     assert "container created" in status_update.status_message.lower()
-    assert status_update.host_url == "http://md-default-test-deployment:8000"
+    assert status_update.host_url == sample_resource_names["host_url"]
 
     # Verify Docker calls (image check + pull for both NIM and sidecar images)
     assert mock_docker_client.images.get.call_count >= 2
     assert mock_docker_client.images.pull.call_count >= 2
     assert mock_docker_client.volumes.create.call_count == 2
-    assert mock_docker_client.volumes.create.call_args_list[0][0][0] == "nim-cache-default-test-deployment"
-    assert mock_docker_client.volumes.create.call_args_list[1][0][0] == "nim-cache-default-test-deployment-scratch"
+    assert mock_docker_client.volumes.create.call_args_list[0][0][0] == sample_resource_names["volume"]
+    assert mock_docker_client.volumes.create.call_args_list[1][0][0] == sample_resource_names["scratch_volume"]
 
     assert mock_docker_client.containers.create.call_count == 2
     nim_create_args = mock_docker_client.containers.create.call_args_list[0][1]
     sidecar_create_args = mock_docker_client.containers.create.call_args_list[1][1]
-    assert nim_create_args["name"] == "md-default-test-deployment"
-    assert sidecar_create_args["name"] == "md-default-test-deployment-sidecar"
+    assert nim_create_args["name"] == sample_resource_names["container"]
+    assert sidecar_create_args["name"] == sample_resource_names["sidecar"]
     assert nim_create_args["labels"][MODEL_MANAGED_BY_LABEL] == MODEL_MANAGED_BY_MODELS_CONTROLLER
     assert sidecar_create_args["labels"][MODEL_MANAGED_BY_LABEL] == MODEL_MANAGED_BY_MODELS_CONTROLLER
     assert mock_container.start.call_count == 2
@@ -450,13 +467,15 @@ async def _drive_vllm_with_puller(docker_backend, sample_deployment, mock_docker
 
 
 @pytest.mark.asyncio
-async def test_docker_backend_create_vllm_deployment(docker_backend, sample_deployment, mock_docker_client):
+async def test_docker_backend_create_vllm_deployment(
+    docker_backend, sample_deployment, mock_docker_client, sample_resource_names
+):
     """Engine=vllm produces a vLLM container with serve args, engine label, and default image."""
     config = _make_vllm_config()
     status_update = await _drive_vllm_with_puller(docker_backend, sample_deployment, mock_docker_client, config)
 
     assert status_update.status == "PENDING"
-    assert status_update.host_url == "http://md-default-test-deployment:8000"
+    assert status_update.host_url == sample_resource_names["host_url"]
 
     create_args = mock_docker_client.containers.create.call_args_list[0][1]
     # Default vLLM image is used when none specified (exact version is config-driven).
@@ -473,7 +492,9 @@ async def test_docker_backend_create_vllm_deployment(docker_backend, sample_depl
 
 
 @pytest.mark.asyncio
-async def test_docker_backend_create_vllm_lora_sidecar(docker_backend, sample_deployment, mock_docker_client):
+async def test_docker_backend_create_vllm_lora_sidecar(
+    docker_backend, sample_deployment, mock_docker_client, sample_resource_names
+):
     """Engine=vllm with lora_enabled wires the adapter sidecar and vLLM LoRA env/args."""
     config = _make_vllm_config(lora_enabled=True)
     await _drive_vllm_with_puller(docker_backend, sample_deployment, mock_docker_client, config)
@@ -482,8 +503,8 @@ async def test_docker_backend_create_vllm_lora_sidecar(docker_backend, sample_de
     assert mock_docker_client.containers.create.call_count == 2
     vllm_args = mock_docker_client.containers.create.call_args_list[0][1]
     sidecar_args = mock_docker_client.containers.create.call_args_list[1][1]
-    assert vllm_args["name"] == "md-default-test-deployment"
-    assert sidecar_args["name"] == "md-default-test-deployment-sidecar"
+    assert vllm_args["name"] == sample_resource_names["container"]
+    assert sidecar_args["name"] == sample_resource_names["sidecar"]
     # vLLM LoRA hot-reload env + serve flag.
     env = vllm_args["environment"]
     assert env["VLLM_PLUGINS"] == "lora_filesystem_resolver"
@@ -739,7 +760,7 @@ async def test_docker_backend_create_sft_model_success(
 
 @pytest.mark.asyncio
 async def test_docker_backend_create_sft_model_puller_fails(
-    docker_backend, sample_deployment, sample_config, mock_docker_client
+    docker_backend, sample_deployment, sample_config, mock_docker_client, sample_resource_names
 ):
     """Test that SFT model deployment fails gracefully when puller fails."""
     # Mock model entity with SFT full weights and artifact
@@ -758,7 +779,7 @@ async def test_docker_backend_create_sft_model_puller_fails(
     # Setup mock puller container that fails
     mock_puller_container = MagicMock()
     mock_puller_container.id = "puller123456789"
-    mock_puller_container.name = "md-puller-default-test-deployment"
+    mock_puller_container.name = sample_resource_names["puller"]
     mock_puller_container.logs.return_value = b"Error: Failed to download model"
     mock_puller_container.status = "exited"
     mock_puller_container.attrs = {"State": {"ExitCode": 1}}
@@ -800,7 +821,7 @@ async def test_docker_backend_create_sft_model_puller_fails(
 
 @pytest.mark.asyncio
 async def test_docker_backend_get_model_deployment_status_running(
-    docker_backend, sample_deployment, mock_docker_client
+    docker_backend, sample_deployment, mock_docker_client, sample_resource_names
 ):
     """Test getting status of a running deployment."""
     # Setup mock container in running state
@@ -817,7 +838,7 @@ async def test_docker_backend_get_model_deployment_status_running(
     assert status_update is not None
     assert status_update.status == "READY"
     assert "running" in status_update.status_message.lower()
-    assert status_update.host_url == "http://md-default-test-deployment:8000"
+    assert status_update.host_url == sample_resource_names["host_url"]
 
 
 @pytest.mark.asyncio
@@ -917,16 +938,19 @@ def test_docker_backend_initialization(mock_nmp_sdk, mock_docker_client):
         assert backend._nmp_sdk == mock_nmp_sdk
 
 
-def test_docker_backend_container_naming(docker_backend, sample_deployment):
+def test_docker_backend_container_naming(docker_backend, sample_deployment, sample_resource_names):
     """Test container naming convention."""
     container_name = docker_backend._reconciler.get_container_name(sample_deployment.workspace, sample_deployment.name)
-    assert container_name == "md-default-test-deployment"
+    assert container_name == sample_resource_names["container"]
+    assert container_name.startswith("md-default-test-deployment-")
+    assert len(f"{container_name}-sidecar") <= 63
 
 
-def test_docker_backend_volume_naming(docker_backend, sample_deployment):
+def test_docker_backend_volume_naming(docker_backend, sample_deployment, sample_resource_names):
     """Test volume naming convention."""
     volume_name = docker_backend._reconciler.get_volume_name(sample_deployment.workspace, sample_deployment.name)
-    assert volume_name == "nim-cache-default-test-deployment"
+    assert volume_name == sample_resource_names["volume"]
+    assert volume_name.startswith("nim-cache-default-test-deployment-")
 
 
 def test_docker_backend_deployment_key(docker_backend, sample_deployment):
@@ -935,12 +959,13 @@ def test_docker_backend_deployment_key(docker_backend, sample_deployment):
     assert deployment_key == "default/test-deployment"
 
 
-def test_docker_backend_puller_container_naming(docker_backend, sample_deployment):
+def test_docker_backend_puller_container_naming(docker_backend, sample_deployment, sample_resource_names):
     """Test puller container naming convention."""
     puller_name = docker_backend._reconciler.get_puller_container_name(
         sample_deployment.workspace, sample_deployment.name
     )
-    assert puller_name == "md-puller-default-test-deployment"
+    assert puller_name == sample_resource_names["puller"]
+    assert puller_name.startswith("md-puller-default-test-deployment-")
 
 
 # =============================================================================
@@ -2050,7 +2075,7 @@ def test_should_attach_network_with_dind_mode(docker_backend_with_dind_mode):
 
 @pytest.mark.asyncio
 async def test_docker_backend_create_with_dond_mode_uses_container_name_url(
-    docker_backend_with_dond_mode, sample_deployment, sample_config, mock_docker_client
+    docker_backend_with_dond_mode, sample_deployment, sample_config, mock_docker_client, sample_resource_names
 ):
     """Test that create_model_deployment uses container name URL when using DonD mode.
 
@@ -2078,7 +2103,7 @@ async def test_docker_backend_create_with_dond_mode_uses_container_name_url(
     assert status_update.status == "PENDING"
 
     # Host URL should use container name (DonD mode uses container names)
-    assert status_update.host_url == "http://md-default-test-deployment:8000"
+    assert status_update.host_url == sample_resource_names["host_url"]
 
     # Verify container was created with the network
     call_args = mock_docker_client.containers.create.call_args_list[0]
@@ -2087,7 +2112,7 @@ async def test_docker_backend_create_with_dond_mode_uses_container_name_url(
 
 @pytest.mark.asyncio
 async def test_docker_backend_get_status_with_dond_mode_uses_container_name_url(
-    docker_backend_with_dond_mode, sample_deployment, mock_docker_client
+    docker_backend_with_dond_mode, sample_deployment, mock_docker_client, sample_resource_names
 ):
     """Test that get_model_deployment_status uses container name URL when using DonD mode."""
     # Mock a running container with port mapping (should be ignored for URL in DonD mode)
@@ -2108,7 +2133,7 @@ async def test_docker_backend_get_status_with_dond_mode_uses_container_name_url(
 
     # Verify status and URL uses container name (DonD mode ignores port bindings)
     assert status_update.status == "READY"
-    assert status_update.host_url == "http://md-default-test-deployment:8000"
+    assert status_update.host_url == sample_resource_names["host_url"]
 
 
 @pytest.mark.asyncio
@@ -3536,9 +3561,9 @@ async def test_scenario7_plugin_from_deployment_config(docker_backend, sample_de
 
 
 @pytest.mark.asyncio
-async def test_plugin_puller_success(docker_backend, sample_deployment, mock_docker_client):
+async def test_plugin_puller_success(docker_backend, sample_deployment, mock_docker_client, sample_resource_names):
     """Test _run_plugin_puller discovers a single .py file and returns its path."""
-    volume_name = "nim-cache-default-test-deployment"
+    volume_name = sample_resource_names["volume"]
 
     # Mock puller container
     mock_puller_container = MagicMock()
@@ -3578,9 +3603,9 @@ async def test_plugin_puller_success(docker_backend, sample_deployment, mock_doc
 
 
 @pytest.mark.asyncio
-async def test_plugin_puller_no_py_files(docker_backend, sample_deployment, mock_docker_client):
+async def test_plugin_puller_no_py_files(docker_backend, sample_deployment, mock_docker_client, sample_resource_names):
     """Test _run_plugin_puller returns error when no .py files found."""
-    volume_name = "nim-cache-default-test-deployment"
+    volume_name = sample_resource_names["volume"]
 
     mock_puller_container = MagicMock()
     mock_puller_container.id = "pluginpuller1234"
@@ -3606,9 +3631,11 @@ async def test_plugin_puller_no_py_files(docker_backend, sample_deployment, mock
 
 
 @pytest.mark.asyncio
-async def test_plugin_puller_multiple_py_files(docker_backend, sample_deployment, mock_docker_client):
+async def test_plugin_puller_multiple_py_files(
+    docker_backend, sample_deployment, mock_docker_client, sample_resource_names
+):
     """Test _run_plugin_puller returns error when multiple .py files found."""
-    volume_name = "nim-cache-default-test-deployment"
+    volume_name = sample_resource_names["volume"]
 
     mock_puller_container = MagicMock()
     mock_puller_container.id = "pluginpuller1234"
@@ -3634,9 +3661,11 @@ async def test_plugin_puller_multiple_py_files(docker_backend, sample_deployment
 
 
 @pytest.mark.asyncio
-async def test_plugin_puller_container_fails(docker_backend, sample_deployment, mock_docker_client):
+async def test_plugin_puller_container_fails(
+    docker_backend, sample_deployment, mock_docker_client, sample_resource_names
+):
     """Test _run_plugin_puller returns error when puller container exits with non-zero."""
-    volume_name = "nim-cache-default-test-deployment"
+    volume_name = sample_resource_names["volume"]
 
     mock_puller_container = MagicMock()
     mock_puller_container.id = "pluginpuller1234"
@@ -3800,7 +3829,7 @@ class TestPendingTimeoutStatusTransition:
 
     @pytest.mark.asyncio
     async def test_running_not_healthy_exceeds_timeout_returns_error(
-        self, docker_backend, sample_deployment, make_mock_container
+        self, docker_backend, sample_deployment, make_mock_container, sample_resource_names
     ):
         """A running container that isn't healthy and exceeds timeout should transition to ERROR."""
         make_mock_container(status="running", logs=b"NIM failed to start: model not supported")
@@ -3814,9 +3843,9 @@ class TestPendingTimeoutStatusTransition:
         assert status.status == "ERROR"
         assert "timed out" in status.status_message
         assert "docker logs" in status.status_message
-        assert "md-default-test-deployment" in status.status_message
+        assert sample_resource_names["container"] in status.status_message
         assert status.error_details["reason"] == "pending_timeout"
-        assert status.error_details["container_name"] == "md-default-test-deployment"
+        assert status.error_details["container_name"] == sample_resource_names["container"]
 
     @pytest.mark.asyncio
     async def test_created_state_within_timeout_returns_pending(
@@ -3894,7 +3923,7 @@ class TestPendingTimeoutErrorMessage:
 
     @pytest.mark.asyncio
     async def test_error_message_includes_docker_logs_command(
-        self, docker_backend, sample_deployment, make_mock_container
+        self, docker_backend, sample_deployment, make_mock_container, sample_resource_names
     ):
         """Timeout error message includes a runnable docker logs command."""
         make_mock_container(status="running", logs=b"Error: model architecture not supported")
@@ -3906,7 +3935,7 @@ class TestPendingTimeoutErrorMessage:
             status = await docker_backend.get_model_deployment_status(ModelContext(model_deployment=sample_deployment))
 
         assert status.status == "ERROR"
-        assert "docker logs md-default-test-deployment" in status.status_message
+        assert f"docker logs {sample_resource_names['container']}" in status.status_message
 
     @pytest.mark.asyncio
     async def test_error_details_contain_container_logs(self, docker_backend, sample_deployment, make_mock_container):


### PR DESCRIPTION
## Summary

Fixes resource name collisions when hyphen-joining workspace and deployment/volume names produces the same display prefix (e.g. `foo` + `bar-baz` and `foo-bar` + `baz` both → `dep-foo-bar-baz`).

Both the **deployments plugin** and the **models service** now always append an 8-character SHA-256 hash suffix to DNS-safe resource names. Names remain ≤63 characters (RFC 1035) with regression tests for ambiguous pairs.

## Design: what we hash and why

### Hash source: `workspace/name`, not the joined prefix

**Problem:** Hashing the hyphen-joined string (`dep-foo-bar-baz`) does **not** fix join ambiguity — different `(workspace, name)` pairs can produce identical joined strings.

**Decision:** Hash the unambiguous identity `"{workspace}/{name}"` (same format as `deployment_key()` / `get_deployment_key()`), while keeping the readable hyphenated prefix for operators (`dep-{ws}-{name}`, `md-{ws}-{name}`, etc.).

| Call site | Display prefix (`base_name`) | Hash input (`hash_input`) |
|-----------|------------------------------|---------------------------|
| `container_name(ws, name)` | `dep-{ws}-{name}` | `{ws}/{name}` |
| `docker_volume_name(ws, vol)` | `dep-vol-{ws}-{vol}` | `{ws}/{vol}` |
| `get_deployment_resource_name` | `md-{ws}-{name}` | `{ws}/{name}` |
| `get_nimcache_resource_name` | `md-{ws}-{name}` | `{ws}/{name}` |
| `get_deployment_secret_name` | `{prefix}-{ws}-{name}` | `{ws}/{name}` |
| Docker/K8s plugin puller | `md-plugin-{ws}-{name}` | `{ws}/{name}` |
| Generic `_get_k8s_safe_name` (init containers, etc.) | caller-provided | defaults to `base_name` |

### Always append `-{hash8}`

**Problem:** The old logic only appended a hash when truncation was needed, so short names with different identities but identical normalized prefixes could still collide.

**Decision:** Every primary resource name is `{normalized}-{hash8}{optional_suffix}`. Deterministic: same `(workspace, name)` → same name across restarts.

### Suffix chaining: `include_hash=False`

Init containers (`-prepare`, `-pull`, `-finalize`) and K8s LoRA sidecars (`-lora-sidecar`) derive names from an **already-hashed** base. A second `_get_k8s_safe_name` call with `include_hash=False` appends the suffix without adding another hash (avoids `{base}-{h1}-{h2}-lora-sidecar`).

### Length headroom for derived names

| Constraint | Limit | Reason |
|------------|-------|--------|
| NIMCache resources | 59 chars | k8s-nim-operator appends `-job` (4 chars) |
| Docker primary container | 55 chars | runtime appends `-sidecar` (8 chars) for LoRA |
| Secrets | 253 chars | RFC 1123 subdomain; suffix after hash: `{base}-{hash8}-hf-token` |

### Identity vs naming

Orphan cleanup and idempotency use **identity labels** (`deployment-workspace`, `deployment-name`, etc.), not container names alone. Container/volume names are for Docker/K8s API addressing; labels remain authoritative.

### Migration / breaking change

- **Existing running containers** keep old names after upgrade.
- **New deployments** get hashed names — acceptable for greenfield deployments plugin per ticket scope.
- **Models service** new Docker/K8s resources also rename; no dual-lookup migration in this MR. Operators should expect one-time orphan cleanup or manual teardown of pre-change resources.

### Out of scope (follow-up)

Extracting shared `k8s_safe_name` logic to `nmp_common` to deduplicate deployments `labels.py` and models `utils.py`.

## Test plan

- [x] `uv run pytest plugins/nemo-deployments/tests/unit/backends/docker/test_labels.py`
- [x] `uv run pytest services/core/models/tests/unit/common/test_utils.py -k "k8s_safe or deployment_resource or nimcache_resource or deployment_secret"`
- [x] `uv run pytest services/core/models/tests/unit/controllers/test_docker_backend.py`
- [x] `uv run pytest services/core/models/tests/unit/controllers/test_nimservice_compiler.py services/core/models/tests/unit/controllers/test_backend_config_fields.py`
- [x] Verified: `container_name("foo","bar-baz") != container_name("foo-bar","baz")`
- [x] Verified: same for `get_deployment_resource_name`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker and Kubernetes resource names now use shared DNS-safe deterministic hashing based on workspace/name identity.
  * Plugin puller containers (and optional LoRA sidecar) follow the same naming rules, including consistent truncation behavior.

* **Bug Fixes**
  * Improved disambiguation for ambiguous workspace/name combinations.
  * Orphan cleanup now relies on identity labels rather than name matching.
  * Existing containers keep their prior names after upgrade.

* **Documentation**
  * Added guidance on Docker resource naming and orphan cleanup behavior.

* **Tests**
  * Updated and expanded unit/integration coverage for the new naming rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->