### PR TITLE
feat(studio): DD row editor in details

### DIFF
--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -21,8 +21,10 @@ function serializeParquetRow(row: unknown): string {
   return JSON.stringify(row, jsonReplacer);
 }
 // Cap text-file preview at 512 KB. Enough to show meaningful JSONL content
-// while preventing OOM crashes on multi-GB external dataset shards.
-const FILE_PREVIEW_MAX_BYTES = 512 * 1024;
+// while preventing OOM crashes on multi-GB external dataset shards. Text files larger
+// than this are fetched with a Range request, so callers that write content back must not
+// overwrite the source (the loaded rows are only a prefix of the file).
+export const FILE_PREVIEW_MAX_BYTES = 512 * 1024;
 
 interface UseDatasetFileContentParams extends Required<EntityIdentifier> {
   path: string;

--- a/web/packages/studio/src/components/FileRowEditor/FileHeader.tsx
+++ b/web/packages/studio/src/components/FileRowEditor/FileHeader.tsx
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Button, Flex, Stack, Tag, Text } from '@nvidia/foundations-react-core';
+import { Button, Flex, Spinner, Stack, Tag, Text } from '@nvidia/foundations-react-core';
 import { FILE_FORMAT_TAG_COLOR } from '@studio/components/FileRowEditor/constants';
 import type { DataFileFormat } from '@studio/components/FileRowEditor/parse';
