### PR TITLE
feat(agents): add deployments runner backend for container agents

### DIFF
--- a/plugins/nemo-agents/README.md
+++ b/plugins/nemo-agents/README.md
@@ -653,3 +653,50 @@ This can cut 20--40 seconds off the first deploy.
   `NMP_BASE_URL=http://127.0.0.1:8080` to ensure agent subprocess processes
   can reach the platform. Python's `httpx` resolves bare `localhost` to IPv6
   `::1` on macOS, which does not match an IPv4-only listener.
+
+### Container (`deployments`) backend — gotchas
+
+These were hit bringing up the container deployment path (`runner_backend:
+deployments`). They are environment/setup issues, not bugs in this plugin
+unless noted:
+
+- **Controllers must be running.** A deployment stays `pending` forever if the
+  `agents-deployment` / `deployments` controllers are not started. `nemo
+  services run` (no flags) starts all services **and** default controllers.
+  Passing `--service-group all` **without** `--controller-group all` starts
+  services but **no** controllers — the reconcile loop never runs. Use
+  `nemo services run` or add `--controller-group all` explicitly.
+
+- **Docker socket discovery (Colima/Podman).** The deployments Docker backend
+  connects via `docker.from_env()`, which honours `DOCKER_HOST`. On Colima the
+  socket is at `~/.colima/default/docker.sock`, not `/var/run/docker.sock`, so
+  startup fails with `FileNotFoundError` on the socket. Export the real socket
+  before starting the platform:
+  `export DOCKER_HOST=unix://$HOME/.colima/default/docker.sock`.
+
+- **`docker_host` executor config is currently unusable.** Setting
+  `docker_host` on a nemo-deployments docker executor triggers `TypeError:
+  kwargs_from_env() got an unexpected keyword argument 'base_url'` — the backend
+  passes `base_url` to `from_env()`, which doesn't accept it. Use the
+  `DOCKER_HOST` env var instead until that is fixed upstream.
+
+- **Don't replace the bundled runner config.** Pointing `NMP_CONFIG_FILE_PATH`
+  at a file containing only `agents:` / `deployments:` sections **replaces** the
+  bundled `local.yaml`, so the files service loses its writable storage path and
+  falls back to the container default `/data/files_storage` → `OSError: [Errno
+  30] Read-only file system: '/data'` on macOS. **Extend** a copy of
+  `packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml` with
+  your `agents` / `deployments` sections rather than starting from scratch.
+
+- **Container env vars via `--env`.** Agent images that need credentials (e.g.
+  `NVIDIA_API_KEY`) receive them through `nemo agents deploy --env`. Use
+  `-e KEY=VALUE` to set a value directly, or bare `-e KEY` to forward the value
+  from your current shell. Ignored by the in-process backend.
+
+- **`verify_ssl` leaks into NIM requests (`nat serve` path).** Under `nat
+  serve`, nvidia-nat's NIM LangChain builder does not exclude `verify_ssl` from
+  the `ChatNVIDIA` kwargs (the OpenAI builder does), so it lands in the request
+  body and NVIDIA endpoints reject it with `Unsupported parameter(s):
+  verify_ssl`. The example `Dockerfile` patches the installed
+  `nat/plugins/langchain/llm.py` to mirror the OpenAI builder's exclude set;
+  remove that `RUN` step once NAT fixes this upstream.

--- a/plugins/nemo-agents/README.md
+++ b/plugins/nemo-agents/README.md
@@ -654,49 +654,21 @@ This can cut 20--40 seconds off the first deploy.
   can reach the platform. Python's `httpx` resolves bare `localhost` to IPv6
   `::1` on macOS, which does not match an IPv4-only listener.
 
-### Container (`deployments`) backend — gotchas
+### Container (`deployments`) backend
 
-These were hit bringing up the container deployment path (`runner_backend:
-deployments`). They are environment/setup issues, not bugs in this plugin
-unless noted:
+With `runner_backend: deployments` the agent runs as a container instead of a
+local subprocess. `nemo agents deploy` adds two flags for this backend:
 
-- **Controllers must be running.** A deployment stays `pending` forever if the
-  `agents-deployment` / `deployments` controllers are not started. `nemo
-  services run` (no flags) starts all services **and** default controllers.
-  Passing `--service-group all` **without** `--controller-group all` starts
-  services but **no** controllers — the reconcile loop never runs. Use
-  `nemo services run` or add `--controller-group all` explicitly.
+- `--image` / `-i` — container image to deploy (e.g. `hello-world-agent:1.0.0`).
+  Required for the `deployments` backend; ignored by the default in-process backend.
+- `--env` / `-e` — environment variable injected into the container, repeatable.
+  Use `KEY=VALUE` to set a value directly, or bare `KEY` to forward the value from
+  your current shell (e.g. an image needing `NVIDIA_API_KEY`). Ignored by the
+  in-process backend.
 
-- **Docker socket discovery (Colima/Podman).** The deployments Docker backend
-  connects via `docker.from_env()`, which honours `DOCKER_HOST`. On Colima the
-  socket is at `~/.colima/default/docker.sock`, not `/var/run/docker.sock`, so
-  startup fails with `FileNotFoundError` on the socket. Export the real socket
-  before starting the platform:
-  `export DOCKER_HOST=unix://$HOME/.colima/default/docker.sock`.
-
-- **`docker_host` executor config is currently unusable.** Setting
-  `docker_host` on a nemo-deployments docker executor triggers `TypeError:
-  kwargs_from_env() got an unexpected keyword argument 'base_url'` — the backend
-  passes `base_url` to `from_env()`, which doesn't accept it. Use the
-  `DOCKER_HOST` env var instead until that is fixed upstream.
-
-- **Don't replace the bundled runner config.** Pointing `NMP_CONFIG_FILE_PATH`
-  at a file containing only `agents:` / `deployments:` sections **replaces** the
-  bundled `local.yaml`, so the files service loses its writable storage path and
-  falls back to the container default `/data/files_storage` → `OSError: [Errno
-  30] Read-only file system: '/data'` on macOS. **Extend** a copy of
-  `packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml` with
-  your `agents` / `deployments` sections rather than starting from scratch.
-
-- **Container env vars via `--env`.** Agent images that need credentials (e.g.
-  `NVIDIA_API_KEY`) receive them through `nemo agents deploy --env`. Use
-  `-e KEY=VALUE` to set a value directly, or bare `-e KEY` to forward the value
-  from your current shell. Ignored by the in-process backend.
-
-- **`verify_ssl` leaks into NIM requests (`nat serve` path).** Under `nat
-  serve`, nvidia-nat's NIM LangChain builder does not exclude `verify_ssl` from
-  the `ChatNVIDIA` kwargs (the OpenAI builder does), so it lands in the request
-  body and NVIDIA endpoints reject it with `Unsupported parameter(s):
-  verify_ssl`. The example `Dockerfile` patches the installed
-  `nat/plugins/langchain/llm.py` to mirror the OpenAI builder's exclude set;
-  remove that `RUN` step once NAT fixes this upstream.
+```bash
+nemo agents deploy \
+    --agent react-agent \
+    --image hello-world-agent:1.0.0 \
+    --env NVIDIA_API_KEY
+```

