### PR TITLE
feat(evaluator-sdk): per-task workspace + held-out overlay verifier for Fabric agent-eval

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
@@ -9,6 +9,13 @@ NeMo Fabric Python SDK and adapts each normalized Fabric ``RunResult`` into an
 ``harness.adapter_id`` (never inferred from a model); an optional ``model`` slug
 is applied as a final profile overlay, mirroring Fabric's own Harbor integration.
 
+Every task runs in its own fresh workspace: the runtime seeds it from
+``inputs['files']`` (a no-op when there are none), runs the harness in it (via
+``environment.workspace``), and exposes its final file tree as ``workspace``
+filesystem evidence, so workspace-reading metrics score a Fabric trial alongside
+the ATIF trajectory. Any ``environment.workspace`` set in the supplied config is
+overridden per task.
+
 ``nemo_fabric`` is an optional native dependency: its types are imported for
 annotations under ``TYPE_CHECKING`` and the package is loaded lazily at runtime,
 so this module stays importable without it.
@@ -24,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
+from nemo_evaluator_sdk.agent_eval.workspace_seeds import SEED_FILES_INPUT_KEY, seed_workspace
 from nemo_evaluator_sdk.values.evidence import (
     EVIDENCE_FORMAT_ATIF,
     EVIDENCE_TRACE,
@@ -55,6 +63,14 @@ _MISSING_RELAY_MSG = (
 # them and hand them to Fabric/Relay, so they are not derived from either library.
 _RELAY_SUBDIR = "relay"
 _ARTIFACTS_SUBDIR = "artifacts"
+# Per-task workspace: where seed files are staged and where the harness reads/writes. We
+# create it, point Fabric's ``environment.workspace`` at it, and expose it as ``workspace`` evidence.
+_WORKSPACE_SUBDIR = "workspace"
+_WORKSPACE_PROFILE_NAME = "eval_workspace"
+# Evidence key + descriptor kind for the staged workspace, consumed by the
+# workspace-reading metrics.
+_WORKSPACE_EVIDENCE_KEY = "workspace"
+_WORKSPACE_EVIDENCE_KIND = "filesystem"
 # Trajectory profile identity + the file-exporter output names we choose (Relay accepts these as inputs).
 _TRAJECTORY_PROFILE_NAME = "eval_trajectory"
 _ATIF_FILENAME_TEMPLATE = "trajectory-{session_id}.atif.json"
@@ -148,12 +164,24 @@ class FabricAgentRuntime:
             artifacts_dir.mkdir(parents=True, exist_ok=True)
             profiles.append(self._trajectory_profile(profile_cls, relay_dir=relay_dir, artifacts_dir=artifacts_dir))
 
+        # Every task runs in its own fresh workspace: seed any ``inputs['files']`` into it (a no-op when
+        # there are none), point the harness at it via ``environment.workspace``, and expose it as
+        # ``workspace`` filesystem evidence — a uniform per-task dir that maps cleanly onto a per-task
+        # container volume later. Seeding runs inside the guarded block so a bad seed (a path escaping
+        # the workspace, an unresolvable fileset) fails just this task, not the whole run; it is
+        # synchronous and may block (a fileset handler downloads), so it is offloaded off the shared
+        # event loop.
+        workspace_dir = evidence_dir / _WORKSPACE_SUBDIR
+        workspace_dir.mkdir(parents=True, exist_ok=True)
         try:
+            seeded_files = await asyncio.to_thread(seed_workspace, workspace_dir, task.inputs.get(SEED_FILES_INPUT_KEY))
+            profiles.append(self._workspace_profile(profile_cls, workspace_dir=workspace_dir))
+
             result = await asyncio.wait_for(
                 client.run(
                     agent_config,
                     profiles=profiles,
-                    input=_fabric_input(task),
+                    input=_fabric_input(task, seeded_files),
                     request_id=task.id,
                     base_dir=self._base_dir,
                 ),
@@ -164,9 +192,11 @@ class FabricAgentRuntime:
         except Exception as exc:  # noqa: BLE001 - a task failure must not abort the whole run
             return self._failed_trial(task, evidence_dir, exc)
 
-        return self._to_trial(task, result, evidence_dir)
+        return self._to_trial(task, result, evidence_dir, workspace_dir)
 
-    def _to_trial(self, task: AgentEvalTask, result: RunResult, evidence_dir: Path) -> AgentEvalTrial:
+    def _to_trial(
+        self, task: AgentEvalTask, result: RunResult, evidence_dir: Path, workspace_dir: Path
+    ) -> AgentEvalTrial:
         # Persist the full normalized Fabric result so graders (and debugging) can see the raw
         # envelope, and expose it as an evidence descriptor.
         result_path = evidence_dir / "fabric_result.json"
@@ -193,13 +223,16 @@ class FabricAgentRuntime:
                 response=result.output,
                 metadata={**base_metadata, "evidence_dir": str(evidence_dir)},
             ),
-            evidence=self._evidence(result, result_path),
+            evidence=self._evidence(result, result_path, workspace_dir),
             metadata={**base_metadata, "generated": True},
         )
 
-    def _evidence(self, result: RunResult, result_path: Path) -> CandidateEvidence:
+    def _evidence(self, result: RunResult, result_path: Path, workspace_dir: Path) -> CandidateEvidence:
+        # The workspace is a host directory the harness ran in, so its final file tree is available on
+        # disk — expose it as filesystem evidence so workspace-reading metrics can score a Fabric trial.
         descriptors: dict[str, EvidenceDescriptor] = {
             "result": EvidenceDescriptor(kind="json", format="json", ref=str(result_path)),
+            _WORKSPACE_EVIDENCE_KEY: EvidenceDescriptor(kind=_WORKSPACE_EVIDENCE_KIND, ref=str(workspace_dir)),
         }
         for artifact in result.artifacts.artifacts:
             descriptors[artifact.name] = EvidenceDescriptor(
@@ -331,6 +364,18 @@ class FabricAgentRuntime:
             }
         )
 
