### PR TITLE
fix: Fix intake CLI generation bugs

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from pathlib import Path
 from typing import Annotated
 
@@ -16,8 +16,8 @@ from nemo_platform_ext.cli.core.formatters import Column, check_output_columns_w
 from nemo_platform_ext.cli.core.help_formatter import collect_warnings, create_typer_app
 from nemo_platform_ext.cli.core.types import ListOutputFormatOption, NoTruncateOption, OutputColumnsOption
 
-_cli_child_filesets = _cli_import_module("nemo_platform_ext.cli.commands.api.files.filesets")
-_cli_child_otlp = _cli_import_module("nemo_platform_ext.cli.commands.api.files.otlp")
+_cli_child_filesets = _importlib_import_module("nemo_platform_ext.cli.commands.api.files.filesets")
+_cli_child_otlp = _importlib_import_module("nemo_platform_ext.cli.commands.api.files.otlp")
 
 app = create_typer_app(name="files", help="Manage files")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/__init__.py
@@ -4,22 +4,25 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
-from nemo_platform_ext.cli.commands.api.files import filesets, otlp
 from nemo_platform_ext.cli.core.context import CLIContext
 from nemo_platform_ext.cli.core.errors import handle_errors
 from nemo_platform_ext.cli.core.formatters import Column, check_output_columns_with_format, format_output
 from nemo_platform_ext.cli.core.help_formatter import collect_warnings, create_typer_app
 from nemo_platform_ext.cli.core.types import ListOutputFormatOption, NoTruncateOption, OutputColumnsOption
 
+_cli_child_filesets = _cli_import_module("nemo_platform_ext.cli.commands.api.files.filesets")
+_cli_child_otlp = _cli_import_module("nemo_platform_ext.cli.commands.api.files.otlp")
+
 app = create_typer_app(name="files", help="Manage files")
 
-app.add_typer(filesets.app, name="filesets")
-app.add_typer(otlp.app, name="otlp")
+app.add_typer(_cli_child_filesets.app, name="filesets")
+app.add_typer(_cli_child_otlp.app, name="otlp")
 
 
 @app.command("upload")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/otlp/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/otlp/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
 
-_cli_child_logs = _cli_import_module("nemo_platform_ext.cli.commands.api.files.otlp.logs")
+_cli_child_logs = _importlib_import_module("nemo_platform_ext.cli.commands.api.files.otlp.logs")
 
 app = create_typer_app(name="otlp", help="Otlp operations")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/otlp/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/otlp/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform_ext.cli.commands.api.files.otlp import logs
+from importlib import import_module as _cli_import_module
+
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
+
+_cli_child_logs = _cli_import_module("nemo_platform_ext.cli.commands.api.files.otlp.logs")
 
 app = create_typer_app(name="otlp", help="Otlp operations")
 
-app.add_typer(logs.app, name="logs")
+app.add_typer(_cli_child_logs.app, name="logs")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/guardrail/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/guardrail/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated
 
 import typer
 
-from nemo_platform_ext.cli.commands.api.guardrail import configs
 from nemo_platform_ext.cli.core.code_generator import handle_code_generation
 from nemo_platform_ext.cli.core.context import CLIContext
 from nemo_platform_ext.cli.core.errors import handle_errors
@@ -17,9 +17,11 @@ from nemo_platform_ext.cli.core.help_formatter import collect_warnings, create_t
 from nemo_platform_ext.cli.core.stdin_utils import read_data_input_with_flags, read_payload, validate_required_fields
 from nemo_platform_ext.cli.core.types import EntityOutputFormatOption
 
+_cli_child_configs = _cli_import_module("nemo_platform_ext.cli.commands.api.guardrail.configs")
+
 app = create_typer_app(name="guardrail", help="Manage guardrail")
 
-app.add_typer(configs.app, name="configs")
+app.add_typer(_cli_child_configs.app, name="configs")
 
 
 @app.command("check")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/guardrail/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/guardrail/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated
 
 import typer
@@ -17,7 +17,7 @@ from nemo_platform_ext.cli.core.help_formatter import collect_warnings, create_t
 from nemo_platform_ext.cli.core.stdin_utils import read_data_input_with_flags, read_payload, validate_required_fields
 from nemo_platform_ext.cli.core.types import EntityOutputFormatOption
 
-_cli_child_configs = _cli_import_module("nemo_platform_ext.cli.commands.api.guardrail.configs")
+_cli_child_configs = _importlib_import_module("nemo_platform_ext.cli.commands.api.guardrail.configs")
 
 app = create_typer_app(name="guardrail", help="Manage guardrail")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/iam/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/iam/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform_ext.cli.commands.api.iam import role_bindings
+from importlib import import_module as _cli_import_module
+
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
+
+_cli_child_role_bindings = _cli_import_module("nemo_platform_ext.cli.commands.api.iam.role_bindings")
 
 app = create_typer_app(name="iam", help="Iam operations")
 
-app.add_typer(role_bindings.app, name="role-bindings")
+app.add_typer(_cli_child_role_bindings.app, name="role-bindings")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/iam/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/iam/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
 
-_cli_child_role_bindings = _cli_import_module("nemo_platform_ext.cli.commands.api.iam.role_bindings")
+_cli_child_role_bindings = _importlib_import_module("nemo_platform_ext.cli.commands.api.iam.role_bindings")
 
 app = create_typer_app(name="iam", help="Iam operations")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/__init__.py
@@ -4,32 +4,32 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated
 
 import typer
 
-from nemo_platform_ext.cli.commands.api.inference import (
-    deployment_configs,
-    deployments,
-    gateway,
-    models,
-    prompts,
-    providers,
-    virtual_models,
-)
 from nemo_platform_ext.cli.core.context import CLIContext
 from nemo_platform_ext.cli.core.errors import handle_errors
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
 
+_cli_child_deployment_configs = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.deployment_configs")
+_cli_child_deployments = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.deployments")
+_cli_child_gateway = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway")
+_cli_child_models = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.models")
+_cli_child_prompts = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.prompts")
+_cli_child_providers = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.providers")
+_cli_child_virtual_models = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.virtual_models")
+
 app = create_typer_app(name="inference", help="Manage inference")
 
-app.add_typer(deployment_configs.app, name="deployment-configs")
-app.add_typer(deployments.app, name="deployments")
-app.add_typer(gateway.app, name="gateway")
-app.add_typer(models.app, name="models")
-app.add_typer(prompts.app, name="prompts")
-app.add_typer(providers.app, name="providers")
-app.add_typer(virtual_models.app, name="virtual-models")
+app.add_typer(_cli_child_deployment_configs.app, name="deployment-configs")
+app.add_typer(_cli_child_deployments.app, name="deployments")
+app.add_typer(_cli_child_gateway.app, name="gateway")
+app.add_typer(_cli_child_models.app, name="models")
+app.add_typer(_cli_child_prompts.app, name="prompts")
+app.add_typer(_cli_child_providers.app, name="providers")
+app.add_typer(_cli_child_virtual_models.app, name="virtual-models")
 
 
 @app.command("get-url")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated
 
 import typer
@@ -13,13 +13,15 @@ from nemo_platform_ext.cli.core.context import CLIContext
 from nemo_platform_ext.cli.core.errors import handle_errors
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
 
-_cli_child_deployment_configs = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.deployment_configs")
-_cli_child_deployments = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.deployments")
-_cli_child_gateway = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway")
-_cli_child_models = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.models")
-_cli_child_prompts = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.prompts")
-_cli_child_providers = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.providers")
-_cli_child_virtual_models = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.virtual_models")
+_cli_child_deployment_configs = _importlib_import_module(
+    "nemo_platform_ext.cli.commands.api.inference.deployment_configs"
+)
+_cli_child_deployments = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.deployments")
+_cli_child_gateway = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.gateway")
+_cli_child_models = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.models")
+_cli_child_prompts = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.prompts")
+_cli_child_providers = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.providers")
+_cli_child_virtual_models = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.virtual_models")
 
 app = create_typer_app(name="inference", help="Manage inference")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/deployment_configs/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/deployment_configs/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -24,7 +24,9 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_versions = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.deployment_configs.versions")
+_cli_child_versions = _importlib_import_module(
+    "nemo_platform_ext.cli.commands.api.inference.deployment_configs.versions"
+)
 
 app = create_typer_app(name="deployment_configs", help="Manage deployment_configs")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/deployment_configs/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/deployment_configs/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform_ext.cli.commands.api.inference.deployment_configs import versions
 from nemo_platform_ext.cli.core.api import build_kwargs, merge_filter_dict
 from nemo_platform_ext.cli.core.code_generator import handle_code_generation
 from nemo_platform_ext.cli.core.context import CLIContext