--- a/plugins/nemo-agents/examples/Dockerfile
+++ b/plugins/nemo-agents/examples/Dockerfile
@@ -36,6 +36,18 @@ RUN --mount=type=cache,id=uv_cache,target=/root/.cache/uv,sharing=locked \
     uv pip install --prerelease=allow "nvidia-nat[most]==${NAT_VERSION}" && \
     chmod -R a+rX /opt/uv /workspace/.venv
 
+# Work around a nvidia-nat serve-path bug: the NIM LangChain builder does not
+# exclude `verify_ssl` from the ChatNVIDIA kwargs (the OpenAI builder does), so
+# under `nat serve` it leaks into the request body and NVIDIA endpoints reject it
+# with "Unsupported parameter(s): verify_ssl". Mirror the OpenAI builder's exclude.
+# The build fails loudly if the target line is absent, e.g. after a NAT upgrade
+# that fixes this upstream — remove this step then.
+RUN set -e; \
+    LLM_FILE="$(echo /workspace/.venv/lib/python*/site-packages/nat/plugins/langchain/llm.py)"; \
+    grep -q 'exclude={"type", "max_tokens", "thinking", "api_type"}' "$LLM_FILE"; \
+    sed -i 's/exclude={"type", "max_tokens", "thinking", "api_type"}/exclude={"type", "max_tokens", "thinking", "api_type", "verify_ssl"}/' "$LLM_FILE"; \
+    grep -q '"api_type", "verify_ssl"' "$LLM_FILE"
+
 LABEL org.opencontainers.image.title="hello_world" \
       org.opencontainers.image.version="26.06.01" \
       org.opencontainers.image.authors="NeMo Agents Team" \

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -2366,6 +2366,19 @@ components:
           title: Config
           description: Resolved agent config with IGW URL injected, written when the
             deployment is created.
+        image:
+          type: string
+          title: Image
+          description: Container image to deploy. Used by the 'deployments' runner
+            backend; ignored by 'in_memory'.
+          default: ''
+        env:
+          additionalProperties:
+            type: string
+          type: object
+          title: Env
+          description: Environment variables injected into the agent container. Used
+            by the 'deployments' backend.
         status:
           type: string
           enum:
@@ -2654,6 +2667,19 @@ components:
           description: Optional deployment name.  Auto-generated from agent name +
             random suffix if omitted.
           type: string
+        image:
+          title: Image
+          description: Container image to deploy.  Required when the 'deployments'
+            runner backend is active.
+          type: string
+        env:
+          title: Env
+          description: 'Environment variables to inject into the agent container (e.g.
+            {''NVIDIA_API_KEY'': ''...''}). Used by the ''deployments'' runner backend;
+            ignored by ''in_memory''.'
+          additionalProperties:
+            type: string
+          type: object
       type: object
       required:
       - agent

--- a/plugins/nemo-agents/pyproject.toml
+++ b/plugins/nemo-agents/pyproject.toml
@@ -61,12 +61,17 @@ container = [
     "jinja2>=3.1",
     "python-on-whales>=0.60",
 ]
+# Enables the 'deployments' runner backend (container deployments via nemo-deployments).
+deployments = [
+    "nemo-deployments-plugin",
+]
 test = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "httpx>=0.27",
     "fastapi>=0.115",
     "jinja2>=3.1",
+    "nemo-deployments-plugin",
 ]
 
 [build-system]