+    def _workspace_profile(self, profile_cls: type[FabricProfileConfig], *, workspace_dir: Path) -> FabricProfileConfig:
+        # Point the harness at this task's staged workspace via ``environment.workspace`` (the codex-cli
+        # adapter resolves its cwd from it). Set as a final profile overlay, the same mechanism the
+        # trajectory profile uses for ``environment.artifacts``.
+        return profile_cls.from_mapping(
+            {
+                "name": _WORKSPACE_PROFILE_NAME,
+                "description": "Run the harness in the per-task evaluation workspace seeded with the task inputs.",
+                "environment": {"workspace": str(workspace_dir)},
+            }
+        )
+
     def _evidence_dir(self, index: int, task: AgentEvalTask, config: AgentEvalRunConfig) -> Path:
         root = self._work_root
         if root is None:
@@ -340,8 +385,22 @@ class FabricAgentRuntime:
         return Path(root) / task_dir
 
 
-def _fabric_input(task: AgentEvalTask) -> str:
-    return f"Task id: {task.id}\nIntent: {task.intent}\nInputs: {task.inputs}\n"
+def _fabric_input(task: AgentEvalTask, seeded_files: Sequence[str] = ()) -> str:
+    """Frame the task as the harness's input text.
+
+    When files were staged into the workspace, list them by name and invite the agent to work in its
+    current directory rather than dumping their contents inline; the seed-files key is dropped from
+    the echoed inputs since those files are already on disk.
+    """
+    body_inputs = {key: value for key, value in task.inputs.items() if key != SEED_FILES_INPUT_KEY}
+    lines = [f"Task id: {task.id}", f"Intent: {task.intent}"]
+    if body_inputs:
+        lines += ["", f"Inputs: {body_inputs}"]
+    if seeded_files:
+        lines += ["", "These files are already in your working directory:"]
+        lines += [f"  - {path}" for path in seeded_files]
+        lines += ["", "Complete the task by reading, creating, and editing files in your current directory."]
+    return "\n".join(lines) + "\n"
 
 
 def _extract_output_text(output: object) -> str | None:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
@@ -224,7 +224,9 @@ class FabricAgentRuntime:
                 metadata={**base_metadata, "evidence_dir": str(evidence_dir)},
             ),
             evidence=self._evidence(result, result_path, workspace_dir),
-            metadata={**base_metadata, "generated": True},
+            # AgentPhaseSuccessMetric reads agent_ok to score whether the agent phase finished cleanly
+            # (an explicit bool, not just trial status).
+            metadata={**base_metadata, "generated": True, "agent_ok": True},
         )
 
     def _evidence(self, result: RunResult, result_path: Path, workspace_dir: Path) -> CandidateEvidence:
@@ -289,6 +291,7 @@ class FabricAgentRuntime:
             metadata={
                 **(dict(extra_metadata) if extra_metadata else {}),
                 "runtime": self._runtime_name,
+                "agent_ok": False,
                 "error_type": error_type,
                 "error": error_message,
             },

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import signal
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -213,27 +214,36 @@ class LocalFilesystemEvidence:
         command: list[str],
         *,
         cwd: str = ".",
+        overlay_files: Mapping[str, str] | None = None,
         timeout_s: float | None = None,
     ) -> CommandResult:
-        """Run ``command`` (no shell) against a throwaway copy of the evidence; not a sandbox (host privileges)."""
-        overlay = Path(tempfile.mkdtemp(prefix="evidence-verify-")).resolve()
+        """Run ``command`` (no shell) against a throwaway copy of the evidence; not a sandbox (host privileges).
+
+        ``overlay_files`` is a ``{relative_path: contents}`` map of trusted files written *over* the copy
+        after it is made, before the command runs. This is how a grader supplies held-out artifacts (a
+        canonical test suite, a reference implementation) that must not live in — and cannot be edited
+        through — the agent's own workspace. Overlay paths that escape the copy are rejected.
+        """
+        sandbox = Path(tempfile.mkdtemp(prefix="evidence-verify-")).resolve()
         try:
