### PR TITLE
feat(deployments): K8s Job workloads (AIRCORE-757 phase 3)

### DIFF
--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/backend.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Kubernetes substrate backend for the deployments plugin (scaffold)."""
+"""Kubernetes substrate backend for the deployments plugin."""
 
 from __future__ import annotations
 
@@ -14,9 +14,13 @@ from nemo_deployments_plugin.backends.base import (
     LogResult,
     VolumeStatusUpdate,
 )
+from nemo_deployments_plugin.backends.k8s import jobs as job_ops
 from nemo_deployments_plugin.backends.k8s import volumes as volume_ops
 from nemo_deployments_plugin.backends.k8s.client import KubernetesClients
 from nemo_deployments_plugin.backends.k8s.config import K8sExecutorConfig
+from nemo_deployments_plugin.entities import Deployment, DeploymentConfig
+from nemo_platform.resources.entities import AsyncEntitiesResource
+from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +33,8 @@ _K8S_INSTALL_HINT = (
 class K8sDeploymentBackend(DeploymentBackend):
     """Manage deployments and volumes as native Kubernetes objects.
 
-    Lifecycle methods not yet implemented raise ``NotImplementedError`` (not ``...``) so
-    accidental calls fail loudly during phased rollout; ``...`` is for ``@abstractmethod``
-    stubs on the ABC itself.
+    Job-backed deployments (``restart_policy`` Never/OnFailure) are implemented in phase 3.
+    Deployment + Service (Always) and full PodSpec compilation land in later phases.
     """
 
     _clients: KubernetesClients
@@ -47,6 +50,7 @@ class K8sDeploymentBackend(DeploymentBackend):
             kubeconfig_path=self._executor_config.kubeconfig_path,
             request_timeout=self._executor_config.request_timeout,
         )
+        self._entities = NemoEntitiesClient(AsyncEntitiesResource(self._sdk))
         logger.debug(
             "K8sDeploymentBackend initialized (default_namespace=%s)",
             self._executor_config.default_namespace,
@@ -64,6 +68,19 @@ class K8sDeploymentBackend(DeploymentBackend):
     def clients(self) -> KubernetesClients:
         return self._clients
 
+    async def _load_deployment_config(self, workspace: str, config_name: str) -> DeploymentConfig:
+        return await self._entities.get(DeploymentConfig, config_name, workspace=workspace)
+
+    async def _load_deployment_context(
+        self,
+        workspace: str,
+        name: str,
+    ) -> tuple[Deployment, DeploymentConfig, dict[str, Any]]:
+        deployment = await self._entities.get(Deployment, name, workspace=workspace)
+        config = await self._load_deployment_config(workspace, deployment.deployment_config)
+        backend_config = config.backend_config.model_dump(by_alias=True, exclude_none=True)
+        return deployment, config, backend_config
+
     async def create_deployment(
         self,
         *,
@@ -73,16 +90,80 @@ class K8sDeploymentBackend(DeploymentBackend):
         labels: dict[str, str],
         backend_config: dict[str, Any],
     ) -> BackendStatusUpdate:
-        raise NotImplementedError("K8s create_deployment is implemented in a later phase.")
+        try:
+            config = await self._load_deployment_config(workspace, config_name)
+        except NemoEntityNotFoundError:
+            return BackendStatusUpdate(
+                status="FAILED",
+                status_message=f"DeploymentConfig '{config_name}' not found in workspace '{workspace}'",
+            )
+        except Exception as exc:
+            logger.exception("Failed to load deployment config %s/%s", workspace, config_name)
+            return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment config: {exc}")
+
+        if config.restart_policy == "Always":
+            raise NotImplementedError("K8s Deployment+Service for restart_policy Always is implemented in phase 4.")
+
+        return await job_ops.create_job(
+            self._clients,
+            default_namespace=self._executor_config.default_namespace,
+            workspace=workspace,
+            name=name,
+            config_name=config_name,
+            labels=labels,
+            backend_config=backend_config,
+            config=config,
+        )
 
     async def read_status(self, *, workspace: str, name: str) -> BackendStatusUpdate:
-        raise NotImplementedError("K8s read_status is implemented in a later phase.")
+        try:
+            _, config, backend_config = await self._load_deployment_context(workspace, name)
+        except NemoEntityNotFoundError:
+            return BackendStatusUpdate(
+                status="FAILED",
+                status_message=f"Deployment '{name}' not found in workspace '{workspace}'",
+            )
+        except Exception as exc:
+            return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment: {exc}")
+
+        if config.restart_policy == "Always":
+            raise NotImplementedError("K8s read_status for restart_policy Always is implemented in phase 4.")
+
+        return await job_ops.read_job_status(
+            self._clients,
+            default_namespace=self._executor_config.default_namespace,
+            workspace=workspace,
+            name=name,
+            backend_config=backend_config,
+        )
 
     async def delete_deployment(self, workspace: str, name: str) -> BackendStatusUpdate:
-        raise NotImplementedError("K8s delete_deployment is implemented in a later phase.")
+        try:
+            _, config, backend_config = await self._load_deployment_context(workspace, name)
+        except NemoEntityNotFoundError:
+            return BackendStatusUpdate(
+                status="SUCCEEDED",
+                status_message=f"Deployment '{name}' entity already removed",
+            )
+        except Exception as exc:
+            return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment: {exc}")
+
+        if config.restart_policy == "Always":
+            raise NotImplementedError("K8s delete_deployment for restart_policy Always is implemented in phase 4.")
+
+        return await job_ops.delete_job(
+            self._clients,
+            default_namespace=self._executor_config.default_namespace,
+            workspace=workspace,
+            name=name,
+            backend_config=backend_config,
+        )
 
     async def list_managed_deployment_names(self) -> list[str]:
-        raise NotImplementedError("K8s list_managed_deployment_names is implemented in a later phase.")
+        return await job_ops.list_managed_job_names(
+            self._clients,
+            default_namespace=self._executor_config.default_namespace,
+        )
 
     async def get_logs(
         self,
@@ -91,7 +172,24 @@ class K8sDeploymentBackend(DeploymentBackend):
         name: str,
         tail: int = 100,
     ) -> LogResult:
-        raise NotImplementedError("K8s get_logs is implemented in a later phase.")
+        try:
+            _, config, backend_config = await self._load_deployment_context(workspace, name)
+        except NemoEntityNotFoundError:
+            return LogResult(lines=[f"Deployment '{name}' not found in workspace '{workspace}'"])
+        except Exception as exc:
+            return LogResult(lines=[f"Failed to load deployment: {exc}"])
+
+        if config.restart_policy == "Always":
+            raise NotImplementedError("K8s get_logs for restart_policy Always is implemented in phase 4.")
+
+        return await job_ops.get_job_logs(
+            self._clients,
+            default_namespace=self._executor_config.default_namespace,
+            workspace=workspace,
+            name=name,
+            backend_config=backend_config,
+            tail=tail,
+        )
 
     async def create_volume(
         self,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/backend.py
@@ -18,6 +18,7 @@ from nemo_deployments_plugin.backends.k8s import jobs as job_ops
 from nemo_deployments_plugin.backends.k8s import volumes as volume_ops
 from nemo_deployments_plugin.backends.k8s.client import KubernetesClients
 from nemo_deployments_plugin.backends.k8s.config import K8sExecutorConfig
+from nemo_deployments_plugin.backends.labels import deployment_identity_labels
 from nemo_deployments_plugin.entities import Deployment, DeploymentConfig
 from nemo_platform.resources.entities import AsyncEntitiesResource
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
@@ -136,6 +137,9 @@ class K8sDeploymentBackend(DeploymentBackend):
             workspace=workspace,
             name=name,
             backend_config=backend_config,
+            config_name=config.name,
+            restart_policy=config.restart_policy,
+            backoff_limit=config.backoff_limit,
         )
 
     async def delete_deployment(self, workspace: str, name: str) -> BackendStatusUpdate:
@@ -148,6 +152,7 @@ class K8sDeploymentBackend(DeploymentBackend):
                 workspace=workspace,
                 name=name,
                 backend_config={},
+                expected_labels=job_ops.deployment_scope_labels(workspace, name),
             )
         except Exception as exc:
             return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment: {exc}")
@@ -161,6 +166,13 @@ class K8sDeploymentBackend(DeploymentBackend):
             workspace=workspace,
             name=name,
             backend_config=backend_config,
+            expected_labels=deployment_identity_labels(
+                workspace,
+                name,
+                config.restart_policy,
+                config_name=config.name,
+                backoff_limit=config.backoff_limit,
+            ),
         )
 
     async def list_managed_deployment_names(self) -> list[str]:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/backend.py
@@ -28,6 +28,7 @@ _K8S_INSTALL_HINT = (
     "kubernetes package is required for K8sDeploymentBackend. "
     "Install with: uv sync --package nemo-deployments-plugin --extra k8s"
 )
+_ALWAYS_POLICY_MESSAGE = "restart_policy Always requires Deployment+Service support (AIRCORE-757 phase 4)"
 
 
 class K8sDeploymentBackend(DeploymentBackend):
@@ -102,7 +103,7 @@ class K8sDeploymentBackend(DeploymentBackend):
             return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment config: {exc}")
 
         if config.restart_policy == "Always":
-            raise NotImplementedError("K8s Deployment+Service for restart_policy Always is implemented in phase 4.")
+            return BackendStatusUpdate(status="FAILED", status_message=_ALWAYS_POLICY_MESSAGE)
 
         return await job_ops.create_job(
             self._clients,
@@ -127,7 +128,7 @@ class K8sDeploymentBackend(DeploymentBackend):
             return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment: {exc}")
 
         if config.restart_policy == "Always":
-            raise NotImplementedError("K8s read_status for restart_policy Always is implemented in phase 4.")
+            return BackendStatusUpdate(status="FAILED", status_message=_ALWAYS_POLICY_MESSAGE)
 
         return await job_ops.read_job_status(
             self._clients,
@@ -141,15 +142,18 @@ class K8sDeploymentBackend(DeploymentBackend):
         try:
             _, config, backend_config = await self._load_deployment_context(workspace, name)
         except NemoEntityNotFoundError:
-            return BackendStatusUpdate(
-                status="SUCCEEDED",
-                status_message=f"Deployment '{name}' entity already removed",
+            return await job_ops.delete_job(
+                self._clients,
+                default_namespace=self._executor_config.default_namespace,
+                workspace=workspace,
+                name=name,
+                backend_config={},
             )
         except Exception as exc:
             return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment: {exc}")
 
         if config.restart_policy == "Always":
-            raise NotImplementedError("K8s delete_deployment for restart_policy Always is implemented in phase 4.")
+            return BackendStatusUpdate(status="FAILED", status_message=_ALWAYS_POLICY_MESSAGE)
 
         return await job_ops.delete_job(
             self._clients,
@@ -180,7 +184,7 @@ class K8sDeploymentBackend(DeploymentBackend):
             return LogResult(lines=[f"Failed to load deployment: {exc}"])
 
         if config.restart_policy == "Always":
-            raise NotImplementedError("K8s get_logs for restart_policy Always is implemented in phase 4.")
+            return LogResult(lines=[_ALWAYS_POLICY_MESSAGE])
 
         return await job_ops.get_job_logs(
             self._clients,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/client.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/client.py
@@ -5,7 +5,7 @@
 
 Copied from the jobs service pattern; tagged for future extraction to a shared substrate lib.
 
-Imports are centralized in ``_kubernetes_modules()`` rather than hoisted to module scope so
+Imports are centralized in ``k8s_client_module()`` rather than hoisted to module scope so
 ``registry`` can load without requiring the optional ``kubernetes`` package until a k8s
 executor is actually constructed.
 """