@@ -24,9 +24,11 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_versions = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.deployment_configs.versions")
+
 app = create_typer_app(name="deployment_configs", help="Manage deployment_configs")
 
-app.add_typer(versions.app, name="versions")
+app.add_typer(_cli_child_versions.app, name="versions")
 
 
 @app.command("create")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/deployments/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/deployments/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -26,7 +26,7 @@ from nemo_platform_ext.cli.core.types import (
 )
 from nemo_platform_ext.cli.core.waiters import wait_for_inference_deployment
 
-_cli_child_versions = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.deployments.versions")
+_cli_child_versions = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.deployments.versions")
 
 app = create_typer_app(name="deployments", help="Manage deployments")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/deployments/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/deployments/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform_ext.cli.commands.api.inference.deployments import versions
 from nemo_platform_ext.cli.core.api import build_kwargs, merge_filter_dict
 from nemo_platform_ext.cli.core.code_generator import handle_code_generation
 from nemo_platform_ext.cli.core.context import CLIContext
@@ -26,9 +26,11 @@ from nemo_platform_ext.cli.core.types import (
 )
 from nemo_platform_ext.cli.core.waiters import wait_for_inference_deployment
 
+_cli_child_versions = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.deployments.versions")
+
 app = create_typer_app(name="deployments", help="Manage deployments")
 
-app.add_typer(versions.app, name="versions")
+app.add_typer(_cli_child_versions.app, name="versions")
 
 
 @app.command("create")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/__init__.py
@@ -4,11 +4,16 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform_ext.cli.commands.api.inference.gateway import model, openai, provider
+from importlib import import_module as _cli_import_module
+
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
+
+_cli_child_model = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.model")
+_cli_child_openai = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.openai")
+_cli_child_provider = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.provider")
 
 app = create_typer_app(name="gateway", help="Gateway operations")
 
-app.add_typer(model.app, name="model")
-app.add_typer(openai.app, name="openai")
-app.add_typer(provider.app, name="provider")
+app.add_typer(_cli_child_model.app, name="model")
+app.add_typer(_cli_child_openai.app, name="openai")
+app.add_typer(_cli_child_provider.app, name="provider")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/__init__.py
@@ -4,13 +4,13 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
 
-_cli_child_model = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.model")
-_cli_child_openai = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.openai")
-_cli_child_provider = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.provider")
+_cli_child_model = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.model")
+_cli_child_openai = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.openai")
+_cli_child_provider = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.provider")
 
 app = create_typer_app(name="gateway", help="Gateway operations")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
 
-_cli_child_v1 = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.openai.v1")
+_cli_child_v1 = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.openai.v1")
 
 app = create_typer_app(name="openai", help="Openai operations")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform_ext.cli.commands.api.inference.gateway.openai import v1
+from importlib import import_module as _cli_import_module
+
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
+
+_cli_child_v1 = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.openai.v1")
 
 app = create_typer_app(name="openai", help="Openai operations")
 
-app.add_typer(v1.app, name="v1")
+app.add_typer(_cli_child_v1.app, name="v1")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/v1/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/v1/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
 
-_cli_child_models = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.openai.v1.models")
+_cli_child_models = _importlib_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.openai.v1.models")
 
 app = create_typer_app(name="v1", help="V1 operations")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/v1/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/v1/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform_ext.cli.commands.api.inference.gateway.openai.v1 import models
+from importlib import import_module as _cli_import_module
+
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
+
+_cli_child_models = _cli_import_module("nemo_platform_ext.cli.commands.api.inference.gateway.openai.v1.models")
 
 app = create_typer_app(name="v1", help="V1 operations")
 
-app.add_typer(models.app, name="models")
+app.add_typer(_cli_child_models.app, name="models")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/__init__.py
@@ -4,13 +4,20 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform_ext.cli.commands.api.intake import annotations, evaluator_results, ingest, spans, traces
+from importlib import import_module as _cli_import_module
+
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
+
+_cli_child_annotations = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.annotations")
+_cli_child_evaluator_results = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.evaluator_results")
+_cli_child_ingest = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest")
+_cli_child_spans = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.spans")
+_cli_child_traces = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.traces")
 
 app = create_typer_app(name="intake", help="Intake operations")
 
-app.add_typer(annotations.app, name="annotations")
-app.add_typer(evaluator_results.app, name="evaluator-results")
-app.add_typer(ingest.app, name="ingest")
-app.add_typer(spans.app, name="spans")
-app.add_typer(traces.app, name="traces")
+app.add_typer(_cli_child_annotations.app, name="annotations")
+app.add_typer(_cli_child_evaluator_results.app, name="evaluator-results")
+app.add_typer(_cli_child_ingest.app, name="ingest")
+app.add_typer(_cli_child_spans.app, name="spans")
+app.add_typer(_cli_child_traces.app, name="traces")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/__init__.py
@@ -4,15 +4,15 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
 
-_cli_child_annotations = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.annotations")
-_cli_child_evaluator_results = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.evaluator_results")
-_cli_child_ingest = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest")
-_cli_child_spans = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.spans")
-_cli_child_traces = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.traces")
+_cli_child_annotations = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.annotations")
+_cli_child_evaluator_results = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.evaluator_results")
+_cli_child_ingest = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.ingest")
+_cli_child_spans = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.spans")
+_cli_child_traces = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.traces")
 
 app = create_typer_app(name="intake", help="Intake operations")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/annotations.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/annotations.py
@@ -37,7 +37,7 @@ def create_annotations(
         Literal["feedback", "note", "metadata", "label"] | None, typer.Option("--kind", help="(required)")
     ] = None,
     session_id: Annotated[str | None, typer.Option("--session-id", help="(required)")] = None,
-    value: Annotated[Literal["positive", "negative"] | str | float | None, typer.Option("--value")] = None,
+    value: Annotated[str | None, typer.Option("--value")] = None,
     span_id: Annotated[str | None, typer.Option("--span-id")] = None,
     text: Annotated[str | None, typer.Option("--text")] = None,
     metadata: Annotated[str | None, typer.Option("--metadata", help="JSON string")] = None,

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/__init__.py
@@ -4,13 +4,15 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
 
-_cli_child_atif = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.atif")
-_cli_child_chat_completions = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.chat_completions")
-_cli_child_otlp = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.otlp")
+_cli_child_atif = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.atif")
+_cli_child_chat_completions = _importlib_import_module(
+    "nemo_platform_ext.cli.commands.api.intake.ingest.chat_completions"
+)
+_cli_child_otlp = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.otlp")
 
 app = create_typer_app(name="ingest", help="Ingest operations")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/__init__.py
@@ -4,11 +4,16 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform_ext.cli.commands.api.intake.ingest import atif, chat_completions, otlp
+from importlib import import_module as _cli_import_module
+
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
+
+_cli_child_atif = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.atif")
+_cli_child_chat_completions = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.chat_completions")
+_cli_child_otlp = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.otlp")
 
 app = create_typer_app(name="ingest", help="Ingest operations")
 
-app.add_typer(atif.app, name="atif")
-app.add_typer(chat_completions.app, name="chat-completions")
-app.add_typer(otlp.app, name="otlp")
+app.add_typer(_cli_child_atif.app, name="atif")
+app.add_typer(_cli_child_chat_completions.app, name="chat-completions")
+app.add_typer(_cli_child_otlp.app, name="otlp")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/otlp/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/otlp/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
 
-_cli_child_v1 = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.otlp.v1")
+_cli_child_v1 = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.otlp.v1")
 
 app = create_typer_app(name="otlp", help="Otlp operations")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/otlp/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/otlp/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform_ext.cli.commands.api.intake.ingest.otlp import v1
+from importlib import import_module as _cli_import_module
+
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
+
+_cli_child_v1 = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.otlp.v1")
 
 app = create_typer_app(name="otlp", help="Otlp operations")
 
-app.add_typer(v1.app, name="v1")
+app.add_typer(_cli_child_v1.app, name="v1")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/otlp/v1/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/otlp/v1/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform_ext.cli.commands.api.intake.ingest.otlp.v1 import traces
+from importlib import import_module as _cli_import_module
+
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
+
+_cli_child_traces = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.otlp.v1.traces")
 
 app = create_typer_app(name="v1", help="V1 operations")
 
-app.add_typer(traces.app, name="traces")
+app.add_typer(_cli_child_traces.app, name="traces")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/otlp/v1/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/ingest/otlp/v1/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform_ext.cli.core.help_formatter import create_typer_app
 