-import { Download, FileSpreadsheet, FolderOpen, Plus } from 'lucide-react';
+import { Download, FileSpreadsheet, FolderOpen, Plus, Save } from 'lucide-react';
 import { type ChangeEvent, type FC, type RefObject } from 'react';
 
 export interface FileHeaderProps {
@@ -24,6 +24,19 @@ export interface FileHeaderProps {
   onAddRow: () => void;
   /** Disables the Download action (e.g. when there are no rows to export). */
   downloadDisabled: boolean;
+  /**
+   * Persists the current rows to the backing store. When provided, a "Save File" action
+   * is shown; when omitted, the editor stays in-memory only (e.g. the standalone demo).
+   */
+  onSaveFile?: () => void;
+  /** Whether a save is in flight — shows a spinner and disables the Save action. */
+  isSaving?: boolean;
+  /** Disables the Save action (e.g. when there are no unsaved changes). */
+  saveDisabled?: boolean;
+  /** When set, disables the Save action and shows this text as its tooltip. */
+  saveDisabledReason?: string;
+  /** Whether there are staged edits not yet persisted — shows an "Unsaved changes" chip. */
+  hasUnsavedChanges?: boolean;
 }
 
 /** Header summary + toolbar for the {@link FileRowEditor}: file identity, stats, actions. */
@@ -41,6 +54,11 @@ export const FileHeader: FC<FileHeaderProps> = ({
   onDownload,
   onAddRow,
   downloadDisabled,
+  onSaveFile,
+  isSaving = false,
+  saveDisabled = false,
+  saveDisabledReason,
+  hasUnsavedChanges = false,
 }) => (
   <Flex align="center" gap="density-md" className="w-full shrink-0">
     <Flex align="center" justify="center" className="size-10 shrink-0 rounded-md bg-surface-sunken">
@@ -95,10 +113,36 @@ export const FileHeader: FC<FileHeaderProps> = ({
         <Download size={16} />
         Download
       </Button>
-      <Button kind="primary" color="brand" onClick={onAddRow}>
+      <Button
+        kind={onSaveFile ? 'secondary' : 'primary'}
+        color={onSaveFile ? 'neutral' : 'brand'}
+        onClick={onAddRow}
+      >
         <Plus size={16} />
         Add Row
       </Button>
+      {onSaveFile && (
+        <span className="relative inline-flex">
+          <Button
+            kind="primary"
+            color="brand"
+            onClick={onSaveFile}
+            disabled={saveDisabled || isSaving || Boolean(saveDisabledReason)}
+            title={saveDisabledReason}
+          >
+            {isSaving ? <Spinner size="small" aria-label="Saving" /> : <Save size={16} />}
+            Save File
+          </Button>
+          {hasUnsavedChanges && (
+            <span
+              title="Unsaved changes"
+              className="pointer-events-none absolute -left-0.5 -top-0.5 size-2.5 rounded-full bg-feedback-danger ring-1 ring-surface-sunken dark:ring-surface-raised"
+            >
+              <span className="sr-only">Unsaved changes</span>
+            </span>
+          )}
+        </span>
+      )}
     </Flex>
   </Flex>
 );

--- a/web/packages/studio/src/components/FileRowEditor/RowEditorPanel.tsx
+++ b/web/packages/studio/src/components/FileRowEditor/RowEditorPanel.tsx
@@ -329,7 +329,7 @@ export const RowEditorPanel: FC<RowEditorPanelProps> = ({
                 Cancel
               </Button>
               <Button type="submit" kind="primary" color="brand">
-                Save Changes
+                Stage Changes
               </Button>
             </Flex>
           </Flex>

--- a/web/packages/studio/src/components/FileRowEditor/index.test.tsx
+++ b/web/packages/studio/src/components/FileRowEditor/index.test.tsx
@@ -37,7 +37,7 @@ describe('FileRowEditor', () => {
 
     expect(screen.getByText('Unsaved edits')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Apply Change' }));
+    await user.click(screen.getByRole('button', { name: 'Stage Changes' }));
 
     expect(screen.queryByText('Unsaved edits')).not.toBeInTheDocument();
   });
@@ -60,7 +60,7 @@ describe('FileRowEditor', () => {
     // Edit a row and commit it to the table.
     await user.click(screen.getByText('cuDNN'));
     await user.type(screen.getByLabelText('topic'), ' updated');
-    await user.click(screen.getByRole('button', { name: 'Apply Change' }));
+    await user.click(screen.getByRole('button', { name: 'Stage Changes' }));
 
     // Now dirty → enabled, with an "Unsaved changes" chip in the toolbar.
     expect(saveFileButton).toBeEnabled();
@@ -84,7 +84,7 @@ describe('FileRowEditor', () => {
 
     await user.click(screen.getByText('cuDNN'));
     await user.type(screen.getByLabelText('topic'), ' updated');
-    await user.click(screen.getByRole('button', { name: 'Apply Change' }));
+    await user.click(screen.getByRole('button', { name: 'Stage Changes' }));
 
     const saveFileButton = screen.getByRole('button', { name: 'Save File' });
     await user.click(saveFileButton);

--- a/web/packages/studio/src/components/FileRowEditor/index.test.tsx
+++ b/web/packages/studio/src/components/FileRowEditor/index.test.tsx
@@ -37,9 +37,73 @@ describe('FileRowEditor', () => {
 
     expect(screen.getByText('Unsaved edits')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+    await user.click(screen.getByRole('button', { name: 'Apply Change' }));
 
     expect(screen.queryByText('Unsaved edits')).not.toBeInTheDocument();
+  });
+
+  it('omits the Save File action when no onSaveFile handler is provided', () => {
+    render(<FileRowEditor initialRows={SAMPLE_ROWS} />);
+
+    expect(screen.queryByRole('button', { name: 'Save File' })).not.toBeInTheDocument();
+  });
+
+  it('enables Save File only after edits, persists rows, then disables it again', async () => {
+    const user = userEvent.setup();
+    const onSaveFile = vi.fn().mockResolvedValue(undefined);
+    render(<FileRowEditor initialRows={SAMPLE_ROWS} onSaveFile={onSaveFile} />);
+
+    // Clean on load → disabled.
+    const saveFileButton = screen.getByRole('button', { name: 'Save File' });
+    expect(saveFileButton).toBeDisabled();
+
+    // Edit a row and commit it to the table.
+    await user.click(screen.getByText('cuDNN'));
+    await user.type(screen.getByLabelText('topic'), ' updated');
+    await user.click(screen.getByRole('button', { name: 'Apply Change' }));
+
+    // Now dirty → enabled, with an "Unsaved changes" chip in the toolbar.
+    expect(saveFileButton).toBeEnabled();
+    expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+
+    await user.click(saveFileButton);
+
+    expect(onSaveFile).toHaveBeenCalledTimes(1);
+    const savedRows = onSaveFile.mock.calls[0][0] as DataFileRow[];
+    expect(savedRows.some((row) => row.topic === 'cuDNN updated')).toBe(true);
+
+    // Baseline resets after a successful save → disabled again, chip gone.
+    await waitFor(() => expect(saveFileButton).toBeDisabled());
+    expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument();
+  });
+
+  it('keeps the dirty state when a save fails so the user can retry', async () => {
+    const user = userEvent.setup();
+    const onSaveFile = vi.fn().mockRejectedValue(new Error('upload failed'));
+    render(<FileRowEditor initialRows={SAMPLE_ROWS} onSaveFile={onSaveFile} />);
+
+    await user.click(screen.getByText('cuDNN'));
+    await user.type(screen.getByLabelText('topic'), ' updated');
+    await user.click(screen.getByRole('button', { name: 'Apply Change' }));
+
+    const saveFileButton = screen.getByRole('button', { name: 'Save File' });
+    await user.click(saveFileButton);
+
+    expect(onSaveFile).toHaveBeenCalledTimes(1);
+    // Still dirty → still enabled for a retry.
+    await waitFor(() => expect(saveFileButton).toBeEnabled());
+  });
+
+  it('disables Save File with a reason when the host blocks saving', () => {
+    render(
+      <FileRowEditor
+        initialRows={SAMPLE_ROWS}
+        onSaveFile={vi.fn()}
+        saveDisabledReason="File too large"
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Save File' })).toBeDisabled();
   });
 
   it('filters rows by the search query', async () => {

--- a/web/packages/studio/src/components/FileRowEditor/index.tsx
+++ b/web/packages/studio/src/components/FileRowEditor/index.tsx
@@ -52,6 +52,20 @@ export interface FileRowEditorProps {
    * swap in an unrelated local file. @defaultValue true
    */
   showOpenFile?: boolean;
+  /**
+   * Persists the current rows to the backing store. When provided, the header shows a
+   * "Save File" action (enabled only when there are unsaved changes) and edits become
+   * durable. When omitted, the editor stays in-memory only. The returned promise must
+   * reject on failure so the editor keeps its dirty state for a retry.
+   */
+  onSaveFile?: (rows: DataFileRow[]) => Promise<void> | void;
+  /** Whether a save is in flight — surfaced on the "Save File" action. */
+  isSaving?: boolean;
+  /**
+   * When set, the "Save File" action is disabled and shows this text as its tooltip — used
+   * by the host to block unsafe saves (e.g. a file too large to load in full).
+   */
+  saveDisabledReason?: string;
   className?: string;
 }
 
@@ -71,10 +85,18 @@ export const FileRowEditor: FC<FileRowEditorProps> = ({
   columns: columnsProp,
   initialRows = [],
   showOpenFile = true,
+  onSaveFile,
+  isSaving = false,
+  saveDisabledReason,
   className,
 }) => {
   const toast = useToast();
   const [rows, setRows] = useState<DataFileRow[]>(() => assignRowIds(initialRows));
+  // Snapshot of the rows as last persisted (or as first loaded), used to detect unsaved
+  // changes so the "Save File" action is enabled only when there is something to save.
+  const [savedSnapshot, setSavedSnapshot] = useState<string>(() =>
+    JSON.stringify(assignRowIds(initialRows))
+  );
   const [columns, setColumns] = useState<DataFileColumn[]>(
     () => columnsProp ?? inferColumns(initialRows)
   );
@@ -87,6 +109,9 @@ export const FileRowEditor: FC<FileRowEditorProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const fileFormat: DataFileFormat = useMemo(() => formatFromFileName(fileName), [fileName]);
+
+  const currentSnapshot = useMemo(() => JSON.stringify(rows), [rows]);
+  const isFileDirty = currentSnapshot !== savedSnapshot;
 
   const dataViewState = useStudioDataViewState({
     defaultPageSize: 10,
@@ -170,7 +195,20 @@ export const FileRowEditor: FC<FileRowEditorProps> = ({
     }
     setRows((prev) => prev.map((row) => (rowId(row) === rowId(draft) ? cloneRow(draft) : row)));
     setEditingId(null);
-    toast.success('Row saved successfully');
+    toast.success(onSaveFile ? 'Change applied — click Save File to persist' : 'Row saved');
+  };
+
+  const handleSaveFile = async () => {
+    if (!onSaveFile || !isFileDirty || isSaving) {
+      return;
+    }
+    const persisted = currentSnapshot;
+    try {
+      await onSaveFile(rows);
+      setSavedSnapshot(persisted);
+    } catch {
+      // The host surfaces the failure; keep the dirty state so the user can retry.
+    }
   };
 
   const handleAddRow = () => {
@@ -229,6 +267,7 @@ export const FileRowEditor: FC<FileRowEditorProps> = ({
       const text = await file.text();
       const parsed = assignRowIds(parseDataFile(text, format));
       setRows(parsed);
+      setSavedSnapshot(JSON.stringify(parsed));
       setColumns(inferColumns(parsed));
       setFileName(file.name);
       setFileSizeLabel(formatBytes(file.size));
@@ -255,6 +294,11 @@ export const FileRowEditor: FC<FileRowEditorProps> = ({
         onDownload={handleDownload}
         onAddRow={handleAddRow}
         downloadDisabled={rows.length === 0}
+        onSaveFile={onSaveFile ? handleSaveFile : undefined}
+        isSaving={isSaving}
+        saveDisabled={!isFileDirty}
+        saveDisabledReason={saveDisabledReason}
+        hasUnsavedChanges={Boolean(onSaveFile) && isFileDirty}
       />
 
       {/* Table */}

--- a/web/packages/studio/src/mocks/data-designer/example_request.txt
+++ b/web/packages/studio/src/mocks/data-designer/example_request.txt
@@ -1,35 +1,16 @@
-I want a made-up spreadsheet of fake company customers so I can practice looking at patterns—not real data. Please aim for about 500 rows (or fewer if that’s easier for a quick test).
+Generate about 100 rows of fake B2B customer data (not real companies).
 
-What each row is
-Each row is one company during one three-month period (like “January–March 2024”).
+Each row is one company for one quarter (e.g. 2024-Q1).
 
-Simple columns to include
+Columns:
+- company_id — random fake code (letters and numbers)
+- description — general company goals
+- quarter — e.g. "2024-Q1"
+- region — North America, Europe, Asia, or Latin America
+- company_size — small, medium, or large
+- user_count — integer; large companies usually have more users
+- annual_payment — dollars, positive integer; scales with company_size
+- churn_risk — low, medium, or high
+- satisfaction — 0–10; lower when churn_risk is high
 
-Company ID – a fake code for the company (random letters/numbers, not real names).
-Time period – which three-month chunk it is (e.g. “2024, first quarter”).
-Part of the world – pick from a short list like North America, Europe, Asia, Latin America.
-Company size – small, medium, or large (large companies should usually look “bigger” in the numbers below).
-How many people use the product – a whole number; bigger companies tend to have more users, but not always.
-How often they log in – a number that makes sense with how many people use it.
-How “into” the product they seem – a score from 0–100 (higher = using more features / more engaged).
-Do they use single sign-on? – yes or no (more common for larger companies).
-Plan level – basic, standard, or premium (premium more likely for larger companies).
-How much they pay per year (in dollars) – a positive number; bigger companies pay more on average.
-Discount % – 0–40%; bigger contracts might have slightly smaller discounts on average.
-Risk that they might leave – label as low, medium, or high (high risk often goes with more support tickets and lower satisfaction).
-Support tickets this period – a whole number; more tickets when risk is higher.
-Satisfaction score – 0–10 (higher is happier; lower when there are many tickets or high leave-risk).
-Last time someone logged in – a date in that three-month window; sometimes blank if they’ve gone quiet.
-When their contract ends – a future date for active customers.
-Two short text columns written by an AI (plain English)
-
-Short summary – 2–4 sentences in everyday language about that company this period (mention region, size, rough payment level, risk, and satisfaction—without using jargon labels like “ARR” or “NPS”).
-What the account manager should do – 3–5 simple bullet ideas for helping that customer (match the risk level and how engaged they are).
-A couple of “calculated” style columns
-
-Payment per user – yearly payment divided by number of users (avoid dividing by zero).
-Engagement level – high / medium / low based on the score and how often they log in.
-Rules
-
-Everything should fit together sensibly (e.g. tiny companies rarely pay millions; unhappy scores often pair with higher leave-risk).
-Use fake company names or codes only—no real brands.
+Rules: keep values plausible together (small companies should not pay millions). Use fake IDs only — no real brands.

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection.tsx
@@ -2,15 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
-import {
-  Banner,
-  Flex,
-  Grid,
-  ProgressBar,
-  Skeleton,
-  Stack,
-  Text,
-} from '@nvidia/foundations-react-core';
+import { Flex, Grid, ProgressBar, Skeleton, Stack, Text } from '@nvidia/foundations-react-core';
+import { Empty } from '@studio/components/Empty';
 import { ColumnProfileCard } from '@studio/routes/DataDesignerJobDetailsRoute/ColumnProfileCard';
 import {
   formatPercent,
@@ -39,18 +32,15 @@ export const DatasetProfilerSection: FC = () => {
 
   // Job still running: the profiler hasn't produced an analysis result yet.
   if (!isTerminal) {
-    return (
-      <Text kind="body/regular/md" className="text-muted">
-        The dataset profile will appear here once the job completes.
-      </Text>
-    );
+    return <Empty title="The dataset profile will appear here once the job completes." />;
   }
 
   if (isError) {
     return (
-      <Banner kind="inline" status="error" title="Failed to load dataset profile">
-        The profiler analysis could not be loaded for this job.
-      </Banner>
+      <Empty
+        title="Failed to load dataset profile"
+        description="The profiler analysis could not be loaded for this job."
+      />
     );
   }
 
@@ -65,11 +55,7 @@ export const DatasetProfilerSection: FC = () => {
   }
 
   if (!hasAnalysis) {
-    return (
-      <Text kind="body/regular/md" className="text-muted">
-        No dataset profile was generated for this job.
-      </Text>
-    );
+    return <Empty title="No dataset profile was generated for this job." />;
   }
 
   const columns = analysis?.column_statistics ?? [];
@@ -103,9 +89,7 @@ export const DatasetProfilerSection: FC = () => {
           ))}
         </ColumnGrid>
       ) : (
-        <Text kind="body/regular/md" className="text-muted">
-          The profile did not include any column statistics.
-        </Text>
+        <Empty title="The profile did not include any column statistics." />
       )}
     </Stack>
   );

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  Card,
+  Flex,
+  SelectContent,
+  SelectItem,
+  SelectListbox,
+  SelectRoot,
+  SelectTrigger,
+  Spinner,
+  Stack,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
+import { Empty } from '@studio/components/Empty';
+import { FileRowEditor } from '@studio/components/FileRowEditor';
+import {
+  type DataFileFormat,
+  formatFromFileName,
+  parseDataFile,
+} from '@studio/components/FileRowEditor/parse';
+import { BUILDER_CONFIG_FILENAME } from '@studio/routes/DataDesignerJobDetailsRoute/builderConfig';
+import { useDataDesignerArtifactsFileset } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerArtifactsFileset';
+import { getFileNameFromPath, getHumanReadableFileSize } from '@studio/util/files';
+import { useEffect, useMemo, useState, type FC, type ReactNode } from 'react';
+
+/** File formats this tab can render as rows. Parquet is decoded to JSONL by the hook. */
+const DATA_FILE_FORMATS: readonly DataFileFormat[] = ['parquet', 'jsonl', 'json', 'csv'];
+
+const centered = (children: ReactNode) => (
+  <Card>
+    <Stack
+      align="center"
+      justify="center"
+      gap="density-md"
+      className="h-full min-h-0 min-w-0 w-full"
+    >
+      {children}
+    </Stack>
+  </Card>
+);
+
+/**
+ * "Data" tab for a Data Designer job: browses the generated data files in the job's
+ * output fileset and renders the selected file in the {@link FileRowEditor}. Content is
+ * fetched via {@link useDatasetFileContent}, which decodes Parquet to JSONL server-side,
+ * so Parquet/JSONL/JSON/CSV all arrive as text and parse through {@link parseDataFile}.
+ *
+ * Edits are in-memory only — the editor's row state is not yet wired back to the Files API.
+ */
+export const JobDatasetEditorSection: FC = () => {
+  const { filesetWorkspace, filesetName, files, isResultsLoading, isFilesLoading } =
+    useDataDesignerArtifactsFileset();
+
+  // Data files only — exclude the builder config and any non-row formats.
+  const dataFiles = useMemo(
+    () =>
+      files.filter(
+        (file) =>
+          file.path !== BUILDER_CONFIG_FILENAME &&
+          !file.path.endsWith(`/${BUILDER_CONFIG_FILENAME}`) &&
+          DATA_FILE_FORMATS.includes(formatFromFileName(file.path))
+      ),
+    [files]
+  );
+
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+
+  // Prefer the first Parquet file (the typical primary output), else the first data file.
+  const defaultPath = useMemo(() => {
+    const firstParquet = dataFiles.find((file) => formatFromFileName(file.path) === 'parquet');
+    return firstParquet?.path ?? dataFiles[0]?.path ?? null;
+  }, [dataFiles]);
+
+  // Default once files resolve; keep the current pick if it survives.
+  useEffect(() => {
+    setSelectedPath((prev) =>
+      prev && dataFiles.some((file) => file.path === prev) ? prev : defaultPath
+    );
+  }, [dataFiles, defaultPath]);
+
+  const selectedFile = useMemo(
+    () => dataFiles.find((file) => file.path === selectedPath) ?? null,
+    [dataFiles, selectedPath]
+  );
+
+  const sourceFormat: DataFileFormat = selectedPath ? formatFromFileName(selectedPath) : 'unknown';
+  // The hook returns Parquet content already decoded to JSONL, so parse it as JSONL.
+  const parseFormat: DataFileFormat = sourceFormat === 'parquet' ? 'jsonl' : sourceFormat;
+
+  const {
+    data: rawContent,
+    isLoading: isContentLoading,
+    isError: isContentError,
+  } = useDatasetFileContent({
+    workspace: filesetWorkspace,
+    name: filesetName,
+    path: selectedPath ?? '',
+    enabled: Boolean(filesetWorkspace && filesetName && selectedPath),
+  });
+
+  const parsed = useMemo(() => {
+    if (rawContent == null) {
+      return null;
+    }
+    try {
+      return { rows: parseDataFile(rawContent, parseFormat), error: null as string | null };
+    } catch (error) {
+      return {
+        rows: [],
+        error: error instanceof Error ? error.message : 'Failed to parse file.',
+      };
+    }
+  }, [rawContent, parseFormat]);
+
+  const isResolving = isResultsLoading || isFilesLoading;
+
+  const fileSelector =
+    dataFiles.length > 1 ? (
+      <Flex align="center" gap="density-sm" className="shrink-0">
+        <Text kind="label/semibold/sm" className="text-secondary">
+          File
+        </Text>
+        <SelectRoot
+          value={selectedPath ?? undefined}
+          onValueChange={(value: string) => setSelectedPath(value)}
+        >
+          <SelectTrigger
+            placeholder="Select a file"
+            // Trigger normally shows the raw value (full path); render the basename to match
+            // the list items, and truncate with a leading ellipsis so the extension stays visible.
+            renderValue={(value) =>
+              typeof value === 'string' ? (
+                <span className="block max-w-[200px] truncate text-left [direction:rtl]">
+                  {getFileNameFromPath(value)}
+                </span>
+              ) : null
+            }
+          />
+          <SelectContent className="w-(--radix-popper-anchor-width)">
+            <SelectListbox>
+              {dataFiles.map((file) => (
+                <SelectItem key={file.path} value={file.path}>
+                  {getFileNameFromPath(file.path)}
+                </SelectItem>
+              ))}
+            </SelectListbox>
+          </SelectContent>
+        </SelectRoot>
+      </Flex>
+    ) : null;
+
+  const renderBody = () => {
+    if (isResolving && dataFiles.length === 0) {
+      return centered(<Spinner aria-label="Loading job data" description="Loading job data..." />);
+    }
+
+    if (dataFiles.length === 0) {
+      return centered(
+        <Empty
+          title="No data files were found in this job's output fileset."
+          description="Generated data appears here once the job has produced its artifacts."
+        />
+      );
+    }
+
+    if (isContentLoading || parsed == null) {
+      return centered(<Spinner aria-label="Loading file" description="Loading file..." />);
+    }
+
+    if (isContentError) {
+      return centered(
+        <Empty
+          title="Could not load file"
+          description="The selected file could not be downloaded from the Files service."
+        />
+      );
+    }
+
+    if (parsed.error) {
+      return <Empty title="Could not parse file" description={parsed.error} />;
+    }
+
+    return (
+      <FileRowEditor
+        key={selectedPath}
+        fileName={selectedPath ?? undefined}
+        fileSizeLabel={selectedFile ? getHumanReadableFileSize(selectedFile.size) : undefined}
+        initialRows={parsed.rows}
+        showOpenFile={false}
+      />
+    );
+  };
+
+  return (
+    <Stack gap="density-md" className="h-full min-h-0 min-w-0 w-full">
+      {fileSelector ? (
+        <Flex align="center" justify="start" className="shrink-0">
+          {fileSelector}
+        </Flex>
+      ) : null}
+      <Stack className="min-h-0 min-w-0 w-full flex-1">{renderBody()}</Stack>
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import {
   Card,
   Flex,
@@ -13,21 +14,37 @@ import {
   Stack,
   Text,
 } from '@nvidia/foundations-react-core';
-import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
+import {
+  FILE_PREVIEW_MAX_BYTES,
+  useDatasetFileContent,
+} from '@studio/api/datasets/useDatasetFileContent';
+import { useDatasetFilesUpload } from '@studio/api/datasets/useDatasetFilesUpload';
 import { Empty } from '@studio/components/Empty';
 import { FileRowEditor } from '@studio/components/FileRowEditor';
 import {
   type DataFileFormat,
   formatFromFileName,
   parseDataFile,
+  serializeDataFile,
 } from '@studio/components/FileRowEditor/parse';
+import type { DataFileRow } from '@studio/components/FileRowEditor/types';
 import { BUILDER_CONFIG_FILENAME } from '@studio/routes/DataDesignerJobDetailsRoute/builderConfig';
 import { useDataDesignerArtifactsFileset } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerArtifactsFileset';
 import { getFileNameFromPath, getHumanReadableFileSize } from '@studio/util/files';
-import { useEffect, useMemo, useState, type FC, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type FC, type ReactNode } from 'react';
 
 /** File formats this tab can render as rows. Parquet is decoded to JSONL by the hook. */
 const DATA_FILE_FORMATS: readonly DataFileFormat[] = ['parquet', 'jsonl', 'json', 'csv'];
+
+/**
+ * Suffix for the JSONL file that holds edits to a Parquet source. Parquet cannot be
+ * re-encoded in the browser, so edits are persisted to a sibling JSONL file instead of
+ * corrupting the original `.parquet`.
+ */
+const PARQUET_EDIT_SUFFIX = '.edited.jsonl';
+
+const parquetEditSiblingPath = (path: string): string =>
+  `${path.replace(/\.[^./]+$/, '')}${PARQUET_EDIT_SUFFIX}`;
 
 const centered = (children: ReactNode) => (
   <Card>
@@ -48,7 +65,9 @@ const centered = (children: ReactNode) => (
  * fetched via {@link useDatasetFileContent}, which decodes Parquet to JSONL server-side,
  * so Parquet/JSONL/JSON/CSV all arrive as text and parse through {@link parseDataFile}.
  *
- * Edits are in-memory only — the editor's row state is not yet wired back to the Files API.
+ * Edits are persisted via the editor's "Save File" action: text formats (JSON/JSONL/CSV)
+ * overwrite the file in place, while Parquet — which cannot be re-encoded in-browser — is
+ * saved to a sibling JSONL file that then becomes the default/selected view.
  */
 export const JobDatasetEditorSection: FC = () => {
   const { filesetWorkspace, filesetName, files, isResultsLoading, isFilesLoading } =
@@ -67,18 +86,32 @@ export const JobDatasetEditorSection: FC = () => {
   );
 
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const pendingSiblingPath = useRef<string | null>(null);
 
-  // Prefer the first Parquet file (the typical primary output), else the first data file.
   const defaultPath = useMemo(() => {
+    const editSibling = dataFiles.find((file) => file.path.endsWith(PARQUET_EDIT_SUFFIX));
+    if (editSibling) {
+      return editSibling.path;
+    }
     const firstParquet = dataFiles.find((file) => formatFromFileName(file.path) === 'parquet');
     return firstParquet?.path ?? dataFiles[0]?.path ?? null;
   }, [dataFiles]);
 
-  // Default once files resolve; keep the current pick if it survives.
+  // Default once files resolve; keep the current pick if it survives (or is a pending save).
   useEffect(() => {
-    setSelectedPath((prev) =>
-      prev && dataFiles.some((file) => file.path === prev) ? prev : defaultPath
-    );
+    setSelectedPath((prev) => {
+      if (prev && dataFiles.some((file) => file.path === prev)) {
+        // Once the pending sibling shows up in the list, it no longer needs the guard.
+        if (prev === pendingSiblingPath.current) {
+          pendingSiblingPath.current = null;
+        }
+        return prev;
+      }
+      if (prev && prev === pendingSiblingPath.current) {
+        return prev;
+      }
+      return defaultPath;
+    });
   }, [dataFiles, defaultPath]);
 
   const selectedFile = useMemo(
@@ -115,6 +148,48 @@ export const JobDatasetEditorSection: FC = () => {
     }
   }, [rawContent, parseFormat]);
 
+  const isContentTruncated = Boolean(
+    selectedFile && sourceFormat !== 'parquet' && selectedFile.size > FILE_PREVIEW_MAX_BYTES
+  );
+  const saveDisabledReason = isContentTruncated
+    ? 'This file is too large to load in full — saving is disabled to avoid truncating it.'
+    : undefined;
+
+  const toast = useToast();
+  const { mutateAsync: uploadFiles, isPending: isSaving } = useDatasetFilesUpload();
+
+  const handleSaveFile = useCallback(
+    async (rows: DataFileRow[]) => {
+      if (!filesetWorkspace || !filesetName || !selectedPath) {
+        return;
+      }
+      const isParquetSource = sourceFormat === 'parquet';
+      const targetPath = isParquetSource ? parquetEditSiblingPath(selectedPath) : selectedPath;
+      const targetFormat: DataFileFormat = isParquetSource ? 'jsonl' : sourceFormat;
+      const content = serializeDataFile(rows, targetFormat);
+      const file = new File([content], targetPath, { type: 'application/octet-stream' });
+
+      try {
+        await uploadFiles({
+          workspace: filesetWorkspace,
+          datasetName: filesetName,
+          files: [file],
+        });
+        if (isParquetSource) {
+          pendingSiblingPath.current = targetPath;
+          setSelectedPath(targetPath);
+          toast.success(`Saved edits to ${getFileNameFromPath(targetPath)}`);
+        } else {
+          toast.success('File saved');
+        }
+      } catch (error) {
+        toast.error('Could not save file. Your changes were not persisted.');
+        throw error;
+      }
+    },
+    [filesetWorkspace, filesetName, selectedPath, sourceFormat, uploadFiles, toast]
+  );
+
   const isResolving = isResultsLoading || isFilesLoading;
 
   const fileSelector =
@@ -129,8 +204,6 @@ export const JobDatasetEditorSection: FC = () => {
         >
           <SelectTrigger
             placeholder="Select a file"
-            // Trigger normally shows the raw value (full path); render the basename to match
-            // the list items, and truncate with a leading ellipsis so the extension stays visible.
             renderValue={(value) =>
               typeof value === 'string' ? (
                 <span className="block max-w-[200px] truncate text-left [direction:rtl]">
@@ -190,6 +263,9 @@ export const JobDatasetEditorSection: FC = () => {
         fileSizeLabel={selectedFile ? getHumanReadableFileSize(selectedFile.size) : undefined}
         initialRows={parsed.rows}
         showOpenFile={false}
+        onSaveFile={handleSaveFile}
+        isSaving={isSaving}
+        saveDisabledReason={saveDisabledReason}
       />
     );
   };

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
@@ -199,7 +199,7 @@ export const JobDatasetEditorSection: FC = () => {
           File
         </Text>
         <SelectRoot
-          value={selectedPath ?? undefined}
+          value={selectedPath ?? defaultPath ?? undefined}
           onValueChange={(value: string) => setSelectedPath(value)}
         >
           <SelectTrigger
@@ -253,7 +253,7 @@ export const JobDatasetEditorSection: FC = () => {
     }
 
     if (parsed.error) {
-      return <Empty title="Could not parse file" description={parsed.error} />;
+      return centered(<Empty title="Could not parse file" description={parsed.error} />);
     }
 
     return (

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection.tsx
@@ -10,7 +10,8 @@ import {
   useFilesRetrieveFileset,
 } from '@nemo/sdk/generated/platform/api';
 import type { FilesetFileOutput } from '@nemo/sdk/generated/platform/schema';
-import { Anchor, Banner, Card, Stack, Text } from '@nvidia/foundations-react-core';
+import { Anchor, Banner, Card, Spinner, Stack, Text } from '@nvidia/foundations-react-core';
+import { Empty } from '@studio/components/Empty';
 import { FilesetFilePreviewPanel } from '@studio/components/FilesetFilePreviewPanel';
 import type { FileSystemFile } from '@studio/components/FilesTable/utils';
 import { useDataDesignerArtifactsFileset } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerArtifactsFileset';
@@ -142,40 +143,45 @@ export const JobOutputFilesetSection: FC = () => {
 
   if (isResultsLoading && !artifactsResult) {
     return (
-      <Card>
-        <Stack gap="4">
-          <Text kind="body/regular/md" className="text-muted">
-            Loading job results…
-          </Text>
-        </Stack>
+      <Card
+        className="min-w-0 w-full"
+        attributes={{ CardContent: { className: 'flex justify-center items-center' } }}
+      >
+        <Spinner description="Loading job results..." />
       </Card>
     );
   }
 
   if (isResultsError) {
+    const errorTitle =
+      resultsError instanceof Error ? 'Error loading job results' : 'Could not load job results';
+    const errorMessage =
+      resultsError instanceof Error
+        ? resultsError.message
+        : 'The job results list could not be loaded.';
     return (
-      <Card>
-        <Stack gap="4">
-          <Banner kind="inline" status="error" title="Could not load job results">
-            {resultsError instanceof Error
-              ? resultsError.message
-              : 'The job results list could not be loaded.'}
-          </Banner>
-        </Stack>
+      <Card
+        className="min-w-0 w-full"
+        attributes={{ CardContent: { className: 'flex justify-center items-center' } }}
+      >
+        <Empty title={errorTitle} description={errorMessage} />
       </Card>
     );
   }
 
   if (!artifactsResult) {
+    const emptyTitle = isTerminal
+      ? 'No artifacts result was returned for this job.'
+      : 'Output files will appear here once the job registers its artifacts result.';
+    const emptyDescription = isTerminal
+      ? 'No artifacts result was returned for this job.'
+      : 'Output files will appear here once the job registers its artifacts result.';
     return (
-      <Card>
-        <Stack gap="4">
-          <Text kind="body/regular/md" className="text-muted">
-            {isTerminal
-              ? 'No artifacts result was returned for this job.'
-              : 'Output files will appear here once the job registers its artifacts result.'}
-          </Text>
-        </Stack>
+      <Card
+        className="min-w-0 w-full"
+        attributes={{ CardContent: { className: 'flex justify-center items-center' } }}
+      >
+        <Empty title={emptyTitle} description={emptyDescription} />
       </Card>
     );
   }

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection.tsx
@@ -18,7 +18,15 @@ import { useDataDesignerArtifactsFileset } from '@studio/routes/DataDesignerJobD
 import { getFilesetDetailsRoute } from '@studio/routes/utils';
 import { getHumanReadableFileSize } from '@studio/util/files';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useState, type ComponentProps, type FC } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ComponentProps,
+  type FC,
+  type ReactNode,
+} from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 type FileRow = FilesetFileOutput & { id: string };
@@ -31,6 +39,15 @@ function fileRowToSystemFile(row: FileRow): FileSystemFile {
     oid: row.file_ref,
   };
 }
+
+const centeredCard = (children: ReactNode) => (
+  <Card
+    className="min-w-0 w-full"
+    attributes={{ CardContent: { className: 'flex justify-center items-center' } }}
+  >
+    {children}
+  </Card>
+);
 
 export const JobOutputFilesetSection: FC = () => {
   const navigate = useNavigate();
@@ -142,14 +159,7 @@ export const JobOutputFilesetSection: FC = () => {
   }, [filesetWorkspace, filesetName]);
 
   if (isResultsLoading && !artifactsResult) {
-    return (
-      <Card
-        className="min-w-0 w-full"
-        attributes={{ CardContent: { className: 'flex justify-center items-center' } }}
-      >
-        <Spinner description="Loading job results..." />
-      </Card>
-    );
+    return centeredCard(<Spinner description="Loading job results..." />);
   }
 
   if (isResultsError) {
@@ -159,14 +169,7 @@ export const JobOutputFilesetSection: FC = () => {
       resultsError instanceof Error
         ? resultsError.message
         : 'The job results list could not be loaded.';
-    return (
-      <Card
-        className="min-w-0 w-full"
-        attributes={{ CardContent: { className: 'flex justify-center items-center' } }}
-      >
-        <Empty title={errorTitle} description={errorMessage} />
-      </Card>
-    );
+    return centeredCard(<Empty title={errorTitle} description={errorMessage} />);
   }
 
   if (!artifactsResult) {
@@ -174,16 +177,9 @@ export const JobOutputFilesetSection: FC = () => {
       ? 'No artifacts result was returned for this job.'
       : 'Output files will appear here once the job registers its artifacts result.';
     const emptyDescription = isTerminal
-      ? 'No artifacts result was returned for this job.'
-      : 'Output files will appear here once the job registers its artifacts result.';
-    return (
-      <Card
-        className="min-w-0 w-full"
-        attributes={{ CardContent: { className: 'flex justify-center items-center' } }}
-      >
-        <Empty title={emptyTitle} description={emptyDescription} />
-      </Card>
-    );
+      ? 'This job completed but did not produce an artifacts result.'
+      : 'Check back after the job registers its artifacts result.';
+    return centeredCard(<Empty title={emptyTitle} description={emptyDescription} />);
   }
 
   if (!filesetLoc) {

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
@@ -20,6 +20,7 @@ import { Loading } from '@studio/components/Layouts/Loading';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { DataDesignerConfigPanel } from '@studio/routes/DataDesignerJobDetailsRoute/DataDesignerConfigPanel';
 import { DatasetProfilerSection } from '@studio/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection';
+import { JobDatasetEditorSection } from '@studio/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection';
 import { JobOutputFilesetSection } from '@studio/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection';
 import { useDataDesignerJobFromRoute } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerJobFromRoute';
 import { getDataDesignerJobListRoute } from '@studio/routes/utils';
@@ -127,11 +128,16 @@ export const DataDesignerJobDetailsRoute: FC = () => {
         <TabsRoot defaultValue="profile" className="flex min-h-0 w-full min-w-0 flex-1 flex-col">
           <TabsList>
             <TabsTrigger value="profile">Profile</TabsTrigger>
+            <TabsTrigger value="data">Data</TabsTrigger>
             <TabsTrigger value="output">Output files</TabsTrigger>
           </TabsList>
 
           <TabsContent value="profile" className="min-h-0 flex-1 overflow-y-auto px-0">
             <DatasetProfilerSection />
+          </TabsContent>
+
+          <TabsContent value="data" className="min-h-0 min-w-0 flex-1 overflow-y-auto px-0">
+            <JobDatasetEditorSection />
           </TabsContent>
 
           <TabsContent value="output" className="min-h-0 flex-1 overflow-y-auto px-0">


### PR DESCRIPTION

<img width="1254" height="784" alt="Screenshot 2026-07-06 at 9 53 50 AM" src="https://github.com/user-attachments/assets/0b063c6e-9982-44c3-b0c8-2ae902092672" />
<img width="1249" height="784" alt="Screenshot 2026-07-06 at 9 53 29 AM" src="https://github.com/user-attachments/assets/7df4b84e-4d16-4d97-93d2-747b3439e929" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new **Data** tab to Data Designer job details for browsing and editing output data files.
  * Added **Save File** persistence to the row editor, including toasts, dirty-state tracking, and an **Unsaved changes** indicator.
* **Bug Fixes**
  * Standardized loading/empty/error states across job detail sections for more consistent messaging and layout.
* **Documentation**
  * Updated the mock dataset request spec to a smaller, simplified fake dataset.
* **Tests**
  * Updated/expanded row editor tests to match the staged-save and persistence behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->