@@ -88,6 +93,7 @@ packages = [
 nemo-platform = { workspace = true }
 nemo-platform-plugin = { workspace = true }
 nemo-agents-example-calculator = { workspace = true }
+nemo-deployments-plugin = { workspace = true }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
@@ -85,6 +85,7 @@ async def create_deployment(
         agent=body.agent,
         config=resolved_config,
         image=body.image or "",
+        env=body.env or {},
         status="pending",
     )
     try:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
@@ -84,6 +84,7 @@ async def create_deployment(
         workspace=workspace,
         agent=body.agent,
         config=resolved_config,
+        image=body.image or "",
         status="pending",
     )
     try:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -707,6 +707,26 @@ def _register_platform_commands(app: typer.Typer) -> None:
     def deploy(
         agent: str = typer.Option(..., "--agent", "-a", help="Name of the agent to deploy."),
         name: Optional[str] = typer.Option(None, "--name", "-n", help="Deployment name (auto-generated if omitted)."),
+        image: Optional[str] = typer.Option(
+            None,
+            "--image",
+            "-i",
+            help=(
+                "Container image to deploy (e.g. 'hello-world-agent:1.0.0'). Required when the "
+                "'deployments' runner backend is active; ignored by the default in-process backend."
+            ),
+        ),
+        env: Optional[list[str]] = typer.Option(
+            None,
+            "--env",
+            "-e",
+            help=(
+                "Environment variable to inject into the agent container, repeatable. "
+                "Use 'KEY=VALUE' to set a value directly, or bare 'KEY' to forward the "
+                "value from your current shell environment (e.g. '-e NVIDIA_API_KEY'). "
+                "Used by the 'deployments' runner backend; ignored by the in-process backend."
+            ),
+        ),
         wait: bool = typer.Option(
             True,
             "--wait/--no-wait",
@@ -739,6 +759,10 @@ def _register_platform_commands(app: typer.Typer) -> None:
         payload: dict = {"agent": agent}
         if name:
             payload["name"] = name
+        if image:
+            payload["image"] = image
+        if env:
+            payload["env"] = _parse_env_options(env)
         resp = _api_request("POST", base_url, f"/apis/agents/v2/workspaces/{workspace}/deployments", json_body=payload)
         if not wait:
             typer.echo(json.dumps(resp, indent=2))
@@ -987,6 +1011,31 @@ def _register_platform_commands(app: typer.Typer) -> None:
 # ---------------------------------------------------------------------------
 
 _TERMINAL_STATUSES = {"running", "failed"}
+
+
+def _parse_env_options(entries: list[str]) -> dict[str, str]:
+    """Return a name->value env mapping from ``--env`` CLI entries.
+
+    Each entry is either ``KEY=VALUE`` (value used verbatim) or a bare ``KEY``
+    (value read from the current shell environment). A bare key that is not set
+    in the environment aborts the command with a clear error.
+    """
+    result: dict[str, str] = {}
+    for entry in entries:
+        if "=" in entry:
+            key, value = entry.split("=", 1)
+        else:
+            key = entry
+            value = os.environ.get(key, "")
+            if key not in os.environ:
+                raise typer.BadParameter(
+                    f"--env {key!r} has no value and is not set in the current environment. "
+                    f"Pass '{key}=VALUE' or export {key} before deploying."
+                )
+        if not key:
+            raise typer.BadParameter(f"--env entry {entry!r} has an empty variable name.")
+        result[key] = value
+    return result
 
 
 def _wait_for_deployment(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/config.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/config.py
@@ -51,6 +51,35 @@ class ControllerConfig(BaseModel):
     )
 
 
+class DeploymentsRunnerConfig(BaseModel):
+    """Settings for the 'deployments' runner backend (containers via nemo-deployments)."""
+
+    executor: str | None = Field(
+        default=None,
+        description=(
+            "Named deployments-plugin executor to target (a docker or k8s executor). "
+            "Falls back to the deployments plugin's default_executor when unset."
+        ),
+    )
+    default_image: str | None = Field(
+        default=None,
+        description="Container image used when a deployment request does not specify one.",
+    )
+    container_port: int = Field(
+        default=8000,
+        ge=1,
+        le=65535,
+        description="Port the agent container listens on (must match the image's served port).",
+    )
+    gateway_url_override: str | None = Field(
+        default=None,
+        description=(
+            "Explicit Inference Gateway base URL reachable from inside the container. When unset, "
+            "the platform base URL's loopback host is rewritten to 'host.docker.internal'."
+        ),
+    )
+
+
 class AgentsConfig(NemoConfig):
     """Configuration for the Agents plugin."""
 
@@ -63,5 +92,12 @@ class AgentsConfig(NemoConfig):
     )
     runner_backend: str = Field(
         default="in_memory",
-        description="Runner backend type. Currently only 'in_memory' is supported.",
+        description=(
+            "Runner backend type: 'in_memory' (local nat subprocesses) or "
+            "'deployments' (containers via the nemo-deployments plugin)."
+        ),
+    )
+    deployments: DeploymentsRunnerConfig = Field(
+        default_factory=DeploymentsRunnerConfig,
+        description="Settings for the 'deployments' runner backend.",
     )

--- a/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
@@ -112,6 +112,10 @@ class AgentDeployment(NemoEntity, entity_type="agent_deployment"):
         default_factory=dict,
         description="Resolved agent config with IGW URL injected, written when the deployment is created.",
     )
+    image: str = Field(
+        default="",
+        description="Container image to deploy. Used by the 'deployments' runner backend; ignored by 'in_memory'.",
+    )
     status: DeploymentStatus = Field(
         default="pending",
         description="Lifecycle status: pending | starting | running | failed | deleting.",

--- a/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
@@ -116,6 +116,10 @@ class AgentDeployment(NemoEntity, entity_type="agent_deployment"):
         default="",
         description="Container image to deploy. Used by the 'deployments' runner backend; ignored by 'in_memory'.",
     )
+    env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Environment variables injected into the agent container. Used by the 'deployments' backend.",
+    )
     status: DeploymentStatus = Field(
         default="pending",
         description="Lifecycle status: pending | starting | running | failed | deleting.",

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/backend.py
@@ -86,8 +86,13 @@ class RunnerBackend(ABC):
         return 0
 
     @abstractmethod
-    async def create_deployment(self, workspace: str, name: str, config: dict[str, Any], port: int) -> DeploymentInfo:
-        """Start the agent process; returns status="starting"."""
+    async def create_deployment(
+        self, workspace: str, name: str, config: dict[str, Any], port: int, image: str | None = None
+    ) -> DeploymentInfo:
+        """Start the agent runtime; returns status="starting".
+
+        *image* is used by container backends; process backends ignore it.
+        """
         ...
 
     @abstractmethod

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/backend.py
@@ -87,11 +87,17 @@ class RunnerBackend(ABC):
 
     @abstractmethod
     async def create_deployment(
-        self, workspace: str, name: str, config: dict[str, Any], port: int, image: str | None = None
+        self,
+        workspace: str,
+        name: str,
+        config: dict[str, Any],
+        port: int,
+        image: str | None = None,
+        env: dict[str, str] | None = None,
     ) -> DeploymentInfo:
         """Start the agent runtime; returns status="starting".
 
-        *image* is used by container backends; process backends ignore it.
+        *image* and *env* are used by container backends; process backends ignore them.
         """
         ...
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
@@ -178,6 +178,7 @@ class AgentDeploymentController(NemoController):
                 name=dep.name,
                 config=dep.config,
                 port=port,
+                image=dep.image or None,
             )
         except Exception as exc:
             logger.exception("Failed to start agent process for deployment '%s'", dep.name)
@@ -239,6 +240,11 @@ class AgentDeploymentController(NemoController):
                 info.log_path or "<none>",
             )
             return
+
+        # Container backends assign the endpoint asynchronously once the runtime is
+        # scheduled; adopt it here so the health check and gateway proxy can reach the agent.
+        if info is not None and info.endpoint:
+            dep.endpoint = info.endpoint
 
         healthy = bool(dep.endpoint) and await self.backend.health_check(dep.endpoint)
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
@@ -179,6 +179,7 @@ class AgentDeploymentController(NemoController):
                 config=dep.config,
                 port=port,
                 image=dep.image or None,
+                env=dep.env or None,
             )
         except Exception as exc:
             logger.exception("Failed to start agent process for deployment '%s'", dep.name)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeploymentsRunnerBackend — runs agents as containers via the nemo-deployments plugin.
