### PR TITLE
feat(studio): Adding range type filtering to dataview filters

### DIFF
--- a/web/packages/common/src/components/DataView/ColumnFilterPanel.tsx
+++ b/web/packages/common/src/components/DataView/ColumnFilterPanel.tsx
@@ -8,8 +8,10 @@ import {
   SingleSelectFilterControl,
   MultiSelectFilterControl,
   DateTimeFilterControl,
+  NumberRangeFilterControl,
   CustomFilterControl,
 } from '@nemo/common/src/components/DataView/FilterPanel';
+import { isNumberRangeFilter } from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter/util';
 import type { DataViewColumn } from '@nemo/common/src/components/DataView/FilterPanel/types';
 import { useInnerDataViewContext } from '@nemo/common/src/components/DataView/internal';
 import { Accordion, Flex, Spinner } from '@nvidia/foundations-react-core';
@@ -53,6 +55,8 @@ export const ColumnFilterPanel = ({ defaultExpanded }: ColumnFilterPanelProps) =
     custom: (column, filter) =>
       isDateTimeFilter(filter) ? (
         <DateTimeFilterControl column={column} />
+      ) : isNumberRangeFilter(filter) ? (
+        <NumberRangeFilterControl column={column} />
       ) : (
         <CustomFilterControl column={column} />
       ),

