### PR TITLE
ci: manage NGC metadata programmatically

### DIFF
--- a/.github/actions/changes/action.yaml
+++ b/.github/actions/changes/action.yaml
@@ -43,6 +43,9 @@ outputs:
   guardrails-benchmark:
     description: "'true' if the nemo-guardrails plugin or guardrails service changed"
     value: ${{ steps.filter.outputs.guardrails-benchmark }}
+  ngc-metadata:
+    description: "'true' if NGC metadata scripts, tests, or assets changed"
+    value: ${{ steps.filter.outputs.ngc-metadata }}
   cpu-smoke:
     description: "'true' if CPU smoke image or Kubernetes smoke test inputs changed"
     value: ${{ steps.filter.outputs.deps == 'true' || steps.filter.outputs.docker == 'true' || steps.filter.outputs.docker-scripts == 'true' || steps.filter.outputs.helm == 'true' || steps.filter.outputs.openapi == 'true' || steps.filter.outputs.python-runtime == 'true' || steps.filter.outputs.web-studio == 'true' || steps.filter.outputs.k8s-smoke == 'true' }}
@@ -103,3 +106,7 @@ runs:
           guardrails-benchmark:
             - 'plugins/nemo-guardrails/**'
             - 'services/guardrails/**'
+          ngc-metadata:
+            - '.github/scripts/ngc_metadata.py'
+            - '.github/scripts/tests/test_ngc_metadata.py'
+            - '.github/assets/ngc/**'

--- a/.github/assets/ngc/charts/nemo-platform.md
+++ b/.github/assets/ngc/charts/nemo-platform.md
@@ -1,0 +1,12 @@
+## NeMo Platform Helm Chart
+
+NVIDIA NeMo Platform Helm Chart for the deployment of NeMo Platform on Kubernetes.
+
+### Resources
+
+[Documentation](https://docs.nvidia.com/nemo-platform)
+
+### License
+
+This container is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).
+

--- a/.github/assets/ngc/charts/nemo-platform.md
+++ b/.github/assets/ngc/charts/nemo-platform.md
@@ -8,5 +8,5 @@ NVIDIA NeMo Platform Helm Chart for the deployment of NeMo Platform on Kubernete
 
 ### License
 
-This container is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).
+This chart is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).
 

--- a/.github/assets/ngc/containers/auditor-tasks.md
+++ b/.github/assets/ngc/containers/auditor-tasks.md
@@ -1,0 +1,14 @@
+---
+description: Job runner for NeMo Auditor, part of NeMo Platform
+---
+## NeMo Auditor Tasks Container
+
+This container provides job support for NeMo Auditor.  It is designed to run as part of NeMo Platform.
+
+### Resources
+
+[Documentation](https://docs.nvidia.com/nemo-platform)
+
+### License
+
+This container is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).

--- a/.github/assets/ngc/containers/nmp-api.md
+++ b/.github/assets/ngc/containers/nmp-api.md
@@ -1,0 +1,14 @@
+---
+description: API component of NeMo Platform
+---
+## NeMo Platform API Container
+
+This container image provides a deployable API interface to NeMo Platform.
+
+### Resources
+
+[Documentation](https://docs.nvidia.com/nemo-platform)
+
+### License
+
+This container is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).

--- a/.github/assets/ngc/containers/nmp-api.md
+++ b/.github/assets/ngc/containers/nmp-api.md
@@ -3,7 +3,7 @@ description: API component of NeMo Platform
 ---
 ## NeMo Platform API Container
 
-This container image provides a deployable API interface to NeMo Platform.
+This container image provides a REST API for NeMo Platform.
 
 ### Resources
 

--- a/.github/assets/ngc/containers/nmp-automodel-tasks.md
+++ b/.github/assets/ngc/containers/nmp-automodel-tasks.md
@@ -1,3 +1,8 @@
+---
+labels:
+  - Fine Tuning
+  - NeMo
+---
 ## NeMo Automodel Tasks Container
 
 This container image provides job support for NeMo Automodel workflows. It is designed to run as part of NeMo Platform.

--- a/.github/assets/ngc/containers/nmp-automodel-tasks.md
+++ b/.github/assets/ngc/containers/nmp-automodel-tasks.md
@@ -1,0 +1,11 @@
+## NeMo Automodel Tasks Container
+
+This container image provides job support for NeMo Automodel workflows. It is designed to run as part of NeMo Platform.
+
+### Resources
+
+[Documentation](https://docs.nvidia.com/nemo-platform)
+
+### License
+
+This container is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).