-            workdir = (overlay / cwd).resolve()
-            if workdir != overlay and overlay not in workdir.parents:
+            workdir = (sandbox / cwd).resolve()
+            if workdir != sandbox and sandbox not in workdir.parents:
                 raise ValueError(f"verifier cwd {cwd!r} resolves outside evidence overlay")
             # symlinks=True copies links as-is (no host deref); the ignore hook drops links whose
             # target escapes the evidence root so the verifier can't read or write through them.
             await asyncio.to_thread(
                 shutil.copytree,
                 self._root,
-                overlay,
+                sandbox,
                 dirs_exist_ok=True,
                 symlinks=True,
                 ignore=self._ignore_escaping_symlinks,
             )
+            if overlay_files:
+                await asyncio.to_thread(_write_overlay_files, sandbox, overlay_files)
             return await self._exec(command, workdir, timeout_s)
         finally:
-            await asyncio.to_thread(shutil.rmtree, overlay, True)
+            await asyncio.to_thread(shutil.rmtree, sandbox, True)
 
     def _ignore_escaping_symlinks(self, directory: str, names: list[str]) -> set[str]:
         """copytree ignore hook: drop absolute symlinks and links whose target escapes the evidence root."""
@@ -271,6 +281,17 @@ class LocalFilesystemEvidence:
             stdout=stdout.decode(errors="replace"),
             stderr=stderr.decode(errors="replace"),
         )