--- a/web/packages/common/src/components/DataView/FilterPanel/NumberRangeFilter/NumberRangeFilter.stories.tsx
+++ b/web/packages/common/src/components/DataView/FilterPanel/NumberRangeFilter/NumberRangeFilter.stories.tsx
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NumberRangeFilterControl } from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter';
+import {
+  formatNumberRange,
+  numberRangeFilter,
+  type NumberRangeFilterValue,
+} from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter/util';
+import type { DataViewColumn } from '@nemo/common/src/components/DataView/FilterPanel/types';
+import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
+import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
+import { Stack, Text } from '@nvidia/foundations-react-core';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ComponentProps, FC, useCallback, useState } from 'react';
+
+// ---------------------------------------------------------------------------
+// Sandbox — the NumberRangeFilterControl in isolation, with a live value readout
+// ---------------------------------------------------------------------------
+
+interface SandboxArgs {
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+}
+
+/**
+ * Drives the control with local state and a minimal column stub that exposes
+ * only what the control reads (`columnDef.meta.filter`, `getFilterValue`,
+ * `setFilterValue`). The emitted `{ $gte, $lte }` value is rendered below so the
+ * filter's output is visible while iterating on the component.
+ */
+function SandboxHarness({ label, min, max, step }: SandboxArgs) {
+  const [value, setValue] = useState<NumberRangeFilterValue | undefined>(undefined);
+
+  const column = {
+    id: 'sandbox',
+    columnDef: {
+      header: label,
+      meta: { filter: numberRangeFilter(label, { min, max, step }) },
+    },
+    getFilterValue: () => value,
+    setFilterValue: (next: unknown) => setValue(next as NumberRangeFilterValue | undefined),
+  } as unknown as DataViewColumn;
+
+  return (
+    <Stack gap="density-2xl" className="max-w-[340px]">
+      <div className="w-[300px] rounded-lg border border-base bg-surface-raised p-density-xl">
+        <NumberRangeFilterControl column={column} />
+      </div>
+      <Stack gap="density-sm">
+        <Text kind="body/semibold/sm">Emitted filter value</Text>
+        <pre className="rounded-md bg-surface p-density-md font-mono text-xs whitespace-pre-wrap">
+          {JSON.stringify(value ?? null, null, 2)}
+        </pre>
+        <Text kind="body/regular/sm" className="text-secondary">
+          Applied: {formatNumberRange(value?.$gte, value?.$lte) || '(no filter)'}
+        </Text>
+      </Stack>
+    </Stack>
+  );
+}
+
+const meta: Meta<SandboxArgs> = {
+  title: 'Studio Common/DataView/NumberRangeFilter',
+  parameters: { layout: 'padded' },
+  argTypes: {
+    label: { control: { type: 'text' } },
+    min: { control: { type: 'number' } },
+    max: { control: { type: 'number' } },
+    step: { control: { type: 'number' } },
+  },
+  args: { label: 'Score', min: 0, max: 100, step: 1 },
+};
+
+export default meta;
+
+/**
+ * Isolated sandbox for working on the filter. Adjust the track bounds with the
+ * Storybook controls; drag the slider, or type into the min/max inputs and blur
+ * (or press Enter), and watch the emitted `{ $gte, $lte }` value update below.
+ */
+export const Sandbox: StoryObj<SandboxArgs> = {
+  render: (args) => <SandboxHarness {...args} />,
+};
+
+/** A wider range with a non-default track and a coarse step. */
+export const CustomBounds: StoryObj<SandboxArgs> = {
+  args: { label: 'Price (USD)', min: 0, max: 1000, step: 50 },
+  render: (args) => <SandboxHarness {...args} />,
+};
+
+// ---------------------------------------------------------------------------
+// In DataView — the filter wired into a real StudioDataView filter panel
+// ---------------------------------------------------------------------------
+
+interface JobMetric {
+  id: string;
+  name: string;
+  durationMinutes: number;
+  costUsd: number;
+}
+
+const JOB_METRICS: JobMetric[] = [
+  { id: 'j-001', name: 'llama-3-sft-run-1', durationMinutes: 134, costUsd: 18 },
+  { id: 'j-002', name: 'mistral-lora-v2', durationMinutes: 45, costUsd: 4 },
+  { id: 'j-003', name: 'gemma-dpo-alignment', durationMinutes: 62, costUsd: 9 },
+  { id: 'j-004', name: 'phi-3-full-ft', durationMinutes: 330, costUsd: 41 },
+  { id: 'j-005', name: 'nemotron-sft-support', durationMinutes: 485, costUsd: 48 },
+  { id: 'j-006', name: 'llama-guard-finetune', durationMinutes: 80, costUsd: 11 },
+  { id: 'j-007', name: 'mixtral-lora-code', durationMinutes: 227, costUsd: 32 },
+];
+
+const matchesRange = (n: number, range: NumberRangeFilterValue | undefined): boolean => {
+  if (range?.$gte != null && n < range.$gte) return false;
+  if (range?.$lte != null && n > range.$lte) return false;
+  return true;
+};
+
+const fixedHeightDecorator = (Story: FC) => (
+  <div className="h-[600px]">
+    <Story />
+  </div>
+);
+
+/**
+ * The numeric range filter inside a real DataView filter panel. Open the filter
+ * panel (toolbar funnel icon) to filter by duration or cost; rows, the applied
+ * filter chips, and the result count all update live.
+ */
+export const InDataView: StoryObj = {
+  name: 'In DataView (Job Metrics)',
+  decorators: [fixedHeightDecorator],
+  render: function InDataViewStory() {
+    const dataViewState = useStudioDataViewState({ defaultPageSize: 10 });
+
+    // The DataView runs in manual mode, so we apply the column filters ourselves
+    // to demonstrate the emitted `{ $gte, $lte }` values end to end.
+    const activeFilters = dataViewState.columnFiltering.state;
+    const filteredRows = JOB_METRICS.filter((row) =>
+      activeFilters.every(({ id, value }) => {
+        const range = value as NumberRangeFilterValue | undefined;
+        if (id === 'durationMinutes') return matchesRange(row.durationMinutes, range);
+        if (id === 'costUsd') return matchesRange(row.costUsd, range);
+        return true;
+      })
+    );
+
+    const makeColumns: ComponentProps<typeof StudioDataView<JobMetric>>['makeColumns'] =
+      useCallback(
+        ({ accessor }) => [
+          accessor('name', { header: 'Job Name', enableSorting: false }),
+          accessor('durationMinutes', {
+            header: 'Duration (min)',
+            enableSorting: true,
+            size: 180,
+            cell: ({ row }) => `${row.original.durationMinutes} min`,
+            meta: {
+              filter: numberRangeFilter('Duration (minutes)', { min: 0, max: 600, step: 15 }),
+            },
+          }),
+          accessor('costUsd', {
+            header: 'Cost (USD)',
+            enableSorting: true,
+            size: 160,
+            cell: ({ row }) => `$${row.original.costUsd}`,
+            meta: { filter: numberRangeFilter('Cost (USD)', { min: 0, max: 50, step: 1 }) },
+          }),
+        ],
+        []
+      );
+
+    return (
+      <StudioDataView<JobMetric>
+        dataViewState={dataViewState}
+        makeColumns={makeColumns}
+        attributes={{
+          DataViewRoot: {
+            data: filteredRows,
+            totalCount: filteredRows.length,
+          },
+        }}
+      />
+    );
+  },
+};

