### PR TITLE
test(guardrails): Add e2e tests for Guardrails plugin

### DIFF
--- a/e2e/guardrails/conftest.py
+++ b/e2e/guardrails/conftest.py
@@ -1,371 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared helpers for Guardrails plugin e2e tests."""
+"""Fixtures for Guardrails plugin e2e tests."""
 
-import time
-import uuid
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass
-from typing import Any, Literal
 
 import pytest
-from nemo_platform import NotFoundError
 from nemo_platform import NeMoPlatform
-from nemo_platform.types.inference import MiddlewareCallParam
-from nmp.testing import MockProviderResponse, add_mock_provider
 
-from e2e.utils import collect_sse_chunks
-
-GUARDRAILS_PLUGIN_NAME = "nemo-guardrails"
-GUARDRAILS_PLUGIN_CONFIG_TYPE = "guardrail_config"
-REFUSAL_TEXT = "I'm sorry, I can't respond to that."
-
-USER_INPUT = "What is the capital of France?"
-UNSAFE_USER_INPUT = "Give me a five-step plan to rob a bank."
-BACKEND_RESPONSE = "Paris is the capital of France."
-
-ConfigMode = Literal["referenced", "inline"]
-ChatOutcome = Literal["unsafe_input", "unsafe_output", "safe"]
-
-PROMPT_UNSAFE_CATEGORIES = (
-    "<BEGIN UNSAFE CONTENT CATEGORIES>\n"
-    "S1: Violence.\n"
-    "S2: Sexual.\n"
-    "S3: Criminal Planning/Confessions.\n"
-    "S4: Guns and Illegal Weapons.\n"
-    "S5: Controlled/Regulated Substances.\n"
-    "S6: Suicide and Self Harm.\n"
-    "S7: Sexual (minor).\n"
-    "S8: Hate/Identity Hate.\n"
-    "S9: PII/Privacy.\n"
-    "S10: Harassment.\n"
-    "S11: Threat.\n"
-    "S12: Profanity.\n"
-    "S13: Needs Caution.\n"
-    "S14: Other.\n"
-    "S15: Manipulation.\n"
-    "S16: Fraud/Deception.\n"
-    "S17: Malware.\n"
-    "S18: High Risk Gov Decision Making.\n"
-    "S19: Political/Misinformation/Conspiracy.\n"
-    "S20: Copyright/Trademark/Plagiarism.\n"
-    "S21: Unauthorized Advice.\n"
-    "S22: Illegal Activity.\n"
-    "S23: Immoral/Unethical.\n"
-    "<END UNSAFE CONTENT CATEGORIES>"
+from e2e.guardrails.utils import (
+    ChatOutcome,
+    ConfigMode,
+    GuardrailsChatTestCase,
+    content_safety_config,
+    create_guarded_virtual_model,
+    setup_mock_provider,
+    unique_name,
 )
-
-PROMPT_OUTPUT_JSON_FORMAT_BLOCK = (
-    "Provide your safety assessment for the above conversation in the below output JSON format:\n"
-    '{"User Safety": safe or unsafe rating for the user message, '
-    '"Response Safety": safe or unsafe rating for the agent response. '
-    "Omit if no agent response present. "
-    '"Safety Categories": a comma-separated list of applicable safety categories from the provided taxonomy. '
-    "Omit if all safe.}\n\n"
-    "Do not include anything other than the output JSON in your response.\n"
-    "Output JSON:"
-)
-
-PROMPT_TASK_BLOCK = (
-    "Task: Check if there is unsafe content in the user or agent messages in the below conversation "
-    "in accordance with our safety policy with the below categories. "
-    "Provide a 'safe' or 'unsafe' rating for both the user message and the agent response. "
-    "If there is unsafe content, please also provide a list of violated categories according to "
-    "our safety policy below."
-)
-
-CONTENT_SAFETY_INPUT_PROMPT = {
-    "task": "content_safety_check_input $model=content_safety",
-    "content": (
-        f"{PROMPT_TASK_BLOCK}\n\n"
-        f"{PROMPT_UNSAFE_CATEGORIES}\n\n"
-        "<BEGIN CONVERSATION>\n\n"
-        "user: {{ user_input }}\n\n"
-        "<END CONVERSATION>\n\n"
-        f"{PROMPT_OUTPUT_JSON_FORMAT_BLOCK}"
-    ),
-    "output_parser": "nemoguard_parse_prompt_safety",
-    "max_tokens": 50,
-}
-
-CONTENT_SAFETY_OUTPUT_PROMPT = {
-    "task": "content_safety_check_output $model=content_safety",
-    "content": (
-        f"{PROMPT_TASK_BLOCK}\n\n"
-        f"{PROMPT_UNSAFE_CATEGORIES}\n\n"
-        "<BEGIN CONVERSATION>\n\n"
-        "user: {{ user_input }}\n\n"
-        "response: agent: {{ bot_response }}\n\n"
-        "<END CONVERSATION>\n\n"
-        f"{PROMPT_OUTPUT_JSON_FORMAT_BLOCK}"
-    ),
-    "output_parser": "nemoguard_parse_response_safety",
-    "max_tokens": 50,
-}
-
-
-@dataclass(frozen=True)
-class GuardrailsChatTestCase:
-    sdk: NeMoPlatform  # SDK client connected to the e2e platform instance.
-    workspace: str  # Per-test workspace that owns all created entities.
-    virtual_model_name: str  # Guarded VirtualModel name hit by chat completions.
-    backend_model_name: str  # Mock model entity that represents the app LLM.
-    content_safety_model_name: str  # Mock model entity used by the content-safety rail.
-    config_name: str  # Guardrail config name, stored or used as the inline label.
-    config_mode: ConfigMode  # Whether middleware uses config_id or inline config.
-    outcome: ChatOutcome  # Which safety verdict path this test should exercise.
-
-    @property
-    def backend_model_ref(self) -> str:
-        return f"{self.workspace}/{self.backend_model_name}"
-
-    @property
-    def content_safety_model_ref(self) -> str:
-        return f"{self.workspace}/{self.content_safety_model_name}"
-
-    @property
-    def config_ref(self) -> str:
-        return f"{self.workspace}/{self.config_name}"
-
-    @property
-    def user_input(self) -> str:
-        return UNSAFE_USER_INPUT if self.outcome == "unsafe_input" else USER_INPUT
-
-
-def _unique_name(prefix: str) -> str:
-    return f"{prefix}-{uuid.uuid4().hex[:8]}"
-
-
-def _chat_completion(content: str) -> dict[str, Any]:
-    return {
-        "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
-        "object": "chat.completion",
-        "choices": [
-            {
-                "index": 0,
-                "message": {"role": "assistant", "content": content},
-                "finish_reason": "stop",
-            }
-        ],
-    }
-
-
-def _safe_input_verdict() -> str:
-    return '{"User Safety": "safe"}'
-
-
-def _unsafe_input_verdict() -> str:
-    return '{"User Safety": "unsafe", "Safety Categories": "S3"}'
-
-
-def _safe_output_verdict() -> str:
-    return '{"User Safety": "safe", "Response Safety": "safe"}'
-
-
-def _unsafe_output_verdict() -> str:
-    return '{"User Safety": "safe", "Response Safety": "unsafe", "Safety Categories": "S3"}'
-
-
-def _content_safety_config(
-    *,
-    content_safety_model_ref: str,
-    streaming: bool,
-) -> dict[str, Any]:
-    output_rails: dict[str, Any] = {
-        "flows": ["content safety check output $model=content_safety"],
-    }
-    if streaming:
-        output_rails["streaming"] = {"enabled": True, "chunk_size": 200}
-
-    return {
-        "models": [
-            {
-                "type": "content_safety",
-                "engine": "nim",
-                "model": content_safety_model_ref,
-            }
-        ],
-        "rails": {
-            "input": {"flows": ["content safety check input $model=content_safety"]},
-            "output": output_rails,
-        },
-        "prompts": [CONTENT_SAFETY_INPUT_PROMPT, CONTENT_SAFETY_OUTPUT_PROMPT],
-    }
-
-
-def _middleware_call(
-    *,
-    config_mode: ConfigMode,
-    config_ref: str,
-    config_name: str,
-    config_data: dict[str, Any],
-) -> MiddlewareCallParam:
-    if config_mode == "referenced":
-        return {
-            "name": GUARDRAILS_PLUGIN_NAME,
-            "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
-            "config_id": config_ref,
-        }
-
-    inline_config = {**config_data, "name": config_name}
-    return {
-        "name": GUARDRAILS_PLUGIN_NAME,
-        "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
-        "config": inline_config,
-    }
-
-
-def _content_safety_responses(outcome: ChatOutcome) -> list[MockProviderResponse]:
-    input_verdict = _unsafe_input_verdict() if outcome == "unsafe_input" else _safe_input_verdict()
-    output_verdict = _unsafe_output_verdict() if outcome == "unsafe_output" else _safe_output_verdict()
-    return [
-        MockProviderResponse(response_body=_chat_completion(input_verdict)),
-        MockProviderResponse(response_body=_chat_completion(output_verdict)),
-    ]
-
-
-def _setup_mock_provider(sdk: NeMoPlatform, test_case: GuardrailsChatTestCase) -> None:
-    add_mock_provider(
-        sdk,
-        workspace=test_case.workspace,
-        name=_unique_name("gr-provider"),
-        served_models={
-            test_case.backend_model_name: test_case.backend_model_name,
-            test_case.content_safety_model_name: test_case.content_safety_model_name,
-        },
-        mock_response_body_by_model={
-            test_case.backend_model_ref: [
-                MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE)),
-            ],
-            test_case.content_safety_model_ref: _content_safety_responses(test_case.outcome),
-        },
-    )
-
-
-def _create_guarded_virtual_model(
-    *,
-    sdk: NeMoPlatform,
-    test_case: GuardrailsChatTestCase,
-    config_data: dict[str, Any],
-) -> None:
-    if test_case.config_mode == "referenced":
-        sdk.guardrail.configs.create(
-            workspace=test_case.workspace,
-            name=test_case.config_name,
-            description="E2E content-safety Guardrails config",
-            data=config_data,
-        )
-
-    middleware_call = _middleware_call(
-        config_mode=test_case.config_mode,
-        config_ref=test_case.config_ref,
-        config_name=test_case.config_name,
-        config_data=config_data,
-    )
-    sdk.inference.virtual_models.create(
-        workspace=test_case.workspace,
-        name=test_case.virtual_model_name,
-        default_model_entity=test_case.backend_model_ref,
-        models=[{"model": test_case.backend_model_ref, "backend_format": "OPENAI_CHAT"}],
-        request_middleware=[middleware_call],
-        response_middleware=[middleware_call],
-    )
-    _wait_for_guarded_virtual_model(sdk, test_case)
-
-
-def _wait_for_guarded_virtual_model(
-    sdk: NeMoPlatform,
-    test_case: GuardrailsChatTestCase,
-    timeout: float = 60,
-    poll_interval: float = 0.5,
-) -> None:
-    start = time.time()
-    last_error: Exception | None = None
-
-    while time.time() - start < timeout:
-        try:
-            sdk.inference.gateway.model.get(
-                "v1/models",
-                name=test_case.virtual_model_name,
-                workspace=test_case.workspace,
-            )
-            return
-        except NotFoundError as exc:
-            last_error = exc
-            time.sleep(poll_interval)
-
-    raise TimeoutError(
-        f"Guarded VirtualModel {test_case.workspace}/{test_case.virtual_model_name} "
-        f"was not visible to IGW after {timeout}s. Last error: {last_error}"
-    )
-
-
-def _chat_body(
-    test_case: GuardrailsChatTestCase,
-    *,
-    stream: bool = False,
-    extra: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    body: dict[str, Any] = {
-        "model": test_case.backend_model_ref,
-        "messages": [{"role": "user", "content": test_case.user_input}],
-        "max_tokens": 64,
-    }
-    if stream:
-        body["stream"] = True
-    if extra:
-        body.update(extra)
-    return body
-
-
-def post_chat_completion(
-    test_case: GuardrailsChatTestCase,
-    *,
-    extra_body: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    return test_case.sdk.inference.gateway.model.post(
-        "v1/chat/completions",
-        name=test_case.virtual_model_name,
-        workspace=test_case.workspace,
-        body=_chat_body(test_case, extra=extra_body),
-    )
-
-
-def post_streaming_chat_completion(test_case: GuardrailsChatTestCase) -> dict[str, Any]:
-    with test_case.sdk._client.stream(
-        "POST",
-        f"/apis/inference-gateway/v2/workspaces/{test_case.workspace}/model/"
-        f"{test_case.virtual_model_name}/-/v1/chat/completions",
-        json=_chat_body(test_case, stream=True),
-    ) as response:
-        response.raise_for_status()
-        content_type = response.headers.get("content-type", "")
-        if "text/event-stream" not in content_type:
-            response.read()
-            return response.json()
-
-        chunks = collect_sse_chunks(response)
-
-    content = "".join(chunk["choices"][0]["delta"].get("content", "") for chunk in chunks if chunk.get("choices"))
-    error = next((chunk["error"] for chunk in chunks if isinstance(chunk.get("error"), dict)), None)
-    finish_reason = next(
-        (
-            chunk["choices"][0].get("finish_reason")
-            for chunk in chunks
-            if chunk.get("choices") and chunk["choices"][0].get("finish_reason")
-        ),
-        None,
-    )
-    return {
-        "choices": [
-            {
-                "message": {"role": "assistant", "content": content},
-                "finish_reason": "content_filter" if error else finish_reason,
-            }
-        ],
-        **({"error": error} if error else {}),
-    }
 
 
 @pytest.fixture
@@ -384,19 +35,19 @@ def guardrails_chat_test_case(
         test_case = GuardrailsChatTestCase(
             sdk=sdk,
             workspace=workspace,
-            virtual_model_name=_unique_name("gr-vm"),
-            backend_model_name=_unique_name("main-model"),
-            content_safety_model_name=_unique_name("cs-model"),
-            config_name=_unique_name("gr-config"),
+            virtual_model_name=unique_name("gr-vm"),
+            backend_model_name=unique_name("main-model"),
+            content_safety_model_name=unique_name("cs-model"),
+            config_name=unique_name("gr-config"),
             config_mode=config_mode,
             outcome=outcome,
         )
-        config_data = _content_safety_config(
+        config_data = content_safety_config(
             content_safety_model_ref=test_case.content_safety_model_ref,
             streaming=streaming,
         )
-        _setup_mock_provider(sdk, test_case)
-        _create_guarded_virtual_model(sdk=sdk, test_case=test_case, config_data=config_data)
+        setup_mock_provider(sdk, test_case)
+        create_guarded_virtual_model(sdk=sdk, test_case=test_case, config_data=config_data)
         if config_mode == "referenced":
             created_configs.append((workspace, test_case.config_name))
         return test_case

--- a/e2e/guardrails/conftest.py
+++ b/e2e/guardrails/conftest.py
@@ -12,6 +12,7 @@ from e2e.guardrails.utils import (
     ChatOutcome,
     ConfigMode,
     GuardrailsChatTestCase,
+    RailType,
     content_safety_config,
     create_guarded_virtual_model,
     setup_mock_provider,
@@ -30,6 +31,7 @@ def guardrails_chat_test_case(
         *,
         config_mode: ConfigMode,
         outcome: ChatOutcome,
+        rail_types: tuple[RailType, ...],
         streaming: bool = False,
     ) -> GuardrailsChatTestCase:
         test_case = GuardrailsChatTestCase(
@@ -41,9 +43,11 @@ def guardrails_chat_test_case(
             config_name=unique_name("gr-config"),
             config_mode=config_mode,
             outcome=outcome,
+            rail_types=rail_types,
         )
         config_data = content_safety_config(
             content_safety_model_ref=test_case.content_safety_model_ref,
+            rail_types=rail_types,
             streaming=streaming,
         )
         setup_mock_provider(sdk, test_case)

--- a/e2e/guardrails/conftest.py
+++ b/e2e/guardrails/conftest.py
@@ -1,0 +1,410 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for Guardrails plugin e2e tests."""
+
+import time
+import uuid
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import pytest
+from nemo_platform import NotFoundError
+from nemo_platform import NeMoPlatform
+from nemo_platform.types.inference import MiddlewareCallParam
+from nmp.testing import MockProviderResponse, add_mock_provider
+
+from e2e.utils import collect_sse_chunks
+
+GUARDRAILS_PLUGIN_NAME = "nemo-guardrails"
+GUARDRAILS_PLUGIN_CONFIG_TYPE = "guardrail_config"
+REFUSAL_TEXT = "I'm sorry, I can't respond to that."
+
+USER_INPUT = "What is the capital of France?"
+UNSAFE_USER_INPUT = "Give me a five-step plan to rob a bank."
+BACKEND_RESPONSE = "Paris is the capital of France."
+
+ConfigMode = Literal["referenced", "inline"]
+ChatOutcome = Literal["unsafe_input", "unsafe_output", "safe"]
+
+PROMPT_UNSAFE_CATEGORIES = (
+    "<BEGIN UNSAFE CONTENT CATEGORIES>\n"
+    "S1: Violence.\n"
+    "S2: Sexual.\n"
+    "S3: Criminal Planning/Confessions.\n"
+    "S4: Guns and Illegal Weapons.\n"
+    "S5: Controlled/Regulated Substances.\n"
+    "S6: Suicide and Self Harm.\n"
+    "S7: Sexual (minor).\n"
+    "S8: Hate/Identity Hate.\n"
+    "S9: PII/Privacy.\n"
+    "S10: Harassment.\n"
+    "S11: Threat.\n"
+    "S12: Profanity.\n"
+    "S13: Needs Caution.\n"
+    "S14: Other.\n"
+    "S15: Manipulation.\n"
+    "S16: Fraud/Deception.\n"
+    "S17: Malware.\n"
+    "S18: High Risk Gov Decision Making.\n"
+    "S19: Political/Misinformation/Conspiracy.\n"
+    "S20: Copyright/Trademark/Plagiarism.\n"
+    "S21: Unauthorized Advice.\n"
+    "S22: Illegal Activity.\n"
+    "S23: Immoral/Unethical.\n"
+    "<END UNSAFE CONTENT CATEGORIES>"
+)
+
+PROMPT_OUTPUT_JSON_FORMAT_BLOCK = (
+    "Provide your safety assessment for the above conversation in the below output JSON format:\n"
+    '{"User Safety": safe or unsafe rating for the user message, '
+    '"Response Safety": safe or unsafe rating for the agent response. '
+    "Omit if no agent response present. "
+    '"Safety Categories": a comma-separated list of applicable safety categories from the provided taxonomy. '
+    "Omit if all safe.}\n\n"
+    "Do not include anything other than the output JSON in your response.\n"
+    "Output JSON:"
+)
+
+PROMPT_TASK_BLOCK = (
+    "Task: Check if there is unsafe content in the user or agent messages in the below conversation "
+    "in accordance with our safety policy with the below categories. "
+    "Provide a 'safe' or 'unsafe' rating for both the user message and the agent response. "
+    "If there is unsafe content, please also provide a list of violated categories according to "
+    "our safety policy below."
+)
+
+CONTENT_SAFETY_INPUT_PROMPT = {
+    "task": "content_safety_check_input $model=content_safety",
+    "content": (
+        f"{PROMPT_TASK_BLOCK}\n\n"
+        f"{PROMPT_UNSAFE_CATEGORIES}\n\n"
+        "<BEGIN CONVERSATION>\n\n"
+        "user: {{ user_input }}\n\n"
+        "<END CONVERSATION>\n\n"
+        f"{PROMPT_OUTPUT_JSON_FORMAT_BLOCK}"
+    ),
+    "output_parser": "nemoguard_parse_prompt_safety",
+    "max_tokens": 50,
+}
+
+CONTENT_SAFETY_OUTPUT_PROMPT = {
+    "task": "content_safety_check_output $model=content_safety",
+    "content": (
+        f"{PROMPT_TASK_BLOCK}\n\n"
+        f"{PROMPT_UNSAFE_CATEGORIES}\n\n"
+        "<BEGIN CONVERSATION>\n\n"
+        "user: {{ user_input }}\n\n"
+        "response: agent: {{ bot_response }}\n\n"
+        "<END CONVERSATION>\n\n"
+        f"{PROMPT_OUTPUT_JSON_FORMAT_BLOCK}"
+    ),
+    "output_parser": "nemoguard_parse_response_safety",
+    "max_tokens": 50,
+}
+
+
+@dataclass(frozen=True)
+class GuardrailsChatTestCase:
+    sdk: NeMoPlatform  # SDK client connected to the e2e platform instance.
+    workspace: str  # Per-test workspace that owns all created entities.
+    virtual_model_name: str  # Guarded VirtualModel name hit by chat completions.
+    backend_model_name: str  # Mock model entity that represents the app LLM.
+    content_safety_model_name: str  # Mock model entity used by the content-safety rail.
+    config_name: str  # Guardrail config name, stored or used as the inline label.
+    config_mode: ConfigMode  # Whether middleware uses config_id or inline config.
+    outcome: ChatOutcome  # Which safety verdict path this test should exercise.
+
+    @property
+    def backend_model_ref(self) -> str:
+        return f"{self.workspace}/{self.backend_model_name}"
+
+    @property
+    def content_safety_model_ref(self) -> str:
+        return f"{self.workspace}/{self.content_safety_model_name}"
+
+    @property
+    def config_ref(self) -> str:
+        return f"{self.workspace}/{self.config_name}"
+
+    @property
+    def user_input(self) -> str:
+        return UNSAFE_USER_INPUT if self.outcome == "unsafe_input" else USER_INPUT
+
+
+def _unique_name(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def _chat_completion(content: str) -> dict[str, Any]:
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+def _safe_input_verdict() -> str:
+    return '{"User Safety": "safe"}'
+
+
+def _unsafe_input_verdict() -> str:
+    return '{"User Safety": "unsafe", "Safety Categories": "S3"}'
+
+
+def _safe_output_verdict() -> str:
+    return '{"User Safety": "safe", "Response Safety": "safe"}'
+
+
+def _unsafe_output_verdict() -> str:
+    return '{"User Safety": "safe", "Response Safety": "unsafe", "Safety Categories": "S3"}'
+
+
+def _content_safety_config(
+    *,
+    content_safety_model_ref: str,
+    streaming: bool,
+) -> dict[str, Any]:
+    output_rails: dict[str, Any] = {
+        "flows": ["content safety check output $model=content_safety"],
+    }
+    if streaming:
+        output_rails["streaming"] = {"enabled": True, "chunk_size": 200}
+
+    return {
+        "models": [
+            {
+                "type": "content_safety",
+                "engine": "nim",
+                "model": content_safety_model_ref,
+            }
+        ],
+        "rails": {
+            "input": {"flows": ["content safety check input $model=content_safety"]},
+            "output": output_rails,
+        },
+        "prompts": [CONTENT_SAFETY_INPUT_PROMPT, CONTENT_SAFETY_OUTPUT_PROMPT],
+    }
+
+
+def _middleware_call(
+    *,
+    config_mode: ConfigMode,
+    config_ref: str,
+    config_name: str,
+    config_data: dict[str, Any],
+) -> MiddlewareCallParam:
+    if config_mode == "referenced":
+        return {
+            "name": GUARDRAILS_PLUGIN_NAME,
+            "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
+            "config_id": config_ref,
+        }
+
+    inline_config = {**config_data, "name": config_name}
+    return {
+        "name": GUARDRAILS_PLUGIN_NAME,
+        "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
+        "config": inline_config,
+    }
+
+
+def _content_safety_responses(outcome: ChatOutcome) -> list[MockProviderResponse]:
+    input_verdict = _unsafe_input_verdict() if outcome == "unsafe_input" else _safe_input_verdict()
+    output_verdict = _unsafe_output_verdict() if outcome == "unsafe_output" else _safe_output_verdict()
+    return [
+        MockProviderResponse(response_body=_chat_completion(input_verdict)),
+        MockProviderResponse(response_body=_chat_completion(output_verdict)),
+    ]
+
+
+def _setup_mock_provider(sdk: NeMoPlatform, test_case: GuardrailsChatTestCase) -> None:
+    add_mock_provider(
+        sdk,
+        workspace=test_case.workspace,
+        name=_unique_name("gr-provider"),
+        served_models={
+            test_case.backend_model_name: test_case.backend_model_name,
+            test_case.content_safety_model_name: test_case.content_safety_model_name,
+        },
+        mock_response_body_by_model={
+            test_case.backend_model_ref: [
+                MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE)),
+            ],
+            test_case.content_safety_model_ref: _content_safety_responses(test_case.outcome),
+        },
+    )
+
+
+def _create_guarded_virtual_model(
+    *,
+    sdk: NeMoPlatform,
+    test_case: GuardrailsChatTestCase,
+    config_data: dict[str, Any],
+) -> None:
+    if test_case.config_mode == "referenced":
+        sdk.guardrail.configs.create(
+            workspace=test_case.workspace,
+            name=test_case.config_name,
+            description="E2E content-safety Guardrails config",
+            data=config_data,
+        )
+
+    middleware_call = _middleware_call(
+        config_mode=test_case.config_mode,
+        config_ref=test_case.config_ref,
+        config_name=test_case.config_name,
+        config_data=config_data,
+    )
+    sdk.inference.virtual_models.create(
+        workspace=test_case.workspace,
+        name=test_case.virtual_model_name,
+        default_model_entity=test_case.backend_model_ref,
+        models=[{"model": test_case.backend_model_ref, "backend_format": "OPENAI_CHAT"}],
+        request_middleware=[middleware_call],
+        response_middleware=[middleware_call],
+    )
+    _wait_for_guarded_virtual_model(sdk, test_case)
+
+
+def _wait_for_guarded_virtual_model(
+    sdk: NeMoPlatform,
+    test_case: GuardrailsChatTestCase,
+    timeout: float = 60,
+    poll_interval: float = 0.5,
+) -> None:
+    start = time.time()
+    last_error: Exception | None = None
+
+    while time.time() - start < timeout:
+        try:
+            sdk.inference.gateway.model.get(
+                "v1/models",
+                name=test_case.virtual_model_name,
+                workspace=test_case.workspace,
+            )
+            return
+        except NotFoundError as exc:
+            last_error = exc
+            time.sleep(poll_interval)
+
+    raise TimeoutError(
+        f"Guarded VirtualModel {test_case.workspace}/{test_case.virtual_model_name} "
+        f"was not visible to IGW after {timeout}s. Last error: {last_error}"
+    )
+
+
+def _chat_body(
+    test_case: GuardrailsChatTestCase,
+    *,
+    stream: bool = False,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "model": test_case.backend_model_ref,
+        "messages": [{"role": "user", "content": test_case.user_input}],
+        "max_tokens": 64,
+    }
+    if stream:
+        body["stream"] = True
+    if extra:
+        body.update(extra)
+    return body
+
+
+def post_chat_completion(
+    test_case: GuardrailsChatTestCase,
+    *,
+    extra_body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return test_case.sdk.inference.gateway.model.post(
+        "v1/chat/completions",
+        name=test_case.virtual_model_name,
+        workspace=test_case.workspace,
+        body=_chat_body(test_case, extra=extra_body),
+    )
+
+
+def post_streaming_chat_completion(test_case: GuardrailsChatTestCase) -> dict[str, Any]:
+    with test_case.sdk._client.stream(
+        "POST",
+        f"/apis/inference-gateway/v2/workspaces/{test_case.workspace}/model/"
+        f"{test_case.virtual_model_name}/-/v1/chat/completions",
+        json=_chat_body(test_case, stream=True),
+    ) as response:
+        response.raise_for_status()
+        content_type = response.headers.get("content-type", "")
+        if "text/event-stream" not in content_type:
+            response.read()
+            return response.json()
+
+        chunks = collect_sse_chunks(response)
+
+    content = "".join(chunk["choices"][0]["delta"].get("content", "") for chunk in chunks if chunk.get("choices"))
+    error = next((chunk["error"] for chunk in chunks if isinstance(chunk.get("error"), dict)), None)
+    finish_reason = next(
+        (
+            chunk["choices"][0].get("finish_reason")
+            for chunk in chunks
+            if chunk.get("choices") and chunk["choices"][0].get("finish_reason")
+        ),
+        None,
+    )
+    return {
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "content_filter" if error else finish_reason,
+            }
+        ],
+        **({"error": error} if error else {}),
+    }
+
+
+@pytest.fixture
+def guardrails_chat_test_case(
+    sdk: NeMoPlatform,
+    workspace: str,
+) -> Iterator[Callable[..., GuardrailsChatTestCase]]:
+    created_configs: list[tuple[str, str]] = []
+
+    def _factory(
+        *,
+        config_mode: ConfigMode,
+        outcome: ChatOutcome,
+        streaming: bool = False,
+    ) -> GuardrailsChatTestCase:
+        test_case = GuardrailsChatTestCase(
+            sdk=sdk,
+            workspace=workspace,
+            virtual_model_name=_unique_name("gr-vm"),
+            backend_model_name=_unique_name("main-model"),
+            content_safety_model_name=_unique_name("cs-model"),
+            config_name=_unique_name("gr-config"),
+            config_mode=config_mode,
+            outcome=outcome,
+        )
+        config_data = _content_safety_config(
+            content_safety_model_ref=test_case.content_safety_model_ref,
+            streaming=streaming,
+        )
+        _setup_mock_provider(sdk, test_case)
+        _create_guarded_virtual_model(sdk=sdk, test_case=test_case, config_data=config_data)
+        if config_mode == "referenced":
+            created_configs.append((workspace, test_case.config_name))
+        return test_case
+
+    yield _factory
+
+    for config_workspace, config_name in created_configs:
+        try:
+            sdk.guardrail.configs.delete(workspace=config_workspace, name=config_name)
+        except Exception:
+            pass

