### PR TITLE
feat(cli): add anonymous usage telemetry

### DIFF
--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -151,6 +151,8 @@ Collected data includes:
 
 The events are batched and sent to NVIDIA's telemetry endpoint with no user or device identifiers attached.
 
+A random per-run session identifier groups the events from a single invocation. It is generated fresh each time you run a `nemo` command, carries no user or device identity, and is discarded when the process exits.
+
 ### What Data Is Not Collected
 
 - User data, prompts, or model outputs

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -131,3 +131,75 @@ nemo models <Tab>
 ```
 
 If completion isn't working, make sure you've restarted your shell and that your shell supports programmable completion. For Bash, ensure `bash-completion` is installed on your system.
+
+## Telemetry
+
+NeMo Platform collects anonymous usage data to improve the product. On your first run, the CLI prints a notice to standard error explaining what data is collected and how to opt out.
+
+### What Data Is Collected
+
+The CLI and bundled plugins emit anonymous usage events. No prompts, user data, personal information, or file contents leave your machine.
+
+Collected data includes:
+
+- Command and job names you invoke
+- Completion status and duration of commands and jobs
+- Plugin and tool names you use
+- Provider type and model counts (bucketed, not exact)
+- Input and output token counts per model (where available)
+- Package version and CPU architecture
+
+The events are batched and sent to NVIDIA's telemetry endpoint with no user or device identifiers attached.
+
+### What Data Is Not Collected
+
+- User data, prompts, or model outputs
+- File contents or references
+- Usernames, email addresses, IP addresses, or hostnames
+- Machine fingerprints or unique identifiers
+
+### Opting Out
+
+Disable telemetry using any of these three methods (they all work):
+
+#### 1. Environment Variable
+
+```bash
+export NEMO_TELEMETRY_ENABLED=false
+```
+
+Then run any `nemo` command. This disables telemetry for the CLI and all bundled plugins for that session and all future sessions (until you unset it).
+
+#### 2. Configuration File
+
+Add this to your configuration file at `~/.config/nmp/config.yaml`:
+
+```yaml
+telemetry_enabled: false
+```
+
+#### 3. Per-Command Flag
+
+```bash
+nemo --no-telemetry workspaces list
+```
+
+The `--no-telemetry` flag disables telemetry for a single command only.
+
+<Note>
+
+These three layers are independent. NeMo Platform sends telemetry only when you have not disabled it in any of them. Setting any one layer to off disables telemetry, and no layer turns it back on. For example, if you leave the environment variable unset but set `telemetry_enabled: false` in your config file, telemetry stays off.
+
+</Note>
+
+### Bundled Plugins
+
+NeMo Platform ships with plugins that emit their own anonymous usage telemetry. The `NEMO_TELEMETRY_ENABLED` environment variable is the recommended single off switch: set it to `false` to disable telemetry for the CLI and for NeMo tools that share this telemetry system. The config file setting and the `--no-telemetry` flag apply to the CLI.
+
+### First-Run Notice
+
+On your first run, the CLI writes this notice to standard error:
+
+> NeMo Platform collects anonymous usage data to improve the product. No prompts, data, or personal information leave your machine. Turn it off any time with NEMO_TELEMETRY_ENABLED=false.
+
+The notice appears only once, and you can opt out at any time using one of the methods above.

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -29,6 +29,7 @@ nemo [GLOBAL OPTIONS] COMMAND [ARGS]...
 * `--timestamp-format <CHOICE>`: Timestamp format for table/markdown/csv output [possible values: relative, iso8601]
 * `--verbose, -v`: Enable verbose messaging. This only impacts logs that are visible, it doesn't change any data outputs.
 * `--agent-mode, -A`: Enable agent-friendly output mode with extra context for coding agents.
+* `--no-telemetry`: Disable anonymous usage telemetry for this invocation.
 
 **Help:**
 

--- a/docs/fern/snippets/_snippets/cli-summary.mdx
+++ b/docs/fern/snippets/_snippets/cli-summary.mdx
@@ -12,6 +12,7 @@ description: ""
 | `--timestamp-format <CHOICE>` | Timestamp format for table/markdown/csv output [possible values: relative, iso8601] |
 | `--verbose, -v` | Enable verbose messaging. This only impacts logs that are visible, it doesn't change any data outputs. |
 | `--agent-mode, -A` | Enable agent-friendly output mode with extra context for coding agents. |
+| `--no-telemetry` | Disable anonymous usage telemetry for this invocation. |
 
 **Commands** are organized into categories:
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/app.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/app.py
@@ -220,6 +220,14 @@ def main(
             hidden=True,
         ),
     ] = False,
+    no_telemetry: Annotated[
+        bool,
+        typer.Option(
+            "--no-telemetry",
+            help="Disable anonymous usage telemetry for this invocation.",
+            rich_help_panel="Global Options",
+        ),
+    ] = False,
 ) -> None:
     """
     Command-line interface for NeMo Platform.
@@ -251,6 +259,12 @@ def main(
         env_val = os.environ.get("NMP_AGENT_MODE", "").lower()
         agent_mode = env_val in ("1", "true", "yes")
     ctx.obj.agent_mode = agent_mode
+
+    # Capture command name + agent mode for the command_invoked telemetry event, wire
+    # the per-invocation opt-out, and print the first-run notice. Best effort inside.
+    from nemo_platform_ext.cli.telemetry import runtime as telemetry_runtime
+
+    telemetry_runtime.on_callback(ctx, no_telemetry=no_telemetry)
 
     # Build ConfigParams from CLI args
     overrides: ConfigParams = {}

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -45,6 +45,8 @@ from nemo_platform_ext.cli.commands.skills.base import Scope, Skill
 from nemo_platform_ext.cli.commands.skills.registry import get_installer, load_skills
 from nemo_platform_ext.cli.core.context import CLIContext
 from nemo_platform_ext.cli.core.errors import handle_errors
+from nemo_platform_ext.cli.telemetry import emit
+from nemo_platform_ext.cli.telemetry.events import OnboardingStepEvent, TaskStatusEnum
 from nemo_platform_ext.config.config import Config
 from nemo_platform_ext.config.models import ConfigFile, ConfigParams, LocalServicesConfig
 from nemo_platform_ext.ui.prompts import (
@@ -423,7 +425,16 @@ def _create_provider(
             kwargs["required_extra_headers"] = {header_name.strip(): header_value.strip()}
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
-    client.inference.providers.create(**kwargs)
+    try:
+        client.inference.providers.create(**kwargs)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(step="provider_connected", task_status=TaskStatusEnum.ERROR, provider_type=name)
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(step="provider_connected", task_status=TaskStatusEnum.COMPLETED, provider_type=name)
+    )
 
 
 def _update_provider(
@@ -450,7 +461,51 @@ _PROVIDER_UNHEALTHY_STATUSES = frozenset({"ERROR", "LOST"})
 _NON_COMPLIANT_MARKER = "Non-OpenAI compliant"
 
 
+def _bucket_model_count(count: int) -> str:
+    """Bucket a discovered-model count into a coarse range for telemetry.
+
+    Keeps the emitted value low-cardinality (no exact counts leave the machine).
+    """
+    if count <= 0:
+        return "0"
+    if count <= 5:
+        return "1-5"
+    if count <= 20:
+        return "6-20"
+    if count <= 100:
+        return "21-100"
+    return "101+"
+
+
 def _wait_for_models(
+    client: NeMoPlatform,
+    provider_name: str,
+    workspace: str,
+    host_url: str = "",
+    round_seconds: int = _MODEL_DISCOVERY_ROUND_SECONDS,
+    max_rounds: int = _MODEL_DISCOVERY_MAX_ROUNDS,
+) -> list[str]:
+    """Poll for served models and emit one ``models_discovered`` event.
+
+    Thin telemetry wrapper around :func:`_wait_for_models_impl`: COMPLETED with
+    the discovered-count bucket on success, ERROR (re-raised) if polling blows up.
+    """
+    try:
+        models = _wait_for_models_impl(client, provider_name, workspace, host_url, round_seconds, max_rounds)
+    except Exception:
+        emit.emit_event(OnboardingStepEvent(step="models_discovered", task_status=TaskStatusEnum.ERROR))
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="models_discovered",
+            task_status=TaskStatusEnum.COMPLETED,
+            models_discovered_bucket=_bucket_model_count(len(models)),
+        )
+    )
+    return models
+
+
+def _wait_for_models_impl(
     client: NeMoPlatform,
     provider_name: str,
     workspace: str,
@@ -930,20 +985,30 @@ def _run_skill_install(
         console.print(f"  {WARN} No skills selected to install.")
         return
 
-    successes = 0
-    failures = 0
-    for agent in agents:
-        try:
-            installer = get_installer(agent)
-            installer.install(scope, project_root, chosen)
-            console.print(f"  {CHECK} Installed {len(chosen)} skill(s) for {agent}")
-            successes += 1
-        except Exception as exc:
-            console.print(f"  {WARN} Failed to install skills for {agent}: {exc}")
-            failures += 1
+    skills_target = ",".join(agents)
+    try:
+        successes = 0
+        failures = 0
+        for agent in agents:
+            try:
+                installer = get_installer(agent)
+                installer.install(scope, project_root, chosen)
+                console.print(f"  {CHECK} Installed {len(chosen)} skill(s) for {agent}")
+                successes += 1
+            except Exception as exc:
+                console.print(f"  {WARN} Failed to install skills for {agent}: {exc}")
+                failures += 1
 
-    if failures and not successes:
-        raise typer.Exit(1)
+        if failures and not successes:
+            raise typer.Exit(1)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(step="skills_installed", task_status=TaskStatusEnum.ERROR, skills_target=skills_target)
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(step="skills_installed", task_status=TaskStatusEnum.COMPLETED, skills_target=skills_target)
+    )
 
 
 def _parse_csv_flag(value: str | None) -> list[str] | None:
@@ -1160,6 +1225,25 @@ def _agents_api_ready(base_url: str, workspace: str) -> bool:
 
 
 def _deploy_demo_agent(base_url: str, workspace: str, config_path: Traversable, default_model: str) -> bool:
+    """Deploy the demo agent and emit one ``agent_deployed`` event.
+
+    Telemetry wrapper around :func:`_deploy_demo_agent_impl`: COMPLETED with the
+    deployment outcome as ``agent_deployed`` on success, ERROR (re-raised) on failure.
+    """
+    try:
+        deployed = _deploy_demo_agent_impl(base_url, workspace, config_path, default_model)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(step="agent_deployed", task_status=TaskStatusEnum.ERROR, agent_deployed=False)
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(step="agent_deployed", task_status=TaskStatusEnum.COMPLETED, agent_deployed=deployed)
+    )
+    return deployed
+
+
+def _deploy_demo_agent_impl(base_url: str, workspace: str, config_path: Traversable, default_model: str) -> bool:
     """Create and deploy the demo calculator agent. Returns True on success."""
     # Optional plugin: import here so ``nemo setup`` works without nemo-agents installed.
     from nemo_agents_plugin.utils import expand_env_vars
@@ -1711,30 +1795,37 @@ def setup_command(
     skills_agents_list = _parse_csv_flag(skills_agents)
     skills_from_list = _parse_csv_flag(skills_from)
 
-    if auto:
-        _run_auto_mode(
-            cli_context,
-            client,
-            workspace,
-            base_url,
-            install_skills,
-            deploy_agent,
-            skills_agents=skills_agents_list,
-            skills_scope=skills_scope,
-            skills_from=skills_from_list,
-        )
-    else:
-        _run_interactive_mode(
-            cli_context,
-            client,
-            workspace,
-            base_url,
-            install_skills,
-            deploy_agent,
-            skills_agents=skills_agents_list,
-            skills_scope=skills_scope,
-            skills_from=skills_from_list,
-        )
+    try:
+        if auto:
+            _run_auto_mode(
+                cli_context,
+                client,
+                workspace,
+                base_url,
+                install_skills,
+                deploy_agent,
+                skills_agents=skills_agents_list,
+                skills_scope=skills_scope,
+                skills_from=skills_from_list,
+            )
+        else:
+            _run_interactive_mode(
+                cli_context,
+                client,
+                workspace,
+                base_url,
+                install_skills,
+                deploy_agent,
+                skills_agents=skills_agents_list,
+                skills_scope=skills_scope,
+                skills_from=skills_from_list,
+            )
+    except Exception:
+        # Covers a non-zero typer.Exit (including the exit(0) raised on user
+        # cancel) and any real failure: setup did not finish cleanly.
+        emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=TaskStatusEnum.ERROR))
+        raise
+    emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=TaskStatusEnum.COMPLETED))
 
 
 def _run_auto_mode(
@@ -1770,6 +1861,16 @@ def _run_auto_mode(
             break
         if attempt < _MODEL_DISCOVERY_MAX_ROUNDS - 1:
             console.print(f"  {WARN} Models not available yet, retrying...")
+
+    # Auto mode discovers models via an inline loop rather than _wait_for_models,
+    # so emit the models_discovered event here to cover the non-interactive path.
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="models_discovered",
+            task_status=TaskStatusEnum.COMPLETED,
+            models_discovered_bucket=_bucket_model_count(len(entity_ids)),
+        )
+    )
 
     default_model = os.environ.get("NEMO_DEFAULT_MODEL", "").strip()
     if not default_model and entity_ids:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -1820,9 +1820,15 @@ def setup_command(
                 skills_scope=skills_scope,
                 skills_from=skills_from_list,
             )
+    except typer.Exit as exc:
+        # A clean user-cancel raises typer.Exit(0); that is a normal end of the
+        # flow, not a failure, so it must not corrupt the onboarding funnel.
+        # Only a non-zero exit code counts as ERROR. Re-raise unchanged either way.
+        status = TaskStatusEnum.COMPLETED if exc.exit_code == 0 else TaskStatusEnum.ERROR
+        emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=status))
+        raise
     except Exception:
-        # Covers a non-zero typer.Exit (including the exit(0) raised on user
-        # cancel) and any real failure: setup did not finish cleanly.
+        # Any real (non-Exit) failure: setup did not finish cleanly.
         emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=TaskStatusEnum.ERROR))
         raise
     emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=TaskStatusEnum.COMPLETED))

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/help_formatter.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/help_formatter.py
@@ -69,6 +69,15 @@ class NmpErrorHandlingMixin:
         is_telemetry_root = type(self).__name__ == "ManifestBackedNmpGroup"
         if is_telemetry_root:
             runtime.reset()
+            # Reading help (e.g. ``nemo docs --help``) is not usage, so it must not emit
+            # a command_invoked event. Detect a help request from the resolved args; the
+            # help option names are the same ones every command registers via
+            # ``_context_settings_with_help``.
+            import sys
+
+            resolved_args = args if args is not None else sys.argv[1:]
+            if any(arg in HELP_OPTION_NAMES for arg in resolved_args):
+                runtime.state.help_requested = True
 
         start = time.monotonic()
         status: TaskStatusEnum | None = None

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/help_formatter.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/help_formatter.py
@@ -47,36 +47,77 @@ class NmpErrorHandlingMixin:
         standalone_mode: bool = True,
         **extra: Any,
     ) -> Any:
-        """Override main to use custom error handling."""
-        from nemo_platform_ext.cli.core.errors import handle_exception
+        """Override main to use custom error handling and emit one telemetry event.
 
+        This is the single path every command type flows through (hand-registered,
+        OpenAPI-generated, plugin entry points), and Click only calls ``main()`` on the
+        root command object, so this is the natural choke point for a per-invocation
+        ``command_invoked`` event. The outcome->status mapping and the emit both live in
+        a ``finally`` so telemetry fires even when a command fails, and the emit body is
+        best-effort (never raises) so a telemetry bug can never change a command's exit
+        code or output.
+        """
+        import time
+
+        from nemo_platform_ext.cli.core.errors import handle_exception
+        from nemo_platform_ext.cli.telemetry import runtime
+        from nemo_platform_ext.cli.telemetry.events import TaskStatusEnum
+
+        # Only the root group (the app-level ManifestBackedNmpGroup) drives telemetry.
+        # Nested groups never have main() called during dispatch, but this guard keeps
+        # the single-emit contract explicit and cheap without an import cycle.
+        is_telemetry_root = type(self).__name__ == "ManifestBackedNmpGroup"
+        if is_telemetry_root:
+            runtime.reset()
+
+        start = time.monotonic()
+        status: TaskStatusEnum | None = None
         try:
-            result = super().main(  # type: ignore[misc]
-                args=args,
-                prog_name=prog_name,
-                complete_var=complete_var,
-                standalone_mode=False,
-                **extra,
-            )
-            # When standalone_mode=False, Click returns the exit code instead of raising
-            # SystemExit. We need to convert non-zero exit codes back to SystemExit
-            # when the original caller expected standalone_mode=True behavior.
-            if standalone_mode and isinstance(result, int) and result != 0:
-                raise SystemExit(result)
-            return result
-        except click.UsageError as e:
-            if standalone_mode:
-                handle_exception(e, e.ctx)
+            try:
+                result = super().main(  # type: ignore[misc]
+                    args=args,
+                    prog_name=prog_name,
+                    complete_var=complete_var,
+                    standalone_mode=False,
+                    **extra,
+                )
+                # When standalone_mode=False, Click returns the exit code instead of
+                # raising. A non-zero code is an error regardless of how the outer caller
+                # ultimately surfaces it.
+                status = TaskStatusEnum.ERROR if isinstance(result, int) and result != 0 else TaskStatusEnum.COMPLETED
+                # Convert non-zero exit codes back to SystemExit when the original caller
+                # expected standalone_mode=True behavior.
+                if standalone_mode and isinstance(result, int) and result != 0:
+                    raise SystemExit(result)
+                return result
+            except click.UsageError as e:
+                status = TaskStatusEnum.ERROR
+                if standalone_mode:
+                    handle_exception(e, e.ctx)
+                raise
+            except click.exceptions.Exit as e:
+                status = TaskStatusEnum.COMPLETED if e.exit_code == 0 else TaskStatusEnum.ERROR
+                if standalone_mode:
+                    raise SystemExit(e.exit_code)
+                raise
+            except click.Abort:
+                status = TaskStatusEnum.CANCELED
+                if standalone_mode:
+                    click.echo("Aborted!", err=True)
+                    raise SystemExit(1)
+                raise
+        except SystemExit as e:
+            if status is None:
+                code = e.code
+                status = TaskStatusEnum.COMPLETED if code in (0, None) else TaskStatusEnum.ERROR
             raise
-        except click.exceptions.Exit as e:
-            if standalone_mode:
-                raise SystemExit(e.exit_code)
+        except BaseException:
+            if status is None:
+                status = TaskStatusEnum.ERROR
             raise
-        except click.Abort:
-            if standalone_mode:
-                click.echo("Aborted!", err=True)
-                raise SystemExit(1)
-            raise
+        finally:
+            if is_telemetry_root:
+                runtime.emit_command_invoked(status or TaskStatusEnum.COMPLETED, time.monotonic() - start)
 
 
 def _get_terminal_width() -> int:
@@ -524,6 +565,14 @@ class NmpGroup(NmpErrorHandlingMixin, TyperGroup):
         if "cls" not in kwargs:
             kwargs["cls"] = NmpCommand
         return super().command(*args, **kwargs)
+
+    def resolve_command(self, ctx: click.Context, args: list[str]) -> tuple[str | None, Command | None, list[str]]:
+        """Record the resolved subcommand name for telemetry, then resolve as usual."""
+        cmd_name, cmd, remaining = super().resolve_command(ctx, args)
+        from nemo_platform_ext.cli.telemetry import runtime
+
+        runtime.note_subcommand(cmd_name)
+        return cmd_name, cmd, remaining
 
     def get_command(self, ctx: click.Context, cmd_name: str) -> Command | None:
         """Override to patch command classes to use NeMo Platform formatting."""

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/waiters.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/waiters.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from datetime import datetime
 from typing import Any
@@ -26,6 +27,7 @@ from rich.console import Console
 from rich.live import Live
 from rich.text import Text
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 _TRANSIENT_GATEWAY_STATUS_CODES = {429, 502, 503, 504}
@@ -53,6 +55,48 @@ def _seconds_since_creation(entry_timestamp: datetime | str | None, created_at: 
 
 def _status_text(status: Any) -> str:
     return str(status or "")
+
+
+def _emit_job_run_event(job_status: Any, *, resource_label: str, status: str, start_time: float) -> None:
+    """Emit a ``job_run`` telemetry event for a terminal platform job.
+
+    Best effort: never raises and never affects the waiter's return value.
+    """
+    try:
+        from nemo_platform_ext.cli.telemetry.emit import emit_event
+        from nemo_platform_ext.cli.telemetry.events import JobRunEvent, TaskStatusEnum
+
+        status_map = {
+            "completed": TaskStatusEnum.COMPLETED,
+            "error": TaskStatusEnum.ERROR,
+            "cancelled": TaskStatusEnum.CANCELED,
+        }
+        task_status = status_map.get(status, TaskStatusEnum.UNDEFINED)
+
+        details = getattr(job_status, "status_details", None)
+        if not isinstance(details, dict):
+            details = {}
+
+        plugins: set[str] = set()
+        for step in getattr(job_status, "steps", None) or []:
+            step_name = getattr(step, "name", "") or ""
+            prefix = step_name.split(".", 1)[0]
+            if prefix:
+                plugins.add(prefix)
+
+        emit_event(
+            JobRunEvent(
+                task_status=task_status,
+                job_type=resource_label,
+                duration_sec=float(time.time() - start_time),
+                plugins=sorted(plugins),
+                model=details.get("model", "undefined"),
+                input_tokens=details.get("input_tokens", -1),
+                output_tokens=details.get("output_tokens", -1),
+            )
+        )
+    except Exception:
+        logger.debug("Failed to emit job_run telemetry event", exc_info=True)
 
 
 def _make_history_line(
@@ -270,11 +314,17 @@ def wait_for_platform_job(
 
             if current_status == "completed":
                 live.stop()
+                _emit_job_run_event(
+                    job_status, resource_label=resource_label, status=current_status, start_time=start_time
+                )
                 console.print(f"\n[green]✓ {resource_label.title()} completed![/green]")
                 return True
 
             if current_status in {"cancelled", "error"}:
                 live.stop()
+                _emit_job_run_event(
+                    job_status, resource_label=resource_label, status=current_status, start_time=start_time
+                )
                 console.print(f"\n[red]✗ {resource_label.title()} entered {current_status} state[/red]")
                 return False
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/waiters.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/waiters.py
@@ -77,12 +77,14 @@ def _emit_job_run_event(job_status: Any, *, resource_label: str, status: str, st
         if not isinstance(details, dict):
             details = {}
 
-        plugins: set[str] = set()
-        for step in getattr(job_status, "steps", None) or []:
-            step_name = getattr(step, "name", "") or ""
-            prefix = step_name.split(".", 1)[0]
-            if prefix:
-                plugins.add(prefix)
+        # job_type is the job's operation entry point(s) (for example "auditor.audit"), read
+        # from the step names per the PRD. These are static plugin.operation identifiers, not
+        # the user-chosen job name, so they carry no user data. It falls back to the resource
+        # label when the job reports no steps. plugins are the distinct plugin prefixes.
+        entry_points = sorted(
+            {name for step in (getattr(job_status, "steps", None) or []) if (name := getattr(step, "name", "") or "")}
+        )
+        plugins = sorted({ep.split(".", 1)[0] for ep in entry_points})
 
         # ``status_details`` can carry an explicit null (e.g. ``model: null``). Passing
         # None to the str-typed / int-typed event fields fails validation and the
@@ -97,9 +99,9 @@ def _emit_job_run_event(job_status: Any, *, resource_label: str, status: str, st
         emit_event(
             JobRunEvent(
                 task_status=task_status,
-                job_type=resource_label,
+                job_type=",".join(entry_points) if entry_points else resource_label,
                 duration_sec=float(time.time() - start_time),
-                plugins=sorted(plugins),
+                plugins=plugins,
                 model=model,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/waiters.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/waiters.py
@@ -84,15 +84,25 @@ def _emit_job_run_event(job_status: Any, *, resource_label: str, status: str, st
             if prefix:
                 plugins.add(prefix)
 
+        # ``status_details`` can carry an explicit null (e.g. ``model: null``). Passing
+        # None to the str-typed / int-typed event fields fails validation and the
+        # best-effort guard would silently drop the whole event, so coerce here.
+        # Tokens use explicit None checks, not ``or``, so a legitimate 0 survives as 0.
+        model = details.get("model") or "undefined"
+        raw_input_tokens = details.get("input_tokens")
+        input_tokens = int(raw_input_tokens) if raw_input_tokens is not None else -1
+        raw_output_tokens = details.get("output_tokens")
+        output_tokens = int(raw_output_tokens) if raw_output_tokens is not None else -1
+
         emit_event(
             JobRunEvent(
                 task_status=task_status,
                 job_type=resource_label,
                 duration_sec=float(time.time() - start_time),
                 plugins=sorted(plugins),
-                model=details.get("model", "undefined"),
-                input_tokens=details.get("input_tokens", -1),
-                output_tokens=details.get("output_tokens", -1),
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
             )
         )
     except Exception:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from nemo_platform_ext.cli.telemetry.handler import (
+    QueuedEvent,
+    TelemetryHandler,
+    _telemetry_enabled,
+    build_payload,
+)
+
+__all__ = [
+    "QueuedEvent",
+    "TelemetryHandler",
+    "_telemetry_enabled",
+    "build_payload",
+]

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/emit.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/emit.py
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 
 _invocation_opt_out = False
 
+# One random session id per process. It groups every event emitted during a single
+# invocation without carrying any user or device identity, and is discarded when the
+# process exits. This is the same pattern the Agno framework uses for session_id/run_id.
+_SESSION_ID = uuid.uuid4().hex
+
 _NOTICE_TEXT = (
     "NeMo Platform collects anonymous usage data to improve the product. "
     "No prompts, data, or personal information leave your machine. "
@@ -37,7 +42,10 @@ def _config_opted_out() -> bool:
         cfg = Config.load()
         return getattr(cfg.get_config_file(), "telemetry_enabled", True) is False
     except Exception:
-        return False
+        # A privacy control must fail closed: if we cannot read the config to confirm
+        # the user is opted in, treat them as opted out and do not send.
+        logger.debug("Could not read telemetry opt-out config; failing closed (opted out)", exc_info=True)
+        return True
 
 
 def telemetry_opted_in() -> bool:
@@ -55,6 +63,7 @@ def _client_version() -> str:
 
         return nemo_platform.__version__
     except Exception:
+        logger.debug("Could not resolve client version for telemetry", exc_info=True)
         return "undefined"
 
 
@@ -63,7 +72,7 @@ def emit_event(event: PlatformTelemetryEvent) -> None:
     try:
         if not telemetry_opted_in():
             return
-        handler = TelemetryHandler(source_client_version=_client_version(), session_id=uuid.uuid4().hex)
+        handler = TelemetryHandler(source_client_version=_client_version(), session_id=_SESSION_ID)
         handler.enqueue(event)
         handler.stop()
     except Exception:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/emit.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/emit.py
@@ -72,7 +72,10 @@ def emit_event(event: PlatformTelemetryEvent) -> None:
     try:
         if not telemetry_opted_in():
             return
-        handler = TelemetryHandler(source_client_version=_client_version(), session_id=_SESSION_ID)
+        # No retries on the CLI exit path: a synchronous send blocks the user's command,
+        # so cap the worst case at one bounded send (SEND_TIMEOUT_SECONDS) rather than
+        # retrying against a slow or unreachable endpoint while the user waits.
+        handler = TelemetryHandler(source_client_version=_client_version(), session_id=_SESSION_ID, max_retries=0)
         handler.enqueue(event)
         handler.stop()
     except Exception:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/emit.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/emit.py
@@ -24,7 +24,8 @@ _SESSION_ID = uuid.uuid4().hex
 _NOTICE_TEXT = (
     "NeMo Platform collects anonymous usage data to improve the product. "
     "No prompts, data, or personal information leave your machine. "
-    "Turn it off any time with NEMO_TELEMETRY_ENABLED=false.\n"
+    "Turn it off any time with NEMO_TELEMETRY_ENABLED=false. "
+    "Run nemo docs cli/configuration for details.\n"
 )
 
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/emit.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/emit.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Fire-and-flush emission with three opt-out layers and the first-run notice."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import uuid
+from pathlib import Path
+
+from nemo_platform_ext.cli.telemetry.events import PlatformTelemetryEvent
+from nemo_platform_ext.cli.telemetry.handler import TelemetryHandler, _telemetry_enabled
+
+logger = logging.getLogger(__name__)
+
+_invocation_opt_out = False
+
+_NOTICE_TEXT = (
+    "NeMo Platform collects anonymous usage data to improve the product. "
+    "No prompts, data, or personal information leave your machine. "
+    "Turn it off any time with NEMO_TELEMETRY_ENABLED=false.\n"
+)
+
+
+def set_invocation_opt_out(value: bool) -> None:
+    """Per-invocation opt-out (e.g. a --no-telemetry flag on the current command)."""
+    global _invocation_opt_out
+    _invocation_opt_out = value
+
+
+def _config_opted_out() -> bool:
+    """True when the persisted config file sets ``telemetry_enabled: false``."""
+    try:
+        from nemo_platform_ext.config.config import Config
+
+        cfg = Config.load()
+        return getattr(cfg.get_config_file(), "telemetry_enabled", True) is False
+    except Exception:
+        return False
+
+
+def telemetry_opted_in() -> bool:
+    """Opted in only when all three layers agree: per-invocation, env, and config."""
+    if _invocation_opt_out:
+        return False
+    if not _telemetry_enabled():
+        return False
+    return not _config_opted_out()
+
+
+def _client_version() -> str:
+    try:
+        import nemo_platform
+
+        return nemo_platform.__version__
+    except Exception:
+        return "undefined"
+
+
+def emit_event(event: PlatformTelemetryEvent) -> None:
+    """Best effort. Telemetry must never break a user command."""
+    try:
+        if not telemetry_opted_in():
+            return
+        handler = TelemetryHandler(source_client_version=_client_version(), session_id=uuid.uuid4().hex)
+        handler.enqueue(event)
+        handler.stop()
+    except Exception:
+        logger.debug("Failed to emit telemetry event", exc_info=True)
+
+
+def _notice_marker_path() -> Path:
+    from nemo_platform_ext.config.config import Config
+
+    return Config.get_default_config_path().parent / "telemetry-notice-shown"
+
+
+def maybe_print_first_run_notice() -> None:
+    """Print the first-run notice to stderr once. Stdout stays machine-clean."""
+    try:
+        if not telemetry_opted_in():
+            return
+        marker = _notice_marker_path()
+        if marker.exists():
+            return
+        sys.stderr.write(_NOTICE_TEXT)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+    except Exception:
+        logger.debug("Failed to print telemetry notice", exc_info=True)

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/events.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/events.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Platform usage-telemetry event models.
+
+Field names and aliases follow the shared NeMo telemetry schema
+(aire/microservices/nemo-telemetry, schemas/anonymous_events.json, v1.9).
+"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_CI_ENV_VARS = ("CI", "GITLAB_CI", "GITHUB_ACTIONS")
+_TRUTHY = ("1", "true", "yes")
+
+
+def is_ci_environment() -> bool:
+    return any(os.getenv(v, "").lower() in _TRUTHY for v in _CI_ENV_VARS)
+
+
+class TaskStatusEnum(str, Enum):
+    COMPLETED = "completed"
+    ERROR = "error"
+    CANCELED = "canceled"
+    UNDEFINED = "undefined"
+
+
+class DeploymentTypeEnum(str, Enum):
+    CLI = "cli"
+    SDK = "sdk"
+    NVIDIA_INTERNAL = "nvidia-internal"
+    UNDEFINED = "undefined"
+
+
+def _deployment_type() -> DeploymentTypeEnum:
+    raw = os.getenv("NEMO_DEPLOYMENT_TYPE", "cli").lower()
+    try:
+        return DeploymentTypeEnum(raw)
+    except ValueError:
+        return DeploymentTypeEnum.UNDEFINED
+
+
+class PlatformTelemetryEvent(BaseModel):
+    """Base for all platform events. extra="forbid" is a privacy guard."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    _event_name: ClassVar[str] = "undefined"
+    _schema_version: ClassVar[str] = "1.9"
+
+    nemo_source: str = Field(default="platform", serialization_alias="nemoSource")
+    task_status: TaskStatusEnum = Field(serialization_alias="taskStatus")
+    deployment_type: DeploymentTypeEnum = Field(default_factory=_deployment_type, serialization_alias="deploymentType")
+    is_ci: bool = Field(default_factory=is_ci_environment, serialization_alias="isCi")
+
+
+class OnboardingStepEvent(PlatformTelemetryEvent):
+    _event_name: ClassVar[str] = "onboarding_step"
+
+    step: str
+    provider_type: str = Field(default="undefined", serialization_alias="providerType")
+    models_discovered_bucket: str = Field(default="undefined", serialization_alias="modelsDiscoveredBucket")
+    skills_target: str = Field(default="undefined", serialization_alias="skillsTarget")
+    agent_deployed: bool = Field(default=False, serialization_alias="agentDeployed")
+
+
+class CommandInvokedEvent(PlatformTelemetryEvent):
+    _event_name: ClassVar[str] = "command_invoked"
+
+    command: str
+    duration_sec: float = Field(serialization_alias="durationSec")
+    agent_mode: bool = Field(default=False, serialization_alias="agentMode")
+
+
+class JobRunEvent(PlatformTelemetryEvent):
+    _event_name: ClassVar[str] = "job_run"
+
+    job_type: str = Field(serialization_alias="jobType")
+    duration_sec: float = Field(default=-1.0, serialization_alias="durationSec")
+    plugins: list[str] = Field(default_factory=list)
+    model: str = "undefined"
+    input_tokens: int = Field(default=-1, serialization_alias="inputTokens")
+    output_tokens: int = Field(default=-1, serialization_alias="outputTokens")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/handler.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/handler.py
@@ -34,6 +34,10 @@ CLIENT_ID = "184482118588404"
 NEMO_TELEMETRY_VERSION = "nemo-telemetry/1.0"
 DEFAULT_ENDPOINT = "https://events.telemetry.data.nvidia.com/v1.1/events/json"
 MAX_RETRIES = 3
+# Tight explicit timeout so a hung or black-holed endpoint can never block a command
+# at exit for longer than this. httpx's default is ~5s, which is too long for a
+# best-effort flush that runs synchronously on the command's exit path.
+SEND_TIMEOUT_SECONDS = 2.0
 CPU_ARCHITECTURE = platform.uname().machine
 logger = logging.getLogger(__name__)
 
@@ -380,9 +384,10 @@ class TelemetryHandler:
         try:
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=SEND_TIMEOUT_SECONDS) as client:
                 await self._send_events_with_client(client, events)
         except Exception:  # noqa: BLE001
+            logger.debug("Telemetry send failed; routing events to DLQ", exc_info=True)
             self._add_to_dlq(events)
 
     async def _send_events_with_client(self, client: httpx.AsyncClient, events: list[QueuedEvent]) -> None:
@@ -424,6 +429,7 @@ class TelemetryHandler:
             if response.status_code == 408 or response.status_code >= 500:
                 self._add_to_dlq(events)
         except Exception:  # noqa: BLE001
+            logger.debug("Telemetry POST failed; routing events to DLQ", exc_info=True)
             self._add_to_dlq(events)
 
     def _add_to_dlq(self, events: list[QueuedEvent]) -> None:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/handler.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/handler.py
@@ -1,0 +1,448 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Telemetry handler for NeMo products.
+
+Environment variables:
+- NEMO_TELEMETRY_ENABLED: Whether telemetry is enabled.
+- NEMO_DEPLOYMENT_TYPE: The deployment type the event came from.
+- NEMO_TELEMETRY_ENDPOINT: The endpoint to send the telemetry events to.
+- NEMO_SESSION_PREFIX: Optional prefix to add to session IDs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import platform
+import threading
+from collections.abc import Coroutine
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol
+from urllib.parse import urlsplit, urlunsplit
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    import httpx
+
+CLIENT_ID = "184482118588404"
+NEMO_TELEMETRY_VERSION = "nemo-telemetry/1.0"
+DEFAULT_ENDPOINT = "https://events.telemetry.data.nvidia.com/v1.1/events/json"
+MAX_RETRIES = 3
+CPU_ARCHITECTURE = platform.uname().machine
+logger = logging.getLogger(__name__)
+
+
+class PlatformTelemetryEvent(Protocol):
+    """Protocol for telemetry events. Task 2 will define the concrete PlatformTelemetryEvent model."""
+
+    _event_name: ClassVar[str]
+    _schema_version: ClassVar[str]
+
+    def model_dump(self, *, by_alias: bool = False, mode: str = "python") -> dict[str, Any]:
+        """Serialize the event to a dictionary."""
+        ...
+
+
+def _telemetry_enabled() -> bool:
+    return os.getenv("NEMO_TELEMETRY_ENABLED", "true").lower() in ("1", "true", "yes")
+
+
+def _telemetry_endpoint() -> str:
+    return os.getenv("NEMO_TELEMETRY_ENDPOINT", DEFAULT_ENDPOINT)
+
+
+def _redact_endpoint(endpoint: str) -> str:
+    """Redact query parameters before logging telemetry endpoints."""
+    try:
+        parsed = urlsplit(endpoint)
+    except ValueError:
+        return "<invalid-endpoint>"
+    query = "<redacted>" if parsed.query else ""
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
+
+
+def _deployment_type() -> str:
+    return os.getenv("NEMO_DEPLOYMENT_TYPE", "sdk")
+
+
+def _session_prefix() -> str | None:
+    return os.getenv("NEMO_SESSION_PREFIX")
+
+
+@dataclass
+class QueuedEvent:
+    event: object
+    timestamp: datetime
+    retry_count: int = 0
+
+
+def _get_iso_timestamp(dt: datetime | None = None) -> str:
+    if dt is None:
+        dt = datetime.now(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+def build_payload(
+    events: list[QueuedEvent], *, source_client_version: str, session_id: str = "undefined"
+) -> dict[str, Any]:
+    if not events:
+        raise ValueError("build_payload requires at least one event")
+    return {
+        "browserType": "undefined",
+        "clientId": CLIENT_ID,
+        "clientType": "Native",
+        "clientVariant": "Release",
+        "clientVer": source_client_version,
+        "cpuArchitecture": CPU_ARCHITECTURE,
+        "deviceGdprBehOptIn": "None",
+        "deviceGdprFuncOptIn": "None",
+        "deviceGdprTechOptIn": "None",
+        "deviceId": "undefined",
+        "deviceMake": "undefined",
+        "deviceModel": "undefined",
+        "deviceOS": "undefined",
+        "deviceOSVersion": "undefined",
+        "deviceType": "undefined",
+        "eventProtocol": "1.6",
+        "eventSchemaVer": events[0].event._schema_version,
+        "eventSysVer": NEMO_TELEMETRY_VERSION,
+        "externalUserId": "undefined",
+        "gdprBehOptIn": "None",
+        "gdprFuncOptIn": "None",
+        "gdprTechOptIn": "None",
+        "idpId": "undefined",
+        "integrationId": "undefined",
+        "productName": "undefined",
+        "productVersion": "undefined",
+        "sentTs": _get_iso_timestamp(),
+        "sessionId": session_id,
+        "userId": "undefined",
+        "events": [
+            {
+                "ts": _get_iso_timestamp(queued.timestamp),
+                "parameters": queued.event.model_dump(by_alias=True, mode="json"),
+                "name": queued.event._event_name,
+            }
+            for queued in events
+        ],
+    }
+
+
+class TelemetryHandler:
+    """
+    Handles telemetry event batching, flushing, and retry logic for NeMo products.
+
+    Supports two usage patterns:
+
+    - **Background mode**: call ``start()`` (or use ``with handler:``) to spawn
+      a daemon thread with its own event loop that drives periodic flushing.
+      ``stop()`` schedules a final flush, then stops the loop and joins the thread.
+    - **Fire-and-flush mode**: skip ``start()``, ``enqueue()`` events, then call
+      ``stop()`` to flush once. No background thread is created unless the caller
+      already has a running event loop, in which case the one-shot flush is
+      offloaded to a worker thread with its own loop.
+
+    Args:
+        flush_interval_seconds (float): The interval in seconds to flush the events.
+        max_queue_size (int): The maximum number of events to queue before flushing.
+        max_retries (int): The maximum number of times to retry sending an event.
+        source_client_version (str): The version of the source client. This should be the version of
+            the actual NeMo product that is sending the events, typically the same as the version of
+            a PyPi package that a user would install.
+        session_id (str): An optional session ID to associate with the events.
+            This should be a unique identifier for the session, such as a UUID.
+            It is used to group events together.
+    """
+
+    def __init__(
+        self,
+        flush_interval_seconds: float = 120.0,
+        max_queue_size: int = 50,
+        max_retries: int = MAX_RETRIES,
+        source_client_version: str = "undefined",
+        session_id: str = "undefined",
+    ):
+        self._flush_interval = flush_interval_seconds
+        self._max_queue_size = max_queue_size
+        self._max_retries = max_retries
+        self._events: list[QueuedEvent] = []
+        self._dlq: list[QueuedEvent] = []
+        self._queue_lock = threading.Lock()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._flush_signal: asyncio.Event | None = None
+        self._timer_task: asyncio.Task | None = None
+        self._running = False
+        self._source_client_version = source_client_version
+        prefix = _session_prefix()
+        self._session_id = f"{prefix}{session_id}" if prefix else session_id
+
+    # -- Async API -----------------------------------------------------------
+
+    async def astart(self) -> None:
+        """Start the background timer task on the current event loop."""
+        if self._running:
+            return
+        self._loop = asyncio.get_running_loop()
+        self._flush_signal = asyncio.Event()
+        self._running = True
+        self._timer_task = asyncio.create_task(self._timer_loop())
+
+    async def astop(self) -> None:
+        """Cancel the timer task and flush any remaining events."""
+        if not self._running:
+            await self._flush_events()
+            return
+        self._running = False
+        if self._flush_signal is not None:
+            self._flush_signal.set()
+        if self._timer_task is not None:
+            self._timer_task.cancel()
+            try:
+                await self._timer_task
+            except asyncio.CancelledError:
+                pass
+            self._timer_task = None
+        await self._flush_events()
+        self._loop = None
+        self._flush_signal = None
+
+    async def aflush(self) -> None:
+        """Flush all queued events immediately and await completion."""
+        await self._flush_events()
+
+    # -- Sync API ------------------------------------------------------------
+
+    def start(self) -> None:
+        """Spawn a daemon thread with a persistent event loop for periodic flushing."""
+        if self._running:
+            return
+        ready = threading.Event()
+        startup_error: list[BaseException] = []
+
+        def _run() -> None:
+            try:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                self._loop = loop
+                self._flush_signal = asyncio.Event()
+                self._timer_task = loop.create_task(self._timer_loop())
+                self._running = True
+            except BaseException as exc:  # noqa: BLE001
+                startup_error.append(exc)
+                ready.set()
+                return
+            ready.set()
+            try:
+                loop.run_forever()
+            finally:
+                loop.close()
+
+        self._thread = threading.Thread(target=_run, name="nemo-telemetry", daemon=True)
+        self._thread.start()
+        ready.wait()
+        if startup_error:
+            self._thread = None
+            raise startup_error[0]
+
+    def stop(self) -> None:
+        """Flush pending events. If a background thread is running, shut it down and join."""
+        if self._running and self._loop is not None and self._thread is not None:
+            loop = self._loop
+            future = asyncio.run_coroutine_threadsafe(self._astop_inner(), loop)
+            try:
+                future.result(timeout=30)
+            except Exception:  # noqa: BLE001
+                pass
+            loop.call_soon_threadsafe(loop.stop)
+            self._thread.join(timeout=5)
+            self._thread = None
+            self._loop = None
+            self._flush_signal = None
+            self._timer_task = None
+            self._running = False
+            return
+        if self._events or self._dlq:
+            try:
+                self._run_sync(self._flush_events())
+            except Exception:  # noqa: BLE001
+                logger.debug("Telemetry stop flush failed", exc_info=True)
+
+    def flush(self) -> None:
+        """Flush all queued events immediately and wait for completion."""
+        if self._running and self._loop is not None and self._thread is not None:
+            future: Future[None] = asyncio.run_coroutine_threadsafe(self._flush_events(), self._loop)
+            try:
+                future.result(timeout=30)
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        if self._events or self._dlq:
+            try:
+                self._run_sync(self._flush_events())
+            except Exception:  # noqa: BLE001
+                logger.debug("Telemetry flush failed", exc_info=True)
+
+    @staticmethod
+    def _run_sync(coro: Coroutine[Any, Any, Any]) -> Any:
+        """Run a coroutine synchronously from sync or async caller contexts.
+
+        ``asyncio.run`` raises when called from a thread that already has a
+        running event loop, such as a notebook kernel or an async SDK caller. In
+        that case, run the coroutine in a worker thread so telemetry still gets
+        a fresh event loop while remaining synchronous to the caller.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None:
+            pool = ThreadPoolExecutor(max_workers=1)
+            future = pool.submit(asyncio.run, coro)
+            return future.result(timeout=30)
+        return asyncio.run(coro)
+
+    async def _astop_inner(self) -> None:
+        """Async shutdown body run on the background loop."""
+        self._running = False
+        if self._flush_signal is not None:
+            self._flush_signal.set()
+        if self._timer_task is not None:
+            self._timer_task.cancel()
+            try:
+                await self._timer_task
+            except asyncio.CancelledError:
+                pass
+            self._timer_task = None
+        await self._flush_events()
+
+    # -- Enqueue / signalling ------------------------------------------------
+
+    def enqueue(self, event: object) -> None:
+        if not _telemetry_enabled():
+            return
+        if not isinstance(event, BaseModel):
+            return
+        if not hasattr(event, "_event_name"):
+            return
+        queued = QueuedEvent(event=event, timestamp=datetime.now(timezone.utc))
+        with self._queue_lock:
+            self._events.append(queued)
+            should_signal = len(self._events) >= self._max_queue_size
+        if should_signal:
+            self._signal_flush()
+
+    def _signal_flush(self) -> None:
+        """Set the flush signal, threadsafe across the background-loop boundary."""
+        loop = self._loop
+        signal = self._flush_signal
+        if loop is None or signal is None:
+            return
+        try:
+            loop.call_soon_threadsafe(signal.set)
+        except RuntimeError:
+            pass
+
+    # -- Context managers ----------------------------------------------------
+
+    def __enter__(self) -> TelemetryHandler:
+        self.start()
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.stop()
+
+    async def __aenter__(self) -> TelemetryHandler:
+        await self.astart()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.astop()
+
+    # -- Internal loop -------------------------------------------------------
+
+    async def _timer_loop(self) -> None:
+        assert self._flush_signal is not None
+        while self._running:
+            try:
+                await asyncio.wait_for(
+                    self._flush_signal.wait(),
+                    timeout=self._flush_interval,
+                )
+            except asyncio.TimeoutError:
+                pass
+            self._flush_signal.clear()
+            await self._flush_events()
+
+    async def _flush_events(self) -> None:
+        with self._queue_lock:
+            dlq_events, self._dlq = self._dlq, []
+            new_events, self._events = self._events, []
+        events_to_send = dlq_events + new_events
+        if events_to_send:
+            await self._send_events(events_to_send)
+
+    async def _send_events(self, events: list[QueuedEvent]) -> None:
+        try:
+            import httpx
+
+            async with httpx.AsyncClient() as client:
+                await self._send_events_with_client(client, events)
+        except Exception:  # noqa: BLE001
+            self._add_to_dlq(events)
+
+    async def _send_events_with_client(self, client: httpx.AsyncClient, events: list[QueuedEvent]) -> None:
+        if not events:
+            return
+
+        payload = build_payload(events, source_client_version=self._source_client_version, session_id=self._session_id)
+        endpoint = _telemetry_endpoint()
+        logger.debug(
+            "Sending telemetry events",
+            extra={
+                "ctx": {
+                    "endpoint": _redact_endpoint(endpoint),
+                    "event_count": len(events),
+                    "events": [
+                        {
+                            "name": queued.event._event_name,
+                            "task": getattr(queued.event, "task", "unknown"),
+                            "task_status": getattr(queued.event, "task_status", "unknown"),
+                            "deployment_type": getattr(queued.event, "deployment_type", "unknown"),
+                            "retry_count": queued.retry_count,
+                        }
+                        for queued in events
+                    ],
+                }
+            },
+        )
+        try:
+            response = await client.post(endpoint, json=payload)
+            if response.status_code in (400, 422) or response.is_success:
+                return
+            if response.status_code == 413:
+                if len(events) == 1:
+                    return
+                mid = len(events) // 2
+                await self._send_events_with_client(client, events[:mid])
+                await self._send_events_with_client(client, events[mid:])
+                return
+            if response.status_code == 408 or response.status_code >= 500:
+                self._add_to_dlq(events)
+        except Exception:  # noqa: BLE001
+            self._add_to_dlq(events)
+
+    def _add_to_dlq(self, events: list[QueuedEvent]) -> None:
+        with self._queue_lock:
+            for queued in events:
+                queued.retry_count += 1
+                if queued.retry_count > self._max_retries:
+                    continue
+                self._dlq.append(queued)

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/handler.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/handler.py
@@ -22,10 +22,10 @@ from collections.abc import Coroutine
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
-from pydantic import BaseModel
+from nemo_platform_ext.cli.telemetry.events import PlatformTelemetryEvent
 
 if TYPE_CHECKING:
     import httpx
@@ -36,17 +36,6 @@ DEFAULT_ENDPOINT = "https://events.telemetry.data.nvidia.com/v1.1/events/json"
 MAX_RETRIES = 3
 CPU_ARCHITECTURE = platform.uname().machine
 logger = logging.getLogger(__name__)
-
-
-class PlatformTelemetryEvent(Protocol):
-    """Protocol for telemetry events. Task 2 will define the concrete PlatformTelemetryEvent model."""
-
-    _event_name: ClassVar[str]
-    _schema_version: ClassVar[str]
-
-    def model_dump(self, *, by_alias: bool = False, mode: str = "python") -> dict[str, Any]:
-        """Serialize the event to a dictionary."""
-        ...
 
 
 def _telemetry_enabled() -> bool:
@@ -77,7 +66,7 @@ def _session_prefix() -> str | None:
 
 @dataclass
 class QueuedEvent:
-    event: object
+    event: PlatformTelemetryEvent
     timestamp: datetime
     retry_count: int = 0
 
@@ -328,9 +317,7 @@ class TelemetryHandler:
     def enqueue(self, event: object) -> None:
         if not _telemetry_enabled():
             return
-        if not isinstance(event, BaseModel):
-            return
-        if not hasattr(event, "_event_name"):
+        if not isinstance(event, PlatformTelemetryEvent):
             return
         queued = QueuedEvent(event=event, timestamp=datetime.now(timezone.utc))
         with self._queue_lock:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/runtime.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/runtime.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-invocation telemetry state bridged between the Typer callback and the Click main wrapper.
+
+The Typer ``@app.callback`` sees the parsed context (command name, agent mode, opt-out
+flag) but not the command outcome. The ``NmpErrorHandlingMixin.main`` wrapper sees the
+outcome and duration but not the parsed flags. This module is the single small piece of
+state both sides read, so exactly one ``command_invoked`` event is emitted per invocation
+from the root command path.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nemo_platform_ext.cli.telemetry.events import TaskStatusEnum
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _InvocationState:
+    command_parts: list[str] = field(default_factory=list)
+    agent_mode: bool = False
+    started: bool = False
+    opted_out: bool = False
+
+
+state = _InvocationState()
+
+
+def reset() -> None:
+    """Clear invocation state. Called at the top of the root ``main()`` so CliRunner
+    invocations sharing a process never leak command names or flags between calls."""
+    state.command_parts = []
+    state.agent_mode = False
+    state.started = False
+    state.opted_out = False
+
+
+def on_callback(ctx, *, no_telemetry: bool) -> None:
+    """Capture command name + agent mode from the root Typer callback.
+
+    Best effort: a telemetry bug must never break ``nemo <anything>``.
+    """
+    try:
+        from nemo_platform_ext.cli.telemetry.emit import maybe_print_first_run_notice, set_invocation_opt_out
+
+        set_invocation_opt_out(no_telemetry)
+        state.opted_out = no_telemetry
+        state.started = True
+        state.agent_mode = bool(getattr(ctx.obj, "agent_mode", False))
+        invoked = getattr(ctx, "invoked_subcommand", None)
+        if invoked:
+            state.command_parts = [invoked]
+        maybe_print_first_run_notice()
+    except Exception:  # noqa: BLE001
+        logger.debug("telemetry on_callback failed", exc_info=True)
+
+
+def note_subcommand(name: str | None) -> None:
+    """Append a resolved sub-subcommand name (e.g. the ``list`` in ``workspaces list``)."""
+    if state.started and name and name not in state.command_parts:
+        state.command_parts.append(name)
+
+
+def emit_command_invoked(task_status: TaskStatusEnum, duration_sec: float) -> None:
+    """Emit exactly one ``command_invoked`` event. Best effort; never raises."""
+    try:
+        if state.opted_out:
+            return
+        if not (state.started and state.command_parts):
+            # Bare ``--help`` and usage errors before a command resolves never emit.
+            return
+        from nemo_platform_ext.cli.telemetry.emit import emit_event
+        from nemo_platform_ext.cli.telemetry.events import CommandInvokedEvent
+
+        event = CommandInvokedEvent(
+            command=" ".join(state.command_parts),
+            duration_sec=max(0.0, duration_sec),
+            agent_mode=state.agent_mode,
+            task_status=task_status,
+        )
+        emit_event(event)
+    except Exception:  # noqa: BLE001
+        logger.debug("telemetry emit_command_invoked failed", exc_info=True)

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/runtime.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/runtime.py
@@ -27,6 +27,7 @@ class _InvocationState:
     agent_mode: bool = False
     started: bool = False
     opted_out: bool = False
+    help_requested: bool = False
 
 
 state = _InvocationState()
@@ -39,6 +40,7 @@ def reset() -> None:
     state.agent_mode = False
     state.started = False
     state.opted_out = False
+    state.help_requested = False
 
 
 def on_callback(ctx, *, no_telemetry: bool) -> None:
@@ -58,6 +60,8 @@ def on_callback(ctx, *, no_telemetry: bool) -> None:
             state.command_parts = [invoked]
         maybe_print_first_run_notice()
     except Exception:  # noqa: BLE001
+        # Fail closed: if telemetry setup breaks, suppress this invocation's event.
+        state.opted_out = True
         logger.debug("telemetry on_callback failed", exc_info=True)
 
 
@@ -71,6 +75,10 @@ def emit_command_invoked(task_status: TaskStatusEnum, duration_sec: float) -> No
     """Emit exactly one ``command_invoked`` event. Best effort; never raises."""
     try:
         if state.opted_out:
+            return
+        if state.help_requested:
+            # Reading help (e.g. ``nemo docs --help``) is not usage. Bare ``--help`` is
+            # already covered by the empty-command_parts guard below.
             return
         if not (state.started and state.command_parts):
             # Bare ``--help`` and usage errors before a command resolves never emit.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/config/models.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/config/models.py
@@ -221,6 +221,10 @@ class ConfigFile(BaseModel):
         default=None,
         description="User-selected paths for local services (set by `nemo setup`).",
     )
+    telemetry_enabled: bool = Field(
+        default=True,
+        description="Whether anonymous usage telemetry is enabled. Set to false to opt out.",
+    )
 
     def ensure_context(
         self,

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -80,6 +80,26 @@ from nemo_platform_ext.config.models import (
 
 SETUP_MOD = "nemo_platform_ext.cli.commands.setup"
 
+
+@pytest.fixture(autouse=True)
+def _silence_telemetry():
+    """Silence stray telemetry side effects across this module.
+
+    These are direct-call unit tests with no telemetry intent. Several exercise
+    the real setup wrappers (`_create_provider`, `_wait_for_models`,
+    `_deploy_demo_agent`, `_auto_setup`), which call the real `emit_event`. With
+    telemetry enabled by default that constructs a `TelemetryHandler` and
+    schedules `_flush_events`, whose orphaned coroutine surfaces later as a
+    "coroutine ... was never awaited" RuntimeWarning (blamed on whichever
+    mock-heavy test triggers GC, not the emitting one). Patch emit_event at module
+    scope so no handler is ever built. No test in this file asserts on emit_event
+    (the telemetry assertions live in test_onboarding_events.py), so this weakens
+    nothing.
+    """
+    with patch("nemo_platform_ext.cli.telemetry.emit.emit_event"):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # KnownProvider catalog tests
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_ext/tests/cli/core/test_waiters.py
+++ b/packages/nemo_platform_ext/tests/cli/core/test_waiters.py
@@ -44,6 +44,13 @@ def _quiet_rich_output() -> Iterator[None]:
         yield
 
 
+@pytest.fixture(autouse=True)
+def _no_telemetry() -> Iterator[None]:
+    """Neutralize best-effort job_run telemetry so waiter tests never do real I/O."""
+    with patch("nemo_platform_ext.cli.telemetry.emit.emit_event"):
+        yield
+
+
 @pytest.fixture
 def frozen_time() -> Iterator[MagicMock]:
     with patch(f"{WAITERS_MODULE}.time.time", return_value=0) as time:

--- a/packages/nemo_platform_ext/tests/cli/telemetry/__init__.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/nemo_platform_ext/tests/cli/telemetry/conftest.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/conftest.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterator
+
+import pytest
+
+# Environment variables that is_ci_environment() treats as a CI signal.
+_CI_ENV_VARS = ("CI", "GITLAB_CI", "GITHUB_ACTIONS")
+
+
+@pytest.fixture(autouse=True)
+def _clear_ci_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Clear CI markers so telemetry tests are deterministic on developer machines and in CI.
+
+    Without this, tests that assert the default ``is_ci`` value pass locally but fail when the
+    suite runs under GitHub Actions (which sets ``CI`` and ``GITHUB_ACTIONS``). Tests that
+    exercise CI detection set these variables explicitly, which overrides this fixture.
+    """
+    for var in _CI_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_command_hook.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_command_hook.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the command_invoked telemetry hook at the root command choke point."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from nemo_platform_ext.cli.app import app
+from nemo_platform_ext.cli.telemetry.events import TaskStatusEnum
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+class TestCommandInvokedHook:
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_successful_command_emits_completed(self, emit):
+        result = runner.invoke(app, ["docs", "--list"])
+        assert result.exit_code == 0
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.command.startswith("docs")
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.duration_sec >= 0
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_agent_mode_flag_captured(self, emit):
+        runner.invoke(app, ["--agent-mode", "docs", "--list"])
+        assert emit.call_args[0][0].agent_mode is True
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_failing_command_emits_error(self, emit):
+        with patch("nemo_platform_ext.cli.commands.docs._list_docs", side_effect=RuntimeError):
+            runner.invoke(app, ["docs", "--list"])
+        assert emit.call_count == 1
+        assert emit.call_args[0][0].task_status == TaskStatusEnum.ERROR
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_no_telemetry_flag_suppresses(self, emit):
+        runner.invoke(app, ["--no-telemetry", "docs", "--list"])
+        emit.assert_not_called()
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_bare_help_does_not_emit(self, emit):
+        runner.invoke(app, ["--help"])
+        emit.assert_not_called()

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_command_hook.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_command_hook.py
@@ -45,3 +45,10 @@ class TestCommandInvokedHook:
     def test_bare_help_does_not_emit(self, emit):
         runner.invoke(app, ["--help"])
         emit.assert_not_called()
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_group_help_does_not_emit(self, emit):
+        """``nemo <group> --help`` reads help; it is not usage and must not emit."""
+        result = runner.invoke(app, ["docs", "--help"])
+        assert result.exit_code == 0
+        emit.assert_not_called()

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_emit.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_emit.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import Mock, patch
+
+from nemo_platform_ext.cli.telemetry import emit as emit_mod
+from nemo_platform_ext.cli.telemetry.events import CommandInvokedEvent, TaskStatusEnum
+
+
+def _event():
+    return CommandInvokedEvent(command="docs", task_status=TaskStatusEnum.COMPLETED, duration_sec=0.1)
+
+
+class TestOptOutLayers:
+    def test_env_layer(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+        assert emit_mod.telemetry_opted_in() is False
+
+    def test_config_layer(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("telemetry_enabled: false\n")
+        monkeypatch.setenv("NMP_CONFIG_FILE", str(cfg))
+        assert emit_mod.telemetry_opted_in() is False
+
+    def test_invocation_flag_layer(self):
+        emit_mod.set_invocation_opt_out(True)
+        try:
+            assert emit_mod.telemetry_opted_in() is False
+        finally:
+            emit_mod.set_invocation_opt_out(False)
+
+    def test_default_is_on(self):
+        assert emit_mod.telemetry_opted_in() is True
+
+
+class TestEmitEvent:
+    @patch.object(emit_mod, "TelemetryHandler")
+    def test_emit_enqueues_and_stops(self, handler_cls):
+        instance = Mock()
+        handler_cls.return_value = instance
+        emit_mod.emit_event(_event())
+        instance.enqueue.assert_called_once()
+        instance.stop.assert_called_once()
+
+    @patch.object(emit_mod, "TelemetryHandler")
+    def test_emit_skipped_when_opted_out(self, handler_cls, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "0")
+        emit_mod.emit_event(_event())
+        handler_cls.assert_not_called()
+
+    @patch.object(emit_mod, "TelemetryHandler", side_effect=RuntimeError("boom"))
+    def test_emit_never_raises(self, handler_cls):
+        emit_mod.emit_event(_event())  # must not raise
+
+
+class TestFirstRunNotice:
+    def test_notice_printed_once_to_stderr(self, capsys, tmp_path, monkeypatch):
+        monkeypatch.setattr(emit_mod, "_notice_marker_path", lambda: tmp_path / "telemetry-notice-shown")
+        emit_mod.maybe_print_first_run_notice()
+        first = capsys.readouterr()
+        assert "anonymous usage data" in first.err
+        assert first.out == ""  # stderr only; stdout stays machine-clean
+        emit_mod.maybe_print_first_run_notice()
+        assert capsys.readouterr().err == ""
+
+    def test_no_notice_when_opted_out(self, capsys, tmp_path, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+        monkeypatch.setattr(emit_mod, "_notice_marker_path", lambda: tmp_path / "telemetry-notice-shown")
+        emit_mod.maybe_print_first_run_notice()
+        assert capsys.readouterr().err == ""

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_emit.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_emit.py
@@ -31,6 +31,16 @@ class TestOptOutLayers:
     def test_default_is_on(self):
         assert emit_mod.telemetry_opted_in() is True
 
+    def test_config_load_error_fails_closed(self, monkeypatch):
+        """A broken/parse-error config must fail closed (opted out), not default to on."""
+        from nemo_platform_ext.config import config as config_mod
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("broken config")
+
+        monkeypatch.setattr(config_mod.Config, "load", boom)
+        assert emit_mod.telemetry_opted_in() is False
+
 
 class TestEmitEvent:
     @patch.object(emit_mod, "TelemetryHandler")
@@ -50,6 +60,15 @@ class TestEmitEvent:
     @patch.object(emit_mod, "TelemetryHandler", side_effect=RuntimeError("boom"))
     def test_emit_never_raises(self, handler_cls):
         emit_mod.emit_event(_event())  # must not raise
+
+    @patch.object(emit_mod, "TelemetryHandler")
+    def test_session_id_is_stable_across_calls(self, handler_cls):
+        """Every event in one process shares the per-process session id."""
+        emit_mod.emit_event(_event())
+        emit_mod.emit_event(_event())
+        session_ids = [call.kwargs["session_id"] for call in handler_cls.call_args_list]
+        assert len(session_ids) == 2
+        assert session_ids[0] == session_ids[1] == emit_mod._SESSION_ID
 
 
 class TestFirstRunNotice:

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_events.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_events.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from nemo_platform_ext.cli.telemetry.events import (
+    CommandInvokedEvent,
+    JobRunEvent,
+    OnboardingStepEvent,
+    TaskStatusEnum,
+    is_ci_environment,
+)
+
+
+class TestCommandInvokedEvent:
+    def test_defaults_and_aliases(self):
+        e = CommandInvokedEvent(command="jobs create", task_status=TaskStatusEnum.COMPLETED, duration_sec=1.25)
+        d = e.model_dump(by_alias=True, mode="json")
+        assert d["nemoSource"] == "platform"
+        assert d["command"] == "jobs create"
+        assert d["taskStatus"] == "completed"
+        assert d["durationSec"] == 1.25
+        assert d["agentMode"] is False
+        assert d["isCi"] is False
+        assert e._event_name == "command_invoked"
+        assert e._schema_version == "1.9"
+
+    def test_no_free_text_fields_beyond_known(self):
+        # privacy guard: the event cannot carry arbitrary payloads
+        with pytest.raises(Exception):
+            CommandInvokedEvent(command="x", task_status=TaskStatusEnum.COMPLETED, duration_sec=0, prompt="secret")
+
+
+class TestOnboardingStepEvent:
+    def test_fields(self):
+        e = OnboardingStepEvent(step="provider_connected", task_status=TaskStatusEnum.COMPLETED, provider_type="openai")
+        d = e.model_dump(by_alias=True, mode="json")
+        assert d["step"] == "provider_connected"
+        assert d["providerType"] == "openai"
+        assert d["modelsDiscoveredBucket"] == "undefined"
+        assert d["skillsTarget"] == "undefined"
+        assert d["agentDeployed"] is False
+        assert e._event_name == "onboarding_step"
+
+
+class TestJobRunEvent:
+    def test_token_defaults_are_minus_one(self):
+        e = JobRunEvent(job_type="auditor.audit", task_status=TaskStatusEnum.ERROR, duration_sec=10.0)
+        d = e.model_dump(by_alias=True, mode="json")
+        assert d["jobType"] == "auditor.audit"
+        assert d["inputTokens"] == -1
+        assert d["outputTokens"] == -1
+        assert d["model"] == "undefined"
+        assert d["plugins"] == []
+        assert e._event_name == "job_run"
+
+
+class TestCiDetection:
+    @pytest.mark.parametrize("var", ["CI", "GITLAB_CI", "GITHUB_ACTIONS"])
+    def test_ci_env_detected(self, monkeypatch, var):
+        monkeypatch.setenv(var, "true")
+        assert is_ci_environment() is True
+
+    def test_no_ci_env(self, monkeypatch):
+        for var in ("CI", "GITLAB_CI", "GITHUB_ACTIONS"):
+            monkeypatch.delenv(var, raising=False)
+        assert is_ci_environment() is False

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_handler.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_handler.py
@@ -5,9 +5,11 @@ import asyncio
 import importlib
 import threading
 from datetime import datetime, timezone
+from typing import ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from nemo_platform_ext.cli.telemetry.events import PlatformTelemetryEvent
 from nemo_platform_ext.cli.telemetry.handler import (
     QueuedEvent,
     TelemetryHandler,
@@ -16,7 +18,7 @@ from nemo_platform_ext.cli.telemetry.handler import (
     _telemetry_endpoint,
     build_payload,
 )
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 telemetry_module = importlib.import_module("nemo_platform_ext.cli.telemetry.handler")
 
@@ -26,17 +28,18 @@ telemetry_module = importlib.import_module("nemo_platform_ext.cli.telemetry.hand
 # =============================================================================
 
 
-class _StubEvent(BaseModel):
-    """Minimal event model for testing. Task 2 will define the concrete PlatformTelemetryEvent."""
+class _StubEvent(PlatformTelemetryEvent):
+    """Minimal concrete event for testing, subclassing the real PlatformTelemetryEvent.
 
-    _event_name: str = "stub_event"
-    _schema_version: str = "1.9"
+    ``task_status`` and ``deployment_type`` are redeclared as plain strings to shed
+    the base's serialization aliases, so the handler tests keep asserting the
+    snake_case keys the Task 1 handler emitted.
+    """
+
+    _event_name: ClassVar[str] = "stub_event"
     task: str = Field(default="test_task")
     task_status: str = Field(default="completed")
     deployment_type: str = Field(default="sdk")
-
-    class Config:
-        validate_assignment = True
 
 
 # =============================================================================

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_handler.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_handler.py
@@ -1,0 +1,557 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import importlib
+import threading
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from nemo_platform_ext.cli.telemetry.handler import (
+    QueuedEvent,
+    TelemetryHandler,
+    _deployment_type,
+    _telemetry_enabled,
+    _telemetry_endpoint,
+    build_payload,
+)
+from pydantic import BaseModel, Field
+
+telemetry_module = importlib.import_module("nemo_platform_ext.cli.telemetry.handler")
+
+
+# =============================================================================
+# Stub Event Model for Testing
+# =============================================================================
+
+
+class _StubEvent(BaseModel):
+    """Minimal event model for testing. Task 2 will define the concrete PlatformTelemetryEvent."""
+
+    _event_name: str = "stub_event"
+    _schema_version: str = "1.9"
+    task: str = Field(default="test_task")
+    task_status: str = Field(default="completed")
+    deployment_type: str = Field(default="sdk")
+
+    class Config:
+        validate_assignment = True
+
+
+# =============================================================================
+# Env-var helpers
+# =============================================================================
+
+
+class TestEnvHelpers:
+    def test_telemetry_enabled_default(self, monkeypatch):
+        monkeypatch.delenv("NEMO_TELEMETRY_ENABLED", raising=False)
+        assert _telemetry_enabled() is True
+
+    def test_telemetry_enabled_disabled(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+        assert _telemetry_enabled() is False
+
+    def test_telemetry_endpoint_preserves_case(self, monkeypatch):
+        custom = "https://Events.Telemetry.example.COM/v1/Events?Token=AbC"
+        monkeypatch.setenv("NEMO_TELEMETRY_ENDPOINT", custom)
+        assert _telemetry_endpoint() == custom
+
+    def test_deployment_type_default(self, monkeypatch):
+        monkeypatch.delenv("NEMO_DEPLOYMENT_TYPE", raising=False)
+        assert _deployment_type() == "sdk"
+
+    def test_deployment_type_invalid_falls_back_to_string(self, monkeypatch):
+        monkeypatch.setenv("NEMO_DEPLOYMENT_TYPE", "definitely-not-real")
+        assert _deployment_type() == "definitely-not-real"
+
+    def test_deployment_type_nvidia_internal(self, monkeypatch):
+        monkeypatch.setenv("NEMO_DEPLOYMENT_TYPE", "nvidia-internal")
+        assert _deployment_type() == "nvidia-internal"
+
+
+# =============================================================================
+# build_payload
+# =============================================================================
+
+
+class TestBuildPayload:
+    def _make_queued(self, task: str = "generate", status: str = "completed") -> QueuedEvent:
+        event = _StubEvent(task=task, task_status=status)
+        return QueuedEvent(event=event, timestamp=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
+
+    def test_structure(self):
+        queued = self._make_queued()
+        payload = build_payload([queued], source_client_version="1.2.3", session_id="test-session")
+        assert payload["clientId"] == "184482118588404"
+        assert payload["clientVer"] == "1.2.3"
+        assert payload["sessionId"] == "test-session"
+        assert len(payload["events"]) == 1
+
+    def test_event_fields_serialize_as_strings(self, monkeypatch):
+        monkeypatch.delenv("NEMO_DEPLOYMENT_TYPE", raising=False)
+
+        queued = self._make_queued(task="train", status="error")
+        payload = build_payload([queued], source_client_version="0.0.1")
+        event_entry = payload["events"][0]
+        assert event_entry["name"] == "stub_event"
+        assert event_entry["ts"] == "2025-01-01T12:00:00.000Z"
+        params = event_entry["parameters"]
+        assert params["task"] == "train"
+        assert params["task_status"] == "error"
+
+    def test_payload_is_json_serializable(self):
+        """Regression: the full payload must be encodable by the stdlib JSON encoder."""
+        import json
+
+        queued = self._make_queued(status="error")
+        payload = build_payload([queued], source_client_version="1.0.0")
+        json.dumps(payload)
+
+    def test_multiple_events(self):
+        events = [self._make_queued(task=t) for t in ("train", "generate", "evaluate")]
+        payload = build_payload(events, source_client_version="1.0.0")
+        assert len(payload["events"]) == 3
+        tasks = [e["parameters"]["task"] for e in payload["events"]]
+        assert tasks == ["train", "generate", "evaluate"]
+
+    def test_default_session_id(self):
+        queued = self._make_queued()
+        payload = build_payload([queued], source_client_version="1.0.0")
+        assert payload["sessionId"] == "undefined"
+
+    def test_empty_events_raises(self):
+        with pytest.raises(ValueError):
+            build_payload([], source_client_version="1.0.0")
+
+
+# =============================================================================
+# TelemetryHandler — telemetry disabled
+# =============================================================================
+
+
+class TestTelemetryDisabled:
+    def test_enqueue_noop_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+        handler = TelemetryHandler()
+        event = _StubEvent(task="generate")
+        handler.enqueue(event)
+        assert handler._events == []
+
+    def test_enqueue_noop_for_non_event(self, monkeypatch):
+        """Silently ignores non-TelemetryEvent objects regardless of env."""
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler()
+        handler.enqueue("not an event")
+        assert handler._events == []
+
+
+# =============================================================================
+# TelemetryHandler — enqueue and flush
+# =============================================================================
+
+
+class TestTelemetryHandlerEnqueue:
+    def test_enqueue_adds_event(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler()
+        event = _StubEvent(task="generate")
+        handler.enqueue(event)
+        assert len(handler._events) == 1
+        assert handler._events[0].event is event
+
+    def test_enqueue_does_not_add_event_when_telemetry_is_disabled(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+        handler = TelemetryHandler()
+        event = _StubEvent(task="generate")
+        handler.enqueue(event)
+        assert len(handler._events) == 0
+
+    def test_enqueue_at_max_queue_size_signals_flush_when_running(self, monkeypatch):
+        """When a background loop is up, hitting max_queue_size should signal it. Without a loop, no-op is safe."""
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(max_queue_size=3)
+        event = _StubEvent(task="run")
+        for _ in range(3):
+            handler.enqueue(event)
+        assert len(handler._events) == 3
+
+
+# =============================================================================
+# TelemetryHandler — _flush_events queue clearing and DLQ
+# =============================================================================
+
+
+class TestFlushEventsQueueClearing:
+    async def test_flush_events_clears_queue(self):
+        """_flush_events() must drain _events even when the underlying send succeeds."""
+        handler = TelemetryHandler(source_client_version="1.0.0")
+        event = _StubEvent(task="generate")
+        handler._events.append(QueuedEvent(event=event, timestamp=datetime.now(timezone.utc)))
+
+        async def fake_send(events):
+            assert len(events) == 1
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            await handler._flush_events()
+
+        assert handler._events == []
+        assert handler._dlq == []
+
+    async def test_flush_events_includes_dlq(self):
+        handler = TelemetryHandler(source_client_version="1.0.0")
+        event = _StubEvent(task="generate")
+        handler._dlq.append(QueuedEvent(event=event, timestamp=datetime.now(timezone.utc), retry_count=1))
+        handler._events.append(QueuedEvent(event=event, timestamp=datetime.now(timezone.utc)))
+
+        sent: list[list[QueuedEvent]] = []
+
+        async def fake_send(events):
+            sent.append(list(events))
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            await handler._flush_events()
+
+        assert handler._events == []
+        assert handler._dlq == []
+        assert len(sent) == 1
+        assert len(sent[0]) == 2
+
+
+# =============================================================================
+# TelemetryHandler — send and retry
+# =============================================================================
+
+
+class TestTelemetryHandlerSend:
+    def _make_handler(self) -> TelemetryHandler:
+        return TelemetryHandler(source_client_version="1.0.0", session_id="s1")
+
+    def _make_queued(self) -> QueuedEvent:
+        event = _StubEvent(task="generate")
+        return QueuedEvent(event=event, timestamp=datetime.now(timezone.utc))
+
+    async def test_debug_logs_event_metadata_before_post(self, monkeypatch):
+        handler = self._make_handler()
+        queued = self._make_queued()
+        events_seen: list[str] = []
+        debug_calls = []
+
+        monkeypatch.setenv("NEMO_TELEMETRY_ENDPOINT", "https://Events.Telemetry.example.COM/v1/Events?Token=AbC")
+
+        def fake_debug(message, *, extra):
+            events_seen.append("debug")
+            debug_calls.append((message, extra))
+
+        async def fake_post(*args, **kwargs):
+            events_seen.append("post")
+            return MagicMock(status_code=200, is_success=True)
+
+        monkeypatch.setattr(telemetry_module.logger, "debug", fake_debug)
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = fake_post
+
+        await handler._send_events_with_client(mock_client, [queued])
+
+        assert events_seen == ["debug", "post"]
+        message, extra = debug_calls[0]
+        assert message == "Sending telemetry events"
+        ctx = extra["ctx"]
+        assert ctx["endpoint"] == "https://Events.Telemetry.example.COM/v1/Events?<redacted>"
+        assert ctx["event_count"] == 1
+        assert ctx["events"] == [
+            {
+                "name": "stub_event",
+                "task": "generate",
+                "task_status": "completed",
+                "deployment_type": "sdk",
+                "retry_count": 0,
+            }
+        ]
+
+    async def test_successful_send_does_not_dlq(self):
+        handler = self._make_handler()
+        queued = self._make_queued()
+
+        mock_response = MagicMock(status_code=200, is_success=True)
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        await handler._send_events_with_client(mock_client, [queued])
+        mock_client.post.assert_awaited_once()
+        assert handler._dlq == []
+
+    async def test_500_adds_to_dlq(self):
+        handler = self._make_handler()
+        queued = self._make_queued()
+
+        mock_response = MagicMock(status_code=500, is_success=False)
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        await handler._send_events_with_client(mock_client, [queued])
+        assert len(handler._dlq) == 1
+        assert handler._dlq[0].retry_count == 1
+
+    async def test_exceeds_max_retries_dropped(self):
+        handler = self._make_handler()
+        queued = self._make_queued()
+        queued.retry_count = handler._max_retries
+
+        mock_response = MagicMock(status_code=500, is_success=False)
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        await handler._send_events_with_client(mock_client, [queued])
+        assert handler._dlq == []
+
+    async def test_413_splits_and_retries(self):
+        handler = self._make_handler()
+        event = _StubEvent(task="generate")
+        events = [
+            QueuedEvent(event=event, timestamp=datetime.now(timezone.utc)),
+            QueuedEvent(event=event, timestamp=datetime.now(timezone.utc)),
+        ]
+
+        success_response = MagicMock(status_code=200, is_success=True)
+        too_large_response = MagicMock(status_code=413, is_success=False)
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = [too_large_response, success_response, success_response]
+
+        await handler._send_events_with_client(mock_client, events)
+        assert mock_client.post.await_count == 3
+
+    async def test_send_events_routes_to_dlq_on_client_setup_failure(self):
+        """If httpx client creation raises, events must land in DLQ rather than vanish."""
+        handler = self._make_handler()
+        queued = self._make_queued()
+
+        with patch("httpx.AsyncClient", side_effect=RuntimeError("boom")):
+            await handler._send_events([queued])
+
+        assert len(handler._dlq) == 1
+
+    def test_session_prefix_applied(self, monkeypatch):
+        monkeypatch.setenv("NEMO_SESSION_PREFIX", "pfx-")
+        handler = TelemetryHandler(session_id="abc")
+        assert handler._session_id == "pfx-abc"
+
+
+# =============================================================================
+# TelemetryHandler — aflush awaits a real flush
+# =============================================================================
+
+
+class TestAflushAwaits:
+    async def test_aflush_actually_flushes(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(source_client_version="1.0.0")
+        event = _StubEvent(task="generate")
+        handler.enqueue(event)
+        assert len(handler._events) == 1
+
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            await handler.aflush()
+
+        assert handler._events == []
+        assert sent == [1]
+
+
+# =============================================================================
+# TelemetryHandler — sync flush from async caller contexts
+# =============================================================================
+
+
+class TestFlushFromRunningLoop:
+    """Regression coverage for notebooks and async SDK callers."""
+
+    def test_flush_runs_to_completion_when_loop_is_running(self) -> None:
+        sent: list[int] = []
+
+        async def fake_flush(self) -> None:  # noqa: ARG001
+            sent.append(1)
+
+        async def driver() -> None:
+            handler = TelemetryHandler(source_client_version="1.0.0")
+            handler._events.append(
+                QueuedEvent(
+                    event=_StubEvent(task="run"),
+                    timestamp=datetime.now(timezone.utc),
+                )
+            )
+            with patch.object(TelemetryHandler, "_flush_events", new=fake_flush):
+                handler.flush()
+
+        asyncio.run(driver())
+        assert sent == [1]
+
+    def test_stop_flushes_fire_and_flush_path_when_loop_is_running(self, monkeypatch) -> None:
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        async def driver() -> None:
+            handler = TelemetryHandler(source_client_version="1.0.0")
+            with patch.object(handler, "_send_events", side_effect=fake_send):
+                handler.enqueue(_StubEvent(task="run"))
+                handler.stop()
+                assert handler._events == []
+
+        asyncio.run(driver())
+        assert sent == [1]
+
+    def test_run_sync_propagates_exception_to_flush_boundary(self) -> None:
+        async def boom() -> None:
+            raise RuntimeError("kaboom")
+
+        async def driver() -> None:
+            with pytest.raises(RuntimeError, match="kaboom"):
+                TelemetryHandler._run_sync(boom())
+
+        asyncio.run(driver())
+
+
+# =============================================================================
+# TelemetryHandler — sync lifecycle and context manager
+# =============================================================================
+
+
+class TestSyncLifecycle:
+    def test_fire_and_flush_without_start(self, monkeypatch):
+        """Pattern used by the SDK: construct, enqueue, stop. No start() call. stop() must flush."""
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(source_client_version="1.0.0")
+        event = _StubEvent(task="generate")
+        handler.enqueue(event)
+        assert len(handler._events) == 1
+
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            handler.stop()
+
+        assert handler._events == []
+        assert sent == [1]
+        assert handler._thread is None
+
+    def test_start_spawns_thread_and_stop_flushes(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=60.0)
+
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            handler.start()
+            assert handler._thread is not None
+            assert handler._thread.is_alive()
+
+            handler.enqueue(_StubEvent(task="run"))
+            handler.stop()
+
+        assert handler._thread is None
+        assert handler._loop is None
+        assert sent == [1]
+
+    def test_sync_context_manager(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        with patch.object(TelemetryHandler, "_send_events", side_effect=fake_send, autospec=False):
+            with TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=60.0) as handler:
+                handler.enqueue(_StubEvent(task="run"))
+
+        assert sent == [1]
+
+    def test_sync_flush_during_background_run(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=60.0)
+
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            handler.start()
+            try:
+                handler.enqueue(_StubEvent(task="run"))
+                handler.flush()
+                assert sent == [1]
+                assert handler._events == []
+            finally:
+                handler.stop()
+
+    def test_timer_driven_flush(self, monkeypatch):
+        """With a short flush interval, the background timer should drive a flush without explicit calls."""
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=0.05)
+
+        flushed = threading.Event()
+
+        async def fake_send(events):
+            flushed.set()
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            handler.start()
+            try:
+                handler.enqueue(_StubEvent(task="run"))
+                assert flushed.wait(timeout=2.0), "timer-driven flush did not fire"
+            finally:
+                handler.stop()
+
+
+# =============================================================================
+# TelemetryHandler — async lifecycle
+# =============================================================================
+
+
+class TestAsyncLifecycle:
+    async def test_async_context_manager_flushes_on_exit(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        async with TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=60.0) as handler:
+            with patch.object(handler, "_send_events", side_effect=fake_send):
+                handler.enqueue(_StubEvent(task="run"))
+                await handler.astop()
+
+        assert sent == [1]
+
+    async def test_enqueue_at_max_size_signals_flush_in_async_mode(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+
+        flushed = asyncio.Event()
+
+        async def fake_send(events):
+            flushed.set()
+
+        handler = TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=60.0, max_queue_size=2)
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            await handler.astart()
+            try:
+                handler.enqueue(_StubEvent(task="run"))
+                handler.enqueue(_StubEvent(task="run"))
+                await asyncio.wait_for(flushed.wait(), timeout=2.0)
+            finally:
+                await handler.astop()

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_job_events.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_job_events.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from nemo_platform_ext.cli.core import waiters
+from nemo_platform_ext.cli.telemetry.events import TaskStatusEnum
+
+WAITERS_MODULE = "nemo_platform_ext.cli.core.waiters"
+EMIT_TARGET = "nemo_platform_ext.cli.telemetry.emit.emit_event"
+
+
+class _DummyLive:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def __enter__(self) -> _DummyLive:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+    def update(self, *args: object) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _quiet_rich_output() -> Iterator[None]:
+    with (
+        patch(f"{WAITERS_MODULE}.Live", _DummyLive),
+        patch(f"{WAITERS_MODULE}.console.print"),
+    ):
+        yield
+
+
+@pytest.fixture
+def frozen_time() -> Iterator[MagicMock]:
+    with patch(f"{WAITERS_MODULE}.time.time", return_value=0) as time:
+        yield time
+
+
+@pytest.fixture
+def waiter_pause() -> Iterator[MagicMock]:
+    with patch(f"{WAITERS_MODULE}._pause") as pause:
+        yield pause
+
+
+def _completed_status() -> SimpleNamespace:
+    return SimpleNamespace(
+        status="completed",
+        steps=[
+            SimpleNamespace(name="auditor.audit"),
+            SimpleNamespace(name="auditor.report"),
+            SimpleNamespace(name="guardrails.check"),
+        ],
+        status_details={"input_tokens": 512, "output_tokens": 2048, "model": "nemotron-super-49b"},
+    )
+
+
+def test_completed_emits_single_job_run_event(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = _completed_status()
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="customization") is True
+
+    emit_event.assert_called_once()
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "customization"
+    assert event.task_status is TaskStatusEnum.COMPLETED
+    assert event.input_tokens == 512
+    assert event.output_tokens == 2048
+    assert event.model == "nemotron-super-49b"
+    assert event.plugins == ["auditor", "guardrails"]
+
+
+def test_status_details_defaults_when_absent(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="completed", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.input_tokens == -1
+    assert event.output_tokens == -1
+    assert event.model == "undefined"
+    assert event.plugins == []
+
+
+def test_error_status_maps_to_error(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="error", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is False
+
+    emit_event.assert_called_once()
+    assert emit_event.call_args.args[0].task_status is TaskStatusEnum.ERROR
+
+
+def test_cancelled_status_maps_to_canceled(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="cancelled", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is False
+
+    emit_event.assert_called_once()
+    assert emit_event.call_args.args[0].task_status is TaskStatusEnum.CANCELED
+
+
+def test_timeout_emits_nothing_and_does_not_crash(waiter_pause: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="running", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", timeout=5, poll_interval=10) is False
+
+    emit_event.assert_not_called()

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_job_events.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_job_events.py
@@ -99,6 +99,25 @@ def test_status_details_defaults_when_absent(frozen_time: MagicMock) -> None:
     assert event.plugins == []
 
 
+def test_null_status_details_still_emits(frozen_time: MagicMock) -> None:
+    """Explicit nulls must not drop the event; a real 0 token count must survive."""
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed",
+        steps=[],
+        status_details={"model": None, "input_tokens": 0, "output_tokens": None},
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    emit_event.assert_called_once()
+    event = emit_event.call_args.args[0]
+    assert event.model == "undefined"
+    assert event.input_tokens == 0
+    assert event.output_tokens == -1
+
+
 def test_error_status_maps_to_error(frozen_time: MagicMock) -> None:
     jobs = MagicMock()
     jobs.get_status.return_value = SimpleNamespace(status="error", steps=[], status_details={})

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_job_events.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_job_events.py
@@ -77,12 +77,39 @@ def test_completed_emits_single_job_run_event(frozen_time: MagicMock) -> None:
 
     emit_event.assert_called_once()
     event = emit_event.call_args.args[0]
-    assert event.job_type == "customization"
+    # job_type is the job's operation entry points from the step names, per the PRD.
+    assert event.job_type == "auditor.audit,auditor.report,guardrails.check"
     assert event.task_status is TaskStatusEnum.COMPLETED
     assert event.input_tokens == 512
     assert event.output_tokens == 2048
     assert event.model == "nemotron-super-49b"
     assert event.plugins == ["auditor", "guardrails"]
+
+
+def test_single_step_job_type_is_the_entry_point(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed", steps=[SimpleNamespace(name="auditor.audit")], status_details={}
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="audit") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "auditor.audit"
+    assert event.plugins == ["auditor"]
+
+
+def test_job_type_falls_back_to_resource_label_without_steps(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="completed", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="customization") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "customization"
+    assert event.plugins == []
 
 
 def test_status_details_defaults_when_absent(frozen_time: MagicMock) -> None:

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_onboarding_events.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_onboarding_events.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for onboarding_step telemetry emitted from the setup flow.
+
+Each instrumented choke point in ``setup.py`` emits exactly one
+``OnboardingStepEvent``: COMPLETED on success, ERROR on failure with the
+original exception still propagating. ``emit_event`` is patched at its
+definition module so the module-attribute call in ``setup.py`` is intercepted.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from nemo_platform.resources.inference.providers import ProvidersResource
+from nemo_platform_ext.cli.commands.setup import (
+    _bucket_model_count,
+    _create_provider,
+    _deploy_demo_agent,
+    _run_skill_install,
+    _wait_for_models,
+)
+from nemo_platform_ext.cli.commands.skills.base import Scope, Skill
+from nemo_platform_ext.cli.telemetry.events import TaskStatusEnum
+
+SETUP_MOD = "nemo_platform_ext.cli.commands.setup"
+EMIT_TARGET = "nemo_platform_ext.cli.telemetry.emit.emit_event"
+
+
+@pytest.fixture
+def spinner_console():
+    """Patch setup.console with a mock status spinner context manager."""
+    mock_status = MagicMock()
+    with patch(f"{SETUP_MOD}.console") as mock_console:
+        mock_console.status.return_value.__enter__ = MagicMock(return_value=mock_status)
+        mock_console.status.return_value.__exit__ = MagicMock(return_value=False)
+        yield mock_console, mock_status
+
+
+def _providers_client() -> MagicMock:
+    client = MagicMock()
+    client.inference.providers = MagicMock(spec=ProvidersResource)
+    return client
+
+
+def _skill(name: str) -> Skill:
+    return Skill(
+        name=name,
+        description=f"{name} desc",
+        version="0.1",
+        content=f"# {name}",
+        raw=f"---\nname: {name}\n---\n# {name}",
+        source_plugin=None,
+    )
+
+
+class TestCreateProviderTelemetry:
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed(self, emit):
+        client = _providers_client()
+        _create_provider(
+            client,
+            name="openai",
+            host_url="https://api.openai.com/v1",
+            secret_name="openai-api-key",
+            workspace="default",
+        )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.provider_type == "openai"
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit):
+        client = _providers_client()
+        client.inference.providers.create.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            _create_provider(
+                client,
+                name="anthropic",
+                host_url="https://api.anthropic.com",
+                secret_name="anthropic-api-key",
+                workspace="default",
+            )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.provider_type == "anthropic"
+
+
+class TestWaitForModelsTelemetry:
+    @patch(EMIT_TARGET)
+    def test_emits_completed_with_bucket(self, emit, spinner_console):
+        client = MagicMock()
+        models = [MagicMock(model_entity_id=f"default/model-{i}") for i in range(3)]
+        client.inference.providers.retrieve.return_value = MagicMock(served_models=models)
+
+        with (
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 0, 1]),
+        ):
+            result = _wait_for_models(client, "nvidia-build", "default", round_seconds=30, max_rounds=1)
+
+        assert result == [f"default/model-{i}" for i in range(3)]
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "models_discovered"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.models_discovered_bucket == "1-5"
+
+    @patch(EMIT_TARGET)
+    def test_no_models_emits_bucket_zero(self, emit, spinner_console):
+        client = MagicMock()
+        client.inference.providers.retrieve.return_value = MagicMock(served_models=[])
+
+        with (
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 1, 2, 100]),
+        ):
+            result = _wait_for_models(client, "nvidia-build", "default", round_seconds=5, max_rounds=1)
+
+        assert result == []
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "models_discovered"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.models_discovered_bucket == "0"
+
+
+class TestRunSkillInstallTelemetry:
+    def _run(self, emit, *, install_raises: bool):
+        installer = MagicMock()
+        if install_raises:
+            installer.install.side_effect = RuntimeError("install failed")
+        all_skills = {"alpha": _skill("alpha")}
+        with patch(f"{SETUP_MOD}.get_installer", return_value=installer):
+            _run_skill_install(
+                agents=["codex"],
+                scope=Scope.PROJECT,
+                skill_names=["alpha"],
+                all_skills=all_skills,
+                project_root=MagicMock(),
+            )
+
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed(self, emit):
+        self._run(emit, install_raises=False)
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "skills_installed"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert "codex" in event.skills_target
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit):
+        import typer
+
+        with pytest.raises(typer.Exit):
+            self._run(emit, install_raises=True)
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "skills_installed"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert "codex" in event.skills_target
+
+
+class TestDeployDemoAgentTelemetry:
+    def _responses(self, *, status_sequence):
+        create_resp = MagicMock(status_code=200)
+        create_resp.raise_for_status = MagicMock()
+        deploy_resp = MagicMock(status_code=200)
+        deploy_resp.raise_for_status = MagicMock()
+        deploy_resp.json.return_value = {"name": "calculator-agent-abc12345"}
+        status_resps = []
+        for s in status_sequence:
+            r = MagicMock(status_code=200)
+            r.json.return_value = {"name": "calculator-agent-abc12345", "status": s}
+            status_resps.append(r)
+        return [create_resp, deploy_resp] + status_resps
+
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed_true(self, emit, tmp_path, spinner_console):
+        config = tmp_path / "calculator-agent.yml"
+        config.write_text("llms: {}\n")
+        responses = self._responses(status_sequence=["running"])
+        with (
+            patch(f"{SETUP_MOD}.httpx.get", side_effect=responses[2:]),
+            patch(f"{SETUP_MOD}.httpx.post", side_effect=responses[:2]),
+            patch(f"{SETUP_MOD}._agent_exists", return_value=False),
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 1, 2, 3]),
+        ):
+            result = _deploy_demo_agent("http://localhost:8080", "default", config, default_model="m")
+        assert result is True
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "agent_deployed"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.agent_deployed is True
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit, tmp_path, spinner_console):
+        config = tmp_path / "calculator-agent.yml"
+        config.write_text("llms: {}\n")
+        create_resp = MagicMock(status_code=500)
+        create_resp.raise_for_status = MagicMock(side_effect=RuntimeError("http 500"))
+        with (
+            patch(f"{SETUP_MOD}.httpx.post", return_value=create_resp),
+            patch(f"{SETUP_MOD}._agent_exists", return_value=False),
+        ):
+            with pytest.raises(RuntimeError):
+                _deploy_demo_agent("http://localhost:8080", "default", config, default_model="m")
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "agent_deployed"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.agent_deployed is False
+
+
+class TestBucketModelCount:
+    @pytest.mark.parametrize(
+        ("count", "expected"),
+        [
+            (0, "0"),
+            (1, "1-5"),
+            (5, "1-5"),
+            (6, "6-20"),
+            (20, "6-20"),
+            (21, "21-100"),
+            (100, "21-100"),
+            (101, "101+"),
+            (5000, "101+"),
+        ],
+    )
+    def test_buckets(self, count, expected):
+        assert _bucket_model_count(count) == expected

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_onboarding_events.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_onboarding_events.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+import typer
 from nemo_platform.resources.inference.providers import ProvidersResource
 from nemo_platform_ext.cli.commands.setup import (
     _bucket_model_count,
@@ -20,6 +21,7 @@ from nemo_platform_ext.cli.commands.setup import (
     _deploy_demo_agent,
     _run_skill_install,
     _wait_for_models,
+    setup_command,
 )
 from nemo_platform_ext.cli.commands.skills.base import Scope, Skill
 from nemo_platform_ext.cli.telemetry.events import TaskStatusEnum
@@ -237,3 +239,69 @@ class TestBucketModelCount:
     )
     def test_buckets(self, count, expected):
         assert _bucket_model_count(count) == expected
+
+
+class TestSetupFinishedTelemetry:
+    """setup_finished must reflect the real outcome of the dispatch.
+
+    A clean user-cancel raises typer.Exit(0); that is a normal end, not a
+    failure, so it must emit COMPLETED. Any non-zero Exit (or real exception)
+    emits ERROR. In every case the Exit propagates unchanged.
+    """
+
+    def _run(self, emit, dispatch_exc):
+        """Drive setup_command to the auto/interactive dispatch, patching all
+        preamble so only the dispatch outcome matters. `dispatch_exc` is raised
+        from _run_interactive_mode; None means a clean finish."""
+        ctx = MagicMock(spec=typer.Context)
+        ctx.obj = MagicMock()
+        ctx.obj.get_base_url.return_value = "http://localhost:3000"
+
+        interactive = MagicMock()
+        if dispatch_exc is not None:
+            interactive.side_effect = dispatch_exc
+
+        with (
+            patch(f"{SETUP_MOD}.console"),
+            patch(f"{SETUP_MOD}.is_interactive", return_value=True),
+            patch(f"{SETUP_MOD}._maybe_start_services"),
+            patch(f"{SETUP_MOD}._check_platform_reachable_with_retries", return_value=True),
+            patch(f"{SETUP_MOD}._bootstrap_config_if_missing"),
+            patch(f"{SETUP_MOD}._run_interactive_mode", interactive),
+        ):
+            setup_command(ctx)
+
+    @patch(EMIT_TARGET)
+    def test_clean_exit_zero_emits_completed(self, emit):
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(emit, typer.Exit(0))
+        assert exc_info.value.exit_code == 0
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.COMPLETED
+
+    @patch(EMIT_TARGET)
+    def test_default_exit_emits_completed(self, emit):
+        # typer.Exit() defaults to exit_code 0, so a bare Exit is a clean end too.
+        with pytest.raises(typer.Exit):
+            self._run(emit, typer.Exit())
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.COMPLETED
+
+    @patch(EMIT_TARGET)
+    def test_nonzero_exit_emits_error(self, emit):
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(emit, typer.Exit(1))
+        assert exc_info.value.exit_code == 1
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.ERROR
+
+    @patch(EMIT_TARGET)
+    def test_real_exception_emits_error(self, emit):
+        with pytest.raises(RuntimeError):
+            self._run(emit, RuntimeError("boom"))
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.ERROR

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_wire_contract_smoke.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_wire_contract_smoke.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CI-safe wire-contract smoke test for telemetry events.
+
+This module verifies that each telemetry event serializes to the wire contract
+without making network calls. Each test constructs a valid event, wraps it in
+QueuedEvent, calls build_payload, and asserts JSON serialization and envelope
+structure.
+
+Live UAT validation (POST against the telemetry endpoint) is a manual runbook:
+set NEMO_TELEMETRY_ENDPOINT to the UAT URL, NEMO_TELEMETRY_ENABLED=true, and
+run one real command; live validation is pending nemoSource schema registration.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from nemo_platform_ext.cli.telemetry.events import (
+    CommandInvokedEvent,
+    JobRunEvent,
+    OnboardingStepEvent,
+    TaskStatusEnum,
+)
+from nemo_platform_ext.cli.telemetry.handler import QueuedEvent, build_payload
+
+
+class TestWireContractSmoke:
+    """Verify each event type serializes to the wire contract envelope."""
+
+    def test_onboarding_step_event_contract(self):
+        """OnboardingStepEvent must serialize with camelCase aliases and correct envelope."""
+        event = OnboardingStepEvent(
+            task_status=TaskStatusEnum.COMPLETED,
+            step="provider_discovery",
+            provider_type="huggingface",
+            models_discovered_bucket="10-100",
+            skills_target="audit_content",
+            agent_deployed=True,
+        )
+        queued = QueuedEvent(event=event, timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
+        payload = build_payload([queued], source_client_version="1.0.0", session_id="test")
+
+        # Envelope keys must match exactly.
+        expected_keys = {
+            "browserType",
+            "clientId",
+            "clientType",
+            "clientVariant",
+            "clientVer",
+            "cpuArchitecture",
+            "deviceGdprBehOptIn",
+            "deviceGdprFuncOptIn",
+            "deviceGdprTechOptIn",
+            "deviceId",
+            "deviceMake",
+            "deviceModel",
+            "deviceOS",
+            "deviceOSVersion",
+            "deviceType",
+            "eventProtocol",
+            "eventSchemaVer",
+            "eventSysVer",
+            "externalUserId",
+            "gdprBehOptIn",
+            "gdprFuncOptIn",
+            "gdprTechOptIn",
+            "idpId",
+            "integrationId",
+            "productName",
+            "productVersion",
+            "sentTs",
+            "sessionId",
+            "userId",
+            "events",
+        }
+        assert set(payload.keys()) == expected_keys, f"Envelope keys mismatch: {set(payload.keys()) ^ expected_keys}"
+
+        # Schema version must be 1.9.
+        assert payload["eventSchemaVer"] == "1.9"
+
+        # Must be JSON serializable.
+        json_str = json.dumps(payload)
+        assert isinstance(json_str, str)
+
+        # Event parameters must include camelCase aliases.
+        event_entry = payload["events"][0]
+        params = event_entry["parameters"]
+        assert params["nemoSource"] == "platform"
+        assert params["taskStatus"] == "completed"
+        assert params["deploymentType"] == "cli"
+        assert params["isCi"] is False
+        assert params["step"] == "provider_discovery"
+        assert params["providerType"] == "huggingface"
+        assert params["modelsDiscoveredBucket"] == "10-100"
+        assert params["skillsTarget"] == "audit_content"
+        assert params["agentDeployed"] is True
+        assert event_entry["name"] == "onboarding_step"
+
+    def test_command_invoked_event_contract(self):
+        """CommandInvokedEvent must serialize with camelCase aliases and correct envelope."""
+        event = CommandInvokedEvent(
+            task_status=TaskStatusEnum.COMPLETED,
+            command="nemo platform apply",
+            duration_sec=2.5,
+            agent_mode=True,
+        )
+        queued = QueuedEvent(event=event, timestamp=datetime(2026, 1, 1, 13, 0, 0, tzinfo=timezone.utc))
+        payload = build_payload([queued], source_client_version="1.2.3", session_id="cmd-test")
+
+        # Envelope keys must match exactly.
+        expected_keys = {
+            "browserType",
+            "clientId",
+            "clientType",
+            "clientVariant",
+            "clientVer",
+            "cpuArchitecture",
+            "deviceGdprBehOptIn",
+            "deviceGdprFuncOptIn",
+            "deviceGdprTechOptIn",
+            "deviceId",
+            "deviceMake",
+            "deviceModel",
+            "deviceOS",
+            "deviceOSVersion",
+            "deviceType",
+            "eventProtocol",
+            "eventSchemaVer",
+            "eventSysVer",
+            "externalUserId",
+            "gdprBehOptIn",
+            "gdprFuncOptIn",
+            "gdprTechOptIn",
+            "idpId",
+            "integrationId",
+            "productName",
+            "productVersion",
+            "sentTs",
+            "sessionId",
+            "userId",
+            "events",
+        }
+        assert set(payload.keys()) == expected_keys, f"Envelope keys mismatch: {set(payload.keys()) ^ expected_keys}"
+
+        # Schema version must be 1.9.
+        assert payload["eventSchemaVer"] == "1.9"
+
+        # Must be JSON serializable.
+        json_str = json.dumps(payload)
+        assert isinstance(json_str, str)
+
+        # Event parameters must include camelCase aliases.
+        event_entry = payload["events"][0]
+        params = event_entry["parameters"]
+        assert params["nemoSource"] == "platform"
+        assert params["taskStatus"] == "completed"
+        assert params["deploymentType"] == "cli"
+        assert params["isCi"] is False
+        assert params["command"] == "nemo platform apply"
+        assert params["durationSec"] == 2.5
+        assert params["agentMode"] is True
+        assert event_entry["name"] == "command_invoked"
+
+    def test_job_run_event_contract(self):
+        """JobRunEvent must serialize with camelCase aliases and correct envelope."""
+        event = JobRunEvent(
+            task_status=TaskStatusEnum.COMPLETED,
+            job_type="evaluate",
+            duration_sec=15.75,
+            plugins=["garak", "llm_judge"],
+            model="nemotron-4-8b",
+            input_tokens=2048,
+            output_tokens=512,
+        )
+        queued = QueuedEvent(event=event, timestamp=datetime(2026, 1, 1, 14, 0, 0, tzinfo=timezone.utc))
+        payload = build_payload([queued], source_client_version="2.0.0", session_id="job-test")
+
+        # Envelope keys must match exactly.
+        expected_keys = {
+            "browserType",
+            "clientId",
+            "clientType",
+            "clientVariant",
+            "clientVer",
+            "cpuArchitecture",
+            "deviceGdprBehOptIn",
+            "deviceGdprFuncOptIn",
+            "deviceGdprTechOptIn",
+            "deviceId",
+            "deviceMake",
+            "deviceModel",
+            "deviceOS",
+            "deviceOSVersion",
+            "deviceType",
+            "eventProtocol",
+            "eventSchemaVer",
+            "eventSysVer",
+            "externalUserId",
+            "gdprBehOptIn",
+            "gdprFuncOptIn",
+            "gdprTechOptIn",
+            "idpId",
+            "integrationId",
+            "productName",
+            "productVersion",
+            "sentTs",
+            "sessionId",
+            "userId",
+            "events",
+        }
+        assert set(payload.keys()) == expected_keys, f"Envelope keys mismatch: {set(payload.keys()) ^ expected_keys}"
+
+        # Schema version must be 1.9.
+        assert payload["eventSchemaVer"] == "1.9"
+
+        # Must be JSON serializable.
+        json_str = json.dumps(payload)
+        assert isinstance(json_str, str)
+
+        # Event parameters must include camelCase aliases.
+        event_entry = payload["events"][0]
+        params = event_entry["parameters"]
+        assert params["nemoSource"] == "platform"
+        assert params["taskStatus"] == "completed"
+        assert params["deploymentType"] == "cli"
+        assert params["isCi"] is False
+        assert params["jobType"] == "evaluate"
+        assert params["durationSec"] == 15.75
+        assert params["plugins"] == ["garak", "llm_judge"]
+        assert params["model"] == "nemotron-4-8b"
+        assert params["inputTokens"] == 2048
+        assert params["outputTokens"] == 512
+        assert event_entry["name"] == "job_run"

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/app.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/app.py
@@ -220,6 +220,14 @@ def main(
             hidden=True,
         ),
     ] = False,
+    no_telemetry: Annotated[
+        bool,
+        typer.Option(
+            "--no-telemetry",
+            help="Disable anonymous usage telemetry for this invocation.",
+            rich_help_panel="Global Options",
+        ),
+    ] = False,
 ) -> None:
     """
     Command-line interface for NeMo Platform.
@@ -251,6 +259,12 @@ def main(
         env_val = os.environ.get("NMP_AGENT_MODE", "").lower()
         agent_mode = env_val in ("1", "true", "yes")
     ctx.obj.agent_mode = agent_mode
+
+    # Capture command name + agent mode for the command_invoked telemetry event, wire
+    # the per-invocation opt-out, and print the first-run notice. Best effort inside.
+    from nemo_platform.cli.telemetry import runtime as telemetry_runtime
+
+    telemetry_runtime.on_callback(ctx, no_telemetry=no_telemetry)
 
     # Build ConfigParams from CLI args
     overrides: ConfigParams = {}

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
@@ -45,6 +45,8 @@ from nemo_platform.cli.commands.skills.base import Scope, Skill
 from nemo_platform.cli.commands.skills.registry import get_installer, load_skills
 from nemo_platform.cli.core.context import CLIContext
 from nemo_platform.cli.core.errors import handle_errors
+from nemo_platform.cli.telemetry import emit
+from nemo_platform.cli.telemetry.events import OnboardingStepEvent, TaskStatusEnum
 from nemo_platform.config.config import Config
 from nemo_platform.config.models import ConfigFile, ConfigParams, LocalServicesConfig
 from nemo_platform.ui.prompts import (
@@ -423,7 +425,16 @@ def _create_provider(
             kwargs["required_extra_headers"] = {header_name.strip(): header_value.strip()}
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
-    client.inference.providers.create(**kwargs)
+    try:
+        client.inference.providers.create(**kwargs)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(step="provider_connected", task_status=TaskStatusEnum.ERROR, provider_type=name)
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(step="provider_connected", task_status=TaskStatusEnum.COMPLETED, provider_type=name)
+    )
 
 
 def _update_provider(
@@ -450,7 +461,51 @@ _PROVIDER_UNHEALTHY_STATUSES = frozenset({"ERROR", "LOST"})
 _NON_COMPLIANT_MARKER = "Non-OpenAI compliant"
 
 
+def _bucket_model_count(count: int) -> str:
+    """Bucket a discovered-model count into a coarse range for telemetry.
+
+    Keeps the emitted value low-cardinality (no exact counts leave the machine).
+    """
+    if count <= 0:
+        return "0"
+    if count <= 5:
+        return "1-5"
+    if count <= 20:
+        return "6-20"
+    if count <= 100:
+        return "21-100"
+    return "101+"
+
+
 def _wait_for_models(
+    client: NeMoPlatform,
+    provider_name: str,
+    workspace: str,
+    host_url: str = "",
+    round_seconds: int = _MODEL_DISCOVERY_ROUND_SECONDS,
+    max_rounds: int = _MODEL_DISCOVERY_MAX_ROUNDS,
+) -> list[str]:
+    """Poll for served models and emit one ``models_discovered`` event.
+
+    Thin telemetry wrapper around :func:`_wait_for_models_impl`: COMPLETED with
+    the discovered-count bucket on success, ERROR (re-raised) if polling blows up.
+    """
+    try:
+        models = _wait_for_models_impl(client, provider_name, workspace, host_url, round_seconds, max_rounds)
+    except Exception:
+        emit.emit_event(OnboardingStepEvent(step="models_discovered", task_status=TaskStatusEnum.ERROR))
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="models_discovered",
+            task_status=TaskStatusEnum.COMPLETED,
+            models_discovered_bucket=_bucket_model_count(len(models)),
+        )
+    )
+    return models
+
+
+def _wait_for_models_impl(
     client: NeMoPlatform,
     provider_name: str,
     workspace: str,
@@ -930,20 +985,30 @@ def _run_skill_install(
         console.print(f"  {WARN} No skills selected to install.")
         return
 
-    successes = 0
-    failures = 0
-    for agent in agents:
-        try:
-            installer = get_installer(agent)
-            installer.install(scope, project_root, chosen)
-            console.print(f"  {CHECK} Installed {len(chosen)} skill(s) for {agent}")
-            successes += 1
-        except Exception as exc:
-            console.print(f"  {WARN} Failed to install skills for {agent}: {exc}")
-            failures += 1
+    skills_target = ",".join(agents)
+    try:
+        successes = 0
+        failures = 0
+        for agent in agents:
+            try:
+                installer = get_installer(agent)
+                installer.install(scope, project_root, chosen)
+                console.print(f"  {CHECK} Installed {len(chosen)} skill(s) for {agent}")
+                successes += 1
+            except Exception as exc:
+                console.print(f"  {WARN} Failed to install skills for {agent}: {exc}")
+                failures += 1
 
-    if failures and not successes:
-        raise typer.Exit(1)
+        if failures and not successes:
+            raise typer.Exit(1)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(step="skills_installed", task_status=TaskStatusEnum.ERROR, skills_target=skills_target)
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(step="skills_installed", task_status=TaskStatusEnum.COMPLETED, skills_target=skills_target)
+    )
 
 
 def _parse_csv_flag(value: str | None) -> list[str] | None:
@@ -1160,6 +1225,25 @@ def _agents_api_ready(base_url: str, workspace: str) -> bool:
 
 
 def _deploy_demo_agent(base_url: str, workspace: str, config_path: Traversable, default_model: str) -> bool:
+    """Deploy the demo agent and emit one ``agent_deployed`` event.
+
+    Telemetry wrapper around :func:`_deploy_demo_agent_impl`: COMPLETED with the
+    deployment outcome as ``agent_deployed`` on success, ERROR (re-raised) on failure.
+    """
+    try:
+        deployed = _deploy_demo_agent_impl(base_url, workspace, config_path, default_model)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(step="agent_deployed", task_status=TaskStatusEnum.ERROR, agent_deployed=False)
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(step="agent_deployed", task_status=TaskStatusEnum.COMPLETED, agent_deployed=deployed)
+    )
+    return deployed
+
+
+def _deploy_demo_agent_impl(base_url: str, workspace: str, config_path: Traversable, default_model: str) -> bool:
     """Create and deploy the demo calculator agent. Returns True on success."""
     # Optional plugin: import here so ``nemo setup`` works without nemo-agents installed.
     from nemo_agents_plugin.utils import expand_env_vars
@@ -1711,30 +1795,43 @@ def setup_command(
     skills_agents_list = _parse_csv_flag(skills_agents)
     skills_from_list = _parse_csv_flag(skills_from)
 
-    if auto:
-        _run_auto_mode(
-            cli_context,
-            client,
-            workspace,
-            base_url,
-            install_skills,
-            deploy_agent,
-            skills_agents=skills_agents_list,
-            skills_scope=skills_scope,
-            skills_from=skills_from_list,
-        )
-    else:
-        _run_interactive_mode(
-            cli_context,
-            client,
-            workspace,
-            base_url,
-            install_skills,
-            deploy_agent,
-            skills_agents=skills_agents_list,
-            skills_scope=skills_scope,
-            skills_from=skills_from_list,
-        )
+    try:
+        if auto:
+            _run_auto_mode(
+                cli_context,
+                client,
+                workspace,
+                base_url,
+                install_skills,
+                deploy_agent,
+                skills_agents=skills_agents_list,
+                skills_scope=skills_scope,
+                skills_from=skills_from_list,
+            )
+        else:
+            _run_interactive_mode(
+                cli_context,
+                client,
+                workspace,
+                base_url,
+                install_skills,
+                deploy_agent,
+                skills_agents=skills_agents_list,
+                skills_scope=skills_scope,
+                skills_from=skills_from_list,
+            )
+    except typer.Exit as exc:
+        # A clean user-cancel raises typer.Exit(0); that is a normal end of the
+        # flow, not a failure, so it must not corrupt the onboarding funnel.
+        # Only a non-zero exit code counts as ERROR. Re-raise unchanged either way.
+        status = TaskStatusEnum.COMPLETED if exc.exit_code == 0 else TaskStatusEnum.ERROR
+        emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=status))
+        raise
+    except Exception:
+        # Any real (non-Exit) failure: setup did not finish cleanly.
+        emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=TaskStatusEnum.ERROR))
+        raise
+    emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=TaskStatusEnum.COMPLETED))
 
 
 def _run_auto_mode(
@@ -1770,6 +1867,16 @@ def _run_auto_mode(
             break
         if attempt < _MODEL_DISCOVERY_MAX_ROUNDS - 1:
             console.print(f"  {WARN} Models not available yet, retrying...")
+
+    # Auto mode discovers models via an inline loop rather than _wait_for_models,
+    # so emit the models_discovered event here to cover the non-interactive path.
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="models_discovered",
+            task_status=TaskStatusEnum.COMPLETED,
+            models_discovered_bucket=_bucket_model_count(len(entity_ids)),
+        )
+    )
 
     default_model = os.environ.get("NEMO_DEFAULT_MODEL", "").strip()
     if not default_model and entity_ids:

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/help_formatter.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/help_formatter.py
@@ -47,36 +47,77 @@ class NmpErrorHandlingMixin:
         standalone_mode: bool = True,
         **extra: Any,
     ) -> Any:
-        """Override main to use custom error handling."""
-        from nemo_platform.cli.core.errors import handle_exception
+        """Override main to use custom error handling and emit one telemetry event.
 
+        This is the single path every command type flows through (hand-registered,
+        OpenAPI-generated, plugin entry points), and Click only calls ``main()`` on the
+        root command object, so this is the natural choke point for a per-invocation
+        ``command_invoked`` event. The outcome->status mapping and the emit both live in
+        a ``finally`` so telemetry fires even when a command fails, and the emit body is
+        best-effort (never raises) so a telemetry bug can never change a command's exit
+        code or output.
+        """
+        import time
+
+        from nemo_platform.cli.core.errors import handle_exception
+        from nemo_platform.cli.telemetry import runtime
+        from nemo_platform.cli.telemetry.events import TaskStatusEnum
+
+        # Only the root group (the app-level ManifestBackedNmpGroup) drives telemetry.
+        # Nested groups never have main() called during dispatch, but this guard keeps
+        # the single-emit contract explicit and cheap without an import cycle.
+        is_telemetry_root = type(self).__name__ == "ManifestBackedNmpGroup"
+        if is_telemetry_root:
+            runtime.reset()
+
+        start = time.monotonic()
+        status: TaskStatusEnum | None = None
         try:
-            result = super().main(  # type: ignore[misc]
-                args=args,
-                prog_name=prog_name,
-                complete_var=complete_var,
-                standalone_mode=False,
-                **extra,
-            )
-            # When standalone_mode=False, Click returns the exit code instead of raising
-            # SystemExit. We need to convert non-zero exit codes back to SystemExit
-            # when the original caller expected standalone_mode=True behavior.
-            if standalone_mode and isinstance(result, int) and result != 0:
-                raise SystemExit(result)
-            return result
-        except click.UsageError as e:
-            if standalone_mode:
-                handle_exception(e, e.ctx)
+            try:
+                result = super().main(  # type: ignore[misc]
+                    args=args,
+                    prog_name=prog_name,
+                    complete_var=complete_var,
+                    standalone_mode=False,
+                    **extra,
+                )
+                # When standalone_mode=False, Click returns the exit code instead of
+                # raising. A non-zero code is an error regardless of how the outer caller
+                # ultimately surfaces it.
+                status = TaskStatusEnum.ERROR if isinstance(result, int) and result != 0 else TaskStatusEnum.COMPLETED
+                # Convert non-zero exit codes back to SystemExit when the original caller
+                # expected standalone_mode=True behavior.
+                if standalone_mode and isinstance(result, int) and result != 0:
+                    raise SystemExit(result)
+                return result
+            except click.UsageError as e:
+                status = TaskStatusEnum.ERROR
+                if standalone_mode:
+                    handle_exception(e, e.ctx)
+                raise
+            except click.exceptions.Exit as e:
+                status = TaskStatusEnum.COMPLETED if e.exit_code == 0 else TaskStatusEnum.ERROR
+                if standalone_mode:
+                    raise SystemExit(e.exit_code)
+                raise
+            except click.Abort:
+                status = TaskStatusEnum.CANCELED
+                if standalone_mode:
+                    click.echo("Aborted!", err=True)
+                    raise SystemExit(1)
+                raise
+        except SystemExit as e:
+            if status is None:
+                code = e.code
+                status = TaskStatusEnum.COMPLETED if code in (0, None) else TaskStatusEnum.ERROR
             raise
-        except click.exceptions.Exit as e:
-            if standalone_mode:
-                raise SystemExit(e.exit_code)
+        except BaseException:
+            if status is None:
+                status = TaskStatusEnum.ERROR
             raise
-        except click.Abort:
-            if standalone_mode:
-                click.echo("Aborted!", err=True)
-                raise SystemExit(1)
-            raise
+        finally:
+            if is_telemetry_root:
+                runtime.emit_command_invoked(status or TaskStatusEnum.COMPLETED, time.monotonic() - start)
 
 
 def _get_terminal_width() -> int:
@@ -524,6 +565,14 @@ class NmpGroup(NmpErrorHandlingMixin, TyperGroup):
         if "cls" not in kwargs:
             kwargs["cls"] = NmpCommand
         return super().command(*args, **kwargs)
+
+    def resolve_command(self, ctx: click.Context, args: list[str]) -> tuple[str | None, Command | None, list[str]]:
+        """Record the resolved subcommand name for telemetry, then resolve as usual."""
+        cmd_name, cmd, remaining = super().resolve_command(ctx, args)
+        from nemo_platform.cli.telemetry import runtime
+
+        runtime.note_subcommand(cmd_name)
+        return cmd_name, cmd, remaining
 
     def get_command(self, ctx: click.Context, cmd_name: str) -> Command | None:
         """Override to patch command classes to use NeMo Platform formatting."""

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/help_formatter.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/help_formatter.py
@@ -69,6 +69,15 @@ class NmpErrorHandlingMixin:
         is_telemetry_root = type(self).__name__ == "ManifestBackedNmpGroup"
         if is_telemetry_root:
             runtime.reset()
+            # Reading help (e.g. ``nemo docs --help``) is not usage, so it must not emit
+            # a command_invoked event. Detect a help request from the resolved args; the
+            # help option names are the same ones every command registers via
+            # ``_context_settings_with_help``.
+            import sys
+
+            resolved_args = args if args is not None else sys.argv[1:]
+            if any(arg in HELP_OPTION_NAMES for arg in resolved_args):
+                runtime.state.help_requested = True
 
         start = time.monotonic()
         status: TaskStatusEnum | None = None

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/waiters.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/waiters.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from datetime import datetime
 from typing import Any
@@ -26,6 +27,7 @@ from rich.console import Console
 from rich.live import Live
 from rich.text import Text
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 _TRANSIENT_GATEWAY_STATUS_CODES = {429, 502, 503, 504}
@@ -53,6 +55,48 @@ def _seconds_since_creation(entry_timestamp: datetime | str | None, created_at: 
 
 def _status_text(status: Any) -> str:
     return str(status or "")
+
+
+def _emit_job_run_event(job_status: Any, *, resource_label: str, status: str, start_time: float) -> None:
+    """Emit a ``job_run`` telemetry event for a terminal platform job.
+
+    Best effort: never raises and never affects the waiter's return value.
+    """
+    try:
+        from nemo_platform.cli.telemetry.emit import emit_event
+        from nemo_platform.cli.telemetry.events import JobRunEvent, TaskStatusEnum
+
+        status_map = {
+            "completed": TaskStatusEnum.COMPLETED,
+            "error": TaskStatusEnum.ERROR,
+            "cancelled": TaskStatusEnum.CANCELED,
+        }
+        task_status = status_map.get(status, TaskStatusEnum.UNDEFINED)
+
+        details = getattr(job_status, "status_details", None)
+        if not isinstance(details, dict):
+            details = {}
+
+        plugins: set[str] = set()
+        for step in getattr(job_status, "steps", None) or []:
+            step_name = getattr(step, "name", "") or ""
+            prefix = step_name.split(".", 1)[0]
+            if prefix:
+                plugins.add(prefix)
+
+        emit_event(
+            JobRunEvent(
+                task_status=task_status,
+                job_type=resource_label,
+                duration_sec=float(time.time() - start_time),
+                plugins=sorted(plugins),
+                model=details.get("model", "undefined"),
+                input_tokens=details.get("input_tokens", -1),
+                output_tokens=details.get("output_tokens", -1),
+            )
+        )
+    except Exception:
+        logger.debug("Failed to emit job_run telemetry event", exc_info=True)
 
 
 def _make_history_line(
@@ -270,11 +314,17 @@ def wait_for_platform_job(
 
             if current_status == "completed":
                 live.stop()
+                _emit_job_run_event(
+                    job_status, resource_label=resource_label, status=current_status, start_time=start_time
+                )
                 console.print(f"\n[green]✓ {resource_label.title()} completed![/green]")
                 return True
 
             if current_status in {"cancelled", "error"}:
                 live.stop()
+                _emit_job_run_event(
+                    job_status, resource_label=resource_label, status=current_status, start_time=start_time
+                )
                 console.print(f"\n[red]✗ {resource_label.title()} entered {current_status} state[/red]")
                 return False
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/waiters.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/waiters.py
@@ -77,12 +77,14 @@ def _emit_job_run_event(job_status: Any, *, resource_label: str, status: str, st
         if not isinstance(details, dict):
             details = {}
 
-        plugins: set[str] = set()
-        for step in getattr(job_status, "steps", None) or []:
-            step_name = getattr(step, "name", "") or ""
-            prefix = step_name.split(".", 1)[0]
-            if prefix:
-                plugins.add(prefix)
+        # job_type is the job's operation entry point(s) (for example "auditor.audit"), read
+        # from the step names per the PRD. These are static plugin.operation identifiers, not
+        # the user-chosen job name, so they carry no user data. It falls back to the resource
+        # label when the job reports no steps. plugins are the distinct plugin prefixes.
+        entry_points = sorted(
+            {name for step in (getattr(job_status, "steps", None) or []) if (name := getattr(step, "name", "") or "")}
+        )
+        plugins = sorted({ep.split(".", 1)[0] for ep in entry_points})
 
         # ``status_details`` can carry an explicit null (e.g. ``model: null``). Passing
         # None to the str-typed / int-typed event fields fails validation and the
@@ -97,9 +99,9 @@ def _emit_job_run_event(job_status: Any, *, resource_label: str, status: str, st
         emit_event(
             JobRunEvent(
                 task_status=task_status,
-                job_type=resource_label,
+                job_type=",".join(entry_points) if entry_points else resource_label,
                 duration_sec=float(time.time() - start_time),
-                plugins=sorted(plugins),
+                plugins=plugins,
                 model=model,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/waiters.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/waiters.py
@@ -84,15 +84,25 @@ def _emit_job_run_event(job_status: Any, *, resource_label: str, status: str, st
             if prefix:
                 plugins.add(prefix)
 
+        # ``status_details`` can carry an explicit null (e.g. ``model: null``). Passing
+        # None to the str-typed / int-typed event fields fails validation and the
+        # best-effort guard would silently drop the whole event, so coerce here.
+        # Tokens use explicit None checks, not ``or``, so a legitimate 0 survives as 0.
+        model = details.get("model") or "undefined"
+        raw_input_tokens = details.get("input_tokens")
+        input_tokens = int(raw_input_tokens) if raw_input_tokens is not None else -1
+        raw_output_tokens = details.get("output_tokens")
+        output_tokens = int(raw_output_tokens) if raw_output_tokens is not None else -1
+
         emit_event(
             JobRunEvent(
                 task_status=task_status,
                 job_type=resource_label,
                 duration_sec=float(time.time() - start_time),
                 plugins=sorted(plugins),
-                model=details.get("model", "undefined"),
-                input_tokens=details.get("input_tokens", -1),
-                output_tokens=details.get("output_tokens", -1),
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
             )
         )
     except Exception:

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from nemo_platform.cli.telemetry.handler import (
+    QueuedEvent,
+    TelemetryHandler,
+    _telemetry_enabled,
+    build_payload,
+)
+
+__all__ = [
+    "QueuedEvent",
+    "TelemetryHandler",
+    "_telemetry_enabled",
+    "build_payload",
+]

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/emit.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/emit.py
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 
 _invocation_opt_out = False
 
+# One random session id per process. It groups every event emitted during a single
+# invocation without carrying any user or device identity, and is discarded when the
+# process exits. This is the same pattern the Agno framework uses for session_id/run_id.
+_SESSION_ID = uuid.uuid4().hex
+
 _NOTICE_TEXT = (
     "NeMo Platform collects anonymous usage data to improve the product. "
     "No prompts, data, or personal information leave your machine. "
@@ -37,7 +42,10 @@ def _config_opted_out() -> bool:
         cfg = Config.load()
         return getattr(cfg.get_config_file(), "telemetry_enabled", True) is False
     except Exception:
-        return False
+        # A privacy control must fail closed: if we cannot read the config to confirm
+        # the user is opted in, treat them as opted out and do not send.
+        logger.debug("Could not read telemetry opt-out config; failing closed (opted out)", exc_info=True)
+        return True
 
 
 def telemetry_opted_in() -> bool:
@@ -55,6 +63,7 @@ def _client_version() -> str:
 
         return nemo_platform.__version__
     except Exception:
+        logger.debug("Could not resolve client version for telemetry", exc_info=True)
         return "undefined"
 
 
@@ -63,7 +72,7 @@ def emit_event(event: PlatformTelemetryEvent) -> None:
     try:
         if not telemetry_opted_in():
             return
-        handler = TelemetryHandler(source_client_version=_client_version(), session_id=uuid.uuid4().hex)
+        handler = TelemetryHandler(source_client_version=_client_version(), session_id=_SESSION_ID)
         handler.enqueue(event)
         handler.stop()
     except Exception:

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/emit.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/emit.py
@@ -72,7 +72,10 @@ def emit_event(event: PlatformTelemetryEvent) -> None:
     try:
         if not telemetry_opted_in():
             return
-        handler = TelemetryHandler(source_client_version=_client_version(), session_id=_SESSION_ID)
+        # No retries on the CLI exit path: a synchronous send blocks the user's command,
+        # so cap the worst case at one bounded send (SEND_TIMEOUT_SECONDS) rather than
+        # retrying against a slow or unreachable endpoint while the user waits.
+        handler = TelemetryHandler(source_client_version=_client_version(), session_id=_SESSION_ID, max_retries=0)
         handler.enqueue(event)
         handler.stop()
     except Exception:

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/emit.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/emit.py
@@ -24,7 +24,8 @@ _SESSION_ID = uuid.uuid4().hex
 _NOTICE_TEXT = (
     "NeMo Platform collects anonymous usage data to improve the product. "
     "No prompts, data, or personal information leave your machine. "
-    "Turn it off any time with NEMO_TELEMETRY_ENABLED=false.\n"
+    "Turn it off any time with NEMO_TELEMETRY_ENABLED=false. "
+    "Run nemo docs cli/configuration for details.\n"
 )
 
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/emit.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/emit.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Fire-and-flush emission with three opt-out layers and the first-run notice."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import uuid
+from pathlib import Path
+
+from nemo_platform.cli.telemetry.events import PlatformTelemetryEvent
+from nemo_platform.cli.telemetry.handler import TelemetryHandler, _telemetry_enabled
+
+logger = logging.getLogger(__name__)
+
+_invocation_opt_out = False
+
+_NOTICE_TEXT = (
+    "NeMo Platform collects anonymous usage data to improve the product. "
+    "No prompts, data, or personal information leave your machine. "
+    "Turn it off any time with NEMO_TELEMETRY_ENABLED=false.\n"
+)
+
+
+def set_invocation_opt_out(value: bool) -> None:
+    """Per-invocation opt-out (e.g. a --no-telemetry flag on the current command)."""
+    global _invocation_opt_out
+    _invocation_opt_out = value
+
+
+def _config_opted_out() -> bool:
+    """True when the persisted config file sets ``telemetry_enabled: false``."""
+    try:
+        from nemo_platform.config.config import Config
+
+        cfg = Config.load()
+        return getattr(cfg.get_config_file(), "telemetry_enabled", True) is False
+    except Exception:
+        return False
+
+
+def telemetry_opted_in() -> bool:
+    """Opted in only when all three layers agree: per-invocation, env, and config."""
+    if _invocation_opt_out:
+        return False
+    if not _telemetry_enabled():
+        return False
+    return not _config_opted_out()
+
+
+def _client_version() -> str:
+    try:
+        import nemo_platform
+
+        return nemo_platform.__version__
+    except Exception:
+        return "undefined"
+
+
+def emit_event(event: PlatformTelemetryEvent) -> None:
+    """Best effort. Telemetry must never break a user command."""
+    try:
+        if not telemetry_opted_in():
+            return
+        handler = TelemetryHandler(source_client_version=_client_version(), session_id=uuid.uuid4().hex)
+        handler.enqueue(event)
+        handler.stop()
+    except Exception:
+        logger.debug("Failed to emit telemetry event", exc_info=True)
+
+
+def _notice_marker_path() -> Path:
+    from nemo_platform.config.config import Config
+
+    return Config.get_default_config_path().parent / "telemetry-notice-shown"
+
+
+def maybe_print_first_run_notice() -> None:
+    """Print the first-run notice to stderr once. Stdout stays machine-clean."""
+    try:
+        if not telemetry_opted_in():
+            return
+        marker = _notice_marker_path()
+        if marker.exists():
+            return
+        sys.stderr.write(_NOTICE_TEXT)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+    except Exception:
+        logger.debug("Failed to print telemetry notice", exc_info=True)

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/events.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/events.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Platform usage-telemetry event models.
+
+Field names and aliases follow the shared NeMo telemetry schema
+(aire/microservices/nemo-telemetry, schemas/anonymous_events.json, v1.9).
+"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_CI_ENV_VARS = ("CI", "GITLAB_CI", "GITHUB_ACTIONS")
+_TRUTHY = ("1", "true", "yes")
+
+
+def is_ci_environment() -> bool:
+    return any(os.getenv(v, "").lower() in _TRUTHY for v in _CI_ENV_VARS)
+
+
+class TaskStatusEnum(str, Enum):
+    COMPLETED = "completed"
+    ERROR = "error"
+    CANCELED = "canceled"
+    UNDEFINED = "undefined"
+
+
+class DeploymentTypeEnum(str, Enum):
+    CLI = "cli"
+    SDK = "sdk"
+    NVIDIA_INTERNAL = "nvidia-internal"
+    UNDEFINED = "undefined"
+
+
+def _deployment_type() -> DeploymentTypeEnum:
+    raw = os.getenv("NEMO_DEPLOYMENT_TYPE", "cli").lower()
+    try:
+        return DeploymentTypeEnum(raw)
+    except ValueError:
+        return DeploymentTypeEnum.UNDEFINED
+
+
+class PlatformTelemetryEvent(BaseModel):
+    """Base for all platform events. extra="forbid" is a privacy guard."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    _event_name: ClassVar[str] = "undefined"
+    _schema_version: ClassVar[str] = "1.9"
+
+    nemo_source: str = Field(default="platform", serialization_alias="nemoSource")
+    task_status: TaskStatusEnum = Field(serialization_alias="taskStatus")
+    deployment_type: DeploymentTypeEnum = Field(default_factory=_deployment_type, serialization_alias="deploymentType")
+    is_ci: bool = Field(default_factory=is_ci_environment, serialization_alias="isCi")
+
+
+class OnboardingStepEvent(PlatformTelemetryEvent):
+    _event_name: ClassVar[str] = "onboarding_step"
+
+    step: str
+    provider_type: str = Field(default="undefined", serialization_alias="providerType")
+    models_discovered_bucket: str = Field(default="undefined", serialization_alias="modelsDiscoveredBucket")
+    skills_target: str = Field(default="undefined", serialization_alias="skillsTarget")
+    agent_deployed: bool = Field(default=False, serialization_alias="agentDeployed")
+
+
+class CommandInvokedEvent(PlatformTelemetryEvent):
+    _event_name: ClassVar[str] = "command_invoked"
+
+    command: str
+    duration_sec: float = Field(serialization_alias="durationSec")
+    agent_mode: bool = Field(default=False, serialization_alias="agentMode")
+
+
+class JobRunEvent(PlatformTelemetryEvent):
+    _event_name: ClassVar[str] = "job_run"
+
+    job_type: str = Field(serialization_alias="jobType")
+    duration_sec: float = Field(default=-1.0, serialization_alias="durationSec")
+    plugins: list[str] = Field(default_factory=list)
+    model: str = "undefined"
+    input_tokens: int = Field(default=-1, serialization_alias="inputTokens")
+    output_tokens: int = Field(default=-1, serialization_alias="outputTokens")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/handler.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/handler.py
@@ -34,6 +34,10 @@ CLIENT_ID = "184482118588404"
 NEMO_TELEMETRY_VERSION = "nemo-telemetry/1.0"
 DEFAULT_ENDPOINT = "https://events.telemetry.data.nvidia.com/v1.1/events/json"
 MAX_RETRIES = 3
+# Tight explicit timeout so a hung or black-holed endpoint can never block a command
+# at exit for longer than this. httpx's default is ~5s, which is too long for a
+# best-effort flush that runs synchronously on the command's exit path.
+SEND_TIMEOUT_SECONDS = 2.0
 CPU_ARCHITECTURE = platform.uname().machine
 logger = logging.getLogger(__name__)
 
@@ -380,9 +384,10 @@ class TelemetryHandler:
         try:
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=SEND_TIMEOUT_SECONDS) as client:
                 await self._send_events_with_client(client, events)
         except Exception:  # noqa: BLE001
+            logger.debug("Telemetry send failed; routing events to DLQ", exc_info=True)
             self._add_to_dlq(events)
 
     async def _send_events_with_client(self, client: httpx.AsyncClient, events: list[QueuedEvent]) -> None:
@@ -424,6 +429,7 @@ class TelemetryHandler:
             if response.status_code == 408 or response.status_code >= 500:
                 self._add_to_dlq(events)
         except Exception:  # noqa: BLE001
+            logger.debug("Telemetry POST failed; routing events to DLQ", exc_info=True)
             self._add_to_dlq(events)
 
     def _add_to_dlq(self, events: list[QueuedEvent]) -> None:

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/handler.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/handler.py
@@ -1,0 +1,435 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Telemetry handler for NeMo products.
+
+Environment variables:
+- NEMO_TELEMETRY_ENABLED: Whether telemetry is enabled.
+- NEMO_DEPLOYMENT_TYPE: The deployment type the event came from.
+- NEMO_TELEMETRY_ENDPOINT: The endpoint to send the telemetry events to.
+- NEMO_SESSION_PREFIX: Optional prefix to add to session IDs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import platform
+import threading
+from collections.abc import Coroutine
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit, urlunsplit
+
+from nemo_platform.cli.telemetry.events import PlatformTelemetryEvent
+
+if TYPE_CHECKING:
+    import httpx
+
+CLIENT_ID = "184482118588404"
+NEMO_TELEMETRY_VERSION = "nemo-telemetry/1.0"
+DEFAULT_ENDPOINT = "https://events.telemetry.data.nvidia.com/v1.1/events/json"
+MAX_RETRIES = 3
+CPU_ARCHITECTURE = platform.uname().machine
+logger = logging.getLogger(__name__)
+
+
+def _telemetry_enabled() -> bool:
+    return os.getenv("NEMO_TELEMETRY_ENABLED", "true").lower() in ("1", "true", "yes")
+
+
+def _telemetry_endpoint() -> str:
+    return os.getenv("NEMO_TELEMETRY_ENDPOINT", DEFAULT_ENDPOINT)
+
+
+def _redact_endpoint(endpoint: str) -> str:
+    """Redact query parameters before logging telemetry endpoints."""
+    try:
+        parsed = urlsplit(endpoint)
+    except ValueError:
+        return "<invalid-endpoint>"
+    query = "<redacted>" if parsed.query else ""
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
+
+
+def _deployment_type() -> str:
+    return os.getenv("NEMO_DEPLOYMENT_TYPE", "sdk")
+
+
+def _session_prefix() -> str | None:
+    return os.getenv("NEMO_SESSION_PREFIX")
+
+
+@dataclass
+class QueuedEvent:
+    event: PlatformTelemetryEvent
+    timestamp: datetime
+    retry_count: int = 0
+
+
+def _get_iso_timestamp(dt: datetime | None = None) -> str:
+    if dt is None:
+        dt = datetime.now(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+def build_payload(
+    events: list[QueuedEvent], *, source_client_version: str, session_id: str = "undefined"
+) -> dict[str, Any]:
+    if not events:
+        raise ValueError("build_payload requires at least one event")
+    return {
+        "browserType": "undefined",
+        "clientId": CLIENT_ID,
+        "clientType": "Native",
+        "clientVariant": "Release",
+        "clientVer": source_client_version,
+        "cpuArchitecture": CPU_ARCHITECTURE,
+        "deviceGdprBehOptIn": "None",
+        "deviceGdprFuncOptIn": "None",
+        "deviceGdprTechOptIn": "None",
+        "deviceId": "undefined",
+        "deviceMake": "undefined",
+        "deviceModel": "undefined",
+        "deviceOS": "undefined",
+        "deviceOSVersion": "undefined",
+        "deviceType": "undefined",
+        "eventProtocol": "1.6",
+        "eventSchemaVer": events[0].event._schema_version,
+        "eventSysVer": NEMO_TELEMETRY_VERSION,
+        "externalUserId": "undefined",
+        "gdprBehOptIn": "None",
+        "gdprFuncOptIn": "None",
+        "gdprTechOptIn": "None",
+        "idpId": "undefined",
+        "integrationId": "undefined",
+        "productName": "undefined",
+        "productVersion": "undefined",
+        "sentTs": _get_iso_timestamp(),
+        "sessionId": session_id,
+        "userId": "undefined",
+        "events": [
+            {
+                "ts": _get_iso_timestamp(queued.timestamp),
+                "parameters": queued.event.model_dump(by_alias=True, mode="json"),
+                "name": queued.event._event_name,
+            }
+            for queued in events
+        ],
+    }
+
+
+class TelemetryHandler:
+    """
+    Handles telemetry event batching, flushing, and retry logic for NeMo products.
+
+    Supports two usage patterns:
+
+    - **Background mode**: call ``start()`` (or use ``with handler:``) to spawn
+      a daemon thread with its own event loop that drives periodic flushing.
+      ``stop()`` schedules a final flush, then stops the loop and joins the thread.
+    - **Fire-and-flush mode**: skip ``start()``, ``enqueue()`` events, then call
+      ``stop()`` to flush once. No background thread is created unless the caller
+      already has a running event loop, in which case the one-shot flush is
+      offloaded to a worker thread with its own loop.
+
+    Args:
+        flush_interval_seconds (float): The interval in seconds to flush the events.
+        max_queue_size (int): The maximum number of events to queue before flushing.
+        max_retries (int): The maximum number of times to retry sending an event.
+        source_client_version (str): The version of the source client. This should be the version of
+            the actual NeMo product that is sending the events, typically the same as the version of
+            a PyPi package that a user would install.
+        session_id (str): An optional session ID to associate with the events.
+            This should be a unique identifier for the session, such as a UUID.
+            It is used to group events together.
+    """
+
+    def __init__(
+        self,
+        flush_interval_seconds: float = 120.0,
+        max_queue_size: int = 50,
+        max_retries: int = MAX_RETRIES,
+        source_client_version: str = "undefined",
+        session_id: str = "undefined",
+    ):
+        self._flush_interval = flush_interval_seconds
+        self._max_queue_size = max_queue_size
+        self._max_retries = max_retries
+        self._events: list[QueuedEvent] = []
+        self._dlq: list[QueuedEvent] = []
+        self._queue_lock = threading.Lock()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._flush_signal: asyncio.Event | None = None
+        self._timer_task: asyncio.Task | None = None
+        self._running = False
+        self._source_client_version = source_client_version
+        prefix = _session_prefix()
+        self._session_id = f"{prefix}{session_id}" if prefix else session_id
+
+    # -- Async API -----------------------------------------------------------
+
+    async def astart(self) -> None:
+        """Start the background timer task on the current event loop."""
+        if self._running:
+            return
+        self._loop = asyncio.get_running_loop()
+        self._flush_signal = asyncio.Event()
+        self._running = True
+        self._timer_task = asyncio.create_task(self._timer_loop())
+
+    async def astop(self) -> None:
+        """Cancel the timer task and flush any remaining events."""
+        if not self._running:
+            await self._flush_events()
+            return
+        self._running = False
+        if self._flush_signal is not None:
+            self._flush_signal.set()
+        if self._timer_task is not None:
+            self._timer_task.cancel()
+            try:
+                await self._timer_task
+            except asyncio.CancelledError:
+                pass
+            self._timer_task = None
+        await self._flush_events()
+        self._loop = None
+        self._flush_signal = None
+
+    async def aflush(self) -> None:
+        """Flush all queued events immediately and await completion."""
+        await self._flush_events()
+
+    # -- Sync API ------------------------------------------------------------
+
+    def start(self) -> None:
+        """Spawn a daemon thread with a persistent event loop for periodic flushing."""
+        if self._running:
+            return
+        ready = threading.Event()
+        startup_error: list[BaseException] = []
+
+        def _run() -> None:
+            try:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                self._loop = loop
+                self._flush_signal = asyncio.Event()
+                self._timer_task = loop.create_task(self._timer_loop())
+                self._running = True
+            except BaseException as exc:  # noqa: BLE001
+                startup_error.append(exc)
+                ready.set()
+                return
+            ready.set()
+            try:
+                loop.run_forever()
+            finally:
+                loop.close()
+
+        self._thread = threading.Thread(target=_run, name="nemo-telemetry", daemon=True)
+        self._thread.start()
+        ready.wait()
+        if startup_error:
+            self._thread = None
+            raise startup_error[0]
+
+    def stop(self) -> None:
+        """Flush pending events. If a background thread is running, shut it down and join."""
+        if self._running and self._loop is not None and self._thread is not None:
+            loop = self._loop
+            future = asyncio.run_coroutine_threadsafe(self._astop_inner(), loop)
+            try:
+                future.result(timeout=30)
+            except Exception:  # noqa: BLE001
+                pass
+            loop.call_soon_threadsafe(loop.stop)
+            self._thread.join(timeout=5)
+            self._thread = None
+            self._loop = None
+            self._flush_signal = None
+            self._timer_task = None
+            self._running = False
+            return
+        if self._events or self._dlq:
+            try:
+                self._run_sync(self._flush_events())
+            except Exception:  # noqa: BLE001
+                logger.debug("Telemetry stop flush failed", exc_info=True)
+
+    def flush(self) -> None:
+        """Flush all queued events immediately and wait for completion."""
+        if self._running and self._loop is not None and self._thread is not None:
+            future: Future[None] = asyncio.run_coroutine_threadsafe(self._flush_events(), self._loop)
+            try:
+                future.result(timeout=30)
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        if self._events or self._dlq:
+            try:
+                self._run_sync(self._flush_events())
+            except Exception:  # noqa: BLE001
+                logger.debug("Telemetry flush failed", exc_info=True)
+
+    @staticmethod
+    def _run_sync(coro: Coroutine[Any, Any, Any]) -> Any:
+        """Run a coroutine synchronously from sync or async caller contexts.
+
+        ``asyncio.run`` raises when called from a thread that already has a
+        running event loop, such as a notebook kernel or an async SDK caller. In
+        that case, run the coroutine in a worker thread so telemetry still gets
+        a fresh event loop while remaining synchronous to the caller.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None:
+            pool = ThreadPoolExecutor(max_workers=1)
+            future = pool.submit(asyncio.run, coro)
+            return future.result(timeout=30)
+        return asyncio.run(coro)
+
+    async def _astop_inner(self) -> None:
+        """Async shutdown body run on the background loop."""
+        self._running = False
+        if self._flush_signal is not None:
+            self._flush_signal.set()
+        if self._timer_task is not None:
+            self._timer_task.cancel()
+            try:
+                await self._timer_task
+            except asyncio.CancelledError:
+                pass
+            self._timer_task = None
+        await self._flush_events()
+
+    # -- Enqueue / signalling ------------------------------------------------
+
+    def enqueue(self, event: object) -> None:
+        if not _telemetry_enabled():
+            return
+        if not isinstance(event, PlatformTelemetryEvent):
+            return
+        queued = QueuedEvent(event=event, timestamp=datetime.now(timezone.utc))
+        with self._queue_lock:
+            self._events.append(queued)
+            should_signal = len(self._events) >= self._max_queue_size
+        if should_signal:
+            self._signal_flush()
+
+    def _signal_flush(self) -> None:
+        """Set the flush signal, threadsafe across the background-loop boundary."""
+        loop = self._loop
+        signal = self._flush_signal
+        if loop is None or signal is None:
+            return
+        try:
+            loop.call_soon_threadsafe(signal.set)
+        except RuntimeError:
+            pass
+
+    # -- Context managers ----------------------------------------------------
+
+    def __enter__(self) -> TelemetryHandler:
+        self.start()
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.stop()
+
+    async def __aenter__(self) -> TelemetryHandler:
+        await self.astart()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.astop()
+
+    # -- Internal loop -------------------------------------------------------
+
+    async def _timer_loop(self) -> None:
+        assert self._flush_signal is not None
+        while self._running:
+            try:
+                await asyncio.wait_for(
+                    self._flush_signal.wait(),
+                    timeout=self._flush_interval,
+                )
+            except asyncio.TimeoutError:
+                pass
+            self._flush_signal.clear()
+            await self._flush_events()
+
+    async def _flush_events(self) -> None:
+        with self._queue_lock:
+            dlq_events, self._dlq = self._dlq, []
+            new_events, self._events = self._events, []
+        events_to_send = dlq_events + new_events
+        if events_to_send:
+            await self._send_events(events_to_send)
+
+    async def _send_events(self, events: list[QueuedEvent]) -> None:
+        try:
+            import httpx
+
+            async with httpx.AsyncClient() as client:
+                await self._send_events_with_client(client, events)
+        except Exception:  # noqa: BLE001
+            self._add_to_dlq(events)
+
+    async def _send_events_with_client(self, client: httpx.AsyncClient, events: list[QueuedEvent]) -> None:
+        if not events:
+            return
+
+        payload = build_payload(events, source_client_version=self._source_client_version, session_id=self._session_id)
+        endpoint = _telemetry_endpoint()
+        logger.debug(
+            "Sending telemetry events",
+            extra={
+                "ctx": {
+                    "endpoint": _redact_endpoint(endpoint),
+                    "event_count": len(events),
+                    "events": [
+                        {
+                            "name": queued.event._event_name,
+                            "task": getattr(queued.event, "task", "unknown"),
+                            "task_status": getattr(queued.event, "task_status", "unknown"),
+                            "deployment_type": getattr(queued.event, "deployment_type", "unknown"),
+                            "retry_count": queued.retry_count,
+                        }
+                        for queued in events
+                    ],
+                }
+            },
+        )
+        try:
+            response = await client.post(endpoint, json=payload)
+            if response.status_code in (400, 422) or response.is_success:
+                return
+            if response.status_code == 413:
+                if len(events) == 1:
+                    return
+                mid = len(events) // 2
+                await self._send_events_with_client(client, events[:mid])
+                await self._send_events_with_client(client, events[mid:])
+                return
+            if response.status_code == 408 or response.status_code >= 500:
+                self._add_to_dlq(events)
+        except Exception:  # noqa: BLE001
+            self._add_to_dlq(events)
+
+    def _add_to_dlq(self, events: list[QueuedEvent]) -> None:
+        with self._queue_lock:
+            for queued in events:
+                queued.retry_count += 1
+                if queued.retry_count > self._max_retries:
+                    continue
+                self._dlq.append(queued)

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/runtime.py
@@ -27,6 +27,7 @@ class _InvocationState:
     agent_mode: bool = False
     started: bool = False
     opted_out: bool = False
+    help_requested: bool = False
 
 
 state = _InvocationState()
@@ -39,6 +40,7 @@ def reset() -> None:
     state.agent_mode = False
     state.started = False
     state.opted_out = False
+    state.help_requested = False
 
 
 def on_callback(ctx, *, no_telemetry: bool) -> None:
@@ -58,6 +60,8 @@ def on_callback(ctx, *, no_telemetry: bool) -> None:
             state.command_parts = [invoked]
         maybe_print_first_run_notice()
     except Exception:  # noqa: BLE001
+        # Fail closed: if telemetry setup breaks, suppress this invocation's event.
+        state.opted_out = True
         logger.debug("telemetry on_callback failed", exc_info=True)
 
 
@@ -71,6 +75,10 @@ def emit_command_invoked(task_status: TaskStatusEnum, duration_sec: float) -> No
     """Emit exactly one ``command_invoked`` event. Best effort; never raises."""
     try:
         if state.opted_out:
+            return
+        if state.help_requested:
+            # Reading help (e.g. ``nemo docs --help``) is not usage. Bare ``--help`` is
+            # already covered by the empty-command_parts guard below.
             return
         if not (state.started and state.command_parts):
             # Bare ``--help`` and usage errors before a command resolves never emit.

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/runtime.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-invocation telemetry state bridged between the Typer callback and the Click main wrapper.
+
+The Typer ``@app.callback`` sees the parsed context (command name, agent mode, opt-out
+flag) but not the command outcome. The ``NmpErrorHandlingMixin.main`` wrapper sees the
+outcome and duration but not the parsed flags. This module is the single small piece of
+state both sides read, so exactly one ``command_invoked`` event is emitted per invocation
+from the root command path.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nemo_platform.cli.telemetry.events import TaskStatusEnum
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _InvocationState:
+    command_parts: list[str] = field(default_factory=list)
+    agent_mode: bool = False
+    started: bool = False
+    opted_out: bool = False
+
+
+state = _InvocationState()
+
+
+def reset() -> None:
+    """Clear invocation state. Called at the top of the root ``main()`` so CliRunner
+    invocations sharing a process never leak command names or flags between calls."""
+    state.command_parts = []
+    state.agent_mode = False
+    state.started = False
+    state.opted_out = False
+
+
+def on_callback(ctx, *, no_telemetry: bool) -> None:
+    """Capture command name + agent mode from the root Typer callback.
+
+    Best effort: a telemetry bug must never break ``nemo <anything>``.
+    """
+    try:
+        from nemo_platform.cli.telemetry.emit import maybe_print_first_run_notice, set_invocation_opt_out
+
+        set_invocation_opt_out(no_telemetry)
+        state.opted_out = no_telemetry
+        state.started = True
+        state.agent_mode = bool(getattr(ctx.obj, "agent_mode", False))
+        invoked = getattr(ctx, "invoked_subcommand", None)
+        if invoked:
+            state.command_parts = [invoked]
+        maybe_print_first_run_notice()
+    except Exception:  # noqa: BLE001
+        logger.debug("telemetry on_callback failed", exc_info=True)
+
+
+def note_subcommand(name: str | None) -> None:
+    """Append a resolved sub-subcommand name (e.g. the ``list`` in ``workspaces list``)."""
+    if state.started and name and name not in state.command_parts:
+        state.command_parts.append(name)
+
+
+def emit_command_invoked(task_status: TaskStatusEnum, duration_sec: float) -> None:
+    """Emit exactly one ``command_invoked`` event. Best effort; never raises."""
+    try:
+        if state.opted_out:
+            return
+        if not (state.started and state.command_parts):
+            # Bare ``--help`` and usage errors before a command resolves never emit.
+            return
+        from nemo_platform.cli.telemetry.emit import emit_event
+        from nemo_platform.cli.telemetry.events import CommandInvokedEvent
+
+        event = CommandInvokedEvent(
+            command=" ".join(state.command_parts),
+            duration_sec=max(0.0, duration_sec),
+            agent_mode=state.agent_mode,
+            task_status=task_status,
+        )
+        emit_event(event)
+    except Exception:  # noqa: BLE001
+        logger.debug("telemetry emit_command_invoked failed", exc_info=True)

--- a/sdk/python/nemo-platform/src/nemo_platform/config/models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/config/models.py
@@ -221,6 +221,10 @@ class ConfigFile(BaseModel):
         default=None,
         description="User-selected paths for local services (set by `nemo setup`).",
     )
+    telemetry_enabled: bool = Field(
+        default=True,
+        description="Whether anonymous usage telemetry is enabled. Set to false to opt out.",
+    )
 
     def ensure_context(
         self,

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
@@ -80,6 +80,26 @@ from nemo_platform.config.models import (
 
 SETUP_MOD = "nemo_platform.cli.commands.setup"
 
+
+@pytest.fixture(autouse=True)
+def _silence_telemetry():
+    """Silence stray telemetry side effects across this module.
+
+    These are direct-call unit tests with no telemetry intent. Several exercise
+    the real setup wrappers (`_create_provider`, `_wait_for_models`,
+    `_deploy_demo_agent`, `_auto_setup`), which call the real `emit_event`. With
+    telemetry enabled by default that constructs a `TelemetryHandler` and
+    schedules `_flush_events`, whose orphaned coroutine surfaces later as a
+    "coroutine ... was never awaited" RuntimeWarning (blamed on whichever
+    mock-heavy test triggers GC, not the emitting one). Patch emit_event at module
+    scope so no handler is ever built. No test in this file asserts on emit_event
+    (the telemetry assertions live in test_onboarding_events.py), so this weakens
+    nothing.
+    """
+    with patch("nemo_platform.cli.telemetry.emit.emit_event"):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # KnownProvider catalog tests
 # ---------------------------------------------------------------------------

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/core/test_waiters.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/core/test_waiters.py
@@ -44,6 +44,13 @@ def _quiet_rich_output() -> Iterator[None]:
         yield
 
 
+@pytest.fixture(autouse=True)
+def _no_telemetry() -> Iterator[None]:
+    """Neutralize best-effort job_run telemetry so waiter tests never do real I/O."""
+    with patch("nemo_platform.cli.telemetry.emit.emit_event"):
+        yield
+
+
 @pytest.fixture
 def frozen_time() -> Iterator[MagicMock]:
     with patch(f"{WAITERS_MODULE}.time.time", return_value=0) as time:

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/__init__.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/conftest.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/conftest.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterator
+
+import pytest
+
+# Environment variables that is_ci_environment() treats as a CI signal.
+_CI_ENV_VARS = ("CI", "GITLAB_CI", "GITHUB_ACTIONS")
+
+
+@pytest.fixture(autouse=True)
+def _clear_ci_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Clear CI markers so telemetry tests are deterministic on developer machines and in CI.
+
+    Without this, tests that assert the default ``is_ci`` value pass locally but fail when the
+    suite runs under GitHub Actions (which sets ``CI`` and ``GITHUB_ACTIONS``). Tests that
+    exercise CI detection set these variables explicitly, which overrides this fixture.
+    """
+    for var in _CI_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_command_hook.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_command_hook.py
@@ -45,3 +45,10 @@ class TestCommandInvokedHook:
     def test_bare_help_does_not_emit(self, emit):
         runner.invoke(app, ["--help"])
         emit.assert_not_called()
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_group_help_does_not_emit(self, emit):
+        """``nemo <group> --help`` reads help; it is not usage and must not emit."""
+        result = runner.invoke(app, ["docs", "--help"])
+        assert result.exit_code == 0
+        emit.assert_not_called()

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_command_hook.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_command_hook.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the command_invoked telemetry hook at the root command choke point."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from nemo_platform.cli.app import app
+from nemo_platform.cli.telemetry.events import TaskStatusEnum
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+class TestCommandInvokedHook:
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_successful_command_emits_completed(self, emit):
+        result = runner.invoke(app, ["docs", "--list"])
+        assert result.exit_code == 0
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.command.startswith("docs")
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.duration_sec >= 0
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_agent_mode_flag_captured(self, emit):
+        runner.invoke(app, ["--agent-mode", "docs", "--list"])
+        assert emit.call_args[0][0].agent_mode is True
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_failing_command_emits_error(self, emit):
+        with patch("nemo_platform.cli.commands.docs._list_docs", side_effect=RuntimeError):
+            runner.invoke(app, ["docs", "--list"])
+        assert emit.call_count == 1
+        assert emit.call_args[0][0].task_status == TaskStatusEnum.ERROR
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_no_telemetry_flag_suppresses(self, emit):
+        runner.invoke(app, ["--no-telemetry", "docs", "--list"])
+        emit.assert_not_called()
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_bare_help_does_not_emit(self, emit):
+        runner.invoke(app, ["--help"])
+        emit.assert_not_called()

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_emit.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_emit.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import Mock, patch
+
+from nemo_platform.cli.telemetry import emit as emit_mod
+from nemo_platform.cli.telemetry.events import CommandInvokedEvent, TaskStatusEnum
+
+
+def _event():
+    return CommandInvokedEvent(command="docs", task_status=TaskStatusEnum.COMPLETED, duration_sec=0.1)
+
+
+class TestOptOutLayers:
+    def test_env_layer(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+        assert emit_mod.telemetry_opted_in() is False
+
+    def test_config_layer(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("telemetry_enabled: false\n")
+        monkeypatch.setenv("NMP_CONFIG_FILE", str(cfg))
+        assert emit_mod.telemetry_opted_in() is False
+
+    def test_invocation_flag_layer(self):
+        emit_mod.set_invocation_opt_out(True)
+        try:
+            assert emit_mod.telemetry_opted_in() is False
+        finally:
+            emit_mod.set_invocation_opt_out(False)
+
+    def test_default_is_on(self):
+        assert emit_mod.telemetry_opted_in() is True
+
+
+class TestEmitEvent:
+    @patch.object(emit_mod, "TelemetryHandler")
+    def test_emit_enqueues_and_stops(self, handler_cls):
+        instance = Mock()
+        handler_cls.return_value = instance
+        emit_mod.emit_event(_event())
+        instance.enqueue.assert_called_once()
+        instance.stop.assert_called_once()
+
+    @patch.object(emit_mod, "TelemetryHandler")
+    def test_emit_skipped_when_opted_out(self, handler_cls, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "0")
+        emit_mod.emit_event(_event())
+        handler_cls.assert_not_called()
+
+    @patch.object(emit_mod, "TelemetryHandler", side_effect=RuntimeError("boom"))
+    def test_emit_never_raises(self, handler_cls):
+        emit_mod.emit_event(_event())  # must not raise
+
+
+class TestFirstRunNotice:
+    def test_notice_printed_once_to_stderr(self, capsys, tmp_path, monkeypatch):
+        monkeypatch.setattr(emit_mod, "_notice_marker_path", lambda: tmp_path / "telemetry-notice-shown")
+        emit_mod.maybe_print_first_run_notice()
+        first = capsys.readouterr()
+        assert "anonymous usage data" in first.err
+        assert first.out == ""  # stderr only; stdout stays machine-clean
+        emit_mod.maybe_print_first_run_notice()
+        assert capsys.readouterr().err == ""
+
+    def test_no_notice_when_opted_out(self, capsys, tmp_path, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+        monkeypatch.setattr(emit_mod, "_notice_marker_path", lambda: tmp_path / "telemetry-notice-shown")
+        emit_mod.maybe_print_first_run_notice()
+        assert capsys.readouterr().err == ""

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_emit.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_emit.py
@@ -31,6 +31,16 @@ class TestOptOutLayers:
     def test_default_is_on(self):
         assert emit_mod.telemetry_opted_in() is True
 
+    def test_config_load_error_fails_closed(self, monkeypatch):
+        """A broken/parse-error config must fail closed (opted out), not default to on."""
+        from nemo_platform.config import config as config_mod
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("broken config")
+
+        monkeypatch.setattr(config_mod.Config, "load", boom)
+        assert emit_mod.telemetry_opted_in() is False
+
 
 class TestEmitEvent:
     @patch.object(emit_mod, "TelemetryHandler")
@@ -50,6 +60,15 @@ class TestEmitEvent:
     @patch.object(emit_mod, "TelemetryHandler", side_effect=RuntimeError("boom"))
     def test_emit_never_raises(self, handler_cls):
         emit_mod.emit_event(_event())  # must not raise
+
+    @patch.object(emit_mod, "TelemetryHandler")
+    def test_session_id_is_stable_across_calls(self, handler_cls):
+        """Every event in one process shares the per-process session id."""
+        emit_mod.emit_event(_event())
+        emit_mod.emit_event(_event())
+        session_ids = [call.kwargs["session_id"] for call in handler_cls.call_args_list]
+        assert len(session_ids) == 2
+        assert session_ids[0] == session_ids[1] == emit_mod._SESSION_ID
 
 
 class TestFirstRunNotice:

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_events.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_events.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from nemo_platform.cli.telemetry.events import (
+    CommandInvokedEvent,
+    JobRunEvent,
+    OnboardingStepEvent,
+    TaskStatusEnum,
+    is_ci_environment,
+)
+
+
+class TestCommandInvokedEvent:
+    def test_defaults_and_aliases(self):
+        e = CommandInvokedEvent(command="jobs create", task_status=TaskStatusEnum.COMPLETED, duration_sec=1.25)
+        d = e.model_dump(by_alias=True, mode="json")
+        assert d["nemoSource"] == "platform"
+        assert d["command"] == "jobs create"
+        assert d["taskStatus"] == "completed"
+        assert d["durationSec"] == 1.25
+        assert d["agentMode"] is False
+        assert d["isCi"] is False
+        assert e._event_name == "command_invoked"
+        assert e._schema_version == "1.9"
+
+    def test_no_free_text_fields_beyond_known(self):
+        # privacy guard: the event cannot carry arbitrary payloads
+        with pytest.raises(Exception):
+            CommandInvokedEvent(command="x", task_status=TaskStatusEnum.COMPLETED, duration_sec=0, prompt="secret")
+
+
+class TestOnboardingStepEvent:
+    def test_fields(self):
+        e = OnboardingStepEvent(step="provider_connected", task_status=TaskStatusEnum.COMPLETED, provider_type="openai")
+        d = e.model_dump(by_alias=True, mode="json")
+        assert d["step"] == "provider_connected"
+        assert d["providerType"] == "openai"
+        assert d["modelsDiscoveredBucket"] == "undefined"
+        assert d["skillsTarget"] == "undefined"
+        assert d["agentDeployed"] is False
+        assert e._event_name == "onboarding_step"
+
+
+class TestJobRunEvent:
+    def test_token_defaults_are_minus_one(self):
+        e = JobRunEvent(job_type="auditor.audit", task_status=TaskStatusEnum.ERROR, duration_sec=10.0)
+        d = e.model_dump(by_alias=True, mode="json")
+        assert d["jobType"] == "auditor.audit"
+        assert d["inputTokens"] == -1
+        assert d["outputTokens"] == -1
+        assert d["model"] == "undefined"
+        assert d["plugins"] == []
+        assert e._event_name == "job_run"
+
+
+class TestCiDetection:
+    @pytest.mark.parametrize("var", ["CI", "GITLAB_CI", "GITHUB_ACTIONS"])
+    def test_ci_env_detected(self, monkeypatch, var):
+        monkeypatch.setenv(var, "true")
+        assert is_ci_environment() is True
+
+    def test_no_ci_env(self, monkeypatch):
+        for var in ("CI", "GITLAB_CI", "GITHUB_ACTIONS"):
+            monkeypatch.delenv(var, raising=False)
+        assert is_ci_environment() is False

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_handler.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_handler.py
@@ -1,0 +1,560 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import importlib
+import threading
+from datetime import datetime, timezone
+from typing import ClassVar
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from nemo_platform.cli.telemetry.events import PlatformTelemetryEvent
+from nemo_platform.cli.telemetry.handler import (
+    QueuedEvent,
+    TelemetryHandler,
+    _deployment_type,
+    _telemetry_enabled,
+    _telemetry_endpoint,
+    build_payload,
+)
+from pydantic import Field
+
+telemetry_module = importlib.import_module("nemo_platform.cli.telemetry.handler")
+
+
+# =============================================================================
+# Stub Event Model for Testing
+# =============================================================================
+
+
+class _StubEvent(PlatformTelemetryEvent):
+    """Minimal concrete event for testing, subclassing the real PlatformTelemetryEvent.
+
+    ``task_status`` and ``deployment_type`` are redeclared as plain strings to shed
+    the base's serialization aliases, so the handler tests keep asserting the
+    snake_case keys the Task 1 handler emitted.
+    """
+
+    _event_name: ClassVar[str] = "stub_event"
+    task: str = Field(default="test_task")
+    task_status: str = Field(default="completed")
+    deployment_type: str = Field(default="sdk")
+
+
+# =============================================================================
+# Env-var helpers
+# =============================================================================
+
+
+class TestEnvHelpers:
+    def test_telemetry_enabled_default(self, monkeypatch):
+        monkeypatch.delenv("NEMO_TELEMETRY_ENABLED", raising=False)
+        assert _telemetry_enabled() is True
+
+    def test_telemetry_enabled_disabled(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+        assert _telemetry_enabled() is False
+
+    def test_telemetry_endpoint_preserves_case(self, monkeypatch):
+        custom = "https://Events.Telemetry.example.COM/v1/Events?Token=AbC"
+        monkeypatch.setenv("NEMO_TELEMETRY_ENDPOINT", custom)
+        assert _telemetry_endpoint() == custom
+
+    def test_deployment_type_default(self, monkeypatch):
+        monkeypatch.delenv("NEMO_DEPLOYMENT_TYPE", raising=False)
+        assert _deployment_type() == "sdk"
+
+    def test_deployment_type_invalid_falls_back_to_string(self, monkeypatch):
+        monkeypatch.setenv("NEMO_DEPLOYMENT_TYPE", "definitely-not-real")
+        assert _deployment_type() == "definitely-not-real"
+
+    def test_deployment_type_nvidia_internal(self, monkeypatch):
+        monkeypatch.setenv("NEMO_DEPLOYMENT_TYPE", "nvidia-internal")
+        assert _deployment_type() == "nvidia-internal"
+
+
+# =============================================================================
+# build_payload
+# =============================================================================
+
+
+class TestBuildPayload:
+    def _make_queued(self, task: str = "generate", status: str = "completed") -> QueuedEvent:
+        event = _StubEvent(task=task, task_status=status)
+        return QueuedEvent(event=event, timestamp=datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
+
+    def test_structure(self):
+        queued = self._make_queued()
+        payload = build_payload([queued], source_client_version="1.2.3", session_id="test-session")
+        assert payload["clientId"] == "184482118588404"
+        assert payload["clientVer"] == "1.2.3"
+        assert payload["sessionId"] == "test-session"
+        assert len(payload["events"]) == 1
+
+    def test_event_fields_serialize_as_strings(self, monkeypatch):
+        monkeypatch.delenv("NEMO_DEPLOYMENT_TYPE", raising=False)
+
+        queued = self._make_queued(task="train", status="error")
+        payload = build_payload([queued], source_client_version="0.0.1")
+        event_entry = payload["events"][0]
+        assert event_entry["name"] == "stub_event"
+        assert event_entry["ts"] == "2025-01-01T12:00:00.000Z"
+        params = event_entry["parameters"]
+        assert params["task"] == "train"
+        assert params["task_status"] == "error"
+
+    def test_payload_is_json_serializable(self):
+        """Regression: the full payload must be encodable by the stdlib JSON encoder."""
+        import json
+
+        queued = self._make_queued(status="error")
+        payload = build_payload([queued], source_client_version="1.0.0")
+        json.dumps(payload)
+
+    def test_multiple_events(self):
+        events = [self._make_queued(task=t) for t in ("train", "generate", "evaluate")]
+        payload = build_payload(events, source_client_version="1.0.0")
+        assert len(payload["events"]) == 3
+        tasks = [e["parameters"]["task"] for e in payload["events"]]
+        assert tasks == ["train", "generate", "evaluate"]
+
+    def test_default_session_id(self):
+        queued = self._make_queued()
+        payload = build_payload([queued], source_client_version="1.0.0")
+        assert payload["sessionId"] == "undefined"
+
+    def test_empty_events_raises(self):
+        with pytest.raises(ValueError):
+            build_payload([], source_client_version="1.0.0")
+
+
+# =============================================================================
+# TelemetryHandler — telemetry disabled
+# =============================================================================
+
+
+class TestTelemetryDisabled:
+    def test_enqueue_noop_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+        handler = TelemetryHandler()
+        event = _StubEvent(task="generate")
+        handler.enqueue(event)
+        assert handler._events == []
+
+    def test_enqueue_noop_for_non_event(self, monkeypatch):
+        """Silently ignores non-TelemetryEvent objects regardless of env."""
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler()
+        handler.enqueue("not an event")
+        assert handler._events == []
+
+
+# =============================================================================
+# TelemetryHandler — enqueue and flush
+# =============================================================================
+
+
+class TestTelemetryHandlerEnqueue:
+    def test_enqueue_adds_event(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler()
+        event = _StubEvent(task="generate")
+        handler.enqueue(event)
+        assert len(handler._events) == 1
+        assert handler._events[0].event is event
+
+    def test_enqueue_does_not_add_event_when_telemetry_is_disabled(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+        handler = TelemetryHandler()
+        event = _StubEvent(task="generate")
+        handler.enqueue(event)
+        assert len(handler._events) == 0
+
+    def test_enqueue_at_max_queue_size_signals_flush_when_running(self, monkeypatch):
+        """When a background loop is up, hitting max_queue_size should signal it. Without a loop, no-op is safe."""
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(max_queue_size=3)
+        event = _StubEvent(task="run")
+        for _ in range(3):
+            handler.enqueue(event)
+        assert len(handler._events) == 3
+
+
+# =============================================================================
+# TelemetryHandler — _flush_events queue clearing and DLQ
+# =============================================================================
+
+
+class TestFlushEventsQueueClearing:
+    async def test_flush_events_clears_queue(self):
+        """_flush_events() must drain _events even when the underlying send succeeds."""
+        handler = TelemetryHandler(source_client_version="1.0.0")
+        event = _StubEvent(task="generate")
+        handler._events.append(QueuedEvent(event=event, timestamp=datetime.now(timezone.utc)))
+
+        async def fake_send(events):
+            assert len(events) == 1
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            await handler._flush_events()
+
+        assert handler._events == []
+        assert handler._dlq == []
+
+    async def test_flush_events_includes_dlq(self):
+        handler = TelemetryHandler(source_client_version="1.0.0")
+        event = _StubEvent(task="generate")
+        handler._dlq.append(QueuedEvent(event=event, timestamp=datetime.now(timezone.utc), retry_count=1))
+        handler._events.append(QueuedEvent(event=event, timestamp=datetime.now(timezone.utc)))
+
+        sent: list[list[QueuedEvent]] = []
+
+        async def fake_send(events):
+            sent.append(list(events))
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            await handler._flush_events()
+
+        assert handler._events == []
+        assert handler._dlq == []
+        assert len(sent) == 1
+        assert len(sent[0]) == 2
+
+
+# =============================================================================
+# TelemetryHandler — send and retry
+# =============================================================================
+
+
+class TestTelemetryHandlerSend:
+    def _make_handler(self) -> TelemetryHandler:
+        return TelemetryHandler(source_client_version="1.0.0", session_id="s1")
+
+    def _make_queued(self) -> QueuedEvent:
+        event = _StubEvent(task="generate")
+        return QueuedEvent(event=event, timestamp=datetime.now(timezone.utc))
+
+    async def test_debug_logs_event_metadata_before_post(self, monkeypatch):
+        handler = self._make_handler()
+        queued = self._make_queued()
+        events_seen: list[str] = []
+        debug_calls = []
+
+        monkeypatch.setenv("NEMO_TELEMETRY_ENDPOINT", "https://Events.Telemetry.example.COM/v1/Events?Token=AbC")
+
+        def fake_debug(message, *, extra):
+            events_seen.append("debug")
+            debug_calls.append((message, extra))
+
+        async def fake_post(*args, **kwargs):
+            events_seen.append("post")
+            return MagicMock(status_code=200, is_success=True)
+
+        monkeypatch.setattr(telemetry_module.logger, "debug", fake_debug)
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = fake_post
+
+        await handler._send_events_with_client(mock_client, [queued])
+
+        assert events_seen == ["debug", "post"]
+        message, extra = debug_calls[0]
+        assert message == "Sending telemetry events"
+        ctx = extra["ctx"]
+        assert ctx["endpoint"] == "https://Events.Telemetry.example.COM/v1/Events?<redacted>"
+        assert ctx["event_count"] == 1
+        assert ctx["events"] == [
+            {
+                "name": "stub_event",
+                "task": "generate",
+                "task_status": "completed",
+                "deployment_type": "sdk",
+                "retry_count": 0,
+            }
+        ]
+
+    async def test_successful_send_does_not_dlq(self):
+        handler = self._make_handler()
+        queued = self._make_queued()
+
+        mock_response = MagicMock(status_code=200, is_success=True)
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        await handler._send_events_with_client(mock_client, [queued])
+        mock_client.post.assert_awaited_once()
+        assert handler._dlq == []
+
+    async def test_500_adds_to_dlq(self):
+        handler = self._make_handler()
+        queued = self._make_queued()
+
+        mock_response = MagicMock(status_code=500, is_success=False)
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        await handler._send_events_with_client(mock_client, [queued])
+        assert len(handler._dlq) == 1
+        assert handler._dlq[0].retry_count == 1
+
+    async def test_exceeds_max_retries_dropped(self):
+        handler = self._make_handler()
+        queued = self._make_queued()
+        queued.retry_count = handler._max_retries
+
+        mock_response = MagicMock(status_code=500, is_success=False)
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        await handler._send_events_with_client(mock_client, [queued])
+        assert handler._dlq == []
+
+    async def test_413_splits_and_retries(self):
+        handler = self._make_handler()
+        event = _StubEvent(task="generate")
+        events = [
+            QueuedEvent(event=event, timestamp=datetime.now(timezone.utc)),
+            QueuedEvent(event=event, timestamp=datetime.now(timezone.utc)),
+        ]
+
+        success_response = MagicMock(status_code=200, is_success=True)
+        too_large_response = MagicMock(status_code=413, is_success=False)
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = [too_large_response, success_response, success_response]
+
+        await handler._send_events_with_client(mock_client, events)
+        assert mock_client.post.await_count == 3
+
+    async def test_send_events_routes_to_dlq_on_client_setup_failure(self):
+        """If httpx client creation raises, events must land in DLQ rather than vanish."""
+        handler = self._make_handler()
+        queued = self._make_queued()
+
+        with patch("httpx.AsyncClient", side_effect=RuntimeError("boom")):
+            await handler._send_events([queued])
+
+        assert len(handler._dlq) == 1
+
+    def test_session_prefix_applied(self, monkeypatch):
+        monkeypatch.setenv("NEMO_SESSION_PREFIX", "pfx-")
+        handler = TelemetryHandler(session_id="abc")
+        assert handler._session_id == "pfx-abc"
+
+
+# =============================================================================
+# TelemetryHandler — aflush awaits a real flush
+# =============================================================================
+
+
+class TestAflushAwaits:
+    async def test_aflush_actually_flushes(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(source_client_version="1.0.0")
+        event = _StubEvent(task="generate")
+        handler.enqueue(event)
+        assert len(handler._events) == 1
+
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            await handler.aflush()
+
+        assert handler._events == []
+        assert sent == [1]
+
+
+# =============================================================================
+# TelemetryHandler — sync flush from async caller contexts
+# =============================================================================
+
+
+class TestFlushFromRunningLoop:
+    """Regression coverage for notebooks and async SDK callers."""
+
+    def test_flush_runs_to_completion_when_loop_is_running(self) -> None:
+        sent: list[int] = []
+
+        async def fake_flush(self) -> None:  # noqa: ARG001
+            sent.append(1)
+
+        async def driver() -> None:
+            handler = TelemetryHandler(source_client_version="1.0.0")
+            handler._events.append(
+                QueuedEvent(
+                    event=_StubEvent(task="run"),
+                    timestamp=datetime.now(timezone.utc),
+                )
+            )
+            with patch.object(TelemetryHandler, "_flush_events", new=fake_flush):
+                handler.flush()
+
+        asyncio.run(driver())
+        assert sent == [1]
+
+    def test_stop_flushes_fire_and_flush_path_when_loop_is_running(self, monkeypatch) -> None:
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        async def driver() -> None:
+            handler = TelemetryHandler(source_client_version="1.0.0")
+            with patch.object(handler, "_send_events", side_effect=fake_send):
+                handler.enqueue(_StubEvent(task="run"))
+                handler.stop()
+                assert handler._events == []
+
+        asyncio.run(driver())
+        assert sent == [1]
+
+    def test_run_sync_propagates_exception_to_flush_boundary(self) -> None:
+        async def boom() -> None:
+            raise RuntimeError("kaboom")
+
+        async def driver() -> None:
+            with pytest.raises(RuntimeError, match="kaboom"):
+                TelemetryHandler._run_sync(boom())
+
+        asyncio.run(driver())
+
+
+# =============================================================================
+# TelemetryHandler — sync lifecycle and context manager
+# =============================================================================
+
+
+class TestSyncLifecycle:
+    def test_fire_and_flush_without_start(self, monkeypatch):
+        """Pattern used by the SDK: construct, enqueue, stop. No start() call. stop() must flush."""
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(source_client_version="1.0.0")
+        event = _StubEvent(task="generate")
+        handler.enqueue(event)
+        assert len(handler._events) == 1
+
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            handler.stop()
+
+        assert handler._events == []
+        assert sent == [1]
+        assert handler._thread is None
+
+    def test_start_spawns_thread_and_stop_flushes(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=60.0)
+
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            handler.start()
+            assert handler._thread is not None
+            assert handler._thread.is_alive()
+
+            handler.enqueue(_StubEvent(task="run"))
+            handler.stop()
+
+        assert handler._thread is None
+        assert handler._loop is None
+        assert sent == [1]
+
+    def test_sync_context_manager(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        with patch.object(TelemetryHandler, "_send_events", side_effect=fake_send, autospec=False):
+            with TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=60.0) as handler:
+                handler.enqueue(_StubEvent(task="run"))
+
+        assert sent == [1]
+
+    def test_sync_flush_during_background_run(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=60.0)
+
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            handler.start()
+            try:
+                handler.enqueue(_StubEvent(task="run"))
+                handler.flush()
+                assert sent == [1]
+                assert handler._events == []
+            finally:
+                handler.stop()
+
+    def test_timer_driven_flush(self, monkeypatch):
+        """With a short flush interval, the background timer should drive a flush without explicit calls."""
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        handler = TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=0.05)
+
+        flushed = threading.Event()
+
+        async def fake_send(events):
+            flushed.set()
+
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            handler.start()
+            try:
+                handler.enqueue(_StubEvent(task="run"))
+                assert flushed.wait(timeout=2.0), "timer-driven flush did not fire"
+            finally:
+                handler.stop()
+
+
+# =============================================================================
+# TelemetryHandler — async lifecycle
+# =============================================================================
+
+
+class TestAsyncLifecycle:
+    async def test_async_context_manager_flushes_on_exit(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        async with TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=60.0) as handler:
+            with patch.object(handler, "_send_events", side_effect=fake_send):
+                handler.enqueue(_StubEvent(task="run"))
+                await handler.astop()
+
+        assert sent == [1]
+
+    async def test_enqueue_at_max_size_signals_flush_in_async_mode(self, monkeypatch):
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+
+        flushed = asyncio.Event()
+
+        async def fake_send(events):
+            flushed.set()
+
+        handler = TelemetryHandler(source_client_version="1.0.0", flush_interval_seconds=60.0, max_queue_size=2)
+        with patch.object(handler, "_send_events", side_effect=fake_send):
+            await handler.astart()
+            try:
+                handler.enqueue(_StubEvent(task="run"))
+                handler.enqueue(_StubEvent(task="run"))
+                await asyncio.wait_for(flushed.wait(), timeout=2.0)
+            finally:
+                await handler.astop()

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_job_events.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_job_events.py
@@ -99,6 +99,25 @@ def test_status_details_defaults_when_absent(frozen_time: MagicMock) -> None:
     assert event.plugins == []
 
 
+def test_null_status_details_still_emits(frozen_time: MagicMock) -> None:
+    """Explicit nulls must not drop the event; a real 0 token count must survive."""
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed",
+        steps=[],
+        status_details={"model": None, "input_tokens": 0, "output_tokens": None},
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    emit_event.assert_called_once()
+    event = emit_event.call_args.args[0]
+    assert event.model == "undefined"
+    assert event.input_tokens == 0
+    assert event.output_tokens == -1
+
+
 def test_error_status_maps_to_error(frozen_time: MagicMock) -> None:
     jobs = MagicMock()
     jobs.get_status.return_value = SimpleNamespace(status="error", steps=[], status_details={})

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_job_events.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_job_events.py
@@ -77,12 +77,39 @@ def test_completed_emits_single_job_run_event(frozen_time: MagicMock) -> None:
 
     emit_event.assert_called_once()
     event = emit_event.call_args.args[0]
-    assert event.job_type == "customization"
+    # job_type is the job's operation entry points from the step names, per the PRD.
+    assert event.job_type == "auditor.audit,auditor.report,guardrails.check"
     assert event.task_status is TaskStatusEnum.COMPLETED
     assert event.input_tokens == 512
     assert event.output_tokens == 2048
     assert event.model == "nemotron-super-49b"
     assert event.plugins == ["auditor", "guardrails"]
+
+
+def test_single_step_job_type_is_the_entry_point(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed", steps=[SimpleNamespace(name="auditor.audit")], status_details={}
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="audit") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "auditor.audit"
+    assert event.plugins == ["auditor"]
+
+
+def test_job_type_falls_back_to_resource_label_without_steps(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="completed", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="customization") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "customization"
+    assert event.plugins == []
 
 
 def test_status_details_defaults_when_absent(frozen_time: MagicMock) -> None:

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_job_events.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_job_events.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from nemo_platform.cli.core import waiters
+from nemo_platform.cli.telemetry.events import TaskStatusEnum
+
+WAITERS_MODULE = "nemo_platform.cli.core.waiters"
+EMIT_TARGET = "nemo_platform.cli.telemetry.emit.emit_event"
+
+
+class _DummyLive:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def __enter__(self) -> _DummyLive:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+    def update(self, *args: object) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _quiet_rich_output() -> Iterator[None]:
+    with (
+        patch(f"{WAITERS_MODULE}.Live", _DummyLive),
+        patch(f"{WAITERS_MODULE}.console.print"),
+    ):
+        yield
+
+
+@pytest.fixture
+def frozen_time() -> Iterator[MagicMock]:
+    with patch(f"{WAITERS_MODULE}.time.time", return_value=0) as time:
+        yield time
+
+
+@pytest.fixture
+def waiter_pause() -> Iterator[MagicMock]:
+    with patch(f"{WAITERS_MODULE}._pause") as pause:
+        yield pause
+
+
+def _completed_status() -> SimpleNamespace:
+    return SimpleNamespace(
+        status="completed",
+        steps=[
+            SimpleNamespace(name="auditor.audit"),
+            SimpleNamespace(name="auditor.report"),
+            SimpleNamespace(name="guardrails.check"),
+        ],
+        status_details={"input_tokens": 512, "output_tokens": 2048, "model": "nemotron-super-49b"},
+    )
+
+
+def test_completed_emits_single_job_run_event(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = _completed_status()
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="customization") is True
+
+    emit_event.assert_called_once()
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "customization"
+    assert event.task_status is TaskStatusEnum.COMPLETED
+    assert event.input_tokens == 512
+    assert event.output_tokens == 2048
+    assert event.model == "nemotron-super-49b"
+    assert event.plugins == ["auditor", "guardrails"]
+
+
+def test_status_details_defaults_when_absent(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="completed", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.input_tokens == -1
+    assert event.output_tokens == -1
+    assert event.model == "undefined"
+    assert event.plugins == []
+
+
+def test_error_status_maps_to_error(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="error", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is False
+
+    emit_event.assert_called_once()
+    assert emit_event.call_args.args[0].task_status is TaskStatusEnum.ERROR
+
+
+def test_cancelled_status_maps_to_canceled(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="cancelled", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is False
+
+    emit_event.assert_called_once()
+    assert emit_event.call_args.args[0].task_status is TaskStatusEnum.CANCELED
+
+
+def test_timeout_emits_nothing_and_does_not_crash(waiter_pause: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="running", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", timeout=5, poll_interval=10) is False
+
+    emit_event.assert_not_called()

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_onboarding_events.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_onboarding_events.py
@@ -1,0 +1,307 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for onboarding_step telemetry emitted from the setup flow.
+
+Each instrumented choke point in ``setup.py`` emits exactly one
+``OnboardingStepEvent``: COMPLETED on success, ERROR on failure with the
+original exception still propagating. ``emit_event`` is patched at its
+definition module so the module-attribute call in ``setup.py`` is intercepted.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from nemo_platform.resources.inference.providers import ProvidersResource
+from nemo_platform.cli.commands.setup import (
+    _bucket_model_count,
+    _create_provider,
+    _deploy_demo_agent,
+    _run_skill_install,
+    _wait_for_models,
+    setup_command,
+)
+from nemo_platform.cli.commands.skills.base import Scope, Skill
+from nemo_platform.cli.telemetry.events import TaskStatusEnum
+
+SETUP_MOD = "nemo_platform.cli.commands.setup"
+EMIT_TARGET = "nemo_platform.cli.telemetry.emit.emit_event"
+
+
+@pytest.fixture
+def spinner_console():
+    """Patch setup.console with a mock status spinner context manager."""
+    mock_status = MagicMock()
+    with patch(f"{SETUP_MOD}.console") as mock_console:
+        mock_console.status.return_value.__enter__ = MagicMock(return_value=mock_status)
+        mock_console.status.return_value.__exit__ = MagicMock(return_value=False)
+        yield mock_console, mock_status
+
+
+def _providers_client() -> MagicMock:
+    client = MagicMock()
+    client.inference.providers = MagicMock(spec=ProvidersResource)
+    return client
+
+
+def _skill(name: str) -> Skill:
+    return Skill(
+        name=name,
+        description=f"{name} desc",
+        version="0.1",
+        content=f"# {name}",
+        raw=f"---\nname: {name}\n---\n# {name}",
+        source_plugin=None,
+    )
+
+
+class TestCreateProviderTelemetry:
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed(self, emit):
+        client = _providers_client()
+        _create_provider(
+            client,
+            name="openai",
+            host_url="https://api.openai.com/v1",
+            secret_name="openai-api-key",
+            workspace="default",
+        )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.provider_type == "openai"
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit):
+        client = _providers_client()
+        client.inference.providers.create.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            _create_provider(
+                client,
+                name="anthropic",
+                host_url="https://api.anthropic.com",
+                secret_name="anthropic-api-key",
+                workspace="default",
+            )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.provider_type == "anthropic"
+
+
+class TestWaitForModelsTelemetry:
+    @patch(EMIT_TARGET)
+    def test_emits_completed_with_bucket(self, emit, spinner_console):
+        client = MagicMock()
+        models = [MagicMock(model_entity_id=f"default/model-{i}") for i in range(3)]
+        client.inference.providers.retrieve.return_value = MagicMock(served_models=models)
+
+        with (
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 0, 1]),
+        ):
+            result = _wait_for_models(client, "nvidia-build", "default", round_seconds=30, max_rounds=1)
+
+        assert result == [f"default/model-{i}" for i in range(3)]
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "models_discovered"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.models_discovered_bucket == "1-5"
+
+    @patch(EMIT_TARGET)
+    def test_no_models_emits_bucket_zero(self, emit, spinner_console):
+        client = MagicMock()
+        client.inference.providers.retrieve.return_value = MagicMock(served_models=[])
+
+        with (
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 1, 2, 100]),
+        ):
+            result = _wait_for_models(client, "nvidia-build", "default", round_seconds=5, max_rounds=1)
+
+        assert result == []
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "models_discovered"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.models_discovered_bucket == "0"
+
+
+class TestRunSkillInstallTelemetry:
+    def _run(self, emit, *, install_raises: bool):
+        installer = MagicMock()
+        if install_raises:
+            installer.install.side_effect = RuntimeError("install failed")
+        all_skills = {"alpha": _skill("alpha")}
+        with patch(f"{SETUP_MOD}.get_installer", return_value=installer):
+            _run_skill_install(
+                agents=["codex"],
+                scope=Scope.PROJECT,
+                skill_names=["alpha"],
+                all_skills=all_skills,
+                project_root=MagicMock(),
+            )
+
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed(self, emit):
+        self._run(emit, install_raises=False)
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "skills_installed"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert "codex" in event.skills_target
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit):
+        import typer
+
+        with pytest.raises(typer.Exit):
+            self._run(emit, install_raises=True)
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "skills_installed"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert "codex" in event.skills_target
+
+
+class TestDeployDemoAgentTelemetry:
+    def _responses(self, *, status_sequence):
+        create_resp = MagicMock(status_code=200)
+        create_resp.raise_for_status = MagicMock()
+        deploy_resp = MagicMock(status_code=200)
+        deploy_resp.raise_for_status = MagicMock()
+        deploy_resp.json.return_value = {"name": "calculator-agent-abc12345"}
+        status_resps = []
+        for s in status_sequence:
+            r = MagicMock(status_code=200)
+            r.json.return_value = {"name": "calculator-agent-abc12345", "status": s}
+            status_resps.append(r)
+        return [create_resp, deploy_resp] + status_resps
+
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed_true(self, emit, tmp_path, spinner_console):
+        config = tmp_path / "calculator-agent.yml"
+        config.write_text("llms: {}\n")
+        responses = self._responses(status_sequence=["running"])
+        with (
+            patch(f"{SETUP_MOD}.httpx.get", side_effect=responses[2:]),
+            patch(f"{SETUP_MOD}.httpx.post", side_effect=responses[:2]),
+            patch(f"{SETUP_MOD}._agent_exists", return_value=False),
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 1, 2, 3]),
+        ):
+            result = _deploy_demo_agent("http://localhost:8080", "default", config, default_model="m")
+        assert result is True
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "agent_deployed"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.agent_deployed is True
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit, tmp_path, spinner_console):
+        config = tmp_path / "calculator-agent.yml"
+        config.write_text("llms: {}\n")
+        create_resp = MagicMock(status_code=500)
+        create_resp.raise_for_status = MagicMock(side_effect=RuntimeError("http 500"))
+        with (
+            patch(f"{SETUP_MOD}.httpx.post", return_value=create_resp),
+            patch(f"{SETUP_MOD}._agent_exists", return_value=False),
+        ):
+            with pytest.raises(RuntimeError):
+                _deploy_demo_agent("http://localhost:8080", "default", config, default_model="m")
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "agent_deployed"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.agent_deployed is False
+
+
+class TestBucketModelCount:
+    @pytest.mark.parametrize(
+        ("count", "expected"),
+        [
+            (0, "0"),
+            (1, "1-5"),
+            (5, "1-5"),
+            (6, "6-20"),
+            (20, "6-20"),
+            (21, "21-100"),
+            (100, "21-100"),
+            (101, "101+"),
+            (5000, "101+"),
+        ],
+    )
+    def test_buckets(self, count, expected):
+        assert _bucket_model_count(count) == expected
+
+
+class TestSetupFinishedTelemetry:
+    """setup_finished must reflect the real outcome of the dispatch.
+
+    A clean user-cancel raises typer.Exit(0); that is a normal end, not a
+    failure, so it must emit COMPLETED. Any non-zero Exit (or real exception)
+    emits ERROR. In every case the Exit propagates unchanged.
+    """
+
+    def _run(self, emit, dispatch_exc):
+        """Drive setup_command to the auto/interactive dispatch, patching all
+        preamble so only the dispatch outcome matters. `dispatch_exc` is raised
+        from _run_interactive_mode; None means a clean finish."""
+        ctx = MagicMock(spec=typer.Context)
+        ctx.obj = MagicMock()
+        ctx.obj.get_base_url.return_value = "http://localhost:3000"
+
+        interactive = MagicMock()
+        if dispatch_exc is not None:
+            interactive.side_effect = dispatch_exc
+
+        with (
+            patch(f"{SETUP_MOD}.console"),
+            patch(f"{SETUP_MOD}.is_interactive", return_value=True),
+            patch(f"{SETUP_MOD}._maybe_start_services"),
+            patch(f"{SETUP_MOD}._check_platform_reachable_with_retries", return_value=True),
+            patch(f"{SETUP_MOD}._bootstrap_config_if_missing"),
+            patch(f"{SETUP_MOD}._run_interactive_mode", interactive),
+        ):
+            setup_command(ctx)
+
+    @patch(EMIT_TARGET)
+    def test_clean_exit_zero_emits_completed(self, emit):
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(emit, typer.Exit(0))
+        assert exc_info.value.exit_code == 0
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.COMPLETED
+
+    @patch(EMIT_TARGET)
+    def test_default_exit_emits_completed(self, emit):
+        # typer.Exit() defaults to exit_code 0, so a bare Exit is a clean end too.
+        with pytest.raises(typer.Exit):
+            self._run(emit, typer.Exit())
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.COMPLETED
+
+    @patch(EMIT_TARGET)
+    def test_nonzero_exit_emits_error(self, emit):
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(emit, typer.Exit(1))
+        assert exc_info.value.exit_code == 1
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.ERROR
+
+    @patch(EMIT_TARGET)
+    def test_real_exception_emits_error(self, emit):
+        with pytest.raises(RuntimeError):
+            self._run(emit, RuntimeError("boom"))
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.ERROR

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_wire_contract_smoke.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_wire_contract_smoke.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CI-safe wire-contract smoke test for telemetry events.
+
+This module verifies that each telemetry event serializes to the wire contract
+without making network calls. Each test constructs a valid event, wraps it in
+QueuedEvent, calls build_payload, and asserts JSON serialization and envelope
+structure.
+
+Live UAT validation (POST against the telemetry endpoint) is a manual runbook:
+set NEMO_TELEMETRY_ENDPOINT to the UAT URL, NEMO_TELEMETRY_ENABLED=true, and
+run one real command; live validation is pending nemoSource schema registration.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from nemo_platform.cli.telemetry.events import (
+    CommandInvokedEvent,
+    JobRunEvent,
+    OnboardingStepEvent,
+    TaskStatusEnum,
+)
+from nemo_platform.cli.telemetry.handler import QueuedEvent, build_payload
+
+
+class TestWireContractSmoke:
+    """Verify each event type serializes to the wire contract envelope."""
+
+    def test_onboarding_step_event_contract(self):
+        """OnboardingStepEvent must serialize with camelCase aliases and correct envelope."""
+        event = OnboardingStepEvent(
+            task_status=TaskStatusEnum.COMPLETED,
+            step="provider_discovery",
+            provider_type="huggingface",
+            models_discovered_bucket="10-100",
+            skills_target="audit_content",
+            agent_deployed=True,
+        )
+        queued = QueuedEvent(event=event, timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
+        payload = build_payload([queued], source_client_version="1.0.0", session_id="test")
+
+        # Envelope keys must match exactly.
+        expected_keys = {
+            "browserType",
+            "clientId",
+            "clientType",
+            "clientVariant",
+            "clientVer",
+            "cpuArchitecture",
+            "deviceGdprBehOptIn",
+            "deviceGdprFuncOptIn",
+            "deviceGdprTechOptIn",
+            "deviceId",
+            "deviceMake",
+            "deviceModel",
+            "deviceOS",
+            "deviceOSVersion",
+            "deviceType",
+            "eventProtocol",
+            "eventSchemaVer",
+            "eventSysVer",
+            "externalUserId",
+            "gdprBehOptIn",
+            "gdprFuncOptIn",
+            "gdprTechOptIn",
+            "idpId",
+            "integrationId",
+            "productName",
+            "productVersion",
+            "sentTs",
+            "sessionId",
+            "userId",
+            "events",
+        }
+        assert set(payload.keys()) == expected_keys, f"Envelope keys mismatch: {set(payload.keys()) ^ expected_keys}"
+
+        # Schema version must be 1.9.
+        assert payload["eventSchemaVer"] == "1.9"
+
+        # Must be JSON serializable.
+        json_str = json.dumps(payload)
+        assert isinstance(json_str, str)
+
+        # Event parameters must include camelCase aliases.
+        event_entry = payload["events"][0]
+        params = event_entry["parameters"]
+        assert params["nemoSource"] == "platform"
+        assert params["taskStatus"] == "completed"
+        assert params["deploymentType"] == "cli"
+        assert params["isCi"] is False
+        assert params["step"] == "provider_discovery"
+        assert params["providerType"] == "huggingface"
+        assert params["modelsDiscoveredBucket"] == "10-100"
+        assert params["skillsTarget"] == "audit_content"
+        assert params["agentDeployed"] is True
+        assert event_entry["name"] == "onboarding_step"
+
+    def test_command_invoked_event_contract(self):
+        """CommandInvokedEvent must serialize with camelCase aliases and correct envelope."""
+        event = CommandInvokedEvent(
+            task_status=TaskStatusEnum.COMPLETED,
+            command="nemo platform apply",
+            duration_sec=2.5,
+            agent_mode=True,
+        )
+        queued = QueuedEvent(event=event, timestamp=datetime(2026, 1, 1, 13, 0, 0, tzinfo=timezone.utc))
+        payload = build_payload([queued], source_client_version="1.2.3", session_id="cmd-test")
+
+        # Envelope keys must match exactly.
+        expected_keys = {
+            "browserType",
+            "clientId",
+            "clientType",
+            "clientVariant",
+            "clientVer",
+            "cpuArchitecture",
+            "deviceGdprBehOptIn",
+            "deviceGdprFuncOptIn",
+            "deviceGdprTechOptIn",
+            "deviceId",
+            "deviceMake",
+            "deviceModel",
+            "deviceOS",
+            "deviceOSVersion",
+            "deviceType",
+            "eventProtocol",
+            "eventSchemaVer",
+            "eventSysVer",
+            "externalUserId",
+            "gdprBehOptIn",
+            "gdprFuncOptIn",
+            "gdprTechOptIn",
+            "idpId",
+            "integrationId",
+            "productName",
+            "productVersion",
+            "sentTs",
+            "sessionId",
+            "userId",
+            "events",
+        }
+        assert set(payload.keys()) == expected_keys, f"Envelope keys mismatch: {set(payload.keys()) ^ expected_keys}"
+
+        # Schema version must be 1.9.
+        assert payload["eventSchemaVer"] == "1.9"
+
+        # Must be JSON serializable.
+        json_str = json.dumps(payload)
+        assert isinstance(json_str, str)
+
+        # Event parameters must include camelCase aliases.
+        event_entry = payload["events"][0]
+        params = event_entry["parameters"]
+        assert params["nemoSource"] == "platform"
+        assert params["taskStatus"] == "completed"
+        assert params["deploymentType"] == "cli"
+        assert params["isCi"] is False
+        assert params["command"] == "nemo platform apply"
+        assert params["durationSec"] == 2.5
+        assert params["agentMode"] is True
+        assert event_entry["name"] == "command_invoked"
+
+    def test_job_run_event_contract(self):
+        """JobRunEvent must serialize with camelCase aliases and correct envelope."""
+        event = JobRunEvent(
+            task_status=TaskStatusEnum.COMPLETED,
+            job_type="evaluate",
+            duration_sec=15.75,
+            plugins=["garak", "llm_judge"],
+            model="nemotron-4-8b",
+            input_tokens=2048,
+            output_tokens=512,
+        )
+        queued = QueuedEvent(event=event, timestamp=datetime(2026, 1, 1, 14, 0, 0, tzinfo=timezone.utc))
+        payload = build_payload([queued], source_client_version="2.0.0", session_id="job-test")
+
+        # Envelope keys must match exactly.
+        expected_keys = {
+            "browserType",
+            "clientId",
+            "clientType",
+            "clientVariant",
+            "clientVer",
+            "cpuArchitecture",
+            "deviceGdprBehOptIn",
+            "deviceGdprFuncOptIn",
+            "deviceGdprTechOptIn",
+            "deviceId",
+            "deviceMake",
+            "deviceModel",
+            "deviceOS",
+            "deviceOSVersion",
+            "deviceType",
+            "eventProtocol",
+            "eventSchemaVer",
+            "eventSysVer",
+            "externalUserId",
+            "gdprBehOptIn",
+            "gdprFuncOptIn",
+            "gdprTechOptIn",
+            "idpId",
+            "integrationId",
+            "productName",
+            "productVersion",
+            "sentTs",
+            "sessionId",
+            "userId",
+            "events",
+        }
+        assert set(payload.keys()) == expected_keys, f"Envelope keys mismatch: {set(payload.keys()) ^ expected_keys}"
+
+        # Schema version must be 1.9.
+        assert payload["eventSchemaVer"] == "1.9"
+
+        # Must be JSON serializable.
+        json_str = json.dumps(payload)
+        assert isinstance(json_str, str)
+
+        # Event parameters must include camelCase aliases.
+        event_entry = payload["events"][0]
+        params = event_entry["parameters"]
+        assert params["nemoSource"] == "platform"
+        assert params["taskStatus"] == "completed"
+        assert params["deploymentType"] == "cli"
+        assert params["isCi"] is False
+        assert params["jobType"] == "evaluate"
+        assert params["durationSec"] == 15.75
+        assert params["plugins"] == ["garak", "llm_judge"]
+        assert params["model"] == "nemotron-4-8b"
+        assert params["inputTokens"] == 2048
+        assert params["outputTokens"] == 512
+        assert event_entry["name"] == "job_run"


### PR DESCRIPTION
## What this does

Adds anonymous usage telemetry to the NeMo Platform CLI and SDK, implementing Phase 1 of the usage-telemetry PRD:
https://docs.google.com/document/d/10zr4yno15Nx_O67inlvamuhVL5t1u3oNcWOE2CQ1_QY/edit

Three anonymous events, emitted from the choke points every command already flows through:

| Event | Fires when | Key fields (all anonymous) |
|---|---|---|
| `command_invoked` | any CLI command finishes | command, status, duration, agent-mode, CI flag |
| `onboarding_step` | each `nemo setup` step | step name, status, provider type, model-count bucket |
| `job_run` | a platform job reaches a terminal state | job type, status, duration, plugins, tokens/model when available |

## Privacy

No prompts, user data, file contents, or personal information leave the machine. Event models use pydantic `extra="forbid"`, so an event physically cannot carry a free-text or arbitrary field. A random per-run session id groups the events from one invocation and is discarded when the process exits; it is not a user or device identifier. stdout stays byte-identical whether telemetry is on or off, so agent-mode consumers that parse stdout are unaffected.

## Opt out (any one disables it)

- `NEMO_TELEMETRY_ENABLED=false` (environment)
- `telemetry_enabled: false` in the config file
- `--no-telemetry` on a single command

The three layers are independent: telemetry runs only if you have not disabled it in any of them, and no layer can turn it back on. If the config cannot be read, telemetry stays off. A first-run notice prints once to stderr explaining what is collected and how to opt out.

## Performance

Emission is best effort and can never break or change the outcome of a command. The send is bounded by a 2 second timeout with no retries on the exit path, so an unreachable telemetry endpoint adds at most about 2 seconds and normally well under a second. Moving the send fully off the command's thread (fire and forget) is a sensible follow-up if maintainers want zero added latency.

## Provenance

The queue/flush/retry handler is vendored from Safe-Synthesizer `src/nemo_safe_synthesizer/telemetry.py` (commit `8a86f8b`), adapted to the CLI's event models and logging. Source lives in `packages/nemo_platform_ext/`; `sdk/python/**` is the `make vendor` mirror.

## Tests

- Telemetry suite: 92 tests (ported handler suite plus per-hook suites), all passing.
- Full `nemo_platform_ext` suite green except pre-existing environment failures unrelated to this change (a local port 8080 conflict).
- A network-free wire-contract smoke test asserts each event serializes to the schema `1.9` envelope. ruff, `ty`, and the vendored-sync lint all pass.

## Open dependencies

- `nemoSource` value is set to `"platform"` as a placeholder. It must be registered with the telemetry schema before events validate end to end. Owner: Matt Kornfield (GXT). Live UAT against the telemetry endpoint is pending that registration; this PR validates against the wire contract locally only.
- `job_run` token and model fields ship now but stay `-1`/`"undefined"` until platform services populate `status_details`. That population is a services follow-up.
- The vendored handler drops non-retryable-looking HTTP responses (for example 429) without a dead-letter retry. Carried over from the reference implementation; flagging for Matt Kornfield to decide whether 429 should retry.

This is a proposal from PM, not assigned work. Happy to adjust scope or approach.
