### PR TITLE
fix(studio): Code Agent stream interruptions when navigating Studio

### DIFF
--- a/services/studio/src/nmp/studio/coding_agents.py
+++ b/services/studio/src/nmp/studio/coding_agents.py
@@ -1041,9 +1041,7 @@ async def _stream_claude(
     try:
         while True:
             try:
-                event_type, payload = await asyncio.wait_for(
-                    queue.get(), timeout=MCP_KEEPALIVE_INTERVAL_SECONDS
-                )
+                event_type, payload = await asyncio.wait_for(queue.get(), timeout=MCP_KEEPALIVE_INTERVAL_SECONDS)
             except asyncio.TimeoutError:
                 yield ":\n\n"
                 continue

--- a/services/studio/src/nmp/studio/coding_agents.py
+++ b/services/studio/src/nmp/studio/coding_agents.py
@@ -1040,7 +1040,13 @@ async def _stream_claude(
 
     try:
         while True:
-            event_type, payload = await queue.get()
+            try:
+                event_type, payload = await asyncio.wait_for(
+                    queue.get(), timeout=MCP_KEEPALIVE_INTERVAL_SECONDS
+                )
+            except asyncio.TimeoutError:
+                yield ":\n\n"
+                continue
             if event_type == "end":
                 break
             if event_type == "claude":

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.test.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.test.ts
@@ -67,15 +67,25 @@ const renderUseClaudeCodeChatRuntime = (options?: Parameters<typeof useClaudeCod
 
 interface PermissionRequestTestHandlers {
   onPermissionRequest: (request: unknown) => void;
+  onDone: () => void;
 }
 
 interface InputRequestTestHandlers {
   onInputRequest: (request: unknown) => void;
+  onDone: () => void;
 }
 
 describe('useClaudeCodeChatRuntime', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: a stream that completes immediately and successfully.
+    // Tests that need custom behaviour (permission requests, finishStream, etc.)
+    // override this in their own setup.
+    mocks.streamClaudeCodeMessage.mockImplementation(
+      async ({ handlers }: { handlers: { onDone: () => void } }) => {
+        handlers.onDone();
+      }
+    );
   });
 
   afterEach(() => {
@@ -85,7 +95,11 @@ describe('useClaudeCodeChatRuntime', () => {
   it('exposes the latest streamed coding-agent model without promoting it to selected model', async () => {
     mocks.createClaudeCodeSession.mockResolvedValue('session-1');
     mocks.streamClaudeCodeMessage.mockImplementation(
-      async ({ handlers }: { handlers: { onClaudeEvent: (event: unknown) => void } }) => {
+      async ({
+        handlers,
+      }: {
+        handlers: { onClaudeEvent: (event: unknown) => void; onDone: () => void };
+      }) => {
         handlers.onClaudeEvent({
           type: 'assistant',
           message: { model: 'claude-sonnet-4-5', content: [] },
@@ -94,6 +108,7 @@ describe('useClaudeCodeChatRuntime', () => {
           type: 'assistant',
           message: { model: 'claude-sonnet-4-6', content: [] },
         });
+        handlers.onDone();
       }
     );
 
@@ -112,7 +127,6 @@ describe('useClaudeCodeChatRuntime', () => {
 
   it('passes Studio route context to streamed messages', async () => {
     mocks.createClaudeCodeSession.mockResolvedValue('session-1');
-    mocks.streamClaudeCodeMessage.mockResolvedValue(undefined);
 
     const { result } = renderUseClaudeCodeChatRuntime({
       studioPathname: '/workspaces/default/jobs?status=running',
@@ -169,7 +183,6 @@ describe('useClaudeCodeChatRuntime', () => {
     let submitPromise!: Promise<void>;
     mockFeatureFlags({ guardrailsEnabled: true });
     mocks.createClaudeCodeSession.mockResolvedValue('session-1');
-    mocks.streamClaudeCodeMessage.mockResolvedValue(undefined);
 
     const { result } = renderUseClaudeCodeChatRuntime({ workspace: 'default' });
 
@@ -231,7 +244,11 @@ describe('useClaudeCodeChatRuntime', () => {
     let submitPromise!: Promise<void>;
     mocks.createClaudeCodeSession.mockResolvedValue('session-1');
     mocks.streamClaudeCodeMessage.mockImplementation(
-      async ({ handlers }: { handlers: { onPermissionRequest: (request: unknown) => void } }) => {
+      async ({
+        handlers,
+      }: {
+        handlers: { onPermissionRequest: (request: unknown) => void; onDone: () => void };
+      }) => {
         handlers.onPermissionRequest({
           requestId: 'request-1',
           toolName: 'Bash',
@@ -240,6 +257,7 @@ describe('useClaudeCodeChatRuntime', () => {
         await new Promise<void>((resolve) => {
           finishStream = resolve;
         });
+        handlers.onDone();
       }
     );
     mocks.resolveClaudeCodePermission.mockRejectedValue(new Error('permission failed'));
@@ -283,7 +301,11 @@ describe('useClaudeCodeChatRuntime', () => {
     let submitPromise!: Promise<void>;
     mocks.createClaudeCodeSession.mockResolvedValue('session-1');
     mocks.streamClaudeCodeMessage.mockImplementation(
-      async ({ handlers }: { handlers: { onPermissionRequest: (request: unknown) => void } }) => {
+      async ({
+        handlers,
+      }: {
+        handlers: { onPermissionRequest: (request: unknown) => void; onDone: () => void };
+      }) => {
         handlers.onPermissionRequest({
           requestId: 'request-1',
           toolName: 'Bash',
@@ -292,6 +314,7 @@ describe('useClaudeCodeChatRuntime', () => {
         await new Promise<void>((resolve) => {
           finishStream = resolve;
         });
+        handlers.onDone();
       }
     );
     mocks.resolveClaudeCodePermission.mockResolvedValue(undefined);
@@ -338,6 +361,7 @@ describe('useClaudeCodeChatRuntime', () => {
         await new Promise<void>((resolve) => {
           finishStream = resolve;
         });
+        handlers.onDone();
       }
     );
     mocks.resolveClaudeCodePermission.mockImplementation(
@@ -390,7 +414,11 @@ describe('useClaudeCodeChatRuntime', () => {
     let submitPromise!: Promise<void>;
     mocks.createClaudeCodeSession.mockResolvedValue('session-1');
     mocks.streamClaudeCodeMessage.mockImplementation(
-      async ({ handlers }: { handlers: { onInputRequest: (request: unknown) => void } }) => {
+      async ({
+        handlers,
+      }: {
+        handlers: { onInputRequest: (request: unknown) => void; onDone: () => void };
+      }) => {
         handlers.onInputRequest({
           requestId: 'request-1',
           kind: 'agent',
@@ -399,6 +427,7 @@ describe('useClaudeCodeChatRuntime', () => {
         await new Promise<void>((resolve) => {
           finishStream = resolve;
         });
+        handlers.onDone();
       }
     );
     mocks.resolveClaudeCodeInput.mockResolvedValue(undefined);
@@ -456,6 +485,7 @@ describe('useClaudeCodeChatRuntime', () => {
         await new Promise<void>((resolve) => {
           finishStream = resolve;
         });
+        handlers.onDone();
       }
     );
     mocks.resolveClaudeCodeInput.mockImplementation(
@@ -517,7 +547,11 @@ describe('useClaudeCodeChatRuntime', () => {
     let submitPromise!: Promise<void>;
     mocks.createClaudeCodeSession.mockResolvedValue('session-1');
     mocks.streamClaudeCodeMessage.mockImplementation(
-      async ({ handlers }: { handlers: { onPermissionRequest: (request: unknown) => void } }) => {
+      async ({
+        handlers,
+      }: {
+        handlers: { onPermissionRequest: (request: unknown) => void; onDone: () => void };
+      }) => {
         handlers.onPermissionRequest({
           requestId: 'request-1',
           toolName: 'AskUserQuestion',
@@ -545,6 +579,7 @@ describe('useClaudeCodeChatRuntime', () => {
         await new Promise<void>((resolve) => {
           finishStream = resolve;
         });
+        handlers.onDone();
       }
     );
     mocks.resolveClaudeCodePermission.mockResolvedValue(undefined);
@@ -616,7 +651,11 @@ describe('useClaudeCodeChatRuntime', () => {
     let submitPromise!: Promise<void>;
     mocks.createClaudeCodeSession.mockResolvedValue('session-1');
     mocks.streamClaudeCodeMessage.mockImplementation(
-      async ({ handlers }: { handlers: { onPermissionRequest: (request: unknown) => void } }) => {
+      async ({
+        handlers,
+      }: {
+        handlers: { onPermissionRequest: (request: unknown) => void; onDone: () => void };
+      }) => {
         handlers.onPermissionRequest({
           requestId: 'request-1',
           toolName: 'AskUserQuestion',
@@ -637,6 +676,7 @@ describe('useClaudeCodeChatRuntime', () => {
         await new Promise<void>((resolve) => {
           finishStream = resolve;
         });
+        handlers.onDone();
       }
     );
     mocks.resolveClaudeCodePermission.mockResolvedValue(undefined);

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useClaudeCodeChatRuntime.ts
@@ -41,7 +41,7 @@ import {
   type CustomAssistantRunResult,
 } from '@studio/routes/agents/ClaudeCodeChatRoute/useCustomAssistantChatRuntime';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 
 const ASK_USER_QUESTION_TOOL_NAME = 'AskUserQuestion';
 const CUSTOM_INSTRUCTION_LABEL = 'No, and tell the Agent what to do';
@@ -392,6 +392,8 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
   const onError = options?.onError;
   const onSessionIdChange = options?.onSessionIdChange;
   const studioPathname = options?.studioPathname;
+  const studioPathnameRef = useRef(studioPathname);
+  studioPathnameRef.current = studioPathname;
 
   // Derive from JSON so callers that create inline objects don't trigger
   // the effect on every render — identity is stable as long as content is unchanged.
@@ -544,7 +546,7 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
         await streamClaudeCodeMessage({
           sessionId: activeSessionId,
           message: prompt,
-          studioPathname,
+          studioPathname: studioPathnameRef.current,
           workspace,
           signal,
           handlers: {
@@ -580,6 +582,11 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
           },
         });
         void queryClient.invalidateQueries({ queryKey: CLAUDE_CODE_HISTORY_SESSIONS_QUERY_KEY });
+        if (!doneReceived && !signal.aborted) {
+          throw new Error(
+            'Connection to Claude was interrupted. Your response may still be processing — check History to see the result.'
+          );
+        }
       } finally {
         if (isCurrentRun()) dispatchBlocking({ type: 'reset' });
       }
@@ -593,7 +600,6 @@ export const useClaudeCodeChatRuntime = (options?: UseClaudeCodeChatRuntimeOptio
       handlePermissionRequest,
       queryClient,
       setArtifacts,
-      studioPathname,
       workspace,
     ]
   );

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useCustomAssistantChatRuntime.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/useCustomAssistantChatRuntime.ts
@@ -65,6 +65,8 @@ interface CompleteAssistantMessageOptions {
 const isAbortError = (error: unknown): boolean =>
   error instanceof DOMException && error.name === 'AbortError';
 
+const convertMessage = (message: ThreadMessageLike): ThreadMessageLike => message;
+
 const mergeAssistantParts = (
   currentParts: readonly ThreadAssistantMessagePart[],
   nextParts: readonly ThreadAssistantMessagePart[]
@@ -449,7 +451,7 @@ export const useCustomAssistantChatRuntime = ({
     isRunning,
     onNew: handleNewMessage,
     onCancel: handleCancel,
-    convertMessage: (message) => message,
+    convertMessage,
     unstable_capabilities: {
       copy: true,
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude Code chat stability by detecting premature/unexpected stream completion and showing a clearer “connection interrupted” message.
  * Added periodic server SSE keepalives when events are idle to prevent the stream from appearing stalled.
  * Reduced unnecessary rerenders during chat run handling by removing render-time path capture.
* **Tests**
  * Updated Claude Code chat streaming tests to consistently signal completion with explicit stream-done handling.
* **Refactor**
  * Simplified a chat runtime message conversion helper while keeping behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->