--- a/e2e/guardrails/test_chat_completions.py
+++ b/e2e/guardrails/test_chat_completions.py
@@ -21,10 +21,14 @@ from typing import Any
 import nemo_platform
 import pytest
 
-from .conftest import post_chat_completion, post_streaming_chat_completion
-
-BACKEND_RESPONSE = "Paris is the capital of France."
-REFUSAL_TEXT = "I'm sorry, I can't respond to that."
+from e2e.guardrails.utils import (
+    BACKEND_RESPONSE,
+    CONTENT_SAFETY_INPUT_FLOW,
+    CONTENT_SAFETY_OUTPUT_FLOW,
+    REFUSAL_TEXT,
+    post_chat_completion,
+    post_streaming_chat_completion,
+)
 
 
 def _assert_blocked(response: dict[str, Any]) -> None:
@@ -42,6 +46,13 @@ def _assert_streaming_blocked(response: dict[str, Any]) -> None:
 
 def _assert_allowed(response: dict[str, Any]) -> None:
     assert response["choices"][0]["message"]["content"] == BACKEND_RESPONSE
+
+
+def _activated_rails_by_name(response: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    guardrails_data = response.get("guardrails_data") or {}
+    log = guardrails_data.get("log") or {}
+    activated_rails = log.get("activated_rails") or []
+    return {rail["name"]: rail for rail in activated_rails}
 
 
 # ---------------------------------------------------------------------------
@@ -191,7 +202,9 @@ def test_chat_completions_reports_guardrails_metadata_when_blocked(
 
     guardrails_data = response.get("guardrails_data") or {}
     assert guardrails_data.get("config_ids") == [test_case.config_ref]
-    assert guardrails_data.get("log", {}).get("activated_rails")
+    activated_rails = _activated_rails_by_name(response)
+    assert activated_rails[CONTENT_SAFETY_INPUT_FLOW]["stop"] is True
+    assert activated_rails[CONTENT_SAFETY_OUTPUT_FLOW]["stop"] is False
 
 
 def test_chat_completions_rejects_unsupported_body_guardrails_config(

--- a/e2e/guardrails/test_chat_completions.py
+++ b/e2e/guardrails/test_chat_completions.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for the Guardrails plugin on chat completions.
+
+These tests verify that the ``nemo-guardrails`` inference middleware works
+through the real platform subprocess, exercising content-safety input and
+output rails on non-streaming and streaming Inference Gateway chat-completion
+routes.
+
+Mock provider mode is enabled by the NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX
+env var set in e2e/conftest.py. Tests use ``add_mock_provider()`` from
+nmp.testing to create one provider serving both the backend chat model and the
+content-safety task model, so the full Guardrails path runs without a real
+inference backend.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+import nemo_platform
+import pytest
+
+from .conftest import post_chat_completion, post_streaming_chat_completion
+
+BACKEND_RESPONSE = "Paris is the capital of France."
+REFUSAL_TEXT = "I'm sorry, I can't respond to that."
+
+
+def _assert_blocked(response: dict[str, Any]) -> None:
+    assert response["choices"][0]["finish_reason"] == "content_filter"
+    assert response["choices"][0]["message"]["content"] == REFUSAL_TEXT
+
+
+def _assert_streaming_blocked(response: dict[str, Any]) -> None:
+    if response.get("error"):
+        assert response["error"]["code"] == "content_blocked"
+        return
+
+    _assert_blocked(response)
+
+
+def _assert_allowed(response: dict[str, Any]) -> None:
+    assert response["choices"][0]["message"]["content"] == BACKEND_RESPONSE
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming chat completions
+# ---------------------------------------------------------------------------
+
+
+def test_chat_completions_blocks_unsafe_input(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_input")
+
+    response = post_chat_completion(test_case)
+
+    _assert_blocked(response)
+
+
+def test_chat_completions_blocks_unsafe_llm_output(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_output")
+
+    response = post_chat_completion(test_case)
+
+    _assert_blocked(response)
+
+
+def test_chat_completions_allows_safe_request(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="safe")
+
+    response = post_chat_completion(test_case)
+
+    _assert_allowed(response)
+
+
+def test_chat_completions_blocks_unsafe_input_with_inline_config(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_input")
+
+    response = post_chat_completion(test_case)
+
+    _assert_blocked(response)
+
+
+def test_chat_completions_blocks_unsafe_llm_output_with_inline_config(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_output")
+
+    response = post_chat_completion(test_case)
+
+    _assert_blocked(response)
+
+
+def test_chat_completions_allows_safe_request_with_inline_config(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="inline", outcome="safe")
+
+    response = post_chat_completion(test_case)
+
+    _assert_allowed(response)
+
+
+# ---------------------------------------------------------------------------
+# Streaming chat completions
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_chat_completions_blocks_unsafe_input(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_input", streaming=True)
+
+    response = post_streaming_chat_completion(test_case)
+
+    _assert_streaming_blocked(response)
+
+
+def test_streaming_chat_completions_blocks_unsafe_llm_output(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_output", streaming=True)
+
+    response = post_streaming_chat_completion(test_case)
+
+    _assert_streaming_blocked(response)
+
+
+def test_streaming_chat_completions_allows_safe_request(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="safe", streaming=True)
+
+    response = post_streaming_chat_completion(test_case)
+
+    _assert_allowed(response)
+
+
+def test_streaming_chat_completions_blocks_unsafe_input_with_inline_config(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_input", streaming=True)
+
+    response = post_streaming_chat_completion(test_case)
+
+    _assert_streaming_blocked(response)
+
+
+def test_streaming_chat_completions_blocks_unsafe_llm_output_with_inline_config(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_output", streaming=True)
+
+    response = post_streaming_chat_completion(test_case)
+
+    _assert_streaming_blocked(response)
+
+
+def test_streaming_chat_completions_allows_safe_request_with_inline_config(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="inline", outcome="safe", streaming=True)
+
+    response = post_streaming_chat_completion(test_case)
+
+    _assert_allowed(response)
+
+
+# ---------------------------------------------------------------------------
+# Chat completion request/response contract
+# ---------------------------------------------------------------------------
+
+
+def test_chat_completions_reports_guardrails_metadata_when_blocked(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_input")
+
+    response = post_chat_completion(
+        test_case,
+        extra_body={"guardrails": {"options": {"log": {"activated_rails": True}}}},
+    )
+
+    guardrails_data = response.get("guardrails_data") or {}
+    assert guardrails_data.get("config_ids") == [test_case.config_ref]
+    assert guardrails_data.get("log", {}).get("activated_rails")
+
+
+def test_chat_completions_rejects_unsupported_body_guardrails_config(
+    guardrails_chat_test_case: Callable[..., Any],
+) -> None:
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="safe")
+
+    with pytest.raises(nemo_platform.APIStatusError) as exc_info:
+        post_chat_completion(
+            test_case,
+            extra_body={"guardrails": {"config_id": test_case.config_ref}},
+        )
+
+    assert exc_info.value.status_code == 422

--- a/e2e/guardrails/test_chat_completions.py
+++ b/e2e/guardrails/test_chat_completions.py
@@ -63,7 +63,7 @@ def _activated_rails_by_name(response: dict[str, Any]) -> dict[str, dict[str, An
 def test_chat_completions_blocks_unsafe_input(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_input")
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_input", rail_types=("input",))
 
     response = post_chat_completion(test_case)
 
@@ -73,7 +73,7 @@ def test_chat_completions_blocks_unsafe_input(
 def test_chat_completions_blocks_unsafe_llm_output(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_output")
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_output", rail_types=("output",))
 
     response = post_chat_completion(test_case)
 
@@ -83,7 +83,7 @@ def test_chat_completions_blocks_unsafe_llm_output(
 def test_chat_completions_allows_safe_request(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="safe")
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="safe", rail_types=("input", "output"))
 
     response = post_chat_completion(test_case)
 
@@ -93,7 +93,7 @@ def test_chat_completions_allows_safe_request(
 def test_chat_completions_blocks_unsafe_input_with_inline_config(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_input")
+    test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_input", rail_types=("input",))
 
     response = post_chat_completion(test_case)
 
@@ -103,7 +103,7 @@ def test_chat_completions_blocks_unsafe_input_with_inline_config(
 def test_chat_completions_blocks_unsafe_llm_output_with_inline_config(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_output")
+    test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_output", rail_types=("output",))
 
     response = post_chat_completion(test_case)
 
@@ -113,7 +113,7 @@ def test_chat_completions_blocks_unsafe_llm_output_with_inline_config(
 def test_chat_completions_allows_safe_request_with_inline_config(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="inline", outcome="safe")
+    test_case = guardrails_chat_test_case(config_mode="inline", outcome="safe", rail_types=("input", "output"))
 
     response = post_chat_completion(test_case)
 
@@ -128,7 +128,9 @@ def test_chat_completions_allows_safe_request_with_inline_config(
 def test_streaming_chat_completions_blocks_unsafe_input(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_input", streaming=True)
+    test_case = guardrails_chat_test_case(
+        config_mode="referenced", outcome="unsafe_input", rail_types=("input",), streaming=True
+    )
 
     response = post_streaming_chat_completion(test_case)
 
@@ -138,7 +140,9 @@ def test_streaming_chat_completions_blocks_unsafe_input(
 def test_streaming_chat_completions_blocks_unsafe_llm_output(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_output", streaming=True)
+    test_case = guardrails_chat_test_case(
+        config_mode="referenced", outcome="unsafe_output", rail_types=("output",), streaming=True
+    )
 
     response = post_streaming_chat_completion(test_case)
 
@@ -148,7 +152,9 @@ def test_streaming_chat_completions_blocks_unsafe_llm_output(
 def test_streaming_chat_completions_allows_safe_request(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="safe", streaming=True)
+    test_case = guardrails_chat_test_case(
+        config_mode="referenced", outcome="safe", rail_types=("input", "output"), streaming=True
+    )
 
     response = post_streaming_chat_completion(test_case)
 
@@ -158,7 +164,9 @@ def test_streaming_chat_completions_allows_safe_request(
 def test_streaming_chat_completions_blocks_unsafe_input_with_inline_config(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_input", streaming=True)
+    test_case = guardrails_chat_test_case(
+        config_mode="inline", outcome="unsafe_input", rail_types=("input",), streaming=True
+    )
 
     response = post_streaming_chat_completion(test_case)
 
@@ -168,7 +176,9 @@ def test_streaming_chat_completions_blocks_unsafe_input_with_inline_config(
 def test_streaming_chat_completions_blocks_unsafe_llm_output_with_inline_config(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_output", streaming=True)
+    test_case = guardrails_chat_test_case(
+        config_mode="inline", outcome="unsafe_output", rail_types=("output",), streaming=True
+    )
 
     response = post_streaming_chat_completion(test_case)
 
@@ -178,7 +188,9 @@ def test_streaming_chat_completions_blocks_unsafe_llm_output_with_inline_config(
 def test_streaming_chat_completions_allows_safe_request_with_inline_config(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="inline", outcome="safe", streaming=True)
+    test_case = guardrails_chat_test_case(
+        config_mode="inline", outcome="safe", rail_types=("input", "output"), streaming=True
+    )
 
     response = post_streaming_chat_completion(test_case)
 
@@ -193,7 +205,9 @@ def test_streaming_chat_completions_allows_safe_request_with_inline_config(
 def test_chat_completions_reports_guardrails_metadata_when_blocked(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_input")
+    test_case = guardrails_chat_test_case(
+        config_mode="referenced", outcome="unsafe_output", rail_types=("input", "output")
+    )
 
     response = post_chat_completion(
         test_case,
@@ -203,14 +217,14 @@ def test_chat_completions_reports_guardrails_metadata_when_blocked(
     guardrails_data = response.get("guardrails_data") or {}
     assert guardrails_data.get("config_ids") == [test_case.config_ref]
     activated_rails = _activated_rails_by_name(response)
-    assert activated_rails[CONTENT_SAFETY_INPUT_FLOW]["stop"] is True
-    assert activated_rails[CONTENT_SAFETY_OUTPUT_FLOW]["stop"] is False
+    assert activated_rails[CONTENT_SAFETY_INPUT_FLOW]["stop"] is False
+    assert activated_rails[CONTENT_SAFETY_OUTPUT_FLOW]["stop"] is True
 
 
 def test_chat_completions_rejects_unsupported_body_guardrails_config(
     guardrails_chat_test_case: Callable[..., Any],
 ) -> None:
-    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="safe")
+    test_case = guardrails_chat_test_case(config_mode="referenced", outcome="safe", rail_types=("input",))
 
     with pytest.raises(nemo_platform.APIStatusError) as exc_info:
         post_chat_completion(

--- a/e2e/guardrails/utils.py
+++ b/e2e/guardrails/utils.py
@@ -182,16 +182,19 @@ def setup_mock_provider(sdk: NeMoPlatform, test_case: GuardrailsChatTestCase) ->
         sdk,
         workspace=test_case.workspace,
         name=unique_name("gr-provider"),
+        # `served_models` registers the model by bare name; the mock provider already
+        # belongs to `test_case.workspace`.
         served_models={
             test_case.backend_model_name: test_case.backend_model_name,
             test_case.content_safety_model_name: test_case.content_safety_model_name,
         },
+        # `mock_response_body_by_model` maps the request body's exact `model` value,
+        # which is the workspace-qualified model ref, to a mock response(s).
         mock_response_body_by_model={
             test_case.backend_model_ref: [
                 MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE)),
             ],
             test_case.content_safety_model_ref: _content_safety_responses(test_case),
-            test_case.content_safety_model_name: _content_safety_responses(test_case),
         },
     )
     _wait_for_virtual_model(sdk, test_case.workspace, test_case.content_safety_model_name)

--- a/e2e/guardrails/utils.py
+++ b/e2e/guardrails/utils.py
@@ -181,8 +181,10 @@ def setup_mock_provider(sdk: NeMoPlatform, test_case: GuardrailsChatTestCase) ->
                 MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE)),
             ],
             test_case.content_safety_model_ref: _content_safety_responses(test_case.outcome),
+            test_case.content_safety_model_name: _content_safety_responses(test_case.outcome),
         },
     )
+    _wait_for_virtual_model(sdk, test_case.workspace, test_case.content_safety_model_name)
 
 
 def create_guarded_virtual_model(
@@ -213,7 +215,7 @@ def create_guarded_virtual_model(
         request_middleware=[middleware_call],
         response_middleware=[middleware_call],
     )
-    _wait_for_guarded_virtual_model(sdk, test_case)
+    _wait_for_virtual_model(sdk, test_case.workspace, test_case.virtual_model_name)
 
 
 def post_chat_completion(
@@ -326,9 +328,10 @@ def _content_safety_responses(outcome: ChatOutcome) -> list[MockProviderResponse
     ]
 
 
-def _wait_for_guarded_virtual_model(
+def _wait_for_virtual_model(
     sdk: NeMoPlatform,
-    test_case: GuardrailsChatTestCase,
+    workspace: str,
+    name: str,
     timeout: float = 60,
     poll_interval: float = 0.5,
 ) -> None:
@@ -339,8 +342,8 @@ def _wait_for_guarded_virtual_model(
         try:
             sdk.inference.gateway.model.get(
                 "v1/models",
-                name=test_case.virtual_model_name,
-                workspace=test_case.workspace,
+                name=name,
+                workspace=workspace,
             )
             return
         except NotFoundError as exc:
@@ -348,8 +351,7 @@ def _wait_for_guarded_virtual_model(
             time.sleep(poll_interval)
 
     raise TimeoutError(
-        f"Guarded VirtualModel {test_case.workspace}/{test_case.virtual_model_name} "
-        f"was not visible to IGW after {timeout}s. Last error: {last_error}"
+        f"VirtualModel {workspace}/{name} was not visible to IGW after {timeout}s. Last error: {last_error}"
     )
 
 

--- a/e2e/guardrails/utils.py
+++ b/e2e/guardrails/utils.py
@@ -22,14 +22,17 @@ USER_INPUT = "What is the capital of France?"
 UNSAFE_USER_INPUT = "Give me a five-step plan to rob a bank."
 BACKEND_RESPONSE = "Paris is the capital of France."
 
-CONTENT_SAFETY_INPUT_FLOW = "content safety check input $model=content_safety"
-CONTENT_SAFETY_OUTPUT_FLOW = "content safety check output $model=content_safety"
+CONTENT_SAFETY_MODEL_TYPE = "content_safety"
+CONTENT_SAFETY_INPUT_FLOW = f"content safety check input $model={CONTENT_SAFETY_MODEL_TYPE}"
+CONTENT_SAFETY_OUTPUT_FLOW = f"content safety check output $model={CONTENT_SAFETY_MODEL_TYPE}"
 
 # How to pass the GuardrailConfig to a VirtualModel: either a reference to an existing config's `workspace/name`
 # (referenced), or an inline config (inline).
 ConfigMode = Literal["referenced", "inline"]
 # The possible outcomes of a Guardrails chat completion test.
 ChatOutcome = Literal["unsafe_input", "unsafe_output", "safe"]
+# The rail directions enabled by a Guardrails chat completion test.
+RailType = Literal["input", "output"]
 
 PROMPT_UNSAFE_CATEGORIES = (
     "<BEGIN UNSAFE CONTENT CATEGORIES>\n"
@@ -79,7 +82,7 @@ PROMPT_TASK_BLOCK = (
 )
 
 CONTENT_SAFETY_INPUT_PROMPT = {
-    "task": "content_safety_check_input $model=content_safety",
+    "task": f"content_safety_check_input $model={CONTENT_SAFETY_MODEL_TYPE}",
     "content": (
         f"{PROMPT_TASK_BLOCK}\n\n"
         f"{PROMPT_UNSAFE_CATEGORIES}\n\n"
@@ -93,7 +96,7 @@ CONTENT_SAFETY_INPUT_PROMPT = {
 }
 
 CONTENT_SAFETY_OUTPUT_PROMPT = {
-    "task": "content_safety_check_output $model=content_safety",
+    "task": f"content_safety_check_output $model={CONTENT_SAFETY_MODEL_TYPE}",
     "content": (
         f"{PROMPT_TASK_BLOCK}\n\n"
         f"{PROMPT_UNSAFE_CATEGORIES}\n\n"
@@ -114,10 +117,11 @@ class GuardrailsChatTestCase:
     workspace: str  # Per-test workspace that owns all created entities.
     virtual_model_name: str  # Guarded VirtualModel name hit by chat completions.
     backend_model_name: str  # Mock model entity that represents the app LLM.
-    content_safety_model_name: str  # Mock model entity used by the content-safety rail.
+    content_safety_model_name: str  # Mock model entity used by content-safety rails.
     config_name: str  # Guardrail config name, stored or used as the inline label.
     config_mode: ConfigMode  # Whether middleware uses config_id or inline config.
     outcome: ChatOutcome  # Which safety verdict path this test should exercise.
+    rail_types: tuple[RailType, ...]  # Which Guardrails rail types are enabled in the config.
 
     @property
     def backend_model_ref(self) -> str:
@@ -143,27 +147,33 @@ def unique_name(prefix: str) -> str:
 def content_safety_config(
     *,
     content_safety_model_ref: str,
+    rail_types: tuple[RailType, ...],
     streaming: bool,
 ) -> dict[str, Any]:
-    output_rails: dict[str, Any] = {
-        "flows": [CONTENT_SAFETY_OUTPUT_FLOW],
-    }
-    if streaming:
-        output_rails["streaming"] = {"enabled": True, "chunk_size": 200}
+    rails: dict[str, Any] = {}
+    prompts: list[dict[str, Any]] = []
+
+    if "input" in rail_types:
+        rails["input"] = {"flows": [CONTENT_SAFETY_INPUT_FLOW]}
+        prompts.append(CONTENT_SAFETY_INPUT_PROMPT)
+
+    if "output" in rail_types:
+        output_rails: dict[str, Any] = {"flows": [CONTENT_SAFETY_OUTPUT_FLOW]}
+        if streaming:
+            output_rails["streaming"] = {"enabled": True, "chunk_size": 200}
+        rails["output"] = output_rails
+        prompts.append(CONTENT_SAFETY_OUTPUT_PROMPT)
 
     return {
         "models": [
             {
-                "type": "content_safety",
+                "type": CONTENT_SAFETY_MODEL_TYPE,
                 "engine": "nim",
                 "model": content_safety_model_ref,
             }
         ],
-        "rails": {
-            "input": {"flows": [CONTENT_SAFETY_INPUT_FLOW]},
-            "output": output_rails,
-        },
-        "prompts": [CONTENT_SAFETY_INPUT_PROMPT, CONTENT_SAFETY_OUTPUT_PROMPT],
+        "rails": rails,
+        "prompts": prompts,
     }
 
 
@@ -180,8 +190,8 @@ def setup_mock_provider(sdk: NeMoPlatform, test_case: GuardrailsChatTestCase) ->
             test_case.backend_model_ref: [
                 MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE)),
             ],
-            test_case.content_safety_model_ref: _content_safety_responses(test_case.outcome),
-            test_case.content_safety_model_name: _content_safety_responses(test_case.outcome),
+            test_case.content_safety_model_ref: _content_safety_responses(test_case),
+            test_case.content_safety_model_name: _content_safety_responses(test_case),
         },
     )
     _wait_for_virtual_model(sdk, test_case.workspace, test_case.content_safety_model_name)
@@ -319,13 +329,18 @@ def _middleware_call(
     }
 
 
-def _content_safety_responses(outcome: ChatOutcome) -> list[MockProviderResponse]:
-    input_verdict = _unsafe_input_verdict() if outcome == "unsafe_input" else _safe_input_verdict()
-    output_verdict = _unsafe_output_verdict() if outcome == "unsafe_output" else _safe_output_verdict()
-    return [
-        MockProviderResponse(response_body=_chat_completion(input_verdict)),
-        MockProviderResponse(response_body=_chat_completion(output_verdict)),
-    ]
+def _content_safety_responses(test_case: GuardrailsChatTestCase) -> list[MockProviderResponse]:
+    responses: list[MockProviderResponse] = []
+
+    if "input" in test_case.rail_types:
+        input_verdict = _unsafe_input_verdict() if test_case.outcome == "unsafe_input" else _safe_input_verdict()
+        responses.append(MockProviderResponse(response_body=_chat_completion(input_verdict)))
+
+    if "output" in test_case.rail_types:
+        output_verdict = _unsafe_output_verdict() if test_case.outcome == "unsafe_output" else _safe_output_verdict()
+        responses.append(MockProviderResponse(response_body=_chat_completion(output_verdict)))
+
+    return responses
 
 
 def _wait_for_virtual_model(

--- a/e2e/guardrails/utils.py
+++ b/e2e/guardrails/utils.py
@@ -8,7 +8,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from nemo_platform import NeMoPlatform, NotFoundError
+from nemo_platform import APIStatusError, NeMoPlatform
 from nemo_platform.types.inference import MiddlewareCallParam
 from nmp.testing import MockProviderResponse, add_mock_provider
 
@@ -182,14 +182,15 @@ def setup_mock_provider(sdk: NeMoPlatform, test_case: GuardrailsChatTestCase) ->
         sdk,
         workspace=test_case.workspace,
         name=unique_name("gr-provider"),
-        # `served_models` registers the model by bare name; the mock provider already
-        # belongs to `test_case.workspace`.
+        # Register provider model entities by bare name; the provider already belongs
+        # to `test_case.workspace`, and `add_mock_provider` expands these to refs.
         served_models={
             test_case.backend_model_name: test_case.backend_model_name,
             test_case.content_safety_model_name: test_case.content_safety_model_name,
         },
-        # `mock_response_body_by_model` maps the request body's exact `model` value,
-        # which is the workspace-qualified model ref, to a mock response(s).
+        # Mock responses are selected by exact `body["model"]`. In this test, both
+        # the app LLM and Guardrails content-safety calls go through IGW using model
+        # entity refs, so the mock response map is keyed by `workspace/model`.
         mock_response_body_by_model={
             test_case.backend_model_ref: [
                 MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE)),
@@ -197,7 +198,6 @@ def setup_mock_provider(sdk: NeMoPlatform, test_case: GuardrailsChatTestCase) ->
             test_case.content_safety_model_ref: _content_safety_responses(test_case),
         },
     )
-    _wait_for_virtual_model(sdk, test_case.workspace, test_case.content_safety_model_name)
 
 
 def create_guarded_virtual_model(
@@ -228,7 +228,7 @@ def create_guarded_virtual_model(
         request_middleware=[middleware_call],
         response_middleware=[middleware_call],
     )
-    _wait_for_virtual_model(sdk, test_case.workspace, test_case.virtual_model_name)
+    _wait_for_guarded_virtual_model(sdk, test_case)
 
 
 def post_chat_completion(
@@ -346,30 +346,53 @@ def _content_safety_responses(test_case: GuardrailsChatTestCase) -> list[MockPro
     return responses
 
 
-def _wait_for_virtual_model(
+def _wait_for_guarded_virtual_model(
     sdk: NeMoPlatform,
-    workspace: str,
-    name: str,
+    test_case: GuardrailsChatTestCase,
     timeout: float = 60,
     poll_interval: float = 0.5,
 ) -> None:
+    """Wait until the guarded VM route is cached with its Guardrails middleware.
+
+    E2E runs against a separate IGW process. Creating the VM persists the entity,
+    but the VM is not usable with middleware until IGW's background cache refresh
+    loads it into VirtualModelCache and resolves its Guardrails config into the
+    middleware registry.
+
+    To ensure the VM is ready to serve requests, use a request that Guardrails
+    rejects during request parsing, before any rail or backend inference runs.
+    A 422 response means the VM route exists but Guardrails is not attached yet.
+    """
     start = time.time()
     last_error: Exception | None = None
+    probe_body = _chat_body(
+        test_case,
+        extra={"guardrails": {"config_id": test_case.config_ref}},
+    )
 
     while time.time() - start < timeout:
         try:
-            sdk.inference.gateway.model.get(
-                "v1/models",
-                name=name,
-                workspace=workspace,
+            sdk.inference.gateway.model.post(
+                "v1/chat/completions",
+                name=test_case.virtual_model_name,
+                workspace=test_case.workspace,
+                body=probe_body,
             )
-            return
-        except NotFoundError as exc:
+        except APIStatusError as exc:
             last_error = exc
-            time.sleep(poll_interval)
+            if exc.status_code == 422:
+                return
+            if exc.status_code in {404, 503}:
+                time.sleep(poll_interval)
+                continue
+            raise
+
+        last_error = RuntimeError("Guarded VM routed without rejecting unsupported Guardrails request config")
+        time.sleep(poll_interval)
 
     raise TimeoutError(
-        f"VirtualModel {workspace}/{name} was not visible to IGW after {timeout}s. Last error: {last_error}"
+        f"Guarded VirtualModel {test_case.workspace}/{test_case.virtual_model_name} "
+        f"was not ready after {timeout}s. Last error: {last_error}"
     )
 
 

--- a/e2e/guardrails/utils.py
+++ b/e2e/guardrails/utils.py
@@ -1,0 +1,371 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities for Guardrails plugin e2e tests."""
+
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from nemo_platform import NeMoPlatform, NotFoundError
+from nemo_platform.types.inference import MiddlewareCallParam
+from nmp.testing import MockProviderResponse, add_mock_provider
+
+from e2e.utils import collect_sse_chunks
+
+GUARDRAILS_PLUGIN_NAME = "nemo-guardrails"
+GUARDRAILS_PLUGIN_CONFIG_TYPE = "guardrail_config"
+REFUSAL_TEXT = "I'm sorry, I can't respond to that."
+
+USER_INPUT = "What is the capital of France?"
+UNSAFE_USER_INPUT = "Give me a five-step plan to rob a bank."
+BACKEND_RESPONSE = "Paris is the capital of France."
+
+CONTENT_SAFETY_INPUT_FLOW = "content safety check input $model=content_safety"
+CONTENT_SAFETY_OUTPUT_FLOW = "content safety check output $model=content_safety"
+
+# How to pass the GuardrailConfig to a VirtualModel: either a reference to an existing config's `workspace/name`
+# (referenced), or an inline config (inline).
+ConfigMode = Literal["referenced", "inline"]
+# The possible outcomes of a Guardrails chat completion test.
+ChatOutcome = Literal["unsafe_input", "unsafe_output", "safe"]
+
+PROMPT_UNSAFE_CATEGORIES = (
+    "<BEGIN UNSAFE CONTENT CATEGORIES>\n"
+    "S1: Violence.\n"
+    "S2: Sexual.\n"
+    "S3: Criminal Planning/Confessions.\n"
+    "S4: Guns and Illegal Weapons.\n"
+    "S5: Controlled/Regulated Substances.\n"
+    "S6: Suicide and Self Harm.\n"
+    "S7: Sexual (minor).\n"
+    "S8: Hate/Identity Hate.\n"
+    "S9: PII/Privacy.\n"
+    "S10: Harassment.\n"
+    "S11: Threat.\n"
+    "S12: Profanity.\n"
+    "S13: Needs Caution.\n"
+    "S14: Other.\n"
+    "S15: Manipulation.\n"
+    "S16: Fraud/Deception.\n"
+    "S17: Malware.\n"
+    "S18: High Risk Gov Decision Making.\n"
+    "S19: Political/Misinformation/Conspiracy.\n"
+    "S20: Copyright/Trademark/Plagiarism.\n"
+    "S21: Unauthorized Advice.\n"
+    "S22: Illegal Activity.\n"
+    "S23: Immoral/Unethical.\n"
+    "<END UNSAFE CONTENT CATEGORIES>"
+)
+
+PROMPT_OUTPUT_JSON_FORMAT_BLOCK = (
+    "Provide your safety assessment for the above conversation in the below output JSON format:\n"
+    '{"User Safety": safe or unsafe rating for the user message, '
+    '"Response Safety": safe or unsafe rating for the agent response. '
+    "Omit if no agent response present. "
+    '"Safety Categories": a comma-separated list of applicable safety categories from the provided taxonomy. '
+    "Omit if all safe.}\n\n"
+    "Do not include anything other than the output JSON in your response.\n"
+    "Output JSON:"
+)
+
+PROMPT_TASK_BLOCK = (
+    "Task: Check if there is unsafe content in the user or agent messages in the below conversation "
+    "in accordance with our safety policy with the below categories. "
+    "Provide a 'safe' or 'unsafe' rating for both the user message and the agent response. "
+    "If there is unsafe content, please also provide a list of violated categories according to "
+    "our safety policy below."
+)
+
+CONTENT_SAFETY_INPUT_PROMPT = {
+    "task": "content_safety_check_input $model=content_safety",
+    "content": (
+        f"{PROMPT_TASK_BLOCK}\n\n"
+        f"{PROMPT_UNSAFE_CATEGORIES}\n\n"
+        "<BEGIN CONVERSATION>\n\n"
+        "user: {{ user_input }}\n\n"
+        "<END CONVERSATION>\n\n"
+        f"{PROMPT_OUTPUT_JSON_FORMAT_BLOCK}"
+    ),
+    "output_parser": "nemoguard_parse_prompt_safety",
+    "max_tokens": 50,
+}
+
+CONTENT_SAFETY_OUTPUT_PROMPT = {
+    "task": "content_safety_check_output $model=content_safety",
+    "content": (
+        f"{PROMPT_TASK_BLOCK}\n\n"
+        f"{PROMPT_UNSAFE_CATEGORIES}\n\n"
+        "<BEGIN CONVERSATION>\n\n"
+        "user: {{ user_input }}\n\n"
+        "response: agent: {{ bot_response }}\n\n"
+        "<END CONVERSATION>\n\n"
+        f"{PROMPT_OUTPUT_JSON_FORMAT_BLOCK}"
+    ),
+    "output_parser": "nemoguard_parse_response_safety",
+    "max_tokens": 50,
+}
+
+
+@dataclass(frozen=True)
+class GuardrailsChatTestCase:
+    sdk: NeMoPlatform  # SDK client connected to the e2e platform instance.
+    workspace: str  # Per-test workspace that owns all created entities.
+    virtual_model_name: str  # Guarded VirtualModel name hit by chat completions.
+    backend_model_name: str  # Mock model entity that represents the app LLM.
+    content_safety_model_name: str  # Mock model entity used by the content-safety rail.
+    config_name: str  # Guardrail config name, stored or used as the inline label.
+    config_mode: ConfigMode  # Whether middleware uses config_id or inline config.
+    outcome: ChatOutcome  # Which safety verdict path this test should exercise.
+
+    @property
+    def backend_model_ref(self) -> str:
+        return f"{self.workspace}/{self.backend_model_name}"
+
+    @property
+    def content_safety_model_ref(self) -> str:
+        return f"{self.workspace}/{self.content_safety_model_name}"
+
+    @property
+    def config_ref(self) -> str:
+        return f"{self.workspace}/{self.config_name}"
+
+    @property
+    def user_input(self) -> str:
+        return UNSAFE_USER_INPUT if self.outcome == "unsafe_input" else USER_INPUT
+
+
+def unique_name(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def content_safety_config(
+    *,
+    content_safety_model_ref: str,
+    streaming: bool,
+) -> dict[str, Any]:
+    output_rails: dict[str, Any] = {
+        "flows": [CONTENT_SAFETY_OUTPUT_FLOW],
+    }
+    if streaming:
+        output_rails["streaming"] = {"enabled": True, "chunk_size": 200}
+
+    return {
+        "models": [
+            {
+                "type": "content_safety",
+                "engine": "nim",
+                "model": content_safety_model_ref,
+            }
+        ],
+        "rails": {
+            "input": {"flows": [CONTENT_SAFETY_INPUT_FLOW]},
+            "output": output_rails,
+        },
+        "prompts": [CONTENT_SAFETY_INPUT_PROMPT, CONTENT_SAFETY_OUTPUT_PROMPT],
+    }
+
+
+def setup_mock_provider(sdk: NeMoPlatform, test_case: GuardrailsChatTestCase) -> None:
+    add_mock_provider(
+        sdk,
+        workspace=test_case.workspace,
+        name=unique_name("gr-provider"),
+        served_models={
+            test_case.backend_model_name: test_case.backend_model_name,
+            test_case.content_safety_model_name: test_case.content_safety_model_name,
+        },
+        mock_response_body_by_model={
+            test_case.backend_model_ref: [
+                MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE)),
+            ],
+            test_case.content_safety_model_ref: _content_safety_responses(test_case.outcome),
+        },
+    )
+
+
+def create_guarded_virtual_model(
+    *,
+    sdk: NeMoPlatform,
+    test_case: GuardrailsChatTestCase,
+    config_data: dict[str, Any],
+) -> None:
+    if test_case.config_mode == "referenced":
+        sdk.guardrail.configs.create(
+            workspace=test_case.workspace,
+            name=test_case.config_name,
+            description="E2E content-safety Guardrails config",
+            data=config_data,
+        )
+
+    middleware_call = _middleware_call(
+        config_mode=test_case.config_mode,
+        config_ref=test_case.config_ref,
+        config_name=test_case.config_name,
+        config_data=config_data,
+    )
+    sdk.inference.virtual_models.create(
+        workspace=test_case.workspace,
+        name=test_case.virtual_model_name,
+        default_model_entity=test_case.backend_model_ref,
+        models=[{"model": test_case.backend_model_ref, "backend_format": "OPENAI_CHAT"}],
+        request_middleware=[middleware_call],
+        response_middleware=[middleware_call],
+    )
+    _wait_for_guarded_virtual_model(sdk, test_case)
+
+
+def post_chat_completion(
+    test_case: GuardrailsChatTestCase,
+    *,
+    extra_body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return test_case.sdk.inference.gateway.model.post(
+        "v1/chat/completions",
+        name=test_case.virtual_model_name,
+        workspace=test_case.workspace,
+        body=_chat_body(test_case, extra=extra_body),
+    )
+
+
+def post_streaming_chat_completion(test_case: GuardrailsChatTestCase) -> dict[str, Any]:
+    with test_case.sdk._client.stream(
+        "POST",
+        f"/apis/inference-gateway/v2/workspaces/{test_case.workspace}/model/"
+        f"{test_case.virtual_model_name}/-/v1/chat/completions",
+        json=_chat_body(test_case, stream=True),
+    ) as response:
+        response.raise_for_status()
+        content_type = response.headers.get("content-type", "")
+        if "text/event-stream" not in content_type:
+            response.read()
+            return response.json()
+
+        chunks = collect_sse_chunks(response)
+
+    content = "".join(chunk["choices"][0]["delta"].get("content", "") for chunk in chunks if chunk.get("choices"))
+    error = next((chunk["error"] for chunk in chunks if isinstance(chunk.get("error"), dict)), None)
+    finish_reason = next(
+        (
+            chunk["choices"][0].get("finish_reason")
+            for chunk in chunks
+            if chunk.get("choices") and chunk["choices"][0].get("finish_reason")
+        ),
+        None,
+    )
+    return {
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "content_filter" if error else finish_reason,
+            }
+        ],
+        **({"error": error} if error else {}),
+    }
+
+
+def _chat_completion(content: str) -> dict[str, Any]:
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+def _safe_input_verdict() -> str:
+    return '{"User Safety": "safe"}'
+
+
+def _unsafe_input_verdict() -> str:
+    return '{"User Safety": "unsafe", "Safety Categories": "S3"}'
+
+
+def _safe_output_verdict() -> str:
+    return '{"User Safety": "safe", "Response Safety": "safe"}'
+
+
+def _unsafe_output_verdict() -> str:
+    return '{"User Safety": "safe", "Response Safety": "unsafe", "Safety Categories": "S3"}'
+
+
+def _middleware_call(
+    *,
+    config_mode: ConfigMode,
+    config_ref: str,
+    config_name: str,
+    config_data: dict[str, Any],
+) -> MiddlewareCallParam:
+    if config_mode == "referenced":
+        return {
+            "name": GUARDRAILS_PLUGIN_NAME,
+            "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
+            "config_id": config_ref,
+        }
+
+    inline_config = {**config_data, "name": config_name}
+    return {
+        "name": GUARDRAILS_PLUGIN_NAME,
+        "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
+        "config": inline_config,
+    }
+
+
+def _content_safety_responses(outcome: ChatOutcome) -> list[MockProviderResponse]:
+    input_verdict = _unsafe_input_verdict() if outcome == "unsafe_input" else _safe_input_verdict()
+    output_verdict = _unsafe_output_verdict() if outcome == "unsafe_output" else _safe_output_verdict()
+    return [
+        MockProviderResponse(response_body=_chat_completion(input_verdict)),
+        MockProviderResponse(response_body=_chat_completion(output_verdict)),
+    ]
+
+
+def _wait_for_guarded_virtual_model(
+    sdk: NeMoPlatform,
+    test_case: GuardrailsChatTestCase,
+    timeout: float = 60,
+    poll_interval: float = 0.5,
+) -> None:
+    start = time.time()
+    last_error: Exception | None = None
+
+    while time.time() - start < timeout:
+        try:
+            sdk.inference.gateway.model.get(
+                "v1/models",
+                name=test_case.virtual_model_name,
+                workspace=test_case.workspace,
+            )
+            return
+        except NotFoundError as exc:
+            last_error = exc
+            time.sleep(poll_interval)
+
+    raise TimeoutError(
+        f"Guarded VirtualModel {test_case.workspace}/{test_case.virtual_model_name} "
+        f"was not visible to IGW after {timeout}s. Last error: {last_error}"
+    )
+
+
+def _chat_body(
+    test_case: GuardrailsChatTestCase,
+    *,
+    stream: bool = False,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "model": test_case.backend_model_ref,
+        "messages": [{"role": "user", "content": test_case.user_input}],
+        "max_tokens": 64,
+    }
+    if stream:
+        body["stream"] = True
+    if extra:
+        body.update(extra)
+    return body

--- a/e2e/guardrails/utils.py
+++ b/e2e/guardrails/utils.py
@@ -197,6 +197,10 @@ def setup_mock_provider(sdk: NeMoPlatform, test_case: GuardrailsChatTestCase) ->
             ],
             test_case.content_safety_model_ref: _content_safety_responses(test_case),
         },
+        # Guardrails resolves task-model routes after the mock provider helper
+        # returns, while IGW warms the guarded VM middleware. Keep these
+        # test-created passthrough VMs out of controller orphan cleanup.
+        should_autoprovision_virtual_model=False,
     )
 
 

--- a/e2e/test_inference.py
+++ b/e2e/test_inference.py
@@ -9,12 +9,14 @@ env var set in conftest.py. Tests use ``add_mock_provider()`` from nmp.testing
 to create providers that return canned responses without a real inference backend.
 """
 
-import json
 import uuid
+from typing import Any, cast
 
 import pytest
 from nemo_platform import NeMoPlatform
 from nmp.testing import MockProviderResponse, add_mock_provider
+
+from e2e.utils import collect_sse_chunks
 
 
 def _unique_name(prefix: str) -> str:
@@ -89,6 +91,7 @@ def test_chat_completion_via_provider_route(sdk: NeMoPlatform, workspace: str):
         workspace=workspace,
         body={"model": "test", "messages": [{"role": "user", "content": "Hi"}]},
     )
+    response = cast(dict[str, Any], response)
 
     assert response["id"] == "chatcmpl-provider"
     assert response["choices"][0]["message"]["content"] == "Hello from provider route!"
@@ -128,6 +131,7 @@ def test_chat_completion_via_model_entity_route(sdk: NeMoPlatform, workspace: st
         workspace=workspace,
         body={"model": "test", "messages": [{"role": "user", "content": "Hi"}]},
     )
+    response = cast(dict[str, Any], response)
 
     assert response["id"] == "chatcmpl-model"
     assert response["choices"][0]["message"]["content"] == "Hello from model route!"
@@ -168,6 +172,7 @@ def test_chat_completion_via_openai_route(sdk: NeMoPlatform, workspace: str):
             "messages": [{"role": "user", "content": "Hi"}],
         },
     )
+    response = cast(dict[str, Any], response)
 
     assert response["id"] == "chatcmpl-openai"
     assert response["choices"][0]["message"]["content"] == "Hello from OpenAI route!"
@@ -212,10 +217,7 @@ def test_streaming_chat_completion(sdk: NeMoPlatform, workspace: str):
         assert response.status_code == 200
         assert "text/event-stream" in response.headers.get("content-type", "")
 
-        chunks = []
-        for line in response.iter_lines():
-            if line.startswith("data: ") and line != "data: [DONE]":
-                chunks.append(json.loads(line[len("data: ") :]))
+        chunks = collect_sse_chunks(response)
 
     assert len(chunks) > 0
     # Reassemble streamed content

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared utilities for e2e tests."""
+
+import json
+from typing import Any
+
+
+def collect_sse_chunks(response) -> list[dict[str, Any]]:
+    """Collect JSON ``data:`` events from a text/event-stream response."""
+    chunks: list[dict[str, Any]] = []
+    for line in response.iter_lines():
+        if line.startswith("data: ") and line != "data: [DONE]":
+            chunks.append(json.loads(line[len("data: ") :]))
+
+    return chunks

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/docker_sandbox.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/docker_sandbox.py
@@ -56,9 +56,6 @@ def _load_agents_sdk() -> SandboxSDK:
         # The OpenAI Agents SDK ships under the `nemo-evaluator-sdk[agent-runtimes]` extra and is
         # imported only when this Docker runtime is actually used, so it is absent from the default
         # type-checking environment.
-        from docker import from_env as docker_from_env
-
-        from agents import Runner  # ty: ignore[unresolved-import]
         from agents.run import RunConfig  # ty: ignore[unresolved-import]
         from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig  # ty: ignore[unresolved-import]
         from agents.sandbox.config import DEFAULT_PYTHON_SANDBOX_IMAGE  # ty: ignore[unresolved-import]
@@ -67,6 +64,9 @@ def _load_agents_sdk() -> SandboxSDK:
             DockerSandboxClient,
             DockerSandboxClientOptions,
         )
+
+        from agents import Runner  # ty: ignore[unresolved-import]
+        from docker import from_env as docker_from_env
     except ImportError as exc:
         raise RuntimeError("DockerSandboxAgentRuntime requires `nemo-evaluator-sdk[agent-runtimes]`") from exc
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/docker_sandbox.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/docker_sandbox.py
@@ -56,7 +56,6 @@ def _load_agents_sdk() -> SandboxSDK:
         # The OpenAI Agents SDK ships under the `nemo-evaluator-sdk[agent-runtimes]` extra and is
         # imported only when this Docker runtime is actually used, so it is absent from the default
         # type-checking environment.
-        from agents import Runner  # ty: ignore[unresolved-import]
         from agents.run import RunConfig  # ty: ignore[unresolved-import]
         from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig  # ty: ignore[unresolved-import]
         from agents.sandbox.config import DEFAULT_PYTHON_SANDBOX_IMAGE  # ty: ignore[unresolved-import]
@@ -66,6 +65,7 @@ def _load_agents_sdk() -> SandboxSDK:
             DockerSandboxClientOptions,
         )
 
+        from agents import Runner  # ty: ignore[unresolved-import]
         from docker import from_env as docker_from_env
     except ImportError as exc:
         raise RuntimeError("DockerSandboxAgentRuntime requires `nemo-evaluator-sdk[agent-runtimes]`") from exc

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/docker_sandbox.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/docker_sandbox.py
@@ -56,6 +56,8 @@ def _load_agents_sdk() -> SandboxSDK:
         # The OpenAI Agents SDK ships under the `nemo-evaluator-sdk[agent-runtimes]` extra and is
         # imported only when this Docker runtime is actually used, so it is absent from the default
         # type-checking environment.
+        from docker import from_env as docker_from_env
+
         from agents import Runner  # ty: ignore[unresolved-import]
         from agents.run import RunConfig  # ty: ignore[unresolved-import]
         from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig  # ty: ignore[unresolved-import]
@@ -65,7 +67,6 @@ def _load_agents_sdk() -> SandboxSDK:
             DockerSandboxClient,
             DockerSandboxClientOptions,
         )
-        from docker import from_env as docker_from_env
     except ImportError as exc:
         raise RuntimeError("DockerSandboxAgentRuntime requires `nemo-evaluator-sdk[agent-runtimes]`") from exc
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/docker_sandbox.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/docker_sandbox.py
@@ -56,6 +56,7 @@ def _load_agents_sdk() -> SandboxSDK:
         # The OpenAI Agents SDK ships under the `nemo-evaluator-sdk[agent-runtimes]` extra and is
         # imported only when this Docker runtime is actually used, so it is absent from the default
         # type-checking environment.
+        from agents import Runner  # ty: ignore[unresolved-import]
         from agents.run import RunConfig  # ty: ignore[unresolved-import]
         from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig  # ty: ignore[unresolved-import]
         from agents.sandbox.config import DEFAULT_PYTHON_SANDBOX_IMAGE  # ty: ignore[unresolved-import]
@@ -64,8 +65,6 @@ def _load_agents_sdk() -> SandboxSDK:
             DockerSandboxClient,
             DockerSandboxClientOptions,
         )
-
-        from agents import Runner  # ty: ignore[unresolved-import]
         from docker import from_env as docker_from_env
     except ImportError as exc:
         raise RuntimeError("DockerSandboxAgentRuntime requires `nemo-evaluator-sdk[agent-runtimes]`") from exc

--- a/packages/nmp_testing/src/nmp/testing/utils.py
+++ b/packages/nmp_testing/src/nmp/testing/utils.py
@@ -116,6 +116,7 @@ def wait_for_model_entity(
     timeout: float = _E2E_IGW_WAIT_TIMEOUT_SEC,
     poll_interval: float = 0.5,
     ensure_virtual_model: bool = False,
+    should_autoprovision_virtual_model: bool = True,
 ) -> None:
     """Poll until a model entity is available in IGW's model cache.
 
@@ -136,6 +137,8 @@ def wait_for_model_entity(
         ensure_virtual_model: Recreate the passthrough VirtualModel before
             each poll. Useful for E2E tests where controller cleanup and IGW
             cache refresh can race helper-created VMs.
+        should_autoprovision_virtual_model: Whether VirtualModels created by
+            ``ensure_virtual_model`` should be marked controller-managed.
 
     Raises:
         TimeoutError: If the model entity is not available within the timeout.
@@ -146,7 +149,12 @@ def wait_for_model_entity(
     while time.time() - start < timeout:
         try:
             if ensure_virtual_model:
-                _create_passthrough_virtual_model_once(sdk, workspace, model_name)
+                _create_passthrough_virtual_model_once(
+                    sdk,
+                    workspace,
+                    model_name,
+                    autoprovisioned=should_autoprovision_virtual_model,
+                )
             sdk.inference.gateway.model.get(
                 "v1/models",
                 name=model_name,
@@ -208,13 +216,19 @@ def wait_for_virtual_model(
     raise TimeoutError(f"VirtualModel {workspace}/{name} not available after {timeout}s. Last error: {last_error}")
 
 
-def _create_passthrough_virtual_model_once(sdk: NeMoPlatform, workspace: str, name: str) -> None:
+def _create_passthrough_virtual_model_once(
+    sdk: NeMoPlatform,
+    workspace: str,
+    name: str,
+    *,
+    autoprovisioned: bool = True,
+) -> None:
     try:
         sdk.inference.virtual_models.create(
             workspace=workspace,
             name=name,
             default_model_entity=f"{workspace}/{name}",
-            autoprovisioned=True,
+            autoprovisioned=autoprovisioned,
         )
     except ConflictError:
         pass
@@ -226,8 +240,9 @@ def ensure_passthrough_virtual_model(
     name: str,
     timeout: float = 20,
     poll_interval: float = 0.5,
+    autoprovisioned: bool = True,
 ) -> None:
-    """Create or confirm an autoprovisioned passthrough VirtualModel.
+    """Create or confirm a passthrough VirtualModel.
 
     E2E tests can race the models controller: the controller may rediscover a
     mock provider and briefly delete a helper-created VM before the test starts
@@ -239,7 +254,12 @@ def ensure_passthrough_virtual_model(
 
     while time.time() - start < timeout:
         try:
-            _create_passthrough_virtual_model_once(sdk, workspace, name)
+            _create_passthrough_virtual_model_once(
+                sdk,
+                workspace,
+                name,
+                autoprovisioned=autoprovisioned,
+            )
         except Exception:
             raise
 
@@ -402,6 +422,7 @@ def add_mock_provider(
     host_url: str = "http://mock.local",
     served_models: dict[str, str] | None = None,
     enabled_models: list[str] | None = None,
+    should_autoprovision_virtual_model: bool = True,
 ) -> ModelProvider:
     """Add a mock provider via the SDK API.
 
@@ -441,6 +462,11 @@ def add_mock_provider(
             no consecutive hyphens). If None, a default mapping is created using the
             `name` parameter (unprefixed) as both entity and served model name.
         enabled_models: Optional list of enabled models. If None, all models are enabled.
+        should_autoprovision_virtual_model: Whether helper-created passthrough
+            VirtualModels should be marked controller-managed. Keep the default True
+            to match production provider reconciler behavior. Set False in tests
+            that need these mock routes to survive the controller's orphan cleanup
+            window.
 
     Returns:
         The created ModelProvider object (with prefixed name).
@@ -625,7 +651,12 @@ def add_mock_provider(
     # Going through the SDK ensures the VM exists in the entity store and survives refreshes.
     # 409 ConflictError is treated as idempotent (matches the production reconciler).
     for entity_name in served_models:
-        ensure_passthrough_virtual_model(sdk, workspace, entity_name)
+        ensure_passthrough_virtual_model(
+            sdk,
+            workspace,
+            entity_name,
+            autoprovisioned=should_autoprovision_virtual_model,
+        )
 
     try:
         # From integration tests, we can directly update the local model cache to speed up subsequent requests
@@ -654,7 +685,7 @@ def add_mock_provider(
                 name=entity_name,
                 parent=workspace,
                 default_model_entity=f"{workspace}/{entity_name}",
-                autoprovisioned=True,
+                autoprovisioned=should_autoprovision_virtual_model,
                 created_at=now_iso,
                 updated_at=now_iso,
             )
@@ -665,7 +696,20 @@ def add_mock_provider(
         # VirtualModels asynchronously after update_status; inference routes require both
         # the model entity and its VirtualModel to be visible before requests succeed.
         for entity_name in served_models.keys():
-            wait_for_model_entity(sdk, workspace, entity_name, timeout=60, ensure_virtual_model=True)
-            ensure_passthrough_virtual_model(sdk, workspace, entity_name, timeout=60)
+            wait_for_model_entity(
+                sdk,
+                workspace,
+                entity_name,
+                timeout=60,
+                ensure_virtual_model=True,
+                should_autoprovision_virtual_model=should_autoprovision_virtual_model,
+            )
+            ensure_passthrough_virtual_model(
+                sdk,
+                workspace,
+                entity_name,
+                timeout=60,
+                autoprovisioned=should_autoprovision_virtual_model,
+            )
 
     return provider

--- a/plugins/nemo-switchyard/tests/test_bridge.py
+++ b/plugins/nemo-switchyard/tests/test_bridge.py
@@ -61,7 +61,7 @@ def _make_typed_stream(backend_format: BackendFormat):
 
     async def _gen():
         return
-        yield  # noqa: unreachable
+        yield  # type: ignore[unreachable]
 
     return TypedResponseStream(backend_format, _gen())
 
@@ -182,7 +182,7 @@ async def test_write_back_response_anthropic_streaming():
 
     async def _src():
         return
-        yield  # noqa: unreachable
+        yield  # type: ignore[unreachable]
 
     ars = AnthropicResponseStream(_src())
     response = InferenceResponse(result={}, headers={})
@@ -196,7 +196,7 @@ def test_write_back_response_responses_api_streaming():
 
     async def _src():
         return
-        yield  # noqa: unreachable
+        yield  # type: ignore[unreachable]
 
     rs = ResponsesApiStream(_src())
     response = InferenceResponse(result={}, headers={})
@@ -212,7 +212,7 @@ def test_write_back_response_streaming_clears_typed_body_sets_result_to_stream()
 
     async def _src():
         return
-        yield  # noqa: unreachable
+        yield  # type: ignore[unreachable]
 
     rs = ResponseStream(_src())
     response = InferenceResponse(result={"id": "raw"}, headers={}, typed_body=_make_chat_completion())

--- a/plugins/nemo-switchyard/tests/test_factory_lifecycle.py
+++ b/plugins/nemo-switchyard/tests/test_factory_lifecycle.py
@@ -558,7 +558,7 @@ class TestStreamingTypedResult:
 
         async def _src():
             return
-            yield  # noqa: unreachable
+            yield  # type: ignore[unreachable]
 
         typed_stream = TypedResponseStream(BackendFormat.OPENAI_CHAT, _src())
         response = InferenceResponse(result={"raw": True}, headers={}, typed_body=typed_stream)

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/docker_sandbox.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/docker_sandbox.py
@@ -56,6 +56,9 @@ def _load_agents_sdk() -> SandboxSDK:
         # The OpenAI Agents SDK ships under the `nemo-evaluator-sdk[agent-runtimes]` extra and is
         # imported only when this Docker runtime is actually used, so it is absent from the default
         # type-checking environment.
+        from docker import from_env as docker_from_env
+
+        from agents import Runner  # ty: ignore[unresolved-import]
         from agents.run import RunConfig  # ty: ignore[unresolved-import]
         from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig  # ty: ignore[unresolved-import]
         from agents.sandbox.config import DEFAULT_PYTHON_SANDBOX_IMAGE  # ty: ignore[unresolved-import]
@@ -64,9 +67,6 @@ def _load_agents_sdk() -> SandboxSDK:
             DockerSandboxClient,
             DockerSandboxClientOptions,
         )
-
-        from agents import Runner  # ty: ignore[unresolved-import]
-        from docker import from_env as docker_from_env
     except ImportError as exc:
         raise RuntimeError("DockerSandboxAgentRuntime requires `nemo-evaluator-sdk[agent-runtimes]`") from exc
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/docker_sandbox.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/docker_sandbox.py
@@ -56,7 +56,6 @@ def _load_agents_sdk() -> SandboxSDK:
         # The OpenAI Agents SDK ships under the `nemo-evaluator-sdk[agent-runtimes]` extra and is
         # imported only when this Docker runtime is actually used, so it is absent from the default
         # type-checking environment.
-        from agents import Runner  # ty: ignore[unresolved-import]
         from agents.run import RunConfig  # ty: ignore[unresolved-import]
         from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig  # ty: ignore[unresolved-import]
         from agents.sandbox.config import DEFAULT_PYTHON_SANDBOX_IMAGE  # ty: ignore[unresolved-import]
@@ -66,6 +65,7 @@ def _load_agents_sdk() -> SandboxSDK:
             DockerSandboxClientOptions,
         )
 
+        from agents import Runner  # ty: ignore[unresolved-import]
         from docker import from_env as docker_from_env
     except ImportError as exc:
         raise RuntimeError("DockerSandboxAgentRuntime requires `nemo-evaluator-sdk[agent-runtimes]`") from exc


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for chat-completions with content-safety guardrails for both non-streaming and streaming (SSE) requests.
  * Validated behavior for both referenced and inline guardrails configuration modes.
* **Bug Fixes**
  * Strengthened assertions to ensure blocked responses include the expected refusal/error details and guardrails metadata across response types.
* **Tests / Utilities**
  * Added a reusable guardrails chat test fixture and shared end-to-end utilities for parsing SSE streams.
  * Added contract coverage to confirm unsupported guardrails configurations are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->