+
+Translates the :class:`~nemo_agents_plugin.runner.backend.RunnerBackend` interface into
+nemo-deployments ``Deployment`` / ``DeploymentConfig`` entity operations. The deployments
+controller reconciles those entities onto a configured executor (docker today, k8s later),
+so the same code path serves both substrates — the only difference is which executor is
+targeted via ``AgentsConfig.deployments.executor``.
+
+Assumes the agent container image is self-contained (NAT config baked in). Gateway routing
+is supplied to the container through env vars rather than config rewriting.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from nemo_agents_plugin.config import AgentsConfig, DeploymentsRunnerConfig
+from nemo_agents_plugin.entities import DeploymentStatus
+from nemo_agents_plugin.runner.backend import DeploymentInfo, ExternalLog, LogLocation, RunnerBackend
+from nemo_agents_plugin.utils import get_base_url
+from nemo_deployments_plugin.entities import Container, ContainerPort, Deployment, DeploymentConfig, EnvVar
+from nemo_platform.resources.entities import AsyncEntitiesResource
+from nemo_platform_plugin.config import LOOPBACK_ADDRESSES
+from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
+from nemo_platform_plugin.sdk_provider import get_async_platform_sdk
+
+logger = logging.getLogger(__name__)
+
+# The deployments docker/k8s backends expect exactly one container.
+_CONTAINER_NAME = "agent"
+_HTTP_PORT_NAME = "http"
+# Prefix for the deployments entities we own, so list/get/delete never collide with
+# user-authored deployments in the same workspace.
+_ENTITY_PREFIX = "agent-"
+
+# agents lifecycle status  <-  deployments-plugin status
+_STATUS_MAP: dict[str, DeploymentStatus] = {
+    "PENDING": "starting",
+    "STARTING": "starting",
+    "READY": "running",
+    "SUCCEEDED": "running",  # Always-restart agents never reach SUCCEEDED in practice.
+    "FAILED": "failed",
+    "LOST": "failed",
+    "UNKNOWN": "starting",
+    "DELETING": "deleting",
+}
+
+
+def map_status(backend_status: str) -> DeploymentStatus:
+    """Return the agents lifecycle status for a deployments-plugin status."""
+    return _STATUS_MAP.get(backend_status, "starting")
+
+
+def container_gateway_url(base_url: str, override: str | None = None) -> str:
+    """Return an Inference Gateway base URL reachable from inside a container.
+
+    Rewrites a loopback host in *base_url* to ``host.docker.internal`` so an agent
+    process inside a container can reach the platform running on the host. When
+    *override* is given it wins verbatim.
+
+    Args:
+        base_url: The platform base URL as seen from the host.
+        override: Optional explicit container-reachable base URL.
+
+    Returns:
+        str: A base URL (no trailing slash) reachable from inside the container.
+
+    """
+    if override:
+        return override.rstrip("/")
+    url = base_url.rstrip("/")
+    for host in LOOPBACK_ADDRESSES:
+        marker = f"//{host}"
+        if marker in url:
+            return url.replace(marker, "//host.docker.internal", 1)
+    return url
+
+
+def build_deployment_config(
+    *,
+    name: str,
+    workspace: str,
+    image: str,
+    port: int,
+    env: dict[str, str],
+) -> DeploymentConfig:
+    """Build the DeploymentConfig entity for a single-container agent deployment.
+
+    Args:
+        name: Name for the DeploymentConfig entity.
+        workspace: Workspace the entity belongs to.
+        image: Container image to run.
+        port: Container port the agent server listens on.
+        env: Environment variables to inject into the container.
+
+    Returns:
+        DeploymentConfig: The entity ready to be created in the entity store.
+
+    """
+    # Aliased fields (containerPort) use their alias names for the constructor.
+    # DeploymentConfig.restart_policy defaults to "Always" (long-running agent server).
+    return DeploymentConfig(
+        name=name,
+        workspace=workspace,
+        containers=[
+            Container(
+                name=_CONTAINER_NAME,
+                image=image,
+                ports=[ContainerPort(name=_HTTP_PORT_NAME, containerPort=port)],
+                env=[EnvVar(name=key, value=value) for key, value in env.items()],
+            )
+        ],
+    )
+
+
+class DeploymentsRunnerBackend(RunnerBackend):
+    """Runs agent deployments as containers via the nemo-deployments plugin.
+
+    Args:
+        config: The agents plugin configuration; ``config.deployments`` selects the
+            target executor, default image, container port, and gateway URL override.
+
+    """
+
+    def __init__(self, config: AgentsConfig) -> None:
+        self._config: DeploymentsRunnerConfig = config.deployments
+        self._entities: NemoEntitiesClient | None = None
+        self._http_client: httpx.AsyncClient | None = None
+
+    def _entity_client(self) -> NemoEntitiesClient:
+        if self._entities is None:
+            sdk = get_async_platform_sdk(as_service="agents", internal=True)
+            self._entities = NemoEntitiesClient(AsyncEntitiesResource(sdk))
+        return self._entities
+
+    @staticmethod
+    def _dep_name(name: str) -> str:
+        return f"{_ENTITY_PREFIX}{name}"
+
+    async def create_deployment(
+        self, workspace: str, name: str, config: dict[str, Any], port: int, image: str | None = None
+    ) -> DeploymentInfo:
+        """Create DeploymentConfig + Deployment entities for the agent container.
+
+        The container image is self-contained, so *config* and *port* (the host port,
+        which the deployments backend allocates) are unused here.
+        """
+        del config, port
+        resolved_image = image or self._config.default_image
+        if not resolved_image:
+            return DeploymentInfo(
+                name=name,
+                status="failed",
+                error="No container image provided and no deployments.default_image configured.",
+            )
+
+        entities = self._entity_client()
+        dep_name = self._dep_name(name)
+        env = {
+            "NMP_GATEWAY_BASE_URL": container_gateway_url(get_base_url(), self._config.gateway_url_override),
+            "NMP_WORKSPACE": workspace,
+            "NMP_AGENT_NAME": name,
+        }
+        deployment_config = build_deployment_config(
+            name=dep_name,
+            workspace=workspace,
+            image=resolved_image,
+            port=self._config.container_port,
+            env=env,
+        )
+        await entities.create(deployment_config)
+        deployment = Deployment(
+            name=dep_name,
+            workspace=workspace,
+            deployment_config=dep_name,
+            executor=self._config.executor,
+            status="PENDING",
+        )
+        await entities.create(deployment)
+        logger.info("Created deployment entities '%s/%s' (image=%s)", workspace, dep_name, resolved_image)
+        # Endpoint is assigned asynchronously once the deployments controller schedules
+        # the container; the agents controller adopts it on a later reconcile cycle.
+        return DeploymentInfo(name=name, status="starting", endpoint="")
+
+    async def get_deployment_status(self, workspace: str, name: str) -> DeploymentInfo | None:
+        entities = self._entity_client()
+        try:
+            deployment = await entities.get(Deployment, name=self._dep_name(name), workspace=workspace)
+        except NemoEntityNotFoundError:
+            return None
+        endpoint = deployment.endpoints[0].url if deployment.endpoints else ""
+        info = DeploymentInfo(name=name, status=map_status(deployment.status), endpoint=endpoint)
+        if info.status == "failed":
+            info.error = deployment.status_message or "Deployment failed."
+        return info
+
+    async def delete_deployment(self, workspace: str, name: str) -> bool:
+        entities = self._entity_client()
+        dep_name = self._dep_name(name)
+        found = False
+        try:
+            deployment = await entities.get(Deployment, name=dep_name, workspace=workspace)
+            deployment.status = "DELETING"
+            await entities.update(deployment)
+            found = True
+        except NemoEntityNotFoundError:
+            pass
+        # The deployments controller removes the container and deletes the Deployment entity
+        # on DELETING; the DeploymentConfig is ours to clean up.
+        try:
+            await entities.delete(DeploymentConfig, name=dep_name, workspace=workspace)
+            found = True
+        except NemoEntityNotFoundError:
+            pass
+        return found
+
+    async def list_deployments(self, workspace: str | None = None) -> list[DeploymentInfo]:
+        entities = self._entity_client()
+        result = await entities.list(Deployment, workspace=workspace or "-")
+        infos: list[DeploymentInfo] = []
+        for deployment in result.data:
+            if not deployment.name.startswith(_ENTITY_PREFIX):
+                continue
+            endpoint = deployment.endpoints[0].url if deployment.endpoints else ""
+            infos.append(
+                DeploymentInfo(
+                    name=deployment.name[len(_ENTITY_PREFIX) :],
+                    status=map_status(deployment.status),
+                    endpoint=endpoint,
+                )
+            )
+        return infos
+
+    async def health_check(self, endpoint: str) -> bool:
+        if not endpoint:
+            return False
+        url = endpoint.rstrip("/") + "/health"
+        try:
+            resp = await self._get_http_client().get(url)
+            return resp.status_code < 400
+        except Exception:
+            return False
+
+    def _get_http_client(self) -> httpx.AsyncClient:
+        if self._http_client is None or self._http_client.is_closed:
+            self._http_client = httpx.AsyncClient(timeout=5.0)
+        return self._http_client
+
+    def get_log_location(self, workspace: str, name: str) -> LogLocation:
+        del workspace, name
+        return ExternalLog(hint="Inspect container logs via the deployments plugin or 'docker logs'.")
+
+    async def shutdown(self) -> None:
+        if self._http_client is not None and not self._http_client.is_closed:
+            try:
+                await self._http_client.aclose()
+            except Exception:
+                logger.warning("Error closing HTTP client during shutdown", exc_info=True)
+            self._http_client = None

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -15,7 +15,9 @@ is supplied to the container through env vars rather than config rewriting.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from typing import Any
 
 import httpx