@@ -21,6 +21,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _kubernetes_modules_cache: tuple[Any, Any] | None = None
+_k8s_client_module: _KubernetesClientModule | None = None
+
+
+class _KubernetesClientModule:
+    """Lazy facade for ``kubernetes.client`` model constructors."""
+
+    __slots__ = ("_client",)
+
+    def __init__(self) -> None:
+        self._client: Any | None = None
+
+    @property
+    def client(self) -> Any:
+        if self._client is None:
+            client, _ = _kubernetes_modules()
+            self._client = client
+        return self._client
 
 
 def _kubernetes_modules() -> tuple[Any, Any]:
@@ -31,6 +48,14 @@ def _kubernetes_modules() -> tuple[Any, Any]:
 
         _kubernetes_modules_cache = (client, config)
     return _kubernetes_modules_cache
+
+
+def k8s_client_module() -> _KubernetesClientModule:
+    """Return lazy access to ``kubernetes.client`` for building API objects."""
+    global _k8s_client_module
+    if _k8s_client_module is None:
+        _k8s_client_module = _KubernetesClientModule()
+    return _k8s_client_module
 
 
 def build_api_client(*, kubeconfig_path: str | None = None) -> ApiClient:
@@ -76,22 +101,19 @@ class KubernetesClients:
     @property
     def core_v1(self) -> CoreV1Api:
         if self._core_v1 is None:
-            client, _ = _kubernetes_modules()
-            self._core_v1 = client.CoreV1Api(self._api())
+            self._core_v1 = k8s_client_module().client.CoreV1Api(self._api())
         return self._core_v1
 
     @property
     def apps_v1(self) -> AppsV1Api:
         if self._apps_v1 is None:
-            client, _ = _kubernetes_modules()
-            self._apps_v1 = client.AppsV1Api(self._api())
+            self._apps_v1 = k8s_client_module().client.AppsV1Api(self._api())
         return self._apps_v1
 
     @property
     def batch_v1(self) -> BatchV1Api:
         if self._batch_v1 is None:
-            client, _ = _kubernetes_modules()
-            self._batch_v1 = client.BatchV1Api(self._api())
+            self._batch_v1 = k8s_client_module().client.BatchV1Api(self._api())
         return self._batch_v1
 
     def close(self) -> None:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
@@ -47,9 +47,21 @@ def resolve_k8s_deployment_config(backend_config: dict[str, Any]) -> K8sDeployme
 
 
 def resolve_deployment_namespace(*, default_namespace: str, k8s_config: K8sDeploymentConfig | None) -> str:
+    """Resolve target namespace from parsed k8s deployment config."""
     if k8s_config is None or not k8s_config.namespace:
         return default_namespace
     return k8s_config.namespace
+
+
+def restart_policy_from_labels(job_labels: dict[str, str], *, default: RestartPolicy = "Never") -> RestartPolicy:
+    value = job_labels.get(RESTART_POLICY_LABEL, default)
+    if value == "Never":
+        return "Never"
+    if value == "OnFailure":
+        return "OnFailure"
+    if value == "Always":
+        return "Always"
+    return default
 
 
 def validate_config_for_job(config: DeploymentConfig) -> Container:
@@ -173,6 +185,40 @@ def build_job_body(
     )
 
 