-_cli_child_traces = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.otlp.v1.traces")
+_cli_child_traces = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.ingest.otlp.v1.traces")
 
 app = create_typer_app(name="v1", help="V1 operations")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -23,8 +23,10 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_evaluator_results = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.spans.evaluator_results")
-_cli_child_groups = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.spans.groups")
+_cli_child_evaluator_results = _importlib_import_module(
+    "nemo_platform_ext.cli.commands.api.intake.spans.evaluator_results"
+)
+_cli_child_groups = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.spans.groups")
 
 app = create_typer_app(name="spans", help="Manage spans")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform_ext.cli.commands.api.intake.spans import evaluator_results, groups
 from nemo_platform_ext.cli.core.api import build_kwargs, merge_filter_dict
 from nemo_platform_ext.cli.core.code_generator import handle_code_generation
 from nemo_platform_ext.cli.core.context import CLIContext
@@ -23,10 +23,13 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_evaluator_results = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.spans.evaluator_results")
+_cli_child_groups = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.spans.groups")
+
 app = create_typer_app(name="spans", help="Manage spans")
 
-app.add_typer(evaluator_results.app, name="evaluator-results")
-app.add_typer(groups.app, name="groups")
+app.add_typer(_cli_child_evaluator_results.app, name="evaluator-results")
+app.add_typer(_cli_child_groups.app, name="groups")
 
 
 @app.command("list")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/jobs/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/jobs/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -24,9 +24,9 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_results = _cli_import_module("nemo_platform_ext.cli.commands.api.jobs.results")
-_cli_child_steps = _cli_import_module("nemo_platform_ext.cli.commands.api.jobs.steps")
-_cli_child_tasks = _cli_import_module("nemo_platform_ext.cli.commands.api.jobs.tasks")
+_cli_child_results = _importlib_import_module("nemo_platform_ext.cli.commands.api.jobs.results")
+_cli_child_steps = _importlib_import_module("nemo_platform_ext.cli.commands.api.jobs.steps")
+_cli_child_tasks = _importlib_import_module("nemo_platform_ext.cli.commands.api.jobs.tasks")
 
 app = create_typer_app(name="jobs", help="Manage jobs")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/jobs/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/jobs/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform_ext.cli.commands.api.jobs import results, steps, tasks
 from nemo_platform_ext.cli.core.api import build_kwargs, merge_filter_dict
 from nemo_platform_ext.cli.core.code_generator import handle_code_generation
 from nemo_platform_ext.cli.core.context import CLIContext
@@ -24,11 +24,15 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_results = _cli_import_module("nemo_platform_ext.cli.commands.api.jobs.results")
+_cli_child_steps = _cli_import_module("nemo_platform_ext.cli.commands.api.jobs.steps")
+_cli_child_tasks = _cli_import_module("nemo_platform_ext.cli.commands.api.jobs.tasks")
+
 app = create_typer_app(name="jobs", help="Manage jobs")
 
-app.add_typer(results.app, name="results")
-app.add_typer(steps.app, name="steps")
-app.add_typer(tasks.app, name="tasks")
+app.add_typer(_cli_child_results.app, name="results")
+app.add_typer(_cli_child_steps.app, name="steps")
+app.add_typer(_cli_child_tasks.app, name="tasks")
 
 
 @app.command("cancel")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/models/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/models/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -24,7 +24,7 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_adapters = _cli_import_module("nemo_platform_ext.cli.commands.api.models.adapters")
+_cli_child_adapters = _importlib_import_module("nemo_platform_ext.cli.commands.api.models.adapters")
 
 app = create_typer_app(name="models", help="Manage models")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/models/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/models/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform_ext.cli.commands.api.models import adapters
 from nemo_platform_ext.cli.core.api import build_kwargs, merge_filter_dict
 from nemo_platform_ext.cli.core.code_generator import handle_code_generation
 from nemo_platform_ext.cli.core.context import CLIContext
@@ -24,9 +24,11 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_adapters = _cli_import_module("nemo_platform_ext.cli.commands.api.models.adapters")
+
 app = create_typer_app(name="models", help="Manage models")
 
-app.add_typer(adapters.app, name="adapters")
+app.add_typer(_cli_child_adapters.app, name="adapters")
 
 
 @app.command("create")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/secrets/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/secrets/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated
 
 import typer
 
-from nemo_platform_ext.cli.commands.api.secrets import admin
 from nemo_platform_ext.cli.core.api import build_kwargs
 from nemo_platform_ext.cli.core.api import merge_filter_dict as merge_filter_dict
 from nemo_platform_ext.cli.core.code_generator import handle_code_generation
@@ -28,9 +28,11 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_admin = _cli_import_module("nemo_platform_ext.cli.commands.api.secrets.admin")
+
 app = create_typer_app(name="secrets", help="Manage secrets")
 
-app.add_typer(admin.app, name="admin")
+app.add_typer(_cli_child_admin.app, name="admin")
 
 
 @app.command("access")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/secrets/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/secrets/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated
 
 import typer
@@ -28,7 +28,7 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_admin = _cli_import_module("nemo_platform_ext.cli.commands.api.secrets.admin")
+_cli_child_admin = _importlib_import_module("nemo_platform_ext.cli.commands.api.secrets.admin")
 
 app = create_typer_app(name="secrets", help="Manage secrets")
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/workspaces/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/workspaces/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform_ext.cli.commands.api.workspaces import members
 from nemo_platform_ext.cli.core.api import build_kwargs
 from nemo_platform_ext.cli.core.api import merge_filter_dict as merge_filter_dict
 from nemo_platform_ext.cli.core.code_generator import handle_code_generation
@@ -26,9 +26,11 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_members = _cli_import_module("nemo_platform_ext.cli.commands.api.workspaces.members")
+
 app = create_typer_app(name="workspaces", help="Manage workspaces")
 
-app.add_typer(members.app, name="members")
+app.add_typer(_cli_child_members.app, name="members")
 
 
 @app.command("create")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/workspaces/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/workspaces/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -26,7 +26,7 @@ from nemo_platform_ext.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_members = _cli_import_module("nemo_platform_ext.cli.commands.api.workspaces.members")
+_cli_child_members = _importlib_import_module("nemo_platform_ext.cli.commands.api.workspaces.members")
 
 app = create_typer_app(name="workspaces", help="Manage workspaces")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from pathlib import Path
 from typing import Annotated
 
@@ -16,8 +16,8 @@ from nemo_platform.cli.core.formatters import Column, check_output_columns_with_
 from nemo_platform.cli.core.help_formatter import collect_warnings, create_typer_app
 from nemo_platform.cli.core.types import ListOutputFormatOption, NoTruncateOption, OutputColumnsOption
 
-_cli_child_filesets = _cli_import_module("nemo_platform.cli.commands.api.files.filesets")
-_cli_child_otlp = _cli_import_module("nemo_platform.cli.commands.api.files.otlp")
+_cli_child_filesets = _importlib_import_module("nemo_platform.cli.commands.api.files.filesets")
+_cli_child_otlp = _importlib_import_module("nemo_platform.cli.commands.api.files.otlp")
 
 app = create_typer_app(name="files", help="Manage files")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/__init__.py
@@ -4,22 +4,25 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
-from nemo_platform.cli.commands.api.files import filesets, otlp
 from nemo_platform.cli.core.context import CLIContext
 from nemo_platform.cli.core.errors import handle_errors
 from nemo_platform.cli.core.formatters import Column, check_output_columns_with_format, format_output
 from nemo_platform.cli.core.help_formatter import collect_warnings, create_typer_app
 from nemo_platform.cli.core.types import ListOutputFormatOption, NoTruncateOption, OutputColumnsOption
 
+_cli_child_filesets = _cli_import_module("nemo_platform.cli.commands.api.files.filesets")
+_cli_child_otlp = _cli_import_module("nemo_platform.cli.commands.api.files.otlp")
+
 app = create_typer_app(name="files", help="Manage files")
 
-app.add_typer(filesets.app, name="filesets")
-app.add_typer(otlp.app, name="otlp")
+app.add_typer(_cli_child_filesets.app, name="filesets")
+app.add_typer(_cli_child_otlp.app, name="otlp")
 
 
 @app.command("upload")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/otlp/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/otlp/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform.cli.commands.api.files.otlp import logs
+from importlib import import_module as _cli_import_module
+
 from nemo_platform.cli.core.help_formatter import create_typer_app
