### PR TITLE
feat(models): allow operator env overrides for HF model puller

### DIFF
--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -473,6 +473,8 @@ models:
         models_docker_port_range_end: 49652
         # Image used to pull model weights. Its entrypoint is overridden to the Hugging Face CLI ('hf download ...'), so any image with the 'hf' CLI on PATH works. Defaults to the platform's nmp-api image (registry/tag from platform config); override to use a different puller image.
         huggingface_model_puller: my-registry/nmp-api:local
+        # Extra environment variables for the model puller container. Values override the reconciler defaults (HF_ENDPOINT, HF_TOKEN). E.g. set HF_HUB_ENABLE_HF_TRANSFER='0' to disable the hf_transfer download path.
+        huggingface_model_puller_env: {}
         # Timeout in seconds for the model puller container to complete (default: 30 minutes) | default: 1800
         model_puller_timeout: 1800
         # Per-file HTTP download timeout in seconds for the model puller (HF_HUB_DOWNLOAD_TIMEOUT). Increase if large model files fail with IncompleteRead/ChunkedEncodingError (default: 2 hours). | default: 7200

--- a/services/core/models/src/nmp/core/models/controllers/backends/docker/config.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/docker/config.py
@@ -140,6 +140,13 @@ class DockerBackendConfig(BaseModel):
         "to use a different puller image.",
     )
 
+    huggingface_model_puller_env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Extra environment variables for the model puller container. Values override the "
+        "reconciler defaults (HF_ENDPOINT, HF_TOKEN). E.g. set HF_HUB_ENABLE_HF_TRANSFER='0' to "
+        "disable the hf_transfer download path.",
+    )
+
     model_puller_timeout: int = Field(
         default=1800,
         description="Timeout in seconds for the model puller container to complete (default: 30 minutes)",

--- a/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/docker/creation_reconciler.py
@@ -1227,6 +1227,10 @@ class DockerDeploymentCreationReconciler:
         else:
             raise ValueError(f"Unsupported model weights type for puller: {model_weights_type}")
 
+        # Operator-provided overrides win over the defaults set above (e.g. HF_ENDPOINT/HF_TOKEN).
+        if self._backend_config.huggingface_model_puller_env:
+            env_vars = {**env_vars, **self._backend_config.huggingface_model_puller_env}
+
         logger.info(
             "Running model puller for %s (container: %s, image: %s)",
             model_repo,

--- a/services/core/models/tests/unit/controllers/test_docker_backend.py
+++ b/services/core/models/tests/unit/controllers/test_docker_backend.py
@@ -16,6 +16,7 @@ from nmp.core.models.controllers.backends.backends import DeploymentStatusUpdate
 from nmp.core.models.controllers.backends.docker import DockerServiceBackend
 from nmp.core.models.controllers.backends.docker.creation_reconciler import (
     CreationStage,
+    CreationState,
     _compute_multi_gpu_shm_size,
 )
 from nmp.core.models.controllers.context import ModelContext
@@ -2710,6 +2711,65 @@ async def test_multi_llm_files_service_deployment_succeeds(
     puller_env = puller_calls[0][1]["environment"]
     assert "HF_ENDPOINT" in puller_env
     assert "/apis/files/v2/hf" in puller_env["HF_ENDPOINT"]
+
+
+def _puller_state(deployment, config):
+    """Build a minimal CreationState for exercising _start_model_puller_container directly."""
+    return CreationState(
+        stage=CreationStage.RUNNING_PULLER,
+        deployment=deployment,
+        config=config,
+        model_entity=None,
+        model_weights_type=ModelWeightsType.FILES_SERVICE,
+        volume_name="vol-test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_puller_env_override_merged(docker_backend, sample_deployment, sample_config, mock_docker_client):
+    """huggingface_model_puller_env is merged into the puller env, with operator values winning."""
+    reconciler = docker_backend._reconciler
+    reconciler._backend_config.huggingface_model_puller_env = {
+        "HF_HUB_ENABLE_HF_TRANSFER": "0",
+        "HF_ENDPOINT": "https://override.example",  # must win over the hardcoded default
+    }
+
+    puller_container = MagicMock()
+    puller_container.id = "puller123456789"
+    reconciler.run_container = MagicMock(return_value=puller_container)
+    reconciler._get_model_repo_from_entity = MagicMock(return_value="nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16")
+
+    await reconciler._start_model_puller_container(_puller_state(sample_deployment, sample_config))
+
+    reconciler.run_container.assert_called_once()
+    env = reconciler.run_container.call_args[1]["environment"]
+    # Operator-provided override is applied
+    assert env["HF_HUB_ENABLE_HF_TRANSFER"] == "0"
+    # Operator value wins over the hardcoded HF_ENDPOINT default
+    assert env["HF_ENDPOINT"] == "https://override.example"
+    # Untouched default remains
+    assert env["HF_TOKEN"] == "service:models"
+
+
+@pytest.mark.asyncio
+async def test_model_puller_env_no_override_uses_defaults(
+    docker_backend, sample_deployment, sample_config, mock_docker_client
+):
+    """With no huggingface_model_puller_env configured, the puller env keeps only its defaults."""
+    reconciler = docker_backend._reconciler
+    assert reconciler._backend_config.huggingface_model_puller_env == {}
+
+    puller_container = MagicMock()
+    puller_container.id = "puller123456789"
+    reconciler.run_container = MagicMock(return_value=puller_container)
+    reconciler._get_model_repo_from_entity = MagicMock(return_value="nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16")
+
+    await reconciler._start_model_puller_container(_puller_state(sample_deployment, sample_config))
+
+    reconciler.run_container.assert_called_once()
+    env = reconciler.run_container.call_args[1]["environment"]
+    assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
+    assert env["HF_TOKEN"] == "service:models"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Adds `huggingface_model_puller_env` to `DockerBackendConfig` and merges it into the model puller container environment just before launch. Operator-provided values win over the reconciler defaults (`HF_ENDPOINT`, `HF_TOKEN`).

## Why

Lets operators set env like `HF_HUB_ENABLE_HF_TRANSFER=0` to disable the `hf_transfer` accelerated download path (baked into some puller images) when it fails — without needing to swap in a different puller image.

## Changes

- `config.py`: new `huggingface_model_puller_env: dict[str, str]` field (default empty)
- `creation_reconciler.py`: merge overrides into puller env, operator values winning
- `test_docker_backend.py`: 2 tests — override merge + defaults-only path
- `docs/set-up/config-reference.mdx`: auto-regenerated

## Testing

New tests pass; pre-commit (ruff/format/ty/copyright) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new configuration setting to supply extra environment variables to the Hugging Face model-puller container.
  - Operator-provided values can override the default Hugging Face endpoint/token used during model pulling.

- **Documentation**
  - Updated the configuration reference to describe the new setting and how it overrides reconciler defaults.

- **Tests**
  - Added unit tests validating both custom override merging and default-only environment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->