### PR TITLE
fix: alias redundant anonymizer run run, import logging fix

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/lazy_load.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/lazy_load.py
@@ -3,16 +3,20 @@
 
 from __future__ import annotations
 
+import logging
 from pkgutil import resolve_name
-from typing import Any, Callable, Sequence
+from typing import Annotated, Any, Callable, Sequence
 
 import click
 from click import Command
-from typer import Typer
+from typer import Argument, Context, Exit, Typer
 from typer.main import get_command as typer_get_command
 
 from nemo_platform_ext.cli.core.help_formatter import NmpGroup
 from nemo_platform_ext.cli.manifest import TopLevelEntry
+
+logger = logging.getLogger(__name__)
+_UNAVAILABLE_COMMAND_CONTEXT_SETTINGS = {"allow_extra_args": True, "ignore_unknown_options": True}
 
 
 def attach_lazy_entries(
@@ -41,7 +45,7 @@ class ManifestBackedNmpGroup(NmpGroup):
         for entry in lazy_entries:
             self._lazy_entries[entry.name] = entry
 
-    def list_commands(self, ctx: click.Context) -> list[str]:
+    def list_commands(self, _ctx: click.Context) -> list[str]:
         names = list(self.commands)
         for name in self._lazy_entries:
             if name not in self.commands:
@@ -74,6 +78,70 @@ def build_lazy_loader(entry: TopLevelEntry) -> Callable[[], click.Command]:
     if entry.kind == "group":
         return lazy_group_loader(entry.import_path)
     return lazy_command_loader(entry.import_path)
+
+
+def _plugin_entry_leaf_name(plugin_name: str, entry_point_name: str) -> str:
+    prefix = f"{plugin_name}."
+    if entry_point_name.startswith(prefix):
+        return entry_point_name.removeprefix(prefix)
+    return entry_point_name
+
+
+def _add_unavailable_plugin_primitive(
+    plugin_app: Typer,
+    *,
+    plugin_name: str,
+    entry_point_name: str,
+    entry_point_value: object,
+    primitive_kind: str,
+    verbs: Sequence[str],
+    rich_help_panel: str,
+    exc: Exception,
+) -> None:
+    command_name = _plugin_entry_leaf_name(plugin_name, entry_point_name)
+    message = f"Plugin {primitive_kind} command {command_name!r} is unavailable due to import error: {exc}"
+    logger.warning(
+        "Failed to load plugin %s %r from %r (%s); registering unavailable command",
+        primitive_kind,
+        entry_point_name,
+        "nemo.jobs" if primitive_kind == "job" else "nemo.functions",
+        entry_point_value,
+        exc_info=True,
+    )
+
+    unavailable_app = Typer(
+        name=command_name,
+        help=f"Plugin {primitive_kind} command {command_name!r} is unavailable due to import error.",
+        context_settings=_UNAVAILABLE_COMMAND_CONTEXT_SETTINGS,
+        no_args_is_help=False,
+    )
+
+    def _raise_unavailable() -> None:
+        click.echo(f"Error: {message}", err=True)
+        raise Exit(code=1)
+
+    @unavailable_app.callback(invoke_without_command=True)
+    def _root(
+        ctx: Context,
+        _args: Annotated[list[str] | None, Argument(hidden=True)] = None,
+    ) -> None:
+        if ctx.invoked_subcommand is None or _args:
+            _raise_unavailable()
+
+    def _unavailable_command(
+        _ctx: Context,
+        _args: Annotated[list[str] | None, Argument(hidden=True)] = None,
+    ) -> None:
+        _raise_unavailable()
+
+    for verb in verbs:
+        unavailable_app.command(
+            name=verb,
+            help="Unavailable due to import error.",
+            context_settings=_UNAVAILABLE_COMMAND_CONTEXT_SETTINGS,
+        )(_unavailable_command)
+
+    plugin_app.add_typer(unavailable_app, name=command_name, rich_help_panel=rich_help_panel)
 
 
 def lazy_plugin_loader(plugin_name: str, import_path: str) -> Callable[[], click.Command]:
@@ -109,7 +177,17 @@ def lazy_plugin_loader(plugin_name: str, import_path: str) -> Callable[[], click
                     continue
                 try:
                     plugin_jobs[job_name] = job_entry_point.load()
-                except Exception:
+                except Exception as exc:
+                    _add_unavailable_plugin_primitive(
+                        plugin_app,
+                        plugin_name=plugin_name,
+                        entry_point_name=job_name,
+                        entry_point_value=getattr(job_entry_point, "value", "<unknown>"),
+                        primitive_kind="job",
+                        verbs=("run", "submit", "explain"),
+                        rich_help_panel="Jobs",
+                        exc=exc,
+                    )
                     continue
             if plugin_jobs:
                 _add_plugin_job_commands(plugin_app, plugin_jobs, cli=cli_obj)
@@ -125,7 +203,17 @@ def lazy_plugin_loader(plugin_name: str, import_path: str) -> Callable[[], click
                     continue
                 try:
                     plugin_functions[fn_name] = fn_entry_point.load()
-                except Exception:
+                except Exception as exc:
+                    _add_unavailable_plugin_primitive(
+                        plugin_app,
+                        plugin_name=plugin_name,
+                        entry_point_name=fn_name,
+                        entry_point_value=getattr(fn_entry_point, "value", "<unknown>"),
+                        primitive_kind="function",
+                        verbs=("run", "submit"),
+                        rich_help_panel="Functions",
+                        exc=exc,
+                    )
                     continue
             if plugin_functions:
                 _add_plugin_function_commands(plugin_app, plugin_functions, cli=cli_obj)

--- a/packages/nemo_platform_ext/tests/cli/test_app.py
+++ b/packages/nemo_platform_ext/tests/cli/test_app.py
@@ -9,6 +9,7 @@ import click
 import nemo_platform
 import pytest
 import typer
+from click.testing import CliRunner as ClickCliRunner
 from nemo_platform_ext.cli.app import app
 from nemo_platform_ext.cli.commands.manifest_registry import TOP_LEVEL_ENTRIES
 from nemo_platform_ext.cli.core.lazy_load import (
@@ -468,7 +469,7 @@ def test_manifest_help_matches_loaded_manual_entry(entry):
     assert loaded.help == entry.help
 
 
-def test_plugin_loader_skips_broken_jobs():
+def test_plugin_loader_registers_unavailable_command_for_broken_jobs():
     plugin_app = typer.Typer(help="Plugin help")
 
     class _PluginCLI(NemoCLI):
@@ -481,6 +482,7 @@ def test_plugin_loader_skips_broken_jobs():
     good_job.load.return_value = object()
     bad_job = MagicMock()
     bad_job.load.side_effect = RuntimeError("boom")
+    bad_job.value = "fake.module:BadJob"
     entry_point = MagicMock()
     entry_point.load.return_value = _PluginCLI
 
@@ -497,6 +499,13 @@ def test_plugin_loader_skips_broken_jobs():
     assert isinstance(loaded, click.Command)
     mock_add_jobs.assert_called_once()
     assert mock_add_jobs.call_args[0][1] == {"example.good": good_job.load.return_value}
+    result = ClickCliRunner().invoke(loaded, ["bad"])
+    assert result.exit_code != 0
+    assert "Plugin job command 'bad' is unavailable due to import error: boom" in result.output
+    result = ClickCliRunner().invoke(loaded, ["bad", "run", "--spec", "{}"])
+    assert result.exit_code != 0
+    assert "Plugin job command 'bad' is unavailable due to import error: boom" in result.output
+    assert "No such option: --spec" not in result.output
 
 
 def test_plugin_loader_returns_placeholder_help_for_broken_cli():

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py
@@ -440,7 +440,7 @@ def _add_run_command(
         if renderer is not None and rctx is not None:
             renderer.on_complete(ctx=rctx)
 
-    help_text = f"Run {job_cls.name} locally, in-process."
+    help_text = "Run locally, in-process."
     _run.__signature__ = _build_job_run_signature(leaves)  # type: ignore[attr-defined]
     group.command(name="run", help=help_text)(_run)
 
@@ -617,7 +617,7 @@ def _add_submit_command(
         if renderer is not None and rctx is not None:
             renderer.on_complete(ctx=rctx)
 
-    help_text = f"Submit {job_cls.name} to a cluster."
+    help_text = "Submit to a cluster."
     _submit.__signature__ = _build_job_submit_signature(leaves)  # type: ignore[attr-defined]
     group.command(name="submit", help=help_text)(_submit)
 
@@ -771,7 +771,7 @@ def _add_explain_command(
         bundle = scheduler.explain(job_cls, profile=profile)
         typer.echo(json.dumps(bundle, indent=2))
 
-    _explain.__doc__ = f"Show the schemas for {job_cls.name}."
+    _explain.__doc__ = "Show input/output schemas."
     group.command(name="explain", help=_explain.__doc__)(_explain)
 
 

--- a/packages/nemo_platform_plugin/tests/test_commands.py
+++ b/packages/nemo_platform_plugin/tests/test_commands.py
@@ -74,6 +74,14 @@ class _FailJob(NemoJob):
         raise RuntimeError("job exploded")
 
 
+class _RunNamedJob(NemoJob):
+    name = "run"
+    description = "A job whose name collides with the local run verb."
+
+    def run(self, config: dict) -> dict:
+        return config
+
+
 runner = CliRunner()
 
 
@@ -143,6 +151,17 @@ class TestSubgroupRegistration:
         app = _app_with_jobs(_GreetJob)
         result = runner.invoke(app, ["greet", "--help"])
         assert "Return a greeting." in result.output
+
+    def test_job_verb_help_text_does_not_repeat_job_name(self) -> None:
+        app = _app_with_jobs(_RunNamedJob)
+        result = runner.invoke(app, ["run", "--help"])
+
+        assert result.exit_code == 0
+        assert "Run locally, in-process." in result.output
+        assert "Submit to a cluster." in result.output
+        assert "Show input/output schemas." in result.output
+        assert "Run run locally" not in result.output
+        assert "schemas for run" not in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/cli.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/cli.py
@@ -5,14 +5,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar, Optional, cast
 
 import typer
 import yaml
 from anonymizer.config.anonymizer_config import AnonymizerConfig
 from nemo_anonymizer_plugin.app.upstream_logging import preserve_root_logging
 from nemo_platform_plugin.cli import NemoCLI
+from nemo_platform_plugin.job import NemoJob
 
 
 class AnonymizerCLI(NemoCLI):
@@ -32,6 +34,27 @@ class AnonymizerCLI(NemoCLI):
 
         app.command("validate")(validate_command)
         return app
+
+    def update_job_cli(self, job_cls: type[NemoJob], group: typer.Typer) -> None:
+        if job_cls.name != "run":
+            return
+
+        run_command = next((command for command in group.registered_commands if command.name == "run"), None)
+        if run_command is None or run_command.callback is None:
+            return
+
+        run_callback = cast(Callable[..., None], run_command.callback)
+        signature = getattr(run_callback, "__signature__", None)
+        if signature is None:
+            return
+
+        def _collapsed_run(typer_ctx: typer.Context, **kwargs: object) -> None:
+            if typer_ctx.invoked_subcommand is not None:
+                return
+            run_callback(typer_ctx, **kwargs)
+
+        setattr(_collapsed_run, "__signature__", signature)
+        group.callback(invoke_without_command=True)(_collapsed_run)
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:

--- a/plugins/nemo-anonymizer/tests/unit/test_cli.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_cli.py
@@ -3,13 +3,24 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import yaml
 from nemo_anonymizer_plugin import cli as cli_module
 from nemo_anonymizer_plugin.cli import AnonymizerCLI
+from nemo_platform_plugin.commands import add_job_commands
+from nemo_platform_plugin.job import NemoJob
 from typer.testing import CliRunner
+
+
+class _RunJob(NemoJob):
+    name: ClassVar[str] = "run"
+    description: ClassVar[str] = "Run test job."
+
+    def run(self, config: dict) -> dict:
+        return {"config": config}
 
 
 def _write_config(path: Path) -> None:
@@ -32,6 +43,25 @@ def test_cli_only_registers_manual_validate_command() -> None:
     assert "validate" in result.output
     assert "preview-local" not in result.output
     assert "run-local" not in result.output
+
+
+def test_run_job_collapses_local_run_alias() -> None:
+    cli = AnonymizerCLI()
+    app = cli.get_cli()
+    add_job_commands(app, {"anonymizer.run": _RunJob}, cli=cli)
+    runner = CliRunner()
+
+    alias_result = runner.invoke(app, ["run", "--config", '{"name": "Alias"}'])
+    nested_result = runner.invoke(app, ["run", "run", "--config", '{"name": "Nested"}'])
+    help_result = runner.invoke(app, ["run", "--help"])
+
+    assert alias_result.exit_code == 0, alias_result.output
+    assert json.loads(alias_result.output) == {"config": {"name": "Alias"}}
+    assert nested_result.exit_code == 0, nested_result.output
+    assert json.loads(nested_result.output) == {"config": {"name": "Nested"}}
+    assert help_result.exit_code == 0, help_result.output
+    assert "Run locally, in-process." in help_result.output
+    assert "Run run locally" not in help_result.output
 
 
 def test_validate_command_runs_library_validation(tmp_path: Path, monkeypatch) -> None:

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/lazy_load.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/lazy_load.py
@@ -3,16 +3,20 @@
 
 from __future__ import annotations
 
+import logging
 from pkgutil import resolve_name
-from typing import Any, Callable, Sequence
+from typing import Annotated, Any, Callable, Sequence
 
 import click
 from click import Command
-from typer import Typer
+from typer import Argument, Context, Exit, Typer
 from typer.main import get_command as typer_get_command
 
 from nemo_platform.cli.core.help_formatter import NmpGroup
 from nemo_platform.cli.manifest import TopLevelEntry
+
+logger = logging.getLogger(__name__)
+_UNAVAILABLE_COMMAND_CONTEXT_SETTINGS = {"allow_extra_args": True, "ignore_unknown_options": True}
 
 
 def attach_lazy_entries(
@@ -41,7 +45,7 @@ class ManifestBackedNmpGroup(NmpGroup):
         for entry in lazy_entries:
             self._lazy_entries[entry.name] = entry
 
-    def list_commands(self, ctx: click.Context) -> list[str]:
+    def list_commands(self, _ctx: click.Context) -> list[str]:
         names = list(self.commands)
         for name in self._lazy_entries:
             if name not in self.commands:
@@ -74,6 +78,70 @@ def build_lazy_loader(entry: TopLevelEntry) -> Callable[[], click.Command]:
     if entry.kind == "group":
         return lazy_group_loader(entry.import_path)
     return lazy_command_loader(entry.import_path)
+
+
+def _plugin_entry_leaf_name(plugin_name: str, entry_point_name: str) -> str:
+    prefix = f"{plugin_name}."
+    if entry_point_name.startswith(prefix):
+        return entry_point_name.removeprefix(prefix)
+    return entry_point_name
+
+
+def _add_unavailable_plugin_primitive(
+    plugin_app: Typer,
+    *,
+    plugin_name: str,
+    entry_point_name: str,
+    entry_point_value: object,
+    primitive_kind: str,
+    verbs: Sequence[str],
+    rich_help_panel: str,
+    exc: Exception,
+) -> None:
+    command_name = _plugin_entry_leaf_name(plugin_name, entry_point_name)
+    message = f"Plugin {primitive_kind} command {command_name!r} is unavailable due to import error: {exc}"
+    logger.warning(
+        "Failed to load plugin %s %r from %r (%s); registering unavailable command",
+        primitive_kind,
+        entry_point_name,
+        "nemo.jobs" if primitive_kind == "job" else "nemo.functions",
+        entry_point_value,
+        exc_info=True,
+    )
+
+    unavailable_app = Typer(
+        name=command_name,
+        help=f"Plugin {primitive_kind} command {command_name!r} is unavailable due to import error.",
+        context_settings=_UNAVAILABLE_COMMAND_CONTEXT_SETTINGS,
+        no_args_is_help=False,
+    )
+
+    def _raise_unavailable() -> None:
+        click.echo(f"Error: {message}", err=True)
+        raise Exit(code=1)
+
+    @unavailable_app.callback(invoke_without_command=True)
+    def _root(
+        ctx: Context,
+        _args: Annotated[list[str] | None, Argument(hidden=True)] = None,
+    ) -> None:
+        if ctx.invoked_subcommand is None or _args:
+            _raise_unavailable()
+
+    def _unavailable_command(
+        _ctx: Context,
+        _args: Annotated[list[str] | None, Argument(hidden=True)] = None,
+    ) -> None:
+        _raise_unavailable()
+
+    for verb in verbs:
+        unavailable_app.command(
+            name=verb,
+            help="Unavailable due to import error.",
+            context_settings=_UNAVAILABLE_COMMAND_CONTEXT_SETTINGS,
+        )(_unavailable_command)
+
+    plugin_app.add_typer(unavailable_app, name=command_name, rich_help_panel=rich_help_panel)
 
 
 def lazy_plugin_loader(plugin_name: str, import_path: str) -> Callable[[], click.Command]:
@@ -109,7 +177,17 @@ def lazy_plugin_loader(plugin_name: str, import_path: str) -> Callable[[], click
                     continue
                 try:
                     plugin_jobs[job_name] = job_entry_point.load()
-                except Exception:
+                except Exception as exc:
+                    _add_unavailable_plugin_primitive(
+                        plugin_app,
+                        plugin_name=plugin_name,
+                        entry_point_name=job_name,
+                        entry_point_value=getattr(job_entry_point, "value", "<unknown>"),
+                        primitive_kind="job",
+                        verbs=("run", "submit", "explain"),
+                        rich_help_panel="Jobs",
+                        exc=exc,
+                    )
                     continue
             if plugin_jobs:
                 _add_plugin_job_commands(plugin_app, plugin_jobs, cli=cli_obj)
@@ -125,7 +203,17 @@ def lazy_plugin_loader(plugin_name: str, import_path: str) -> Callable[[], click
                     continue
                 try:
                     plugin_functions[fn_name] = fn_entry_point.load()
-                except Exception:
+                except Exception as exc:
+                    _add_unavailable_plugin_primitive(
+                        plugin_app,
+                        plugin_name=plugin_name,
+                        entry_point_name=fn_name,
+                        entry_point_value=getattr(fn_entry_point, "value", "<unknown>"),
+                        primitive_kind="function",
+                        verbs=("run", "submit"),
+                        rich_help_panel="Functions",
+                        exc=exc,
+                    )
                     continue
             if plugin_functions:
                 _add_plugin_function_commands(plugin_app, plugin_functions, cli=cli_obj)

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/test_app.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/test_app.py
@@ -9,6 +9,7 @@ import click
 import nemo_platform
 import pytest
 import typer
+from click.testing import CliRunner as ClickCliRunner
 from nemo_platform.cli.app import app
 from nemo_platform.cli.commands.manifest_registry import TOP_LEVEL_ENTRIES
 from nemo_platform.cli.core.lazy_load import (
@@ -468,7 +469,7 @@ def test_manifest_help_matches_loaded_manual_entry(entry):
     assert loaded.help == entry.help
 
 
-def test_plugin_loader_skips_broken_jobs():
+def test_plugin_loader_registers_unavailable_command_for_broken_jobs():
     plugin_app = typer.Typer(help="Plugin help")
 
     class _PluginCLI(NemoCLI):
@@ -481,6 +482,7 @@ def test_plugin_loader_skips_broken_jobs():
     good_job.load.return_value = object()
     bad_job = MagicMock()
     bad_job.load.side_effect = RuntimeError("boom")
+    bad_job.value = "fake.module:BadJob"
     entry_point = MagicMock()
     entry_point.load.return_value = _PluginCLI
 
@@ -497,6 +499,13 @@ def test_plugin_loader_skips_broken_jobs():
     assert isinstance(loaded, click.Command)
     mock_add_jobs.assert_called_once()
     assert mock_add_jobs.call_args[0][1] == {"example.good": good_job.load.return_value}
+    result = ClickCliRunner().invoke(loaded, ["bad"])
+    assert result.exit_code != 0
+    assert "Plugin job command 'bad' is unavailable due to import error: boom" in result.output
+    result = ClickCliRunner().invoke(loaded, ["bad", "run", "--spec", "{}"])
+    assert result.exit_code != 0
+    assert "Plugin job command 'bad' is unavailable due to import error: boom" in result.output
+    assert "No such option: --spec" not in result.output
 
 
 def test_plugin_loader_returns_placeholder_help_for_broken_cli():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin commands that fail to load now appear as unavailable in the CLI, with a clear error message when invoked.
  * Job help text is now more consistent and generic across local run, submit, and schema-explanation commands.

* **Bug Fixes**
  * Improved handling for plugin import failures so one broken plugin no longer hides its command entirely.
  * Fixed help and command behavior for jobs named `run`, including support for both `run` and `run run` usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->