+
+_cli_child_logs = _cli_import_module("nemo_platform.cli.commands.api.files.otlp.logs")
 
 app = create_typer_app(name="otlp", help="Otlp operations")
 
-app.add_typer(logs.app, name="logs")
+app.add_typer(_cli_child_logs.app, name="logs")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/otlp/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/otlp/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform.cli.core.help_formatter import create_typer_app
 
-_cli_child_logs = _cli_import_module("nemo_platform.cli.commands.api.files.otlp.logs")
+_cli_child_logs = _importlib_import_module("nemo_platform.cli.commands.api.files.otlp.logs")
 
 app = create_typer_app(name="otlp", help="Otlp operations")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/guardrail/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/guardrail/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated
 
 import typer
@@ -17,7 +17,7 @@ from nemo_platform.cli.core.help_formatter import collect_warnings, create_typer
 from nemo_platform.cli.core.stdin_utils import read_data_input_with_flags, read_payload, validate_required_fields
 from nemo_platform.cli.core.types import EntityOutputFormatOption
 
-_cli_child_configs = _cli_import_module("nemo_platform.cli.commands.api.guardrail.configs")
+_cli_child_configs = _importlib_import_module("nemo_platform.cli.commands.api.guardrail.configs")
 
 app = create_typer_app(name="guardrail", help="Manage guardrail")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/guardrail/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/guardrail/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated
 
 import typer
 
-from nemo_platform.cli.commands.api.guardrail import configs
 from nemo_platform.cli.core.code_generator import handle_code_generation
 from nemo_platform.cli.core.context import CLIContext
 from nemo_platform.cli.core.errors import handle_errors
@@ -17,9 +17,11 @@ from nemo_platform.cli.core.help_formatter import collect_warnings, create_typer
 from nemo_platform.cli.core.stdin_utils import read_data_input_with_flags, read_payload, validate_required_fields
 from nemo_platform.cli.core.types import EntityOutputFormatOption
 
+_cli_child_configs = _cli_import_module("nemo_platform.cli.commands.api.guardrail.configs")
+
 app = create_typer_app(name="guardrail", help="Manage guardrail")
 
-app.add_typer(configs.app, name="configs")
+app.add_typer(_cli_child_configs.app, name="configs")
 
 
 @app.command("check")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/iam/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/iam/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform.cli.commands.api.iam import role_bindings
+from importlib import import_module as _cli_import_module
+
 from nemo_platform.cli.core.help_formatter import create_typer_app
+
+_cli_child_role_bindings = _cli_import_module("nemo_platform.cli.commands.api.iam.role_bindings")
 
 app = create_typer_app(name="iam", help="Iam operations")
 
-app.add_typer(role_bindings.app, name="role-bindings")
+app.add_typer(_cli_child_role_bindings.app, name="role-bindings")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/iam/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/iam/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform.cli.core.help_formatter import create_typer_app
 
-_cli_child_role_bindings = _cli_import_module("nemo_platform.cli.commands.api.iam.role_bindings")
+_cli_child_role_bindings = _importlib_import_module("nemo_platform.cli.commands.api.iam.role_bindings")
 
 app = create_typer_app(name="iam", help="Iam operations")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated
 
 import typer
@@ -13,13 +13,15 @@ from nemo_platform.cli.core.context import CLIContext
 from nemo_platform.cli.core.errors import handle_errors
 from nemo_platform.cli.core.help_formatter import create_typer_app
 
-_cli_child_deployment_configs = _cli_import_module("nemo_platform.cli.commands.api.inference.deployment_configs")
-_cli_child_deployments = _cli_import_module("nemo_platform.cli.commands.api.inference.deployments")
-_cli_child_gateway = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway")
-_cli_child_models = _cli_import_module("nemo_platform.cli.commands.api.inference.models")
-_cli_child_prompts = _cli_import_module("nemo_platform.cli.commands.api.inference.prompts")
-_cli_child_providers = _cli_import_module("nemo_platform.cli.commands.api.inference.providers")
-_cli_child_virtual_models = _cli_import_module("nemo_platform.cli.commands.api.inference.virtual_models")
+_cli_child_deployment_configs = _importlib_import_module(
+    "nemo_platform.cli.commands.api.inference.deployment_configs"
+)
+_cli_child_deployments = _importlib_import_module("nemo_platform.cli.commands.api.inference.deployments")
+_cli_child_gateway = _importlib_import_module("nemo_platform.cli.commands.api.inference.gateway")
+_cli_child_models = _importlib_import_module("nemo_platform.cli.commands.api.inference.models")
+_cli_child_prompts = _importlib_import_module("nemo_platform.cli.commands.api.inference.prompts")
+_cli_child_providers = _importlib_import_module("nemo_platform.cli.commands.api.inference.providers")
+_cli_child_virtual_models = _importlib_import_module("nemo_platform.cli.commands.api.inference.virtual_models")
 
 app = create_typer_app(name="inference", help="Manage inference")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/__init__.py
@@ -4,32 +4,32 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated
 
 import typer
 
-from nemo_platform.cli.commands.api.inference import (
-    deployment_configs,
-    deployments,
-    gateway,
-    models,
-    prompts,
-    providers,
-    virtual_models,
-)
 from nemo_platform.cli.core.context import CLIContext
 from nemo_platform.cli.core.errors import handle_errors
 from nemo_platform.cli.core.help_formatter import create_typer_app
 
+_cli_child_deployment_configs = _cli_import_module("nemo_platform.cli.commands.api.inference.deployment_configs")
+_cli_child_deployments = _cli_import_module("nemo_platform.cli.commands.api.inference.deployments")
+_cli_child_gateway = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway")
+_cli_child_models = _cli_import_module("nemo_platform.cli.commands.api.inference.models")
+_cli_child_prompts = _cli_import_module("nemo_platform.cli.commands.api.inference.prompts")
+_cli_child_providers = _cli_import_module("nemo_platform.cli.commands.api.inference.providers")
+_cli_child_virtual_models = _cli_import_module("nemo_platform.cli.commands.api.inference.virtual_models")
+
 app = create_typer_app(name="inference", help="Manage inference")
 
-app.add_typer(deployment_configs.app, name="deployment-configs")
-app.add_typer(deployments.app, name="deployments")
-app.add_typer(gateway.app, name="gateway")
-app.add_typer(models.app, name="models")
-app.add_typer(prompts.app, name="prompts")
-app.add_typer(providers.app, name="providers")
-app.add_typer(virtual_models.app, name="virtual-models")
+app.add_typer(_cli_child_deployment_configs.app, name="deployment-configs")
+app.add_typer(_cli_child_deployments.app, name="deployments")
+app.add_typer(_cli_child_gateway.app, name="gateway")
+app.add_typer(_cli_child_models.app, name="models")
+app.add_typer(_cli_child_prompts.app, name="prompts")
+app.add_typer(_cli_child_providers.app, name="providers")
+app.add_typer(_cli_child_virtual_models.app, name="virtual-models")
 
 
 @app.command("get-url")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/deployment_configs/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/deployment_configs/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform.cli.commands.api.inference.deployment_configs import versions
 from nemo_platform.cli.core.api import build_kwargs, merge_filter_dict
 from nemo_platform.cli.core.code_generator import handle_code_generation
 from nemo_platform.cli.core.context import CLIContext
@@ -24,9 +24,11 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_versions = _cli_import_module("nemo_platform.cli.commands.api.inference.deployment_configs.versions")
+
 app = create_typer_app(name="deployment_configs", help="Manage deployment_configs")
 
-app.add_typer(versions.app, name="versions")
+app.add_typer(_cli_child_versions.app, name="versions")
 
 
 @app.command("create")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/deployment_configs/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/deployment_configs/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -24,7 +24,9 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_versions = _cli_import_module("nemo_platform.cli.commands.api.inference.deployment_configs.versions")
+_cli_child_versions = _importlib_import_module(
+    "nemo_platform.cli.commands.api.inference.deployment_configs.versions"
+)
 
 app = create_typer_app(name="deployment_configs", help="Manage deployment_configs")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/deployments/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/deployments/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform.cli.commands.api.inference.deployments import versions
 from nemo_platform.cli.core.api import build_kwargs, merge_filter_dict
 from nemo_platform.cli.core.code_generator import handle_code_generation
 from nemo_platform.cli.core.context import CLIContext
@@ -26,9 +26,11 @@ from nemo_platform.cli.core.types import (
 )
 from nemo_platform.cli.core.waiters import wait_for_inference_deployment
 