--- a/.github/assets/ngc/containers/nmp-automodel-training.md
+++ b/.github/assets/ngc/containers/nmp-automodel-training.md
@@ -1,3 +1,8 @@
+---
+labels:
+  - Fine Tuning
+  - NeMo
+---
 ## NeMo Automodel Training Container
 
 This container image provides the model training runtime for NeMo Automodel. It is designed to run as part of NeMo Platform.

--- a/.github/assets/ngc/containers/nmp-automodel-training.md
+++ b/.github/assets/ngc/containers/nmp-automodel-training.md
@@ -1,0 +1,11 @@
+## NeMo Automodel Training Container
+
+This container image provides the model training runtime for NeMo Automodel. It is designed to run as part of NeMo Platform.
+
+### Resources
+
+[Documentation](https://docs.nvidia.com/nemo-platform)
+
+### License
+
+This container is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).

--- a/.github/assets/ngc/containers/nmp-core.md
+++ b/.github/assets/ngc/containers/nmp-core.md
@@ -1,0 +1,11 @@
+## NeMo Platform Core Container
+
+This container image provides required services for a deployed version of the NeMo Platform.
+
+### Resources
+
+[Documentation](https://docs.nvidia.com/nemo-platform)
+
+### License
+
+This container is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).

--- a/.github/assets/ngc/containers/nmp-cpu-tasks.md
+++ b/.github/assets/ngc/containers/nmp-cpu-tasks.md
@@ -1,0 +1,11 @@
+## NeMo Platform CPU Tasks Container
+
+This container image provides platform components needed for a deployed NeMo Platform.
+
+### Resources
+
+[Documentation](https://docs.nvidia.com/nemo-platform)
+
+### License
+
+This container is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).

--- a/.github/assets/ngc/containers/nmp-unsloth-training.md
+++ b/.github/assets/ngc/containers/nmp-unsloth-training.md
@@ -1,3 +1,8 @@
+---
+labels:
+  - Fine Tuning
+  - NeMo
+---
 ## NeMo Unsloth Training Container
 
 This container image provides an Unsloth-based model training runtime. It is designed to run as part of NeMo Platform.

--- a/.github/assets/ngc/containers/nmp-unsloth-training.md
+++ b/.github/assets/ngc/containers/nmp-unsloth-training.md
@@ -1,0 +1,11 @@
+## NeMo Unsloth Training Container
+
+This container image provides an Unsloth-based model training runtime. It is designed to run as part of NeMo Platform.
+
+### Resources
+
+[Documentation](https://docs.nvidia.com/nemo-platform)
+
+### License
+
+This container is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).

--- a/.github/assets/ngc/containers/safe-synthesizer-tasks.md
+++ b/.github/assets/ngc/containers/safe-synthesizer-tasks.md
@@ -1,0 +1,11 @@
+## NeMo Safe Synthesizer Tasks Container
+
+This Docker container image provides the NeMo Platform GPU task runtime for NeMo Safe Synthesizer.
+
+### Resources
+
+[Documentation](https://docs.nvidia.com/nemo-platform)
+
+### License
+
+This container is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).