+
+
+def _write_overlay_files(root: Path, files: Mapping[str, str]) -> None:
+    """Write ``{relative_path: contents}`` into ``root``, rejecting paths that escape it."""
+    resolved_root = root.resolve()
+    for rel_path, contents in files.items():
+        target = (resolved_root / str(rel_path)).resolve()
+        if target != resolved_root and resolved_root not in target.parents:
+            raise ValueError(f"overlay file path escapes the verifier copy: {rel_path!r}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents, encoding="utf-8")
 
 
 class EvidenceDescriptor(BaseModel):

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evidence.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evidence.py
@@ -114,6 +114,37 @@ async def test_run_verifier_uses_overlay_and_reports_outcome(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_run_verifier_overlay_files_are_staged_over_the_copy(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "answer.txt").write_text("agent", encoding="utf-8")  # the agent could edit this
+    handle = LocalFilesystemEvidence(root)
+
+    # A held-out file the agent never had: it appears in the copy the verifier runs against.
+    made = await handle.run_verifier(["cat", "held_out.txt"], overlay_files={"held_out.txt": "truth"})
+    assert made.ok and made.stdout.strip() == "truth"
+
+    # An overlay file wins over the agent's version (so held-out ground truth can't be edited away).
+    over = await handle.run_verifier(["cat", "answer.txt"], overlay_files={"answer.txt": "truth"})
+    assert over.stdout.strip() == "truth"
+
+    # Overlaying does not mutate the stored evidence, and it accepts nested paths.
+    nested = await handle.run_verifier(["cat", "tests/t.txt"], overlay_files={"tests/t.txt": "ok"})
+    assert nested.stdout.strip() == "ok"
+    assert await handle.list_files("**/*") == ["answer.txt"]
+
+
+@pytest.mark.asyncio
+async def test_run_verifier_overlay_rejects_path_escaping_the_copy(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    handle = LocalFilesystemEvidence(root)
+
+    with pytest.raises(ValueError, match="escapes the verifier copy"):
+        await handle.run_verifier(["true"], overlay_files={"../escape.txt": "nope"})
+
+
+@pytest.mark.asyncio
 async def test_escaping_symlinks_are_not_hashed_or_copied(tmp_path: Path) -> None:
     secret = tmp_path / "secret.txt"
     secret.write_text("TOPSECRET", encoding="utf-8")

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
@@ -224,6 +224,96 @@ async def test_fabric_runtime_maps_atif_artifact_to_trace_evidence(
     assert trace.ref == str(tmp_path / "trajectory.atif.json")
 
 
+def _workspace_from_profiles(profiles: list[Any]) -> Path:
+    """Pull the staged workspace path out of the ``eval_workspace`` profile overlay."""
+    profile = next(p for p in profiles if p.name == fabric_runtime._WORKSPACE_PROFILE_NAME)
+    return Path(profile.mapping["environment"]["workspace"])
+
+
+@pytest.mark.asyncio
+async def test_fabric_runtime_seeds_workspace_and_exposes_workspace_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task = AgentEvalTask(
+        id="fix/bug",
+        intent="Fix the bug.",
+        inputs={"instruction": "make the tests pass", "files": {"calc.py": "value = 1\n"}},
+    )
+
+    def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
+        # The harness runs in the staged workspace; simulate an edit it leaves behind.
+        workspace = _workspace_from_profiles(kwargs["profiles"])
+        (workspace / "result.txt").write_text("done", encoding="utf-8")
+        return _FakeResult(status="succeeded", output={"response": "ok"})
+
+    client_cls = _install_fake_fabric(monkeypatch, handler)
+    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric")
+
+    trials = await runtime.run_tasks([task])
+
+    trial = trials[0]
+    assert trial.status == "completed"
+    # A dedicated workspace profile overlay carries environment.workspace (the harness's cwd).
+    profiles = client_cls.recorded[0]["profiles"]
+    assert fabric_runtime._WORKSPACE_PROFILE_NAME in [p.name for p in profiles]
+    workspace = _workspace_from_profiles(profiles)
+    # The seed file is staged and the agent's edit is present in the same dir.
+    assert (workspace / "calc.py").read_text(encoding="utf-8") == "value = 1\n"
+    assert (workspace / "result.txt").read_text(encoding="utf-8") == "done"
+    # The final workspace is exposed as filesystem evidence (same key/kind as the Codex runtime).
+    assert trial.evidence is not None
+    workspace_evidence = trial.evidence.descriptors["workspace"]
+    assert workspace_evidence.kind == "filesystem"
+    assert workspace_evidence.ref == str(workspace)
+    # Seed-file contents are listed by name in the input, not dumped inline (they are already on disk).
+    harness_input = client_cls.recorded[0]["input"]
+    assert "calc.py" in harness_input
+    assert "value = 1" not in harness_input
+
+
+@pytest.mark.asyncio
+async def test_fabric_runtime_stages_workspace_even_without_seed_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Every task gets a workspace, even with no inputs['files'] — the harness may still create files,
+    # and the per-task dir is exposed as evidence uniformly (a from-scratch coding task, say).
+    def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
+        return _FakeResult(status="succeeded", output="ok")
+
+    client_cls = _install_fake_fabric(monkeypatch, handler)
+    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric")
+
+    trials = await runtime.run_tasks([_TASK])  # _TASK has no 'files' input
+
+    profiles = client_cls.recorded[0]["profiles"]
+    assert fabric_runtime._WORKSPACE_PROFILE_NAME in [p.name for p in profiles]
+    workspace = _workspace_from_profiles(profiles)
+    assert workspace.is_dir()
+    assert trials[0].evidence is not None
+    assert trials[0].evidence.descriptors["workspace"].ref == str(workspace)
+
+
+@pytest.mark.asyncio
+async def test_fabric_runtime_bad_seed_fails_only_that_task(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A seed path escaping the workspace must fail just this task (as a failed trial), not abort the run.
+    bad_task = AgentEvalTask(
+        id="bad/seed",
+        intent="unused",
+        inputs={"files": {"../escape.py": "nope"}},
+    )
+
+    def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
+        return _FakeResult(status="succeeded", output="unreached")
+
+    _install_fake_fabric(monkeypatch, handler)
+    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric")
+
+    trials = await runtime.run_tasks([bad_task])
+
+    assert trials[0].status == "failed"
+    assert trials[0].metadata["error_type"] == "WorkspaceSeedError"
+
+
 @pytest.mark.asyncio
 async def test_fabric_runtime_capture_trajectory_false_skips_relay_overlay(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
@@ -182,6 +182,8 @@ async def test_fabric_runtime_maps_succeeded_result_to_completed_trial(
     assert trial.metadata["harness"] == "codex"
     assert trial.metadata["adapter_id"] == "nvidia.fabric.codex.cli"
     assert trial.metadata["generated"] is True
+    # agent_ok mirrors the Codex runtime so AgentPhaseSuccessMetric scores the phase as clean.
+    assert trial.metadata["agent_ok"] is True
     # Evidence: the persisted result envelope + each Fabric artifact by name.
     assert trial.evidence is not None
     assert trial.evidence.descriptors["result"].ref.endswith("fabric_result.json")
@@ -350,6 +352,7 @@ async def test_fabric_runtime_maps_failed_result_to_failed_trial(
     assert trial.output is None
     assert trial.metadata["error_type"] == "process_exit_nonzero"
     assert trial.metadata["error"] == "boom"
+    assert trial.metadata["agent_ok"] is False
     assert trial.evidence is not None
     assert "error" in trial.evidence.descriptors
 
@@ -413,3 +416,27 @@ async def test_fabric_runtime_trajectory_capture_requires_nemo_relay(
     runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric")
     with pytest.raises(RuntimeError, match="nemo-relay"):
         await runtime.run_tasks([_TASK])
+
+
+@pytest.mark.asyncio
+async def test_fabric_success_trial_scores_agent_phase_success_true(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression guard: AgentPhaseSuccessMetric reads candidate.metadata["agent_ok"]; a successful Fabric
+    # trial must set it (via the same _trial_sample path the evaluator uses) so the metric scores True.
+    from nemo_evaluator_sdk.agent_eval.evaluator import _metric_row, _trial_sample
+    from nemo_evaluator_sdk.agent_eval.metrics import AgentPhaseSuccessMetric
+    from nemo_evaluator_sdk.execution.samples import build_metric_input
+
+    def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
+        return _FakeResult(status="succeeded", output={"response": "ok"})
+
+    _install_fake_fabric(monkeypatch, handler)
+    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric")
+
+    trial = (await runtime.run_tasks([_TASK]))[0]
+    metric_input = build_metric_input(_metric_row(_TASK, trial), _trial_sample(trial), 0)
+    result = await AgentPhaseSuccessMetric().compute_scores(metric_input)
+
+    assert result.outputs[0].name == "agent_phase_success"
+    assert result.outputs[0].value is True

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/runtime.py
@@ -9,6 +9,14 @@ NeMo Fabric Python SDK and adapts each normalized Fabric ``RunResult`` into an
 ``harness.adapter_id`` (never inferred from a model); an optional ``model`` slug
 is applied as a final profile overlay, mirroring Fabric's own Harbor integration.
 
+Every task runs in its own fresh workspace: the runtime seeds it from
+``inputs['files']`` (a no-op when there are none), runs the harness in it (via
+``environment.workspace``), and exposes its final file tree as ``workspace``
+filesystem evidence — the same contract the Codex runtime provides, so
+workspace-reading metrics score a Fabric trial unchanged, alongside the ATIF
+trajectory. Any ``environment.workspace`` set in the supplied config is
+overridden per task.
+
 ``nemo_fabric`` is an optional native dependency: its types are imported for
 annotations under ``TYPE_CHECKING`` and the package is loaded lazily at runtime,
 so this module stays importable without it.
@@ -24,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 from nemo_platform.beta.evaluator.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_platform.beta.evaluator.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
+from nemo_platform.beta.evaluator.agent_eval.workspace_seeds import SEED_FILES_INPUT_KEY, seed_workspace
 from nemo_platform.beta.evaluator.values.evidence import (
     EVIDENCE_FORMAT_ATIF,
     EVIDENCE_TRACE,
@@ -55,6 +64,14 @@ _MISSING_RELAY_MSG = (
 # them and hand them to Fabric/Relay, so they are not derived from either library.
 _RELAY_SUBDIR = "relay"
 _ARTIFACTS_SUBDIR = "artifacts"
+# Per-task workspace: where seed files are staged and where the harness (Codex, ...) reads/writes. We
+# create it, point Fabric's ``environment.workspace`` at it, and expose it as ``workspace`` evidence.
+_WORKSPACE_SUBDIR = "workspace"
+_WORKSPACE_PROFILE_NAME = "eval_workspace"
+# Evidence key + descriptor kind for the staged workspace (mirrors the Codex runtime so the same
+# workspace-reading metrics score a Fabric trial unchanged).
+_WORKSPACE_EVIDENCE_KEY = "workspace"
+_WORKSPACE_EVIDENCE_KIND = "filesystem"
 # Trajectory profile identity + the file-exporter output names we choose (Relay accepts these as inputs).
 _TRAJECTORY_PROFILE_NAME = "eval_trajectory"
 _ATIF_FILENAME_TEMPLATE = "trajectory-{session_id}.atif.json"
@@ -148,12 +165,24 @@ class FabricAgentRuntime:
             artifacts_dir.mkdir(parents=True, exist_ok=True)
             profiles.append(self._trajectory_profile(profile_cls, relay_dir=relay_dir, artifacts_dir=artifacts_dir))
 
+        # Every task runs in its own fresh workspace: seed any ``inputs['files']`` into it (a no-op when
+        # there are none), point the harness at it via ``environment.workspace``, and expose it as
+        # ``workspace`` filesystem evidence — the coding-agent contract the Codex runtime provides, and a
+        # uniform per-task dir that maps cleanly onto a per-task container volume later. Seeding runs
+        # inside the guarded block so a bad seed (a path escaping the workspace, an unresolvable fileset)
+        # fails just this task, not the whole run; it is synchronous and may block (a fileset handler
+        # downloads), so it is offloaded off the shared event loop, exactly as the Codex runtime does.
+        workspace_dir = evidence_dir / _WORKSPACE_SUBDIR
+        workspace_dir.mkdir(parents=True, exist_ok=True)
         try:
+            seeded_files = await asyncio.to_thread(seed_workspace, workspace_dir, task.inputs.get(SEED_FILES_INPUT_KEY))
+            profiles.append(self._workspace_profile(profile_cls, workspace_dir=workspace_dir))
+
             result = await asyncio.wait_for(
                 client.run(
                     agent_config,
                     profiles=profiles,
-                    input=_fabric_input(task),
+                    input=_fabric_input(task, seeded_files),
                     request_id=task.id,
                     base_dir=self._base_dir,
                 ),
@@ -164,9 +193,11 @@ class FabricAgentRuntime:
         except Exception as exc:  # noqa: BLE001 - a task failure must not abort the whole run
             return self._failed_trial(task, evidence_dir, exc)
 
-        return self._to_trial(task, result, evidence_dir)
+        return self._to_trial(task, result, evidence_dir, workspace_dir)
 
-    def _to_trial(self, task: AgentEvalTask, result: RunResult, evidence_dir: Path) -> AgentEvalTrial:
+    def _to_trial(
+        self, task: AgentEvalTask, result: RunResult, evidence_dir: Path, workspace_dir: Path
+    ) -> AgentEvalTrial:
         # Persist the full normalized Fabric result so graders (and debugging) can see the raw
         # envelope, and expose it as an evidence descriptor.
         result_path = evidence_dir / "fabric_result.json"
@@ -193,13 +224,17 @@ class FabricAgentRuntime:
                 response=result.output,
                 metadata={**base_metadata, "evidence_dir": str(evidence_dir)},
             ),
-            evidence=self._evidence(result, result_path),
+            evidence=self._evidence(result, result_path, workspace_dir),
             metadata={**base_metadata, "generated": True},
         )
 
-    def _evidence(self, result: RunResult, result_path: Path) -> CandidateEvidence:
+    def _evidence(self, result: RunResult, result_path: Path, workspace_dir: Path) -> CandidateEvidence:
+        # The workspace is a host directory the harness ran in, so its final file tree is available on
+        # disk — expose it as filesystem evidence (same key/kind as the Codex runtime) so
+        # workspace-reading metrics score a Fabric trial without change.
         descriptors: dict[str, EvidenceDescriptor] = {
             "result": EvidenceDescriptor(kind="json", format="json", ref=str(result_path)),
+            _WORKSPACE_EVIDENCE_KEY: EvidenceDescriptor(kind=_WORKSPACE_EVIDENCE_KIND, ref=str(workspace_dir)),
         }
         for artifact in result.artifacts.artifacts:
             descriptors[artifact.name] = EvidenceDescriptor(
@@ -331,6 +366,18 @@ class FabricAgentRuntime:
             }
         )
 
+    def _workspace_profile(self, profile_cls: type[FabricProfileConfig], *, workspace_dir: Path) -> FabricProfileConfig:
+        # Point the harness at this task's staged workspace via ``environment.workspace`` (the codex-cli
+        # adapter resolves its cwd from it). Set as a final profile overlay, the same mechanism the
+        # trajectory profile uses for ``environment.artifacts``.
+        return profile_cls.from_mapping(
+            {
+                "name": _WORKSPACE_PROFILE_NAME,
+                "description": "Run the harness in the per-task evaluation workspace seeded with the task inputs.",
+                "environment": {"workspace": str(workspace_dir)},
+            }
+        )
+
     def _evidence_dir(self, index: int, task: AgentEvalTask, config: AgentEvalRunConfig) -> Path:
         root = self._work_root
         if root is None:
@@ -340,8 +387,22 @@ class FabricAgentRuntime:
         return Path(root) / task_dir
 
 
-def _fabric_input(task: AgentEvalTask) -> str:
-    return f"Task id: {task.id}\nIntent: {task.intent}\nInputs: {task.inputs}\n"
+def _fabric_input(task: AgentEvalTask, seeded_files: Sequence[str] = ()) -> str:
+    """Frame the task as the harness's input text.
+
+    When files were staged into the workspace, list them by name and invite the agent to work in its
+    current directory (mirroring the Codex runtime's default prompt) rather than dumping their contents
+    inline; the seed-files key is dropped from the echoed inputs since those files are already on disk.
+    """
+    body_inputs = {key: value for key, value in task.inputs.items() if key != SEED_FILES_INPUT_KEY}
+    lines = [f"Task id: {task.id}", f"Intent: {task.intent}"]
+    if body_inputs:
+        lines += ["", f"Inputs: {body_inputs}"]
+    if seeded_files:
+        lines += ["", "These files are already in your working directory:"]
+        lines += [f"  - {path}" for path in seeded_files]
+        lines += ["", "Complete the task by reading, creating, and editing files in your current directory."]
+    return "\n".join(lines) + "\n"
 
 
 def _extract_output_text(output: object) -> str | None:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/runtime.py
@@ -12,9 +12,8 @@ is applied as a final profile overlay, mirroring Fabric's own Harbor integration
 Every task runs in its own fresh workspace: the runtime seeds it from
 ``inputs['files']`` (a no-op when there are none), runs the harness in it (via
 ``environment.workspace``), and exposes its final file tree as ``workspace``
-filesystem evidence — the same contract the Codex runtime provides, so
-workspace-reading metrics score a Fabric trial unchanged, alongside the ATIF
-trajectory. Any ``environment.workspace`` set in the supplied config is
+filesystem evidence, so workspace-reading metrics score a Fabric trial alongside
+the ATIF trajectory. Any ``environment.workspace`` set in the supplied config is
 overridden per task.
 
 ``nemo_fabric`` is an optional native dependency: its types are imported for
@@ -64,12 +63,12 @@ _MISSING_RELAY_MSG = (
 # them and hand them to Fabric/Relay, so they are not derived from either library.
 _RELAY_SUBDIR = "relay"
 _ARTIFACTS_SUBDIR = "artifacts"
-# Per-task workspace: where seed files are staged and where the harness (Codex, ...) reads/writes. We
+# Per-task workspace: where seed files are staged and where the harness reads/writes. We
 # create it, point Fabric's ``environment.workspace`` at it, and expose it as ``workspace`` evidence.
 _WORKSPACE_SUBDIR = "workspace"
 _WORKSPACE_PROFILE_NAME = "eval_workspace"
-# Evidence key + descriptor kind for the staged workspace (mirrors the Codex runtime so the same
-# workspace-reading metrics score a Fabric trial unchanged).
+# Evidence key + descriptor kind for the staged workspace, consumed by the
+# workspace-reading metrics.
 _WORKSPACE_EVIDENCE_KEY = "workspace"
 _WORKSPACE_EVIDENCE_KIND = "filesystem"
 # Trajectory profile identity + the file-exporter output names we choose (Relay accepts these as inputs).
@@ -167,11 +166,11 @@ class FabricAgentRuntime:
 
         # Every task runs in its own fresh workspace: seed any ``inputs['files']`` into it (a no-op when
         # there are none), point the harness at it via ``environment.workspace``, and expose it as
-        # ``workspace`` filesystem evidence — the coding-agent contract the Codex runtime provides, and a
-        # uniform per-task dir that maps cleanly onto a per-task container volume later. Seeding runs
-        # inside the guarded block so a bad seed (a path escaping the workspace, an unresolvable fileset)
-        # fails just this task, not the whole run; it is synchronous and may block (a fileset handler
-        # downloads), so it is offloaded off the shared event loop, exactly as the Codex runtime does.
+        # ``workspace`` filesystem evidence — a uniform per-task dir that maps cleanly onto a per-task
+        # container volume later. Seeding runs inside the guarded block so a bad seed (a path escaping
+        # the workspace, an unresolvable fileset) fails just this task, not the whole run; it is
+        # synchronous and may block (a fileset handler downloads), so it is offloaded off the shared
+        # event loop.
         workspace_dir = evidence_dir / _WORKSPACE_SUBDIR
         workspace_dir.mkdir(parents=True, exist_ok=True)
         try:
@@ -225,13 +224,14 @@ class FabricAgentRuntime:
                 metadata={**base_metadata, "evidence_dir": str(evidence_dir)},
             ),
             evidence=self._evidence(result, result_path, workspace_dir),
-            metadata={**base_metadata, "generated": True},
+            # AgentPhaseSuccessMetric reads agent_ok to score whether the agent phase finished cleanly
+            # (an explicit bool, not just trial status).
+            metadata={**base_metadata, "generated": True, "agent_ok": True},
         )
 
     def _evidence(self, result: RunResult, result_path: Path, workspace_dir: Path) -> CandidateEvidence:
         # The workspace is a host directory the harness ran in, so its final file tree is available on
-        # disk — expose it as filesystem evidence (same key/kind as the Codex runtime) so
-        # workspace-reading metrics score a Fabric trial without change.
+        # disk — expose it as filesystem evidence so workspace-reading metrics can score a Fabric trial.
         descriptors: dict[str, EvidenceDescriptor] = {
             "result": EvidenceDescriptor(kind="json", format="json", ref=str(result_path)),
             _WORKSPACE_EVIDENCE_KEY: EvidenceDescriptor(kind=_WORKSPACE_EVIDENCE_KIND, ref=str(workspace_dir)),
@@ -291,6 +291,7 @@ class FabricAgentRuntime:
             metadata={
                 **(dict(extra_metadata) if extra_metadata else {}),
                 "runtime": self._runtime_name,
+                "agent_ok": False,
                 "error_type": error_type,
                 "error": error_message,
             },
@@ -391,8 +392,8 @@ def _fabric_input(task: AgentEvalTask, seeded_files: Sequence[str] = ()) -> str:
     """Frame the task as the harness's input text.
 
     When files were staged into the workspace, list them by name and invite the agent to work in its
-    current directory (mirroring the Codex runtime's default prompt) rather than dumping their contents
-    inline; the seed-files key is dropped from the echoed inputs since those files are already on disk.
+    current directory rather than dumping their contents inline; the seed-files key is dropped from
+    the echoed inputs since those files are already on disk.
     """
     body_inputs = {key: value for key, value in task.inputs.items() if key != SEED_FILES_INPUT_KEY}
     lines = [f"Task id: {task.id}", f"Intent: {task.intent}"]

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import signal
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -213,27 +214,36 @@ class LocalFilesystemEvidence:
         command: list[str],
         *,
         cwd: str = ".",
+        overlay_files: Mapping[str, str] | None = None,
         timeout_s: float | None = None,
     ) -> CommandResult:
-        """Run ``command`` (no shell) against a throwaway copy of the evidence; not a sandbox (host privileges)."""
-        overlay = Path(tempfile.mkdtemp(prefix="evidence-verify-")).resolve()
+        """Run ``command`` (no shell) against a throwaway copy of the evidence; not a sandbox (host privileges).
+
+        ``overlay_files`` is a ``{relative_path: contents}`` map of trusted files written *over* the copy
+        after it is made, before the command runs. This is how a grader supplies held-out artifacts (a
+        canonical test suite, a reference implementation) that must not live in — and cannot be edited
+        through — the agent's own workspace. Overlay paths that escape the copy are rejected.
+        """
+        sandbox = Path(tempfile.mkdtemp(prefix="evidence-verify-")).resolve()
         try:
-            workdir = (overlay / cwd).resolve()
-            if workdir != overlay and overlay not in workdir.parents:
+            workdir = (sandbox / cwd).resolve()
+            if workdir != sandbox and sandbox not in workdir.parents:
                 raise ValueError(f"verifier cwd {cwd!r} resolves outside evidence overlay")
             # symlinks=True copies links as-is (no host deref); the ignore hook drops links whose
             # target escapes the evidence root so the verifier can't read or write through them.
             await asyncio.to_thread(
                 shutil.copytree,
                 self._root,
-                overlay,
+                sandbox,
                 dirs_exist_ok=True,
                 symlinks=True,
                 ignore=self._ignore_escaping_symlinks,
             )
+            if overlay_files:
+                await asyncio.to_thread(_write_overlay_files, sandbox, overlay_files)
             return await self._exec(command, workdir, timeout_s)
         finally:
-            await asyncio.to_thread(shutil.rmtree, overlay, True)
+            await asyncio.to_thread(shutil.rmtree, sandbox, True)
 
     def _ignore_escaping_symlinks(self, directory: str, names: list[str]) -> set[str]:
         """copytree ignore hook: drop absolute symlinks and links whose target escapes the evidence root."""
@@ -271,6 +281,17 @@ class LocalFilesystemEvidence:
             stdout=stdout.decode(errors="replace"),
             stderr=stderr.decode(errors="replace"),
         )
+
+
+def _write_overlay_files(root: Path, files: Mapping[str, str]) -> None:
+    """Write ``{relative_path: contents}`` into ``root``, rejecting paths that escape it."""
+    resolved_root = root.resolve()
+    for rel_path, contents in files.items():
+        target = (resolved_root / str(rel_path)).resolve()
+        if target != resolved_root and resolved_root not in target.parents:
+            raise ValueError(f"overlay file path escapes the verifier copy: {rel_path!r}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents, encoding="utf-8")
 
 
 class EvidenceDescriptor(BaseModel):


### PR DESCRIPTION
Two related changes that let Fabric run **workspace-based coding-agent evaluations** and grade them against held-out ground truth.

## 1. Per-task workspace in `FabricAgentRuntime`

`FabricAgentRuntime` was trajectory-only — it never seeded `inputs['files']` and exposed no `workspace` filesystem evidence, so the workspace-scoring metrics that work against the Codex runtime couldn't score a Fabric trial. Since Fabric drives the harness on the **host filesystem** in a dir we choose (no container), the agent's edited files are recoverable directly.

Now **every task runs in its own fresh per-task workspace**: `inputs['files']` are seeded into it (a no-op when there are none), the harness runs in it via an `environment.workspace` profile overlay, and the final tree is exposed as a `workspace` filesystem `EvidenceDescriptor` — identical key/kind to the Codex runtime, so existing workspace-reading metrics work unchanged. Staging is unconditional (not a flag): a uniform per-task workspace matches the Codex runtime and maps cleanly onto a per-task container volume later. A config-supplied `environment.workspace` is overridden per task.

## 2. `overlay_files` on `LocalFilesystemEvidence.run_verifier`

A `{relative_path: contents}` map of trusted files written *over* the throwaway verifier copy before the command runs — the reusable "load workspace + overlay held-out files + run verifier" primitive. This is how a grader supplies held-out artifacts (a canonical test suite, a reference implementation) that must not live in, and cannot be edited through, the agent's own workspace. Paths escaping the copy are rejected; stored evidence is never mutated.

Together: seed only agent-facing files into the workspace, keep graders' ground truth in the task's `reference`, overlay it at scoring time.

## Testing

- `pytest packages/nemo_evaluator_sdk/tests/agent_eval/` → 109 passed, 1 skipped (gated live test).
- Fabric runtime: workspace seeded + agent edit captured + evidence exposed; a no-files task still gets a workspace; a bad seed fails only that task.
- `run_verifier` overlay: held-out file appears in the copy, overlay wins over the agent's version, nested paths work, evidence untouched, path-escape rejected.
- `ruff` / `ruff format` / CI `ty` clean; `make vendor` synced.

## Stack

`main` ← #561 (Taskset) ← **#573** ← #565 (notebook). Base retargets to `main` as #561 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fabric task execution now stages each task in an isolated workspace, seeds provided input files, and includes the resulting workspace filesystem as evidence.
  * Evidence verification now supports optional overlay files applied to the verifier copy.
* **Bug Fixes**
  * Trial metadata now consistently reports `agent_ok` for both successful and failed trials.
  * Added stronger path containment protections for both workspace seeding and verifier overlays.
* **Tests**
  * Expanded coverage for overlay behavior, security validation, per-task workspace evidence/seeding (including empty inputs), traversal failures, and metric correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->