+_cli_child_versions = _cli_import_module("nemo_platform.cli.commands.api.inference.deployments.versions")
+
 app = create_typer_app(name="deployments", help="Manage deployments")
 
-app.add_typer(versions.app, name="versions")
+app.add_typer(_cli_child_versions.app, name="versions")
 
 
 @app.command("create")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/deployments/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/deployments/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -26,7 +26,7 @@ from nemo_platform.cli.core.types import (
 )
 from nemo_platform.cli.core.waiters import wait_for_inference_deployment
 
-_cli_child_versions = _cli_import_module("nemo_platform.cli.commands.api.inference.deployments.versions")
+_cli_child_versions = _importlib_import_module("nemo_platform.cli.commands.api.inference.deployments.versions")
 
 app = create_typer_app(name="deployments", help="Manage deployments")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/__init__.py
@@ -4,13 +4,13 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform.cli.core.help_formatter import create_typer_app
 
-_cli_child_model = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway.model")
-_cli_child_openai = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway.openai")
-_cli_child_provider = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway.provider")
+_cli_child_model = _importlib_import_module("nemo_platform.cli.commands.api.inference.gateway.model")
+_cli_child_openai = _importlib_import_module("nemo_platform.cli.commands.api.inference.gateway.openai")
+_cli_child_provider = _importlib_import_module("nemo_platform.cli.commands.api.inference.gateway.provider")
 
 app = create_typer_app(name="gateway", help="Gateway operations")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/__init__.py
@@ -4,11 +4,16 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform.cli.commands.api.inference.gateway import model, openai, provider
+from importlib import import_module as _cli_import_module
+
 from nemo_platform.cli.core.help_formatter import create_typer_app
+
+_cli_child_model = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway.model")
+_cli_child_openai = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway.openai")
+_cli_child_provider = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway.provider")
 
 app = create_typer_app(name="gateway", help="Gateway operations")
 
-app.add_typer(model.app, name="model")
-app.add_typer(openai.app, name="openai")
-app.add_typer(provider.app, name="provider")
+app.add_typer(_cli_child_model.app, name="model")
+app.add_typer(_cli_child_openai.app, name="openai")
+app.add_typer(_cli_child_provider.app, name="provider")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform.cli.core.help_formatter import create_typer_app
 
-_cli_child_v1 = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway.openai.v1")
+_cli_child_v1 = _importlib_import_module("nemo_platform.cli.commands.api.inference.gateway.openai.v1")
 
 app = create_typer_app(name="openai", help="Openai operations")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform.cli.commands.api.inference.gateway.openai import v1
+from importlib import import_module as _cli_import_module
+
 from nemo_platform.cli.core.help_formatter import create_typer_app
+
+_cli_child_v1 = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway.openai.v1")
 
 app = create_typer_app(name="openai", help="Openai operations")
 
-app.add_typer(v1.app, name="v1")
+app.add_typer(_cli_child_v1.app, name="v1")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/v1/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/v1/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform.cli.core.help_formatter import create_typer_app
 
-_cli_child_models = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway.openai.v1.models")
+_cli_child_models = _importlib_import_module("nemo_platform.cli.commands.api.inference.gateway.openai.v1.models")
 
 app = create_typer_app(name="v1", help="V1 operations")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/v1/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/v1/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform.cli.commands.api.inference.gateway.openai.v1 import models
+from importlib import import_module as _cli_import_module
+
 from nemo_platform.cli.core.help_formatter import create_typer_app
+
+_cli_child_models = _cli_import_module("nemo_platform.cli.commands.api.inference.gateway.openai.v1.models")
 
 app = create_typer_app(name="v1", help="V1 operations")
 
-app.add_typer(models.app, name="models")
+app.add_typer(_cli_child_models.app, name="models")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/__init__.py
@@ -4,15 +4,15 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform.cli.core.help_formatter import create_typer_app
 
-_cli_child_annotations = _cli_import_module("nemo_platform.cli.commands.api.intake.annotations")
-_cli_child_evaluator_results = _cli_import_module("nemo_platform.cli.commands.api.intake.evaluator_results")
-_cli_child_ingest = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest")
-_cli_child_spans = _cli_import_module("nemo_platform.cli.commands.api.intake.spans")
-_cli_child_traces = _cli_import_module("nemo_platform.cli.commands.api.intake.traces")
+_cli_child_annotations = _importlib_import_module("nemo_platform.cli.commands.api.intake.annotations")
+_cli_child_evaluator_results = _importlib_import_module("nemo_platform.cli.commands.api.intake.evaluator_results")
+_cli_child_ingest = _importlib_import_module("nemo_platform.cli.commands.api.intake.ingest")
+_cli_child_spans = _importlib_import_module("nemo_platform.cli.commands.api.intake.spans")
+_cli_child_traces = _importlib_import_module("nemo_platform.cli.commands.api.intake.traces")
 
 app = create_typer_app(name="intake", help="Intake operations")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/__init__.py
@@ -4,13 +4,20 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform.cli.commands.api.intake import annotations, evaluator_results, ingest, spans, traces
+from importlib import import_module as _cli_import_module
+
 from nemo_platform.cli.core.help_formatter import create_typer_app
+
+_cli_child_annotations = _cli_import_module("nemo_platform.cli.commands.api.intake.annotations")
+_cli_child_evaluator_results = _cli_import_module("nemo_platform.cli.commands.api.intake.evaluator_results")
+_cli_child_ingest = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest")
+_cli_child_spans = _cli_import_module("nemo_platform.cli.commands.api.intake.spans")
+_cli_child_traces = _cli_import_module("nemo_platform.cli.commands.api.intake.traces")
 
 app = create_typer_app(name="intake", help="Intake operations")
 
-app.add_typer(annotations.app, name="annotations")
-app.add_typer(evaluator_results.app, name="evaluator-results")
-app.add_typer(ingest.app, name="ingest")
-app.add_typer(spans.app, name="spans")
-app.add_typer(traces.app, name="traces")
+app.add_typer(_cli_child_annotations.app, name="annotations")
+app.add_typer(_cli_child_evaluator_results.app, name="evaluator-results")
+app.add_typer(_cli_child_ingest.app, name="ingest")
+app.add_typer(_cli_child_spans.app, name="spans")
+app.add_typer(_cli_child_traces.app, name="traces")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/annotations.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/annotations.py
@@ -37,7 +37,7 @@ def create_annotations(
         Literal["feedback", "note", "metadata", "label"] | None, typer.Option("--kind", help="(required)")
     ] = None,
     session_id: Annotated[str | None, typer.Option("--session-id", help="(required)")] = None,
-    value: Annotated[Literal["positive", "negative"] | str | float | None, typer.Option("--value")] = None,
+    value: Annotated[str | None, typer.Option("--value")] = None,
     span_id: Annotated[str | None, typer.Option("--span-id")] = None,
     text: Annotated[str | None, typer.Option("--text")] = None,
     metadata: Annotated[str | None, typer.Option("--metadata", help="JSON string")] = None,

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/__init__.py
@@ -4,13 +4,15 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform.cli.core.help_formatter import create_typer_app
 
-_cli_child_atif = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest.atif")
-_cli_child_chat_completions = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest.chat_completions")
-_cli_child_otlp = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest.otlp")
+_cli_child_atif = _importlib_import_module("nemo_platform.cli.commands.api.intake.ingest.atif")
+_cli_child_chat_completions = _importlib_import_module(
+    "nemo_platform.cli.commands.api.intake.ingest.chat_completions"
+)
+_cli_child_otlp = _importlib_import_module("nemo_platform.cli.commands.api.intake.ingest.otlp")
 
 app = create_typer_app(name="ingest", help="Ingest operations")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/__init__.py
@@ -4,11 +4,16 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform.cli.commands.api.intake.ingest import atif, chat_completions, otlp
+from importlib import import_module as _cli_import_module
+
 from nemo_platform.cli.core.help_formatter import create_typer_app
+
+_cli_child_atif = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest.atif")
+_cli_child_chat_completions = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest.chat_completions")
+_cli_child_otlp = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest.otlp")
 
 app = create_typer_app(name="ingest", help="Ingest operations")
 
-app.add_typer(atif.app, name="atif")
-app.add_typer(chat_completions.app, name="chat-completions")
-app.add_typer(otlp.app, name="otlp")
+app.add_typer(_cli_child_atif.app, name="atif")
+app.add_typer(_cli_child_chat_completions.app, name="chat-completions")
+app.add_typer(_cli_child_otlp.app, name="otlp")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/otlp/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/otlp/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform.cli.core.help_formatter import create_typer_app
 