@@ -37,6 +39,13 @@ _HTTP_PORT_NAME = "http"
 # Prefix for the deployments entities we own, so list/get/delete never collide with
 # user-authored deployments in the same workspace.
 _ENTITY_PREFIX = "agent-"
+
+# On delete, wait up to this long for the deployments controller to tear down the
+# container and remove the Deployment entity before we drop the DeploymentConfig. This
+# keeps the config alive while a Deployment still references it, so the controller's
+# _load_configs never 404s on a config we deleted out from under it.
+_DELETE_CONFIG_WAIT_S = 30.0
+_DELETE_CONFIG_POLL_S = 1.0
 
 # agents lifecycle status  <-  deployments-plugin status
 _STATUS_MAP: dict[str, DeploymentStatus] = {
@@ -143,12 +152,19 @@ class DeploymentsRunnerBackend(RunnerBackend):
         return f"{_ENTITY_PREFIX}{name}"
 
     async def create_deployment(
-        self, workspace: str, name: str, config: dict[str, Any], port: int, image: str | None = None
+        self,
+        workspace: str,
+        name: str,
+        config: dict[str, Any],
+        port: int,
+        image: str | None = None,
+        env: dict[str, str] | None = None,
     ) -> DeploymentInfo:
         """Create DeploymentConfig + Deployment entities for the agent container.
 
         The container image is self-contained, so *config* and *port* (the host port,
-        which the deployments backend allocates) are unused here.
+        which the deployments backend allocates) are unused here. *env* is merged into
+        the container environment on top of the platform-supplied gateway variables.
         """
         del config, port
         resolved_image = image or self._config.default_image
@@ -161,17 +177,21 @@ class DeploymentsRunnerBackend(RunnerBackend):
 
         entities = self._entity_client()
         dep_name = self._dep_name(name)
-        env = {
+        container_env = {
             "NMP_GATEWAY_BASE_URL": container_gateway_url(get_base_url(), self._config.gateway_url_override),
             "NMP_WORKSPACE": workspace,
             "NMP_AGENT_NAME": name,
         }
+        # Caller-supplied env (e.g. NVIDIA_API_KEY passed on the deploy command line)
+        # overrides the platform defaults above.
+        if env:
+            container_env.update(env)
         deployment_config = build_deployment_config(
             name=dep_name,
             workspace=workspace,
             image=resolved_image,
             port=self._config.container_port,
-            env=env,
+            env=container_env,
         )
         await entities.create(deployment_config)
         deployment = Deployment(
@@ -205,19 +225,51 @@ class DeploymentsRunnerBackend(RunnerBackend):
         found = False
         try:
             deployment = await entities.get(Deployment, name=dep_name, workspace=workspace)
-            deployment.status = "DELETING"
-            await entities.update(deployment)
+            if deployment.status != "DELETING":
+                deployment.status = "DELETING"
+                await entities.update(deployment)
             found = True
         except NemoEntityNotFoundError:
             pass
         # The deployments controller removes the container and deletes the Deployment entity
-        # on DELETING; the DeploymentConfig is ours to clean up.
+        # on DELETING; the DeploymentConfig is ours to clean up. Wait for the Deployment to
+        # be gone first — deleting the config while the controller still holds a DELETING
+        # Deployment makes its _load_configs 404 every cycle (harmless but noisy log spam).
+        if found:
+            await self._wait_for_deployment_gone(workspace, dep_name)
         try:
             await entities.delete(DeploymentConfig, name=dep_name, workspace=workspace)
             found = True
         except NemoEntityNotFoundError:
             pass
         return found
+
+    async def _wait_for_deployment_gone(self, workspace: str, dep_name: str) -> None:
+        """Block until the Deployment entity is deleted or the wait budget elapses.
+
+        Args:
+            workspace: Workspace the Deployment belongs to.
+            dep_name: Prefixed Deployment entity name.
+
+        """
+        # ponytail: bounded polling blocks this reconcile iteration for up to
+        # _DELETE_CONFIG_WAIT_S; on timeout we delete the config anyway and accept a
+        # single 404 warning rather than leak the config or hang the loop. Upgrade path
+        # is a multi-cycle, reconcile-driven delete if this ever needs to be non-blocking.
+        entities = self._entity_client()
+        deadline = time.monotonic() + _DELETE_CONFIG_WAIT_S
+        while time.monotonic() < deadline:
+            try:
+                await entities.get(Deployment, name=dep_name, workspace=workspace)
+            except NemoEntityNotFoundError:
+                return
+            await asyncio.sleep(_DELETE_CONFIG_POLL_S)
+        logger.warning(
+            "Deployment '%s/%s' still present after %.0fs; deleting its config anyway.",
+            workspace,
+            dep_name,
+            _DELETE_CONFIG_WAIT_S,
+        )
 
     async def list_deployments(self, workspace: str | None = None) -> list[DeploymentInfo]:
         entities = self._entity_client()

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py
@@ -192,8 +192,14 @@ class InMemoryRunnerBackend(RunnerBackend):
             except OSError:
                 return False
 
-    async def create_deployment(self, workspace: str, name: str, config: dict[str, Any], port: int) -> DeploymentInfo:
-        """Write config to a deterministic file and spawn ``nat serve``."""
+    async def create_deployment(
+        self, workspace: str, name: str, config: dict[str, Any], port: int, image: str | None = None
+    ) -> DeploymentInfo:
+        """Write config to a deterministic file and spawn ``nat serve``.
+
+        *image* is accepted for interface parity with container backends and ignored here.
+        """
+        del image
         key = (workspace, name)
         config_path = await asyncio.to_thread(self._write_config, workspace, name, config)
         log_path = self.log_path_for(workspace, name)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py
@@ -193,13 +193,19 @@ class InMemoryRunnerBackend(RunnerBackend):
                 return False
 
     async def create_deployment(
-        self, workspace: str, name: str, config: dict[str, Any], port: int, image: str | None = None
+        self,
+        workspace: str,
+        name: str,
+        config: dict[str, Any],
+        port: int,
+        image: str | None = None,
+        env: dict[str, str] | None = None,
     ) -> DeploymentInfo:
         """Write config to a deterministic file and spawn ``nat serve``.
 
-        *image* is accepted for interface parity with container backends and ignored here.
+        *image* and *env* are accepted for interface parity with container backends and ignored here.
         """
-        del image
+        del image, env
         key = (workspace, name)
         config_path = await asyncio.to_thread(self._write_config, workspace, name, config)
         log_path = self.log_path_for(workspace, name)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/registry.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/registry.py
@@ -34,8 +34,15 @@ class RunnerBackendRegistry:
             logger.info(
                 "Runner backend: InMemoryRunnerBackend (port range start=%d)", config.controller.port_range_start
             )
+        elif backend_type == "deployments":
+            from nemo_agents_plugin.runner.deployments_backend import DeploymentsRunnerBackend
+
+            self._backend = DeploymentsRunnerBackend(config)
+            logger.info("Runner backend: DeploymentsRunnerBackend (executor=%s)", config.deployments.executor)
         else:
-            raise ValueError(f"Unknown runner_backend type '{backend_type}'. Supported values: 'in_memory'.")
+            raise ValueError(
+                f"Unknown runner_backend type '{backend_type}'. Supported values: 'in_memory', 'deployments'."
+            )
 
     @property
     def backend(self) -> RunnerBackend:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/registry.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/registry.py
@@ -18,11 +18,10 @@ class RunnerBackendRegistry:
     """Instantiates and holds the active :class:`~nemo_agents_plugin.runner.backend.RunnerBackend`.
 
     The backend type is determined by :attr:`~nemo_agents_plugin.config.AgentsConfig.runner_backend`.
-    Currently only ``"in_memory"`` is supported.
-
-    Future backends register here:
-    - ``"docker"``  → ``DockerRunnerBackend``
-    - ``"k8s"``     → ``K8sRunnerBackend``
+    Supported backends:
+    - ``"in_memory"`` (default) → ``InMemoryRunnerBackend`` (local ``nat`` subprocesses)
+    - ``"deployments"``         → ``DeploymentsRunnerBackend`` (containers via the
+      nemo-deployments plugin; docker or k8s per ``deployments.executor``)
     """
 
     def __init__(self, config: AgentsConfig) -> None:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/schema.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/schema.py
@@ -52,6 +52,13 @@ class CreateDeploymentRequest(BaseModel):
         default=None,
         description="Container image to deploy.  Required when the 'deployments' runner backend is active.",
     )
+    env: dict[str, str] | None = Field(
+        default=None,
+        description=(
+            "Environment variables to inject into the agent container (e.g. {'NVIDIA_API_KEY': '...'}). "
+            "Used by the 'deployments' runner backend; ignored by 'in_memory'."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-agents/src/nemo_agents_plugin/schema.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/schema.py
@@ -48,6 +48,10 @@ class CreateDeploymentRequest(BaseModel):
         default=None,
         description="Optional deployment name.  Auto-generated from agent name + random suffix if omitted.",
     )
+    image: str | None = Field(
+        default=None,
+        description="Container image to deploy.  Required when the 'deployments' runner backend is active.",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -72,7 +72,9 @@ async def test_create_deployment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(mod, "get_base_url", lambda: "http://localhost:8080")
     backend = _backend(executor="local-docker")
 
-    info = await backend.create_deployment("ws", "foo", config={}, port=0, image="img:1")
+    info = await backend.create_deployment(
+        "ws", "foo", config={}, port=0, image="img:1", env={"NVIDIA_API_KEY": "secret"}
+    )
 
     assert info.status == "starting"
     assert backend._entities.create.await_count == 2
@@ -80,8 +82,10 @@ async def test_create_deployment(monkeypatch: pytest.MonkeyPatch) -> None:
     assert created_config.name == "agent-foo"  # prefixed to avoid user-deployment collisions
     assert created_deployment.deployment_config == "agent-foo"
     assert created_deployment.executor == "local-docker"
-    gateway_env = {e.name: e.value for e in created_config.containers[0].env}["NMP_GATEWAY_BASE_URL"]
-    assert gateway_env == "http://host.docker.internal:8080"
+    container_env = {e.name: e.value for e in created_config.containers[0].env}
+    assert container_env["NMP_GATEWAY_BASE_URL"] == "http://host.docker.internal:8080"
+    # Caller-supplied env is merged into the container alongside the platform defaults.
+    assert container_env["NVIDIA_API_KEY"] == "secret"
 
     # No image and no default_image → fail fast without touching the entity store.
     backend2 = _backend()
@@ -111,9 +115,11 @@ async def test_status_delete_and_list() -> None:
     backend._entities.get.side_effect = NemoEntityNotFoundError("nope")
     assert await backend.get_deployment_status("ws", "foo") is None
 
-    # Delete: mark Deployment DELETING (controller removes container + entity) and drop the config.
-    backend._entities.get.side_effect = None
-    backend._entities.get.return_value = ready
+    # Delete: mark Deployment DELETING (controller removes container + entity), wait for the
+    # Deployment to disappear, then drop the config. First get returns the live Deployment;
+    # the second get (the wait poll) 404s, so the config is deleted only once it's gone.
+    backend._entities.get.return_value = None
+    backend._entities.get.side_effect = [ready, NemoEntityNotFoundError("gone")]
     assert await backend.delete_deployment("ws", "foo") is True
     updated = backend._entities.update.await_args.args[0]
     assert updated.status == "DELETING"

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``DeploymentsRunnerBackend`` — mapping and entity lifecycle.
+
+Covers the pure helpers (status mapping, container gateway URL rewrite,
+DeploymentConfig shape) and the backend's translation of the RunnerBackend
+interface into nemo-deployments entity operations, using a mocked entity client
+so no platform is required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from nemo_agents_plugin.config import DeploymentsRunnerConfig
+from nemo_agents_plugin.runner import deployments_backend as mod
+from nemo_agents_plugin.runner.deployments_backend import (
+    DeploymentsRunnerBackend,
+    build_deployment_config,
+    container_gateway_url,
+    map_status,
+)
+from nemo_deployments_plugin.entities import Deployment
+from nemo_deployments_plugin.types import Endpoint
+from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
+
+
+def _backend(**deployment_kwargs) -> DeploymentsRunnerBackend:
+    cfg = SimpleNamespace(deployments=DeploymentsRunnerConfig(**deployment_kwargs))
+    backend = DeploymentsRunnerBackend(cfg)  # type: ignore[arg-type]
+    backend._entities = AsyncMock()
+    return backend
+
+
+def test_pure_helpers() -> None:
+    """Status map, gateway-URL rewrite, and DeploymentConfig shape."""
+    # Status mapping (incl. default fallback).
+    assert map_status("READY") == "running"
+    assert map_status("PENDING") == "starting"
+    assert map_status("FAILED") == "failed"
+    assert map_status("DELETING") == "deleting"
+    assert map_status("SOMETHING_NEW") == "starting"
+
+    # Loopback rewrite for container reachability; explicit override wins; non-loopback passes through.
+    assert container_gateway_url("http://localhost:8080/") == "http://host.docker.internal:8080"
+    assert container_gateway_url("http://127.0.0.1:8080") == "http://host.docker.internal:8080"
+    assert container_gateway_url("http://localhost:8080", override="http://gw:9/") == "http://gw:9"
+    assert container_gateway_url("https://platform.example.com") == "https://platform.example.com"
+
+    # DeploymentConfig compiles to a single container with the expected image/port/env.
+    dc = build_deployment_config(
+        name="agent-foo",
+        workspace="ws",
+        image="img:1",
+        port=8000,
+        env={"NMP_WORKSPACE": "ws"},
+    )
+    assert dc.name == "agent-foo"
+    assert dc.restart_policy == "Always"
+    assert len(dc.containers) == 1
+    container = dc.containers[0]
+    assert container.image == "img:1"
+    assert container.ports[0].container_port == 8000
+    assert {e.name: e.value for e in container.env} == {"NMP_WORKSPACE": "ws"}
+
+
+async def test_create_deployment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """create_deployment writes a prefixed DeploymentConfig + Deployment, injects gateway env."""
+    monkeypatch.setattr(mod, "get_base_url", lambda: "http://localhost:8080")
+    backend = _backend(executor="local-docker")
+
+    info = await backend.create_deployment("ws", "foo", config={}, port=0, image="img:1")
+
+    assert info.status == "starting"
+    assert backend._entities.create.await_count == 2
+    created_config, created_deployment = (c.args[0] for c in backend._entities.create.await_args_list)
+    assert created_config.name == "agent-foo"  # prefixed to avoid user-deployment collisions
+    assert created_deployment.deployment_config == "agent-foo"
+    assert created_deployment.executor == "local-docker"
+    gateway_env = {e.name: e.value for e in created_config.containers[0].env}["NMP_GATEWAY_BASE_URL"]
+    assert gateway_env == "http://host.docker.internal:8080"
+
+    # No image and no default_image → fail fast without touching the entity store.
+    backend2 = _backend()
+    info2 = await backend2.create_deployment("ws", "foo", config={}, port=0, image=None)
+    assert info2.status == "failed"
+    backend2._entities.create.assert_not_awaited()
+
+
+async def test_status_delete_and_list() -> None:
+    """get_deployment_status maps status/endpoint; delete tears down; list filters by prefix."""
+    backend = _backend()
+
+    ready = Deployment(
+        name="agent-foo",
+        workspace="ws",
+        deployment_config="agent-foo",
+        status="READY",
+        endpoints=[Endpoint(name="http", url="http://127.0.0.1:9000")],
+    )
+    backend._entities.get.return_value = ready
+    info = await backend.get_deployment_status("ws", "foo")
+    assert info is not None
+    assert info.status == "running"
+    assert info.endpoint == "http://127.0.0.1:9000"
+
+    # Missing entity → None.
+    backend._entities.get.side_effect = NemoEntityNotFoundError("nope")
+    assert await backend.get_deployment_status("ws", "foo") is None
+
+    # Delete: mark Deployment DELETING (controller removes container + entity) and drop the config.
+    backend._entities.get.side_effect = None
+    backend._entities.get.return_value = ready
+    assert await backend.delete_deployment("ws", "foo") is True
+    updated = backend._entities.update.await_args.args[0]
+    assert updated.status == "DELETING"
+    assert backend._entities.delete.await_count == 1
+
+    # list_deployments returns only our prefixed entities, with the prefix stripped.
+    backend._entities.list.return_value = SimpleNamespace(
+        data=[
+            Deployment(name="agent-foo", workspace="ws", deployment_config="agent-foo", status="READY"),
+            Deployment(name="user-thing", workspace="ws", deployment_config="cfg", status="READY"),
+        ]
+    )
+    listed = await backend.list_deployments("ws")
+    assert [d.name for d in listed] == ["foo"]

--- a/uv.lock
+++ b/uv.lock
@@ -3807,10 +3807,14 @@ container = [
     { name = "jinja2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "python-on-whales", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
+deployments = [
+    { name = "nemo-deployments-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
 test = [
     { name = "fastapi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "jinja2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-deployments-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pytest-asyncio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
@@ -3827,6 +3831,8 @@ requires-dist = [
     { name = "jinja2", marker = "extra == 'test'", specifier = ">=3.1" },
     { name = "langchain-aws", specifier = "==1.1.0" },
     { name = "nemo-agents-example-calculator", editable = "plugins/nemo-agents/examples/calculator-agent" },
+    { name = "nemo-deployments-plugin", marker = "extra == 'deployments'", editable = "plugins/nemo-deployments" },
+    { name = "nemo-deployments-plugin", marker = "extra == 'test'", editable = "plugins/nemo-deployments" },
     { name = "nemo-platform", editable = "packages/nemo_platform" },
     { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
     { name = "nvidia-nat-config-optimizer", specifier = ">=1.8.0,<1.9" },
@@ -3838,7 +3844,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.7.1" },
 ]
-provides-extras = ["container", "test"]
+provides-extras = ["container", "deployments", "test"]
 
 [[package]]
 name = "nemo-anonymizer"

--- a/web/packages/sdk/generated/agents/schema/DeploymentLogsResponse.ts
+++ b/web/packages/sdk/generated/agents/schema/DeploymentLogsResponse.ts
@@ -6,7 +6,7 @@
  * Do not edit manually.
  * agents (plugin)
  */
-import type { LogLine } from './LogLine';
+import type { LogLine } from './LogLine.ts';
 
 /**
  * Response body for ``GET /deployments/{name}/logs``.

--- a/web/packages/sdk/generated/agents/schema/DeploymentLogsResponse.ts
+++ b/web/packages/sdk/generated/agents/schema/DeploymentLogsResponse.ts
@@ -6,7 +6,7 @@
  * Do not edit manually.
  * agents (plugin)
  */
-import type { LogLine } from './LogLine.ts';
+import type { LogLine } from './LogLine';
 
 /**
  * Response body for ``GET /deployments/{name}/logs``.


### PR DESCRIPTION
## Summary

Wires `nemo-agents` to the `nemo-deployments` plugin so agents can run as **containers** in addition to local `nat` subprocesses. A new `DeploymentsRunnerBackend` translates the existing `RunnerBackend` interface into `Deployment` / `DeploymentConfig` entity operations, which the deployments controller reconciles onto a configured executor.

Because `nemo-deployments` already targets both **Docker and Kubernetes**, substrate selection is config-only (`deployments.executor`) — no agents-side code change is needed to move from Docker to K8s later.

Assumes the agent image is self-contained (NAT config baked in); gateway routing is passed via env vars rather than config rewriting.

## Changes

- **New** `runner/deployments_backend.py` — `DeploymentsRunnerBackend`:
  - `create_deployment` writes a prefixed (`agent-<name>`) `DeploymentConfig` + `Deployment`; `get_deployment_status`, `delete_deployment`, `list_deployments`, `health_check` (`GET /health`), `get_log_location`, `shutdown`.
  - `delete_deployment` sets `DELETING`, then **waits (bounded 30s poll) for the deployments controller to remove the `Deployment` entity before deleting the `DeploymentConfig`** — so the controller's `_load_configs` never 404s on a config we deleted out from under it.
  - Pure helpers: `map_status`, `container_gateway_url` (rewrites loopback host → `host.docker.internal` so the container reaches the host Inference Gateway), `build_deployment_config`.
- `runner/registry.py` — lazy-import `"deployments"` branch.
- `config.py` — `DeploymentsRunnerConfig` (`executor`, `default_image`, `container_port`, `gateway_url_override`).
- `runner/backend.py` + `in_memory.py` — `image` and `env` params on `create_deployment` (in-memory ignores them).
- `runner/controller.py` — passes `dep.image` / `dep.env`; adopts the async-assigned endpoint on health check.
- `entities.py` / `schema.py` / `api/v2/deployments.py` — `image` + `env` fields end-to-end.
- `cli.py` — `nemo agents deploy --image/-i` and repeatable `--env/-e` (`KEY=VALUE` or bare `KEY` forwarded from the shell).
- `examples/Dockerfile` — patch nvidia-nat's NIM LangChain builder to exclude `verify_ssl` (see Issues encountered).
- `pyproject.toml` — optional `[deployments]` extra + workspace source.
- `README.md` — container-backend setup gotchas.

## Issues encountered

Documented in the plugin README ("Container (`deployments`) backend — gotchas"). Environment/setup issues unless noted as a bug:

| # | Symptom | Root cause | Resolution |
|---|---|---|---|

| 1 | `TypeError: kwargs_from_env() got an unexpected keyword argument 'base_url'` | **Bug** in nemo-deployments docker backend: `docker_host` config is passed as `base_url` to `from_env()` | Use `DOCKER_HOST` env var; `docker_host` executor config is unusable until fixed upstream (follow-up) |
| 2 | No way to pass the image / secrets via CLI | `deploy` command didn't expose image/env | Added `--image/-i` and `--env/-e` (this PR) |
| 3 | Invoke fails: `Validation: Unsupported parameter(s): verify_ssl` | **Bug** in nvidia-nat: under `nat serve`, the NIM LangChain builder does not exclude `verify_ssl` from `ChatNVIDIA` kwargs (the OpenAI builder does), so it leaks into the request body and NVIDIA endpoints reject it | `examples/Dockerfile` patches `nat/plugins/langchain/llm.py` to mirror the OpenAI exclude set; remove once fixed upstream |
| 4 | `Failed to load DeploymentConfig ...` 404 traceback spammed every cycle on delete | **Race**: `delete_deployment` deleted the `DeploymentConfig` while the deployments controller still held a `DELETING` `Deployment` referencing it | `delete_deployment` now waits for the `Deployment` entity to be gone before deleting the config (this PR) |

## Test plan

- [x] `uv run pytest plugins/nemo-agents/tests/unit/test_runner_deployments.py` — unit tests: status mapping, gateway URL rewrite, config shape, entity lifecycle (create/status/delete/list) via mocked client, `env` threaded through `create_deployment`, and delete gated on the `Deployment` disappearing before config deletion.
- [x] `uv run pytest plugins/nemo-agents/tests/unit/test_runner_in_memory.py` — regression from ABC signature (`image`/`env`) change. **20 tests pass.**
- [x] `uv run ruff check`, `ruff format --check`, `ty check` — clean on all changed files.
- [ ] Verify K8s executor path (incl. `imagePullSecrets` for private registries).

### End-to-end verification (real run, Docker executor via Colima)

Deployed a packaged agent image through the new `deployments` backend and drove it to `running`, passing `NVIDIA_API_KEY` from the shell via the new `--env` flag:

```console
$ nemo agents deploy \
    --agent hello-world-agent \
    --image hello_world-e24e65eb1983:26.04.17 \
    -e NVIDIA_API_KEY \
    --wait --timeout 300
Waiting for deployment 'hello-world-agent-645e87b9' (timeout=300s)...
  [   0s] status: pending
  [   2s] status: starting
  [  22s] status: running
Deployment 'hello-world-agent-645e87b9' is running at http://localhost:30000
```

Invoked the running container through the agents gateway and got a valid model response (the `verify_ssl` Dockerfile fix is what lets the NIM call through):

```console
$ curl -s -X POST \
    "$NMP_BASE_URL/apis/agents/v2/workspaces/default/deployments/hello-world-agent-c7cba8d3/-/generate" \
    -H 'Content-Type: application/json' \
    -d '{"input_message": "Who are you?"}'
{"value":"I am Nemotron Nano, a language model trained by research…"}
```

- [x] **Deploy → running** on a real Docker executor (pending → starting → running in ~22s; endpoint assigned asynchronously and adopted by the controller).
- [x] **Invoke → valid answer** end-to-end through the gateway with `{"input_message": "Who are you?"}`.
- [x] **`--env` secret injection** verified (`-e NVIDIA_API_KEY` forwarded from the shell into the container).
- [x] **Delete-race fix verified live:** on `nemo agents undeploy`, the `DeploymentConfig` is deleted only after the deployments controller removed the `Deployment` entity — no `Failed to load DeploymentConfig` warning in platform logs during teardown.

## Follow-ups (out of scope)

- **nemo-deployments `docker_host` bug** (issue #3 above): `_create_client` passes `base_url` to `from_env()`; branch to `DockerClient(base_url=...)` vs `from_env()`. Separate PR.
- **Upstream nvidia-nat `verify_ssl` fix** (issue #6): drop the Dockerfile patch once the NIM builder excludes `verify_ssl`.
- **Secrets hardening**: env vars are injected as plain values; neither deployments backend supports `secretKeyRef` yet.
- **Server-side logs**: `get_log_location` returns a hint only; no remote log fetch for containerized deployments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running agents with a container-based deployment backend.
  * `nemo agents deploy` now accepts a container image and environment variables.
  * Deployment settings can now include backend-specific image and environment configuration.

* **Bug Fixes**
  * Improved startup health checks so deployments can use the latest endpoint once it becomes available.
  * Container deployments now surface status and endpoint updates more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->