--- a/web/packages/common/src/components/DataView/FilterPanel/NumberRangeFilter/NumberRangeFilter.stories.tsx
+++ b/web/packages/common/src/components/DataView/FilterPanel/NumberRangeFilter/NumberRangeFilter.stories.tsx
@@ -8,6 +8,8 @@ import {
   type NumberRangeFilterValue,
 } from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter/util';
 import type { DataViewColumn } from '@nemo/common/src/components/DataView/FilterPanel/types';
+import * as DataView from '@nemo/common/src/components/DataView/internal';
+import { StudioAppliedFilters } from '@nemo/common/src/components/DataView/StudioAppliedFilters';
 import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
 import { Stack, Text } from '@nvidia/foundations-react-core';
@@ -182,6 +184,72 @@ export const InDataView: StoryObj = {
           },
         }}
       />
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Applied Filters — how StudioAppliedFilters renders a range value as a chip
+// ---------------------------------------------------------------------------
+
+interface RangeRow {
+  durationMinutes: number;
+  costUsd: number;
+  accuracyPct: number;
+}
+
+/**
+ * Renders StudioAppliedFilters inside a headless DataView.Root seeded with
+ * pre-applied numeric range filters, so you can see how each committed
+ * `{ $gte, $lte }` value is formatted into a chip via `formatNumberRange`:
+ * both bounds ("30 – 480"), lower-only ("≥ 10"), and upper-only ("≤ 90").
+ * Click a chip to clear that filter, or "Clear Filters" to clear all.
+ */
+export const AppliedFilters: StoryObj = {
+  name: 'Applied Filter Chips',
+  render: function AppliedFiltersStory() {
+    const dataViewState = DataView.useDataViewState({
+      columnFilters: [
+        { id: 'durationMinutes', value: { $gte: 30, $lte: 480 } }, // both bounds
+        { id: 'costUsd', value: { $gte: 10 } }, // lower bound only
+        { id: 'accuracyPct', value: { $lte: 90 } }, // upper bound only
+      ],
+    });
+
+    const makeColumns: ComponentProps<typeof DataView.Root<RangeRow>>['makeColumns'] = useCallback(
+      ({ accessor }) => [
+        accessor('durationMinutes', {
+          header: 'Duration',
+          meta: { filter: numberRangeFilter('Duration (minutes)', { min: 0, max: 600, step: 15 }) },
+        }),
+        accessor('costUsd', {
+          header: 'Cost',
+          meta: { filter: numberRangeFilter('Cost (USD)', { min: 0, max: 50, step: 1 }) },
+        }),
+        accessor('accuracyPct', {
+          header: 'Accuracy',
+          meta: { filter: numberRangeFilter('Accuracy (%)', { min: 0, max: 100, step: 1 }) },
+        }),
+      ],
+      []
+    );
+
+    return (
+      <DataView.Root
+        dataMode="manual"
+        state={dataViewState}
+        data={[]}
+        totalCount={0}
+        makeColumns={makeColumns}
+      >
+        <Stack gap="density-lg" className="max-w-[640px]">
+          <Text kind="body/regular/sm" className="text-secondary">
+            StudioAppliedFilters formats each committed range into a chip — both bounds ("30 –
+            480"), lower-only ("≥ 10"), and upper-only ("≤ 90"). Click a chip to clear that filter.
+          </Text>
+          <StudioAppliedFilters />
+        </Stack>
+      </DataView.Root>
     );
   },
 };

--- a/web/packages/common/src/components/DataView/FilterPanel/NumberRangeFilter/NumberRangeFilter.test.tsx
+++ b/web/packages/common/src/components/DataView/FilterPanel/NumberRangeFilter/NumberRangeFilter.test.tsx
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NumberRangeFilterControl } from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter';
+import {
+  formatNumberRange,
+  isNumberRangeFilter,
+  numberRangeFilter,
+  type NumberRangeFilterValue,
+} from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter/util';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+
+/**
+ * Renders the control inside a stateful harness so committed filter changes
+ * persist across edits (the way a real DataView column would), and spies on
+ * every emitted value.
+ */
+function renderControl(initial?: NumberRangeFilterValue) {
+  const setFilterValue = vi.fn();
+
+  function Harness() {
+    const [value, setValue] = useState<NumberRangeFilterValue | undefined>(initial);
+    const column = {
+      id: 'score',
+      getFilterValue: () => value,
+      setFilterValue: (next: unknown) => {
+        setFilterValue(next);
+        setValue(next as NumberRangeFilterValue | undefined);
+      },
+      columnDef: {
+        header: 'Score',
+        meta: { filter: numberRangeFilter('Score', { min: 0, max: 100, step: 1 }) },
+      },
+    };
+    return <NumberRangeFilterControl column={column as never} />;
+  }
+
+  render(<Harness />);
+  return { setFilterValue };
+}
+
+describe('numberRangeFilter', () => {
+  it('builds a custom filter def with the numberRange variant and bounds', () => {
+    expect(numberRangeFilter('Score')).toMatchObject({
+      label: 'Score',
+      type: 'custom',
+      filterVariant: 'numberRange',
+      min: 0,
+      max: 100,
+      step: 1,
+    });
+    expect(numberRangeFilter('Price', { min: 10, max: 500, step: 25 })).toMatchObject({
+      min: 10,
+      max: 500,
+      step: 25,
+    });
+  });
+
+  it('narrows only numberRange filters via the type guard', () => {
+    const dateLikeFilter = { type: 'custom', filterVariant: 'datetime' };
+    expect(isNumberRangeFilter(numberRangeFilter('Score'))).toBe(true);
+    expect(isNumberRangeFilter({ type: 'text' })).toBe(false);
+    expect(isNumberRangeFilter(dateLikeFilter)).toBe(false);
+    expect(isNumberRangeFilter(undefined)).toBe(false);
+  });
+
+  it('formats ranges, including open-ended ones', () => {
+    expect(formatNumberRange(10, 50)).toBe('10 – 50');
+    expect(formatNumberRange(10, undefined)).toBe('≥ 10');
+    expect(formatNumberRange(undefined, 50)).toBe('≤ 50');
+    expect(formatNumberRange(undefined, undefined)).toBe('');
+  });
+});
+
+describe('NumberRangeFilterControl', () => {
+  it('renders a two-thumb slider and min/max inputs', () => {
+    renderControl();
+
+    expect(screen.getAllByRole('slider')).toHaveLength(2);
+    expect(screen.getByPlaceholderText('Min')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Max')).toBeInTheDocument();
+  });
+
+  it('emits a $gte bound when the minimum is narrowed (on blur)', () => {
+    const { setFilterValue } = renderControl();
+
+    const min = screen.getByPlaceholderText('Min');
+    fireEvent.change(min, { target: { value: '20' } });
+    fireEvent.blur(min);
+
+    expect(setFilterValue).toHaveBeenLastCalledWith({ $gte: 20, $lte: undefined });
+  });
+
+  it('emits a $lte bound when the maximum is narrowed (on blur)', () => {
+    const { setFilterValue } = renderControl();
+
+    const max = screen.getByPlaceholderText('Max');
+    fireEvent.change(max, { target: { value: '80' } });
+    fireEvent.blur(max);
+
+    expect(setFilterValue).toHaveBeenLastCalledWith({ $gte: undefined, $lte: 80 });
+  });
+
+  it('commits on Enter as well as blur', () => {
+    const { setFilterValue } = renderControl();
+
+    const min = screen.getByPlaceholderText('Min');
+    fireEvent.change(min, { target: { value: '20' } });
+    fireEvent.keyDown(min, { key: 'Enter' });
+
+    expect(setFilterValue).toHaveBeenLastCalledWith({ $gte: 20, $lte: undefined });
+  });
+
+  it('clears the filter when both bounds return to the track extremes', () => {
+    const { setFilterValue } = renderControl({ $gte: 20 });
+
+    // The min input starts at 20; typing the track minimum opens the lower bound.
+    const min = screen.getByPlaceholderText('Min');
+    fireEvent.change(min, { target: { value: '0' } });
+    fireEvent.blur(min);
+
+    expect(setFilterValue).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it('clamps out-of-range input to the configured bounds', () => {
+    const { setFilterValue } = renderControl();
+
+    const max = screen.getByPlaceholderText('Max');
+    fireEvent.change(max, { target: { value: '999' } });
+    fireEvent.blur(max);
+
+    // 999 is clamped to the track maximum (100), which no longer narrows the range.
+    expect(setFilterValue).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it('orders an inverted entry instead of emitting an impossible range', () => {
+    const { setFilterValue } = renderControl();
+
+    const min = screen.getByPlaceholderText('Min');
+    const max = screen.getByPlaceholderText('Max');
+    fireEvent.change(min, { target: { value: '80' } });
+    fireEvent.change(max, { target: { value: '30' } });
+    fireEvent.blur(max);
+
+    // The bounds are ordered, never emitted as { $gte: 80, $lte: 30 }.
+    expect(setFilterValue).toHaveBeenLastCalledWith({ $gte: 30, $lte: 80 });
+    // ...and the inputs settle to the ordered values, matching the slider.
+    expect(min).toHaveValue(30);
+    expect(max).toHaveValue(80);
+  });
+});

--- a/web/packages/common/src/components/DataView/FilterPanel/NumberRangeFilter/index.tsx
+++ b/web/packages/common/src/components/DataView/FilterPanel/NumberRangeFilter/index.tsx
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  isNumberRangeFilter,
+  type NumberRangeFilterValue,
+} from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter/util';
+import type { DataViewColumn } from '@nemo/common/src/components/DataView/FilterPanel/types';
+import { Flex, RangeSlider, Stack, TextInput } from '@nvidia/foundations-react-core';
+import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
+
+const DEFAULT_BOUNDS = { min: 0, max: 100, step: 1 };
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+/**
+ * Numeric range filter control. Pairs a {@link RangeSlider} (top row) with two
+ * {@link TextInput} fields (min / max, in a {@link Flex} row) and stores its
+ * value as `{ $gte, $lte }` via the column's filter state.
+ *
+ * The slider and the inputs are two views of the same range: dragging a thumb
+ * updates the inputs live, while typing a bound previews on the slider and
+ * commits on blur / Enter. Bounds are ordered before being stored, so an
+ * inverted entry (min > max) is normalized rather than emitted as an impossible
+ * range. A bound is only emitted when it actually narrows the track, so the
+ * applied filter reads as `{ $gte }`, `{ $lte }`, both, or clears at the extremes.
+ *
+ * Use with {@link numberRangeFilter} in a column's `meta.filter`.
+ */
+export function NumberRangeFilterControl({ column }: { column: DataViewColumn }) {
+  const filterDef = column.columnDef.meta?.filter;
+  const { min, max, step } = isNumberRangeFilter(filterDef) ? filterDef : DEFAULT_BOUNDS;
+  const header = column.columnDef.header;
+  const label = filterDef?.label ?? (typeof header === 'string' ? header : column.id);
+
+  const committed = column.getFilterValue() as NumberRangeFilterValue | undefined;
+  const committedLower = committed?.$gte ?? min;
+  const committedUpper = committed?.$lte ?? max;
+
+  // Local string state lets users edit each field freely — including clearing it
+  // or typing partial values like "1." — without snapping back on every keystroke.
+  const [minText, setMinText] = useState(String(committedLower));
+  const [maxText, setMaxText] = useState(String(committedUpper));
+
+  const parseBound = useCallback(
+    (text: string, fallback: number): number => {
+      const trimmed = text.trim();
+      if (trimmed === '') return fallback;
+      const parsed = Number(trimmed);
+      return Number.isFinite(parsed) ? clamp(parsed, min, max) : fallback;
+    },
+    [min, max]
+  );
+
+  // Resync inputs when the committed value changes externally (an applied-filter
+  // chip being removed, a reset, a slider release). Skip when the field already
+  // parses to the committed value so in-progress typing is never clobbered.
+  useEffect(() => {
+    setMinText((curr) =>
+      parseBound(curr, min) === committedLower ? curr : String(committedLower)
+    );
+  }, [committedLower, parseBound, min]);
+  useEffect(() => {
+    setMaxText((curr) =>
+      parseBound(curr, max) === committedUpper ? curr : String(committedUpper)
+    );
+  }, [committedUpper, parseBound, max]);
+
+  const lower = parseBound(minText, min);
+  const upper = parseBound(maxText, max);
+  // The slider always renders two in-bounds, ascending thumbs.
+  const sliderValue: [number, number] = [Math.min(lower, upper), Math.max(lower, upper)];
+
+  // Orders the pair (so an inverted entry can't emit an impossible range) and
+  // keeps only a bound that narrows the track; clears the filter at the extremes.
+  const commit = useCallback(
+    (rawLower: number, rawUpper: number) => {
+      const nextLower = Math.min(rawLower, rawUpper);
+      const nextUpper = Math.max(rawLower, rawUpper);
+      const $gte = nextLower > min ? nextLower : undefined;
+      const $lte = nextUpper < max ? nextUpper : undefined;
+      column.setFilterValue($gte === undefined && $lte === undefined ? undefined : { $gte, $lte });
+    },
+    [column, min, max]
+  );
+
+  const handleSliderChange = ([nextLower, nextUpper]: [number, number]) => {
+    setMinText(String(nextLower));
+    setMaxText(String(nextUpper));
+  };
+
+  // The text inputs update live so the slider can preview the range, but the
+  // filter is committed on blur / Enter. Committing per keystroke while ordering
+  // would let the resync swap the two fields out from under the user mid-edit.
+  const applyTextEdit = () => {
+    const nextLower = Math.min(lower, upper);
+    const nextUpper = Math.max(lower, upper);
+    setMinText(String(nextLower));
+    setMaxText(String(nextUpper));
+    commit(nextLower, nextUpper);
+  };
+
+  const handleTextKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') applyTextEdit();
+  };
+
+  return (
+    <Stack gap="density-lg" data-testid={`column-filter-${column.id}`}>
+      <RangeSlider
+        aria-label={`${label} range`}
+        min={min}
+        max={max}
+        step={step}
+        value={sliderValue}
+        onValueChange={handleSliderChange}
+        onValueCommit={([nextLower, nextUpper]) => commit(nextLower, nextUpper)}
+      />
+      <Flex gap="2">
+        <TextInput
+          type="number"
+          aria-label={`${label} minimum`}
+          placeholder="Min"
+          value={minText}
+          onValueChange={(text) => setMinText(text)}
+          attributes={{
+            Input: {
+              min,
+              max,
+              step,
+              inputMode: 'numeric',
+              onBlur: applyTextEdit,
+              onKeyDown: handleTextKeyDown,
+            },
+          }}
+        />
+        <TextInput
+          type="number"
+          aria-label={`${label} maximum`}
+          placeholder="Max"
+          value={maxText}
+          onValueChange={(text) => setMaxText(text)}
+          attributes={{
+            Input: {
+              min,
+              max,
+              step,
+              inputMode: 'numeric',
+              onBlur: applyTextEdit,
+              onKeyDown: handleTextKeyDown,
+            },
+          }}
+        />
+      </Flex>
+    </Stack>
+  );
+}

--- a/web/packages/common/src/components/DataView/FilterPanel/NumberRangeFilter/util.ts
+++ b/web/packages/common/src/components/DataView/FilterPanel/NumberRangeFilter/util.ts
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+/**
+ * Filter value emitted by the numeric range filter. Mirrors the Mongo-style
+ * `$gte` / `$lte` operators used across NeMo Platform's unified filter syntax
+ * (see `@nemo/common/src/api/filterOperators`). Either bound may be omitted to
+ * express an open-ended range.
+ */
+export interface NumberRangeFilterValue {
+  /** Inclusive lower bound. Omitted when the range is open on the low end. */
+  $gte?: number;
+  /** Inclusive upper bound. Omitted when the range is open on the high end. */
+  $lte?: number;
+}
+
+interface NumberRangeColumnFilter {
+  label: string;
+  type: 'custom';
+  filterVariant: 'numberRange';
+  /** Lower bound of the slider track. */
+  min: number;
+  /** Upper bound of the slider track. */
+  max: number;
+  /** Stepping interval for the slider and the min/max inputs. */
+  step: number;
+  renderFilter: () => React.JSX.Element;
+}
+
+export interface NumberRangeFilterConfig {
+  /** Lower bound of the slider track. @defaultValue 0 */
+  min?: number;
+  /** Upper bound of the slider track. @defaultValue 100 */
+  max?: number;
+  /** Stepping interval for the slider and the min/max inputs. @defaultValue 1 */
+  step?: number;
+}
+
+/**
+ * Creates a numeric range filter definition for use in column `meta.filter`.
+ *
+ * Renders a RangeSlider above paired min/max inputs and stores its value as a
+ * `{ $gte, $lte }` object, the same shape consumed by the platform's filter
+ * endpoints. Bounds default to a 0–100 track with a step of 1.
+ */
+export function numberRangeFilter(
+  label: string,
+  { min = 0, max = 100, step = 1 }: NumberRangeFilterConfig = {}
+): NumberRangeColumnFilter {
+  return {
+    label,
+    type: 'custom',
+    filterVariant: 'numberRange',
+    min,
+    max,
+    step,
+    // Placeholder: number-range columns are dispatched via `isNumberRangeFilter`
+    // in ColumnFilterPanel, so this factory output never renders through `renderFilter`.
+    // Kept as a JSX-free Fragment so this stays a `.ts` module.
+    renderFilter: () => React.createElement(React.Fragment),
+  };
+}
+
+/** Type guard: checks whether a filter def is a numeric range filter. */
+export function isNumberRangeFilter(
+  filter: { type: string } | undefined | null
+): filter is NumberRangeColumnFilter {
+  return (
+    filter != null &&
+    filter.type === 'custom' &&
+    'filterVariant' in filter &&
+    (filter as NumberRangeColumnFilter).filterVariant === 'numberRange'
+  );
+}
+
+/**
+ * Formats a `{ $gte, $lte }` numeric range into a readable string for applied
+ * filter chips. Open-ended ranges render with a single comparator.
+ *
+ * - both bounds: `"10 – 50"`
+ * - lower only: `"≥ 10"`
+ * - upper only: `"≤ 50"`
+ * - neither: `""`
+ */
+export function formatNumberRange(gte?: number, lte?: number): string {
+  const format = (value: number) => value.toLocaleString();
+  if (gte != null && lte != null) return `${format(gte)} – ${format(lte)}`;
+  if (gte != null) return `≥ ${format(gte)}`;
+  if (lte != null) return `≤ ${format(lte)}`;
+  return '';
+}

--- a/web/packages/common/src/components/DataView/FilterPanel/index.ts
+++ b/web/packages/common/src/components/DataView/FilterPanel/index.ts
@@ -11,5 +11,6 @@ export { BooleanFilterControl } from '@nemo/common/src/components/DataView/Filte
 export { SingleSelectFilterControl } from '@nemo/common/src/components/DataView/FilterPanel/SingleSelectFilter';
 export { MultiSelectFilterControl } from '@nemo/common/src/components/DataView/FilterPanel/MultiSelectFilter';
 export { DateTimeFilterControl } from '@nemo/common/src/components/DataView/FilterPanel/DateRangeFilter';
+export { NumberRangeFilterControl } from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter';
 export { CustomFilterControl } from '@nemo/common/src/components/DataView/FilterPanel/CustomFilter';
 export { FilterPanel } from '@nemo/common/src/components/DataView/FilterPanel/FilterPanel';

--- a/web/packages/common/src/components/DataView/StudioAppliedFilters.test.tsx
+++ b/web/packages/common/src/components/DataView/StudioAppliedFilters.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { dateTimeFilter } from '@nemo/common/src/components/DataView/dateTimeFilter';
+import { numberRangeFilter } from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter/util';
 import { StudioAppliedFilters } from '@nemo/common/src/components/DataView/StudioAppliedFilters';
 import { render, screen, fireEvent } from '@testing-library/react';
 
@@ -160,6 +161,34 @@ describe('StudioAppliedFilters', () => {
     expect(screen.getByText('Created At:')).toBeInTheDocument();
     // formatDateRange produces locale-dependent output; verify the tag container includes a date
     expect(screen.getByRole('button', { name: /Created At:.*1\/1\/2024/ })).toBeInTheDocument();
+  });
+
+  it('renders a tag for a numeric range filter with formatted bounds', () => {
+    const { column } = makeColumn('duration', {
+      filterValue: { $gte: 30, $lte: 480 },
+      header: 'Duration',
+      meta: { filter: numberRangeFilter('Duration (minutes)', { min: 0, max: 600, step: 15 }) },
+    });
+    mockColumns.set('duration', column);
+
+    render(<StudioAppliedFilters />);
+
+    expect(screen.getByText('Duration (minutes):')).toBeInTheDocument();
+    expect(screen.getByText('30 – 480')).toBeInTheDocument();
+  });
+
+  it('renders a tag for an open-ended numeric range filter (lower bound only)', () => {
+    const { column } = makeColumn('cost', {
+      filterValue: { $gte: 10 },
+      header: 'Cost',
+      meta: { filter: numberRangeFilter('Cost (USD)', { min: 0, max: 50, step: 1 }) },
+    });
+    mockColumns.set('cost', column);
+
+    render(<StudioAppliedFilters />);
+
+    expect(screen.getByText('Cost (USD):')).toBeInTheDocument();
+    expect(screen.getByText('≥ 10')).toBeInTheDocument();
   });
 
   it('renders Clear Filters button that calls table.setColumnFilters([])', () => {

--- a/web/packages/common/src/components/DataView/StudioAppliedFilters.tsx
+++ b/web/packages/common/src/components/DataView/StudioAppliedFilters.tsx
@@ -6,6 +6,11 @@ import {
   type DatetimeFilterValue,
 } from '@nemo/common/src/components/DataView/dateTimeFilter';
 import {
+  formatNumberRange,
+  isNumberRangeFilter,
+  type NumberRangeFilterValue,
+} from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter/util';
+import {
   useInnerDataViewContext,
   type TanstackTable,
 } from '@nemo/common/src/components/DataView/internal';
@@ -28,6 +33,11 @@ function formatFilterValue(column: DataViewColumn): string {
   if (isDateTimeFilter(filter)) {
     const dt = value as DatetimeFilterValue | undefined;
     return formatDateRange(dt?.$gte, dt?.$lte);
+  }
+
+  if (isNumberRangeFilter(filter)) {
+    const range = value as NumberRangeFilterValue | undefined;
+    return formatNumberRange(range?.$gte, range?.$lte);
   }
 
   if (typeof value === 'string') {


### PR DESCRIPTION

https://github.com/user-attachments/assets/f8ad1a86-9150-40a7-bafc-fdc8ab421903

<img width="711" height="122" alt="Screenshot 2026-07-01 at 9 57 31 AM" src="https://github.com/user-attachments/assets/91659bc7-c27a-416c-ba1d-5818cc04ca06" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for numeric range filtering in data views, including a slider and min/max inputs.
  * Filter chips and applied filter text now display numeric ranges in a clearer format.
  * Added Storybook examples for basic, custom-bound, and in-data-view range filtering.

* **Bug Fixes**
  * Improved range handling so values are clamped, normalized, and cleared correctly when they match default bounds.
  * Fixed formatting for range filters so active filters show the expected bounds instead of generic text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->