-_cli_child_v1 = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest.otlp.v1")
+_cli_child_v1 = _importlib_import_module("nemo_platform.cli.commands.api.intake.ingest.otlp.v1")
 
 app = create_typer_app(name="otlp", help="Otlp operations")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/otlp/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/otlp/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform.cli.commands.api.intake.ingest.otlp import v1
+from importlib import import_module as _cli_import_module
+
 from nemo_platform.cli.core.help_formatter import create_typer_app
+
+_cli_child_v1 = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest.otlp.v1")
 
 app = create_typer_app(name="otlp", help="Otlp operations")
 
-app.add_typer(v1.app, name="v1")
+app.add_typer(_cli_child_v1.app, name="v1")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/otlp/v1/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/otlp/v1/__init__.py
@@ -4,9 +4,12 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from nemo_platform.cli.commands.api.intake.ingest.otlp.v1 import traces
+from importlib import import_module as _cli_import_module
+
 from nemo_platform.cli.core.help_formatter import create_typer_app
+
+_cli_child_traces = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest.otlp.v1.traces")
 
 app = create_typer_app(name="v1", help="V1 operations")
 
-app.add_typer(traces.app, name="traces")
+app.add_typer(_cli_child_traces.app, name="traces")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/otlp/v1/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/ingest/otlp/v1/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 
 from nemo_platform.cli.core.help_formatter import create_typer_app
 
-_cli_child_traces = _cli_import_module("nemo_platform.cli.commands.api.intake.ingest.otlp.v1.traces")
+_cli_child_traces = _importlib_import_module("nemo_platform.cli.commands.api.intake.ingest.otlp.v1.traces")
 
 app = create_typer_app(name="v1", help="V1 operations")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform.cli.commands.api.intake.spans import evaluator_results, groups
 from nemo_platform.cli.core.api import build_kwargs, merge_filter_dict
 from nemo_platform.cli.core.code_generator import handle_code_generation
 from nemo_platform.cli.core.context import CLIContext
@@ -23,10 +23,13 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_evaluator_results = _cli_import_module("nemo_platform.cli.commands.api.intake.spans.evaluator_results")
+_cli_child_groups = _cli_import_module("nemo_platform.cli.commands.api.intake.spans.groups")
+
 app = create_typer_app(name="spans", help="Manage spans")
 
-app.add_typer(evaluator_results.app, name="evaluator-results")
-app.add_typer(groups.app, name="groups")
+app.add_typer(_cli_child_evaluator_results.app, name="evaluator-results")
+app.add_typer(_cli_child_groups.app, name="groups")
 
 
 @app.command("list")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -23,8 +23,10 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_evaluator_results = _cli_import_module("nemo_platform.cli.commands.api.intake.spans.evaluator_results")
-_cli_child_groups = _cli_import_module("nemo_platform.cli.commands.api.intake.spans.groups")
+_cli_child_evaluator_results = _importlib_import_module(
+    "nemo_platform.cli.commands.api.intake.spans.evaluator_results"
+)
+_cli_child_groups = _importlib_import_module("nemo_platform.cli.commands.api.intake.spans.groups")
 
 app = create_typer_app(name="spans", help="Manage spans")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/jobs/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/jobs/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -24,9 +24,9 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_results = _cli_import_module("nemo_platform.cli.commands.api.jobs.results")
-_cli_child_steps = _cli_import_module("nemo_platform.cli.commands.api.jobs.steps")
-_cli_child_tasks = _cli_import_module("nemo_platform.cli.commands.api.jobs.tasks")
+_cli_child_results = _importlib_import_module("nemo_platform.cli.commands.api.jobs.results")
+_cli_child_steps = _importlib_import_module("nemo_platform.cli.commands.api.jobs.steps")
+_cli_child_tasks = _importlib_import_module("nemo_platform.cli.commands.api.jobs.tasks")
 
 app = create_typer_app(name="jobs", help="Manage jobs")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/jobs/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/jobs/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform.cli.commands.api.jobs import results, steps, tasks
 from nemo_platform.cli.core.api import build_kwargs, merge_filter_dict
 from nemo_platform.cli.core.code_generator import handle_code_generation
 from nemo_platform.cli.core.context import CLIContext
@@ -24,11 +24,15 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_results = _cli_import_module("nemo_platform.cli.commands.api.jobs.results")
+_cli_child_steps = _cli_import_module("nemo_platform.cli.commands.api.jobs.steps")
+_cli_child_tasks = _cli_import_module("nemo_platform.cli.commands.api.jobs.tasks")
+
 app = create_typer_app(name="jobs", help="Manage jobs")
 
-app.add_typer(results.app, name="results")
-app.add_typer(steps.app, name="steps")
-app.add_typer(tasks.app, name="tasks")
+app.add_typer(_cli_child_results.app, name="results")
+app.add_typer(_cli_child_steps.app, name="steps")
+app.add_typer(_cli_child_tasks.app, name="tasks")
 
 
 @app.command("cancel")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/models/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/models/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -24,7 +24,7 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_adapters = _cli_import_module("nemo_platform.cli.commands.api.models.adapters")
+_cli_child_adapters = _importlib_import_module("nemo_platform.cli.commands.api.models.adapters")
 
 app = create_typer_app(name="models", help="Manage models")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/models/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/models/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform.cli.commands.api.models import adapters
 from nemo_platform.cli.core.api import build_kwargs, merge_filter_dict
 from nemo_platform.cli.core.code_generator import handle_code_generation
 from nemo_platform.cli.core.context import CLIContext
@@ -24,9 +24,11 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_adapters = _cli_import_module("nemo_platform.cli.commands.api.models.adapters")
+
 app = create_typer_app(name="models", help="Manage models")
 
-app.add_typer(adapters.app, name="adapters")
+app.add_typer(_cli_child_adapters.app, name="adapters")
 
 
 @app.command("create")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/secrets/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/secrets/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated
 
 import typer
@@ -28,7 +28,7 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_admin = _cli_import_module("nemo_platform.cli.commands.api.secrets.admin")
+_cli_child_admin = _importlib_import_module("nemo_platform.cli.commands.api.secrets.admin")
 
 app = create_typer_app(name="secrets", help="Manage secrets")
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/secrets/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/secrets/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated
 
 import typer
 
-from nemo_platform.cli.commands.api.secrets import admin
 from nemo_platform.cli.core.api import build_kwargs
 from nemo_platform.cli.core.api import merge_filter_dict as merge_filter_dict
 from nemo_platform.cli.core.code_generator import handle_code_generation
@@ -28,9 +28,11 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_admin = _cli_import_module("nemo_platform.cli.commands.api.secrets.admin")
+
 app = create_typer_app(name="secrets", help="Manage secrets")
 
-app.add_typer(admin.app, name="admin")
+app.add_typer(_cli_child_admin.app, name="admin")
 
 
 @app.command("access")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/workspaces/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/workspaces/__init__.py
@@ -4,11 +4,11 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
+from importlib import import_module as _cli_import_module
 from typing import Annotated, Literal
 
 import typer
 
-from nemo_platform.cli.commands.api.workspaces import members
 from nemo_platform.cli.core.api import build_kwargs
 from nemo_platform.cli.core.api import merge_filter_dict as merge_filter_dict
 from nemo_platform.cli.core.code_generator import handle_code_generation
@@ -26,9 +26,11 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
+_cli_child_members = _cli_import_module("nemo_platform.cli.commands.api.workspaces.members")
+
 app = create_typer_app(name="workspaces", help="Manage workspaces")
 
-app.add_typer(members.app, name="members")
+app.add_typer(_cli_child_members.app, name="members")
 
 
 @app.command("create")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/workspaces/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/workspaces/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: This file is auto-generated
 from __future__ import annotations
 
-from importlib import import_module as _cli_import_module
+from importlib import import_module as _importlib_import_module
 from typing import Annotated, Literal
 
 import typer
@@ -26,7 +26,7 @@ from nemo_platform.cli.core.types import (
     OutputColumnsOption,
 )
 
-_cli_child_members = _cli_import_module("nemo_platform.cli.commands.api.workspaces.members")
+_cli_child_members = _importlib_import_module("nemo_platform.cli.commands.api.workspaces.members")
 
 app = create_typer_app(name="workspaces", help="Manage workspaces")
 

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/generator.py
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/generator.py
@@ -368,15 +368,17 @@ class SimpleGenerator:
         # Build the file content
         import_base = "nemo_platform_ext.cli.commands.api"
         parent_import = f"{import_base}.{'.'.join(resource_path)}"
