### PR TITLE
feat(deployments): K8s Deployment+Service for Always workloads (AIRCORE-757 phase 4)

### DIFF
--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/backend.py
@@ -14,6 +14,7 @@ from nemo_deployments_plugin.backends.base import (
     LogResult,
     VolumeStatusUpdate,
 )
+from nemo_deployments_plugin.backends.k8s import deployments as deployment_ops
 from nemo_deployments_plugin.backends.k8s import jobs as job_ops
 from nemo_deployments_plugin.backends.k8s import volumes as volume_ops
 from nemo_deployments_plugin.backends.k8s.client import KubernetesClients
@@ -29,14 +30,13 @@ _K8S_INSTALL_HINT = (
     "kubernetes package is required for K8sDeploymentBackend. "
     "Install with: uv sync --package nemo-deployments-plugin --extra k8s"
 )
-_ALWAYS_POLICY_MESSAGE = "restart_policy Always requires Deployment+Service support (AIRCORE-757 phase 4)"
 
 
 class K8sDeploymentBackend(DeploymentBackend):
     """Manage deployments and volumes as native Kubernetes objects.
 
     Job-backed deployments (``restart_policy`` Never/OnFailure) are implemented in phase 3.
-    Deployment + Service (Always) and full PodSpec compilation land in later phases.
+    Deployment + Service (Always) is implemented in phase 4; full PodSpec compilation lands in phase 5.
     """
 
     _clients: KubernetesClients
@@ -104,7 +104,16 @@ class K8sDeploymentBackend(DeploymentBackend):
             return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment config: {exc}")
 
         if config.restart_policy == "Always":
