### PR TITLE
test(auth): add group-based OBO delegation tests for SDK and secrets

### DIFF
--- a/packages/nmp_common/tests/auth/test_client.py
+++ b/packages/nmp_common/tests/auth/test_client.py
@@ -384,6 +384,27 @@ class TestGetSdkOnBehalfOf:
         assert "X-NMP-Principal-On-Behalf-Of" in delegated_sdk.default_headers
         assert delegated_sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "user@example.com"
 
+    def test_get_sdk_on_behalf_of_with_principal_includes_email_and_groups(self):
+        """Test that Principal delegation includes delegated email and groups headers."""
+        base_sdk = NeMoPlatform(
+            base_url="http://testserver",
+            default_headers={"X-NMP-Principal-Id": "service:my-service"},
+        )
+
+        delegated_sdk = get_sdk_on_behalf_of(
+            base_sdk,
+            Principal(
+                id="user@example.com",
+                email="user@example.com",
+                groups=["workspace-editors", "ml-team"],
+            ),
+        )
+
+        assert delegated_sdk.default_headers["X-NMP-Principal-Id"] == "service:my-service"
+        assert delegated_sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "user@example.com"
+        assert delegated_sdk.default_headers["X-NMP-Principal-On-Behalf-Of-Email"] == "user@example.com"
+        assert delegated_sdk.default_headers["X-NMP-Principal-On-Behalf-Of-Groups"] == "workspace-editors,ml-team"
+
     def test_preserves_original_sdk(self):
         """Test that get_sdk_on_behalf_of doesn't modify the original SDK."""
         base_sdk = NeMoPlatform(

--- a/services/core/secrets/tests/integration/test_secrets_with_auth.py
+++ b/services/core/secrets/tests/integration/test_secrets_with_auth.py
@@ -17,6 +17,7 @@ from typing import Generator
 
 import pytest
 from nemo_platform import NeMoPlatform, PermissionDeniedError, UnprocessableEntityError
+from nmp.common.auth.models import Principal
 from nmp.common.sdk_factory import get_sdk_on_behalf_of
 from nmp.core.secrets.config import SecretsServiceConfig
 from nmp.core.secrets.service import SecretsService
@@ -739,6 +740,42 @@ class TestDelegatedSecretAccess:
         assert result.name == secret_name
         assert result.value == secret_value
 
+    def test_service_principal_can_access_on_behalf_of_group_bound_viewer(self, sdk: NeMoPlatform):
+        """Test delegated access succeeds when the delegated user's group has Viewer."""
+        workspace_name = short_unique_name("del-grp")
+        secret_name = short_unique_name("secret")
+        secret_value = "delegated-group-secret"
+        delegated_email = unique_email("viewer")
+        delegated_group = f"group-{short_unique_name('vw')}"
+
+        platform_admin_sdk = as_user(sdk, TEST_ADMIN_EMAIL)
+        platform_admin_sdk.workspaces.create(name=workspace_name)
+        grant_workspace_role(
+            platform_admin_sdk,
+            workspace=workspace_name,
+            principal=delegated_group,
+            roles=["Viewer"],
+        )
+        platform_admin_sdk.secrets.create(
+            workspace=workspace_name,
+            name=secret_name,
+            value=secret_value,
+        )
+
+        delegated_sdk = get_sdk_on_behalf_of(
+            as_user(sdk, SERVICE_PRINCIPAL),
+            Principal(
+                id=delegated_email,
+                email=delegated_email,
+                groups=[delegated_group],
+            ),
+        )
+
+        result = delegated_sdk.secrets.access(workspace=workspace_name, name=secret_name)
+
+        assert result.name == secret_name
+        assert result.value == secret_value
+
     def test_platform_admin_cannot_access_on_behalf_of_non_member(self, sdk: NeMoPlatform):
         """Test platform admin accessing secret on behalf of a non-member user."""
         workspace_name = short_unique_name("del-nm")
@@ -758,6 +795,40 @@ class TestDelegatedSecretAccess:
         # Platform admin accesses secret on behalf of non-member
         # Non-member doesn't have any role in workspace, so this should fail
         delegated_sdk = get_sdk_on_behalf_of(as_user(sdk, TEST_ADMIN_EMAIL), non_member_email)
+        with pytest.raises(PermissionDeniedError):
+            delegated_sdk.secrets.access(workspace=workspace_name, name=secret_name)
+
+    def test_service_principal_denies_on_behalf_of_user_missing_group_bound_role(self, sdk: NeMoPlatform):
+        """Test delegated access fails when the delegated user lacks the bound group."""
+        workspace_name = short_unique_name("del-grp-no")
+        secret_name = short_unique_name("secret")
+        delegated_email = unique_email("viewer")
+        bound_group = f"group-{short_unique_name('bound')}"
+        other_group = f"group-{short_unique_name('other')}"
+
+        platform_admin_sdk = as_user(sdk, TEST_ADMIN_EMAIL)
+        platform_admin_sdk.workspaces.create(name=workspace_name)
+        grant_workspace_role(
+            platform_admin_sdk,
+            workspace=workspace_name,
+            principal=bound_group,
+            roles=["Viewer"],
+        )
+        platform_admin_sdk.secrets.create(
+            workspace=workspace_name,
+            name=secret_name,
+            value="delegated-group-secret",
+        )
+
+        delegated_sdk = get_sdk_on_behalf_of(
+            as_user(sdk, SERVICE_PRINCIPAL),
+            Principal(
+                id=delegated_email,
+                email=delegated_email,
+                groups=[other_group],
+            ),
+        )
+
         with pytest.raises(PermissionDeniedError):
             delegated_sdk.secrets.access(workspace=workspace_name, name=secret_name)
 


### PR DESCRIPTION
Add unit test verifying that get_sdk_on_behalf_of propagates delegated user email and group membership as X-NMP-Principal-On-Behalf-Of-* headers when a Principal with groups is provided.

Add integration tests for delegated secret access via group-bound roles:
* allow access when the delegated user's group holds a Viewer role
* deny access when the delegated user lacks the bound group membership

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for delegated access flows.
  * Verified that delegated requests can carry user identity details like email and group memberships.
  * Added integration checks showing secret access succeeds when group permissions allow it and fails when required group access is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->