### PR TITLE
feat(studio): DAG for DD

### DIFF
--- a/web/packages/studio/package.json
+++ b/web/packages/studio/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@assistant-ui/react": "^0.12.28",
+    "@dagrejs/dagre": "^3.0.0",
     "@hookform/resolvers": "^4.1.3",
     "@mui/x-charts": "catalog:",
     "@mui/x-data-grid": "catalog:",
@@ -59,9 +60,10 @@
     "@opentelemetry/sdk-trace-web": "^2.8.0",
     "@opentelemetry/semantic-conventions": "^1.41.1",
     "@tanstack/react-query": "catalog:",
-    "@tanstack/react-virtual": "^3.13.6",
     "@tanstack/react-query-devtools": "catalog:",
+    "@tanstack/react-virtual": "^3.13.6",
     "@vitejs/plugin-react": "catalog:",
+    "@xyflow/react": "^12.11.1",
     "axios": "catalog:",
     "classnames": "catalog:",
     "handlebars": "catalog:",
@@ -91,8 +93,8 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
-    "@nemo/testing": "workspace:*",
     "@huggingface/hub": "^1.0.0",
+    "@nemo/testing": "workspace:*",
     "@nvidia/foundations-tailwind-plugin": "catalog:",
     "@playwright/test": "^1.57.0",
     "@storybook/react": "catalog:",

--- a/web/packages/studio/src/components/AddColumnPalette/ColumnTypeCard.tsx
+++ b/web/packages/studio/src/components/AddColumnPalette/ColumnTypeCard.tsx
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Flex, Stack, Text } from '@nvidia/foundations-react-core';
 import { ICON_COLOR_CLASS } from '@studio/components/AddColumnPalette/constants';
 import type {
   AddColumnSelection,
   ColumnTypeOption,
 } from '@studio/components/AddColumnPalette/types';
+import { CardIconBadge, SelectableCard } from '@studio/components/common/SelectableCard';
 import type { FC } from 'react';
 
 interface ColumnTypeCardProps {
@@ -15,32 +15,21 @@ interface ColumnTypeCardProps {
 }
 
 /**
- * A single column-type option, rendered as a native `<button>` so it is reachable and
+ * A single column-type option, rendered as a {@link SelectableCard} so it is reachable and
  * activatable by keyboard (Tab to focus, Enter/Space to add) with no drag interaction.
  */
 export const ColumnTypeCard: FC<ColumnTypeCardProps> = ({ option, onSelect }) => {
   const { icon: Icon, label, description, color, columnType, samplerType } = option;
   return (
-    <button
-      type="button"
-      onClick={() => onSelect({ columnType, samplerType })}
-      className="flex cursor-pointer w-full items-center gap-2 rounded-md border border-base bg-surface-raised px-2 py-1.5 text-left transition-colors hover:border-interaction-primary-base hover:bg-surface-hover focus-visible:border-interaction-primary-base focus-visible:outline-none active:border-interaction-primary-selected"
-    >
-      <Flex
-        align="center"
-        justify="center"
-        className="size-[26px] shrink-0 rounded-sm bg-surface-sunken"
-      >
-        <Icon size={15} className={ICON_COLOR_CLASS[color]} aria-hidden />
-      </Flex>
-      <Stack gap="density-xxs" className="min-w-0">
-        <Text kind="body/semibold/sm" className="truncate text-primary">
-          {label}
-        </Text>
-        <Text kind="body/regular/xs" className="truncate text-secondary">
-          {description}
-        </Text>
-      </Stack>
-    </button>
+    <SelectableCard
+      title={label}
+      subtitle={description}
+      onActivate={() => onSelect({ columnType, samplerType })}
+      leading={
+        <CardIconBadge>
+          <Icon size={15} className={ICON_COLOR_CLASS[color]} aria-hidden />
+        </CardIconBadge>
+      }
+    />
   );
 };

--- a/web/packages/studio/src/components/DagCanvas/CardNode.tsx
+++ b/web/packages/studio/src/components/DagCanvas/CardNode.tsx
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CardIconBadge, SelectableCard } from '@studio/components/common/SelectableCard';
+import type { DagNodeData, DagNodeStatus } from '@studio/components/DagCanvas/types';
+import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
+import { Box } from 'lucide-react';
+import { type FC } from 'react';
+
+/** Internal node data: the public {@link DagNodeData} plus the activation callback. */
+export interface CardNodeData extends DagNodeData {
+  /** Invoked when the card is clicked or activated via keyboard. */
+  onActivate?: () => void;
+  [key: string]: unknown;
+}
+
+export type CardNodeType = Node<CardNodeData, 'card'>;
+
+/** Status → leading icon color, using NVIDIA Foundations feedback tokens. */
+const STATUS_ICON_CLASS: Record<DagNodeStatus, string> = {
+  idle: 'text-[color:var(--text-color-accent-blue)]',
+  running: 'text-[color:var(--text-color-feedback-info)]',
+  success: 'text-[color:var(--text-color-feedback-success)]',
+  error: 'text-[color:var(--text-color-feedback-danger)]',
+};
+
+/**
+ * A DAG node rendered as a {@link SelectableCard} — the same card the Data Designer
+ * column palette uses — with an icon badge, an accent type label, a description, and
+ * variable tags, plus React Flow connection handles on the leading/trailing edges.
+ */
+export const CardNode: FC<NodeProps<CardNodeType>> = ({
+  data,
+  selected,
+  sourcePosition = Position.Bottom,
+  targetPosition = Position.Top,
+}) => {
+  const {
+    title,
+    type,
+    description,
+    tags,
+    icon: Icon = Box,
+    status = 'idle',
+    colorClassName,
+    onActivate,
+  } = data;
+  const iconClassName =
+    status === 'idle' && colorClassName ? colorClassName : STATUS_ICON_CLASS[status];
+  return (
+    <>
+      <Handle type="target" position={targetPosition} className="bg-strong border-none" />
+      <SelectableCard
+        title={title}
+        subtitle={type}
+        subtitleClassName={`uppercase tracking-wide ${colorClassName ?? 'text-[color:var(--text-color-accent-blue)]'}`}
+        description={description}
+        tags={tags}
+        selected={selected}
+        onActivate={onActivate}
+        leading={
+          <CardIconBadge>
+            <Icon size={16} className={iconClassName} aria-hidden />
+          </CardIconBadge>
+        }
+      />
+      <Handle type="source" position={sourcePosition} className="bg-strong border-none" />
+    </>
+  );
+};