--- a/.github/scripts/ngc_metadata.py
+++ b/.github/scripts/ngc_metadata.py
@@ -1,0 +1,218 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "ngcsdk==4.20.1",
+#   "pyyaml>=6.0.2",
+#   "typer>=0.24.1,<0.25",
+# ]
+# ///
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Create or update NGC metadata from Markdown files."""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated, Literal
+
+import typer
+import yaml
+from ngcbase.errors import ResourceNotFoundException
+from ngcsdk import Client
+from registry.errors import ChartNotFoundException
+
+DEFAULT_ASSETS_DIR = Path(".github/assets/ngc")
+DEFAULT_LABELS = ["NeMo"]
+DEFAULT_LOGO = "https://images.ngc.nvidia.com/public-images/llm-social-data-flywheel-gtc25-1200x675.png"
+PUBLISHER = "NVIDIA"
+SUPPORTED_DIRECTORIES: dict[str, Literal["container", "chart"]] = {
+    "containers": "container",
+    "charts": "chart",
+}
+WORD_OVERRIDES = {
+    "api": "API",
+    "cpu": "CPU",
+    "gpu": "GPU",
+    "nemo": "NeMo",
+    "nmp": "NeMo Platform",
+    "sdk": "SDK",
+}
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+@dataclass(frozen=True)
+class Asset:
+    asset_type: Literal["container", "chart"]
+    name: str
+    overview: str
+    display_name: str
+    description: str
+    labels: list[str]
+    logo: str
+
+
+def default_display_name(name: str) -> str:
+    """Convert an NGC asset name into a human-readable display name."""
+    return " ".join(WORD_OVERRIDES.get(word.lower(), word.capitalize()) for word in name.split("-"))
+
+
+def split_front_matter(content: str) -> tuple[dict[str, object], str]:
+    """Split optional YAML front matter from Markdown content."""
+    if not content.startswith("---\n"):
+        return {}, content
+
+    try:
+        front_matter, overview = content[4:].split("\n---\n", maxsplit=1)
+    except ValueError as error:
+        raise ValueError("Markdown front matter must end with '---'") from error
+
+    metadata = yaml.safe_load(front_matter) or {}
+    if not isinstance(metadata, dict):
+        raise ValueError("Markdown front matter must be a mapping")
+    return metadata, overview
+
+
+def load_asset(path: Path, asset_type: Literal["container", "chart"]) -> Asset:
+    """Load one asset and apply its metadata defaults."""
+    metadata, overview = split_front_matter(path.read_text(encoding="utf-8"))
+    name = path.stem
+    display_name = str(metadata.get("display_name") or default_display_name(name))
+    default_description = (
+        f"Deploy {display_name} to Kubernetes"
+        if asset_type == "chart"
+        else f"{display_name} is part of the NeMo Platform"
+    )
+    description = str(metadata.get("description") or default_description)
+    labels = metadata.get("labels", DEFAULT_LABELS)
+    if not isinstance(labels, list) or not all(isinstance(label, str) for label in labels):
+        raise ValueError(f"labels must be a list of strings: {path}")
+    labels = [str(label) for label in labels]
+
+    return Asset(
+        asset_type=asset_type,
+        name=name,
+        overview=overview,
+        display_name=display_name,
+        description=description,
+        labels=labels,
+        logo=str(metadata.get("logo") or DEFAULT_LOGO),
+    )
+
+
+def discover_assets(assets_dir: Path) -> list[Asset]:
+    """Discover assets from the directory name and Markdown filename."""
+    assets = []
+    for directory, asset_type in SUPPORTED_DIRECTORIES.items():
+        assets.extend(load_asset(path, asset_type) for path in sorted((assets_dir / directory).glob("*.md")))
+    return assets
+
+
+def _target(org: str, team: str, name: str) -> str:
+    return f"{org}/{team}/{name}"
+
+
+def sync_container(client: Client, asset: Asset, target: str) -> Literal["created", "updated"]:
+    """Create or update one container repository."""
+    try:
+        client.registry.image.info(target)
+    except ResourceNotFoundException:
+        client.registry.image.create(
+            image=target,
+            desc=asset.description,
+            overview=asset.overview,
+            label=asset.labels,
+            logo=asset.logo,
+            publisher=PUBLISHER,
+            display_name=asset.display_name,
+        )
+        return "created"
+
+    client.registry.image.update(
+        image=target,
+        desc=asset.description,
+        overview=asset.overview,
+        labels=asset.labels,
+        logo=asset.logo,
+        publisher=PUBLISHER,
+        display_name=asset.display_name,
+    )
+    return "updated"
+
+
+def sync_chart(client: Client, asset: Asset, target: str) -> Literal["created", "updated"]:
+    """Create or update one Helm chart."""
+    try:
+        client.registry.chart.info(target)
+        exists = True
+    except (ChartNotFoundException, ResourceNotFoundException):
+        exists = False
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", encoding="utf-8") as overview_file:
+        overview_file.write(asset.overview)
+        overview_file.flush()
+        metadata = {
+            "target": target,
+            "overview_filepath": overview_file.name,
+            "display_name": asset.display_name,
+            "labels": asset.labels,
+            "logo": asset.logo,
+            "publisher": PUBLISHER,
+            "short_description": asset.description,
+        }
+        if exists:
+            client.registry.chart.update(**metadata)
+            return "updated"
+
+        client.registry.chart.create(**metadata)
+        return "created"
+
+
+def sync_asset(client: Client, asset: Asset, org: str, team: str) -> Literal["created", "updated"]:
+    target = _target(org, team, asset.name)
+    if asset.asset_type == "container":
+        return sync_container(client, asset, target)
+    return sync_chart(client, asset, target)
+
+
+@app.command()
+def main(
+    org: Annotated[str, typer.Option(help="NGC organization.", envvar="NGC_ORG_NAME")],
+    team: Annotated[str, typer.Option(help="NGC team.", envvar="NGC_TEAM_NAME")],
+    assets_dir: Annotated[
+        Path, typer.Option(help="Directory containing charts/ and containers/.")
+    ] = DEFAULT_ASSETS_DIR,
+    api_key: Annotated[str | None, typer.Option(help="NGC API key.", envvar="NGC_API_KEY")] = None,
+    dry_run: Annotated[bool, typer.Option(help="List assets without changing NGC.")] = False,
+) -> None:
+    """Synchronize Markdown metadata with NGC.
+
+    The parent directory selects the asset type and the filename selects its
+    NGC name. Optional YAML front matter can override display_name,
+    description, labels, and logo.
+    """
+    assets = discover_assets(assets_dir)
+    if not assets:
+        raise typer.BadParameter(f"no Markdown assets found in {assets_dir}")
+
+    if dry_run:
+        for asset in assets:
+            typer.echo(f"Would sync {asset.asset_type} {_target(org, team, asset.name)}")
+        return
+
+    if not api_key:
+        raise typer.BadParameter("NGC API key is required")
+
+    client = Client()
+    client.configure(api_key=api_key, org_name=org, team_name=team)
+    for asset in assets:
+        action = sync_asset(client, asset, org, team)
+        typer.echo(f"{action.capitalize()} {asset.asset_type} {_target(org, team, asset.name)}")
+
+
+if __name__ == "__main__":
+    app()

--- a/.github/scripts/ngc_metadata.py
+++ b/.github/scripts/ngc_metadata.py
@@ -187,6 +187,10 @@ def main(
         Path, typer.Option(help="Directory containing charts/ and containers/.")
     ] = DEFAULT_ASSETS_DIR,
     api_key: Annotated[str | None, typer.Option(help="NGC API key.", envvar="NGC_API_KEY")] = None,
+    auth_match_team: Annotated[
+        bool,
+        typer.Option(help="Configure SDK authentication for the target team."),
+    ] = False,
     dry_run: Annotated[bool, typer.Option(help="List assets without changing NGC.")] = False,
 ) -> None:
     """Synchronize Markdown metadata with NGC.