+        sorted_sub_resources = sorted(sub_resources)
 
         lines = [*AUTO_GENERATED_FILE_HEADER]
 
-        # Add sub-resource imports (will be generated later)
-        for sub in sorted(sub_resources):
-            lines.append(f"from {parent_import} import {sub}")
-
         if sub_resources:
-            lines.append("")
+            lines.extend(
+                [
+                    "from importlib import import_module as _cli_import_module",
+                    "",
+                ]
+            )
 
         # Add imports extracted from templates
         lines.extend(imports)
@@ -389,15 +391,23 @@ class SimpleGenerator:
             ]
         )
 
+        # Import child modules after regular imports. import_module forces the
+        # submodule load instead of reading same-named package globals.
+        for sub in sorted_sub_resources:
+            lines.append(f'{self._sub_resource_import_alias(sub)} = _cli_import_module("{parent_import}.{sub}")')
+
+        if sub_resources:
+            lines.append("")
+
         # App creation
         app_help = self._get_resource_help(resource_path, f"Manage {resource_name}")
         lines.append(f'app = create_typer_app(name="{resource_name}", help="{escape_for_python_string(app_help)}")')
         lines.append("")
 
         # Register sub-apps
-        for sub in sorted(sub_resources):
+        for sub in sorted_sub_resources:
             cli_name = sub.replace("_", "-")
-            lines.append(f'app.add_typer({sub}.app, name="{cli_name}")')
+            lines.append(f'app.add_typer({self._sub_resource_import_alias(sub)}.app, name="{cli_name}")')
 
         if sub_resources:
             lines.append("")
@@ -588,14 +598,21 @@ class SimpleGenerator:
         resource_name = parent_path[-1]
         lines = [*AUTO_GENERATED_FILE_HEADER]
 
