### PR TITLE
fix(studio): Code agent link issues and blocked action menu on fileset header

### DIFF
--- a/services/studio/src/nmp/studio/studio_links.py
+++ b/services/studio/src/nmp/studio/studio_links.py
@@ -561,6 +561,13 @@ def tool_for_destinations(destinations: Mapping[str, StudioLinkDestination]) -> 
     return tool
 
 
+# Destinations whose `{name}` segment is the route's `:filesetId` param, which is the
+# namespaced entity reference `{workspace}/{name}` encoded as a single path segment
+# (e.g. `default%2Fmy-fileset`) — not the bare name. The `fileset` (…/detail) route uses
+# `:filesetName` (bare) instead, so it is intentionally excluded.
+_NAMESPACED_FILESET_DESTINATIONS = frozenset({"fileset_panel", "fileset_file"})
+
+
 def _path_part(value: str) -> str:
     return quote(value, safe="")
 
@@ -632,9 +639,19 @@ def build_studio_link_result(
         missing = "name" if missing_args == ["name"] else ", ".join(missing_args)
         return {"error": f"{missing} is required for Studio destination: {destination}"}
 
+    def _path_value(arg_name: str, value: str | None) -> str:
+        if value is None:
+            return ""
+        # The `:filesetId` route param is the namespaced entity reference
+        # `{workspace}/{name}`; prefix the workspace unless a namespaced value
+        # was supplied already.
+        if arg_name == "name" and destination in _NAMESPACED_FILESET_DESTINATIONS and "/" not in value:
+            return _path_part(f"{workspace}/{value}")
+        return _path_part(value)
+
     path_values = {
         "workspace": _path_part(workspace),
-        **{arg_name: _path_part(value) if value is not None else "" for arg_name, value in raw_values.items()},
+        **{arg_name: _path_value(arg_name, value) for arg_name, value in raw_values.items()},
     }
     path = config.path_template.format(**path_values)
     label_values = {arg_name: value for arg_name, value in raw_values.items() if value is not None}

--- a/services/studio/tests/unit/test_coding_agents.py
+++ b/services/studio/tests/unit/test_coding_agents.py
@@ -1071,10 +1071,44 @@ def test_mcp_studio_link_returns_fileset_file_markdown(service_client: TestClien
     assert json.loads(result_text) == {
         "workspace": "default",
         "destination": "fileset_file",
-        "path": "/workspaces/default/filesets/training%20data/file/nested%2Fexamples.jsonl",
+        "path": "/workspaces/default/filesets/default%2Ftraining%20data/file/nested%2Fexamples.jsonl",
         "url": None,
-        "markdown": "[File nested/examples.jsonl](/workspaces/default/filesets/training%20data/file/nested%2Fexamples.jsonl)",
+        "markdown": (
+            "[File nested/examples.jsonl]"
+            "(/workspaces/default/filesets/default%2Ftraining%20data/file/nested%2Fexamples.jsonl)"
+        ),
     }
+
+
+def test_build_studio_link_result_namespaces_fileset_panel_id():
+    result = studio_links.build_studio_link_result(
+        workspace="default",
+        studio_base_url=None,
+        args={"destination": "fileset_panel", "name": "my fileset"},
+    )
+    # `fileset_panel` -> filesetDetails route `:filesetId` is the namespaced
+    # entity reference `{workspace}/{name}` encoded as one segment.
+    assert result["path"] == "/workspaces/default/filesets/default%2Fmy%20fileset"
+
+
+def test_build_studio_link_result_does_not_double_prefix_namespaced_fileset():
+    result = studio_links.build_studio_link_result(
+        workspace="default",
+        studio_base_url=None,
+        args={"destination": "fileset_file", "name": "default/my-fileset", "file_path": "a.csv"},
+    )
+    # An already-namespaced name must not be prefixed again.
+    assert result["path"] == "/workspaces/default/filesets/default%2Fmy-fileset/file/a.csv"
+
+
+def test_build_studio_link_result_keeps_bare_name_for_fileset_detail():
+    result = studio_links.build_studio_link_result(
+        workspace="default",
+        studio_base_url=None,
+        args={"destination": "fileset", "name": "my-fileset"},
+    )
+    # `fileset` -> filesetDetail route `:filesetName` is the bare name.
+    assert result["path"] == "/workspaces/default/filesets/my-fileset/detail"
 
 
 def test_mcp_studio_link_returns_intake_span_markdown(monkeypatch: pytest.MonkeyPatch):

--- a/web/packages/common/src/components/FileContentPreview/FileContentPreview.test.tsx
+++ b/web/packages/common/src/components/FileContentPreview/FileContentPreview.test.tsx
@@ -165,6 +165,27 @@ describe('FileContentPreview', () => {
     });
   });
 