@@ -208,7 +212,7 @@ def main(
         raise typer.BadParameter("NGC API key is required")
 
     client = Client()
-    client.configure(api_key=api_key, org_name=org, team_name=team)
+    client.configure(api_key=api_key, org_name=org, team_name=team if auth_match_team else "no-team")
     for asset in assets:
         action = sync_asset(client, asset, org, team)
         typer.echo(f"{action.capitalize()} {asset.asset_type} {_target(org, team, asset.name)}")

--- a/.github/scripts/tests/test_ngc_metadata.py
+++ b/.github/scripts/tests/test_ngc_metadata.py
@@ -1,0 +1,254 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "ngcsdk==4.20.1",
+#   "pytest>=9.0.3,<10",
+#   "pyyaml>=6.0.2",
+#   "typer>=0.24.1,<0.25",
+# ]
+# ///
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import tomllib
+from importlib.metadata import version
+from inspect import signature
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from ngcbase.errors import ResourceNotFoundException
+from typer.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+
+from ngc_metadata import (  # noqa: E402
+    DEFAULT_LABELS,
+    DEFAULT_LOGO,
+    PUBLISHER,
+    Client,
+    app,
+    default_display_name,
+    discover_assets,
+    load_asset,
+    sync_chart,
+    sync_container,
+)
+
+
+def test_ngc_sdk_pin_matches_production_script() -> None:
+    script_path = Path(__file__).parents[1] / "ngc_metadata.py"
+    metadata_block = script_path.read_text(encoding="utf-8").split("# ///", maxsplit=2)[1]
+    metadata = tomllib.loads("\n".join(line.removeprefix("# ") for line in metadata_block.splitlines()[1:]))
+    ngc_sdk_pin = next(
+        dependency.removeprefix("ngcsdk==")
+        for dependency in metadata["dependencies"]
+        if dependency.startswith("ngcsdk==")
+    )
+
+    assert version("ngcsdk") == ngc_sdk_pin
+
+
+def test_ngc_sdk_supports_required_metadata_parameters() -> None:
+    client = Client()
+
+    container_parameters = {
+        "image",
+        "desc",
+        "overview",
+        "logo",
+        "publisher",
+        "display_name",
+    }
+    assert container_parameters | {"label"} <= signature(client.registry.image.create).parameters.keys()
+    assert container_parameters | {"labels"} <= signature(client.registry.image.update).parameters.keys()
+
+    chart_parameters = {
+        "target",
+        "short_description",
+        "overview_filepath",
+        "display_name",
+        "labels",
+        "logo",
+        "publisher",
+    }
+    assert chart_parameters <= signature(client.registry.chart.create).parameters.keys()
+    assert chart_parameters <= signature(client.registry.chart.update).parameters.keys()
+
+
+def test_default_display_name_preserves_known_names() -> None:
+    assert default_display_name("nmp-cpu-tasks") == "NeMo Platform CPU Tasks"
+    assert default_display_name("safe-synthesizer-tasks") == "Safe Synthesizer Tasks"
+
+
+def test_load_asset_uses_defaults(tmp_path: Path) -> None:
+    path = tmp_path / "auditor-tasks.md"
+    path.write_text("# Overview\n", encoding="utf-8")
+
+    asset = load_asset(path, "container")
+
+    assert asset.name == "auditor-tasks"
+    assert asset.display_name == "Auditor Tasks"
+    assert asset.description == "Auditor Tasks is part of the NeMo Platform"
+    assert asset.labels == DEFAULT_LABELS
+    assert asset.logo == DEFAULT_LOGO
+    assert asset.overview == "# Overview\n"
+
+
+def test_load_chart_uses_deployment_description(tmp_path: Path) -> None:
+    path = tmp_path / "nemo-platform.md"
+    path.write_text("# Overview\n", encoding="utf-8")
+
+    asset = load_asset(path, "chart")
+
+    assert asset.description == "Deploy NeMo Platform to Kubernetes"
+
+
+def test_load_asset_applies_front_matter_overrides(tmp_path: Path) -> None:
+    path = tmp_path / "auditor-tasks.md"
+    path.write_text(
+        "---\n"
+        "display_name: NeMo Auditor\n"
+        "description: Runs auditor jobs\n"
+        "labels: [NeMo, Security]\n"
+        "logo: https://example.com/logo.png\n"
+        "---\n"
+        "# Overview\n",
+        encoding="utf-8",
+    )
+
+    asset = load_asset(path, "container")
+
+    assert asset.display_name == "NeMo Auditor"
+    assert asset.description == "Runs auditor jobs"
+    assert asset.labels == ["NeMo", "Security"]
+    assert asset.logo == "https://example.com/logo.png"
+    assert asset.overview == "# Overview\n"
+
+
+def test_discover_assets_infers_type_and_name(tmp_path: Path) -> None:
+    (tmp_path / "charts").mkdir()
+    (tmp_path / "containers").mkdir()
+    (tmp_path / "charts" / "nemo-platform.md").write_text("chart", encoding="utf-8")
+    (tmp_path / "containers" / "nmp-api.md").write_text("container", encoding="utf-8")
+
+    assets = discover_assets(tmp_path)
+
+    assert [(asset.asset_type, asset.name) for asset in assets] == [
+        ("container", "nmp-api"),
+        ("chart", "nemo-platform"),
+    ]
+
+
+def test_repository_assets_are_valid() -> None:
+    assets_dir = Path(__file__).parents[2] / "assets" / "ngc"
+
+    assert discover_assets(assets_dir)
+
+
+def test_sync_container_updates_existing_asset(tmp_path: Path) -> None:
+    asset = load_asset(_write_overview(tmp_path / "nmp-api.md"), "container")
+    client = MagicMock()
+
+    action = sync_container(client, asset, "org/team/nmp-api")
+
+    assert action == "updated"
+    client.registry.image.update.assert_called_once_with(
+        image="org/team/nmp-api",
+        desc=asset.description,
+        overview=asset.overview,
+        labels=DEFAULT_LABELS,
+        logo=DEFAULT_LOGO,
+        publisher=PUBLISHER,
+        display_name=asset.display_name,
+    )
+    client.registry.image.create.assert_not_called()
+
+
+def test_sync_container_creates_missing_asset(tmp_path: Path) -> None:
+    asset = load_asset(_write_overview(tmp_path / "nmp-api.md"), "container")
+    client = MagicMock()
+    client.registry.image.info.side_effect = ResourceNotFoundException("missing")
+
+    action = sync_container(client, asset, "org/team/nmp-api")
+
+    assert action == "created"
+    client.registry.image.create.assert_called_once_with(
+        image="org/team/nmp-api",
+        desc=asset.description,
+        overview=asset.overview,
+        label=DEFAULT_LABELS,
+        logo=DEFAULT_LOGO,
+        publisher=PUBLISHER,
+        display_name=asset.display_name,
+    )
+    client.registry.image.update.assert_not_called()
+
+
+def test_sync_chart_creates_missing_asset(tmp_path: Path) -> None:
+    asset = load_asset(_write_overview(tmp_path / "nemo-platform.md"), "chart")
+    client = MagicMock()
+    client.registry.chart.info.side_effect = ResourceNotFoundException("missing")
+    uploaded_overview = ""
+
+    def capture_overview(**kwargs: object) -> None:
+        nonlocal uploaded_overview
+        uploaded_overview = Path(str(kwargs["overview_filepath"])).read_text(encoding="utf-8")
+
+    client.registry.chart.create.side_effect = capture_overview
+
+    action = sync_chart(client, asset, "org/team/nemo-platform")
+
+    assert action == "created"
+    kwargs = client.registry.chart.create.call_args.kwargs
+    assert kwargs | {"overview_filepath": None} == {
+        "target": "org/team/nemo-platform",
+        "overview_filepath": None,
+        "display_name": asset.display_name,
+        "labels": DEFAULT_LABELS,
+        "logo": DEFAULT_LOGO,
+        "publisher": PUBLISHER,
+        "short_description": asset.description,
+    }
+    assert uploaded_overview == asset.overview
+    client.registry.chart.update.assert_not_called()
+
+
+def test_cli_dry_run_lists_assets(tmp_path: Path) -> None:
+    (tmp_path / "containers").mkdir()
+    _write_overview(tmp_path / "containers" / "nmp-api.md")
+
+    result = CliRunner().invoke(
+        app,
+        ["--org", "org", "--team", "team", "--assets-dir", str(tmp_path), "--dry-run"],
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout == "Would sync container org/team/nmp-api\n"
+
+
+def _write_overview(path: Path) -> Path:
+    path.write_text("# Overview\n", encoding="utf-8")
+    return path
+
+
+if __name__ == "__main__":
+    raise SystemExit(
+        pytest.main(
+            [
+                __file__,
+                "-q",
+                "-c",
+                os.devnull,
+                "-p",
+                "no:cacheprovider",
+                "-W",
+                "ignore::SyntaxWarning",
+                "--confcutdir",
+                str(Path(__file__).parent),
+            ]
+        )
+    )

--- a/.github/scripts/tests/test_ngc_metadata.py
+++ b/.github/scripts/tests/test_ngc_metadata.py
@@ -17,7 +17,7 @@ import tomllib
 from importlib.metadata import version
 from inspect import signature
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from ngcbase.errors import ResourceNotFoundException
@@ -228,6 +228,56 @@ def test_cli_dry_run_lists_assets(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert result.stdout == "Would sync container org/team/nmp-api\n"
+
+
+def test_cli_configures_org_auth_for_team_target(tmp_path: Path) -> None:
+    (tmp_path / "containers").mkdir()
+    _write_overview(tmp_path / "containers" / "nmp-api.md")
+    client = MagicMock()
+
+    with patch("ngc_metadata.Client", return_value=client):
+        result = CliRunner().invoke(
+            app,
+            [
+                "--org",
+                "org",
+                "--team",
+                "team",
+                "--assets-dir",
+                str(tmp_path),
+                "--api-key",
+                "service-key",
+            ],
+        )
+
+    assert result.exit_code == 0
+    client.configure.assert_called_once_with(api_key="service-key", org_name="org", team_name="no-team")
+    client.registry.image.info.assert_called_once_with("org/team/nmp-api")
+
+
+def test_cli_can_match_authentication_team(tmp_path: Path) -> None:
+    (tmp_path / "containers").mkdir()
+    _write_overview(tmp_path / "containers" / "nmp-api.md")
+    client = MagicMock()
+
+    with patch("ngc_metadata.Client", return_value=client):
+        result = CliRunner().invoke(
+            app,
+            [
+                "--org",
+                "org",
+                "--team",
+                "team",
+                "--assets-dir",
+                str(tmp_path),
+                "--api-key",
+                "personal-key",
+                "--auth-match-team",
+            ],
+        )
+
+    assert result.exit_code == 0
+    client.configure.assert_called_once_with(api_key="personal-key", org_name="org", team_name="team")
 
 
 def _write_overview(path: Path) -> Path:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -360,6 +360,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
         with:
           disable_swap: "true"
+          remove_go: "true"
           remove_haskell: "true"
           remove_java: "true"
           remove_ruby: "true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
       helm: ${{ steps.changes.outputs.helm }}
       cpu-smoke: ${{ steps.changes.outputs.cpu-smoke }}
       guardrails-benchmark: ${{ steps.changes.outputs.guardrails-benchmark }}
+      ngc-metadata: ${{ steps.changes.outputs.ngc-metadata }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/changes
@@ -70,6 +71,25 @@ jobs:
         shell: bash
         run: |
           "${RUNNER_TEMP}/actionlint/actionlint"
+
+  ngc-metadata-test:
+    name: Test NGC metadata sync
+    needs: [changes]
+    if: >
+      !cancelled() &&
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.ngc-metadata == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version-file: pyproject.toml
+          enable-cache: false
+      - name: Run NGC metadata unit tests
+        run: uv run --no-cache .github/scripts/tests/test_ngc_metadata.py
 
   docker-bake-graph:
     name: Docker bake graph
@@ -1532,6 +1552,7 @@ jobs:
       - helm-lint
       - helm-chart-verifier
       - lint
+      - ngc-metadata-test
       - policy-wasm
       - python-unit-test-tools
       - python-unit-test

--- a/.github/workflows/ngc-metadata.yaml
+++ b/.github/workflows/ngc-metadata.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Sync NGC metadata
         env:
-          NGC_API_KEY: ${{ secrets.AIRE_NVCR_GITHUB }}
+          NGC_API_KEY: ${{ secrets.AIRE_NGC_GITHUB_PLATFORM_RW }}
         run: >-
           uv run --no-cache .github/scripts/ngc_metadata.py
           --org 0921617854601259

--- a/.github/workflows/ngc-metadata.yaml
+++ b/.github/workflows/ngc-metadata.yaml
@@ -1,0 +1,38 @@
+name: NGC Metadata Sync
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        team:
+          - nemo-platform
+          - nemo-platform-dev
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: false
+
+      - name: Sync NGC metadata
+        env:
+          NGC_API_KEY: ${{ secrets.AIRE_NVCR_GITHUB }}
+        run: >-
+          uv run --no-cache .github/scripts/ngc_metadata.py
+          --org 0921617854601259
+          --team ${{ matrix.team }}

--- a/.github/workflows/ngc-metadata.yaml
+++ b/.github/workflows/ngc-metadata.yaml
@@ -1,9 +1,7 @@
 name: NGC Metadata Sync
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ngc-metadata.yaml
+++ b/.github/workflows/ngc-metadata.yaml
@@ -9,7 +9,6 @@ permissions:
 
 jobs:
   sync:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Using PEP 723 inline requirements to avoid polluting the actual product, this is a simple python script and test file to manage NGC metadata in a visible and reviewable fashion. The markdown files include optional frontmatter
which can be used to apply fields besides the overview with non-default values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NGC metadata synchronization via a new script and the **NGC Metadata Sync** workflow (manual or reusable calls).
  * Extended CI path-change detection with a new **ngc-metadata** flag and exposed it in the changes action output for targeted runs.
* **Tests**
  * Added/expanded unit tests for metadata parsing, sync create-vs-update behavior, and dry-run output.
* **Documentation**
  * Added documentation pages for the NeMo Platform Helm chart and related container images used during metadata sync.
* **Chores**
  * Improved CI disk usage by enabling Go cleanup in a test-image job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->