-        for child in all_children:
-            lines.append(f"from {parent_import} import {child}")
-
         app_help = self._get_resource_help(parent_path, f"{resource_name.replace('_', ' ').title()} operations")
         lines.extend(
             [
+                "from importlib import import_module as _cli_import_module",
                 "",
                 "from nemo_platform_ext.cli.core.help_formatter import create_typer_app",
+                "",
+            ]
+        )
+
+        for child in all_children:
+            lines.append(f'{self._sub_resource_import_alias(child)} = _cli_import_module("{parent_import}.{child}")')
+
+        lines.extend(
+            [
                 "",
                 f'app = create_typer_app(name="{resource_name}", help="{escape_for_python_string(app_help)}")',
                 "",
@@ -604,10 +621,15 @@ class SimpleGenerator:
 
         for child in all_children:
             cli_name = child.replace("_", "-")
-            lines.append(f'app.add_typer({child}.app, name="{cli_name}")')
+            lines.append(f'app.add_typer({self._sub_resource_import_alias(child)}.app, name="{cli_name}")')
 
         lines.append("")
         init_file.write_text("\n".join(lines))
+
+    @staticmethod
+    def _sub_resource_import_alias(resource_name: str) -> str:
+        """Return a private alias for generated sub-resource module imports."""
+        return f"_cli_child_{resource_name}"
 
     def _clear_generated_files(self) -> None:
         """Clear all generated files in the target directory."""
@@ -712,8 +734,9 @@ class SimpleGenerator:
                     sys.modules.pop(name, None)
             for name in generated_package_names:
                 sys.modules.pop(name, None)
-                if saved_modules[name] is not None:
-                    sys.modules[name] = saved_modules[name]
+                saved_module = saved_modules[name]
+                if saved_module is not None:
+                    sys.modules[name] = saved_module
 
         help_text = getattr(module.app, "info", None)
         if help_text is not None:

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/generator.py
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/generator.py
@@ -42,6 +42,8 @@ AUTO_GENERATED_FILE_HEADER = [
     "",
 ]
 
+_SUB_RESOURCE_IMPORT_ALIAS_TEMPLATE = "_cli_child_{resource_name}"
+
 
 logger = logging.getLogger(__name__)
 
@@ -375,7 +377,7 @@ class SimpleGenerator:
         if sub_resources:
             lines.extend(
                 [
-                    "from importlib import import_module as _cli_import_module",
+                    "from importlib import import_module as _importlib_import_module",
                     "",
                 ]
             )
@@ -394,7 +396,8 @@ class SimpleGenerator:
         # Import child modules after regular imports. import_module forces the
         # submodule load instead of reading same-named package globals.
         for sub in sorted_sub_resources:
-            lines.append(f'{self._sub_resource_import_alias(sub)} = _cli_import_module("{parent_import}.{sub}")')
+            import_alias = _SUB_RESOURCE_IMPORT_ALIAS_TEMPLATE.format(resource_name=sub)
+            lines.append(f'{import_alias} = _importlib_import_module("{parent_import}.{sub}")')
 
         if sub_resources:
             lines.append("")
@@ -407,7 +410,8 @@ class SimpleGenerator:
         # Register sub-apps
         for sub in sorted_sub_resources:
             cli_name = sub.replace("_", "-")
-            lines.append(f'app.add_typer({self._sub_resource_import_alias(sub)}.app, name="{cli_name}")')
+            import_alias = _SUB_RESOURCE_IMPORT_ALIAS_TEMPLATE.format(resource_name=sub)
+            lines.append(f'app.add_typer({import_alias}.app, name="{cli_name}")')
 
         if sub_resources:
             lines.append("")
@@ -601,7 +605,7 @@ class SimpleGenerator:
         app_help = self._get_resource_help(parent_path, f"{resource_name.replace('_', ' ').title()} operations")
         lines.extend(
             [
-                "from importlib import import_module as _cli_import_module",
+                "from importlib import import_module as _importlib_import_module",
                 "",
                 "from nemo_platform_ext.cli.core.help_formatter import create_typer_app",
                 "",
@@ -609,7 +613,8 @@ class SimpleGenerator:
         )
 
         for child in all_children:
-            lines.append(f'{self._sub_resource_import_alias(child)} = _cli_import_module("{parent_import}.{child}")')
+            import_alias = _SUB_RESOURCE_IMPORT_ALIAS_TEMPLATE.format(resource_name=child)
+            lines.append(f'{import_alias} = _importlib_import_module("{parent_import}.{child}")')
 
         lines.extend(
             [
@@ -621,15 +626,11 @@ class SimpleGenerator:
 
         for child in all_children:
             cli_name = child.replace("_", "-")
-            lines.append(f'app.add_typer({self._sub_resource_import_alias(child)}.app, name="{cli_name}")')
+            import_alias = _SUB_RESOURCE_IMPORT_ALIAS_TEMPLATE.format(resource_name=child)
+            lines.append(f'app.add_typer({import_alias}.app, name="{cli_name}")')
 
         lines.append("")
         init_file.write_text("\n".join(lines))
-
-    @staticmethod
-    def _sub_resource_import_alias(resource_name: str) -> str:
-        """Return a private alias for generated sub-resource module imports."""
-        return f"_cli_child_{resource_name}"
 
     def _clear_generated_files(self) -> None:
         """Clear all generated files in the target directory."""

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/models.py
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/models.py
@@ -195,9 +195,7 @@ def _collapse_typer_union_types(type_names: list[str]) -> list[str]:
         return type_names
 
     has_none = len(concrete_types) != len(type_names)
-    if "str" in concrete_types or any(type_name.startswith("Literal[") for type_name in concrete_types):
-        collapsed = ["str"]
-    elif set(concrete_types) <= {"int", "float"}:
+    if set(concrete_types) <= {"int", "float"}:
         collapsed = ["float"]
     else:
         collapsed = ["str"]

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/models.py
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/models.py
@@ -183,6 +183,30 @@ def _simplify_list_type(tp: Type) -> str | None:
     return "list[str]"
 
 
+def _collapse_typer_union_types(type_names: list[str]) -> list[str]:
+    """Collapse multi-type unions into annotations Typer can build.
+
+    Example: Literal["positive", "negative"] | str | float | None
+    becomes str | None because Typer cannot build one option from multiple
+    concrete runtime types.
+    """
+    concrete_types = [type_name for type_name in type_names if type_name != "None"]
+    if len(concrete_types) <= 1:
+        return type_names
+
+    has_none = len(concrete_types) != len(type_names)
+    if "str" in concrete_types or any(type_name.startswith("Literal[") for type_name in concrete_types):
+        collapsed = ["str"]
+    elif set(concrete_types) <= {"int", "float"}:
+        collapsed = ["float"]
+    else:
+        collapsed = ["str"]
+
+    if has_none:
+        collapsed.append("None")
+    return collapsed
+
+
 def clean_type_annotation(tp: Type) -> str:
     """Clean up a type annotation string for CLI use.
 
@@ -276,6 +300,7 @@ def clean_type_annotation(tp: Type) -> str:
                 seen.add(t)
                 deduped.append(t)
 
+        deduped = _collapse_typer_union_types(deduped)
         return " | ".join(deduped)
 
     return format_type(tp)

--- a/tools/nemo-platform-sdk-tools/tests/sdk/cli_generator/test_generator.py
+++ b/tools/nemo-platform-sdk-tools/tests/sdk/cli_generator/test_generator.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -97,9 +99,9 @@ class TestCleanTypeAnnotation:
         assert clean_type_annotation(str | None) == "str | None"
 
     def test_handle_multiple_union_members(self):
-        """Should handle types with multiple union members."""
+        """Should collapse mixed scalar unions to a Typer-compatible type."""
         result = clean_type_annotation(str | int | Omit)
-        assert result == "str | int | None"
+        assert result == "str | None"
 
     def test_handle_no_omit(self):
         """Should return unchanged if no Omit present."""
@@ -143,13 +145,18 @@ class TestCleanTypeAnnotation:
         assert "bool" not in result  # Only one of True/False, not full bool
 
     def test_literal_with_other_types(self):
-        """Should handle Literal[True] | Literal[False] combined with other types."""
+        """Should collapse Literal[True] | Literal[False] combined with other types."""
         from typing import Literal
 
         result = clean_type_annotation(Literal[True] | Literal[False] | str | None)
-        assert "bool" in result
-        assert "str" in result
-        assert "None" in result
+        assert result == "str | None"
+
+    def test_literal_string_with_str_and_float_simplifies_to_str(self):
+        """Should collapse mixed string/numeric value unions for Typer."""
+        from typing import Literal
+
+        result = clean_type_annotation(Literal["positive", "negative"] | str | float | None)
+        assert result == "str | None"
 
     def test_deduplicate_types(self):
         """Should deduplicate type names in union."""
@@ -320,6 +327,88 @@ def test_func():
         result = self._filter_skip_lines(content)
         assert "from typing import Annotated" in result
         assert "@app.command" in result
+
+
+class TestInitFileGeneration:
+    def test_imports_subresources_without_annotations_package_attribute_collision(self, tmp_path: Path):
+        class _NoResourceConfig:
+            def get_resource_config(self, resource_path: list[str]) -> None:
+                return None
+
+        def get_sub_resources(resource_path: list[str]) -> list[str]:
+            return ["annotations", "traces"]
+
+        package_root = tmp_path
+        target_dir = package_root / "nemo_platform_ext" / "cli" / "commands" / "api"
+        for package_dir in [
+            package_root / "nemo_platform_ext",
+            package_root / "nemo_platform_ext" / "cli",
+            package_root / "nemo_platform_ext" / "cli" / "commands",
+            target_dir,
+        ]:
+            package_dir.mkdir(parents=True, exist_ok=True)
+            (package_dir / "__init__.py").write_text("")
+
+        core_dir = package_root / "nemo_platform_ext" / "cli" / "core"
+        core_dir.mkdir(parents=True, exist_ok=True)
+        (core_dir / "__init__.py").write_text("")
+        (core_dir / "help_formatter.py").write_text(
+            "\n".join(
+                [
+                    "class _App:",
+                    "    def __init__(self):",
+                    "        self.children = []",
+                    "",
+                    "    def add_typer(self, app, name):",
+                    "        self.children.append((name, app))",
+                    "",
+                    "def create_typer_app(*, name: str, help: str):",
+                    "    return _App()",
+                    "",
+                ]
+            )
+        )
+
+        generator = SimpleGenerator.__new__(SimpleGenerator)
+        generator._target_dir = target_dir
+        generator._cli_config = _NoResourceConfig()
+        generator._get_sub_resources = get_sub_resources
+
+        generator._generate_init_with_commands(["intake"], "", [])
+
+        intake_dir = target_dir / "intake"
+        (intake_dir / "annotations.py").write_text('app = "annotations-app"\n')
+        (intake_dir / "traces.py").write_text('app = "traces-app"\n')
+
+        content = (intake_dir / "__init__.py").read_text()
+        assert "from __future__ import annotations" in content
+        assert (
+            '_cli_child_annotations = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.annotations")'
+            in content
+        )
+        assert '_cli_child_traces = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.traces")' in content
+        assert 'app.add_typer(_cli_child_annotations.app, name="annotations")' in content
+        assert 'app.add_typer(_cli_child_traces.app, name="traces")' in content
+        assert "from nemo_platform_ext.cli.commands.api.intake import annotations" not in content
+        assert "app.add_typer(annotations.app" not in content
+
+        saved_modules = {
+            name: module
+            for name, module in sys.modules.items()
+            if name == "nemo_platform_ext" or name.startswith("nemo_platform_ext.")
+        }
+        sys.path.insert(0, str(package_root))
+        try:
+            for name in saved_modules:
+                sys.modules.pop(name, None)
+            module = importlib.import_module("nemo_platform_ext.cli.commands.api.intake")
+            assert module.app.children == [("annotations", "annotations-app"), ("traces", "traces-app")]
+        finally:
+            sys.path.pop(0)
+            for name in list(sys.modules):
+                if name == "nemo_platform_ext" or name.startswith("nemo_platform_ext."):
+                    sys.modules.pop(name, None)
+            sys.modules.update(saved_modules)
 
 
 class TestGetApiModules:

--- a/tools/nemo-platform-sdk-tools/tests/sdk/cli_generator/test_generator.py
+++ b/tools/nemo-platform-sdk-tools/tests/sdk/cli_generator/test_generator.py
@@ -7,6 +7,7 @@ import importlib
 import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from typing import Any
 
 import pytest
 from nemo_platform._types import Omit
@@ -157,6 +158,20 @@ class TestCleanTypeAnnotation:
 
         result = clean_type_annotation(Literal["positive", "negative"] | str | float | None)
         assert result == "str | None"
+
+    @pytest.mark.parametrize(
+        ("annotation", "expected"),
+        [
+            (str | int, "str"),
+            (int | float, "float"),
+            (int | float | None, "float | None"),
+            (int | bool, "str"),
+            (list[str] | float, "str"),
+        ],
+    )
+    def test_collapse_mixed_union_types(self, annotation: Any, expected: str):
+        """Should collapse mixed unions to one Typer-compatible runtime type."""
+        assert clean_type_annotation(annotation) == expected
 
     def test_deduplicate_types(self):
         """Should deduplicate type names in union."""
@@ -383,10 +398,13 @@ class TestInitFileGeneration:
         content = (intake_dir / "__init__.py").read_text()
         assert "from __future__ import annotations" in content
         assert (
-            '_cli_child_annotations = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.annotations")'
+            '_cli_child_annotations = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.annotations")'
             in content
         )
-        assert '_cli_child_traces = _cli_import_module("nemo_platform_ext.cli.commands.api.intake.traces")' in content
+        assert (
+            '_cli_child_traces = _importlib_import_module("nemo_platform_ext.cli.commands.api.intake.traces")'
+            in content
+        )
         assert 'app.add_typer(_cli_child_annotations.app, name="annotations")' in content
         assert 'app.add_typer(_cli_child_traces.app, name="traces")' in content
         assert "from nemo_platform_ext.cli.commands.api.intake import annotations" not in content


### PR DESCRIPTION
Fixes two generated CLI load failures in nemo intake:

  1. annotations submodule shadowing: generated group __init__.py
     files used from parent import child, which can resolve an
     already-bound package attribute during partial initialization.
     from __future__ import annotations binds annotations, so
     intake.annotations resolved to _Feature instead of
     annotations.py. The generator now imports child modules
     explicitly via importlib.import_module(...).

  2. Unsupported Typer union typing: once the intake group loaded,
     intake annotations create exposed a generated option type
     Literal["positive", "negative"] | str | float | None, which Typer
     cannot convert into one Click option. The generator now collapses
     mixed scalar unions to a single Typer-compatible CLI type,
     preserving optionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated CLI code now mounts nested command groups using runtime subcommand loading, improving reliability for complex CLI structures.

* **Bug Fixes**
  * Improved Typer-compatible normalization of union/literal option types, collapsing mixed numeric and literal unions into cleaner annotations.
  * Fixed subcommand registration in multiple CLI areas so nested subcommands consistently appear under the expected parent commands.

* **Tests**
  * Updated CLI generator tests and added a regression test covering generated `__init__` imports and wiring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->