--- a/web/packages/studio/src/components/DagCanvas/DagCanvas.stories.tsx
+++ b/web/packages/studio/src/components/DagCanvas/DagCanvas.stories.tsx
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { DagCanvas } from '@studio/components/DagCanvas';
+import type { DagEdge, DagNode } from '@studio/components/DagCanvas/types';
+import { Database, FlaskConical, MessageSquare, Rocket, Sparkles, Wand2 } from 'lucide-react';
+
+const nodes: DagNode[] = [
+  {
+    id: 'ingest',
+    data: {
+      title: 'Ingest',
+      type: 'SOURCE',
+      description: 'Load raw data',
+      icon: Database,
+      status: 'success',
+    },
+  },
+  {
+    id: 'clean',
+    data: {
+      title: 'Clean',
+      type: 'TRANSFORM',
+      description: 'Dedupe & normalize',
+      icon: Wand2,
+      status: 'success',
+    },
+  },
+  {
+    id: 'features',
+    data: {
+      title: 'Instruction',
+      type: 'LLM TEXT',
+      description: 'Writes a question about the topic',
+      tags: ['{{topic}}', '{{difficulty}}'],
+      icon: MessageSquare,
+      status: 'running',
+    },
+  },
+  {
+    id: 'train',
+    data: {
+      title: 'Train',
+      type: 'GENERATE',
+      description: 'Fit model',
+      icon: Sparkles,
+      status: 'idle',
+    },
+  },
+  {
+    id: 'evaluate',
+    data: {
+      title: 'Evaluate',
+      type: 'VALIDATE',
+      description: 'Score on holdout',
+      icon: FlaskConical,
+      status: 'idle',
+    },
+  },
+  {
+    id: 'deploy',
+    data: {
+      title: 'Deploy',
+      type: 'SINK',
+      description: 'Ship to gateway',
+      icon: Rocket,
+      status: 'error',
+      colorClassName: 'text-[color:var(--text-color-feedback-danger)]',
+      tags: ['{{deployment_id}}', '{{model_id}}'],
+    },
+  },
+];
+
+const edges: DagEdge[] = [
+  { source: 'ingest', target: 'clean' },
+  { source: 'clean', target: 'features' },
+  { source: 'features', target: 'train' },
+  { source: 'train', target: 'evaluate' },
+  { source: 'evaluate', target: 'deploy' },
+  { source: 'features', target: 'evaluate', label: 'baseline' },
+];
+
+const meta = {
+  component: DagCanvas,
+  title: 'Components/DagCanvas',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    nodes,
+    edges,
+    direction: 'TB',
+    // eslint-disable-next-line no-console
+    onNodeClick: (id, data) => console.log('node click', id, data),
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-dvh w-dvw bg-surface-base">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DagCanvas>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A six-step pipeline laid out top-to-bottom. */
+export const Default: Story = {};
+
+/** The same graph flowing left-to-right. */
+export const LeftToRight: Story = {
+  args: { direction: 'LR' },
+};

--- a/web/packages/studio/src/components/DagCanvas/index.test.tsx
+++ b/web/packages/studio/src/components/DagCanvas/index.test.tsx
@@ -1,21 +1,39 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { DagCanvas } from '@studio/components/DagCanvas';
 import {
   CardNode,
   type CardNodeData,
   type CardNodeType,
 } from '@studio/components/DagCanvas/CardNode';
 import { NODE_HEIGHT, NODE_WIDTH, layoutGraph } from '@studio/components/DagCanvas/layout';
+import type { DagNode } from '@studio/components/DagCanvas/types';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type Edge, type Node, type NodeProps, Position } from '@xyflow/react';
 
-// Handle reads from React Flow's internal store/context, which only exists inside a
-// rendered <ReactFlow>. Stub it so CardNode can be unit-tested in isolation.
+// React Flow reads from an internal store/context that only exists inside a fully
+// measured <ReactFlow> (needs ResizeObserver + real layout, absent in jsdom). Stub
+// Handle for isolated CardNode tests, and stub ReactFlow to render each node's
+// activation handler so DagCanvas's own onActivate → onNodeClick wiring is testable.
 vi.mock('@xyflow/react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@xyflow/react')>();
