### PR TITLE
docs(intake): Initial pass at intake documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ User-facing skills in `packages/nemo_platform_ext/src/nemo_platform_ext/skills/`
 - `nemo-build-agent`: scaffolds NAT workflow YAML from the spec and deploys.
 - `nemo-try-agent`: test a deployed agent or chat with a model.
 - `nemo-status`: read-only health dashboard.
+- `nemo-intake`: ingest agent telemetry (OTLP, chat-completions, ATIF) and query traces, spans, annotations, and evaluator results. Requires a reachable ClickHouse.
 - `nemo-teardown`: guided shutdown with confirmation.
 
 Plugin-owned skills under `plugins/*/src/*/skills/` handle their own routing for customization, guardrails, evaluations, optimization, data designer, anonymizer, and auditor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ User-facing skills in `packages/nemo_platform_ext/src/nemo_platform_ext/skills/`
 - `nemo-build-agent`: scaffolds NAT workflow YAML from the spec and deploys.
 - `nemo-try-agent`: test a deployed agent or chat with a model.
 - `nemo-status`: read-only health dashboard. Run this before assuming the platform is up.
+- `nemo-intake`: ingest agent telemetry (OTLP, chat-completions, ATIF) and query traces, spans, annotations, and evaluator results. Requires a reachable ClickHouse.
 - `nemo-teardown`: guided shutdown with confirmation.
 
 Plugin-owned skills live under `plugins/*/src/*/skills/` and handle their own routing for customization, guardrails, evaluations, optimization, data designer, anonymizer, and auditor.

--- a/docs/fern/gated-nav.yml
+++ b/docs/fern/gated-nav.yml
@@ -51,6 +51,12 @@
     path: ../../auth/security-model.mdx
   - page: Troubleshooting
     path: ../../auth/troubleshooting.mdx
+- section: Intake
+  contents:
+  - page: Overview
+    path: ../../intake/index.mdx
+  - page: Getting Started
+    path: ../../intake/getting-started.mdx
 - section: Safe Synthesizer
   contents:
   - page: Data Synthesis