+  describe('Parquet files', () => {
+    it('renders parquet (serialized as JSONL) rows in a table', () => {
+      render(
+        <FileContentPreview
+          file={{ path: 'trace.parquet' }}
+          isLoading={false}
+          error={null}
+          content={'{"subject":"Hello","label":"ham"}\n{"subject":"Win cash","label":"phishing"}'}
+        />
+      );
+      // Column headers derived from the object keys
+      expect(screen.getByText('subject')).toBeInTheDocument();
+      expect(screen.getByText('label')).toBeInTheDocument();
+      // Cell values
+      expect(screen.getByText('Hello')).toBeInTheDocument();
+      expect(screen.getByText('phishing')).toBeInTheDocument();
+      // Not rendered as a raw code editor
+      expect(screen.queryByTestId('code-editor')).toBeNull();
+    });
+  });
+
   describe('Plain text fallback', () => {
     it('routes unknown extensions through CodeEditor with contentType=text', () => {
       render(

--- a/web/packages/common/src/components/FileContentPreview/index.tsx
+++ b/web/packages/common/src/components/FileContentPreview/index.tsx
@@ -11,6 +11,11 @@ import {
 import type { FileListItem } from '@nemo/common/src/components/FileList';
 import { MarkdownContent } from '@nemo/common/src/components/MarkdownContent';
 import { ScrollTable } from '@nemo/common/src/components/ScrollTable';
+import {
+  buildRowsAndKeysFromJsonlSample,
+  formatJsonlSampleCellValue,
+  labelForJsonlSampleColumnKey,
+} from '@nemo/common/src/utils/parseJsonlObjectSample';
 import { Flex, Spinner, TableRowDefinition, Text } from '@nvidia/foundations-react-core';
 import Papa from 'papaparse';
 import { FC, useEffect, useMemo, useState } from 'react';
@@ -41,7 +46,15 @@ export const FileContentPreview: FC<FileContentPreviewProps> = ({
   const isJson = useMemo(() => isJsonFile(jsonContentType), [jsonContentType]);
   const extension = useMemo(() => getFileExtension(file.path), [file.path]);
   const isCsv = extension === '.csv';
+  const isParquet = extension === '.parquet';
   const isMarkdown = extension !== null && MARKDOWN_EXTENSIONS.has(extension);
+
+  // Parquet is decoded upstream to newline-delimited JSON objects (one row per
+  // line). Render it as a table rather than raw JSON text.
+  const parquetTable = useMemo(() => {
+    if (!isParquet || !content) return null;
+    return buildRowsAndKeysFromJsonlSample(content);
+  }, [isParquet, content]);
 
   // Parse CSV if applicable
   useEffect(() => {
@@ -136,6 +149,26 @@ export const FileContentPreview: FC<FileContentPreviewProps> = ({
       id: index.toString(),
       cells: csvData.columns.map((column: string) => ({
         children: String(row[column] ?? ''),
+      })),
+    }));
+
+    return (
+      <div className="h-full p-4">
+        <ScrollTable columns={columns} rows={rows} pagination={false} allowHorizontalScroll />
+      </div>
+    );
+  }
+
+  // Parquet files - rendered as a table from the upstream JSONL serialization
+  if (isParquet && parquetTable && parquetTable.rows.length > 0) {
+    const columns = parquetTable.columnKeys.map((key: string) => ({
+      children: labelForJsonlSampleColumnKey(key),
+    }));
+
+    const rows: TableRowDefinition[] = parquetTable.rows.map((row) => ({
+      id: row.id,
+      cells: parquetTable.columnKeys.map((key: string) => ({
+        children: formatJsonlSampleCellValue(row.values[key]),
       })),
     }));
 

--- a/web/packages/studio/src/components/FilesetFilePreviewPanel/components/FilesetFilePreviewHeader/index.tsx
+++ b/web/packages/studio/src/components/FilesetFilePreviewPanel/components/FilesetFilePreviewHeader/index.tsx
@@ -30,9 +30,9 @@ export const FilesetFilePreviewHeader: FC<FilesetFilePreviewHeaderProps> = ({
   onDeleteSuccess,
   onRenameSuccess,
 }) => (
-  <Flex justify="between" align="center" gap="density-sm" className="shrink-0 w-full">
-    <Flex gap="density-sm" align="center" className="min-w-0">
-      <FolderOpen width={16} height={16} />
+  <Flex justify="between" align="center" gap="density-sm" className="shrink-0 w-full pr-28">
+    <Flex gap="density-sm" align="center" className="min-w-0 overflow-hidden">
+      <FolderOpen width={16} height={16} className="shrink-0" />
       <FileBreadcrumbs
         filesetName={filesetName}
         filePath={filePath}

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/artifacts.test.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/artifacts.test.ts
@@ -136,7 +136,48 @@ describe('Claude Code chat artifacts', () => {
       {
         label: 'Dataset file',
         destination: 'fileset_file',
-        href: '/workspaces/default/filesets/training%20data/file/nested%2Fexamples.jsonl',
+        href: '/workspaces/default/filesets/default%2Ftraining%20data/file/nested%2Fexamples.jsonl',
+      },
+    ]);
+  });
+
+  it('namespaces the fileset id but does not double-prefix an already-namespaced name', () => {
+    const artifacts = updateClaudeCodeChatArtifactsFromEvent(
+      { ...createEmptyClaudeCodeChatArtifacts(), workspace: 'default' },
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'mcp__nemo_studio__studio_link',
+              input: { destination: 'fileset_panel', name: 'my fileset', label: 'Fileset' },
+            },
+            {
+              type: 'tool_use',
+              name: 'mcp__nemo_studio__studio_link',
+              input: {
+                destination: 'fileset_file',
+                name: 'default/my-fileset',
+                file_path: 'a.csv',
+                label: 'File',
+              },
+            },
+          ],
+        },
+      }
+    );
+
+    expect(artifacts.links).toEqual([
+      {
+        label: 'Fileset',
+        destination: 'fileset_panel',
+        href: '/workspaces/default/filesets/default%2Fmy%20fileset',
+      },
+      {
+        label: 'File',
+        destination: 'fileset_file',
+        href: '/workspaces/default/filesets/default%2Fmy-fileset/file/a.csv',
       },
     ]);
   });

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/artifacts.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/artifacts.ts
@@ -100,6 +100,11 @@ const STUDIO_LINK_PATH_TEMPLATES: Record<string, string> = {
   experiment_group: '/workspaces/{workspace}/experiment/{name}',
   experiment_detail: '/workspaces/{workspace}/experiment/{name}/{experiment_name}',
 };
+// Destinations whose `{name}` segment is the route's `:filesetId` param, which is the
+// namespaced entity reference `{workspace}/{name}` encoded as a single path segment
+// (e.g. `default%2Fmy-fileset`) — not the bare name. The `fileset` (…/detail) route
+// uses `:filesetName` (bare) instead, so it is intentionally excluded.
+const NAMESPACED_FILESET_DESTINATIONS = new Set(['fileset_panel', 'fileset_file']);
 const STUDIO_LINK_ARGUMENT_ALIASES = {
   name: [
     'resource_name',
@@ -224,7 +229,18 @@ const buildStudioLinkHrefFromInput = (
     const value = getStudioLinkArgument(input, argumentName);
     if (!value) return undefined;
 
-    values[argumentName] = encodeURIComponent(value);
+    // The `:filesetId` route param is the namespaced entity reference
+    // `{workspace}/{name}`; prefix the workspace unless the agent already
+    // supplied a namespaced value.
+    const resolved =
+      argumentName === 'name' &&
+      destination !== undefined &&
+      NAMESPACED_FILESET_DESTINATIONS.has(destination) &&
+      !value.includes('/')
+        ? `${workspaceValue}/${value}`
+        : value;
+
+    values[argumentName] = encodeURIComponent(resolved);
   }
 
   return template.replace(


### PR DESCRIPTION
This PR aims to fix Code Agent links to filesets, fileset file headers blocking the action menu and allowing parquet files to be rendered as tables.

Fileset header Issue:
<img width="588" height="322" alt="image" src="https://github.com/user-attachments/assets/5c88e67f-fe0e-4ab9-ab24-29b6de6edee4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Studio file links now correctly open fileset-related pages using workspace-scoped names, improving navigation for filesets and fileset files.
  * File previews now render Parquet files as readable tables instead of plain text.

* **Bug Fixes**
  * Fixed double-encoding and double-prefixing issues in generated fileset links.
  * Improved fileset link behavior so already namespaced names continue to work correctly.

* **Style**
  * Adjusted file preview header spacing and layout for better display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->