+async def read_pod_exit_code(
+    clients: KubernetesClients,
+    *,
+    namespace: str,
+    job_name: str,
+) -> int | None:
+    """Best-effort container exit code from the Job's most recent pod."""
+    timeout = clients.request_timeout
+    core_v1 = clients.core_v1
+
+    def _read() -> int | None:
+        pods = core_v1.list_namespaced_pod(
+            namespace=namespace,
+            label_selector=f"job-name={job_name}",
+            _request_timeout=timeout,
+        )
+        if not pods.items:
+            return None
+        pod = pods.items[-1]
+        if pod.status is None or not pod.status.container_statuses:
+            return None
+        for container_status in pod.status.container_statuses:
+            terminated = container_status.state.terminated if container_status.state else None
+            if terminated is not None:
+                return int(terminated.exit_code)
+        return None
+
+    try:
+        return await asyncio.to_thread(_read)
+    except Exception:
+        logger.debug("Could not read exit code for Job %s", job_name, exc_info=True)
+        return None
+
+
 async def create_job(
     clients: KubernetesClients,
     *,
@@ -224,12 +270,12 @@ async def create_job(
                 raise
 
         job = await asyncio.to_thread(_create)
-        return status_from_job(
-            job=job,
-            job_name=job_name,
-            expected_labels=identity_labels,
-            restart_policy=config.restart_policy,
-        )
+        update = status_from_job(job=job, job_name=job_name, expected_labels=identity_labels)
+        if update.status in ("SUCCEEDED", "FAILED"):
+            exit_code = await read_pod_exit_code(clients, namespace=namespace, job_name=job_name)
+            if exit_code is not None:
+                update = update.model_copy(update={"exit_code": exit_code})
+        return update
     except DeploymentConfigError as exc:
         return BackendStatusUpdate(status="FAILED", status_message=str(exc))
     except Exception as exc:
@@ -267,7 +313,7 @@ async def read_job_status(
                 status="FAILED",
                 status_message=f"Job {job_name} is missing deployment config identity labels",
             )
-        restart_policy: RestartPolicy = job_labels.get(RESTART_POLICY_LABEL, "Never")  # type: ignore[assignment]
+        restart_policy = restart_policy_from_labels(job_labels)
         read_expected = deployment_identity_labels(
             workspace,
             name,
@@ -275,12 +321,12 @@ async def read_job_status(
             config_name=config_name,
             backoff_limit=int(job_labels.get(BACKOFF_LIMIT_LABEL, "6")),
         )
-        return status_from_job(
-            job=job,
-            job_name=job_name,
-            expected_labels=read_expected,
-            restart_policy=restart_policy,
-        )
+        update = status_from_job(job=job, job_name=job_name, expected_labels=read_expected)
+        if update.status in ("SUCCEEDED", "FAILED"):
+            exit_code = await read_pod_exit_code(clients, namespace=namespace, job_name=job_name)
+            if exit_code is not None:
+                update = update.model_copy(update={"exit_code": exit_code})
+        return update
     except ApiException as exc:
         if exc.status == 404:
             return missing_job_status(job_name=job_name)

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from kubernetes.client.rest import ApiException
 from nemo_deployments_plugin.backends.base import BackendStatusUpdate, LogResult
-from nemo_deployments_plugin.backends.k8s.client import KubernetesClients, _kubernetes_modules
+from nemo_deployments_plugin.backends.k8s.client import KubernetesClients, k8s_client_module
 from nemo_deployments_plugin.backends.k8s.status import (
     LOG_MAX_CHARS,
     missing_job_status,
@@ -97,12 +97,12 @@ def validate_config_for_job(config: DeploymentConfig) -> Container:
 
 
 def merged_volume_mounts(config: DeploymentConfig, container: Container) -> list[VolumeMount]:
-    by_name: dict[str, VolumeMount] = {}
+    mounts_by_name: dict[str, VolumeMount] = {}
     for mount in config.volume_mounts:
-        by_name[mount.name] = mount
+        mounts_by_name[mount.name] = mount
     for mount in container.volume_mounts:
-        by_name[mount.name] = mount
-    return list(by_name.values())
+        mounts_by_name[mount.name] = mount
+    return list(mounts_by_name.values())
 
 
 def job_backoff_limit(config: DeploymentConfig) -> int:
@@ -112,8 +112,8 @@ def job_backoff_limit(config: DeploymentConfig) -> int:
 
 
 def build_env_vars(container: Container) -> list[Any]:
-    client, _ = _kubernetes_modules()
-    return [client.V1EnvVar(name=item.name, value=item.value) for item in container.env if item.value is not None]
+    k8s = k8s_client_module()
+    return [k8s.client.V1EnvVar(name=item.name, value=item.value) for item in container.env if item.value is not None]
 
 
 def build_resource_requirements(container: Container) -> Any | None:
@@ -121,18 +121,18 @@ def build_resource_requirements(container: Container) -> Any | None:
     requests = container.resources.requests or None
     if not limits and not requests:
         return None
-    client, _ = _kubernetes_modules()
-    return client.V1ResourceRequirements(limits=limits, requests=requests)
+    k8s = k8s_client_module()
+    return k8s.client.V1ResourceRequirements(limits=limits, requests=requests)
 
 
 def build_pod_volumes(*, workspace: str, mounts: list[VolumeMount]) -> list[Any]:
     if not mounts:
         return []
-    client, _ = _kubernetes_modules()
+    k8s = k8s_client_module()
     return [
-        client.V1Volume(
+        k8s.client.V1Volume(
             name=mount.name,
-            persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
+            persistent_volume_claim=k8s.client.V1PersistentVolumeClaimVolumeSource(
                 claim_name=k8s_volume_resource_name(workspace, mount.name),
             ),
         )
@@ -143,9 +143,9 @@ def build_pod_volumes(*, workspace: str, mounts: list[VolumeMount]) -> list[Any]
 def build_volume_mounts(mounts: list[VolumeMount]) -> list[Any]:
     if not mounts:
         return []
-    client, _ = _kubernetes_modules()
+    k8s = k8s_client_module()
     return [
-        client.V1VolumeMount(
+        k8s.client.V1VolumeMount(
             name=mount.name,
             mount_path=mount.mount_path,
             read_only=mount.read_only,
@@ -156,7 +156,7 @@ def build_volume_mounts(mounts: list[VolumeMount]) -> list[Any]:
 
 
 def build_container_spec(container: Container, *, volume_mounts: list[VolumeMount] | None = None) -> Any:
-    client, _ = _kubernetes_modules()
+    k8s = k8s_client_module()
     kwargs: dict[str, Any] = {
         "name": container.name,
         "image": container.image,
@@ -169,7 +169,7 @@ def build_container_spec(container: Container, *, volume_mounts: list[VolumeMoun
         kwargs["args"] = list(container.args)
     if volume_mounts:
         kwargs["volume_mounts"] = build_volume_mounts(volume_mounts)
-    return client.V1Container(**kwargs)
+    return k8s.client.V1Container(**kwargs)
 
 
 def build_job_body(
@@ -181,7 +181,7 @@ def build_job_body(
     workspace: str,
 ) -> Any:
     """Build a ``batch/v1.Job`` for create."""
-    client, _ = _kubernetes_modules()
+    k8s = k8s_client_module()
     mounts = merged_volume_mounts(config, container)
     pod_spec_kwargs: dict[str, Any] = {
         "restart_policy": config.restart_policy,
@@ -191,15 +191,15 @@ def build_job_body(
     if volumes:
         pod_spec_kwargs["volumes"] = volumes
 
-    return client.V1Job(
+    return k8s.client.V1Job(
         api_version="batch/v1",
         kind="Job",
-        metadata=client.V1ObjectMeta(name=job_name, labels=labels),
-        spec=client.V1JobSpec(
+        metadata=k8s.client.V1ObjectMeta(name=job_name, labels=labels),
+        spec=k8s.client.V1JobSpec(
             backoff_limit=job_backoff_limit(config),
-            template=client.V1PodTemplateSpec(
-                metadata=client.V1ObjectMeta(labels=labels),
-                spec=client.V1PodSpec(**pod_spec_kwargs),
+            template=k8s.client.V1PodTemplateSpec(
+                metadata=k8s.client.V1ObjectMeta(labels=labels),
+                spec=k8s.client.V1PodSpec(**pod_spec_kwargs),
             ),
         ),
     )

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
@@ -1,0 +1,399 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Kubernetes Job lifecycle helpers for finite deployments (Never / OnFailure)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from kubernetes.client.rest import ApiException
+from nemo_deployments_plugin.backends.base import BackendStatusUpdate, LogResult
+from nemo_deployments_plugin.backends.k8s.client import KubernetesClients, _kubernetes_modules
+from nemo_deployments_plugin.backends.k8s.status import (
+    LOG_MAX_CHARS,
+    missing_job_status,
+    status_from_job,
+)
+from nemo_deployments_plugin.backends.labels import (
+    BACKOFF_LIMIT_LABEL,
+    CONFIG_NAME_LABEL,
+    DEPLOYMENT_NAME_LABEL,
+    DEPLOYMENT_WORKSPACE_LABEL,
+    RESTART_POLICY_LABEL,
+    deployment_identity_labels,
+    k8s_deployment_resource_name,
+    k8s_volume_resource_name,
+    managed_by_label_selector,
+)
+from nemo_deployments_plugin.entities import Container, DeploymentConfig, K8sDeploymentConfig, VolumeMount
+from nemo_deployments_plugin.types import RestartPolicy
+
+logger = logging.getLogger(__name__)
+
+
+class DeploymentConfigError(ValueError):
+    """Invalid deployment config for k8s Job backend."""
+
+
+def resolve_k8s_deployment_config(backend_config: dict[str, Any]) -> K8sDeploymentConfig | None:
+    """Parse and validate the k8s section of entity backend_config."""
+    k8s_section = backend_config.get("k8s")
+    if not k8s_section:
+        return None
+    return K8sDeploymentConfig.model_validate(k8s_section)
+
+
+def resolve_deployment_namespace(*, default_namespace: str, k8s_config: K8sDeploymentConfig | None) -> str:
+    if k8s_config is None or not k8s_config.namespace:
+        return default_namespace
+    return k8s_config.namespace
+
+
+def validate_config_for_job(config: DeploymentConfig) -> Container:
+    """Return the sole container spec for a Job-backed deployment."""
+    if config.init_containers:
+        raise DeploymentConfigError("init_containers are not supported by the k8s Job backend in this phase")
+    if len(config.containers) != 1:
+        raise DeploymentConfigError(f"k8s Job backend supports exactly one container; got {len(config.containers)}")
+    if config.restart_policy == "Always":
+        raise DeploymentConfigError("restart_policy Always uses Deployment, not Job")
+    return config.containers[0]
+
+
+def merged_volume_mounts(config: DeploymentConfig, container: Container) -> list[VolumeMount]:
+    by_name: dict[str, VolumeMount] = {}
+    for mount in config.volume_mounts:
+        by_name[mount.name] = mount
+    for mount in container.volume_mounts:
+        by_name[mount.name] = mount
+    return list(by_name.values())
+
+
+def job_backoff_limit(config: DeploymentConfig) -> int:
+    if config.restart_policy == "Never":
+        return 0
+    return config.backoff_limit
+
+
+def build_env_vars(container: Container) -> list[Any]:
+    client, _ = _kubernetes_modules()
+    return [client.V1EnvVar(name=item.name, value=item.value) for item in container.env if item.value is not None]
+
+
+def build_resource_requirements(container: Container) -> Any | None:
+    limits = container.resources.limits or None
+    requests = container.resources.requests or None
+    if not limits and not requests:
+        return None
+    client, _ = _kubernetes_modules()
+    return client.V1ResourceRequirements(limits=limits, requests=requests)
+
+
+def build_pod_volumes(*, workspace: str, mounts: list[VolumeMount]) -> list[Any]:
+    if not mounts:
+        return []
+    client, _ = _kubernetes_modules()
+    return [
+        client.V1Volume(
+            name=mount.name,
+            persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
+                claim_name=k8s_volume_resource_name(workspace, mount.name),
+            ),
+        )
+        for mount in mounts
+    ]
+
+
+def build_volume_mounts(mounts: list[VolumeMount]) -> list[Any]:
+    if not mounts:
+        return []
+    client, _ = _kubernetes_modules()
+    return [
+        client.V1VolumeMount(
+            name=mount.name,
+            mount_path=mount.mount_path,
+            read_only=mount.read_only,
+            sub_path=mount.sub_path,
+        )
+        for mount in mounts
+    ]
+
+
+def build_container_spec(container: Container, *, volume_mounts: list[VolumeMount] | None = None) -> Any:
+    client, _ = _kubernetes_modules()
+    command: list[str] | None = None
+    if container.command or container.args:
+        command = list(container.command) + list(container.args)
+    kwargs: dict[str, Any] = {
+        "name": container.name,
+        "image": container.image,
+        "env": build_env_vars(container) or None,
+        "resources": build_resource_requirements(container),
+    }
+    if command:
+        kwargs["command"] = command
+    if volume_mounts:
+        kwargs["volume_mounts"] = build_volume_mounts(volume_mounts)
+    return client.V1Container(**kwargs)
+
+
+def build_job_body(
+    *,
+    job_name: str,
+    labels: dict[str, str],
+    config: DeploymentConfig,
+    container: Container,
+    workspace: str,
+) -> Any:
+    """Build a ``batch/v1.Job`` for create."""
+    client, _ = _kubernetes_modules()
+    mounts = merged_volume_mounts(config, container)
+    pod_spec_kwargs: dict[str, Any] = {
+        "restart_policy": "Never",
+        "containers": [build_container_spec(container, volume_mounts=mounts or None)],
+    }
+    volumes = build_pod_volumes(workspace=workspace, mounts=mounts)
+    if volumes:
+        pod_spec_kwargs["volumes"] = volumes
+
+    return client.V1Job(
+        api_version="batch/v1",
+        kind="Job",
+        metadata=client.V1ObjectMeta(name=job_name, labels=labels),
+        spec=client.V1JobSpec(
+            backoff_limit=job_backoff_limit(config),
+            template=client.V1PodTemplateSpec(
+                metadata=client.V1ObjectMeta(labels=labels),
+                spec=client.V1PodSpec(**pod_spec_kwargs),
+            ),
+        ),
+    )
+
+
+async def create_job(
+    clients: KubernetesClients,
+    *,
+    default_namespace: str,
+    workspace: str,
+    name: str,
+    config_name: str,
+    labels: dict[str, str],
+    backend_config: dict[str, Any],
+    config: DeploymentConfig,
+) -> BackendStatusUpdate:
+    job_name = k8s_deployment_resource_name(workspace, name)
+    try:
+        container = validate_config_for_job(config)
+        k8s_config = resolve_k8s_deployment_config(backend_config)
+        namespace = resolve_deployment_namespace(default_namespace=default_namespace, k8s_config=k8s_config)
+        identity_labels = deployment_identity_labels(
+            workspace,
+            name,
+            config.restart_policy,
+            config_name=config_name,
+            backoff_limit=config.backoff_limit,
+        )
+        all_labels = {**labels, **config.labels, **identity_labels}
+        body = build_job_body(
+            job_name=job_name,
+            labels=all_labels,
+            config=config,
+            container=container,
+            workspace=workspace,
+        )
+        timeout = clients.request_timeout
+        batch_v1 = clients.batch_v1
+
+        def _create() -> Any:
+            try:
+                return batch_v1.create_namespaced_job(
+                    namespace=namespace,
+                    body=body,
+                    _request_timeout=timeout,
+                )
+            except ApiException as exc:
+                if exc.status == 409:
+                    return batch_v1.read_namespaced_job(
+                        name=job_name,
+                        namespace=namespace,
+                        _request_timeout=timeout,
+                    )
+                raise
+
+        job = await asyncio.to_thread(_create)
+        return status_from_job(
+            job=job,
+            job_name=job_name,
+            expected_labels=identity_labels,
+            restart_policy=config.restart_policy,
+        )
+    except DeploymentConfigError as exc:
+        return BackendStatusUpdate(status="FAILED", status_message=str(exc))
+    except Exception as exc:
+        logger.exception("Failed to create Job %s", job_name)
+        return BackendStatusUpdate(status="FAILED", status_message=f"Failed to create Job: {exc}")
+
+
+async def read_job_status(
+    clients: KubernetesClients,
+    *,
+    default_namespace: str,
+    workspace: str,
+    name: str,
+    backend_config: dict[str, Any],
+) -> BackendStatusUpdate:
+    job_name = k8s_deployment_resource_name(workspace, name)
+    try:
+        k8s_config = resolve_k8s_deployment_config(backend_config)
+        namespace = resolve_deployment_namespace(default_namespace=default_namespace, k8s_config=k8s_config)
+        timeout = clients.request_timeout
+        batch_v1 = clients.batch_v1
+
+        def _read() -> Any:
+            return batch_v1.read_namespaced_job(
+                name=job_name,
+                namespace=namespace,
+                _request_timeout=timeout,
+            )
+
+        job = await asyncio.to_thread(_read)
+        job_labels = (job.metadata.labels or {}) if job.metadata else {}
+        config_name = job_labels.get(CONFIG_NAME_LABEL)
+        if not config_name:
+            return BackendStatusUpdate(
+                status="FAILED",
+                status_message=f"Job {job_name} is missing deployment config identity labels",
+            )
+        restart_policy: RestartPolicy = job_labels.get(RESTART_POLICY_LABEL, "Never")  # type: ignore[assignment]
+        read_expected = deployment_identity_labels(
+            workspace,
+            name,
+            restart_policy,
+            config_name=config_name,
+            backoff_limit=int(job_labels.get(BACKOFF_LIMIT_LABEL, "6")),
+        )
+        return status_from_job(
+            job=job,
+            job_name=job_name,
+            expected_labels=read_expected,
+            restart_policy=restart_policy,
+        )
+    except ApiException as exc:
+        if exc.status == 404:
+            return missing_job_status(job_name=job_name)
+        return BackendStatusUpdate(status="FAILED", status_message=f"Failed to read Job: {exc}")
+    except Exception as exc:
+        return BackendStatusUpdate(status="FAILED", status_message=f"Failed to read Job: {exc}")
+
+
+async def delete_job(
+    clients: KubernetesClients,
+    *,
+    default_namespace: str,
+    workspace: str,
+    name: str,
+    backend_config: dict[str, Any],
+) -> BackendStatusUpdate:
+    job_name = k8s_deployment_resource_name(workspace, name)
+    try:
+        k8s_config = resolve_k8s_deployment_config(backend_config)
+        namespace = resolve_deployment_namespace(default_namespace=default_namespace, k8s_config=k8s_config)
+        timeout = clients.request_timeout
+        batch_v1 = clients.batch_v1
+
+        def _delete() -> None:
+            try:
+                batch_v1.delete_namespaced_job(
+                    name=job_name,
+                    namespace=namespace,
+                    propagation_policy="Background",
+                    _request_timeout=timeout,
+                )
+            except ApiException as exc:
+                if exc.status == 404:
+                    return
+                raise
+
+        await asyncio.to_thread(_delete)
+        return BackendStatusUpdate(status="SUCCEEDED", status_message=f"Job {job_name} deleted")
+    except Exception as exc:
+        return BackendStatusUpdate(status="FAILED", status_message=f"Failed to delete Job: {exc}")
+
+
+async def list_managed_job_names(clients: KubernetesClients, *, default_namespace: str) -> list[str]:
+    timeout = clients.request_timeout
+    batch_v1 = clients.batch_v1
+    label_selector = managed_by_label_selector()
+
+    def _list() -> Any:
+        return batch_v1.list_namespaced_job(
+            namespace=default_namespace,
+            label_selector=label_selector,
+            _request_timeout=timeout,
+        )
+
+    try:
+        result = await asyncio.to_thread(_list)
+    except Exception:
+        logger.warning("Failed to list managed Jobs", exc_info=True)
+        return []
+
+    seen: set[str] = set()
+    for job in result.items or []:
+        labels = (job.metadata.labels or {}) if job.metadata else {}
+        workspace = labels.get(DEPLOYMENT_WORKSPACE_LABEL)
+        dep_name = labels.get(DEPLOYMENT_NAME_LABEL)
+        if workspace and dep_name:
+            seen.add(f"{workspace}/{dep_name}")
+    return sorted(seen)
+
+
+async def get_job_logs(
+    clients: KubernetesClients,
+    *,
+    default_namespace: str,
+    workspace: str,
+    name: str,
+    backend_config: dict[str, Any],
+    tail: int,
+) -> LogResult:
+    job_name = k8s_deployment_resource_name(workspace, name)
+    try:
+        k8s_config = resolve_k8s_deployment_config(backend_config)
+        namespace = resolve_deployment_namespace(default_namespace=default_namespace, k8s_config=k8s_config)
+        timeout = clients.request_timeout
+        core_v1 = clients.core_v1
+
+        def _logs() -> str:
+            pods = core_v1.list_namespaced_pod(
+                namespace=namespace,
+                label_selector=f"job-name={job_name}",
+                _request_timeout=timeout,
+            )
+            if not pods.items:
+                return ""
+            pod_name = pods.items[0].metadata.name
+            raw = core_v1.read_namespaced_pod_log(
+                name=pod_name,
+                namespace=namespace,
+                tail_lines=tail,
+                timestamps=True,
+                _request_timeout=timeout,
+            )
+            return raw
+
+        text = await asyncio.to_thread(_logs)
+        lines = text.splitlines() if text else []
+        truncated = len(text) > LOG_MAX_CHARS
+        if truncated:
+            lines = lines[-tail:]
+        return LogResult(lines=lines, truncated=truncated)
+    except ApiException as exc:
+        if exc.status == 404:
+            return LogResult(lines=[])
+        return LogResult(lines=[f"Failed to read Job logs: {exc}"])
+    except Exception as exc:
+        return LogResult(lines=[f"Failed to read Job logs: {exc}"])

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
@@ -15,19 +15,20 @@ from nemo_deployments_plugin.backends.k8s.client import KubernetesClients, _kube
 from nemo_deployments_plugin.backends.k8s.status import (
     LOG_MAX_CHARS,
     missing_job_status,
+    resource_labels_match,
     status_from_job,
 )
 from nemo_deployments_plugin.backends.labels import (
-    BACKOFF_LIMIT_LABEL,
     CONFIG_NAME_LABEL,
     DEPLOYMENT_NAME_LABEL,
     DEPLOYMENT_WORKSPACE_LABEL,
-    RESTART_POLICY_LABEL,
+    MANAGED_BY_KEY,
     deployment_identity_labels,
     k8s_deployment_resource_name,
     k8s_volume_resource_name,
     managed_by_label_selector,
 )
+from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
 from nemo_deployments_plugin.entities import Container, DeploymentConfig, K8sDeploymentConfig, VolumeMount
 from nemo_deployments_plugin.types import RestartPolicy
 
@@ -53,15 +54,35 @@ def resolve_deployment_namespace(*, default_namespace: str, k8s_config: K8sDeplo
     return k8s_config.namespace
 
 
-def restart_policy_from_labels(job_labels: dict[str, str], *, default: RestartPolicy = "Never") -> RestartPolicy:
-    value = job_labels.get(RESTART_POLICY_LABEL, default)
-    if value == "Never":
-        return "Never"
-    if value == "OnFailure":
-        return "OnFailure"
-    if value == "Always":
-        return "Always"
-    return default
+def deployment_scope_labels(workspace: str, name: str) -> dict[str, str]:
+    """Minimum identity labels for orphan delete when the Deployment entity is gone."""
+    return {
+        MANAGED_BY_KEY: MANAGED_BY_LABEL,
+        DEPLOYMENT_WORKSPACE_LABEL: workspace,
+        DEPLOYMENT_NAME_LABEL: name,
+    }
+
+
+def newest_pod(pods: list[Any]) -> Any | None:
+    """Return the pod with the latest metadata.creation_timestamp."""
+    if not pods:
+        return None
+
+    def creation_timestamp(pod: Any) -> str:
+        metadata = getattr(pod, "metadata", None)
+        if metadata is None:
+            return ""
+        return getattr(metadata, "creation_timestamp", None) or ""
+
+    return max(pods, key=creation_timestamp)
+
+
+def trim_log_text(text: str) -> tuple[list[str], bool]:
+    truncated = len(text) > LOG_MAX_CHARS
+    if truncated:
+        text = text[-LOG_MAX_CHARS:]
+    lines = text.splitlines() if text else []
+    return lines, truncated
 
 
 def validate_config_for_job(config: DeploymentConfig) -> Container:
@@ -136,17 +157,16 @@ def build_volume_mounts(mounts: list[VolumeMount]) -> list[Any]:
 
 def build_container_spec(container: Container, *, volume_mounts: list[VolumeMount] | None = None) -> Any:
     client, _ = _kubernetes_modules()
-    command: list[str] | None = None
-    if container.command or container.args:
-        command = list(container.command) + list(container.args)
     kwargs: dict[str, Any] = {
         "name": container.name,
         "image": container.image,
         "env": build_env_vars(container) or None,
         "resources": build_resource_requirements(container),
     }
-    if command:
-        kwargs["command"] = command
+    if container.command:
+        kwargs["command"] = list(container.command)
+    if container.args:
+        kwargs["args"] = list(container.args)
     if volume_mounts:
         kwargs["volume_mounts"] = build_volume_mounts(volume_mounts)
     return client.V1Container(**kwargs)
@@ -164,7 +184,7 @@ def build_job_body(
     client, _ = _kubernetes_modules()
     mounts = merged_volume_mounts(config, container)
     pod_spec_kwargs: dict[str, Any] = {
-        "restart_policy": "Never",
+        "restart_policy": config.restart_policy,
         "containers": [build_container_spec(container, volume_mounts=mounts or None)],
     }
     volumes = build_pod_volumes(workspace=workspace, mounts=mounts)
@@ -203,8 +223,8 @@ async def read_pod_exit_code(
         )
         if not pods.items:
             return None
-        pod = pods.items[-1]
-        if pod.status is None or not pod.status.container_statuses:
+        pod = newest_pod(list(pods.items))
+        if pod is None or pod.status is None or not pod.status.container_statuses:
             return None
         for container_status in pod.status.container_statuses:
             terminated = container_status.state.terminated if container_status.state else None
@@ -290,8 +310,18 @@ async def read_job_status(
     workspace: str,
     name: str,
     backend_config: dict[str, Any],
+    config_name: str,
+    restart_policy: RestartPolicy,
+    backoff_limit: int,
 ) -> BackendStatusUpdate:
     job_name = k8s_deployment_resource_name(workspace, name)
+    expected_labels = deployment_identity_labels(
+        workspace,
+        name,
+        restart_policy,
+        config_name=config_name,
+        backoff_limit=backoff_limit,
+    )
     try:
         k8s_config = resolve_k8s_deployment_config(backend_config)
         namespace = resolve_deployment_namespace(default_namespace=default_namespace, k8s_config=k8s_config)
@@ -307,21 +337,12 @@ async def read_job_status(
 
         job = await asyncio.to_thread(_read)
         job_labels = (job.metadata.labels or {}) if job.metadata else {}
-        config_name = job_labels.get(CONFIG_NAME_LABEL)
-        if not config_name:
+        if not job_labels.get(CONFIG_NAME_LABEL):
             return BackendStatusUpdate(
                 status="FAILED",
                 status_message=f"Job {job_name} is missing deployment config identity labels",
             )
-        restart_policy = restart_policy_from_labels(job_labels)
-        read_expected = deployment_identity_labels(
-            workspace,
-            name,
-            restart_policy,
-            config_name=config_name,
-            backoff_limit=int(job_labels.get(BACKOFF_LIMIT_LABEL, "6")),
-        )
-        update = status_from_job(job=job, job_name=job_name, expected_labels=read_expected)
+        update = status_from_job(job=job, job_name=job_name, expected_labels=expected_labels)
         if update.status in ("SUCCEEDED", "FAILED"):
             exit_code = await read_pod_exit_code(clients, namespace=namespace, job_name=job_name)
             if exit_code is not None:
@@ -342,6 +363,7 @@ async def delete_job(
     workspace: str,
     name: str,
     backend_config: dict[str, Any],
+    expected_labels: dict[str, str],
 ) -> BackendStatusUpdate:
     job_name = k8s_deployment_resource_name(workspace, name)
     try:
@@ -350,20 +372,33 @@ async def delete_job(
         timeout = clients.request_timeout
         batch_v1 = clients.batch_v1
 
-        def _delete() -> None:
+        def _delete() -> str | None:
             try:
-                batch_v1.delete_namespaced_job(
+                job = batch_v1.read_namespaced_job(
                     name=job_name,
                     namespace=namespace,
-                    propagation_policy="Background",
                     _request_timeout=timeout,
                 )
             except ApiException as exc:
                 if exc.status == 404:
-                    return
+                    return None
                 raise
+            if not resource_labels_match(job, expected_labels):
+                return "foreign"
+            batch_v1.delete_namespaced_job(
+                name=job_name,
+                namespace=namespace,
+                propagation_policy="Background",
+                _request_timeout=timeout,
+            )
+            return "deleted"
 
-        await asyncio.to_thread(_delete)
+        result = await asyncio.to_thread(_delete)
+        if result == "foreign":
+            return BackendStatusUpdate(
+                status="FAILED",
+                status_message=f"Job {job_name} exists but is not managed by this plugin",
+            )
         return BackendStatusUpdate(status="SUCCEEDED", status_message=f"Job {job_name} deleted")
     except Exception as exc:
         return BackendStatusUpdate(status="FAILED", status_message=f"Failed to delete Job: {exc}")
@@ -426,7 +461,10 @@ async def get_job_logs(
             )
             if not pods.items:
                 return ""
-            pod_name = pods.items[-1].metadata.name
+            pod = newest_pod(list(pods.items))
+            if pod is None or pod.metadata is None:
+                return ""
+            pod_name = pod.metadata.name
             raw = core_v1.read_namespaced_pod_log(
                 name=pod_name,
                 namespace=namespace,
@@ -437,10 +475,7 @@ async def get_job_logs(
             return raw
 
         text = await asyncio.to_thread(_logs)
-        lines = text.splitlines() if text else []
-        truncated = len(text) > LOG_MAX_CHARS
-        if truncated:
-            lines = lines[-tail:]
+        lines, truncated = trim_log_text(text)
         return LogResult(lines=lines, truncated=truncated)
     except ApiException as exc:
         if exc.status == 404:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
@@ -370,6 +370,11 @@ async def delete_job(
 
 
 async def list_managed_job_names(clients: KubernetesClients, *, default_namespace: str) -> list[str]:
+    """List plugin-managed Jobs in the executor default namespace.
+
+    Per-deployment namespaces from ``backend_config.k8s.namespace`` are not scanned
+    here; phase 4 will extend listing when Deployment resources land.
+    """
     timeout = clients.request_timeout
     batch_v1 = clients.batch_v1
     label_selector = managed_by_label_selector()
@@ -421,7 +426,7 @@ async def get_job_logs(
             )
             if not pods.items:
                 return ""
-            pod_name = pods.items[0].metadata.name
+            pod_name = pods.items[-1].metadata.name
             raw = core_v1.read_namespaced_pod_log(
                 name=pod_name,
                 namespace=namespace,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 from nemo_deployments_plugin.backends.base import BackendStatusUpdate
-from nemo_deployments_plugin.types import RestartPolicy
 
-LOG_TAIL_LINES = 80
 LOG_MAX_CHARS = 8000
 
 
@@ -49,10 +47,8 @@ def status_from_job(
     job: Any,
     job_name: str,
     expected_labels: dict[str, str],
-    restart_policy: RestartPolicy,
 ) -> BackendStatusUpdate:
     """Map a Job object to plugin status, enforcing identity labels and delete propagation."""
-    del restart_policy
     if not _job_labels_match(job, expected_labels):
         return BackendStatusUpdate(
             status="FAILED",

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Map Kubernetes Job status to plugin DeploymentStatus values."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nemo_deployments_plugin.backends.base import BackendStatusUpdate
+from nemo_deployments_plugin.types import RestartPolicy
+
+LOG_TAIL_LINES = 80
+LOG_MAX_CHARS = 8000
+
+
+def _job_is_deleting(job: Any) -> bool:
+    metadata = getattr(job, "metadata", None)
+    return bool(metadata and getattr(metadata, "deletion_timestamp", None))
+
+
+def _job_labels_match(job: Any, expected_labels: dict[str, str]) -> bool:
+    metadata = getattr(job, "metadata", None)
+    if metadata is None or not metadata.labels:
+        return False
+    return all(metadata.labels.get(key) == value for key, value in expected_labels.items())
+
+
+def _job_condition(job: Any, condition_type: str) -> Any | None:
+    status = getattr(job, "status", None)
+    if status is None or not status.conditions:
+        return None
+    for condition in status.conditions:
+        if condition.type == condition_type:
+            return condition
+    return None
+
+
+def missing_job_status(*, job_name: str) -> BackendStatusUpdate:
+    return BackendStatusUpdate(
+        status="FAILED",
+        status_message=f"Job not found. Expected name: {job_name}",
+        error_details={"expected_job_name": job_name},
+    )
+
+
+def status_from_job(
+    *,
+    job: Any,
+    job_name: str,
+    expected_labels: dict[str, str],
+    restart_policy: RestartPolicy,
+) -> BackendStatusUpdate:
+    """Map a Job object to plugin status, enforcing identity labels and delete propagation."""
+    del restart_policy
+    if not _job_labels_match(job, expected_labels):
+        return BackendStatusUpdate(
+            status="FAILED",
+            status_message=f"Job {job_name} exists but is not managed by this plugin",
+        )
+    if _job_is_deleting(job):
+        return BackendStatusUpdate(status="DELETING", status_message=f"Job {job_name} is terminating")
+
+    complete = _job_condition(job, "Complete")
+    if complete is not None and complete.status == "True":
+        return BackendStatusUpdate(
+            status="SUCCEEDED",
+            status_message=f"Job {job_name} completed successfully",
+        )
+
+    failed = _job_condition(job, "Failed")
+    if failed is not None and failed.status == "True":
+        message = failed.message or f"Job {job_name} failed"
+        return BackendStatusUpdate(status="FAILED", status_message=message)
+
+    status = job.status
+    if status is not None and status.active:
+        return BackendStatusUpdate(
+            status="STARTING",
+            status_message=f"Job {job_name} is running ({status.active} active pod(s))",
+        )
+
+    return BackendStatusUpdate(status="STARTING", status_message=f"Job {job_name} is pending")

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
@@ -17,11 +17,15 @@ def _job_is_deleting(job: Any) -> bool:
     return bool(metadata and getattr(metadata, "deletion_timestamp", None))
 
 
-def _job_labels_match(job: Any, expected_labels: dict[str, str]) -> bool:
-    metadata = getattr(job, "metadata", None)
+def resource_labels_match(resource: Any, expected_labels: dict[str, str]) -> bool:
+    metadata = getattr(resource, "metadata", None)
     if metadata is None or not metadata.labels:
         return False
     return all(metadata.labels.get(key) == value for key, value in expected_labels.items())
+
+
+def _job_labels_match(job: Any, expected_labels: dict[str, str]) -> bool:
+    return resource_labels_match(job, expected_labels)
 
 
 def _job_condition(job: Any, condition_type: str) -> Any | None:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
@@ -74,10 +74,11 @@ def status_from_job(
         return BackendStatusUpdate(status="FAILED", status_message=message)
 
     status = job.status
-    if status is not None and status.active:
+    active_pods = int(status.active or 0) if status is not None else 0
+    if active_pods > 0:
         return BackendStatusUpdate(
             status="STARTING",
-            status_message=f"Job {job_name} is running ({status.active} active pod(s))",
+            status_message=f"Job {job_name} is running ({active_pods} active pod(s))",
         )
 
     return BackendStatusUpdate(status="STARTING", status_message=f"Job {job_name} is pending")

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/volumes.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/volumes.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from kubernetes.client.rest import ApiException
 from nemo_deployments_plugin.backends.base import VolumeStatusUpdate
-from nemo_deployments_plugin.backends.k8s.client import KubernetesClients, _kubernetes_modules
+from nemo_deployments_plugin.backends.k8s.client import KubernetesClients, k8s_client_module
 from nemo_deployments_plugin.backends.labels import k8s_volume_resource_name, volume_identity_labels
 from nemo_deployments_plugin.entities import K8sVolumeConfig
 
@@ -42,18 +42,18 @@ def build_pvc_body(
     storage_class: str | None,
 ) -> Any:
     """Build a ``V1PersistentVolumeClaim`` for create."""
-    client, _ = _kubernetes_modules()
+    k8s = k8s_client_module()
     spec_kwargs: dict[str, Any] = {
         "access_modes": list(access_modes),
-        "resources": client.V1VolumeResourceRequirements(requests={"storage": size}),
+        "resources": k8s.client.V1VolumeResourceRequirements(requests={"storage": size}),
     }
     if storage_class is not None:
         spec_kwargs["storage_class_name"] = storage_class
-    return client.V1PersistentVolumeClaim(
+    return k8s.client.V1PersistentVolumeClaim(
         api_version="v1",
         kind="PersistentVolumeClaim",
-        metadata=client.V1ObjectMeta(name=pvc_name, labels=labels),
-        spec=client.V1PersistentVolumeClaimSpec(**spec_kwargs),
+        metadata=k8s.client.V1ObjectMeta(name=pvc_name, labels=labels),
+        spec=k8s.client.V1PersistentVolumeClaimSpec(**spec_kwargs),
     )
 
 

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/conftest.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/conftest.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from nemo_deployments_plugin.backends.k8s.backend import K8sDeploymentBackend
@@ -15,6 +15,11 @@ from nemo_deployments_plugin.backends.k8s.backend import K8sDeploymentBackend
 @pytest.fixture
 def mock_sdk() -> MagicMock:
     return MagicMock()
+
+
+@pytest.fixture
+def mock_entities() -> AsyncMock:
+    return AsyncMock()
 
 
 @pytest.fixture
@@ -28,10 +33,15 @@ def mock_k8s_clients() -> MagicMock:
 
 
 @pytest.fixture
-def k8s_backend(mock_sdk: MagicMock, mock_k8s_clients: MagicMock) -> Iterator[K8sDeploymentBackend]:
+def k8s_backend(
+    mock_sdk: MagicMock,
+    mock_k8s_clients: MagicMock,
+    mock_entities: AsyncMock,
+) -> Iterator[K8sDeploymentBackend]:
     with patch("nemo_deployments_plugin.backends.k8s.backend.KubernetesClients", return_value=mock_k8s_clients):
         backend = K8sDeploymentBackend(
             mock_sdk,
             {"default_namespace": "nemo-deployments", "request_timeout": 30},
         )
+        backend._entities = mock_entities
         yield backend

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/k8s_helpers.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/k8s_helpers.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test helpers for k8s backend unit tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from nemo_deployments_plugin.backends.labels import (
+    BACKOFF_LIMIT_LABEL,
+    CONFIG_NAME_LABEL,
+    DEPLOYMENT_NAME_LABEL,
+    DEPLOYMENT_WORKSPACE_LABEL,
+    RESTART_POLICY_LABEL,
+    deployment_identity_labels,
+)
+from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
+from nemo_deployments_plugin.entities import Container, Deployment, DeploymentConfig
+from nemo_deployments_plugin.types import RestartPolicy
+
+
+def sample_config(*, restart_policy: RestartPolicy = "Never") -> DeploymentConfig:
+    return DeploymentConfig(
+        name="cfg1",
+        workspace="default",
+        containers=[
+            Container(
+                name="main",
+                image="alpine:latest",
+                command=["echo"],
+                args=["hello"],
+            )
+        ],
+        restart_policy=restart_policy,
+    )
+
+
+def sample_deployment(*, config_name: str = "cfg1") -> Deployment:
+    return Deployment(
+        name="task",
+        workspace="default",
+        deployment_config=config_name,
+    )
+
+
+def job_identity_labels(
+    workspace: str = "default",
+    name: str = "task",
+    *,
+    restart_policy: RestartPolicy = "Never",
+    config_name: str = "cfg1",
+    backoff_limit: int = 6,
+) -> dict[str, str]:
+    return deployment_identity_labels(
+        workspace,
+        name,
+        restart_policy,
+        config_name=config_name,
+        backoff_limit=backoff_limit,
+    )
+
+
+def mock_job(
+    *,
+    workspace: str = "default",
+    name: str = "task",
+    restart_policy: RestartPolicy = "Never",
+    config_name: str = "cfg1",
+    active: int = 0,
+    complete: bool = False,
+    failed: bool = False,
+    deleting: bool = False,
+) -> MagicMock:
+    labels = job_identity_labels(
+        workspace,
+        name,
+        restart_policy=restart_policy,
+        config_name=config_name,
+    )
+    job = MagicMock()
+    job.metadata.labels = labels
+    job.metadata.deletion_timestamp = "2026-01-01T00:00:00Z" if deleting else None
+    job.status.active = active
+    job.status.succeeded = 1 if complete else 0
+    job.status.failed = 1 if failed else 0
+    job.status.conditions = []
+    if complete:
+        condition = MagicMock()
+        condition.type = "Complete"
+        condition.status = "True"
+        condition.message = None
+        job.status.conditions.append(condition)
+    if failed:
+        condition = MagicMock()
+        condition.type = "Failed"
+        condition.status = "True"
+        condition.message = "BackoffLimitExceeded"
+        job.status.conditions.append(condition)
+    return job
+
+
+def job_list_item(*, workspace: str, name: str) -> MagicMock:
+    item = MagicMock()
+    item.metadata.labels = {
+        "managed-by": MANAGED_BY_LABEL,
+        DEPLOYMENT_WORKSPACE_LABEL: workspace,
+        DEPLOYMENT_NAME_LABEL: name,
+        RESTART_POLICY_LABEL: "Never",
+        CONFIG_NAME_LABEL: "cfg1",
+        BACKOFF_LIMIT_LABEL: "0",
+    }
+    return item

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/k8s_helpers.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/k8s_helpers.py
@@ -12,6 +12,7 @@ from nemo_deployments_plugin.backends.labels import (
     CONFIG_NAME_LABEL,
     DEPLOYMENT_NAME_LABEL,
     DEPLOYMENT_WORKSPACE_LABEL,
+    MANAGED_BY_KEY,
     RESTART_POLICY_LABEL,
     deployment_identity_labels,
 )
@@ -103,7 +104,7 @@ def mock_job(
 def job_list_item(*, workspace: str, name: str) -> MagicMock:
     item = MagicMock()
     item.metadata.labels = {
-        "managed-by": MANAGED_BY_LABEL,
+        MANAGED_BY_KEY: MANAGED_BY_LABEL,
         DEPLOYMENT_WORKSPACE_LABEL: workspace,
         DEPLOYMENT_NAME_LABEL: name,
         RESTART_POLICY_LABEL: "Never",

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/k8s_helpers.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/k8s_helpers.py
@@ -33,8 +33,7 @@ def sample_config(*, restart_policy: RestartPolicy = "Never") -> DeploymentConfi
                 args=["hello"],
             )
         ],
-        restart_policy=restart_policy,
-    )
+    ).model_copy(update={"restart_policy": restart_policy})
 
 
 def sample_deployment(*, config_name: str = "cfg1") -> Deployment:

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_backend.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_backend.py
@@ -10,18 +10,6 @@ from nemo_deployments_plugin.backends.k8s.backend import K8sDeploymentBackend
 from nemo_deployments_plugin.backends.k8s.config import K8sExecutorConfig
 
 
-@pytest.mark.asyncio
-async def test_create_deployment_not_implemented_yet(k8s_backend: K8sDeploymentBackend) -> None:
-    with pytest.raises(NotImplementedError, match="create_deployment"):
-        await k8s_backend.create_deployment(
-            workspace="default",
-            name="srv",
-            config_name="cfg1",
-            labels={},
-            backend_config={},
-        )
-
-
 def test_executor_config_parsed_from_dict(k8s_backend: K8sDeploymentBackend) -> None:
     assert k8s_backend.executor_config.default_namespace == "nemo-deployments"
     assert k8s_backend.executor_config.request_timeout == 30

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_client.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_client.py
@@ -18,8 +18,10 @@ def _reset_kubernetes_modules_cache() -> Iterator[None]:
     import nemo_deployments_plugin.backends.k8s.client as k8s_client
 
     k8s_client._kubernetes_modules_cache = None
+    k8s_client._k8s_client_module = None
     yield
     k8s_client._kubernetes_modules_cache = None
+    k8s_client._k8s_client_module = None
 
 
 def test_k8s_backend_registered() -> None:

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from backends.k8s.k8s_helpers import job_list_item, mock_job, sample_config, sample_deployment
+from kubernetes.client.rest import ApiException
+from nemo_deployments_plugin.backends.k8s import jobs as job_ops
+from nemo_deployments_plugin.backends.k8s.client import KubernetesClients
+from nemo_deployments_plugin.backends.k8s.jobs import job_backoff_limit, validate_config_for_job
+from nemo_deployments_plugin.backends.labels import MANAGED_BY_KEY
+from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
+
+
+@pytest.mark.parametrize(
+    ("restart_policy", "expected"),
+    [
+        ("Never", 0),
+        ("OnFailure", 6),
+    ],
+)
+def test_job_backoff_limit(restart_policy: str, expected: int) -> None:
+    config = sample_config(restart_policy=restart_policy)  # type: ignore[arg-type]
+    assert job_backoff_limit(config) == expected
+
+
+def test_validate_config_for_job_rejects_always() -> None:
+    with pytest.raises(job_ops.DeploymentConfigError, match="Always"):
+        validate_config_for_job(sample_config(restart_policy="Always"))
+
+
+@pytest.mark.asyncio
+async def test_create_job_emits_batch_job(k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="Never")
+    pending = mock_job(active=1)
+    mock_k8s_clients.batch_v1.create_namespaced_job.return_value = pending
+
+    update = await k8s_backend.create_deployment(
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "STARTING"
+    call = mock_k8s_clients.batch_v1.create_namespaced_job
+    call.assert_called_once()
+    body = call.call_args.kwargs["body"]
+    assert body.spec.backoff_limit == 0
+    assert body.spec.template.spec.restart_policy == "Never"
+    assert body.spec.template.spec.containers[0].image == "alpine:latest"
+
+
+@pytest.mark.asyncio
+async def test_create_job_conflict_reads_existing(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="Never")
+    existing = mock_job(complete=True)
+    mock_k8s_clients.batch_v1.create_namespaced_job.side_effect = ApiException(status=409)
+    mock_k8s_clients.batch_v1.read_namespaced_job.return_value = existing
+
+    update = await k8s_backend.create_deployment(
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={},
+        backend_config={},
+    )
+
+    assert update.status == "SUCCEEDED"
+    mock_k8s_clients.batch_v1.read_namespaced_job.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_job_conflict_rejects_foreign(mock_k8s_clients: MagicMock) -> None:
+    foreign = mock_job(complete=True)
+    foreign.metadata.labels = {MANAGED_BY_KEY: "other-plugin"}
+    mock_k8s_clients.batch_v1.create_namespaced_job.side_effect = ApiException(status=409)
+    mock_k8s_clients.batch_v1.read_namespaced_job.return_value = foreign
+    clients = MagicMock(spec=KubernetesClients)
+    clients.batch_v1 = mock_k8s_clients.batch_v1
+    clients.request_timeout = 30
+
+    update = await job_ops.create_job(
+        clients,
+        default_namespace="default",
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={},
+        backend_config={},
+        config=sample_config(restart_policy="Never"),
+    )
+
+    assert update.status == "FAILED"
+    assert "not managed" in update.status_message
+
+
+@pytest.mark.asyncio
+async def test_read_job_status_complete(k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock) -> None:
+    mock_entities.get.side_effect = [sample_deployment(), sample_config(restart_policy="Never")]
+    mock_k8s_clients.batch_v1.read_namespaced_job.return_value = mock_job(complete=True)
+
+    update = await k8s_backend.read_status(workspace="default", name="task")
+
+    assert update.status == "SUCCEEDED"
+
+
+@pytest.mark.asyncio
+async def test_delete_job_missing_is_success(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.side_effect = [sample_deployment(), sample_config(restart_policy="Never")]
+    mock_k8s_clients.batch_v1.delete_namespaced_job.side_effect = ApiException(status=404)
+
+    update = await k8s_backend.delete_deployment("default", "task")
+
+    assert update.status == "SUCCEEDED"
+
+
+@pytest.mark.asyncio
+async def test_list_managed_deployment_names(k8s_backend, mock_k8s_clients: MagicMock) -> None:
+    listed = MagicMock()
+    listed.items = [job_list_item(workspace="default", name="task"), job_list_item(workspace="ws", name="other")]
+    mock_k8s_clients.batch_v1.list_namespaced_job.return_value = listed
+
+    names = await k8s_backend.list_managed_deployment_names()
+
+    assert names == ["default/task", "ws/other"]
+
+
+@pytest.mark.asyncio
+async def test_get_job_logs(k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock) -> None:
+    mock_entities.get.side_effect = [sample_deployment(), sample_config(restart_policy="Never")]
+    pod = MagicMock()
+    pod.metadata.name = "task-pod"
+    mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(items=[pod])
+    mock_k8s_clients.core_v1.read_namespaced_pod_log.return_value = "hello\nworld\n"
+
+    result = await k8s_backend.get_logs(workspace="default", name="task", tail=10)
+
+    assert result.lines == ["hello", "world"]
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_always_not_implemented(k8s_backend, mock_entities: AsyncMock) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="Always")
+
+    with pytest.raises(NotImplementedError, match="phase 4"):
+        await k8s_backend.create_deployment(
+            workspace="default",
+            name="task",
+            config_name="cfg1",
+            labels={},
+            backend_config={},
+        )

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
@@ -14,6 +14,7 @@ from nemo_deployments_plugin.backends.k8s.jobs import job_backoff_limit, validat
 from nemo_deployments_plugin.backends.labels import MANAGED_BY_KEY
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
 from nemo_deployments_plugin.types import RestartPolicy
+from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
 
 
 @pytest.fixture
@@ -189,14 +190,29 @@ async def test_create_job_malformed_backend_config_returns_failed(job_ops_client
 
 
 @pytest.mark.asyncio
-async def test_create_deployment_always_not_implemented(k8s_backend, mock_entities: AsyncMock) -> None:
+async def test_delete_deployment_still_deletes_job_when_entity_missing(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.side_effect = NemoEntityNotFoundError("missing")
+    mock_k8s_clients.batch_v1.delete_namespaced_job.return_value = MagicMock()
+
+    update = await k8s_backend.delete_deployment("default", "task")
+
+    assert update.status == "SUCCEEDED"
+    mock_k8s_clients.batch_v1.delete_namespaced_job.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_always_returns_failed(k8s_backend, mock_entities: AsyncMock) -> None:
     mock_entities.get.return_value = sample_config(restart_policy="Always")
 
-    with pytest.raises(NotImplementedError, match="phase 4"):
-        await k8s_backend.create_deployment(
-            workspace="default",
-            name="task",
-            config_name="cfg1",
-            labels={},
-            backend_config={},
-        )
+    update = await k8s_backend.create_deployment(
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={},
+        backend_config={},
+    )
+
+    assert update.status == "FAILED"
+    assert "phase 4" in update.status_message

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
@@ -13,6 +13,16 @@ from nemo_deployments_plugin.backends.k8s.client import KubernetesClients
 from nemo_deployments_plugin.backends.k8s.jobs import job_backoff_limit, validate_config_for_job
 from nemo_deployments_plugin.backends.labels import MANAGED_BY_KEY
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
+from nemo_deployments_plugin.types import RestartPolicy
+
+
+@pytest.fixture
+def job_ops_clients(mock_k8s_clients: MagicMock) -> MagicMock:
+    clients = MagicMock(spec=KubernetesClients)
+    clients.batch_v1 = mock_k8s_clients.batch_v1
+    clients.core_v1 = mock_k8s_clients.core_v1
+    clients.request_timeout = mock_k8s_clients.request_timeout
+    return clients
 
 
 @pytest.mark.parametrize(
@@ -22,8 +32,8 @@ from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
         ("OnFailure", 6),
     ],
 )
-def test_job_backoff_limit(restart_policy: str, expected: int) -> None:
-    config = sample_config(restart_policy=restart_policy)  # type: ignore[arg-type]
+def test_job_backoff_limit(restart_policy: RestartPolicy, expected: int) -> None:
+    config = sample_config(restart_policy=restart_policy)
     assert job_backoff_limit(config) == expected
 
 
@@ -77,17 +87,14 @@ async def test_create_job_conflict_reads_existing(
 
 
 @pytest.mark.asyncio
-async def test_create_job_conflict_rejects_foreign(mock_k8s_clients: MagicMock) -> None:
+async def test_create_job_conflict_rejects_foreign(job_ops_clients: MagicMock, mock_k8s_clients: MagicMock) -> None:
     foreign = mock_job(complete=True)
     foreign.metadata.labels = {MANAGED_BY_KEY: "other-plugin"}
     mock_k8s_clients.batch_v1.create_namespaced_job.side_effect = ApiException(status=409)
     mock_k8s_clients.batch_v1.read_namespaced_job.return_value = foreign
-    clients = MagicMock(spec=KubernetesClients)
-    clients.batch_v1 = mock_k8s_clients.batch_v1
-    clients.request_timeout = 30
 
     update = await job_ops.create_job(
-        clients,
+        job_ops_clients,
         default_namespace="default",
         workspace="default",
         name="task",
@@ -145,6 +152,40 @@ async def test_get_job_logs(k8s_backend, mock_k8s_clients: MagicMock, mock_entit
     result = await k8s_backend.get_logs(workspace="default", name="task", tail=10)
 
     assert result.lines == ["hello", "world"]
+
+
+@pytest.mark.asyncio
+async def test_read_job_status_includes_exit_code(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.side_effect = [sample_deployment(), sample_config(restart_policy="Never")]
+    mock_k8s_clients.batch_v1.read_namespaced_job.return_value = mock_job(complete=True)
+    pod = MagicMock()
+    pod.status.container_statuses = [MagicMock()]
+    pod.status.container_statuses[0].state.terminated.exit_code = 0
+    mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(items=[pod])
+
+    update = await k8s_backend.read_status(workspace="default", name="task")
+
+    assert update.status == "SUCCEEDED"
+    assert update.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_create_job_malformed_backend_config_returns_failed(job_ops_clients: MagicMock) -> None:
+    update = await job_ops.create_job(
+        job_ops_clients,
+        default_namespace="default",
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={},
+        backend_config={"k8s": {"namespace": 42}},
+        config=sample_config(restart_policy="Never"),
+    )
+
+    assert update.status == "FAILED"
+    job_ops_clients.batch_v1.create_namespaced_job.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from backends.k8s.k8s_helpers import job_list_item, mock_job, sample_config, sample_deployment
+from backends.k8s.k8s_helpers import job_identity_labels, job_list_item, mock_job, sample_config, sample_deployment
 from kubernetes.client.rest import ApiException
 from nemo_deployments_plugin.backends.k8s import jobs as job_ops
 from nemo_deployments_plugin.backends.k8s.client import KubernetesClients
-from nemo_deployments_plugin.backends.k8s.jobs import job_backoff_limit, validate_config_for_job
+from nemo_deployments_plugin.backends.k8s.jobs import job_backoff_limit, trim_log_text, validate_config_for_job
 from nemo_deployments_plugin.backends.labels import MANAGED_BY_KEY
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
 from nemo_deployments_plugin.types import RestartPolicy
@@ -41,6 +41,51 @@ def test_job_backoff_limit(restart_policy: RestartPolicy, expected: int) -> None
 def test_validate_config_for_job_rejects_always() -> None:
     with pytest.raises(job_ops.DeploymentConfigError, match="Always"):
         validate_config_for_job(sample_config(restart_policy="Always"))
+
+
+@pytest.mark.asyncio
+async def test_create_job_on_failure_uses_requested_restart_policy(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="OnFailure")
+    mock_k8s_clients.batch_v1.create_namespaced_job.return_value = mock_job(restart_policy="OnFailure", active=1)
+
+    await k8s_backend.create_deployment(
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={},
+        backend_config={},
+    )
+
+    body = mock_k8s_clients.batch_v1.create_namespaced_job.call_args.kwargs["body"]
+    assert body.spec.template.spec.restart_policy == "OnFailure"
+    assert body.spec.backoff_limit == 6
+
+
+@pytest.mark.asyncio
+async def test_create_job_emits_separate_command_and_args(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    config = sample_config(restart_policy="Never")
+    config.containers[0].command = ["echo"]
+    config.containers[0].args = ["hello"]
+    mock_entities.get.return_value = config
+    mock_k8s_clients.batch_v1.create_namespaced_job.return_value = mock_job(active=1)
+
+    await k8s_backend.create_deployment(
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={},
+        backend_config={},
+    )
+
+    container = mock_k8s_clients.batch_v1.create_namespaced_job.call_args.kwargs["body"].spec.template.spec.containers[
+        0
+    ]
+    assert container.command == ["echo"]
+    assert container.args == ["hello"]
 
 
 @pytest.mark.asyncio
@@ -110,6 +155,20 @@ async def test_create_job_conflict_rejects_foreign(job_ops_clients: MagicMock, m
 
 
 @pytest.mark.asyncio
+async def test_read_job_status_rejects_stale_identity(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.side_effect = [sample_deployment(), sample_config(restart_policy="Never")]
+    stale = mock_job(config_name="old-config", complete=True)
+    mock_k8s_clients.batch_v1.read_namespaced_job.return_value = stale
+
+    update = await k8s_backend.read_status(workspace="default", name="task")
+
+    assert update.status == "FAILED"
+    assert "not managed" in update.status_message
+
+
+@pytest.mark.asyncio
 async def test_read_job_status_complete(k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock) -> None:
     mock_entities.get.side_effect = [sample_deployment(), sample_config(restart_policy="Never")]
     mock_k8s_clients.batch_v1.read_namespaced_job.return_value = mock_job(complete=True)
@@ -124,11 +183,31 @@ async def test_delete_job_missing_is_success(
     k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
 ) -> None:
     mock_entities.get.side_effect = [sample_deployment(), sample_config(restart_policy="Never")]
-    mock_k8s_clients.batch_v1.delete_namespaced_job.side_effect = ApiException(status=404)
+    mock_k8s_clients.batch_v1.read_namespaced_job.side_effect = ApiException(status=404)
 
     update = await k8s_backend.delete_deployment("default", "task")
 
     assert update.status == "SUCCEEDED"
+    mock_k8s_clients.batch_v1.delete_namespaced_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_job_rejects_foreign(job_ops_clients: MagicMock, mock_k8s_clients: MagicMock) -> None:
+    foreign = mock_job(complete=True)
+    foreign.metadata.labels = {MANAGED_BY_KEY: "other-plugin"}
+    mock_k8s_clients.batch_v1.read_namespaced_job.return_value = foreign
+
+    update = await job_ops.delete_job(
+        job_ops_clients,
+        default_namespace="default",
+        workspace="default",
+        name="task",
+        backend_config={},
+        expected_labels=job_identity_labels(),
+    )
+
+    assert update.status == "FAILED"
+    mock_k8s_clients.batch_v1.delete_namespaced_job.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -142,11 +221,19 @@ async def test_list_managed_deployment_names(k8s_backend, mock_k8s_clients: Magi
     assert names == ["default/task", "ws/other"]
 
 
+def test_trim_log_text_caps_payload() -> None:
+    text = "x" * 9000
+    lines, truncated = trim_log_text(text)
+    assert truncated is True
+    assert sum(len(line) for line in lines) <= 8000
+
+
 @pytest.mark.asyncio
 async def test_get_job_logs(k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock) -> None:
     mock_entities.get.side_effect = [sample_deployment(), sample_config(restart_policy="Never")]
     pod = MagicMock()
     pod.metadata.name = "task-pod"
+    pod.metadata.creation_timestamp = "2026-01-02T00:00:00Z"
     mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(items=[pod])
     mock_k8s_clients.core_v1.read_namespaced_pod_log.return_value = "hello\nworld\n"
 
@@ -162,6 +249,8 @@ async def test_read_job_status_includes_exit_code(
     mock_entities.get.side_effect = [sample_deployment(), sample_config(restart_policy="Never")]
     mock_k8s_clients.batch_v1.read_namespaced_job.return_value = mock_job(complete=True)
     pod = MagicMock()
+    pod.metadata.name = "task-pod"
+    pod.metadata.creation_timestamp = "2026-01-02T00:00:00Z"
     pod.status.container_statuses = [MagicMock()]
     pod.status.container_statuses[0].state.terminated.exit_code = 0
     mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(items=[pod])
@@ -194,7 +283,7 @@ async def test_delete_deployment_still_deletes_job_when_entity_missing(
     k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
 ) -> None:
     mock_entities.get.side_effect = NemoEntityNotFoundError("missing")
-    mock_k8s_clients.batch_v1.delete_namespaced_job.return_value = MagicMock()
+    mock_k8s_clients.batch_v1.read_namespaced_job.return_value = mock_job(complete=True)
 
     update = await k8s_backend.delete_deployment("default", "task")
 

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_k8s_status_mapping.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_k8s_status_mapping.py
@@ -3,54 +3,31 @@
 
 from __future__ import annotations
 
+import pytest
 from backends.k8s.k8s_helpers import job_identity_labels, mock_job
 from nemo_deployments_plugin.backends.k8s.status import missing_job_status, status_from_job
 
 
-def test_status_from_job_complete() -> None:
+@pytest.mark.parametrize(
+    ("job", "expected_status", "message_substring"),
+    [
+        (lambda: mock_job(complete=True), "SUCCEEDED", "completed successfully"),
+        (lambda: mock_job(restart_policy="OnFailure", failed=True), "FAILED", "BackoffLimitExceeded"),
+        (lambda: mock_job(active=1), "STARTING", "active pod"),
+        (lambda: mock_job(deleting=True), "DELETING", "terminating"),
+    ],
+)
+def test_status_from_job(job, expected_status: str, message_substring: str) -> None:
     labels = job_identity_labels()
+    if expected_status == "FAILED":
+        labels = job_identity_labels(restart_policy="OnFailure")
     update = status_from_job(
-        job=mock_job(complete=True),
+        job=job(),
         job_name="dep-default-task-abc12345",
         expected_labels=labels,
-        restart_policy="Never",
     )
-    assert update.status == "SUCCEEDED"
-
-
-def test_status_from_job_failed() -> None:
-    labels = job_identity_labels(restart_policy="OnFailure")
-    update = status_from_job(
-        job=mock_job(restart_policy="OnFailure", failed=True),
-        job_name="dep-default-task-abc12345",
-        expected_labels=labels,
-        restart_policy="OnFailure",
-    )
-    assert update.status == "FAILED"
-    assert "BackoffLimitExceeded" in update.status_message
-
-
-def test_status_from_job_active_is_starting() -> None:
-    labels = job_identity_labels()
-    update = status_from_job(
-        job=mock_job(active=1),
-        job_name="dep-default-task-abc12345",
-        expected_labels=labels,
-        restart_policy="Never",
-    )
-    assert update.status == "STARTING"
-    assert "active pod" in update.status_message
-
-
-def test_status_from_job_deleting() -> None:
-    labels = job_identity_labels()
-    update = status_from_job(
-        job=mock_job(deleting=True),
-        job_name="dep-default-task-abc12345",
-        expected_labels=labels,
-        restart_policy="Never",
-    )
-    assert update.status == "DELETING"
+    assert update.status == expected_status
+    assert message_substring in update.status_message
 
 
 def test_missing_job_status() -> None:

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_k8s_status_mapping.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_k8s_status_mapping.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from backends.k8s.k8s_helpers import job_identity_labels, mock_job
+from nemo_deployments_plugin.backends.k8s.status import missing_job_status, status_from_job
+
+
+def test_status_from_job_complete() -> None:
+    labels = job_identity_labels()
+    update = status_from_job(
+        job=mock_job(complete=True),
+        job_name="dep-default-task-abc12345",
+        expected_labels=labels,
+        restart_policy="Never",
+    )
+    assert update.status == "SUCCEEDED"
+
+
+def test_status_from_job_failed() -> None:
+    labels = job_identity_labels(restart_policy="OnFailure")
+    update = status_from_job(
+        job=mock_job(restart_policy="OnFailure", failed=True),
+        job_name="dep-default-task-abc12345",
+        expected_labels=labels,
+        restart_policy="OnFailure",
+    )
+    assert update.status == "FAILED"
+    assert "BackoffLimitExceeded" in update.status_message
+
+
+def test_status_from_job_active_is_starting() -> None:
+    labels = job_identity_labels()
+    update = status_from_job(
+        job=mock_job(active=1),
+        job_name="dep-default-task-abc12345",
+        expected_labels=labels,
+        restart_policy="Never",
+    )
+    assert update.status == "STARTING"
+    assert "active pod" in update.status_message
+
+
+def test_status_from_job_deleting() -> None:
+    labels = job_identity_labels()
+    update = status_from_job(
+        job=mock_job(deleting=True),
+        job_name="dep-default-task-abc12345",
+        expected_labels=labels,
+        restart_policy="Never",
+    )
+    assert update.status == "DELETING"
+
+
+def test_missing_job_status() -> None:
+    update = missing_job_status(job_name="dep-default-task-abc12345")
+    assert update.status == "FAILED"
+    assert "not found" in update.status_message


### PR DESCRIPTION
## Summary

* Implement `batch/v1.Job` lifecycle for `restart_policy` **Never** / **OnFailure**: create, read status, delete, logs, and managed-name listing
* Add `jobs.py` (Job compile + API ops) and `status.py` (condition → plugin status + pod exit code)
* Wire `K8sDeploymentBackend` with entity loading; **Always** returns `FAILED` until Phase 4

Stacked on Phase 2 (#536). After #536 merges: rebase onto `main` and retarget this PR's base branch.

## Test plan

* [x] `uv run pytest plugins/nemo-deployments/tests/unit -v` (208 passed)
* New: `test_jobs.py`, `test_k8s_status_mapping.py` — Job emission, 409 idempotency, status mapping, exit code, orphan delete, logs

## Linear

AIRCORE-757 — Phase 3 of 7

---

## Reviewer notes (intentional / deferred)

### `merged_volume_mounts` duplicated from `docker/containers.py`

Phase 3 inlines a minimal volume-mount merge in `jobs.py`. Phase 5's `compiler.py` will unify PodSpec compilation for Job and Deployment paths. Duplicating ~8 lines now avoids a premature shared module and cross-backend import layering.

### `list_managed_deployment_names` scans only the executor default namespace

`create` / `read` / `delete` honor `backend_config.k8s.namespace`, but `list_managed_job_names` lists Jobs in `K8sExecutorConfig.default_namespace` only. Deployments in custom namespaces won't appear in orphan cleanup until Phase 4 extends listing (likely union of default namespace + Deployment list, or a namespace label on resources). Documented in `list_managed_job_names` docstring.

### `restart_policy: Always` not supported until Phase 4

`DeploymentConfig` defaults to `Always`. The k8s executor returns `FAILED` with an explicit phase-4 message rather than raising `NotImplementedError`, so the reconciler doesn't spin on uncaught exceptions during polling. Long-running workloads land in Phase 4 (Deployment + Service).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full Kubernetes Job–based deployments backend, including deployment config/context loading, managed deployment listing, and namespace-scoped log retrieval.
  * Implemented complete create/status/delete flows with consistent lifecycle status mapping.
* **Bug Fixes**
  * Blocked unsupported `restartPolicy="Always"` with clear failure messaging across status, logs, and deletion.
  * Improved handling for missing resources, label ownership mismatches, Kubernetes create conflicts, and backend/config load failures.
  * Added pod exit-code reporting and truncated log output for readability.
* **Refactor**
  * Streamlined Kubernetes client module initialization for more efficient access.
* **Tests**
  * Added/expanded unit tests covering Job lifecycle, status mapping, logs, and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->