-  return { ...actual, Handle: () => null };
+  return {
+    ...actual,
+    Handle: () => null,
+    Background: () => null,
+    Controls: () => null,
+    ReactFlow: ({ nodes }: { nodes: CardNodeType[] }) => (
+      <div>
+        {nodes.map((node) => (
+          <button key={node.id} type="button" onClick={() => node.data.onActivate?.()}>
+            {node.data.title}
+          </button>
+        ))}
+      </div>
+    ),
+  };
 });
 
 const makeNode = (id: string): Node<CardNodeData> => ({
@@ -124,5 +142,45 @@ describe('CardNode', () => {
     await user.keyboard('{Enter}');
 
     expect(onActivate).toHaveBeenCalled();
+  });
+});
+
+describe('DagCanvas', () => {
+  it('bridges a node activation to onNodeClick with the node id and data', async () => {
+    const user = userEvent.setup();
+    const onNodeClick = vi.fn();
+    const nodes: DagNode[] = [
+      { id: 'train', data: { title: 'Train', type: 'CUSTOMIZER' } },
+      { id: 'evaluate', data: { title: 'Evaluate' } },
+    ];
+
+    render(
+      <DagCanvas
+        nodes={nodes}
+        edges={[{ source: 'train', target: 'evaluate' }]}
+        onNodeClick={onNodeClick}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Train' }));
+
+    expect(onNodeClick).toHaveBeenCalledTimes(1);
+    expect(onNodeClick).toHaveBeenCalledWith('train', nodes[0].data);
+  });
+
+  it('always calls the latest onNodeClick after the callback identity changes', async () => {
+    const user = userEvent.setup();
+    const first = vi.fn();
+    const second = vi.fn();
+    const nodes: DagNode[] = [{ id: 'train', data: { title: 'Train' } }];
+
+    const { rerender } = render(<DagCanvas nodes={nodes} edges={[]} onNodeClick={first} />);
+    // Swap in a fresh callback reference, mirroring a parent passing an inline arrow.
+    rerender(<DagCanvas nodes={nodes} edges={[]} onNodeClick={second} />);
+
+    await user.click(screen.getByRole('button', { name: 'Train' }));
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith('train', nodes[0].data);
   });
 });

--- a/web/packages/studio/src/components/DagCanvas/index.test.tsx
+++ b/web/packages/studio/src/components/DagCanvas/index.test.tsx
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  CardNode,
+  type CardNodeData,
+  type CardNodeType,
+} from '@studio/components/DagCanvas/CardNode';
+import { NODE_HEIGHT, NODE_WIDTH, layoutGraph } from '@studio/components/DagCanvas/layout';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type Edge, type Node, type NodeProps, Position } from '@xyflow/react';
+
+// Handle reads from React Flow's internal store/context, which only exists inside a
+// rendered <ReactFlow>. Stub it so CardNode can be unit-tested in isolation.
+vi.mock('@xyflow/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@xyflow/react')>();
+  return { ...actual, Handle: () => null };
+});
+
+const makeNode = (id: string): Node<CardNodeData> => ({
+  id,
+  position: { x: 0, y: 0 },
+  data: { title: id },
+});
+
+describe('layoutGraph', () => {
+  it('assigns a distinct position to every node', () => {
+    const nodes = [makeNode('a'), makeNode('b'), makeNode('c')];
+    const edges: Edge[] = [
+      { id: 'a-b', source: 'a', target: 'b' },
+      { id: 'b-c', source: 'b', target: 'c' },
+    ];
+
+    const result = layoutGraph(nodes, edges, 'TB');
+
+    expect(result).toHaveLength(3);
+    const ys = result.map((node) => node.position.y);
+    // Top-to-bottom: each rank sits below the previous one.
+    expect(new Set(ys).size).toBe(3);
+    expect(result.every((node) => Number.isFinite(node.position.x))).toBe(true);
+  });
+
+  it('orients handles top/bottom for TB and left/right for LR', () => {
+    const nodes = [makeNode('a'), makeNode('b')];
+    const edges: Edge[] = [{ id: 'a-b', source: 'a', target: 'b' }];
+
+    const [tb] = layoutGraph(nodes, edges, 'TB');
+    expect(tb.targetPosition).toBe(Position.Top);
+    expect(tb.sourcePosition).toBe(Position.Bottom);
+
+    const [lr] = layoutGraph(nodes, edges, 'LR');
+    expect(lr.targetPosition).toBe(Position.Left);
+    expect(lr.sourcePosition).toBe(Position.Right);
+  });
+
+  it('moves a node off a skip edge that would otherwise run through it', () => {
+    // a → b → c chained, plus a → c skipping over b. dagre stacks a and c in the
+    // same column, so the straight a→c edge (and its label) would cross b.
+    const nodes = [makeNode('a'), makeNode('b'), makeNode('c')];
+    const edges: Edge[] = [
+      { id: 'a-b', source: 'a', target: 'b' },
+      { id: 'b-c', source: 'b', target: 'c' },
+      { id: 'a-c', source: 'a', target: 'c', label: 'skip' },
+    ];
+
+    const result = layoutGraph(nodes, edges, 'TB');
+    const byId = Object.fromEntries(result.map((n) => [n.id, n]));
+
+    // The skip edge is drawn straight down a and c's shared column.
+    const column = byId.a.position.x;
+    expect(byId.c.position.x).toBeCloseTo(column);
+
+    // b's card must not straddle that column.
+    const bLeft = byId.b.position.x;
+    const bRight = byId.b.position.x + NODE_WIDTH;
+    expect(column < bLeft || column > bRight).toBe(true);
+  });
+
+  it('offsets positions from dagre centers by half the card size', () => {
+    const [only] = layoutGraph([makeNode('solo')], [], 'TB');
+    // A single node centers at (NODE_WIDTH/2, NODE_HEIGHT/2), so the top-left origin is (0, 0).
+    expect(only.position.x).toBeCloseTo(0);
+    expect(only.position.y).toBeCloseTo(0);
+    expect(NODE_WIDTH).toBeGreaterThan(0);
+    expect(NODE_HEIGHT).toBeGreaterThan(0);
+  });
+});
+
+const renderCard = (data: CardNodeType['data']) =>
+  render(<CardNode {...({ data } as unknown as NodeProps<CardNodeType>)} />);
+
+describe('CardNode', () => {
+  it('renders the title, type label, description, and tags', () => {
+    renderCard({
+      title: 'Instruction',
+      type: 'LLM TEXT',
+      description: 'Writes a question about the topic',
+      tags: ['{{topic}}', '{{difficulty}}'],
+    });
+    expect(screen.getByText('Instruction')).toBeInTheDocument();
+    expect(screen.getByText('LLM TEXT')).toBeInTheDocument();
+    expect(screen.getByText('Writes a question about the topic')).toBeInTheDocument();
+    expect(screen.getByText('{{topic}}')).toBeInTheDocument();
+    expect(screen.getByText('{{difficulty}}')).toBeInTheDocument();
+  });
+
+  it('fires onActivate when clicked', async () => {
+    const user = userEvent.setup();
+    const onActivate = vi.fn();
+    renderCard({ title: 'Deploy', onActivate });
+
+    await user.click(screen.getByRole('button', { name: /Deploy/ }));
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it('is keyboard-activatable', async () => {
+    const user = userEvent.setup();
+    const onActivate = vi.fn();
+    renderCard({ title: 'Evaluate', onActivate });
+
+    await user.tab();
+    await user.keyboard('{Enter}');
+
+    expect(onActivate).toHaveBeenCalled();
+  });
+});

--- a/web/packages/studio/src/components/DagCanvas/index.tsx
+++ b/web/packages/studio/src/components/DagCanvas/index.tsx
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CardNode, type CardNodeType } from '@studio/components/DagCanvas/CardNode';
+import { layoutGraph } from '@studio/components/DagCanvas/layout';
+import type {
+  DagDirection,
+  DagEdge,
+  DagNode,
+  DagNodeData,
+} from '@studio/components/DagCanvas/types';
+import { useNvColorMode } from '@studio/components/DagCanvas/useNvColorMode';
+import {
+  Background,
+  type ColorMode,
+  Controls,
+  type Edge,
+  MarkerType,
+  ReactFlow,
+  useEdgesState,
+  useNodesState,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { type FC, useEffect, useMemo } from 'react';
+
+const NODE_TYPES = { card: CardNode };
+
+export interface DagCanvasProps {
+  /** Graph nodes; positions are computed automatically. */
+  nodes: DagNode[];
+  /** Directed edges between nodes, drawn as arrows. */
+  edges: DagEdge[];
+  /** Fired with the node id and its data when a card is clicked or keyboard-activated. */
+  onNodeClick?: (id: string, data: DagNodeData) => void;
+  /** Layout flow direction; defaults to `'TB'` (top-to-bottom). */
+  direction?: DagDirection;
+  /**
+   * Light/dark mode for the canvas. Defaults to following the Studio theme (the
+   * `nv-dark` class on `<html>`). Set explicitly to override.
+   */
+  colorMode?: ColorMode;
+  className?: string;
+}
+
+/**
+ * A pan-and-zoom canvas that renders a DAG of clickable card nodes connected by
+ * arrows. Nodes are auto-laid-out top-down (or left-right) with dagre, so callers
+ * supply only `nodes` and `edges` — no coordinates. The canvas pans on drag and
+ * zooms on scroll/pinch; nodes are fixed in their computed layout (not draggable).
+ *
+ * The host element must have a defined size (e.g. `h-full w-full` inside a sized
+ * parent); React Flow fills its container.
+ */
+export const DagCanvas: FC<DagCanvasProps> = ({
+  nodes,
+  edges,
+  onNodeClick,
+  direction = 'TB',
+  colorMode,
+  className,
+}) => {
+  const themeColorMode = useNvColorMode();
+  const laidOutNodes = useMemo<CardNodeType[]>(() => {
+    const rfNodes: CardNodeType[] = nodes.map((node) => ({
+      id: node.id,
+      type: 'card',
+      position: { x: 0, y: 0 },
+      data: { ...node.data, onActivate: () => onNodeClick?.(node.id, node.data) },
+    }));
+    const rfEdges: Edge[] = edges.map((edge) => ({
+      id: edge.id ?? `${edge.source}->${edge.target}`,
+      source: edge.source,
+      target: edge.target,
+      // Pass the label through so dagre can reserve space for it during layout.
+      label: edge.label,
+    }));
+    return layoutGraph(rfNodes, rfEdges, direction) as CardNodeType[];
+  }, [nodes, edges, direction, onNodeClick]);
+
+  const styledEdges = useMemo<Edge[]>(
+    () =>
+      edges.map((edge) => ({
+        id: edge.id ?? `${edge.source}->${edge.target}`,
+        source: edge.source,
+        target: edge.target,
+        label: edge.label,
+        type: 'smoothstep',
+        markerEnd: { type: MarkerType.ArrowClosed },
+      })),
+    [edges]
+  );
+
+  const [flowNodes, setFlowNodes, onNodesChange] = useNodesState(laidOutNodes);
+  const [flowEdges, setFlowEdges, onEdgesChange] = useEdgesState(styledEdges);
+
+  // Re-sync internal React Flow state when the input graph (or layout) changes.
+  useEffect(() => setFlowNodes(laidOutNodes), [laidOutNodes, setFlowNodes]);
+  useEffect(() => setFlowEdges(styledEdges), [styledEdges, setFlowEdges]);
+
+  return (
+    <div className={`size-full bg-surface-sunken ${className ?? ''}`}>
+      <ReactFlow
+        nodes={flowNodes}
+        edges={flowEdges}
+        nodeTypes={NODE_TYPES}
+        colorMode={colorMode ?? themeColorMode}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        nodesDraggable={false}
+        fitView
+        minZoom={0.2}
+        maxZoom={2}
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background />
+        <Controls />
+      </ReactFlow>
+    </div>
+  );
+};

--- a/web/packages/studio/src/components/DagCanvas/index.tsx
+++ b/web/packages/studio/src/components/DagCanvas/index.tsx
@@ -21,9 +21,12 @@ import {
   useNodesState,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { type FC, useEffect, useMemo } from 'react';
+import { type FC, useEffect, useMemo, useRef } from 'react';
 
 const NODE_TYPES = { card: CardNode };
+
+/** Stable id for an edge; falls back to a source/target pair when none is given. */
+const edgeId = (edge: DagEdge): string => edge.id ?? `${edge.source}->${edge.target}`;
 
 export interface DagCanvasProps {
   /** Graph nodes; positions are computed automatically. */
@@ -60,27 +63,32 @@ export const DagCanvas: FC<DagCanvasProps> = ({
   className,
 }) => {
   const themeColorMode = useNvColorMode();
+  const onNodeClickRef = useRef(onNodeClick);
+  useEffect(() => {
+    onNodeClickRef.current = onNodeClick;
+  }, [onNodeClick]);
+
   const laidOutNodes = useMemo<CardNodeType[]>(() => {
     const rfNodes: CardNodeType[] = nodes.map((node) => ({
       id: node.id,
       type: 'card',
       position: { x: 0, y: 0 },
-      data: { ...node.data, onActivate: () => onNodeClick?.(node.id, node.data) },
+      data: { ...node.data, onActivate: () => onNodeClickRef.current?.(node.id, node.data) },
     }));
     const rfEdges: Edge[] = edges.map((edge) => ({
-      id: edge.id ?? `${edge.source}->${edge.target}`,
+      id: edgeId(edge),
       source: edge.source,
       target: edge.target,
       // Pass the label through so dagre can reserve space for it during layout.
       label: edge.label,
     }));
-    return layoutGraph(rfNodes, rfEdges, direction) as CardNodeType[];
-  }, [nodes, edges, direction, onNodeClick]);
+    return layoutGraph(rfNodes, rfEdges, direction);
+  }, [nodes, edges, direction]);
 
   const styledEdges = useMemo<Edge[]>(
     () =>
       edges.map((edge) => ({
-        id: edge.id ?? `${edge.source}->${edge.target}`,
+        id: edgeId(edge),
         source: edge.source,
         target: edge.target,
         label: edge.label,

--- a/web/packages/studio/src/components/DagCanvas/layout.ts
+++ b/web/packages/studio/src/components/DagCanvas/layout.ts
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import dagre from '@dagrejs/dagre';
+import type { DagDirection } from '@studio/components/DagCanvas/types';
+import { type Edge, type Node, Position } from '@xyflow/react';
+
+/** Card dimensions fed to dagre so it can reserve space and route arrows. */
+export const NODE_WIDTH = 240;
+export const NODE_HEIGHT = 116;
+
+/** Minimum empty gap to keep between a node and an edge that merely passes by it. */
+const EDGE_CLEARANCE = 24;
+
+/** Rough on-screen size of an edge label, used to keep nodes clear of it. */
+const LABEL_CHAR_WIDTH = 7;
+const LABEL_PADDING = 16;
+const LABEL_HEIGHT = 20;
+const estimateLabelWidth = (label: string): number =>
+  label.length * LABEL_CHAR_WIDTH + LABEL_PADDING;
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Nudges nodes out from under edges that skip over their rank.
+ *
+ * React Flow draws an edge as a straight run between the source and target
+ * handles, ignoring dagre's routing. When a "skip" edge connects two nodes that
+ * dagre stacks in the same column (e.g. `features → evaluate`), that straight run
+ * — and the label React Flow centers on it — passes right through whatever node
+ * sits between them (`train`). dagre nudges the middle node aside but not always
+ * far enough, and never accounts for the label's width.
+ *
+ * So after layout we shift any intervening node along the cross-axis until the
+ * edge's column (plus its label and a clearance gap) no longer touches it. Mutates
+ * the passed centers in place.
+ */
+const clearNodesOffEdges = (
+  centers: Map<string, Point>,
+  edges: Edge[],
+  isHorizontal: boolean
+): void => {
+  edges.forEach((edge) => {
+    const source = centers.get(edge.source);
+    const target = centers.get(edge.target);
+    if (!source || !target) return;
+
+    // Cross-axis half-width to keep clear: half the node, the clearance gap, and
+    // half the label (label width along the flow's cross-axis).
+    const label = typeof edge.label === 'string' ? edge.label : undefined;
+    const labelHalf = label ? (isHorizontal ? LABEL_HEIGHT : estimateLabelWidth(label)) / 2 : 0;
+    const nodeHalf = (isHorizontal ? NODE_HEIGHT : NODE_WIDTH) / 2;
+    const keepClear = nodeHalf + EDGE_CLEARANCE + labelHalf;
+
+    // Along-flow span the edge covers (y for top-down, x for left-right).
+    const start = isHorizontal ? source.x : source.y;
+    const end = isHorizontal ? target.x : target.y;
+    const [lo, hi] = start < end ? [start, end] : [end, start];
+
+    centers.forEach((center, id) => {
+      if (id === edge.source || id === edge.target) return;
+
+      const along = isHorizontal ? center.x : center.y;
+      // Only nodes whose rank falls strictly between the edge's endpoints.
+      if (along <= lo + 1 || along >= hi - 1) return;
+
+      // Where the straight edge sits on the cross-axis at this node's rank.
+      const t = (along - start) / (end - start);
+      const edgeCross = isHorizontal
+        ? source.y + (target.y - source.y) * t
+        : source.x + (target.x - source.x) * t;
+
+      const cross = isHorizontal ? center.y : center.x;
+      const delta = cross - edgeCross;
+      if (Math.abs(delta) >= keepClear) return;
+
+      const direction = delta === 0 ? 1 : Math.sign(delta);
+      const shifted = edgeCross + direction * keepClear;
+      if (isHorizontal) center.y = shifted;
+      else center.x = shifted;
+    });
+  });
+};
+
+/**
+ * Runs a top-down (or left-right) DAG layout over `nodes`/`edges` with dagre and
+ * returns React Flow nodes with absolute `position` set, plus the correct
+ * source/target handle positions for the chosen direction.
+ *
+ * dagre reports node centers, so we offset by half the card size to get the
+ * top-left origin React Flow expects.
+ */
+export const layoutGraph = <T extends Record<string, unknown>>(
+  nodes: Node<T>[],
+  edges: Edge[],
+  direction: DagDirection
+): Node<T>[] => {
+  const graph = new dagre.graphlib.Graph();
+  graph.setDefaultEdgeLabel(() => ({}));
+  graph.setGraph({ rankdir: direction, nodesep: 48, ranksep: 64 });
+
+  nodes.forEach((node) => {
+    graph.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  });
+  edges.forEach((edge) => {
+    graph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(graph);
+
+  const isHorizontal = direction === 'LR';
+
+  const centers = new Map<string, Point>(
+    nodes.map((node) => {
+      const { x, y } = graph.node(node.id);
+      return [node.id, { x, y }];
+    })
+  );
+  clearNodesOffEdges(centers, edges, isHorizontal);
+
+  return nodes.map((node) => {
+    const { x, y } = centers.get(node.id) ?? { x: 0, y: 0 };
+    return {
+      ...node,
+      targetPosition: isHorizontal ? Position.Left : Position.Top,
+      sourcePosition: isHorizontal ? Position.Right : Position.Bottom,
+      position: { x: x - NODE_WIDTH / 2, y: y - NODE_HEIGHT / 2 },
+    };
+  });
+};

--- a/web/packages/studio/src/components/DagCanvas/layout.ts
+++ b/web/packages/studio/src/components/DagCanvas/layout.ts
@@ -93,11 +93,11 @@ const clearNodesOffEdges = (
  * dagre reports node centers, so we offset by half the card size to get the
  * top-left origin React Flow expects.
  */
-export const layoutGraph = <T extends Record<string, unknown>>(
-  nodes: Node<T>[],
+export const layoutGraph = <N extends Node>(
+  nodes: N[],
   edges: Edge[],
   direction: DagDirection
-): Node<T>[] => {
+): N[] => {
   const graph = new dagre.graphlib.Graph();
   graph.setDefaultEdgeLabel(() => ({}));
   graph.setGraph({ rankdir: direction, nodesep: 48, ranksep: 64 });

--- a/web/packages/studio/src/components/DagCanvas/types.ts
+++ b/web/packages/studio/src/components/DagCanvas/types.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { LucideIcon } from 'lucide-react';
+
+/** Visual status of a node, used to tint the card's leading icon. */
+export type DagNodeStatus = 'idle' | 'running' | 'success' | 'error';
+
+/** Presentational content rendered inside a card node. */
+export interface DagNodeData {
+  /** Primary label shown on the card. */
+  title: string;
+  /** Accent type label beneath the title (e.g. "LLM TEXT"). */
+  type?: string;
+  /** Muted one-line description below the header. */
+  description?: string;
+  /** Variable/parameter tokens rendered as monospace pills (e.g. `"{{topic}}"`). */
+  tags?: string[];
+  /** Leading icon shown in the card's icon badge. */
+  icon?: LucideIcon;
+  /** Optional status accent; defaults to `'idle'`. Tints the leading icon. */
+  status?: DagNodeStatus;
+  /**
+   * Accent classes applied to the icon (when idle) and subtitle, e.g.
+   * `text-[color:var(--text-color-accent-purple)]`. Non-idle statuses keep their
+   * semantic feedback color on the icon regardless of this prop.
+   */
+  colorClassName?: string;
+}
+
+/** A single node in the DAG, identified by a unique `id`. */
+export interface DagNode {
+  id: string;
+  data: DagNodeData;
+}
+
+/** A directed edge drawn as an arrow from `source` to `target` (by node id). */
+export interface DagEdge {
+  /** Optional id; defaults to `${source}->${target}`. */
+  id?: string;
+  source: string;
+  target: string;
+  /** Optional label rendered on the arrow. */
+  label?: string;
+}
+
+/** Layout flow direction: top-to-bottom or left-to-right. */
+export type DagDirection = 'TB' | 'LR';

--- a/web/packages/studio/src/components/DagCanvas/useNvColorMode.ts
+++ b/web/packages/studio/src/components/DagCanvas/useNvColorMode.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ColorMode } from '@xyflow/react';
+import { useEffect, useState } from 'react';
+
+const readColorMode = (): ColorMode =>
+  typeof document !== 'undefined' && document.documentElement.classList.contains('nv-dark')
+    ? 'dark'
+    : 'light';
+
+/**
+ * Tracks the active Studio theme by watching the `nv-dark` class on `<html>` (the
+ * same signal that drives NVIDIA Foundations design tokens) and returns the matching
+ * React Flow {@link ColorMode}.
+ *
+ * React Flow scopes its rendering surface with a `light`/`dark` class derived from its
+ * `colorMode` prop, which otherwise defaults to `light` and overrides the app's dark
+ * tokens inside the canvas — leaving nodes white-on-dark. Feeding this value back into
+ * `colorMode` keeps the canvas in sync with the rest of the UI.
+ */
+export const useNvColorMode = (): ColorMode => {
+  const [colorMode, setColorMode] = useState<ColorMode>(readColorMode);
+
+  useEffect(() => {
+    const update = () => setColorMode(readColorMode());
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return colorMode;
+};

--- a/web/packages/studio/src/components/common/SelectableCard/index.tsx
+++ b/web/packages/studio/src/components/common/SelectableCard/index.tsx
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Badge, Flex, Stack, Text } from '@nvidia/foundations-react-core';
+import { type FC, type ReactNode } from 'react';
+
+export interface CardIconBadgeProps {
+  /** The icon (or other glyph) to center inside the badge. */
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * The small rounded, sunken square that holds a card's leading icon — the icon box
+ * in the Data Designer card design.
+ */
+export const CardIconBadge: FC<CardIconBadgeProps> = ({ children, className }) => (
+  <Flex
+    align="center"
+    justify="center"
+    className={`size-[26px] shrink-0 rounded-sm bg-surface-sunken ${className ?? ''}`}
+  >
+    {children}
+  </Flex>
+);
+
+export interface SelectableCardProps {
+  /** Leading visual: an icon badge ({@link CardIconBadge}), a status dot, etc. */
+  leading?: ReactNode;
+  /** Primary label. */
+  title: string;
+  /** Optional secondary line beneath the title, in the header row beside `leading`. */
+  subtitle?: string;
+  /** Extra classes for the subtitle — e.g. an accent color or uppercase type label. */
+  subtitleClassName?: string;
+  /** Optional muted description line below the header row. */
+  description?: string;
+  /** Optional tokens rendered as badges below the description. */
+  tags?: string[];
+  /** Whether the card reads as selected (draws the strong border). */
+  selected?: boolean;
+  /** Activation handler; fired on click and on keyboard Enter/Space. */
+  onActivate?: () => void;
+  className?: string;
+}
+
+/**
+ * A compact, keyboard-activatable card: a leading visual beside a title and an
+ * optional subtitle, optionally followed by a description and a row of badges,
+ * in a bordered box that highlights on hover, focus, and when selected. Shared by
+ * the Data Designer column palette and the DAG canvas nodes so the two stay
+ * visually identical.
+ *
+ * Rendered as a native `<button>` so it is focusable and activatable with no extra
+ * wiring.
+ */
+export const SelectableCard: FC<SelectableCardProps> = ({
+  leading,
+  title,
+  subtitle,
+  subtitleClassName,
+  description,
+  tags,
+  selected = false,
+  onActivate,
+  className,
+}) => (
+  <button
+    type="button"
+    onClick={onActivate}
+    aria-pressed={selected}
+    className={`flex w-[240px] justify-between cursor-pointer flex-col items-start gap-1.5 rounded-md border bg-surface-raised px-2 py-1.5 text-left transition-colors hover:border-strong hover:bg-surface-hover focus-visible:border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#76b900] ${selected ? 'border-strong' : 'border-base'} ${className ?? ''}`}
+  >
+    <Stack gap="1.5">
+      <Flex className="w-full items-center gap-2">
+        {leading}
+        <Stack gap="density-xxs" className="min-w-0">
+          <Text kind="body/semibold/sm" className="truncate text-primary">
+            {title}
+          </Text>
+          {subtitle ? (
+            <Text
+              kind="body/regular/xs"
+              className={`truncate ${subtitleClassName ?? 'text-secondary'}`}
+            >
+              {subtitle}
+            </Text>
+          ) : null}
+        </Stack>
+      </Flex>
+
+      {description ? (
+        <Text kind="body/regular/xs" className="w-full text-secondary">
+          {description}
+        </Text>
+      ) : null}
+    </Stack>
+
+    {tags && tags.length > 0 ? (
+      <Flex wrap="wrap" gap="density-xs" className="w-full">
+        {tags.map((tag) => (
+          <Badge key={tag} color="blue" kind="solid" className="text-[10px]">
+            {tag}
+          </Badge>
+        ))}
+      </Flex>
+    ) : null}
+  </button>
+);

--- a/web/packages/studio/src/components/common/SelectableCard/index.tsx
+++ b/web/packages/studio/src/components/common/SelectableCard/index.tsx
@@ -69,7 +69,7 @@ export const SelectableCard: FC<SelectableCardProps> = ({
     type="button"
     onClick={onActivate}
     aria-pressed={selected}
-    className={`flex w-[240px] justify-between cursor-pointer flex-col items-start gap-1.5 rounded-md border bg-surface-raised px-2 py-1.5 text-left transition-colors hover:border-strong hover:bg-surface-hover focus-visible:border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#76b900] ${selected ? 'border-strong' : 'border-base'} ${className ?? ''}`}
+    className={`flex w-[240px] justify-between cursor-pointer flex-col items-start gap-1.5 rounded-md border bg-surface-raised px-2 py-1.5 text-left transition-colors hover:border-strong hover:bg-surface-hover focus-visible:border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-brand,#76b900) ${selected ? 'border-strong' : 'border-base'} ${className ?? ''}`}
   >
     <Stack gap="1.5">
       <Flex className="w-full items-center gap-2">

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -590,6 +590,9 @@ importers:
       '@assistant-ui/react':
         specifier: ^0.12.28
         version: 0.12.28(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@dagrejs/dagre':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@hookform/resolvers':
         specifier: ^4.1.3
         version: 4.1.3(react-hook-form@7.71.2(react@19.2.7))
@@ -653,6 +656,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.2(vite@8.0.16(@types/node@24.12.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))
+      '@xyflow/react':
+        specifier: ^12.11.1
+        version: 12.11.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       axios:
         specifier: 'catalog:'
         version: 1.18.0(debug@4.4.3)
@@ -1162,6 +1168,12 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dagrejs/dagre@3.0.0':
+    resolution: {integrity: sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==}
+
+  '@dagrejs/graphlib@4.0.1':
+    resolution: {integrity: sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -3738,6 +3750,9 @@ packages:
   '@types/d3-delaunay@6.0.4':
     resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
 
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
   '@types/d3-ease@3.0.2':
     resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
 
@@ -3750,6 +3765,9 @@ packages:
   '@types/d3-scale@4.0.9':
     resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
 
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
   '@types/d3-shape@3.1.8':
     resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
 
@@ -3758,6 +3776,12 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -4263,6 +4287,22 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@xyflow/react@12.11.1':
+    resolution: {integrity: sha512-L+zBoLGSXham0MnlY8QqjfR7/C5JNw0zxkaey5aZ5XmCgJBAdH4+WRIu8CR40d3l/BdU635V6YbhBK1jMo8/6Q==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@xyflow/system@0.0.78':
+    resolution: {integrity: sha512-lY0z2qP33fUhTva9Vaxrk0lqZta2pkbxB1trHAx1omnJqRtPvDlAQYV2r5fhS6AdpkulYmbNW0svy+A4/t4B/g==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -4536,6 +4576,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
@@ -4661,6 +4704,14 @@ packages:
     resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
     engines: {node: '>=12'}
 
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
     engines: {node: '>=12'}
@@ -4681,6 +4732,10 @@ packages:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
 
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
     engines: {node: '>=12'}
@@ -4695,6 +4750,16 @@ packages:
 
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
@@ -7573,6 +7638,21 @@ packages:
   zone.js@0.15.1:
     resolution: {integrity: sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==}
 
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
     engines: {node: '>=12.20.0'}
@@ -7964,6 +8044,12 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dagrejs/dagre@3.0.0':
+    dependencies:
+      '@dagrejs/graphlib': 4.0.1
+
+  '@dagrejs/graphlib@4.0.1': {}
 
   '@date-fns/tz@1.4.1': {}
 
@@ -10539,6 +10625,10 @@ snapshots:
 
   '@types/d3-delaunay@6.0.4': {}
 
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
   '@types/d3-ease@3.0.2': {}
 
   '@types/d3-interpolate@3.0.4':
@@ -10551,6 +10641,8 @@ snapshots:
     dependencies:
       '@types/d3-time': 3.0.4
 
+  '@types/d3-selection@3.0.11': {}
+
   '@types/d3-shape@3.1.8':
     dependencies:
       '@types/d3-path': 3.1.1
@@ -10558,6 +10650,15 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
 
   '@types/debug@4.1.12':
     dependencies:
@@ -11110,6 +11211,31 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@xyflow/react@12.11.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@xyflow/system': 0.0.78
+      classcat: 5.0.5
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+    transitivePeerDependencies:
+      - immer
+
+  '@xyflow/system@0.0.78':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -11381,6 +11507,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classcat@5.0.5: {}
+
   classnames@2.5.1: {}
 
   cli-cursor@5.0.0:
@@ -11505,6 +11633,13 @@ snapshots:
     dependencies:
       delaunator: 5.0.1
 
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
   d3-ease@3.0.1: {}
 
   d3-format@3.1.2: {}
@@ -11523,6 +11658,8 @@ snapshots:
       d3-time: 3.1.0
       d3-time-format: 4.1.0
 
+  d3-selection@3.0.0: {}
+
   d3-shape@3.2.0:
     dependencies:
       d3-path: 3.1.0
@@ -11536,6 +11673,23 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   damerau-levenshtein@1.0.8: {}
 
@@ -15091,6 +15245,13 @@ snapshots:
   zod@4.3.6: {}
 
   zone.js@0.15.1: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.7):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.7
 
   zustand@5.0.12(@types/react@19.2.14)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:


### PR DESCRIPTION
<img width="499" height="755" alt="Screenshot 2026-07-02 at 2 45 23 PM" src="https://github.com/user-attachments/assets/5dddd027-04c8-4984-b2d8-8b68c9839fe5" />

Signed-off-by: Sean Teramae <steramae@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DAG canvas with automatic layout, pan/zoom controls, node labels, tags, status indicators, and selectable, keyboard-friendly node cards.
  * Introduced a reusable selectable card component to standardize interactions and visual selection state.
  * Added theme-aware light/dark syncing for the canvas.
  * Included Storybook coverage for the new DAG canvas layouts.
* **Bug Fixes**
  * Improved spacing for node placement to reduce overlaps and label collisions, including clearer routing around intermediate nodes.
* **Tests**
  * Added unit tests covering layout, node rendering, and activation (mouse + keyboard), plus node-click callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->