### PR TITLE
feat(studio): Add latency range filtering to ExperimentGroupDataView

### DIFF
--- a/web/packages/common/src/components/DataView/internal/hooks/useMakeColumns.tsx
+++ b/web/packages/common/src/components/DataView/internal/hooks/useMakeColumns.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isNumberRangeFilter } from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter/util';
 import { LoadingCell } from '@nemo/common/src/components/DataView/internal/cells/LoadingCell';
 import {
   RowActionsCell,
@@ -170,6 +171,12 @@ export function useMakeColumns<TData>({
         col.enableColumnFilter = true;
         if (col.meta.filter.type === 'text' && !col.filterFn) {
           col.filterFn = 'fuzzy' as unknown as FilterFn<TData>;
+        }
+        // Number-range columns store `{ $gte, $lte }`. Without an explicit filterFn, TanStack
+        // resolves a numeric column to `inNumberRange`, whose `autoRemove` treats that object as
+        // an empty `[min, max]` tuple and silently drops the filter on every commit.
+        if (isNumberRangeFilter(col.meta.filter) && !col.filterFn) {
+          col.filterFn = 'numberRange' as unknown as FilterFn<TData>;
         }
         if (col.meta.filter.type === 'multi-select' || col.meta.filter.type === 'single-select') {
           if (!col.filterFn) {

--- a/web/packages/common/src/components/DataView/internal/utils/filterFunctions.test.ts
+++ b/web/packages/common/src/components/DataView/internal/utils/filterFunctions.test.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { filterFunctions } from '@nemo/common/src/components/DataView/internal/utils/filterFunctions';
+import type { Row } from '@tanstack/react-table';
+
+/** Minimal row stub exposing just the getValue the filter functions read. */
+const rowWith = (value: unknown): Row<unknown> =>
+  ({ getValue: () => value }) as unknown as Row<unknown>;
+
+describe('filterFunctions.numberRange', () => {
+  const { numberRange } = filterFunctions;
+
+  it('keeps rows within the inclusive bounds', () => {
+    expect(numberRange(rowWith(50), 'v', { $gte: 10, $lte: 100 }, () => {})).toBe(true);
+    expect(numberRange(rowWith(10), 'v', { $gte: 10, $lte: 100 }, () => {})).toBe(true); // inclusive lower
+    expect(numberRange(rowWith(100), 'v', { $gte: 10, $lte: 100 }, () => {})).toBe(true); // inclusive upper
+  });
+
+  it('excludes rows outside the bounds', () => {
+    expect(numberRange(rowWith(5), 'v', { $gte: 10 }, () => {})).toBe(false);
+    expect(numberRange(rowWith(200), 'v', { $lte: 100 }, () => {})).toBe(false);
+  });
+
+  it('treats a missing bound as open-ended', () => {
+    expect(numberRange(rowWith(9999), 'v', { $gte: 10 }, () => {})).toBe(true);
+    expect(numberRange(rowWith(-5), 'v', { $lte: 100 }, () => {})).toBe(true);
+  });
+
+  it('excludes non-numeric row values', () => {
+    expect(numberRange(rowWith(undefined), 'v', { $gte: 10 }, () => {})).toBe(false);
+    expect(numberRange(rowWith('50'), 'v', { $gte: 10 }, () => {})).toBe(false);
+  });
+
+  // The crux of the bug: TanStack auto-removes a column filter when `filterFn.autoRemove(value)`
+  // returns true. The built-in `inNumberRange.autoRemove` reads `value[0]`/`value[1]` and so
+  // treats our `{ $gte, $lte }` object as empty, silently dropping the filter. Our autoRemove must
+  // keep any range with at least one bound and only clear when both are absent.
+  describe('autoRemove', () => {
+    const autoRemove = numberRange.autoRemove!;
+
+    it('does NOT remove a range with either bound set', () => {
+      expect(autoRemove({ $gte: 10 }, undefined as never)).toBe(false);
+      expect(autoRemove({ $lte: 100 }, undefined as never)).toBe(false);
+      expect(autoRemove({ $gte: 10, $lte: 100 }, undefined as never)).toBe(false);
+      expect(autoRemove({ $gte: 0 }, undefined as never)).toBe(false); // zero is a valid bound
+    });
+
+    it('removes when the value is empty or absent', () => {
+      expect(autoRemove(undefined, undefined as never)).toBe(true);
+      expect(autoRemove({}, undefined as never)).toBe(true);
+    });
+  });
+});

--- a/web/packages/common/src/components/DataView/internal/utils/filterFunctions.ts
+++ b/web/packages/common/src/components/DataView/internal/utils/filterFunctions.ts
@@ -53,7 +53,7 @@ export const filterFunctions = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic across data types
     (row: Row<any>, columnId: string, value: NumberRangeFilterValue | undefined) => {
       const rowValue = row.getValue(columnId);
-      if (typeof rowValue !== 'number') return false;
+      if (typeof rowValue !== 'number' || Number.isNaN(rowValue)) return false;
       const { $gte, $lte } = value ?? {};
       if ($gte != null && rowValue < $gte) return false;
       if ($lte != null && rowValue > $lte) return false;

--- a/web/packages/common/src/components/DataView/internal/utils/filterFunctions.ts
+++ b/web/packages/common/src/components/DataView/internal/utils/filterFunctions.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { NumberRangeFilterValue } from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter/util';
 import type { MultiState } from '@nemo/common/src/components/DataView/internal/types';
 import { rankItem } from '@tanstack/match-sorter-utils';
-import type { FilterMeta, Row } from '@tanstack/react-table';
+import type { FilterFn, FilterMeta, Row } from '@tanstack/react-table';
 
 /**
  * Supplemental filter functions for the DataView component. These are custom filter functions
@@ -38,4 +39,30 @@ export const filterFunctions = {
     const rowValue = `${row.getValue(columnId)}`;
     return Object.keys(value ?? {}).some((v) => v === rowValue);
   },
+  /**
+   * Numeric range filter for `{ $gte, $lte }` values. Keeps rows whose numeric value falls
+   * within the inclusive bounds; either bound may be omitted for an open-ended range.
+   *
+   * An explicit `autoRemove` is essential: without a `filterFn`, TanStack resolves a numeric
+   * column to its built-in `inNumberRange`, whose `autoRemove` reads the value as a `[min, max]`
+   * tuple and treats our `{ $gte, $lte }` object as empty — silently dropping the filter on every
+   * `setFilterValue`. This keeps a filter with either bound set and only clears it when both are
+   * absent (matching the control, which emits `undefined` to clear).
+   */
+  numberRange: Object.assign(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic across data types
+    (row: Row<any>, columnId: string, value: NumberRangeFilterValue | undefined) => {
+      const rowValue = row.getValue(columnId);
+      if (typeof rowValue !== 'number') return false;
+      const { $gte, $lte } = value ?? {};
+      if ($gte != null && rowValue < $gte) return false;
+      if ($lte != null && rowValue > $lte) return false;
+      return true;
+    },
+    {
+      autoRemove: (value: NumberRangeFilterValue | undefined) =>
+        value == null || (value.$gte == null && value.$lte == null),
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FilterFn generic is data-type agnostic here
+  ) as FilterFn<any>,
 };

--- a/web/packages/common/src/hooks/useStudioDataViewState/filterFieldMap.integration.test.tsx
+++ b/web/packages/common/src/hooks/useStudioDataViewState/filterFieldMap.integration.test.tsx
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NumberRangeFilterControl } from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter';
+import { numberRangeFilter } from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter/util';
+import { useCustomReactTable } from '@nemo/common/src/components/DataView/internal/hooks/useCustomReactTable';
+import { useMakeColumns } from '@nemo/common/src/components/DataView/internal/hooks/useMakeColumns';
+import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+/**
+ * Integration tests for the end-to-end range-filter path used by server-side (manual) data views:
+ * a numeric column with a `numberRange` filter, built through the real `useMakeColumns` and wired to
+ * a real TanStack table via `useCustomReactTable`, must commit a `{ $gte, $lte }` value that then
+ * surfaces (remapped via `filterFieldMap`) in `apiFilter.filter` — the object that keys the request.
+ *
+ * These exercise the real hooks/components (no mocks). Crucially the harness feeds **numeric** rows,
+ * so without an explicit `numberRange` filterFn TanStack would resolve the column to its built-in
+ * `inNumberRange`, whose `autoRemove` drops the `{ $gte, $lte }` object and silently kills the
+ * filter (the production bug this guards against).
+ */
+
+interface Row {
+  latency_ms?: { mean?: number };
+}
+
+// Numeric rows so TanStack's auto filterFn resolution would pick `inNumberRange` without the fix.
+const DATA: Row[] = [
+  { latency_ms: { mean: 5 } },
+  { latency_ms: { mean: 150 } },
+  { latency_ms: { mean: 500 } },
+];
+
+function useHarness() {
+  const dataViewState = useStudioDataViewState({
+    filterFieldMap: { latency_ms: 'latency_ms.mean' },
+  });
+  const columns = useMakeColumns<Row>({
+    makeColumns: (columnHelper) => [
+      columnHelper.accessor((r) => r.latency_ms?.mean, {
+        id: 'latency_ms',
+        header: 'Avg Latency',
+        meta: { filter: numberRangeFilter('Avg Latency') },
+      }),
+    ],
+    overrideToLoadingCells: false,
+  });
+  const table = useCustomReactTable<Row>({
+    columns,
+    data: DATA,
+    dataMode: 'manual',
+    state: dataViewState,
+    totalCount: DATA.length,
+  });
+  return { dataViewState, table };
+}
+
+describe('useStudioDataViewState range-filter integration', () => {
+  it('assigns the numberRange filterFn so setFilterValue commits (not auto-removed)', async () => {
+    const { result } = renderHook(() => useHarness(), { wrapper: MemoryRouter });
+
+    // Regression guard: the column must not fall through to TanStack's `inNumberRange`.
+    expect(result.current.table.getColumn('latency_ms')?.columnDef.filterFn).toBe('numberRange');
+    expect(result.current.dataViewState.apiFilter.filter).toBeUndefined();
+
+    act(() => {
+      result.current.table.getColumn('latency_ms')?.setFilterValue({ $gte: 5, $lte: undefined });
+    });
+
+    await waitFor(
+      () =>
+        expect(result.current.dataViewState.apiFilter.filter).toEqual({
+          'latency_ms.mean': { $gte: 5 },
+        }),
+      { timeout: 2000 }
+    );
+  });
+
+  it('emits both bounds under the dotted API key for a closed range', async () => {
+    const { result } = renderHook(() => useHarness(), { wrapper: MemoryRouter });
+
+    act(() => {
+      result.current.table.getColumn('latency_ms')?.setFilterValue({ $gte: 5, $lte: 250 });
+    });
+
+    await waitFor(
+      () =>
+        expect(result.current.dataViewState.apiFilter.filter).toEqual({
+          'latency_ms.mean': { $gte: 5, $lte: 250 },
+        }),
+      { timeout: 2000 }
+    );
+  });
+
+  it('drives apiFilter from the rendered range control (type + blur)', async () => {
+    function Harness() {
+      const { dataViewState, table } = useHarness();
+      const column = table.getColumn('latency_ms');
+      return (
+        <>
+          {column ? <NumberRangeFilterControl column={column as never} /> : null}
+          <div data-testid="api-filter">
+            {JSON.stringify(dataViewState.apiFilter.filter ?? null)}
+          </div>
+        </>
+      );
+    }
+
+    render(<Harness />, { wrapper: MemoryRouter });
+
+    const min = screen.getByPlaceholderText('Min');
+    fireEvent.change(min, { target: { value: '100' } });
+    fireEvent.blur(min);
+
+    await waitFor(
+      () =>
+        expect(screen.getByTestId('api-filter').textContent).toBe(
+          JSON.stringify({ 'latency_ms.mean': { $gte: 100 } })
+        ),
+      { timeout: 2000 }
+    );
+  });
+});

--- a/web/packages/common/src/hooks/useStudioDataViewState/index.test.tsx
+++ b/web/packages/common/src/hooks/useStudioDataViewState/index.test.tsx
@@ -801,6 +801,38 @@ describe('useStudioDataViewState', () => {
         filter: { type: 'local' },
       });
     });
+
+    it('should remap a column filter id to its API key via filterFieldMap', () => {
+      const filters = JSON.stringify([{ id: 'latency_ms', value: { $gte: 5, $lte: 10 } }]);
+      const wrapper = createWrapper([`/?filters=${encodeURIComponent(filters)}`]);
+
+      const { result } = renderHook(
+        () => useStudioDataViewState({ filterFieldMap: { latency_ms: 'latency_ms.mean' } }),
+        { wrapper }
+      );
+
+      expect(result.current.apiFilter.filter).toEqual({
+        'latency_ms.mean': { $gte: 5, $lte: 10 },
+      });
+    });
+
+    it('should leave unmapped column filter ids under their own id', () => {
+      const filters = JSON.stringify([
+        { id: 'latency_ms', value: { $gte: 5 } },
+        { id: 'storage_type', value: 's3' },
+      ]);
+      const wrapper = createWrapper([`/?filters=${encodeURIComponent(filters)}`]);
+
+      const { result } = renderHook(
+        () => useStudioDataViewState({ filterFieldMap: { latency_ms: 'latency_ms.mean' } }),
+        { wrapper }
+      );
+
+      expect(result.current.apiFilter.filter).toEqual({
+        'latency_ms.mean': { $gte: 5 },
+        storage_type: 's3',
+      });
+    });
   });
 
   describe('resetFilters', () => {

--- a/web/packages/common/src/hooks/useStudioDataViewState/index.ts
+++ b/web/packages/common/src/hooks/useStudioDataViewState/index.ts
@@ -38,6 +38,13 @@ export interface UseStudioDataViewStateOptions extends Omit<
    * Example: { id: 'created_at', desc: true } for descending by created_at.
    */
   defaultSort?: { id: string; desc: boolean };
+  /**
+   * Maps a column filter id to the API filter key it should be emitted under.
+   * A column not present in the map is emitted under its own id (current behavior).
+   * Use for columns whose API field differs from the column id, e.g.
+   * `{ latency_ms: 'latency_ms.mean' }`.
+   */
+  filterFieldMap?: Record<string, string>;
 }
 
 /**
@@ -68,7 +75,8 @@ export interface StudioDataViewState<FilterType = Record<string, unknown>>
   debouncedColumnFilters: DataView.TanstackTable.ColumnFiltersState;
   /**
    * Convention-mapped API filter object built from debounced columnFilters and searchBar.
-   * - `columnFilters` entries map to `filter` keys: `{id, value}` → `filter[id] = value`
+   * - `columnFilters` entries map to `filter` keys: `{id, value}` → `filter[id] = value`,
+   *   unless a `filterFieldMap` entry remaps the id to a different API key.
    * - `searchBar` is exposed as `searchText` when non-empty. Consumers are responsible for
    *   mapping `searchText` onto the appropriate filter field (and wrapping it in an operator
    *   like `$like` if fuzzy matching is desired).
@@ -107,6 +115,7 @@ export const useStudioDataViewState = <FilterType = Record<string, unknown>>(
     defaultPage = DEFAULT_PAGE,
     defaultPageSize = DEFAULT_PAGE_SIZE,
     defaultSort,
+    filterFieldMap,
     ...dataViewOptions
   } = options ?? {};
 
@@ -489,12 +498,12 @@ export const useStudioDataViewState = <FilterType = Record<string, unknown>>(
               return false;
             return true;
           })
-          .map((f) => [f.id, f.value])
+          .map((f) => [filterFieldMap?.[f.id] ?? f.id, f.value])
       ) as Partial<FilterType>;
     }
 
     return result;
-  }, [debouncedSearchBar, debouncedColumnFilters]);
+  }, [debouncedSearchBar, debouncedColumnFilters, filterFieldMap]);
 
   // Reset all filters and search
   const resetFilters = useCallback(() => {

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { dateTimeFilter } from '@nemo/common/src/components/DataView/dateTimeFilter';
+import { numberRangeFilter } from '@nemo/common/src/components/DataView/FilterPanel/NumberRangeFilter/util';
 import {
   Root as DataViewRoot,
   EditColumnsMenu,
@@ -41,6 +42,13 @@ const STATIC_SORT_FIELD_MAP: Readonly<Record<string, string>> = {
   cost_usd: 'cost_usd.mean',
   latency_ms: 'latency_ms.mean',
   run_count: 'run_count',
+};
+
+// Maps filterable column ids to their API rollup-stat filter field. The dotted key
+// (e.g. `latency_ms.mean`) is required by the backend's rollup-metric filter parser;
+// the nested shape (`latency_ms.mean` split into objects) is rejected.
+const FILTER_FIELD_MAP: Readonly<Record<string, string>> = {
+  latency_ms: 'latency_ms.mean',
 };
 
 const getExperimentSortParam = (
@@ -93,6 +101,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
     columnVisibility: { created_by: false, updated_at: false },
     // Keep the pin toggle reachable while horizontally scrolling this wide table.
     columnPinning: { left: ['pin'] },
+    filterFieldMap: FILTER_FIELD_MAP,
   });
 
   const page = dataViewState.pagination.state.pageIndex + 1;
@@ -320,7 +329,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({
       accessor((original) => original.latency_ms?.mean, {
         id: 'latency_ms',
         header: 'Avg Latency',
-        meta: { title: false },
+        meta: { title: false, filter: numberRangeFilter('Avg Latency') },
         enableSorting: true,
         cell: ({ row }) => {
           const { latency_ms, run_count } = row.original;


### PR DESCRIPTION

https://github.com/user-attachments/assets/a922c1d7-4654-4765-8942-2a5687092ed7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added numeric “range” filtering support for relevant data table columns, including min/max handling for latency.
  * Enabled mapping of displayed filter fields to the backend’s required filter keys for range queries.
* **Bug Fixes**
  * Prevented numeric range filters from being auto-removed when one bound (or zero) is present.
  * Ensured range filters only apply to numeric values and handle missing bounds safely.
* **Tests**
  * Added unit tests for `numberRange` behavior and auto-remove rules.
  * Added integration coverage for end-to-end range filtering and filter-field remapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->