-            return BackendStatusUpdate(status="FAILED", status_message=_ALWAYS_POLICY_MESSAGE)
+            return await deployment_ops.create_deployment(
+                self._clients,
+                default_namespace=self._executor_config.default_namespace,
+                workspace=workspace,
+                name=name,
+                config_name=config_name,
+                labels=labels,
+                backend_config=backend_config,
+                config=config,
+            )
 
         return await job_ops.create_job(
             self._clients,
@@ -129,7 +138,18 @@ class K8sDeploymentBackend(DeploymentBackend):
             return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment: {exc}")
 
         if config.restart_policy == "Always":
-            return BackendStatusUpdate(status="FAILED", status_message=_ALWAYS_POLICY_MESSAGE)
+            container = deployment_ops.validate_config_for_deployment(config)
+            return await deployment_ops.read_deployment_status(
+                self._clients,
+                default_namespace=self._executor_config.default_namespace,
+                workspace=workspace,
+                name=name,
+                backend_config=backend_config,
+                config_name=config.name,
+                restart_policy=config.restart_policy,
+                backoff_limit=config.backoff_limit,
+                container=container,
+            )
 
         return await job_ops.read_job_status(
             self._clients,
@@ -146,19 +166,42 @@ class K8sDeploymentBackend(DeploymentBackend):
         try:
             _, config, backend_config = await self._load_deployment_context(workspace, name)
         except NemoEntityNotFoundError:
+            scope_labels = job_ops.deployment_scope_labels(workspace, name)
+            await deployment_ops.delete_deployment(
+                self._clients,
+                default_namespace=self._executor_config.default_namespace,
+                workspace=workspace,
+                name=name,
+                backend_config={},
+                expected_labels=scope_labels,
+            )
             return await job_ops.delete_job(
                 self._clients,
                 default_namespace=self._executor_config.default_namespace,
                 workspace=workspace,
                 name=name,
                 backend_config={},
-                expected_labels=job_ops.deployment_scope_labels(workspace, name),
+                expected_labels=scope_labels,
             )
         except Exception as exc:
             return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment: {exc}")
 
+        expected_labels = deployment_identity_labels(
+            workspace,
+            name,
+            config.restart_policy,
+            config_name=config.name,
+            backoff_limit=config.backoff_limit,
+        )
         if config.restart_policy == "Always":
-            return BackendStatusUpdate(status="FAILED", status_message=_ALWAYS_POLICY_MESSAGE)
+            return await deployment_ops.delete_deployment(
+                self._clients,
+                default_namespace=self._executor_config.default_namespace,
+                workspace=workspace,
+                name=name,
+                backend_config=backend_config,
+                expected_labels=expected_labels,
+            )
 
         return await job_ops.delete_job(
             self._clients,
@@ -166,20 +209,19 @@ class K8sDeploymentBackend(DeploymentBackend):
             workspace=workspace,
             name=name,
             backend_config=backend_config,
-            expected_labels=deployment_identity_labels(
-                workspace,
-                name,
-                config.restart_policy,
-                config_name=config.name,
-                backoff_limit=config.backoff_limit,
-            ),
+            expected_labels=expected_labels,
         )
 
     async def list_managed_deployment_names(self) -> list[str]:
-        return await job_ops.list_managed_job_names(
+        job_names = await job_ops.list_managed_job_names(
             self._clients,
             default_namespace=self._executor_config.default_namespace,
         )
+        deployment_names = await deployment_ops.list_managed_deployment_names(
+            self._clients,
+            default_namespace=self._executor_config.default_namespace,
+        )
+        return sorted(set(job_names) | set(deployment_names))
 
     async def get_logs(
         self,
@@ -196,7 +238,14 @@ class K8sDeploymentBackend(DeploymentBackend):
             return LogResult(lines=[f"Failed to load deployment: {exc}"])
 
         if config.restart_policy == "Always":
-            return LogResult(lines=[_ALWAYS_POLICY_MESSAGE])
+            return await deployment_ops.get_deployment_logs(
+                self._clients,
+                default_namespace=self._executor_config.default_namespace,
+                workspace=workspace,
+                name=name,
+                backend_config=backend_config,
+                tail=tail,
+            )
 
         return await job_ops.get_job_logs(
             self._clients,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/backend.py
@@ -32,6 +32,13 @@ _K8S_INSTALL_HINT = (
 )
 
 
+def _prefer_failed_delete_result(*results: BackendStatusUpdate) -> BackendStatusUpdate:
+    for result in results:
+        if result.status == "FAILED":
+            return result
+    return results[-1]
+
+
 class K8sDeploymentBackend(DeploymentBackend):
     """Manage deployments and volumes as native Kubernetes objects.
 
@@ -138,7 +145,10 @@ class K8sDeploymentBackend(DeploymentBackend):
             return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment: {exc}")
 
         if config.restart_policy == "Always":
-            container = deployment_ops.validate_config_for_deployment(config)
+            try:
+                container = deployment_ops.validate_config_for_deployment(config)
+            except job_ops.DeploymentConfigError as exc:
+                return BackendStatusUpdate(status="FAILED", status_message=str(exc))
             return await deployment_ops.read_deployment_status(
                 self._clients,
                 default_namespace=self._executor_config.default_namespace,
@@ -167,7 +177,7 @@ class K8sDeploymentBackend(DeploymentBackend):
             _, config, backend_config = await self._load_deployment_context(workspace, name)
         except NemoEntityNotFoundError:
             scope_labels = job_ops.deployment_scope_labels(workspace, name)
-            await deployment_ops.delete_deployment(
+            deployment_result = await deployment_ops.delete_deployment(
                 self._clients,
                 default_namespace=self._executor_config.default_namespace,
                 workspace=workspace,
@@ -175,7 +185,7 @@ class K8sDeploymentBackend(DeploymentBackend):
                 backend_config={},
                 expected_labels=scope_labels,
             )
-            return await job_ops.delete_job(
+            job_result = await job_ops.delete_job(
                 self._clients,
                 default_namespace=self._executor_config.default_namespace,
                 workspace=workspace,
@@ -183,6 +193,7 @@ class K8sDeploymentBackend(DeploymentBackend):
                 backend_config={},
                 expected_labels=scope_labels,
             )
+            return _prefer_failed_delete_result(deployment_result, job_result)
         except Exception as exc:
             return BackendStatusUpdate(status="FAILED", status_message=f"Failed to load deployment: {exc}")
 

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
@@ -14,6 +14,9 @@ from nemo_deployments_plugin.backends.base import BackendStatusUpdate, LogResult
 from nemo_deployments_plugin.backends.k8s.client import KubernetesClients, k8s_client_module
 from nemo_deployments_plugin.backends.k8s.jobs import (
     DeploymentConfigError,
+    build_container_spec,
+    build_pod_volumes,
+    build_volume_mounts,
     merged_volume_mounts,
     newest_pod,
     resolve_deployment_namespace,
@@ -40,6 +43,7 @@ from nemo_deployments_plugin.types import Endpoint, RestartPolicy
 logger = logging.getLogger(__name__)
 
 APP_LABEL = "app"
+DEFAULT_SERVICE_PORT = 8080
 
 
 def app_selector_labels(resource_name: str) -> dict[str, str]:
@@ -99,11 +103,6 @@ def _build_container_ports(ports: list[ContainerPort]) -> list[Any]:
 
 
 def build_deployment_container_spec(container: Container, *, volume_mounts: list[VolumeMount] | None = None) -> Any:
-    from nemo_deployments_plugin.backends.k8s.jobs import (
-        build_container_spec,
-        build_volume_mounts,
-    )
-
     k8s = k8s_client_module()
     base = build_container_spec(container, volume_mounts=volume_mounts)
     ports = _build_container_ports(container.ports)
@@ -131,8 +130,6 @@ def build_deployment_body(
     workspace: str,
 ) -> Any:
     """Build an ``apps/v1.Deployment`` for create."""
-    from nemo_deployments_plugin.backends.k8s.jobs import build_pod_volumes
-
     k8s = k8s_client_module()
     selector_labels = app_selector_labels(resource_name)
     pod_labels = {**selector_labels, **labels}
@@ -178,8 +175,8 @@ def build_service_body(*, resource_name: str, labels: dict[str, str], container:
         service_ports.append(
             k8s.client.V1ServicePort(
                 name="http",
-                port=8080,
-                target_port=8080,
+                port=DEFAULT_SERVICE_PORT,
+                target_port=DEFAULT_SERVICE_PORT,
                 protocol="TCP",
             )
         )
@@ -212,7 +209,7 @@ def build_in_cluster_endpoints(*, resource_name: str, namespace: str, container:
                 )
             )
         return endpoints
-    endpoints.append(Endpoint(name="http", url=f"http://{host}:8080", protocol="http"))
+    endpoints.append(Endpoint(name="http", url=f"http://{host}:{DEFAULT_SERVICE_PORT}", protocol="http"))
     return endpoints
 
 
@@ -283,15 +280,36 @@ async def create_deployment(
         core_v1 = clients.core_v1
 
         def _create() -> Any:
+            deployment_created = False
             try:
                 apps_v1.create_namespaced_deployment(
                     namespace=namespace,
                     body=deployment_body,
                     _request_timeout=timeout,
                 )
+                deployment_created = True
             except ApiException as exc:
                 if exc.status != 409:
                     raise
+
+            deployment = apps_v1.read_namespaced_deployment(
+                name=resource_name,
+                namespace=namespace,
+                _request_timeout=timeout,
+            )
+            if not resource_labels_match(deployment, identity_labels):
+                if deployment_created:
+                    try:
+                        apps_v1.delete_namespaced_deployment(
+                            name=resource_name,
+                            namespace=namespace,
+                            propagation_policy="Background",
+                            _request_timeout=timeout,
+                        )
+                    except ApiException:
+                        pass
+                return deployment
+
             try:
                 core_v1.create_namespaced_service(
                     namespace=namespace,
@@ -299,13 +317,20 @@ async def create_deployment(
                     _request_timeout=timeout,
                 )
             except ApiException as exc:
-                if exc.status != 409:
-                    raise
-            return apps_v1.read_namespaced_deployment(
-                name=resource_name,
-                namespace=namespace,
-                _request_timeout=timeout,
-            )
+                if exc.status == 409:
+                    return deployment
+                if deployment_created:
+                    try:
+                        apps_v1.delete_namespaced_deployment(
+                            name=resource_name,
+                            namespace=namespace,
+                            propagation_policy="Background",
+                            _request_timeout=timeout,
+                        )
+                    except ApiException:
+                        pass
+                raise
+            return deployment
 
         deployment = await asyncio.to_thread(_create)
         endpoints = build_in_cluster_endpoints(resource_name=resource_name, namespace=namespace, container=container)

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Kubernetes Deployment + Service lifecycle for long-running workloads (Always)."""
+"""Kubernetes Deployment + Service lifecycle for long-running workloads (Always).
+
+The official kubernetes-client is synchronous; ``asyncio.to_thread`` matches the
+Job backend (``jobs.py``). Async client support is not in scope for this phase.
+"""
 
 from __future__ import annotations
 
@@ -53,6 +57,8 @@ def app_selector_labels(resource_name: str) -> dict[str, str]:
 def validate_config_for_deployment(config: DeploymentConfig) -> Container:
     """Return the sole container spec for a Deployment-backed deployment."""
     if config.init_containers:
+        # User-specified initContainers are deferred to phase 5. Mesh sidecars (Istio,
+        # Linkerd) inject at admission time and do not appear in DeploymentConfig.
         raise DeploymentConfigError("init_containers are not supported by the k8s Deployment backend in this phase")
     if len(config.containers) != 1:
         raise DeploymentConfigError(
@@ -132,7 +138,7 @@ def build_deployment_body(
     """Build an ``apps/v1.Deployment`` for create."""
     k8s = k8s_client_module()
     selector_labels = app_selector_labels(resource_name)
-    pod_labels = {**selector_labels, **labels}
+    pod_labels = selector_labels | labels
     mounts = merged_volume_mounts(config, container)
     pod_spec_kwargs: dict[str, Any] = {
         "containers": [build_deployment_container_spec(container, volume_mounts=mounts or None)],
@@ -244,6 +250,14 @@ async def _read_newest_pod(
         return None
 
 
+def _log_cleanup_ignored(resource_name: str, exc: ApiException) -> None:
+    logger.debug(
+        "Best-effort cleanup of %s failed (resource may already be deleted)",
+        resource_name,
+        exc_info=exc,
+    )
+
+
 async def create_deployment(
     clients: KubernetesClients,
     *,
@@ -307,8 +321,8 @@ async def create_deployment(
                             propagation_policy="Background",
                             _request_timeout=timeout,
                         )
-                    except ApiException:
-                        pass
+                    except ApiException as cleanup_exc:
+                        _log_cleanup_ignored(resource_name, cleanup_exc)
                 return deployment
 
             try:
@@ -333,8 +347,8 @@ async def create_deployment(
                                     propagation_policy="Background",
                                     _request_timeout=timeout,
                                 )
-                            except ApiException:
-                                pass
+                            except ApiException as cleanup_exc:
+                                _log_cleanup_ignored(resource_name, cleanup_exc)
                         raise
                     return deployment
                 if deployment_created:
@@ -345,8 +359,8 @@ async def create_deployment(
                             propagation_policy="Background",
                             _request_timeout=timeout,
                         )
-                    except ApiException:
-                        pass
+                    except ApiException as cleanup_exc:
+                        _log_cleanup_ignored(resource_name, cleanup_exc)
                 raise
             return deployment
 

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
@@ -199,8 +199,9 @@ def build_in_cluster_endpoints(*, resource_name: str, namespace: str, container:
     if container.ports:
         for port in container.ports:
             endpoint_name = port.name or f"port-{port.container_port}"
-            protocol = "tcp" if port.protocol == "UDP" else "http"
-            scheme = "http"
+            is_udp = port.protocol == "UDP"
+            protocol = "tcp" if is_udp else "http"
+            scheme = "tcp" if is_udp else "http"
             endpoints.append(
                 Endpoint(
                     name=endpoint_name,
@@ -318,6 +319,23 @@ async def create_deployment(
                 )
             except ApiException as exc:
                 if exc.status == 409:
+                    existing_service = core_v1.read_namespaced_service(
+                        name=resource_name,
+                        namespace=namespace,
+                        _request_timeout=timeout,
+                    )
+                    if not resource_labels_match(existing_service, identity_labels):
+                        if deployment_created:
+                            try:
+                                apps_v1.delete_namespaced_deployment(
+                                    name=resource_name,
+                                    namespace=namespace,
+                                    propagation_policy="Background",
+                                    _request_timeout=timeout,
+                                )
+                            except ApiException:
+                                pass
+                        raise
                     return deployment
                 if deployment_created:
                     try:
@@ -433,14 +451,25 @@ async def delete_deployment(
             except ApiException as exc:
                 if exc.status == 404:
                     try:
-                        core_v1.delete_namespaced_service(
+                        service = core_v1.read_namespaced_service(
                             name=resource_name,
                             namespace=namespace,
                             _request_timeout=timeout,
                         )
-                    except ApiException as service_exc:
-                        if service_exc.status != 404:
+                    except ApiException as service_read_exc:
+                        if service_read_exc.status != 404:
                             raise
+                        return None
+                    if resource_labels_match(service, expected_labels):
+                        try:
+                            core_v1.delete_namespaced_service(
+                                name=resource_name,
+                                namespace=namespace,
+                                _request_timeout=timeout,
+                            )
+                        except ApiException as service_exc:
+                            if service_exc.status != 404:
+                                raise
                     return None
                 raise
             if not resource_labels_match(deployment, expected_labels):

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/deployments.py
@@ -1,0 +1,524 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Kubernetes Deployment + Service lifecycle for long-running workloads (Always)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from kubernetes.client.rest import ApiException
+from nemo_deployments_plugin.backends.base import BackendStatusUpdate, LogResult
+from nemo_deployments_plugin.backends.k8s.client import KubernetesClients, k8s_client_module
+from nemo_deployments_plugin.backends.k8s.jobs import (
+    DeploymentConfigError,
+    merged_volume_mounts,
+    newest_pod,
+    resolve_deployment_namespace,
+    resolve_k8s_deployment_config,
+    trim_log_text,
+)
+from nemo_deployments_plugin.backends.k8s.status import (
+    missing_deployment_status,
+    resource_labels_match,
+    status_from_deployment,
+)
+from nemo_deployments_plugin.backends.labels import (
+    CONFIG_NAME_LABEL,
+    DEPLOYMENT_NAME_LABEL,
+    DEPLOYMENT_WORKSPACE_LABEL,
+    RESTART_POLICY_LABEL,
+    deployment_identity_labels,
+    k8s_deployment_resource_name,
+    managed_by_label_selector,
+)
+from nemo_deployments_plugin.entities import Container, ContainerPort, DeploymentConfig, Probe, VolumeMount
+from nemo_deployments_plugin.types import Endpoint, RestartPolicy
+
+logger = logging.getLogger(__name__)
+
+APP_LABEL = "app"
+
+
+def app_selector_labels(resource_name: str) -> dict[str, str]:
+    return {APP_LABEL: resource_name}
+
+
+def validate_config_for_deployment(config: DeploymentConfig) -> Container:
+    """Return the sole container spec for a Deployment-backed deployment."""
+    if config.init_containers:
+        raise DeploymentConfigError("init_containers are not supported by the k8s Deployment backend in this phase")
+    if len(config.containers) != 1:
+        raise DeploymentConfigError(
+            f"k8s Deployment backend supports exactly one container; got {len(config.containers)}"
+        )
+    if config.restart_policy != "Always":
+        raise DeploymentConfigError("restart_policy Always is required for Deployment + Service")
+    return config.containers[0]
+
+
+def _build_probe(probe: Probe | None) -> Any | None:
+    if probe is None:
+        return None
+    k8s = k8s_client_module()
+    kwargs: dict[str, Any] = {
+        "initial_delay_seconds": probe.initial_delay_seconds,
+        "period_seconds": probe.period_seconds,
+        "timeout_seconds": probe.timeout_seconds,
+        "failure_threshold": probe.failure_threshold,
+    }
+    if probe.exec_action is not None:
+        kwargs["exec"] = k8s.client.V1ExecAction(command=list(probe.exec_action.command))
+    elif probe.http_get is not None:
+        kwargs["http_get"] = k8s.client.V1HTTPGetAction(
+            path=probe.http_get.path,
+            port=probe.http_get.port,
+            scheme=probe.http_get.scheme,
+        )
+    elif probe.tcp_socket is not None:
+        kwargs["tcp_socket"] = k8s.client.V1TCPSocketAction(port=probe.tcp_socket.port)
+    else:
+        return None
+    return k8s.client.V1Probe(**kwargs)
+
+
+def _build_container_ports(ports: list[ContainerPort]) -> list[Any]:
+    if not ports:
+        return []
+    k8s = k8s_client_module()
+    return [
+        k8s.client.V1ContainerPort(
+            name=port.name or f"port-{port.container_port}",
+            container_port=port.container_port,
+            protocol=port.protocol,
+        )
+        for port in ports
+    ]
+
+
+def build_deployment_container_spec(container: Container, *, volume_mounts: list[VolumeMount] | None = None) -> Any:
+    from nemo_deployments_plugin.backends.k8s.jobs import (
+        build_container_spec,
+        build_volume_mounts,
+    )
+
+    k8s = k8s_client_module()
+    base = build_container_spec(container, volume_mounts=volume_mounts)
+    ports = _build_container_ports(container.ports)
+    kwargs: dict[str, Any] = {
+        "name": base.name,
+        "image": base.image,
+        "command": base.command,
+        "args": base.args,
+        "env": base.env,
+        "resources": base.resources,
+        "volume_mounts": build_volume_mounts(volume_mounts) if volume_mounts else base.volume_mounts,
+        "ports": ports or None,
+        "liveness_probe": _build_probe(container.liveness_probe),
+        "readiness_probe": _build_probe(container.readiness_probe),
+    }
+    return k8s.client.V1Container(**{key: value for key, value in kwargs.items() if value is not None})
+
+
+def build_deployment_body(
+    *,
+    resource_name: str,
+    labels: dict[str, str],
+    config: DeploymentConfig,
+    container: Container,
+    workspace: str,
+) -> Any:
+    """Build an ``apps/v1.Deployment`` for create."""
+    from nemo_deployments_plugin.backends.k8s.jobs import build_pod_volumes
+
+    k8s = k8s_client_module()
+    selector_labels = app_selector_labels(resource_name)
+    pod_labels = {**selector_labels, **labels}
+    mounts = merged_volume_mounts(config, container)
+    pod_spec_kwargs: dict[str, Any] = {
+        "containers": [build_deployment_container_spec(container, volume_mounts=mounts or None)],
+    }
+    volumes = build_pod_volumes(workspace=workspace, mounts=mounts)
+    if volumes:
+        pod_spec_kwargs["volumes"] = volumes
+
+    return k8s.client.V1Deployment(
+        api_version="apps/v1",
+        kind="Deployment",
+        metadata=k8s.client.V1ObjectMeta(name=resource_name, labels=labels),
+        spec=k8s.client.V1DeploymentSpec(
+            replicas=1,
+            selector=k8s.client.V1LabelSelector(match_labels=selector_labels),
+            template=k8s.client.V1PodTemplateSpec(
+                metadata=k8s.client.V1ObjectMeta(labels=pod_labels),
+                spec=k8s.client.V1PodSpec(**pod_spec_kwargs),
+            ),
+        ),
+    )
+
+
+def build_service_body(*, resource_name: str, labels: dict[str, str], container: Container) -> Any:
+    """Build a ClusterIP ``v1.Service`` exposing container ports in-cluster."""
+    k8s = k8s_client_module()
+    selector_labels = app_selector_labels(resource_name)
+    service_ports: list[Any] = []
+    for port in container.ports:
+        port_name = port.name or f"port-{port.container_port}"
+        service_ports.append(
+            k8s.client.V1ServicePort(
+                name=port_name,
+                port=port.container_port,
+                target_port=port_name,
+                protocol=port.protocol,
+            )
+        )
+    if not service_ports:
+        service_ports.append(
+            k8s.client.V1ServicePort(
+                name="http",
+                port=8080,
+                target_port=8080,
+                protocol="TCP",
+            )
+        )
+    return k8s.client.V1Service(
+        api_version="v1",
+        kind="Service",
+        metadata=k8s.client.V1ObjectMeta(name=resource_name, labels=labels),
+        spec=k8s.client.V1ServiceSpec(
+            type="ClusterIP",
+            selector=selector_labels,
+            ports=service_ports,
+        ),
+    )
+
+
+def build_in_cluster_endpoints(*, resource_name: str, namespace: str, container: Container) -> list[Endpoint]:
+    """Build in-cluster HTTP endpoints for exposed container ports."""
+    endpoints: list[Endpoint] = []
+    host = f"{resource_name}.{namespace}.svc.cluster.local"
+    if container.ports:
+        for port in container.ports:
+            endpoint_name = port.name or f"port-{port.container_port}"
+            protocol = "tcp" if port.protocol == "UDP" else "http"
+            scheme = "http"
+            endpoints.append(
+                Endpoint(
+                    name=endpoint_name,
+                    url=f"{scheme}://{host}:{port.container_port}",
+                    protocol=protocol,
+                )
+            )
+        return endpoints
+    endpoints.append(Endpoint(name="http", url=f"http://{host}:8080", protocol="http"))
+    return endpoints
+
+
+def _label_selector(match_labels: dict[str, str]) -> str:
+    return ",".join(f"{key}={value}" for key, value in match_labels.items())
+
+
+async def _read_newest_pod(
+    clients: KubernetesClients,
+    *,
+    namespace: str,
+    match_labels: dict[str, str],
+) -> Any | None:
+    timeout = clients.request_timeout
+    core_v1 = clients.core_v1
+
+    def _list() -> Any | None:
+        pods = core_v1.list_namespaced_pod(
+            namespace=namespace,
+            label_selector=_label_selector(match_labels),
+            _request_timeout=timeout,
+        )
+        if not pods.items:
+            return None
+        return newest_pod(list(pods.items))
+
+    try:
+        return await asyncio.to_thread(_list)
+    except Exception:
+        logger.debug("Could not list pods for selector %s", match_labels, exc_info=True)
+        return None
+
+
+async def create_deployment(
+    clients: KubernetesClients,
+    *,
+    default_namespace: str,
+    workspace: str,
+    name: str,
+    config_name: str,
+    labels: dict[str, str],
+    backend_config: dict[str, Any],
+    config: DeploymentConfig,
+) -> BackendStatusUpdate:
+    resource_name = k8s_deployment_resource_name(workspace, name)
+    try:
+        container = validate_config_for_deployment(config)
+        k8s_config = resolve_k8s_deployment_config(backend_config)
+        namespace = resolve_deployment_namespace(default_namespace=default_namespace, k8s_config=k8s_config)
+        identity_labels = deployment_identity_labels(
+            workspace,
+            name,
+            config.restart_policy,
+            config_name=config_name,
+            backoff_limit=config.backoff_limit,
+        )
+        all_labels = {**labels, **config.labels, **identity_labels}
+        deployment_body = build_deployment_body(
+            resource_name=resource_name,
+            labels=all_labels,
+            config=config,
+            container=container,
+            workspace=workspace,
+        )
+        service_body = build_service_body(resource_name=resource_name, labels=all_labels, container=container)
+        timeout = clients.request_timeout
+        apps_v1 = clients.apps_v1
+        core_v1 = clients.core_v1
+
+        def _create() -> Any:
+            try:
+                apps_v1.create_namespaced_deployment(
+                    namespace=namespace,
+                    body=deployment_body,
+                    _request_timeout=timeout,
+                )
+            except ApiException as exc:
+                if exc.status != 409:
+                    raise
+            try:
+                core_v1.create_namespaced_service(
+                    namespace=namespace,
+                    body=service_body,
+                    _request_timeout=timeout,
+                )
+            except ApiException as exc:
+                if exc.status != 409:
+                    raise
+            return apps_v1.read_namespaced_deployment(
+                name=resource_name,
+                namespace=namespace,
+                _request_timeout=timeout,
+            )
+
+        deployment = await asyncio.to_thread(_create)
+        endpoints = build_in_cluster_endpoints(resource_name=resource_name, namespace=namespace, container=container)
+        pod = await _read_newest_pod(clients, namespace=namespace, match_labels=app_selector_labels(resource_name))
+        return status_from_deployment(
+            deployment=deployment,
+            deployment_name=resource_name,
+            expected_labels=identity_labels,
+            endpoints=endpoints,
+            pod=pod,
+        )
+    except DeploymentConfigError as exc:
+        return BackendStatusUpdate(status="FAILED", status_message=str(exc))
+    except Exception as exc:
+        logger.exception("Failed to create Deployment %s", resource_name)
+        return BackendStatusUpdate(status="FAILED", status_message=f"Failed to create Deployment: {exc}")
+
+
+async def read_deployment_status(
+    clients: KubernetesClients,
+    *,
+    default_namespace: str,
+    workspace: str,
+    name: str,
+    backend_config: dict[str, Any],
+    config_name: str,
+    restart_policy: RestartPolicy,
+    backoff_limit: int,
+    container: Container,
+) -> BackendStatusUpdate:
+    resource_name = k8s_deployment_resource_name(workspace, name)
+    expected_labels = deployment_identity_labels(
+        workspace,
+        name,
+        restart_policy,
+        config_name=config_name,
+        backoff_limit=backoff_limit,
+    )
+    try:
+        k8s_config = resolve_k8s_deployment_config(backend_config)
+        namespace = resolve_deployment_namespace(default_namespace=default_namespace, k8s_config=k8s_config)
+        timeout = clients.request_timeout
+        apps_v1 = clients.apps_v1
+
+        def _read() -> Any:
+            return apps_v1.read_namespaced_deployment(
+                name=resource_name,
+                namespace=namespace,
+                _request_timeout=timeout,
+            )
+
+        deployment = await asyncio.to_thread(_read)
+        deployment_labels = (deployment.metadata.labels or {}) if deployment.metadata else {}
+        if not deployment_labels.get(CONFIG_NAME_LABEL):
+            return BackendStatusUpdate(
+                status="FAILED",
+                status_message=f"Deployment {resource_name} is missing deployment config identity labels",
+            )
+        endpoints = build_in_cluster_endpoints(resource_name=resource_name, namespace=namespace, container=container)
+        pod = await _read_newest_pod(clients, namespace=namespace, match_labels=app_selector_labels(resource_name))
+        return status_from_deployment(
+            deployment=deployment,
+            deployment_name=resource_name,
+            expected_labels=expected_labels,
+            endpoints=endpoints,
+            pod=pod,
+        )
+    except ApiException as exc:
+        if exc.status == 404:
+            return missing_deployment_status(deployment_name=resource_name)
+        return BackendStatusUpdate(status="FAILED", status_message=f"Failed to read Deployment: {exc}")
+    except Exception as exc:
+        return BackendStatusUpdate(status="FAILED", status_message=f"Failed to read Deployment: {exc}")
+
+
+async def delete_deployment(
+    clients: KubernetesClients,
+    *,
+    default_namespace: str,
+    workspace: str,
+    name: str,
+    backend_config: dict[str, Any],
+    expected_labels: dict[str, str],
+) -> BackendStatusUpdate:
+    resource_name = k8s_deployment_resource_name(workspace, name)
+    try:
+        k8s_config = resolve_k8s_deployment_config(backend_config)
+        namespace = resolve_deployment_namespace(default_namespace=default_namespace, k8s_config=k8s_config)
+        timeout = clients.request_timeout
+        apps_v1 = clients.apps_v1
+        core_v1 = clients.core_v1
+
+        def _delete() -> str | None:
+            try:
+                deployment = apps_v1.read_namespaced_deployment(
+                    name=resource_name,
+                    namespace=namespace,
+                    _request_timeout=timeout,
+                )
+            except ApiException as exc:
+                if exc.status == 404:
+                    try:
+                        core_v1.delete_namespaced_service(
+                            name=resource_name,
+                            namespace=namespace,
+                            _request_timeout=timeout,
+                        )
+                    except ApiException as service_exc:
+                        if service_exc.status != 404:
+                            raise
+                    return None
+                raise
+            if not resource_labels_match(deployment, expected_labels):
+                return "foreign"
+            apps_v1.delete_namespaced_deployment(
+                name=resource_name,
+                namespace=namespace,
+                propagation_policy="Background",
+                _request_timeout=timeout,
+            )
+            try:
+                core_v1.delete_namespaced_service(
+                    name=resource_name,
+                    namespace=namespace,
+                    _request_timeout=timeout,
+                )
+            except ApiException as exc:
+                if exc.status != 404:
+                    raise
+            return "deleted"
+
+        result = await asyncio.to_thread(_delete)
+        if result == "foreign":
+            return BackendStatusUpdate(
+                status="FAILED",
+                status_message=f"Deployment {resource_name} exists but is not managed by this plugin",
+            )
+        return BackendStatusUpdate(status="SUCCEEDED", status_message=f"Deployment {resource_name} deleted")
+    except Exception as exc:
+        return BackendStatusUpdate(status="FAILED", status_message=f"Failed to delete Deployment: {exc}")
+
+
+async def list_managed_deployment_names(clients: KubernetesClients, *, default_namespace: str) -> list[str]:
+    """List plugin-managed Deployments with restart_policy Always in the default namespace."""
+    timeout = clients.request_timeout
+    apps_v1 = clients.apps_v1
+    label_selector = f"{managed_by_label_selector()},{RESTART_POLICY_LABEL}=Always"
+
+    def _list() -> Any:
+        return apps_v1.list_namespaced_deployment(
+            namespace=default_namespace,
+            label_selector=label_selector,
+            _request_timeout=timeout,
+        )
+
+    try:
+        result = await asyncio.to_thread(_list)
+    except Exception:
+        logger.warning("Failed to list managed Deployments", exc_info=True)
+        return []
+
+    seen: set[str] = set()
+    for deployment in result.items or []:
+        labels = (deployment.metadata.labels or {}) if deployment.metadata else {}
+        workspace = labels.get(DEPLOYMENT_WORKSPACE_LABEL)
+        dep_name = labels.get(DEPLOYMENT_NAME_LABEL)
+        if workspace and dep_name:
+            seen.add(f"{workspace}/{dep_name}")
+    return sorted(seen)
+
+
+async def get_deployment_logs(
+    clients: KubernetesClients,
+    *,
+    default_namespace: str,
+    workspace: str,
+    name: str,
+    backend_config: dict[str, Any],
+    tail: int,
+) -> LogResult:
+    resource_name = k8s_deployment_resource_name(workspace, name)
+    try:
+        k8s_config = resolve_k8s_deployment_config(backend_config)
+        namespace = resolve_deployment_namespace(default_namespace=default_namespace, k8s_config=k8s_config)
+        timeout = clients.request_timeout
+        core_v1 = clients.core_v1
+        selector = _label_selector(app_selector_labels(resource_name))
+
+        def _logs() -> str:
+            pods = core_v1.list_namespaced_pod(
+                namespace=namespace,
+                label_selector=selector,
+                _request_timeout=timeout,
+            )
+            if not pods.items:
+                return ""
+            pod = newest_pod(list(pods.items))
+            if pod is None or pod.metadata is None:
+                return ""
+            return core_v1.read_namespaced_pod_log(
+                name=pod.metadata.name,
+                namespace=namespace,
+                tail_lines=tail,
+                timestamps=True,
+                _request_timeout=timeout,
+            )
+
+        text = await asyncio.to_thread(_logs)
+        lines, truncated = trim_log_text(text)
+        return LogResult(lines=lines, truncated=truncated)
+    except ApiException as exc:
+        if exc.status == 404:
+            return LogResult(lines=[])
+        return LogResult(lines=[f"Failed to read Deployment logs: {exc}"])
+    except Exception as exc:
+        return LogResult(lines=[f"Failed to read Deployment logs: {exc}"])

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/jobs.py
@@ -408,7 +408,7 @@ async def list_managed_job_names(clients: KubernetesClients, *, default_namespac
     """List plugin-managed Jobs in the executor default namespace.
 
     Per-deployment namespaces from ``backend_config.k8s.namespace`` are not scanned
-    here; phase 4 will extend listing when Deployment resources land.
+    here; custom namespaces are listed when Deployment resources are scanned in phase 4.
     """
     timeout = clients.request_timeout
     batch_v1 = clients.batch_v1

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
@@ -87,7 +87,7 @@ def status_from_job(
     return BackendStatusUpdate(status="STARTING", status_message=f"Job {job_name} is pending")
 
 
-def _deployment_is_deleting(deployment: Any) -> bool:
+def _is_deployment_deleting(deployment: Any) -> bool:
     metadata = getattr(deployment, "metadata", None)
     return bool(metadata and getattr(metadata, "deletion_timestamp", None))
 
@@ -168,7 +168,7 @@ def status_from_deployment(
             status="FAILED",
             status_message=f"Deployment {deployment_name} exists but is not managed by this plugin",
         )
-    if _deployment_is_deleting(deployment):
+    if _is_deployment_deleting(deployment):
         return BackendStatusUpdate(
             status="DELETING",
             status_message=f"Deployment {deployment_name} is terminating",

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
@@ -114,7 +114,6 @@ def status_message_from_pod(pod: Any) -> str | None:
         phase = getattr(status, "phase", None) if status is not None else None
         return f"Pod phase is {phase}" if phase else None
 
-    restart_count = _pod_restart_count(pod)
     for container_status in status.container_statuses:
         state = container_status.state
         if state is None:
@@ -125,8 +124,6 @@ def status_message_from_pod(pod: Any) -> str | None:
         reason = waiting.reason or "Waiting"
         message = waiting.message or ""
         detail = f"{reason}: {message}" if message else reason
-        if reason == "CrashLoopBackOff" and restart_count >= CRASH_LOOP_RESTART_THRESHOLD:
-            return detail
         if reason in _TRANSIENT_WAITING_REASONS or reason == "CrashLoopBackOff":
             return detail
     phase = status.phase or "Unknown"
@@ -135,13 +132,24 @@ def status_message_from_pod(pod: Any) -> str | None:
 
 def pod_failure_status(*, deployment_name: str, pod: Any) -> BackendStatusUpdate | None:
     """Return FAILED when a pod is in a sustained crash loop."""
-    message = status_message_from_pod(pod)
-    if message is None:
+    status = getattr(pod, "status", None)
+    if status is None or not status.container_statuses:
         return None
-    if message.startswith("CrashLoopBackOff") and _pod_restart_count(pod) >= CRASH_LOOP_RESTART_THRESHOLD:
+    restart_count = _pod_restart_count(pod)
+    if restart_count < CRASH_LOOP_RESTART_THRESHOLD:
+        return None
+    for container_status in status.container_statuses:
+        state = container_status.state
+        if state is None or state.waiting is None:
+            continue
+        reason = state.waiting.reason or ""
+        if reason != "CrashLoopBackOff":
+            continue
+        message = state.waiting.message or ""
+        detail = f"{reason}: {message}" if message else reason
         return BackendStatusUpdate(
             status="FAILED",
-            status_message=f"Deployment {deployment_name} pod crash loop: {message}",
+            status_message=f"Deployment {deployment_name} pod crash loop: {detail}",
         )
     return None
 

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/k8s/status.py
@@ -1,15 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Map Kubernetes Job status to plugin DeploymentStatus values."""
+"""Map Kubernetes Job and Deployment status to plugin DeploymentStatus values."""
 
 from __future__ import annotations
 
 from typing import Any
 
 from nemo_deployments_plugin.backends.base import BackendStatusUpdate
+from nemo_deployments_plugin.types import Endpoint
 
 LOG_MAX_CHARS = 8000
+CRASH_LOOP_RESTART_THRESHOLD = 3
+_TRANSIENT_WAITING_REASONS = frozenset({"ContainerCreating", "PodInitializing", "ImagePullBackOff", "ErrImagePull"})
 
 
 def _job_is_deleting(job: Any) -> bool:
@@ -82,3 +85,108 @@ def status_from_job(
         )
 
     return BackendStatusUpdate(status="STARTING", status_message=f"Job {job_name} is pending")
+
+
+def _deployment_is_deleting(deployment: Any) -> bool:
+    metadata = getattr(deployment, "metadata", None)
+    return bool(metadata and getattr(metadata, "deletion_timestamp", None))
+
+
+def missing_deployment_status(*, deployment_name: str) -> BackendStatusUpdate:
+    return BackendStatusUpdate(
+        status="LOST",
+        status_message=(f"Deployment not found — may have been manually deleted. Expected name: {deployment_name}"),
+        error_details={"expected_deployment_name": deployment_name},
+    )
+
+
+def _pod_restart_count(pod: Any) -> int:
+    status = getattr(pod, "status", None)
+    if status is None or not status.container_statuses:
+        return 0
+    return max(int(container_status.restart_count or 0) for container_status in status.container_statuses)
+
+
+def status_message_from_pod(pod: Any) -> str | None:
+    """Surface pod waiting reasons such as ImagePullBackOff or CrashLoopBackOff."""
+    status = getattr(pod, "status", None)
+    if status is None or not status.container_statuses:
+        phase = getattr(status, "phase", None) if status is not None else None
+        return f"Pod phase is {phase}" if phase else None
+
+    restart_count = _pod_restart_count(pod)
+    for container_status in status.container_statuses:
+        state = container_status.state
+        if state is None:
+            continue
+        waiting = state.waiting
+        if waiting is None:
+            continue
+        reason = waiting.reason or "Waiting"
+        message = waiting.message or ""
+        detail = f"{reason}: {message}" if message else reason
+        if reason == "CrashLoopBackOff" and restart_count >= CRASH_LOOP_RESTART_THRESHOLD:
+            return detail
+        if reason in _TRANSIENT_WAITING_REASONS or reason == "CrashLoopBackOff":
+            return detail
+    phase = status.phase or "Unknown"
+    return f"Pod phase is {phase}"
+
+
+def pod_failure_status(*, deployment_name: str, pod: Any) -> BackendStatusUpdate | None:
+    """Return FAILED when a pod is in a sustained crash loop."""
+    message = status_message_from_pod(pod)
+    if message is None:
+        return None
+    if message.startswith("CrashLoopBackOff") and _pod_restart_count(pod) >= CRASH_LOOP_RESTART_THRESHOLD:
+        return BackendStatusUpdate(
+            status="FAILED",
+            status_message=f"Deployment {deployment_name} pod crash loop: {message}",
+        )
+    return None
+
+
+def status_from_deployment(
+    *,
+    deployment: Any,
+    deployment_name: str,
+    expected_labels: dict[str, str],
+    endpoints: list[Endpoint],
+    pod: Any | None = None,
+) -> BackendStatusUpdate:
+    """Map a Deployment object to plugin status, with optional pod drill-down."""
+    if not resource_labels_match(deployment, expected_labels):
+        return BackendStatusUpdate(
+            status="FAILED",
+            status_message=f"Deployment {deployment_name} exists but is not managed by this plugin",
+        )
+    if _deployment_is_deleting(deployment):
+        return BackendStatusUpdate(
+            status="DELETING",
+            status_message=f"Deployment {deployment_name} is terminating",
+        )
+
+    dep_status = deployment.status
+    ready_replicas = int(dep_status.ready_replicas or 0) if dep_status is not None else 0
+    if ready_replicas >= 1:
+        return BackendStatusUpdate(
+            status="READY",
+            status_message=f"Deployment {deployment_name} is ready",
+            endpoints=endpoints,
+        )
+
+    if pod is not None:
+        failure = pod_failure_status(deployment_name=deployment_name, pod=pod)
+        if failure is not None:
+            return failure
+        pod_message = status_message_from_pod(pod)
+        if pod_message:
+            return BackendStatusUpdate(
+                status="STARTING",
+                status_message=f"Deployment {deployment_name}: {pod_message}",
+            )
+
+    return BackendStatusUpdate(
+        status="STARTING",
+        status_message=f"Deployment {deployment_name} is starting",
+    )

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/k8s_helpers.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/k8s_helpers.py
@@ -15,9 +15,10 @@ from nemo_deployments_plugin.backends.labels import (
     MANAGED_BY_KEY,
     RESTART_POLICY_LABEL,
     deployment_identity_labels,
+    k8s_deployment_resource_name,
 )
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
-from nemo_deployments_plugin.entities import Container, Deployment, DeploymentConfig
+from nemo_deployments_plugin.entities import Container, ContainerPort, Deployment, DeploymentConfig
 from nemo_deployments_plugin.types import RestartPolicy
 
 
@@ -42,6 +43,90 @@ def sample_deployment(*, config_name: str = "cfg1") -> Deployment:
         workspace="default",
         deployment_config=config_name,
     )
+
+
+def sample_always_config(*, with_port: bool = True) -> DeploymentConfig:
+    ports = [ContainerPort(name="http", containerPort=8080)] if with_port else []
+    return DeploymentConfig(
+        name="cfg1",
+        workspace="default",
+        containers=[
+            Container(
+                name="main",
+                image="nginx:alpine",
+                ports=ports,
+            )
+        ],
+    ).model_copy(update={"restart_policy": "Always"})
+
+
+def always_identity_labels(
+    workspace: str = "default",
+    name: str = "task",
+    *,
+    config_name: str = "cfg1",
+    backoff_limit: int = 6,
+) -> dict[str, str]:
+    return deployment_identity_labels(
+        workspace,
+        name,
+        "Always",
+        config_name=config_name,
+        backoff_limit=backoff_limit,
+    )
+
+
+def mock_deployment(
+    *,
+    workspace: str = "default",
+    name: str = "task",
+    ready_replicas: int = 0,
+    deleting: bool = False,
+) -> MagicMock:
+    labels = always_identity_labels(workspace=workspace, name=name)
+    resource_name = k8s_deployment_resource_name(workspace, name)
+    deployment = MagicMock()
+    deployment.metadata.labels = labels
+    deployment.metadata.deletion_timestamp = "2026-01-01T00:00:00Z" if deleting else None
+    deployment.status.ready_replicas = ready_replicas
+    deployment.status.available_replicas = ready_replicas
+    deployment.spec.selector.match_labels = {"app": resource_name}
+    return deployment
+
+
+def mock_pod(
+    *,
+    waiting_reason: str | None = None,
+    waiting_message: str = "",
+    restart_count: int = 0,
+    phase: str = "Pending",
+) -> MagicMock:
+    pod = MagicMock()
+    pod.metadata.name = "task-pod-1"
+    pod.metadata.creation_timestamp = "2026-01-02T00:00:00Z"
+    pod.status.phase = phase
+    container_status = MagicMock()
+    container_status.restart_count = restart_count
+    if waiting_reason is None:
+        container_status.state.waiting = None
+    else:
+        container_status.state.waiting.reason = waiting_reason
+        container_status.state.waiting.message = waiting_message
+    pod.status.container_statuses = [container_status]
+    return pod
+
+
+def deployment_list_item(*, workspace: str, name: str) -> MagicMock:
+    item = MagicMock()
+    item.metadata.labels = {
+        MANAGED_BY_KEY: MANAGED_BY_LABEL,
+        DEPLOYMENT_WORKSPACE_LABEL: workspace,
+        DEPLOYMENT_NAME_LABEL: name,
+        RESTART_POLICY_LABEL: "Always",
+        CONFIG_NAME_LABEL: "cfg1",
+        BACKOFF_LIMIT_LABEL: "6",
+    }
+    return item
 
 
 def job_identity_labels(

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/k8s_helpers.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/k8s_helpers.py
@@ -24,7 +24,7 @@ from nemo_deployments_plugin.types import RestartPolicy
 
 def sample_config(*, restart_policy: RestartPolicy = "Never") -> DeploymentConfig:
     return DeploymentConfig(
-        name="cfg1",
+        name="config1",
         workspace="default",
         containers=[
             Container(
@@ -37,7 +37,7 @@ def sample_config(*, restart_policy: RestartPolicy = "Never") -> DeploymentConfi
     ).model_copy(update={"restart_policy": restart_policy})
 
 
-def sample_deployment(*, config_name: str = "cfg1") -> Deployment:
+def sample_deployment(*, config_name: str = "config1") -> Deployment:
     return Deployment(
         name="task",
         workspace="default",
@@ -48,7 +48,7 @@ def sample_deployment(*, config_name: str = "cfg1") -> Deployment:
 def sample_always_config(*, with_port: bool = True) -> DeploymentConfig:
     ports = [ContainerPort(name="http", containerPort=8080)] if with_port else []
     return DeploymentConfig(
-        name="cfg1",
+        name="config1",
         workspace="default",
         containers=[
             Container(
@@ -64,7 +64,7 @@ def always_identity_labels(
     workspace: str = "default",
     name: str = "task",
     *,
-    config_name: str = "cfg1",
+    config_name: str = "config1",
     backoff_limit: int = 6,
 ) -> dict[str, str]:
     return deployment_identity_labels(
@@ -123,7 +123,7 @@ def deployment_list_item(*, workspace: str, name: str) -> MagicMock:
         DEPLOYMENT_WORKSPACE_LABEL: workspace,
         DEPLOYMENT_NAME_LABEL: name,
         RESTART_POLICY_LABEL: "Always",
-        CONFIG_NAME_LABEL: "cfg1",
+        CONFIG_NAME_LABEL: "config1",
         BACKOFF_LIMIT_LABEL: "6",
     }
     return item
@@ -134,7 +134,7 @@ def job_identity_labels(
     name: str = "task",
     *,
     restart_policy: RestartPolicy = "Never",
-    config_name: str = "cfg1",
+    config_name: str = "config1",
     backoff_limit: int = 6,
 ) -> dict[str, str]:
     return deployment_identity_labels(
@@ -151,7 +151,7 @@ def mock_job(
     workspace: str = "default",
     name: str = "task",
     restart_policy: RestartPolicy = "Never",
-    config_name: str = "cfg1",
+    config_name: str = "config1",
     active: int = 0,
     complete: bool = False,
     failed: bool = False,
@@ -192,7 +192,7 @@ def job_list_item(*, workspace: str, name: str) -> MagicMock:
         DEPLOYMENT_WORKSPACE_LABEL: workspace,
         DEPLOYMENT_NAME_LABEL: name,
         RESTART_POLICY_LABEL: "Never",
-        CONFIG_NAME_LABEL: "cfg1",
+        CONFIG_NAME_LABEL: "config1",
         BACKOFF_LIMIT_LABEL: "0",
     }
     return item

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_deployments.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_deployments.py
@@ -22,7 +22,13 @@ from nemo_deployments_plugin.backends.k8s.deployments import (
     validate_config_for_deployment,
 )
 from nemo_deployments_plugin.backends.labels import MANAGED_BY_KEY, k8s_deployment_resource_name
+from nemo_deployments_plugin.entities import Container
 from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
+
+
+@pytest.fixture
+def always_deployment_context(mock_entities: AsyncMock) -> None:
+    mock_entities.get.side_effect = [sample_deployment(), sample_always_config()]
 
 
 @pytest.fixture
@@ -99,10 +105,68 @@ async def test_create_deployment_ready_reports_endpoints(
 
 
 @pytest.mark.asyncio
-async def test_read_deployment_status_lost_on_404(
-    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+async def test_create_deployment_conflict_rejects_foreign(
+    deployment_ops_clients: MagicMock, mock_k8s_clients: MagicMock
 ) -> None:
-    mock_entities.get.side_effect = [sample_deployment(), sample_always_config()]
+    foreign = mock_deployment()
+    foreign.metadata.labels = {MANAGED_BY_KEY: "other-plugin"}
+    mock_k8s_clients.apps_v1.create_namespaced_deployment.side_effect = ApiException(status=409)
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = foreign
+
+    update = await deployment_ops.create_deployment(
+        deployment_ops_clients,
+        default_namespace="default",
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={},
+        backend_config={},
+        config=sample_always_config(),
+    )
+
+    assert update.status == "FAILED"
+    assert "not managed" in update.status_message
+    mock_k8s_clients.core_v1.create_namespaced_service.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_rolls_back_when_service_create_fails(
+    deployment_ops_clients: MagicMock, mock_k8s_clients: MagicMock
+) -> None:
+    mock_k8s_clients.apps_v1.create_namespaced_deployment.return_value = mock_deployment()
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = mock_deployment()
+    mock_k8s_clients.core_v1.create_namespaced_service.side_effect = ApiException(status=500)
+
+    update = await deployment_ops.create_deployment(
+        deployment_ops_clients,
+        default_namespace="default",
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={},
+        backend_config={},
+        config=sample_always_config(),
+    )
+
+    assert update.status == "FAILED"
+    mock_k8s_clients.apps_v1.delete_namespaced_deployment.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_read_status_rejects_unsupported_always_config(k8s_backend, mock_entities: AsyncMock) -> None:
+    config = sample_always_config().model_copy(update={"init_containers": [Container(name="init", image="busybox")]})
+    mock_entities.get.side_effect = [sample_deployment(), config]
+
+    update = await k8s_backend.read_status(workspace="default", name="task")
+
+    assert update.status == "FAILED"
+    assert "init_containers" in update.status_message
+
+
+@pytest.mark.asyncio
+async def test_read_deployment_status_lost_on_404(
+    k8s_backend, mock_k8s_clients: MagicMock, always_deployment_context: None
+) -> None:
     mock_k8s_clients.apps_v1.read_namespaced_deployment.side_effect = ApiException(status=404)
 
     update = await k8s_backend.read_status(workspace="default", name="task")
@@ -113,9 +177,8 @@ async def test_read_deployment_status_lost_on_404(
 
 @pytest.mark.asyncio
 async def test_read_deployment_status_image_pull_backoff(
-    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+    k8s_backend, mock_k8s_clients: MagicMock, always_deployment_context: None
 ) -> None:
-    mock_entities.get.side_effect = [sample_deployment(), sample_always_config()]
     mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = mock_deployment(ready_replicas=0)
     mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(
         items=[mock_pod(waiting_reason="ImagePullBackOff", waiting_message="pull access denied")]
@@ -129,9 +192,8 @@ async def test_read_deployment_status_image_pull_backoff(
 
 @pytest.mark.asyncio
 async def test_read_deployment_status_crash_loop_failed(
-    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+    k8s_backend, mock_k8s_clients: MagicMock, always_deployment_context: None
 ) -> None:
-    mock_entities.get.side_effect = [sample_deployment(), sample_always_config()]
     mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = mock_deployment(ready_replicas=0)
     mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(
         items=[mock_pod(waiting_reason="CrashLoopBackOff", waiting_message="back-off", restart_count=3)]
@@ -145,9 +207,8 @@ async def test_read_deployment_status_crash_loop_failed(
 
 @pytest.mark.asyncio
 async def test_delete_deployment_removes_service(
-    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+    k8s_backend, mock_k8s_clients: MagicMock, always_deployment_context: None
 ) -> None:
-    mock_entities.get.side_effect = [sample_deployment(), sample_always_config()]
     mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = mock_deployment()
 
     update = await k8s_backend.delete_deployment("default", "task")
@@ -191,8 +252,7 @@ async def test_list_managed_deployment_names_includes_always(k8s_backend, mock_k
 
 
 @pytest.mark.asyncio
-async def test_get_deployment_logs(k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock) -> None:
-    mock_entities.get.side_effect = [sample_deployment(), sample_always_config()]
+async def test_get_deployment_logs(k8s_backend, mock_k8s_clients: MagicMock, always_deployment_context: None) -> None:
     pod = mock_pod()
     mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(items=[pod])
     mock_k8s_clients.core_v1.read_namespaced_pod_log.return_value = "listening\n"
@@ -200,6 +260,23 @@ async def test_get_deployment_logs(k8s_backend, mock_k8s_clients: MagicMock, moc
     result = await k8s_backend.get_logs(workspace="default", name="task", tail=10)
 
     assert result.lines == ["listening"]
+
+
+@pytest.mark.asyncio
+async def test_delete_deployment_orphan_returns_deployment_failure(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.side_effect = NemoEntityNotFoundError("missing")
+    foreign = mock_deployment()
+    foreign.metadata.labels = {MANAGED_BY_KEY: "other-plugin"}
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = foreign
+    mock_k8s_clients.batch_v1.read_namespaced_job.side_effect = ApiException(status=404)
+
+    update = await k8s_backend.delete_deployment("default", "task")
+
+    assert update.status == "FAILED"
+    assert "not managed" in update.status_message
+    mock_k8s_clients.apps_v1.delete_namespaced_deployment.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_deployments.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_deployments.py
@@ -22,7 +22,7 @@ from nemo_deployments_plugin.backends.k8s.deployments import (
     validate_config_for_deployment,
 )
 from nemo_deployments_plugin.backends.labels import MANAGED_BY_KEY, k8s_deployment_resource_name
-from nemo_deployments_plugin.entities import Container
+from nemo_deployments_plugin.entities import Container, ContainerPort
 from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
 
 
@@ -53,6 +53,22 @@ def test_build_in_cluster_endpoints_uses_cluster_dns() -> None:
         container=sample_always_config().containers[0],
     )
     assert endpoints[0].url == f"http://{resource_name}.nemo-deployments.svc.cluster.local:8080"
+
+
+def test_build_in_cluster_endpoints_uses_tcp_scheme_for_udp() -> None:
+    resource_name = k8s_deployment_resource_name("default", "task")
+    container = (
+        sample_always_config()
+        .containers[0]
+        .model_copy(update={"ports": [ContainerPort(name="metrics", containerPort=9090, protocol="UDP")]})
+    )
+    endpoints = build_in_cluster_endpoints(
+        resource_name=resource_name,
+        namespace="nemo-deployments",
+        container=container,
+    )
+    assert endpoints[0].protocol == "tcp"
+    assert endpoints[0].url == f"tcp://{resource_name}.nemo-deployments.svc.cluster.local:9090"
 
 
 @pytest.mark.asyncio
@@ -127,6 +143,32 @@ async def test_create_deployment_conflict_rejects_foreign(
     assert update.status == "FAILED"
     assert "not managed" in update.status_message
     mock_k8s_clients.core_v1.create_namespaced_service.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_service_conflict_rejects_foreign(
+    deployment_ops_clients: MagicMock, mock_k8s_clients: MagicMock
+) -> None:
+    mock_k8s_clients.apps_v1.create_namespaced_deployment.return_value = mock_deployment()
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = mock_deployment()
+    foreign_service = MagicMock()
+    foreign_service.metadata.labels = {MANAGED_BY_KEY: "other-plugin"}
+    mock_k8s_clients.core_v1.create_namespaced_service.side_effect = ApiException(status=409)
+    mock_k8s_clients.core_v1.read_namespaced_service.return_value = foreign_service
+
+    update = await deployment_ops.create_deployment(
+        deployment_ops_clients,
+        default_namespace="default",
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={},
+        backend_config={},
+        config=sample_always_config(),
+    )
+
+    assert update.status == "FAILED"
+    mock_k8s_clients.apps_v1.delete_namespaced_deployment.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -277,6 +319,28 @@ async def test_delete_deployment_orphan_returns_deployment_failure(
     assert update.status == "FAILED"
     assert "not managed" in update.status_message
     mock_k8s_clients.apps_v1.delete_namespaced_deployment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_deployment_orphan_skips_foreign_service(
+    deployment_ops_clients: MagicMock, mock_k8s_clients: MagicMock
+) -> None:
+    foreign_service = MagicMock()
+    foreign_service.metadata.labels = {MANAGED_BY_KEY: "other-plugin"}
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.side_effect = ApiException(status=404)
+    mock_k8s_clients.core_v1.read_namespaced_service.return_value = foreign_service
+
+    update = await deployment_ops.delete_deployment(
+        deployment_ops_clients,
+        default_namespace="default",
+        workspace="default",
+        name="task",
+        backend_config={},
+        expected_labels=always_identity_labels(),
+    )
+
+    assert update.status == "SUCCEEDED"
+    mock_k8s_clients.core_v1.delete_namespaced_service.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_deployments.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_deployments.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from backends.k8s.k8s_helpers import (
+    always_identity_labels,
+    deployment_list_item,
+    mock_deployment,
+    mock_pod,
+    sample_always_config,
+    sample_deployment,
+)
+from kubernetes.client.rest import ApiException
+from nemo_deployments_plugin.backends.k8s import deployments as deployment_ops
+from nemo_deployments_plugin.backends.k8s.client import KubernetesClients
+from nemo_deployments_plugin.backends.k8s.deployments import (
+    build_in_cluster_endpoints,
+    validate_config_for_deployment,
+)
+from nemo_deployments_plugin.backends.labels import MANAGED_BY_KEY, k8s_deployment_resource_name
+from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
+
+
+@pytest.fixture
+def deployment_ops_clients(mock_k8s_clients: MagicMock) -> MagicMock:
+    clients = MagicMock(spec=KubernetesClients)
+    clients.apps_v1 = mock_k8s_clients.apps_v1
+    clients.core_v1 = mock_k8s_clients.core_v1
+    clients.request_timeout = mock_k8s_clients.request_timeout
+    return clients
+
+
+def test_validate_config_for_deployment_rejects_never() -> None:
+    with pytest.raises(deployment_ops.DeploymentConfigError, match="Always"):
+        validate_config_for_deployment(sample_always_config().model_copy(update={"restart_policy": "Never"}))
+
+
+def test_build_in_cluster_endpoints_uses_cluster_dns() -> None:
+    resource_name = k8s_deployment_resource_name("default", "task")
+    endpoints = build_in_cluster_endpoints(
+        resource_name=resource_name,
+        namespace="nemo-deployments",
+        container=sample_always_config().containers[0],
+    )
+    assert endpoints[0].url == f"http://{resource_name}.nemo-deployments.svc.cluster.local:8080"
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_emits_deployment_and_service(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = sample_always_config()
+    mock_k8s_clients.apps_v1.create_namespaced_deployment.return_value = mock_deployment()
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = mock_deployment()
+    mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(items=[])
+
+    await k8s_backend.create_deployment(
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={},
+        backend_config={},
+    )
+
+    deployment_body = mock_k8s_clients.apps_v1.create_namespaced_deployment.call_args.kwargs["body"]
+    service_body = mock_k8s_clients.core_v1.create_namespaced_service.call_args.kwargs["body"]
+    assert deployment_body.kind == "Deployment"
+    assert deployment_body.spec.replicas == 1
+    assert deployment_body.spec.selector.match_labels["app"] == deployment_body.metadata.name
+    assert service_body.spec.type == "ClusterIP"
+    assert service_body.spec.selector["app"] == service_body.metadata.name
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_ready_reports_endpoints(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = sample_always_config()
+    ready = mock_deployment(ready_replicas=1)
+    mock_k8s_clients.apps_v1.create_namespaced_deployment.return_value = ready
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = ready
+    mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(items=[])
+
+    update = await k8s_backend.create_deployment(
+        workspace="default",
+        name="task",
+        config_name="cfg1",
+        labels={},
+        backend_config={},
+    )
+
+    assert update.status == "READY"
+    assert update.endpoints
+    assert "svc.cluster.local" in update.endpoints[0].url
+
+
+@pytest.mark.asyncio
+async def test_read_deployment_status_lost_on_404(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.side_effect = [sample_deployment(), sample_always_config()]
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.side_effect = ApiException(status=404)
+
+    update = await k8s_backend.read_status(workspace="default", name="task")
+
+    assert update.status == "LOST"
+    assert "not found" in update.status_message
+
+
+@pytest.mark.asyncio
+async def test_read_deployment_status_image_pull_backoff(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.side_effect = [sample_deployment(), sample_always_config()]
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = mock_deployment(ready_replicas=0)
+    mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(
+        items=[mock_pod(waiting_reason="ImagePullBackOff", waiting_message="pull access denied")]
+    )
+
+    update = await k8s_backend.read_status(workspace="default", name="task")
+
+    assert update.status == "STARTING"
+    assert "ImagePullBackOff" in update.status_message
+
+
+@pytest.mark.asyncio
+async def test_read_deployment_status_crash_loop_failed(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.side_effect = [sample_deployment(), sample_always_config()]
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = mock_deployment(ready_replicas=0)
+    mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(
+        items=[mock_pod(waiting_reason="CrashLoopBackOff", waiting_message="back-off", restart_count=3)]
+    )
+
+    update = await k8s_backend.read_status(workspace="default", name="task")
+
+    assert update.status == "FAILED"
+    assert "CrashLoopBackOff" in update.status_message
+
+
+@pytest.mark.asyncio
+async def test_delete_deployment_removes_service(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.side_effect = [sample_deployment(), sample_always_config()]
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = mock_deployment()
+
+    update = await k8s_backend.delete_deployment("default", "task")
+
+    assert update.status == "SUCCEEDED"
+    mock_k8s_clients.apps_v1.delete_namespaced_deployment.assert_called_once()
+    mock_k8s_clients.core_v1.delete_namespaced_service.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_deployment_rejects_foreign(
+    deployment_ops_clients: MagicMock, mock_k8s_clients: MagicMock
+) -> None:
+    foreign = mock_deployment()
+    foreign.metadata.labels = {MANAGED_BY_KEY: "other-plugin"}
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = foreign
+
+    update = await deployment_ops.delete_deployment(
+        deployment_ops_clients,
+        default_namespace="default",
+        workspace="default",
+        name="task",
+        backend_config={},
+        expected_labels=always_identity_labels(),
+    )
+
+    assert update.status == "FAILED"
+    mock_k8s_clients.apps_v1.delete_namespaced_deployment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_managed_deployment_names_includes_always(k8s_backend, mock_k8s_clients: MagicMock) -> None:
+    listed = MagicMock()
+    listed.items = [deployment_list_item(workspace="default", name="server")]
+    mock_k8s_clients.apps_v1.list_namespaced_deployment.return_value = listed
+    mock_k8s_clients.batch_v1.list_namespaced_job.return_value = MagicMock(items=[])
+
+    names = await k8s_backend.list_managed_deployment_names()
+
+    assert names == ["default/server"]
+
+
+@pytest.mark.asyncio
+async def test_get_deployment_logs(k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock) -> None:
+    mock_entities.get.side_effect = [sample_deployment(), sample_always_config()]
+    pod = mock_pod()
+    mock_k8s_clients.core_v1.list_namespaced_pod.return_value = MagicMock(items=[pod])
+    mock_k8s_clients.core_v1.read_namespaced_pod_log.return_value = "listening\n"
+
+    result = await k8s_backend.get_logs(workspace="default", name="task", tail=10)
+
+    assert result.lines == ["listening"]
+
+
+@pytest.mark.asyncio
+async def test_delete_deployment_orphan_when_entity_missing(
+    k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.side_effect = NemoEntityNotFoundError("missing")
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.return_value = mock_deployment()
+    mock_k8s_clients.batch_v1.read_namespaced_job.side_effect = ApiException(status=404)
+
+    update = await k8s_backend.delete_deployment("default", "task")
+
+    assert update.status == "SUCCEEDED"
+    mock_k8s_clients.apps_v1.delete_namespaced_deployment.assert_called_once()

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_deployments.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_deployments.py
@@ -83,7 +83,7 @@ async def test_create_deployment_emits_deployment_and_service(
     await k8s_backend.create_deployment(
         workspace="default",
         name="task",
-        config_name="cfg1",
+        config_name="config1",
         labels={},
         backend_config={},
     )
@@ -110,7 +110,7 @@ async def test_create_deployment_ready_reports_endpoints(
     update = await k8s_backend.create_deployment(
         workspace="default",
         name="task",
-        config_name="cfg1",
+        config_name="config1",
         labels={},
         backend_config={},
     )
@@ -134,7 +134,7 @@ async def test_create_deployment_conflict_rejects_foreign(
         default_namespace="default",
         workspace="default",
         name="task",
-        config_name="cfg1",
+        config_name="config1",
         labels={},
         backend_config={},
         config=sample_always_config(),
@@ -161,7 +161,7 @@ async def test_create_deployment_service_conflict_rejects_foreign(
         default_namespace="default",
         workspace="default",
         name="task",
-        config_name="cfg1",
+        config_name="config1",
         labels={},
         backend_config={},
         config=sample_always_config(),
@@ -184,7 +184,7 @@ async def test_create_deployment_rolls_back_when_service_create_fails(
         default_namespace="default",
         workspace="default",
         name="task",
-        config_name="cfg1",
+        config_name="config1",
         labels={},
         backend_config={},
         config=sample_always_config(),

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
@@ -283,6 +283,7 @@ async def test_delete_deployment_still_deletes_job_when_entity_missing(
     k8s_backend, mock_k8s_clients: MagicMock, mock_entities: AsyncMock
 ) -> None:
     mock_entities.get.side_effect = NemoEntityNotFoundError("missing")
+    mock_k8s_clients.apps_v1.read_namespaced_deployment.side_effect = ApiException(status=404)
     mock_k8s_clients.batch_v1.read_namespaced_job.return_value = mock_job(complete=True)
 
     update = await k8s_backend.delete_deployment("default", "task")

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
@@ -53,7 +53,7 @@ async def test_create_job_on_failure_uses_requested_restart_policy(
     await k8s_backend.create_deployment(
         workspace="default",
         name="task",
-        config_name="cfg1",
+        config_name="config1",
         labels={},
         backend_config={},
     )
@@ -76,7 +76,7 @@ async def test_create_job_emits_separate_command_and_args(
     await k8s_backend.create_deployment(
         workspace="default",
         name="task",
-        config_name="cfg1",
+        config_name="config1",
         labels={},
         backend_config={},
     )
@@ -97,7 +97,7 @@ async def test_create_job_emits_batch_job(k8s_backend, mock_k8s_clients: MagicMo
     update = await k8s_backend.create_deployment(
         workspace="default",
         name="task",
-        config_name="cfg1",
+        config_name="config1",
         labels={"managed-by": MANAGED_BY_LABEL},
         backend_config={},
     )
@@ -123,7 +123,7 @@ async def test_create_job_conflict_reads_existing(
     update = await k8s_backend.create_deployment(
         workspace="default",
         name="task",
-        config_name="cfg1",
+        config_name="config1",
         labels={},
         backend_config={},
     )
@@ -144,7 +144,7 @@ async def test_create_job_conflict_rejects_foreign(job_ops_clients: MagicMock, m
         default_namespace="default",
         workspace="default",
         name="task",
-        config_name="cfg1",
+        config_name="config1",
         labels={},
         backend_config={},
         config=sample_config(restart_policy="Never"),
@@ -268,7 +268,7 @@ async def test_create_job_malformed_backend_config_returns_failed(job_ops_client
         default_namespace="default",
         workspace="default",
         name="task",
-        config_name="cfg1",
+        config_name="config1",
         labels={},
         backend_config={"k8s": {"namespace": 42}},
         config=sample_config(restart_policy="Never"),

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py
@@ -289,19 +289,3 @@ async def test_delete_deployment_still_deletes_job_when_entity_missing(
 
     assert update.status == "SUCCEEDED"
     mock_k8s_clients.batch_v1.delete_namespaced_job.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_create_deployment_always_returns_failed(k8s_backend, mock_entities: AsyncMock) -> None:
-    mock_entities.get.return_value = sample_config(restart_policy="Always")
-
-    update = await k8s_backend.create_deployment(
-        workspace="default",
-        name="task",
-        config_name="cfg1",
-        labels={},
-        backend_config={},
-    )
-
-    assert update.status == "FAILED"
-    assert "phase 4" in update.status_message

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_k8s_status_mapping.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_k8s_status_mapping.py
@@ -60,6 +60,7 @@ def test_missing_deployment_status_is_lost() -> None:
     [
         (1, False, None, "READY", "ready"),
         (0, False, mock_pod(waiting_reason="ImagePullBackOff"), "STARTING", "ImagePullBackOff"),
+        (0, False, mock_pod(waiting_reason="CrashLoopBackOff", restart_count=1), "STARTING", "CrashLoopBackOff"),
         (0, False, mock_pod(waiting_reason="CrashLoopBackOff", restart_count=3), "FAILED", "CrashLoopBackOff"),
         (0, True, None, "DELETING", "terminating"),
     ],

--- a/plugins/nemo-deployments/tests/unit/backends/k8s/test_k8s_status_mapping.py
+++ b/plugins/nemo-deployments/tests/unit/backends/k8s/test_k8s_status_mapping.py
@@ -4,8 +4,22 @@
 from __future__ import annotations
 
 import pytest
-from backends.k8s.k8s_helpers import job_identity_labels, mock_job
-from nemo_deployments_plugin.backends.k8s.status import missing_job_status, status_from_job
+from backends.k8s.k8s_helpers import (
+    always_identity_labels,
+    job_identity_labels,
+    mock_deployment,
+    mock_job,
+    mock_pod,
+    sample_always_config,
+)
+from nemo_deployments_plugin.backends.k8s.deployments import build_in_cluster_endpoints
+from nemo_deployments_plugin.backends.k8s.status import (
+    missing_deployment_status,
+    missing_job_status,
+    status_from_deployment,
+    status_from_job,
+)
+from nemo_deployments_plugin.backends.labels import k8s_deployment_resource_name
 
 
 @pytest.mark.parametrize(
@@ -34,3 +48,37 @@ def test_missing_job_status() -> None:
     update = missing_job_status(job_name="dep-default-task-abc12345")
     assert update.status == "FAILED"
     assert "not found" in update.status_message
+
+
+def test_missing_deployment_status_is_lost() -> None:
+    update = missing_deployment_status(deployment_name="dep-default-task-abc12345")
+    assert update.status == "LOST"
+
+
+@pytest.mark.parametrize(
+    ("ready_replicas", "deleting", "pod", "expected_status", "message_substring"),
+    [
+        (1, False, None, "READY", "ready"),
+        (0, False, mock_pod(waiting_reason="ImagePullBackOff"), "STARTING", "ImagePullBackOff"),
+        (0, False, mock_pod(waiting_reason="CrashLoopBackOff", restart_count=3), "FAILED", "CrashLoopBackOff"),
+        (0, True, None, "DELETING", "terminating"),
+    ],
+)
+def test_status_from_deployment(ready_replicas, deleting, pod, expected_status, message_substring) -> None:
+    resource_name = k8s_deployment_resource_name("default", "task")
+    labels = always_identity_labels()
+    deployment = mock_deployment(ready_replicas=ready_replicas, deleting=deleting)
+    endpoints = build_in_cluster_endpoints(
+        resource_name=resource_name,
+        namespace="default",
+        container=sample_always_config().containers[0],
+    )
+    update = status_from_deployment(
+        deployment=deployment,
+        deployment_name=resource_name,
+        expected_labels=labels,
+        endpoints=endpoints,
+        pod=pod,
+    )
+    assert update.status == expected_status
+    assert message_substring in update.status_message


### PR DESCRIPTION
## Summary

- Implements AIRCORE-757 **phase 4**: `restart_policy: Always` workloads are created as `apps/v1.Deployment` + `v1.Service` (ClusterIP) with in-cluster endpoints (`http://{name}.{namespace}.svc.cluster.local:{port}`).
- Extends K8s status mapping for Deployments: `LOST` when missing, `ImagePullBackOff` → `STARTING`, `CrashLoopBackOff` (≥3 restarts) → `FAILED`.
- Wires `K8sDeploymentBackend` to route Always → `deployments.py`, merge Job + Deployment names in `list_managed_deployment_names`, and attempt both deletes during orphan cleanup.
- Hardens create/delete: verify Deployment ownership before Service creation, roll back Deployment on Service failure, surface config validation errors in `read_status`, and propagate deployment delete failures during orphan cleanup.

**Deferred to later phases:** full `K8sDeploymentConfig` / PodSpec compilation (init containers, multi-container, ConfigMaps — phase 5); custom-namespace listing for managed deployments; RBAC/chart (phase 6); integration tests (phase 7).

## Test plan

- [x] `uv run pytest plugins/nemo-deployments/tests/unit -q` (233 passed)
- [x] Pre-commit hooks on both commits
- [x] Pre-MR review + Bugbot pass on branch changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes “Deployment-backed” support for restart policy **Always**, including service exposure, log retrieval, and full lifecycle handling (create/read/delete).
  * Improved resource discovery by listing managed deployments alongside jobs and consolidating managed name reporting.
* **Bug Fixes**
  * More resilient deletion with best-effort cleanup when Kubernetes resources are missing or partially present.
  * Enhanced status reporting for missing, terminating, and crash-loop scenarios with clearer status messages.
* **Tests**
  * Expanded unit tests for deployment lifecycle, status mapping, and edge-case behaviors (including log and endpoint handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->