--- a/docs/intake/getting-started.mdx
+++ b/docs/intake/getting-started.mdx
@@ -1,0 +1,150 @@
+---
+title: "Getting Started with Intake"
+description: Start ClickHouse, run the Intake service, send a trace, and query it back with the CLI.
+---
+
+<Warning>
+
+NVIDIA NeMo Intake is released with _early access_ availability and is subject to limited support and potential API changes in future releases.
+
+</Warning>
+
+This guide takes you from nothing to a queryable trace: start ClickHouse, run the platform with the Intake service, send telemetry, and read it back.
+
+## Prerequisites
+
+- Docker installed and running (for the local ClickHouse container).
+- A NeMo Platform environment. Intake ships in the platform's API service group and depends on the `entities` and `auth` services.
+
+## 1. Start ClickHouse
+
+Intake stores all telemetry in ClickHouse. Start a local instance:
+
+```bash
+docker run -d --name nemo-intake-clickhouse \
+  -p 8123:8123 -p 9000:9000 \
+  clickhouse/clickhouse-server:26.3
+```
+
+If you are working from a source checkout, `services/intake/scripts/spans/run_clickhouse.sh` does the same thing with a persistent local data directory.
+
+Pin an explicit ClickHouse version rather than `latest` so schema migrations always run against a known server.
+
+Verify ClickHouse is answering:
+
+```bash
+curl -s http://localhost:8123/ping
+# Ok.
+```
+
+### Configuration
+
+Intake reads its ClickHouse connection from the environment. The defaults match the container above, so you only need these when pointing at a remote or secured server:
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `NMP_INTAKE_CLICKHOUSE_URL` | `http://localhost:8123` | HTTP(S) URL of the ClickHouse server |
+| `NMP_INTAKE_CLICKHOUSE_USER` | `default` | ClickHouse username |
+| `NMP_INTAKE_CLICKHOUSE_PASSWORD` | (empty) | ClickHouse password |
+| `NMP_INTAKE_CLICKHOUSE_DATABASE` | `intake` | Database for Intake tables |
+| `NMP_INTAKE_OTLP_MAX_BODY_BYTES` | `5242880` (5 MiB) | Maximum accepted OTLP ingest request body |
+
+The service creates the database and tables itself — no manual schema setup. Tables are bootstrapped lazily on the first request, and Intake endpoints return `503` until ClickHouse is reachable.
+
+### Sizing
+
+For local development the container defaults are fine — a few GB of RAM handles a single developer's ingest and query volume. For production, follow [ClickHouse's sizing guidance](https://clickhouse.com/docs/guides/sizing-and-hardware-recommendations): start at 16 GB of RAM and 4+ cores on SSD-backed storage, then size memory against retained data — roughly a 1:100 memory-to-storage ratio for long-retention telemetry, moving toward 1:30–1:50 when the data is queried interactively (for example, dashboards over recent traces). Intake retains span data for 90 days, so estimate storage from your span volume over that window.
+
+## 2. Run the Intake service
+
+Intake is included when you run the full platform. To run a minimal subset:
+
+```bash
+nemo services run --services auth,entities,intake --host 127.0.0.1 --port 8000
+```
+
+Verify the route surface is up:
+
+```bash
+curl -i "http://127.0.0.1:8000/apis/intake/v2/workspaces/default/spans"
+```
+
+A `200` with an empty list means Intake and ClickHouse are both healthy. A `503` means Intake is up but cannot reach ClickHouse.
+
+## 3. Send a trace
+
+### From an OpenTelemetry exporter
+
+Point any OTLP/HTTP trace exporter — your agent framework's instrumentation, an OpenTelemetry collector, or the NeMo relay — at the workspace ingest endpoint:
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:8000/apis/intake/v2/workspaces/default/ingest/otlp/v1/traces
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+Then run your instrumented agent. Intake understands OpenInference and OpenTelemetry GenAI semantic conventions and maps them onto its span model.
+
+### From a captured chat completion
+
+If you capture OpenAI-compatible request/response pairs yourself, post them directly. Session IDs just need to be unique per session — a UUID works well (`uuidgen` ships with macOS and most Linux distributions):
+
+```bash
+SESSION_ID=$(uuidgen)
+nemo intake ingest chat-completions create \
+  --request '{"model": "meta/llama-3.1-8b-instruct", "messages": [{"role": "user", "content": "Hi"}]}' \
+  --response '{"choices": [{"message": {"role": "assistant", "content": "Hello!"}}]}' \
+  --session-id "$SESSION_ID"
+```
+
+ATIF trajectories work the same way through `nemo intake ingest atif create` (see `--help` for the payload fields, or pass a full document with `--input-file`).
+
+## 4. Query it back
+
+List recent traces:
+
+```bash
+nemo intake traces list
+```
+
+List the spans in one session, or drill into a single span:
+
+```bash
+nemo intake spans list --filter.session-id "$SESSION_ID"
+nemo intake spans get <span-id>
+```
+
+Spans support rich filters — by `kind`, `status`, `model`, `provider`, `tool-name`, `agent-name`, `project`, evaluation context, and time range. Aggregate with `nemo intake spans groups list`. All commands accept `--workspace`; they default to the workspace configured in your CLI context.
+
+## 5. Annotate
+
+Attach feedback, labels, or notes to a session or a specific span:
+
+```bash
+nemo intake annotations create thumbs-up \
+  --kind feedback \
+  --session-id "$SESSION_ID" \
+  --text "Correct answer, good tool use"
+```
+
+Read annotations back with `nemo intake annotations list --filter.session-id "$SESSION_ID"`. Evaluator results work the same way under `nemo intake evaluator-results`.
+
+## 6. Browse in Studio
+
+The Studio Intake pages (trace list, span list, and trace detail waterfall) are behind a preview feature flag. Run Studio with `VITE_FF_INTAKE_ENABLED=true` and open:
+
+```text
+/workspaces/default/intake/traces
+```
+
+## Data Retention
+
+Span and trace-index tables carry a 90-day TTL in ClickHouse. Annotations and evaluator results are retained indefinitely. Experiment and experiment-group metadata lives in the platform entity store, not ClickHouse.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Intake endpoints return `503` | ClickHouse unreachable | Check `curl http://localhost:8123/ping` and the `NMP_INTAKE_CLICKHOUSE_*` variables |
+| OTLP ingest returns `413` | Payload exceeds the body limit | Raise `NMP_INTAKE_OTLP_MAX_BODY_BYTES` or batch smaller exports |
+| Traces ingest but the list is empty | Querying the wrong workspace | Ingest and read are workspace-scoped; make sure both use the same workspace |
+| Studio shows no Intake pages | Feature flag off | Start Studio with `VITE_FF_INTAKE_ENABLED=true` |

--- a/docs/intake/index.mdx
+++ b/docs/intake/index.mdx
@@ -1,0 +1,73 @@
+---
+title: "Intake"
+description: Ingest, store, and query agent telemetry — traces, spans, annotations, and evaluator results — backed by ClickHouse.
+---
+
+<a id="about-intake"></a>
+
+<Warning>
+
+NVIDIA NeMo Intake is released with _early access_ availability and is subject to limited support and potential API changes in future releases.
+
+</Warning>
+
+Intake is the telemetry ingestion and read API for NeMo Platform. It captures what your agents actually did — every model call, tool invocation, and chain step — stores it in ClickHouse, and lets you query it back through the API, the `nemo` CLI, the Python SDK, and the Studio UI. On top of the raw telemetry, Intake supports post-hoc annotations (feedback, labels, notes) and evaluator-result lookup, so evaluation scores and human feedback live next to the traces they describe.
+
+---
+
+## Core Concepts
+
+### Sessions, traces, and spans
+
+Telemetry is organized in a three-level hierarchy:
+
+- A **span** is a single timed operation: one LLM call, one tool invocation, one retrieval. Spans carry a kind (`llm`, `chain`, `tool`, `retriever`, `embedding`, `agent`, `reranker`, `evaluator`, `guardrail`), a status, timing, typed attribute maps, and captured input/output payloads.
+- A **trace** is one end-to-end run of your agent — a tree of spans sharing a trace ID. The root span (the one with no parent) provides the trace summary: name, status, latency, and top-level input/output.
+- A **session** groups related traces, such as a multi-turn conversation or one evaluation run.
+
+### Annotations
+
+Annotations attach human or programmatic context to a span or a whole session after the fact: `feedback`, `label`, `note`, or `metadata`. Use them to record thumbs-up/down signals, triage labels, or reviewer notes without mutating the underlying telemetry.
+
+### Evaluator results
+
+Evaluator results are per-span scores — numeric, categorical, boolean, or text — written by evaluation runs (for example, an LLM-as-judge faithfulness score). NeMo Evaluator can write its results into Intake so you can query scores alongside the spans they measured.
+
+### Experiments
+
+Experiments and experiment groups organize evaluation runs into leaderboard views: an experiment represents one agent or configuration run against a dataset, and a group collects experiments for comparison. Experiment metadata lives in the platform entity store; the metrics rollups are derived from ClickHouse at read time. Experiments are exposed through the API and Python SDK (`client.experiments`, `client.experiment_groups`).
+
+## Ingest Formats
+
+Intake accepts telemetry in three formats:
+
+| Format | Endpoint | Use when |
+|---|---|---|
+| OTLP/HTTP (protobuf) | `POST .../ingest/otlp/v1/traces` | Your agent or framework already emits OpenTelemetry traces (OpenInference or OTel GenAI semantic conventions). Point the exporter at Intake. |
+| Chat completions | `POST .../ingest/chat-completions` | You capture raw OpenAI-compatible request/response pairs and want them recorded as LLM spans. |
+| ATIF | `POST .../ingest/atif` | You have Agent Trajectory Interchange Format trajectories (for example, from NeMo Agent Toolkit or evaluation runs). |
+
+All ingest and read endpoints are workspace-scoped under `/apis/intake/v2/workspaces/{workspace}/`.
+
+## Typical Workflow
+
+1. Start ClickHouse and run the platform with the `intake` service enabled. See [Getting Started](/documentation/intake/getting-started).
+2. Point your agent's OTLP trace exporter at the Intake ingest endpoint, or post captured chat-completions or ATIF payloads.
+3. Query traces and spans back with `nemo intake traces list` and `nemo intake spans list`, filtering by session, kind, status, model, agent, or evaluation context.
+4. Annotate interesting spans or sessions with `nemo intake annotations create`.
+5. Review evaluator results per span, or browse everything visually in the Studio Intake pages.
+
+## Architecture Notes
+
+- **ClickHouse is the datastore.** Span, trace-index, annotation, and evaluator-result tables live in a ClickHouse database (default name `intake`). The service manages its own schema migrations and bootstraps tables lazily on first request.
+- **Telemetry has a TTL.** Span and trace-index tables expire rows after 90 days.
+- **Experiments use the entity store.** Only experiment and experiment-group metadata lives in the platform's relational entity store; everything telemetry-shaped stays in ClickHouse.
+- **Read API returns 503 until ClickHouse is reachable.** The service starts without a ClickHouse connection and connects on first use.
+
+## Next Steps
+
+<Cards>
+<Card title="Getting Started" href="/documentation/intake/getting-started">
+Start ClickHouse, run the Intake service, send your first trace, and query it back.
+</Card>
+</Cards>

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-intake/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-intake/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: nemo-intake
+description: >
+  Ingest and query agent telemetry with NeMo Intake. Send traces (OTLP,
+  chat-completions, ATIF) into the platform, query spans and traces back,
+  and attach annotations or look up evaluator results. Use when the user
+  asks where their traces are, wants to see what their agent did, or wants
+  to annotate a session.
+triggers:
+  - show my traces
+  - where are my agent traces
+  - query my spans
+  - send traces to nemo
+  - annotate this session
+  - agent telemetry
+  - intake
+not-for:
+  - nemo-status (use for overall platform health, not telemetry queries)
+  - nemo-evaluator (use to run evaluations; intake only stores/reads their results)
+  - nemo-try-agent (use to send a query to a deployed agent)
+  - nemo-setup (use to install or start the platform)
+compatibility: nemo-platform >= 0.1.0; requires the `intake` service running and a reachable ClickHouse (Docker for the local container); ingest and annotation commands change state — queries are read-only.
+maturity: beta
+license: Apache-2.0
+user-invocable: true
+allowed-tools: [Bash, Read]
+---
+
+# NeMo Intake — agent telemetry
+
+Ingest agent traces into the platform and query them back. Intake stores spans, traces, annotations, and evaluator results in ClickHouse, workspace-scoped under `/apis/intake/v2/workspaces/{workspace}/`.
+
+## Pre-flight
+
+Run both probes before anything else. If either fails, stop and report which one.
+
+```bash
+# 1. Platform up and ready?
+curl -sS --connect-timeout 2 --max-time 5 http://localhost:8080/health/ready | grep -q ready && echo "PLATFORM_UP" || echo "PLATFORM_DOWN"
+
+# 2. Intake reachable and backed by ClickHouse?
+HTTP=$(curl -sS --connect-timeout 2 --max-time 5 -o /dev/null -w "%{http_code}" "http://localhost:8080/apis/intake/v2/workspaces/default/spans")
+case "$HTTP" in
+  200) echo "INTAKE_OK" ;;
+  503) echo "INTAKE_UP_CLICKHOUSE_DOWN" ;;
+  404) echo "INTAKE_SERVICE_NOT_RUNNING" ;;
+  *)   echo "INTAKE_UNEXPECTED ($HTTP)" ;;
+esac
+```
+
+| Probe result | Action |
+|---|---|
+| `PLATFORM_DOWN` | Route to `nemo-setup` and stop |
+| `INTAKE_SERVICE_NOT_RUNNING` | The running service set does not include `intake`. Tell the user to restart with intake included, e.g. `nemo services run --services auth,entities,intake` (or the full service group). Do not restart services without asking. |
+| `INTAKE_UP_CLICKHOUSE_DOWN` | ClickHouse is not reachable. Offer to start the local container (below) — ask before running Docker. |
+| `INTAKE_OK` | Proceed |
+
+Local ClickHouse container (only with the user's go-ahead):
+
+```bash
+docker run -d --name nemo-intake-clickhouse -p 8123:8123 -p 9000:9000 clickhouse/clickhouse-server:26.3
+curl -s http://localhost:8123/ping   # expect: Ok.
+```
+
+In a source checkout, prefer `services/intake/scripts/spans/run_clickhouse.sh` (persistent data dir). Connection overrides use `NMP_INTAKE_CLICKHOUSE_URL/USER/PASSWORD/DATABASE` env vars on the platform process; defaults match the container above. Re-run probe 2 after starting ClickHouse — the schema bootstraps lazily on the first request.
+
+## Route by intent
+
+| User wants | Do |
+|---|---|
+| Send telemetry in | **Ingest** |
+| See traces / spans / what the agent did | **Query** |
+| Attach feedback, labels, notes | **Annotate** |
+| See evaluation scores on spans | **Evaluator results** |
+| Browse visually | **Studio** |
+
+All commands accept `--workspace`; omitted, they use the CLI context's workspace. Keep ingest and query in the same workspace.
+
+## Ingest
+
+Three formats. Pick by what the user has:
+
+- **OTLP** (agent already emits OpenTelemetry/OpenInference traces) — configure their exporter, don't post by hand:
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:8080/apis/intake/v2/workspaces/default/ingest/otlp/v1/traces
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+- **Captured chat completion** (raw OpenAI-compatible request/response pair):
+
+```bash
+nemo intake ingest chat-completions create \
+  --request '<request JSON>' \
+  --response '<response JSON>' \
+  --session-id <session>
+```
+
+When the user has no session ID, generate one with `uuidgen` and tell them what it is — do not invent memorable-looking strings that could collide.
+
+- **ATIF trajectory** (from NeMo Agent Toolkit or an eval run): `nemo intake ingest atif create --input-file <file.json>`. Check `--help` for field-level flags; do not guess the schema.
+
+**Verify every ingest** by reading it back before reporting success:
+
+```bash
+nemo intake spans list --filter.session-id <session>
+```
+
+## Query
+
+```bash
+nemo intake traces list                                  # recent traces (root-span summaries)
+nemo intake traces get <trace-id>
+nemo intake spans list --filter.session-id <session>     # spans, richly filterable
+nemo intake spans get <span-id>                          # full span incl. input/output
+nemo intake spans groups list                            # aggregations
+```
+
+Useful span filters: `--filter.kind` (llm, tool, agent, chain, retriever, …), `--filter.status`, `--filter.model`, `--filter.provider`, `--filter.tool-name`, `--filter.agent-name`, `--filter.project`, `--filter.trace-id`. Time ranges go through `--filter '{"started_at": {"gte": "...", "lte": "..."}}'`. Add `--output-format json` when you need to parse.
+
+## Annotate
+
+```bash
+nemo intake annotations create <name> \
+  --kind feedback \
+  --session-id <session> \
+  --text "<free text>"
+```
+
+`--kind` is one of `feedback`, `label`, `note`, `metadata`. Add `--span-id` to target one span instead of the whole session. Verify with `nemo intake annotations list --filter.session-id <session>`. Delete only when the user explicitly asks (`nemo intake annotations delete <annotation-id>`).
+
+## Evaluator results
+
+Read-only lookup of scores written by evaluation runs:
+
+```bash
+nemo intake evaluator-results list
+nemo intake spans evaluator-results list <span-id>
+```
+
+To *produce* results, route to `nemo-evaluator` — do not hand-write evaluator results unless the user explicitly wants to inject one.
+
+## Studio
+
+The Intake UI (trace list, trace detail waterfall) is behind a preview flag. If the user wants the visual view, Studio must run with `VITE_FF_INTAKE_ENABLED=true`; pages live at `/workspaces/<workspace>/intake/traces`.
+
+## Gotchas
+
+- **503 means ClickHouse, not intake.** The service starts fine without ClickHouse and fails per-request. Fix the connection, don't restart the platform.
+- **Workspace mismatch is the top "my traces are missing" cause.** The OTLP endpoint embeds the workspace in its path; queries must use the same one.
+- **OTLP bodies are capped at 5 MiB** by default (`NMP_INTAKE_OTLP_MAX_BODY_BYTES`). A `413` means batch smaller exports or raise the limit.
+- **Telemetry expires.** Span and trace tables have a 90-day TTL. Old traces disappearing is retention, not data loss.
+- **Experiments have no CLI.** Experiment/experiment-group leaderboards are API/SDK-only (`client.experiments`, `client.experiment_groups`). Say so instead of inventing `nemo intake experiments ...`.
+- **Never fabricate telemetry to make a query demo work.** If there is nothing to read back, say the store is empty and offer the ingest path.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-intake/tests.json
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-intake/tests.json
@@ -1,0 +1,65 @@
+{
+  "skill": "nemo-intake",
+  "tests": [
+    {
+      "type": "explicit",
+      "prompt": "Run nemo-intake and show me my recent traces.",
+      "expected_skill": "nemo-intake"
+    },
+    {
+      "type": "explicit",
+      "prompt": "Use the nemo-intake skill to annotate this session.",
+      "expected_skill": "nemo-intake"
+    },
+    {
+      "type": "explicit",
+      "prompt": "Invoke nemo-intake to send this trajectory into the platform.",
+      "expected_skill": "nemo-intake"
+    },
+    {
+      "type": "implicit",
+      "prompt": "Where are the traces from my agent run? I want to see what it actually did.",
+      "expected_skill": "nemo-intake"
+    },
+    {
+      "type": "implicit",
+      "prompt": "Point my OpenTelemetry exporter at NeMo so my agent's spans get stored.",
+      "expected_skill": "nemo-intake"
+    },
+    {
+      "type": "implicit",
+      "prompt": "Add a thumbs-up annotation to session abc-123.",
+      "expected_skill": "nemo-intake"
+    },
+    {
+      "type": "contextual",
+      "prompt": "I just ran my agent against ten test questions. Show me the LLM spans that errored and how long the tool calls took.",
+      "expected_skill": "nemo-intake"
+    },
+    {
+      "type": "contextual",
+      "prompt": "The eval finished earlier today. Pull up the evaluator scores attached to the spans from that run.",
+      "expected_skill": "nemo-intake"
+    },
+    {
+      "type": "contextual",
+      "prompt": "My teammate says the traces from yesterday's demo are in the platform, but I query and get nothing back. Help me figure out why.",
+      "expected_skill": "nemo-intake"
+    },
+    {
+      "type": "negative-control",
+      "prompt": "Run an LLM-as-judge evaluation of my agent against this benchmark.",
+      "expected_skill_not": "nemo-intake"
+    },
+    {
+      "type": "negative-control",
+      "prompt": "Is the platform up? Show me overall health.",
+      "expected_skill_not": "nemo-intake"
+    },
+    {
+      "type": "negative-control",
+      "prompt": "Set up an intake form on my website for new customer leads.",
+      "expected_skill_not": "nemo-intake"
+    }
+  ]
+}

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-skill-selection/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-skill-selection/SKILL.md
@@ -52,7 +52,7 @@ Match the user's intent to one downstream skill. Pick exactly one.
 | "optimize my agent", "make it cheaper", "reduce latency", "smaller model", "switchyard", "routing split", "compare against a newer model" | `agents-optimize` (plugin-owned, in `plugins/nemo-agents`) | Cost / latency / quality optimization for a **deployed** agent. Routing splits, skill tuning, prompt tuning, new-model scans. |
 | "secure my agent", "harden my agent", "check for PII", "leaked secrets", "guardrail coverage" | `agents-secure` (plugin-owned, in `plugins/nemo-agents`) | Safety and security audit for a **deployed** agent. Guardrails, PII, secrets scan. |
 | "evaluate my agent", "run a benchmark", "eval suite" | `nemo-evaluator` (plugin-owned, in `plugins/nemo-evaluator`) | Evaluation metrics, LLM-judge, benchmark jobs against a deployed agent or model. |
-| "show my traces", "where are my agent traces", "what did my agent do", "send traces to nemo", "annotate this session" | `nemo-intake` | Ingest agent telemetry (OTLP, chat-completions, ATIF) and query spans, traces, annotations, and evaluator results back. |
+| "show my traces", "show me spans", "query my spans", "where are my agent traces", "what did my agent do", "send traces to nemo", "annotate this session" | `nemo-intake` | Ingest agent telemetry (OTLP, chat-completions, ATIF) and query spans, traces, annotations, and evaluator results back. |
 
 **Optimize vs build:** Do NOT route optimize asks to `nemo-build-agent`. Build is for creating new agents from a spec; optimize is for tuning **already deployed** agents. If the user says "make my agent faster" or "use a cheaper model," that is `agents-optimize`, not `nemo-build-agent`.
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-skill-selection/SKILL.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-skill-selection/SKILL.md
@@ -52,6 +52,7 @@ Match the user's intent to one downstream skill. Pick exactly one.
 | "optimize my agent", "make it cheaper", "reduce latency", "smaller model", "switchyard", "routing split", "compare against a newer model" | `agents-optimize` (plugin-owned, in `plugins/nemo-agents`) | Cost / latency / quality optimization for a **deployed** agent. Routing splits, skill tuning, prompt tuning, new-model scans. |
 | "secure my agent", "harden my agent", "check for PII", "leaked secrets", "guardrail coverage" | `agents-secure` (plugin-owned, in `plugins/nemo-agents`) | Safety and security audit for a **deployed** agent. Guardrails, PII, secrets scan. |
 | "evaluate my agent", "run a benchmark", "eval suite" | `nemo-evaluator` (plugin-owned, in `plugins/nemo-evaluator`) | Evaluation metrics, LLM-judge, benchmark jobs against a deployed agent or model. |
+| "show my traces", "where are my agent traces", "what did my agent do", "send traces to nemo", "annotate this session" | `nemo-intake` | Ingest agent telemetry (OTLP, chat-completions, ATIF) and query spans, traces, annotations, and evaluator results back. |
 
 **Optimize vs build:** Do NOT route optimize asks to `nemo-build-agent`. Build is for creating new agents from a spec; optimize is for tuning **already deployed** agents. If the user says "make my agent faster" or "use a cheaper model," that is `agents-optimize`, not `nemo-build-agent`.
 
@@ -103,6 +104,7 @@ NeMo Platform skills I can route to:
   nemo-build-agent  scaffold the NAT workflow YAML and deploy
   nemo-try-agent  query a deployed agent or chat with a model
   nemo-status     read-only platform health dashboard
+  nemo-intake     ingest agent telemetry and query traces, spans, annotations
   nemo-teardown   guided shutdown
 
 Plugin-owned skills:

--- a/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
+++ b/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
@@ -46,7 +46,7 @@ EXPERIMENT_NAME = "intake-it-exp"
 RUN_ID = "intake-it-run"
 NAN_EXPERIMENT_NAME = "intake-it-nan-exp"
 NAN_RUN_ID = "intake-it-nan-run"
-CLICKHOUSE_CONTAINER = "nmp-intake-clickhouse"
+CLICKHOUSE_CONTAINER = "nemo-intake-clickhouse"
 
 
 def _docker_available() -> bool:

--- a/services/intake/scripts/spans/run_clickhouse.sh
+++ b/services/intake/scripts/spans/run_clickhouse.sh
@@ -4,8 +4,9 @@
 
 set -euo pipefail
 
-container_name="nmp-intake-clickhouse"
-image="${CLICKHOUSE_IMAGE:-clickhouse/clickhouse-server:24.3}"
+container_name="nemo-intake-clickhouse"
+legacy_container_name="nmp-intake-clickhouse"
+image="${CLICKHOUSE_IMAGE:-clickhouse/clickhouse-server:26.3}"
 clickhouse_user="${CLICKHOUSE_USER:-default}"
 clickhouse_password="${CLICKHOUSE_PASSWORD:-}"
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -20,6 +21,12 @@ ensure_host_dirs() {
 ensure_tmp_dir() {
   docker exec "${container_name}" sh -c "mkdir -p /var/lib/clickhouse/tmp && chown clickhouse:clickhouse /var/lib/clickhouse/tmp" >/dev/null
 }
+
+if docker ps -a --filter "name=^/${legacy_container_name}$" --format "{{.Names}}" | grep -qx "${legacy_container_name}"; then
+  echo "Found legacy container ${legacy_container_name}; it binds the same ports as ${container_name}." >&2
+  echo "Remove it first: docker rm -f ${legacy_container_name} (data persists in ${data_dir})" >&2
+  exit 1
+fi
 
 if docker ps --filter "name=^/${container_name}$" --filter "status=running" --format "{{.Names}}" | grep -qx "${container_name}"; then
   ensure_tmp_dir

--- a/services/intake/tests/integration/spans/conftest.py
+++ b/services/intake/tests/integration/spans/conftest.py
@@ -55,7 +55,7 @@ def clickhouse_container():
     from testcontainers.clickhouse import ClickHouseContainer
 
     with ClickHouseContainer(
-        "clickhouse/clickhouse-server:24.3",
+        "clickhouse/clickhouse-server:26.3",
         username="test",
         password="test",
         dbname="default",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced **nemo-intake**, an Intake experience for ingesting and reviewing agent telemetry (traces, spans, annotations, evaluator results).
  * Updated skill routing to send trace/telemetry requests to Intake.
  * Added new Intake documentation, including end-to-end setup, ingest/query workflows, and Studio access instructions.

* **Bug Fixes**
  * Improved Intake startup behavior and guidance when ClickHouse is unavailable.
  * Updated local/test ClickHouse defaults to the latest supported version and aligned container naming.

* **Tests**
  * Refreshed Intake-related integration tests for the updated ClickHouse setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->