### PR TITLE
test(intake): seed ATIF ingest spans relative to now to stay within TTL

### DIFF
--- a/services/intake/tests/integration/spans/test_atif_ingest.py
+++ b/services/intake/tests/integration/spans/test_atif_ingest.py
@@ -12,8 +12,14 @@ from fastapi.testclient import TestClient
 
 _HISTORICAL_GTE = "2024-01-01T00:00:00Z"
 
-# Frozen so ingested timestamps (and everything derived from them) are deterministic.
-_BASE_TIME = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+# Seeded relative to "now" (not a fixed calendar date) with a fixed sub-second offset:
+#   - relative so the spans stay inside the 90-day ClickHouse TTL (see clickhouse_migrations.py); a
+#     fixed past date silently ages out of retention and this test flakes red (TTL eviction runs on
+#     async merges). ~45 days is well beyond the (removed) 30-day list lookback yet within retention.
+#   - .500000 microseconds so no derived timestamp lands on a whole second, which the span read-side
+#     returns without a fractional part (e.g. "...:12" vs "...:12.000000") and would fail exact matches.
+# Everything derived from this base moves with it, so the reconstructed-timestamp assertions stay exact.
+_BASE_TIME = (datetime.now(timezone.utc) - timedelta(days=45)).replace(microsecond=500_000)
 
 
 def _atif_timestamp(dt: datetime) -> str:


### PR DESCRIPTION
## Problem

`test_atif_ingest_accepts_example_trajectory_and_reconstructs_read_side_data` intermittently fails `assert 0 == 7` (read-side spans empty), and has been blocking the merge queue for unrelated PRs (e.g. #561, which passed only on a lucky re-queue).

## Root cause

Two issues, both introduced by **#580 (`9d16a122c4`)** when it swapped the test's relative `now() - timedelta(hours=2)` seed for a **fixed** `_BASE_TIME = datetime(2026, 1, 15)` (µs=0):

1. **TTL time-bomb (the flakiness).** The spans/traces ClickHouse tables carry `TTL toDate(start_time) + INTERVAL 90 DAY` (`services/intake/src/nmp/intake/spans/clickhouse_migrations.py:142`, `:295`). The fixed `2026-01-15` seed is now ~170+ days in the past — beyond the 90-day TTL — so the rows are eligible for eviction. TTL eviction runs on **async background merges**, so the read returns 7 or 0 depending on whether a merge fired first → flaky red.
2. **Whole-second formatting (latent).** With a µs=0 base, the first step lands on a whole second; the span read-side returns `...:12` (no fractional part) while `_span_started_at` formats `...:12.000000`, failing the exact-timestamp assertion. The pre-#580 `now()-2h` seed always had sub-second µs and avoided this.

Repro: same payload dated `now()-2h` → `session_only=7, gte=7`; dated `2026-01-15` → `0/0` (verified locally). Querying by `session_id` **only** (no time filter) is also 0, confirming it's storage-side TTL, not the removed list lookback.

## Fix

Seed `_BASE_TIME` **relative to `now()` (~45 days back)** with a fixed `.500000` µs offset:
- ~45 days is past the (removed) 30-day list lookback this test exercises, yet safely inside the 90-day TTL — so it no longer rots.
- `.500000` µs ensures no derived timestamp lands on a whole second.

Everything derived from the base moves with it, so all reconstructed-timestamp assertions stay exact. Keeps #580's explicit-`gte` query behavior.

## Testing

`services/intake/tests/integration/spans/test_atif_ingest.py` → **16 passed**, on two consecutive runs (stable). `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling so generated span times remain precise and consistent, including fractional microseconds.
  * Updated time-based validation to better reflect retention and TTL behavior, reducing the chance of flaky time-dependent results.

* **Tests**
  * Strengthened integration coverage for span ingestion scenarios with deterministic, relative timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->