### PR TITLE
docs: refresh post-0.2 capability guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ NeMo Platform brings together NVIDIA NeMo libraries under one CLI, Python SDK, a
 
 - **Harden agents**: guardrails (content safety, jailbreak detection, PII redaction), auditor (red-teaming via garak), anonymizer (PII handling for training data).
 - **Evaluate agents**: evaluator (LLM-as-judge, deterministic, agentic, RAG benchmarks), Harbor-backed eval suites.
-- **Tune agents**: skill optimization, prompt/hyperparameter tuning, Switchyard model routing. Fine-tuning coming soon.
+- **Tune agents and models**: skill optimization, prompt/hyperparameter tuning, Switchyard model routing, and fine-tuning through Customizer.
 - **Build agents**: NeMo Agent Toolkit (NAT) for LangGraph-based agents. Broader framework support on the roadmap.
 
 NeMo Platform optimizes LangGraph agents wrapped in NAT today. Other frameworks require a user-written NAT wrapper. Be honest about this when users ask.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ NeMo Platform brings together NVIDIA NeMo libraries under one CLI, Python SDK, a
 
 - **Harden agents**: guardrails (content safety, jailbreak detection, PII redaction), auditor (red-teaming via garak), anonymizer (PII handling for training data).
 - **Evaluate agents**: evaluator (LLM-as-judge, deterministic, agentic, RAG benchmarks), Harbor-backed eval suites.
-- **Tune agents**: skill optimization, prompt/hyperparameter tuning, Switchyard model routing. Fine-tuning coming soon.
+- **Tune agents and models**: skill optimization, prompt/hyperparameter tuning, Switchyard model routing, and fine-tuning through Customizer.
 - **Build agents**: NeMo Agent Toolkit (NAT) for LangGraph-based agents. Broader framework support on the roadmap.
 - **Shared infrastructure**: Inference Gateway, Secrets, Files, Entity Store, Jobs.
 

--- a/README.md
+++ b/README.md
@@ -114,11 +114,9 @@ Things you can ask it to do, once the platform is running:
 - **Generate synthetic data.** Generate synthetic data for training or evaluation purposes using Data Designer.
 - **NeMo Studio (alpha).** Installed automatically with the platform. Browser UI for chat, monitoring, and reviewing optimization suggestions. Studio's agent-focused features are still a work in progress; the CLI is the primary surface today.
 
-## What's coming soon
+## Release notes
 
-- Fine-tuning
-- Safe Synthesizer (synthetic data with privacy guarantees)
-- Broader agent framework support. Today NeMo Platform optimizes LangGraph agents wrapped in NAT. If your agent is in another framework, you need to write the NAT wrapper.
+See the [current release notes](https://docs.nvidia.com/nemo-platform/documentation/reference/release-notes/current-release) for the latest features, improvements, and known limitations.
 
 ## Skills
 


### PR DESCRIPTION
The README roadmap still listed fine-tuning and Safe Synthesizer as upcoming even though both are available in the 0.2 release. This replaces that stale roadmap with a stable link to the [current release notes](https://docs.nvidia.com/nemo-platform/documentation/reference/release-notes/current-release) and updates `AGENTS.md` and `CLAUDE.md` so contributors and coding agents see the same capability status. The change is documentation-only and was verified by rendering the README, checking the public link, and scanning for the stale wording.

## Human attention needed

- Decision: approve the current release notes as the README source of truth instead of maintaining roadmap bullets there
- Read carefully: the replacement wording in `README.md` and the shared capability line in `AGENTS.md` / `CLAUDE.md`
- Safe to skim: the repeated one-line agent-instruction synchronization
- Proof: file-scoped pre-commit passed; the release-notes URL returned HTTP 200; the rendered README was inspected; `git diff --check` passed
- Biggest risk: low and documentation-only; the duplicated Customizer wording can drift if product terminology changes again


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project capability descriptions to reflect expanded tuning and fine-tuning support.
  * Replaced the “coming soon” content with a direct release notes section linking to the latest release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->