### PR TITLE
fix(studio): regenerate web SDK for DeploymentLogsResponse import

### DIFF
--- a/web/packages/sdk/generated/agents/schema/DeploymentLogsResponse.ts
+++ b/web/packages/sdk/generated/agents/schema/DeploymentLogsResponse.ts
@@ -6,7 +6,7 @@
  * Do not edit manually.
  * agents (plugin)
  */
-import type { LogLine } from './LogLine.ts';
+import type { LogLine } from './LogLine';
 
 /**
  * Response body for ``GET /deployments/{name}/logs``.


### PR DESCRIPTION
## Summary

`web/packages/sdk` drifted from the OpenAPI spec on `main`: the generated `agents/schema/DeploymentLogsResponse.ts` imports `./LogLine.ts` with a `.ts` extension that the current generator no longer emits. This fails `lint-web-sdk` (`pnpm gen:check`) on every branch built off `main`.

This PR regenerates the affected file (`cd web && pnpm gen`) — a single-line change — to resync the web SDK with the spec.

```diff
- import type { LogLine } from './LogLine.ts';
+ import type { LogLine } from './LogLine';
```

## Test plan

- [x] `cd web && pnpm gen` produces only this one-line change
- [x] `cd web && pnpm gen:check` passes after the change
- [ ] CI green