### PR TITLE
chore(intake): give instructions if clickhouse is disabled

### DIFF
--- a/services/intake/src/nmp/intake/service.py
+++ b/services/intake/src/nmp/intake/service.py
@@ -72,7 +72,9 @@ class IntakeService(Service[IntakeConfig]):
         self.clickhouse_client = ClickHouseSpanClient(ClickHouseSettings.from_config(cfg))
         logger.warning(
             "ClickHouse schema setup was not run during Intake startup; "
-            "trace endpoints will initialize ClickHouse on first use and return 503 until it is reachable",
+            "trace endpoints will initialize ClickHouse on first use and return 503 until it is reachable. "
+            "For local development, start ClickHouse with services/intake/scripts/spans/run_clickhouse.sh; "
+            "see services/intake/README.md#local-development.",
             extra={
                 "service": self.name,
                 "clickhouse_url": cfg.clickhouse_config.url,

--- a/services/intake/tests/test_clickhouse_startup.py
+++ b/services/intake/tests/test_clickhouse_startup.py
@@ -37,4 +37,9 @@ def test_intake_ready_when_clickhouse_is_unavailable(
     assert any(
         "ClickHouse schema setup was not run during Intake startup" in record.message for record in caplog.records
     )
+    assert any(
+        "services/intake/scripts/spans/run_clickhouse.sh" in record.message
+        and "services/intake/README.md#local-development" in record.message
+        for record in caplog.records
+    )
     assert not any("ClickHouse readiness check failed" in record.message for record in caplog.records)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the startup warning to better explain what happens when ClickHouse is not available, including that trace endpoints may return HTTP 503 until it comes online.
  * Added clearer guidance for local development, pointing users to the ClickHouse startup script and related setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->