### PR TITLE
feat(evaluator-sdk): native Harbor runtime with one-call run_harbor_eval

### DIFF
--- a/packages/nemo_evaluator_sdk/examples/harbor/README.md
+++ b/packages/nemo_evaluator_sdk/examples/harbor/README.md
@@ -87,12 +87,24 @@ Both modes call `run_harbor_eval`; the only difference is what they print.
 
 ## Custom (wrapped) agents
 
-To run a real agent instead of the oracle, set `agent_import_path` on the config
-(the NeMo Optimizer path):
+To run a real agent instead of the oracle, point the config at your own
+`harbor_wrapper.py`: set `agent_import_path` and the `agent_dir` that holds it.
 
 ```python
-config = HarborRuntimeConfig(jobs_dir=jobs_dir, agent_import_path="harbor_wrapper:WrappedAgent")
+config = HarborRuntimeConfig(
+    jobs_dir=jobs_dir,
+    agent_dir="path/to/agent",            # directory containing harbor_wrapper.py
+    agent_import_path="harbor_wrapper:WrappedAgent",
+)
+result = await run_harbor_eval(config, "hello_world_dataset")
 ```
+
+The SDK makes the wrapper importable by injecting `agent_dir` into `sys.modules`
+under a unique synthetic package for the duration of the run and removing it
+afterwards — so the caller never mutates global import state (the mutation is
+lock-guarded, and each run gets its own package name so concurrent runs don't
+collide). This is `scoped_harbor_agent_import`, wired in automatically when
+`agent_import_path` is set.
 
 ## End-to-end test
 

--- a/packages/nemo_evaluator_sdk/examples/harbor/README.md
+++ b/packages/nemo_evaluator_sdk/examples/harbor/README.md
@@ -87,24 +87,33 @@ Both modes call `run_harbor_eval`; the only difference is what they print.
 
 ## Custom (wrapped) agents
 
-To run a real agent instead of the oracle, point the config at your own
-`harbor_wrapper.py`: set `agent_import_path` and the `agent_dir` that holds it.
+To run a real agent instead of the oracle, set `agent_import_path`. Two packaging
+shapes are supported, and the SDK imposes neither:
 
 ```python
+# Loose wrapper file: point agent_dir at the directory that holds harbor_wrapper.py.
 config = HarborRuntimeConfig(
     jobs_dir=jobs_dir,
     agent_dir="path/to/agent",            # directory containing harbor_wrapper.py
     agent_import_path="harbor_wrapper:WrappedAgent",
 )
+
+# Already-importable module (installed package): omit agent_dir entirely.
+config = HarborRuntimeConfig(
+    jobs_dir=jobs_dir,
+    agent_import_path="mypkg.agent:WrappedAgent",
+)
+
 result = await run_harbor_eval(config, "hello_world_dataset")
 ```
 
-The SDK makes the wrapper importable by injecting `agent_dir` into `sys.modules`
-under a unique synthetic package for the duration of the run and removing it
-afterwards — so the caller never mutates global import state (the mutation is
-lock-guarded, and each run gets its own package name so concurrent runs don't
-collide). This is `scoped_harbor_agent_import`, wired in automatically when
-`agent_import_path` is set.
+When `agent_dir` is set, the SDK makes the wrapper importable by injecting that
+directory into `sys.modules` under a unique synthetic package for the duration of
+the run and removing it afterwards — so the caller never mutates global import
+state (the mutation is lock-guarded, and each run gets its own package name so
+concurrent runs don't collide). This is `scoped_harbor_agent_import`. When
+`agent_dir` is omitted, the import path is handed to Harbor's own importer
+unchanged (Harbor resolves it with a plain `importlib.import_module`).
 
 ## End-to-end test
 

--- a/packages/nemo_evaluator_sdk/examples/harbor/README.md
+++ b/packages/nemo_evaluator_sdk/examples/harbor/README.md
@@ -1,14 +1,43 @@
 # harbor — run a Harbor job through the agent-eval SDK
 
-Two examples over a Harbor **local dataset directory**,
-[`hello_world_dataset/`](hello_world_dataset), which holds Harbor's `hello-world`
-task. Both score with Harbor's deterministic **oracle** agent, so they need no
-model or API key — only `harbor` installed and a working Docker daemon.
+Run a Harbor **local dataset directory**,
+[`hello_world_dataset/`](hello_world_dataset), natively through the SDK. The
+example scores with Harbor's deterministic **oracle** agent, so it needs no model
+or API key — only the `harbor` extra installed and a working Docker daemon.
+
+## Minimal plumbing
+
+The SDK owns the Harbor plumbing. Apart from imports, running a whole dataset is
+two lines — build a config, make one call:
+
+```python
+from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import (
+    HarborRuntimeConfig, run_harbor_eval,
+)
+
+config = HarborRuntimeConfig(jobs_dir=jobs_dir, agent_name="oracle")
+result = await run_harbor_eval(config, "hello_world_dataset")  # loads tasks, runs, scores
+```
+
+`run_harbor_eval` discovers the tasks, builds and runs Harbor's `JobConfig`, and
+scores each task with `HarborRewardMetric` — the caller never imports `harbor` or
+assembles a job. `harbor` is imported lazily inside the runtime, so importing the
+SDK never requires it.
+
+## Install
+
+Harbor is imported lazily and is **not** in the SDK's locked dependencies (it
+requires Python ≥ 3.12 while the workspace supports ≥ 3.11, like `nemo_fabric`).
+Install it separately into the environment that runs the example:
+
+```bash
+uv pip install "harbor>=0.16.1"
+```
 
 ## The dataset directory (how Harbor tasks are found)
 
-A Harbor local dataset is just a directory whose immediate subdirectories are
-task folders:
+A Harbor local dataset is a directory whose immediate subdirectories are task
+folders:
 
 ```
 hello_world_dataset/
@@ -20,24 +49,26 @@ hello_world_dataset/
     solution/solve.sh
 ```
 
-Pointing `DatasetConfig(path=hello_world_dataset)` at this directory is exactly
-how user Harbor task collections are discovered: Harbor scans the subdirs, treats
-each folder with a `task.toml` as a task, and runs them all. Drop another task
-folder in here and both Harbor and this example pick it up with no code changes —
-`discover_tasks()` mirrors the same scan to produce one scoring task per folder
-(reading the AgentEvalTask id from each `[task] name`).
+Pointing the runtime at this directory is exactly how user Harbor task
+collections are discovered: Harbor scans the subdirs, treats each folder with a
+`task.toml` as a task, and runs them all. Drop another task folder in here and it
+is picked up with no code changes — the SDK's `discover_harbor_tasks()` mirrors
+the same scan to produce one scoring task per folder (reading the task id from
+each `[task] name`).
 
-They exercise the SDK's dependency-light Harbor runtime,
-[`harbor_runtime.py`](../../src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py),
-whose design is the point of these examples:
+## Under the hood
 
-- The SDK never imports `harbor`. Job *execution* is injected as a `run_job`
-  callback (the caller owns the `JobConfig` build and Docker), while
-  `HarborAgentTaskRunner` only *reads* Harbor's on-disk
-  `<job>/<trial>/result.json` files and adapts them into `AgentEvalTrial`s.
-- `HarborRewardMetric` scores the verifier reward stamped on each trial.
-- `reward_payload_from_result` collapses a scored `AgentEvalResult` back into the
-  legacy `{reward, reward_details, exceptions}` shape older NeMo Optimizer
+The runtime is [`harbor_runtime.py`](../../src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py):
+
+- `HarborRuntimeConfig` — declarative config (agent, attempts, concurrency,
+  timeouts, artifacts) mapped onto Harbor's `JobConfig` lazily.
+- `HarborAgentTaskRunner` — runs the job (native mode) or adapts an existing job
+  dir (offline mode), then reads Harbor's on-disk `result.json` files into
+  `AgentEvalTrial`s.
+- `HarborTasksetLoader` / `discover_harbor_tasks` — turn a dataset dir into tasks.
+- `HarborRewardMetric` — scores the verifier reward stamped on each trial.
+- `reward_payload_from_result` — collapses a scored `AgentEvalResult` back into
+  the legacy `{reward, reward_details, exceptions}` shape older NeMo Optimizer
   consumers expect.
 
 ## Run it
@@ -45,31 +76,30 @@ whose design is the point of these examples:
 From the repository root:
 
 ```bash
-# Native path: build a Harbor JobConfig, run it, score through AgentEvaluator.
+# Native path: run and print the SDK summary.
 python -m packages.nemo_evaluator_sdk.examples.harbor.run_harbor_example --mode native
 
 # Optimizer path: run, then rebuild NeMo Optimizer's legacy reward payload.
 python -m packages.nemo_evaluator_sdk.examples.harbor.run_harbor_example --mode optimizer
 ```
 
-Both modes call the same `build_hello_world_job_runner` helper. The only
-difference is what they do with the result: `native` prints the SDK summary,
-`optimizer` prints the `{reward, reward_details, exceptions}` payload.
+Both modes call `run_harbor_eval`; the only difference is what they print.
 
-## How NeMo Optimizer uses this
+## Custom (wrapped) agents
 
-`NeMo-Optimizer`'s `HarborEvaluator` builds a `JobConfig` with a custom agent
-(`AgentConfig(import_path="harbor_wrapper:WrappedAgent")`), runs the job, and
-adapts the results. The `optimizer` mode mirrors that flow with the oracle agent
-so it stays runnable offline; pass `agent_import_path=...` to
-`build_hello_world_job_runner` to swap in a real wrapped agent instead.
+To run a real agent instead of the oracle, set `agent_import_path` on the config
+(the NeMo Optimizer path):
+
+```python
+config = HarborRuntimeConfig(jobs_dir=jobs_dir, agent_import_path="harbor_wrapper:WrappedAgent")
+```
 
 ## End-to-end test
 
 [`tests/agent_eval/test_harbor_runtime_e2e.py`](../../tests/agent_eval/test_harbor_runtime_e2e.py)
-imports `build_hello_world_job_runner`, runs the hello-world job natively, and
-asserts the SDK scores it as `reward == 1.0`. It is marked `e2e`/`slow` and skips
-automatically when `harbor` or Docker is unavailable:
+calls `run_harbor_eval` over the hello-world dataset and asserts the SDK scores it
+as `reward == 1.0`. It is marked `e2e`/`slow` and skips automatically when
+`harbor` or Docker is unavailable:
 
 ```bash
 uv run --frozen pytest packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime_e2e.py -v
@@ -80,13 +110,13 @@ the verifier reward. Some macOS Docker backends (e.g. colima) only reflect
 bind-mount writes for paths they share — often `$HOME` but not `/tmp`. If the
 run reports `RewardFileNotFoundError`, point the job/temp directory at a shared
 path, e.g. `pytest --basetemp="$HOME/.cache/harbor-e2e-tmp" ...` or
-`--jobs-dir "$HOME/.cache/harbor-example"` for the scripts. Linux Docker shares
+`--jobs-dir "$HOME/.cache/harbor-example"` for the script. Linux Docker shares
 all paths, so this is only a local-macOS caveat.
 
-The no-Docker unit coverage of the adapter itself lives in
+The no-Docker unit coverage of the adapter and task discovery lives in
 [`test_harbor_runtime.py`](../../tests/agent_eval/test_harbor_runtime.py).
 
 ## Files
 
-- `run_harbor_example.py` — both examples plus the shared `build_hello_world_job_runner` helper and `discover_tasks()`.
-- `hello_world_dataset/` — a Harbor local dataset directory; each subfolder is a task (`hello-world/` holds `task.toml`, `instruction.md`, `environment/`, `tests/`, `solution/`).
+- `run_harbor_example.py` — the two-line native/optimizer example.
+- `hello_world_dataset/` — a Harbor local dataset directory; each subfolder is a task.

--- a/packages/nemo_evaluator_sdk/examples/harbor/README.md
+++ b/packages/nemo_evaluator_sdk/examples/harbor/README.md
@@ -71,6 +71,21 @@ The runtime is [`harbor_runtime.py`](../../src/nemo_evaluator_sdk/agent_eval/run
   the legacy `{reward, reward_details, exceptions}` shape older NeMo Optimizer
   consumers expect.
 
+### Re-running and caching
+
+In native mode the `job_dir` doubles as a cache: if every requested task already
+has `n_attempts` completed (non-errored) results there, the Harbor run is skipped
+and the results are re-adapted instead. This only engages when you **pin a stable
+`job_name`** on the config — the default `job_name` is a timestamp, so each run
+writes a fresh dir and never hits the cache. Set `force_rerun=True` to delete the
+job dir and re-run unconditionally.
+
+```python
+config = HarborRuntimeConfig(jobs_dir=jobs_dir, job_name="hello-world", agent_name="oracle")
+await run_harbor_eval(config, "hello_world_dataset")  # first call runs Harbor
+await run_harbor_eval(config, "hello_world_dataset")  # second call re-adapts the cached job dir
+```
+
 ## Run it
 
 From the repository root:
@@ -114,6 +129,12 @@ state (the mutation is lock-guarded, and each run gets its own package name so
 concurrent runs don't collide). This is `scoped_harbor_agent_import`. When
 `agent_dir` is omitted, the import path is handed to Harbor's own importer
 unchanged (Harbor resolves it with a plain `importlib.import_module`).
+
+Only `agent_dir` itself is made importable (not `sys.path`), so a loose wrapper
+must be **self-contained**: a single module, or one that reaches sibling files
+via relative imports (`from .helper import ...`). A wrapper that does an absolute
+`import helper` of a sibling won't resolve — package and install it, then use the
+`agent_dir`-less form above.
 
 ## End-to-end test
 

--- a/packages/nemo_evaluator_sdk/examples/harbor/run_harbor_example.py
+++ b/packages/nemo_evaluator_sdk/examples/harbor/run_harbor_example.py
@@ -1,24 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Run a Harbor job through the SDK's dependency-light Harbor runtime.
+"""Run a Harbor dataset through the SDK's native Harbor runtime.
 
-Two runnable modes, both over the bundled ``hello_world_task`` (a copy of
-Harbor's ``hello-world`` task) scored with the deterministic **oracle** agent so
-no LLM/API key is needed:
+The point of this example is how *little* plumbing the caller needs: apart from
+imports, running a whole Harbor local dataset is two lines — build a
+:class:`HarborRuntimeConfig`, call :func:`run_harbor_eval`. The SDK builds and
+runs Harbor's ``JobConfig`` and scores the results; the caller never imports
+``harbor`` or assembles a job.
 
-* ``--mode native`` — the plain path: build a Harbor :class:`JobConfig`, wrap
-  ``job.run()`` in the ``run_job`` callback the SDK's
-  :class:`HarborAgentTaskRunner` expects, and score it through
-  :class:`AgentEvaluator` + :class:`HarborRewardMetric`.
-* ``--mode optimizer`` — mirrors how NeMo Optimizer consumes Harbor: run the
-  same job, then collapse the scored :class:`AgentEvalResult` back into the
-  legacy ``{reward, reward_details, exceptions}`` payload via
-  :func:`reward_payload_from_result`.
+Two modes, both over the bundled ``hello_world_dataset`` (Harbor's ``hello-world``
+task) scored with the deterministic **oracle** agent, so no LLM/API key is needed:
 
-Harbor is imported lazily inside :func:`build_hello_world_job_runner` so this
-module stays importable (e.g. from the e2e test) even when ``harbor`` is not
-installed. Running either mode requires ``harbor`` and a working Docker daemon.
+* ``--mode native`` — print the SDK summary.
+* ``--mode optimizer`` — collapse the result into NeMo Optimizer's legacy
+  ``{reward, reward_details, exceptions}`` payload.
+
+Running either mode requires ``harbor`` installed and a working Docker daemon.
 
 Run it as a module from the repository root::
 
@@ -32,155 +30,37 @@ import argparse
 import asyncio
 import json
 import logging
-import tomllib
 from pathlib import Path
 
-from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
-from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import (
-    HarborAgentTaskRunner,
-    HarborRewardMetric,
+    HarborRuntimeConfig,
     reward_payload_from_result,
+    run_harbor_eval,
 )
-from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 
 logger = logging.getLogger(__name__)
 
-# A Harbor "local dataset" is just a directory whose immediate subdirectories are
-# task folders (each with task.toml, environment/, tests/, solution/). Pointing a
-# DatasetConfig at this directory is exactly how user Harbor tasks are found: Harbor
-# scans the subdirs and runs every valid task. Drop more task folders in here and
-# both Harbor and this example pick them up with no code changes.
+# A Harbor "local dataset" is a directory whose immediate subdirectories are task
+# folders. Point the runtime at it and every task is discovered, run, and scored.
 HELLO_WORLD_DATASET_DIR = Path(__file__).resolve().parent / "hello_world_dataset"
 
-# Each task's ``task.toml`` declares ``[task] name`` (here "harbor/hello-world").
-# Harbor stamps that exact string onto each trial's ``result.json["task_name"]``,
-# and ``build_trials_from_job_dir`` matches trials to tasks by equality, so each
-# AgentEvalTask id must be the full task name (not the "hello-world" dir leaf).
-HELLO_WORLD_TASK_NAME = "harbor/hello-world"
 
+async def _main(mode: str, jobs_dir: Path) -> None:
+    # The entire caller-side plumbing: a config and one call.
+    config = HarborRuntimeConfig(jobs_dir=jobs_dir, agent_name="oracle")
+    result = await run_harbor_eval(config, HELLO_WORLD_DATASET_DIR)
 
-def discover_tasks(dataset_dir: Path) -> list[AgentEvalTask]:
-    """Build one :class:`AgentEvalTask` per Harbor task folder in ``dataset_dir``.
+    if mode == "optimizer":
+        print("Legacy optimizer reward payload:")
+        print(json.dumps(reward_payload_from_result(result), indent=2, sort_keys=True))
+        return
 
-    Mirrors Harbor's own local-dataset discovery: every immediate subdirectory
-    that contains a ``task.toml`` is a task. The AgentEvalTask id is read from
-    ``[task] name`` so it matches the ``task_name`` Harbor writes into each
-    trial's ``result.json``.
-
-    Args:
-        dataset_dir: Directory whose subdirectories are Harbor task folders.
-
-    Returns:
-        One scoring task per discovered Harbor task, ordered by directory name.
-    """
-    tasks: list[AgentEvalTask] = []
-    for task_dir in sorted(p for p in dataset_dir.iterdir() if (p / "task.toml").is_file()):
-        config = tomllib.loads((task_dir / "task.toml").read_text())
-        task_name = config.get("task", {}).get("name", task_dir.name)
-        instruction_path = task_dir / "instruction.md"
-        intent = instruction_path.read_text().strip() if instruction_path.is_file() else task_name
-        tasks.append(
-            AgentEvalTask(
-                id=task_name,
-                intent=intent,
-                inputs={"instruction": intent},
-                metrics=[HarborRewardMetric()],
-            )
-        )
-    return tasks
-
-
-def build_hello_world_job_runner(
-    jobs_dir: Path,
-    *,
-    dataset_dir: Path = HELLO_WORLD_DATASET_DIR,
-    job_name: str = "harbor-hello-world",
-    agent_import_path: str | None = None,
-) -> tuple[HarborAgentTaskRunner, list[AgentEvalTask]]:
-    """Build a :class:`HarborAgentTaskRunner` and the tasks it will score.
-
-    Points a Harbor :class:`JobConfig` at ``dataset_dir`` — a directory of task
-    folders — so Harbor discovers and runs every task in it, the same way user
-    Harbor task collections are found. The returned runner's ``run_job`` callback
-    creates and runs that job; ``build_hello_world_job_runner`` owns the Harbor
-    ``JobConfig`` build (the SDK runtime never imports Harbor), and the runner only
-    reads the job's on-disk ``result.json`` files afterward.
-
-    Args:
-        jobs_dir: Parent directory Harbor writes the ``<job_name>/`` tree into.
-        dataset_dir: Harbor local-dataset directory whose subfolders are tasks
-            (defaults to the bundled ``hello_world_dataset``).
-        job_name: Harbor job name; also the results subdirectory name.
-        agent_import_path: When set, run a custom Harbor agent via
-            ``AgentConfig(import_path=...)`` (the NeMo Optimizer path). When
-            ``None``, use Harbor's deterministic ``oracle`` agent so the run
-            needs no model or API key.
-
-    Returns:
-        A ``(runner, tasks)`` pair ready to pass to ``AgentEvaluator.run``.
-    """
-    from harbor.job import DatasetConfig, Job, JobConfig  # ty: ignore[unresolved-import]
-    from harbor.models.job.config import AgentConfig  # ty: ignore[unresolved-import]
-
-    if agent_import_path is not None:
-        agent = AgentConfig(import_path=agent_import_path)
-    else:
-        agent = AgentConfig(name="oracle")
-
-    job_config = JobConfig(
-        job_name=job_name,
-        jobs_dir=jobs_dir,
-        quiet=True,
-        agents=[agent],
-        datasets=[DatasetConfig(path=dataset_dir)],
-    )
-    job_dir = job_config.jobs_dir / job_config.job_name
-
-    async def run_job() -> None:
-        job = await Job.create(job_config)
-        await job.run()
-
-    runner = HarborAgentTaskRunner(job_dir=job_dir, run_job=run_job)
-    return runner, discover_tasks(dataset_dir)
-
-
-async def run_native(jobs_dir: Path) -> AgentEvalResult:
-    """Run the hello-world Harbor job and score it through the SDK."""
-    runner, tasks = build_hello_world_job_runner(jobs_dir)
-    result = await AgentEvaluator().run(
-        tasks=tasks,
-        target=runner,
-        config=AgentEvalRunConfig(write_dashboard=False),
-    )
     print(f"run_id: {result.run_id}  tasks: {result.summary.task_count}  trials: {result.summary.trial_count}")
     for aggregate in result.summary.scores.scores:
         print(f"  {aggregate.name}: mean={aggregate.mean}")
     for score in result.scores:
         reward = score.outputs[0].value if score.outputs else None
         print(f"  {score.task_id}: reward={reward} status={score.status.value}")
-    return result
-
-
-async def run_optimizer_style(jobs_dir: Path) -> dict:
-    """Run the same job, then rebuild NeMo Optimizer's legacy reward payload."""
-    runner, tasks = build_hello_world_job_runner(jobs_dir)
-    result = await AgentEvaluator().run(
-        tasks=tasks,
-        target=runner,
-        config=AgentEvalRunConfig(write_dashboard=False),
-    )
-    payload = reward_payload_from_result(result)
-    print("Legacy optimizer reward payload:")
-    print(json.dumps(payload, indent=2, sort_keys=True))
-    return payload
-
-
-async def _main(mode: str, jobs_dir: Path) -> None:
-    if mode == "native":
-        await run_native(jobs_dir)
-    else:
-        await run_optimizer_style(jobs_dir)
 
 
 if __name__ == "__main__":

--- a/packages/nemo_evaluator_sdk/pyproject.toml
+++ b/packages/nemo_evaluator_sdk/pyproject.toml
@@ -41,6 +41,11 @@ agent-runtimes = [
   "openai-agents[docker]>=0.17.3,<0.18",
 ]
 engine = []
+# NOTE: The native Harbor runtime (HarborAgentTaskRunner / run_harbor_eval) needs
+# `harbor`, which is intentionally NOT declared here. Harbor requires Python
+# >=3.12 while this workspace supports >=3.11, so pinning it would make the lock
+# unsatisfiable. It is imported lazily (like nemo_fabric) and installed
+# separately: `uv pip install "harbor>=0.16.1"`.
 nemo-platform = [
   "nemo-platform-sdk",
 ]

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
@@ -167,8 +167,11 @@ class HarborAgentTaskRunner:
       :func:`discover_harbor_tasks`), or from an explicit ``dataset_path``
       override, so it isn't repeated. ``task_names`` optionally restricts the run
       to a subset of tasks, and the ``config``'s ``job_dir`` doubles as a cache:
-      an existing run whose results already cover every requested task is
-      re-adapted instead of re-run (unless ``force_rerun`` is set).
+      an existing run whose results already cover every requested task (with
+      ``n_attempts`` completed, non-errored trials each) is re-adapted instead of
+      re-run (unless ``force_rerun`` is set). Caching only takes effect when a
+      stable ``job_name`` is set on the config — the default timestamped
+      ``job_name`` writes a fresh dir per run and never hits the cache.
     * **Injected / offline** — pass ``job_dir`` (and optionally a ``run_job``
       callback); ``run_job`` is awaited before the job dir is read, and
       ``run_job=None`` simply adapts an already-completed job dir.
@@ -208,12 +211,14 @@ class HarborAgentTaskRunner:
         :func:`discover_harbor_tasks`) unless a ``dataset_path`` override was given,
         so callers don't repeat it. ``job_dir`` doubles as a cache: the Harbor run
         is skipped and results are simply re-adapted when every requested task
-        already has a ``result.json`` there (unless ``force_rerun`` is set).
+        already has ``n_attempts`` completed, non-errored results there (unless
+        ``force_rerun`` is set). The cache only engages when the config pins a
+        stable ``job_name``; the default timestamped name never hits it.
         """
         if self._config is not None:
             dataset_path = self._dataset_path or _dataset_path_from_tasks(tasks)
             job_dir, run_job = _build_native_job(self._config, dataset_path, self._task_names)
-            if self._config.force_rerun or not _all_tasks_cached(job_dir, tasks):
+            if self._config.force_rerun or not _all_tasks_cached(job_dir, tasks, n_attempts=self._config.n_attempts):
                 await run_job()
             return build_trials_from_job_dir(job_dir, tasks, reward_key=self._reward_key)
 
@@ -236,23 +241,31 @@ def _dataset_path_from_tasks(tasks: Sequence[AgentEvalTask]) -> Path:
     )
 
 
-def _all_tasks_cached(job_dir: Path, tasks: Sequence[AgentEvalTask]) -> bool:
-    """Return True when every requested task already has a ``result.json`` under ``job_dir``.
+def _all_tasks_cached(job_dir: Path, tasks: Sequence[AgentEvalTask], *, n_attempts: int) -> bool:
+    """Return True when every requested task already has ``n_attempts`` completed results.
 
     Lets ``job_dir`` act as a cache so a native run whose results are all present
-    is re-adapted instead of re-run.
+    is re-adapted instead of re-run. The cache is **success-aware**: only trials
+    that finished without an ``exception_info`` count, and a task must have at
+    least ``n_attempts`` of them, so an interrupted, errored, or under-sampled run
+    is re-run rather than silently served from a partial cache. Caching only takes
+    effect when a stable ``job_name`` is set on the config; with the default
+    timestamped ``job_name`` every run writes a fresh dir and never hits the cache.
     """
     if not job_dir.is_dir():
         return False
-    present: set[str] = set()
+    counts: dict[str, int] = {}
     for result_path in job_dir.glob("*/result.json"):
         try:
-            name = json.loads(result_path.read_text()).get("task_name")
+            data = json.loads(result_path.read_text())
         except (json.JSONDecodeError, OSError):
             continue
+        if data.get("exception_info") is not None:
+            continue
+        name = data.get("task_name")
         if isinstance(name, str):
-            present.add(name)
-    return {task.id for task in tasks}.issubset(present)
+            counts[name] = counts.get(name, 0) + 1
+    return all(counts.get(task.id, 0) >= n_attempts for task in tasks)
 
 
 def _build_native_job(
@@ -272,9 +285,15 @@ def _build_native_job(
     job_dir = config.jobs_dir / job_name
 
     async def run_job() -> None:
-        from harbor.job import DatasetConfig, Job, JobConfig  # ty: ignore[unresolved-import]
-        from harbor.models.job.config import RetryConfig  # ty: ignore[unresolved-import]
-        from harbor.models.trial.config import AgentConfig, ArtifactConfig  # ty: ignore[unresolved-import]
+        try:
+            from harbor.job import DatasetConfig, Job, JobConfig  # ty: ignore[unresolved-import]
+            from harbor.models.job.config import RetryConfig  # ty: ignore[unresolved-import]
+            from harbor.models.trial.config import AgentConfig, ArtifactConfig  # ty: ignore[unresolved-import]
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "the native Harbor runtime needs `harbor`, which is not an SDK dependency "
+                '(it requires Python >=3.12). Install it separately: uv pip install "harbor>=0.16.1"'
+            ) from exc
 
         if config.force_rerun and job_dir.exists():
             shutil.rmtree(job_dir)
@@ -343,6 +362,12 @@ def scoped_harbor_agent_import(agent_dir: Path, import_path: str) -> Iterator[st
     On exit the injected ``sys.modules`` entries are removed. The mutation is
     guarded by a process-wide lock so concurrent runs don't corrupt import state;
     each run gets its own uniquely-named package so distinct agents never collide.
+
+    Only ``agent_dir`` (not ``sys.path``) is made importable, so a loose wrapper
+    must be self-contained: a single module, or one that reaches siblings via
+    relative imports (``from .helper import ...``). A wrapper that does an absolute
+    ``import helper`` of a sibling file won't resolve — install it as a package and
+    use the ``agent_dir``-less path instead.
     """
     module_name, sep, attribute = import_path.partition(":")
     module_name = module_name.strip().lstrip(".")
@@ -564,14 +589,26 @@ def discover_harbor_tasks(dataset_path: str | Path) -> list[AgentEvalTask]:
     with a ``task.toml`` is a task. The task id is read from ``[task] name`` so it
     matches the ``task_name`` Harbor writes into each trial's ``result.json``, and
     each task is scored by a :class:`HarborRewardMetric`.
+
+    Raises:
+        ValueError: if a task's ``task.toml`` or ``instruction.md`` is malformed or
+            unreadable — the offending path is named. A discovered task is never
+            silently dropped, since that would quietly shrink eval coverage.
     """
     dataset_path = Path(dataset_path)
     tasks: list[AgentEvalTask] = []
     for task_dir in _harbor_task_dirs(dataset_path):
-        config = tomllib.loads((task_dir / _TASK_CONFIG_FILENAME).read_text())
+        config_path = task_dir / _TASK_CONFIG_FILENAME
+        try:
+            config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+            raise ValueError(f"malformed Harbor task config at {config_path}: {exc}") from exc
         task_name = config.get("task", {}).get("name", task_dir.name)
         instruction_path = task_dir / "instruction.md"
-        intent = instruction_path.read_text().strip() if instruction_path.is_file() else task_name
+        try:
+            intent = instruction_path.read_text(encoding="utf-8").strip() if instruction_path.is_file() else task_name
+        except (OSError, UnicodeDecodeError) as exc:
+            raise ValueError(f"unreadable Harbor instruction at {instruction_path}: {exc}") from exc
         tasks.append(
             AgentEvalTask(
                 id=task_name,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
@@ -9,40 +9,92 @@ job directory. This runtime adapts that tree into SDK :class:`AgentEvalTrial`
 objects so an :class:`AgentEvaluator` can score and report Harbor runs through the
 same seam as any other runtime.
 
-The module is intentionally dependency-light: it does **not** import ``harbor``.
-Job *execution* is injected as the ``run_job`` callback (the caller owns Harbor's
-``JobConfig`` build, the import lock, and ``docker network prune`` cleanup), and
-trial *adaptation* only reads Harbor's on-disk ``result.json`` files. This mirrors
-how :class:`CallableAgentTaskRunner` stays free of any agent SDK, and matches the
-design note that Harbor-runtime concerns live with the caller, not the SDK.
+Two ways to drive it:
+
+* **Native** — pass a :class:`HarborRuntimeConfig` and a dataset directory; the
+  runtime builds Harbor's ``JobConfig`` and runs it itself. The one-call
+  :func:`run_harbor_eval` loads the tasks, runs, and scores, so caller code is a
+  couple of lines. ``harbor`` is imported lazily inside ``run_tasks`` (it is an
+  optional extra), so importing this module never requires Harbor.
+* **Injected / offline** — pass a ``job_dir`` (and optionally a ``run_job``
+  callback) to adapt an already-completed job dir or to run a caller-built job.
+
+Trial *adaptation* only ever reads Harbor's on-disk ``result.json`` files, so
+that half stays dependency-free regardless of how the job was produced.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import shutil
+import tomllib
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus
-from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask, AgentEvalTaskset
 from nemo_evaluator_sdk.agent_eval.trials import (
     AgentEvalTrial,
     AgentEvalTrialStatus,
     AgentOutput,
     standard_evidence_descriptors,
 )
-from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
+from nemo_evaluator_sdk.metrics.protocol import Metric, MetricInput, MetricOutput, MetricOutputSpec, MetricResult
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence
+from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
 
 # Default reward key inside Harbor's ``verifier_result.rewards`` mapping.
 DEFAULT_REWARD_KEY = "reward"
+# Filename that marks a directory as a Harbor task, and the template dir to skip.
+_TASK_CONFIG_FILENAME = "task.toml"
+_TASK_TEMPLATE_DIRNAME = "task_template"
 
 RunJob = Callable[[], Awaitable[None]]
+
+
+class HarborRuntimeConfig(BaseModel):
+    """Declarative config for running a Harbor job natively through the SDK.
+
+    Holds only plain/pydantic fields so importing this module never needs Harbor;
+    the fields are mapped onto Harbor's ``JobConfig`` lazily at run time.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    jobs_dir: Path = Field(description="Parent directory Harbor writes the ``<job_name>/`` results tree into.")
+    job_name: str | None = Field(default=None, description="Harbor job name; a timestamp is generated when omitted.")
+    agent_name: str | None = Field(
+        default="oracle",
+        description="Built-in Harbor agent to run (e.g. 'oracle'). Ignored when ``agent_import_path`` is set.",
+    )
+    agent_import_path: str | None = Field(
+        default=None,
+        description="Custom Harbor agent import path (e.g. 'harbor_wrapper:WrappedAgent'); overrides ``agent_name``.",
+    )
+    agent_model_name: str | None = Field(default=None, description="Optional model slug passed to the Harbor agent.")
+    n_attempts: int = Field(default=1, ge=1, description="Number of attempts Harbor runs per task.")
+    n_concurrent_trials: int = Field(default=4, ge=1, description="Maximum concurrent Harbor trials.")
+    quiet: bool = Field(default=True, description="Suppress Harbor's trial progress displays.")
+    force_rerun: bool = Field(default=False, description="Delete an existing job dir before running.")
+    artifacts: list[str] = Field(default_factory=list, description="Harbor artifact sources to collect per trial.")
+    trace_dir: str | None = Field(
+        default=None,
+        description="Container path of agent traces to collect as the 'traces' artifact (e.g. '/app/traces').",
+    )
+    max_retries: int = Field(default=0, ge=0, description="Harbor per-trial retry attempts on transient failures.")
+    timeout_multiplier: float | None = Field(default=None, description="Global Harbor timeout multiplier.")
+    agent_timeout_multiplier: float | None = Field(default=None, description="Agent-phase timeout multiplier.")
+    verifier_timeout_multiplier: float | None = Field(default=None, description="Verifier-phase timeout multiplier.")
+    agent_setup_timeout_multiplier: float | None = Field(default=None, description="Agent-setup timeout multiplier.")
+    environment_build_timeout_multiplier: float | None = Field(
+        default=None, description="Environment-build timeout multiplier."
+    )
+    reward_key: str = Field(default=DEFAULT_REWARD_KEY, description="Key read from Harbor's rewards mapping.")
 
 
 class HarborRewardMetric:
@@ -74,20 +126,37 @@ class HarborRewardMetric:
 class HarborAgentTaskRunner:
     """An :class:`AgentTaskRunner` that runs a Harbor job, then adapts its results.
 
-    ``run_job`` executes the Harbor job (the caller builds the ``JobConfig`` and
-    owns any locking/cleanup); it is awaited once before the job directory is
-    read. Pass ``run_job=None`` to adapt an already-completed job directory
-    (offline re-scoring). ``job_dir`` is the directory Harbor writes its
-    per-trial ``<task>__<hash>/result.json`` files into.
+    Two construction modes:
+
+    * **Native** — pass ``config`` (a :class:`HarborRuntimeConfig`) and
+      ``dataset_path``; the runtime builds and runs Harbor's ``JobConfig`` itself
+      (Harbor is imported lazily). ``task_names`` optionally restricts the run to
+      a subset of the dataset's tasks.
+    * **Injected / offline** — pass ``job_dir`` (and optionally a ``run_job``
+      callback); ``run_job`` is awaited before the job dir is read, and
+      ``run_job=None`` simply adapts an already-completed job dir.
+
+    ``job_dir`` is the directory Harbor writes its per-trial
+    ``<task>__<hash>/result.json`` files into.
     """
 
     def __init__(
         self,
         *,
-        job_dir: str | Path,
+        config: HarborRuntimeConfig | None = None,
+        dataset_path: str | Path | None = None,
+        task_names: Sequence[str] | None = None,
+        job_dir: str | Path | None = None,
         run_job: RunJob | None = None,
         reward_key: str = DEFAULT_REWARD_KEY,
     ) -> None:
+        if config is not None:
+            if dataset_path is None:
+                raise ValueError("dataset_path is required when a HarborRuntimeConfig is given")
+            job_dir, run_job = _build_native_job(config, Path(dataset_path), task_names)
+            reward_key = config.reward_key
+        if job_dir is None:
+            raise ValueError("provide either config (+dataset_path) or an explicit job_dir")
         self._job_dir = Path(job_dir)
         self._run_job = run_job
         self._reward_key = reward_key
@@ -101,6 +170,64 @@ class HarborAgentTaskRunner:
         if self._run_job is not None:
             await self._run_job()
         return build_trials_from_job_dir(self._job_dir, tasks, reward_key=self._reward_key)
+
+
+def _build_native_job(
+    config: HarborRuntimeConfig,
+    dataset_path: Path,
+    task_names: Sequence[str] | None,
+) -> tuple[Path, RunJob]:
+    """Build a Harbor ``JobConfig`` from ``config`` and return ``(job_dir, run_job)``.
+
+    Harbor is imported here (not at module load) because it is an optional extra.
+    The returned ``run_job`` coroutine applies ``force_rerun`` and runs the job.
+    """
+    from harbor.job import DatasetConfig, Job, JobConfig  # ty: ignore[unresolved-import]
+    from harbor.models.job.config import RetryConfig  # ty: ignore[unresolved-import]
+    from harbor.models.trial.config import AgentConfig, ArtifactConfig  # ty: ignore[unresolved-import]
+
+    if config.agent_import_path is not None:
+        agent = AgentConfig(import_path=config.agent_import_path, model_name=config.agent_model_name)
+    else:
+        agent = AgentConfig(name=config.agent_name or "oracle", model_name=config.agent_model_name)
+
+    artifacts: list[str | ArtifactConfig] = list(config.artifacts)
+    if config.trace_dir is not None:
+        artifacts = [ArtifactConfig(source=config.trace_dir, destination="traces"), *artifacts]
+
+    timeout_kwargs = {
+        key: value
+        for key, value in {
+            "timeout_multiplier": config.timeout_multiplier,
+            "agent_timeout_multiplier": config.agent_timeout_multiplier,
+            "verifier_timeout_multiplier": config.verifier_timeout_multiplier,
+            "agent_setup_timeout_multiplier": config.agent_setup_timeout_multiplier,
+            "environment_build_timeout_multiplier": config.environment_build_timeout_multiplier,
+        }.items()
+        if value is not None
+    }
+
+    job_config = JobConfig(
+        jobs_dir=config.jobs_dir,
+        n_attempts=config.n_attempts,
+        n_concurrent_trials=config.n_concurrent_trials,
+        quiet=config.quiet,
+        retry=RetryConfig(max_retries=config.max_retries),
+        artifacts=artifacts,
+        agents=[agent],
+        datasets=[DatasetConfig(path=dataset_path, task_names=list(task_names) if task_names else None)],
+        **({"job_name": config.job_name} if config.job_name else {}),
+        **timeout_kwargs,
+    )
+    job_dir = job_config.jobs_dir / job_config.job_name
+
+    async def run_job() -> None:
+        if config.force_rerun and job_dir.exists():
+            shutil.rmtree(job_dir)
+        job = await Job.create(job_config)
+        await job.run()
+
+    return job_dir, run_job
 
 
 def build_trials_from_job_dir(
@@ -256,6 +383,105 @@ def _token_measurements(agent_result: Any) -> dict[str, int | float]:
     return out
 
 
+def _harbor_task_dirs(dataset_path: Path) -> list[Path]:
+    """Return the Harbor task folders under ``dataset_path`` (or itself if it is one)."""
+    if (dataset_path / _TASK_CONFIG_FILENAME).is_file():
+        return [dataset_path]
+    return sorted(
+        path
+        for path in dataset_path.iterdir()
+        if path.is_dir() and path.name != _TASK_TEMPLATE_DIRNAME and (path / _TASK_CONFIG_FILENAME).is_file()
+    )
+
+
+def discover_harbor_tasks(dataset_path: str | Path) -> list[AgentEvalTask]:
+    """Build one :class:`AgentEvalTask` per Harbor task folder in ``dataset_path``.
+
+    Mirrors Harbor's own local-dataset discovery: every immediate subdirectory
+    with a ``task.toml`` is a task. The task id is read from ``[task] name`` so it
+    matches the ``task_name`` Harbor writes into each trial's ``result.json``, and
+    each task is scored by a :class:`HarborRewardMetric`.
+    """
+    dataset_path = Path(dataset_path)
+    tasks: list[AgentEvalTask] = []
+    for task_dir in _harbor_task_dirs(dataset_path):
+        config = tomllib.loads((task_dir / _TASK_CONFIG_FILENAME).read_text())
+        task_name = config.get("task", {}).get("name", task_dir.name)
+        instruction_path = task_dir / "instruction.md"
+        intent = instruction_path.read_text().strip() if instruction_path.is_file() else task_name
+        tasks.append(
+            AgentEvalTask(
+                id=task_name,
+                intent=intent,
+                inputs={"instruction": intent},
+                metrics=[HarborRewardMetric()],
+            )
+        )
+    return tasks
+
+
+class HarborTasksetLoader:
+    """Load a Harbor local-dataset directory as an :class:`AgentEvalTaskset`.
+
+    Implements the :class:`AgentEvalTasksetLoader` protocol so "dataset dir in →
+    tasks out" is a single call.
+    """
+
+    def __init__(self, dataset_path: str | Path, *, name: str = "harbor") -> None:
+        self._dataset_path = Path(dataset_path)
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def load(
+        self,
+        *,
+        source: str | Path | None = None,
+        limit: int | None = None,
+        evidence_dir: Path | None = None,
+    ) -> AgentEvalTaskset:
+        """Discover Harbor tasks under ``source`` (or the configured path) into a taskset."""
+        dataset_path = Path(source) if source is not None else self._dataset_path
+        tasks = discover_harbor_tasks(dataset_path)
+        if limit is not None:
+            tasks = tasks[:limit]
+        return AgentEvalTaskset(tasks=tasks, metadata={"harbor_dataset_path": str(dataset_path)})
+
+
+async def run_harbor_eval(
+    config: HarborRuntimeConfig,
+    dataset_path: str | Path,
+    *,
+    task_names: Sequence[str] | None = None,
+    metrics: Sequence[Metric] | None = None,
+    run_config: AgentEvalRunConfig | None = None,
+) -> AgentEvalResult:
+    """Run a Harbor dataset natively and score it — the minimal-plumbing entry point.
+
+    Loads the taskset from ``dataset_path``, runs Harbor via ``config``, and scores
+    through :class:`AgentEvaluator`. Tasks are scored by :class:`HarborRewardMetric`
+    unless ``metrics`` overrides them. Returns the scored :class:`AgentEvalResult`.
+    """
+    from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
+
+    dataset_path = Path(dataset_path)
+    tasks = HarborTasksetLoader(dataset_path).load().tasks
+    if task_names is not None:
+        wanted = set(task_names)
+        tasks = [task for task in tasks if task.id in wanted]
+    if metrics is not None:
+        tasks = [task.model_copy(update={"metrics": list(metrics)}) for task in tasks]
+
+    runner = HarborAgentTaskRunner(config=config, dataset_path=dataset_path, task_names=task_names)
+    return await AgentEvaluator().run(
+        tasks=tasks,
+        target=runner,
+        config=run_config or AgentEvalRunConfig(write_dashboard=False),
+    )
+
+
 def reward_payload_from_result(
     result: AgentEvalResult,
     *,
@@ -302,6 +528,10 @@ __all__ = [
     "DEFAULT_REWARD_KEY",
     "HarborAgentTaskRunner",
     "HarborRewardMetric",
+    "HarborRuntimeConfig",
+    "HarborTasksetLoader",
     "build_trials_from_job_dir",
+    "discover_harbor_tasks",
     "reward_payload_from_result",
+    "run_harbor_eval",
 ]

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
@@ -16,10 +16,12 @@ Two ways to drive it:
   :func:`run_harbor_eval` loads the tasks, runs, and scores, so caller code is a
   couple of lines. ``harbor`` is imported lazily inside ``run_tasks`` (it is an
   optional extra), so importing this module never requires Harbor. Custom
-  ``import_path`` agents (a user ``harbor_wrapper.py``) are supported too: set
-  ``agent_import_path`` + ``agent_dir`` and the runtime injects the agent package
-  into ``sys.modules`` for the duration of the run and tears it down after, so
-  callers never touch global import state (see :func:`scoped_harbor_agent_import`).
+  ``import_path`` agents are supported too: set ``agent_import_path`` and, for a
+  loose ``harbor_wrapper.py``, also ``agent_dir`` — the runtime then injects that
+  directory into ``sys.modules`` for the duration of the run and tears it down
+  after (see :func:`scoped_harbor_agent_import`). When ``agent_dir`` is omitted
+  (the module is already importable) the path is handed to Harbor's importer
+  unchanged, so nothing is imposed on how the agent is packaged.
 * **Injected / offline** — pass a ``job_dir`` (and optionally a ``run_job``
   callback) to adapt an already-completed job dir or to run a caller-built job.
 
@@ -94,7 +96,11 @@ class HarborRuntimeConfig(BaseModel):
     )
     agent_dir: Path | None = Field(
         default=None,
-        description="Directory holding the module named by ``agent_import_path``; required when it is set.",
+        description=(
+            "Directory holding the module named by ``agent_import_path``. Set it for a loose "
+            "wrapper file (the SDK makes it importable); leave it unset when the module is "
+            "already importable (installed package), and Harbor imports it directly."
+        ),
     )
     agent_model_name: str | None = Field(default=None, description="Optional model slug passed to the Harbor agent.")
     n_attempts: int = Field(default=1, ge=1, description="Number of attempts Harbor runs per task.")
@@ -117,9 +123,9 @@ class HarborRuntimeConfig(BaseModel):
     reward_key: str = Field(default=DEFAULT_REWARD_KEY, description="Key read from Harbor's rewards mapping.")
 
     @model_validator(mode="after")
-    def _require_agent_dir_for_import_path(self) -> HarborRuntimeConfig:
-        if self.agent_import_path is not None and self.agent_dir is None:
-            raise ValueError("agent_dir is required when agent_import_path is set")
+    def _agent_dir_needs_import_path(self) -> HarborRuntimeConfig:
+        if self.agent_dir is not None and self.agent_import_path is None:
+            raise ValueError("agent_dir only applies to a custom agent_import_path")
         return self
 
 
@@ -254,12 +260,16 @@ def _build_native_job(
             job = await Job.create(job_config)
             await job.run()
 
-        if config.agent_import_path is not None:
-            agent_dir = Path(config.agent_dir).expanduser().resolve()  # ty: ignore[invalid-argument-type]
+        if config.agent_import_path is None:
+            await _create_and_run(AgentConfig(name=config.agent_name or "oracle", model_name=config.agent_model_name))
+        elif config.agent_dir is not None:
+            # Loose wrapper file: make its directory importable for the run.
+            agent_dir = config.agent_dir.expanduser().resolve()
             with scoped_harbor_agent_import(agent_dir, config.agent_import_path) as scoped_import:
                 await _create_and_run(AgentConfig(import_path=scoped_import, model_name=config.agent_model_name))
         else:
-            await _create_and_run(AgentConfig(name=config.agent_name or "oracle", model_name=config.agent_model_name))
+            # Already-importable module (installed package): let Harbor import it directly.
+            await _create_and_run(AgentConfig(import_path=config.agent_import_path, model_name=config.agent_model_name))
 
     return job_dir, run_job
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
@@ -160,10 +160,15 @@ class HarborAgentTaskRunner:
 
     Two construction modes:
 
-    * **Native** — pass ``config`` (a :class:`HarborRuntimeConfig`) and
-      ``dataset_path``; the runtime builds and runs Harbor's ``JobConfig`` itself
-      (Harbor is imported lazily). ``task_names`` optionally restricts the run to
-      a subset of the dataset's tasks.
+    * **Native** — pass ``config`` (a :class:`HarborRuntimeConfig`); the runtime
+      builds and runs Harbor's ``JobConfig`` itself (Harbor is imported lazily).
+      The dataset directory is taken from the tasks handed to :meth:`run_tasks`
+      (each carries ``metadata['harbor_dataset_path']`` from
+      :func:`discover_harbor_tasks`), or from an explicit ``dataset_path``
+      override, so it isn't repeated. ``task_names`` optionally restricts the run
+      to a subset of tasks, and the ``config``'s ``job_dir`` doubles as a cache:
+      an existing run whose results already cover every requested task is
+      re-adapted instead of re-run (unless ``force_rerun`` is set).
     * **Injected / offline** — pass ``job_dir`` (and optionally a ``run_job``
       callback); ``run_job`` is awaited before the job dir is read, and
       ``run_job=None`` simply adapts an already-completed job dir.
@@ -182,26 +187,72 @@ class HarborAgentTaskRunner:
         run_job: RunJob | None = None,
         reward_key: str = DEFAULT_REWARD_KEY,
     ) -> None:
-        if config is not None:
-            if dataset_path is None:
-                raise ValueError("dataset_path is required when a HarborRuntimeConfig is given")
-            job_dir, run_job = _build_native_job(config, Path(dataset_path), task_names)
-            reward_key = config.reward_key
-        if job_dir is None:
-            raise ValueError("provide either config (+dataset_path) or an explicit job_dir")
-        self._job_dir = Path(job_dir)
+        if config is None and job_dir is None:
+            raise ValueError("provide either a HarborRuntimeConfig or an explicit job_dir")
+        self._config = config
+        self._dataset_path = Path(dataset_path) if dataset_path is not None else None
+        self._task_names = task_names
+        self._job_dir = Path(job_dir) if job_dir is not None else None
         self._run_job = run_job
-        self._reward_key = reward_key
+        self._reward_key = config.reward_key if config is not None else reward_key
 
     async def run_tasks(
         self,
         tasks: Sequence[AgentEvalTask],
         config: AgentEvalRunConfig | None = None,
     ) -> list[AgentEvalTrial]:
-        """Execute the Harbor job (if supplied) and return one trial per Harbor trial."""
+        """Run the Harbor job when needed, then return one trial per Harbor trial.
+
+        In native mode the dataset directory is recovered from the tasks (each
+        carries ``metadata['harbor_dataset_path']`` from
+        :func:`discover_harbor_tasks`) unless a ``dataset_path`` override was given,
+        so callers don't repeat it. ``job_dir`` doubles as a cache: the Harbor run
+        is skipped and results are simply re-adapted when every requested task
+        already has a ``result.json`` there (unless ``force_rerun`` is set).
+        """
+        if self._config is not None:
+            dataset_path = self._dataset_path or _dataset_path_from_tasks(tasks)
+            job_dir, run_job = _build_native_job(self._config, dataset_path, self._task_names)
+            if self._config.force_rerun or not _all_tasks_cached(job_dir, tasks):
+                await run_job()
+            return build_trials_from_job_dir(job_dir, tasks, reward_key=self._reward_key)
+
+        if self._job_dir is None:  # unreachable: __init__ guarantees config or job_dir
+            raise ValueError("no job_dir configured")
         if self._run_job is not None:
             await self._run_job()
         return build_trials_from_job_dir(self._job_dir, tasks, reward_key=self._reward_key)
+
+
+def _dataset_path_from_tasks(tasks: Sequence[AgentEvalTask]) -> Path:
+    """Recover the Harbor dataset dir stamped on tasks by :func:`discover_harbor_tasks`."""
+    for task in tasks:
+        stamped = task.metadata.get("harbor_dataset_path")
+        if isinstance(stamped, str) and stamped:
+            return Path(stamped)
+    raise ValueError(
+        "native Harbor run needs a dataset path: pass dataset_path, or build tasks with "
+        "discover_harbor_tasks/HarborTasksetLoader (which stamp metadata['harbor_dataset_path'])"
+    )
+
+
+def _all_tasks_cached(job_dir: Path, tasks: Sequence[AgentEvalTask]) -> bool:
+    """Return True when every requested task already has a ``result.json`` under ``job_dir``.
+
+    Lets ``job_dir`` act as a cache so a native run whose results are all present
+    is re-adapted instead of re-run.
+    """
+    if not job_dir.is_dir():
+        return False
+    present: set[str] = set()
+    for result_path in job_dir.glob("*/result.json"):
+        try:
+            name = json.loads(result_path.read_text()).get("task_name")
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(name, str):
+            present.add(name)
+    return {task.id for task in tasks}.issubset(present)
 
 
 def _build_native_job(
@@ -527,6 +578,7 @@ def discover_harbor_tasks(dataset_path: str | Path) -> list[AgentEvalTask]:
                 intent=intent,
                 inputs={"instruction": intent},
                 metrics=[HarborRewardMetric()],
+                metadata={"harbor_dataset_path": str(dataset_path), "harbor_task_dir": str(task_dir)},
             )
         )
     return tasks
@@ -586,7 +638,7 @@ async def run_harbor_eval(
     if metrics is not None:
         tasks = [task.model_copy(update={"metrics": list(metrics)}) for task in tasks]
 
-    runner = HarborAgentTaskRunner(config=config, dataset_path=dataset_path, task_names=task_names)
+    runner = HarborAgentTaskRunner(config=config, task_names=task_names)
     return await AgentEvaluator().run(
         tasks=tasks,
         target=runner,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
@@ -15,7 +15,11 @@ Two ways to drive it:
   runtime builds Harbor's ``JobConfig`` and runs it itself. The one-call
   :func:`run_harbor_eval` loads the tasks, runs, and scores, so caller code is a
   couple of lines. ``harbor`` is imported lazily inside ``run_tasks`` (it is an
-  optional extra), so importing this module never requires Harbor.
+  optional extra), so importing this module never requires Harbor. Custom
+  ``import_path`` agents (a user ``harbor_wrapper.py``) are supported too: set
+  ``agent_import_path`` + ``agent_dir`` and the runtime injects the agent package
+  into ``sys.modules`` for the duration of the run and tears it down after, so
+  callers never touch global import state (see :func:`scoped_harbor_agent_import`).
 * **Injected / offline** — pass a ``job_dir`` (and optionally a ``run_job``
   callback) to adapt an already-completed job dir or to run a caller-built job.
 
@@ -25,13 +29,21 @@ that half stays dependency-free regardless of how the job was produced.
 
 from __future__ import annotations
 
+import contextlib
+import importlib.machinery
 import json
 import logging
+import re
 import shutil
+import sys
+import threading
 import tomllib
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
+from datetime import datetime, timezone
 from pathlib import Path
+from types import ModuleType
 from typing import Any
+from uuid import uuid4
 
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus
@@ -44,7 +56,7 @@ from nemo_evaluator_sdk.agent_eval.trials import (
 )
 from nemo_evaluator_sdk.metrics.protocol import Metric, MetricInput, MetricOutput, MetricOutputSpec, MetricResult
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +65,10 @@ DEFAULT_REWARD_KEY = "reward"
 # Filename that marks a directory as a Harbor task, and the template dir to skip.
 _TASK_CONFIG_FILENAME = "task.toml"
 _TASK_TEMPLATE_DIRNAME = "task_template"
+# Synthetic sys.modules root a custom ``import_path`` agent package is injected under.
+_AGENT_IMPORT_ROOT = "_nemo_evaluator_harbor_agents"
+# Guards the sys.modules mutation while injecting/removing scoped agent packages.
+_IMPORT_LOCK = threading.Lock()
 
 RunJob = Callable[[], Awaitable[None]]
 
@@ -76,6 +92,10 @@ class HarborRuntimeConfig(BaseModel):
         default=None,
         description="Custom Harbor agent import path (e.g. 'harbor_wrapper:WrappedAgent'); overrides ``agent_name``.",
     )
+    agent_dir: Path | None = Field(
+        default=None,
+        description="Directory holding the module named by ``agent_import_path``; required when it is set.",
+    )
     agent_model_name: str | None = Field(default=None, description="Optional model slug passed to the Harbor agent.")
     n_attempts: int = Field(default=1, ge=1, description="Number of attempts Harbor runs per task.")
     n_concurrent_trials: int = Field(default=4, ge=1, description="Maximum concurrent Harbor trials.")
@@ -95,6 +115,12 @@ class HarborRuntimeConfig(BaseModel):
         default=None, description="Environment-build timeout multiplier."
     )
     reward_key: str = Field(default=DEFAULT_REWARD_KEY, description="Key read from Harbor's rewards mapping.")
+
+    @model_validator(mode="after")
+    def _require_agent_dir_for_import_path(self) -> HarborRuntimeConfig:
+        if self.agent_import_path is not None and self.agent_dir is None:
+            raise ValueError("agent_dir is required when agent_import_path is set")
+        return self
 
 
 class HarborRewardMetric:
@@ -179,55 +205,131 @@ def _build_native_job(
 ) -> tuple[Path, RunJob]:
     """Build a Harbor ``JobConfig`` from ``config`` and return ``(job_dir, run_job)``.
 
-    Harbor is imported here (not at module load) because it is an optional extra.
-    The returned ``run_job`` coroutine applies ``force_rerun`` and runs the job.
+    Harbor is imported inside ``run_job`` (not at module load) because it is an
+    optional extra. The job name is resolved up front so ``job_dir`` is known
+    without importing Harbor. When ``agent_import_path`` is set, ``run_job``
+    scopes the user's agent package into ``sys.modules`` for the run and removes
+    it afterwards (see :func:`scoped_harbor_agent_import`).
     """
-    from harbor.job import DatasetConfig, Job, JobConfig  # ty: ignore[unresolved-import]
-    from harbor.models.job.config import RetryConfig  # ty: ignore[unresolved-import]
-    from harbor.models.trial.config import AgentConfig, ArtifactConfig  # ty: ignore[unresolved-import]
-
-    if config.agent_import_path is not None:
-        agent = AgentConfig(import_path=config.agent_import_path, model_name=config.agent_model_name)
-    else:
-        agent = AgentConfig(name=config.agent_name or "oracle", model_name=config.agent_model_name)
-
-    artifacts: list[str | ArtifactConfig] = list(config.artifacts)
-    if config.trace_dir is not None:
-        artifacts = [ArtifactConfig(source=config.trace_dir, destination="traces"), *artifacts]
-
-    timeout_kwargs = {
-        key: value
-        for key, value in {
-            "timeout_multiplier": config.timeout_multiplier,
-            "agent_timeout_multiplier": config.agent_timeout_multiplier,
-            "verifier_timeout_multiplier": config.verifier_timeout_multiplier,
-            "agent_setup_timeout_multiplier": config.agent_setup_timeout_multiplier,
-            "environment_build_timeout_multiplier": config.environment_build_timeout_multiplier,
-        }.items()
-        if value is not None
-    }
-
-    job_config = JobConfig(
-        jobs_dir=config.jobs_dir,
-        n_attempts=config.n_attempts,
-        n_concurrent_trials=config.n_concurrent_trials,
-        quiet=config.quiet,
-        retry=RetryConfig(max_retries=config.max_retries),
-        artifacts=artifacts,
-        agents=[agent],
-        datasets=[DatasetConfig(path=dataset_path, task_names=list(task_names) if task_names else None)],
-        **({"job_name": config.job_name} if config.job_name else {}),
-        **timeout_kwargs,
-    )
-    job_dir = job_config.jobs_dir / job_config.job_name
+    job_name = config.job_name or datetime.now(timezone.utc).strftime("%Y-%m-%d__%H-%M-%S__%f")
+    job_dir = config.jobs_dir / job_name
 
     async def run_job() -> None:
+        from harbor.job import DatasetConfig, Job, JobConfig  # ty: ignore[unresolved-import]
+        from harbor.models.job.config import RetryConfig  # ty: ignore[unresolved-import]
+        from harbor.models.trial.config import AgentConfig, ArtifactConfig  # ty: ignore[unresolved-import]
+
         if config.force_rerun and job_dir.exists():
             shutil.rmtree(job_dir)
-        job = await Job.create(job_config)
-        await job.run()
+
+        artifacts: list[str | ArtifactConfig] = list(config.artifacts)
+        if config.trace_dir is not None:
+            artifacts = [ArtifactConfig(source=config.trace_dir, destination="traces"), *artifacts]
+
+        timeout_kwargs = {
+            key: value
+            for key, value in {
+                "timeout_multiplier": config.timeout_multiplier,
+                "agent_timeout_multiplier": config.agent_timeout_multiplier,
+                "verifier_timeout_multiplier": config.verifier_timeout_multiplier,
+                "agent_setup_timeout_multiplier": config.agent_setup_timeout_multiplier,
+                "environment_build_timeout_multiplier": config.environment_build_timeout_multiplier,
+            }.items()
+            if value is not None
+        }
+
+        async def _create_and_run(agent: Any) -> None:
+            job_config = JobConfig(
+                job_name=job_name,
+                jobs_dir=config.jobs_dir,
+                n_attempts=config.n_attempts,
+                n_concurrent_trials=config.n_concurrent_trials,
+                quiet=config.quiet,
+                retry=RetryConfig(max_retries=config.max_retries),
+                artifacts=artifacts,
+                agents=[agent],
+                datasets=[DatasetConfig(path=dataset_path, task_names=list(task_names) if task_names else None)],
+                **timeout_kwargs,
+            )
+            job = await Job.create(job_config)
+            await job.run()
+
+        if config.agent_import_path is not None:
+            agent_dir = Path(config.agent_dir).expanduser().resolve()  # ty: ignore[invalid-argument-type]
+            with scoped_harbor_agent_import(agent_dir, config.agent_import_path) as scoped_import:
+                await _create_and_run(AgentConfig(import_path=scoped_import, model_name=config.agent_model_name))
+        else:
+            await _create_and_run(AgentConfig(name=config.agent_name or "oracle", model_name=config.agent_model_name))
 
     return job_dir, run_job
+
+
+@contextlib.contextmanager
+def scoped_harbor_agent_import(agent_dir: Path, import_path: str) -> Iterator[str]:
+    """Make ``agent_dir`` importable under a unique synthetic package for the block.
+
+    Args:
+        agent_dir: directory containing the module referenced by ``import_path``.
+        import_path: Harbor agent path, ``"module"`` or ``"module:attribute"``.
+
+    Yields:
+        str: the rewritten import path Harbor should load (the module rooted under
+        the injected synthetic package, preserving any ``:attribute`` suffix).
+
+    Raises:
+        ValueError: if ``import_path`` has no module component.
+
+    On exit the injected ``sys.modules`` entries are removed. The mutation is
+    guarded by a process-wide lock so concurrent runs don't corrupt import state;
+    each run gets its own uniquely-named package so distinct agents never collide.
+    """
+    module_name, sep, attribute = import_path.partition(":")
+    module_name = module_name.strip().lstrip(".")
+    if not module_name:
+        raise ValueError("import_path must be 'module' or 'module:attribute'")
+    package = f"{_AGENT_IMPORT_ROOT}.{_safe_identifier(agent_dir.name)}_{uuid4().hex[:8]}"
+    with _IMPORT_LOCK:
+        _install_agent_package(package, agent_dir)
+    try:
+        scoped = f"{package}.{module_name}"
+        yield f"{scoped}:{attribute}" if sep else scoped
+    finally:
+        with _IMPORT_LOCK:
+            _uninstall_agent_package(package)
+
+
+def _safe_identifier(value: str) -> str:
+    """Turn an arbitrary directory name into a valid Python identifier."""
+    identifier = re.sub(r"\W+", "_", value).strip("_")
+    if not identifier:
+        return "agent"
+    return identifier if identifier[0].isalpha() or identifier[0] == "_" else f"_{identifier}"
+
+
+def _install_agent_package(package: str, agent_dir: Path) -> None:
+    """Register ``package`` (and its parents) in ``sys.modules`` rooted at ``agent_dir``."""
+    parts = package.split(".")
+    for idx in range(1, len(parts) + 1):
+        name = ".".join(parts[:idx])
+        if name not in sys.modules:
+            module = ModuleType(name)
+            module.__path__ = []  # namespace package; leaf __path__ is set below
+            module.__spec__ = importlib.machinery.ModuleSpec(name, loader=None, is_package=True)
+            sys.modules[name] = module
+            if idx > 1:
+                setattr(sys.modules[".".join(parts[: idx - 1])], parts[idx - 1], module)
+    sys.modules[package].__path__ = [str(agent_dir)]
+
+
+def _uninstall_agent_package(package: str) -> None:
+    """Remove ``package`` and any submodules imported through it from ``sys.modules``."""
+    for name in [n for n in sys.modules if n == package or n.startswith(f"{package}.")]:
+        sys.modules.pop(name, None)
+    parent, _, child = package.rpartition(".")
+    parent_module = sys.modules.get(parent)
+    if parent_module is not None:
+        with contextlib.suppress(AttributeError):
+            delattr(parent_module, child)
 
 
 def build_trials_from_job_dir(
@@ -534,4 +636,5 @@ __all__ = [
     "discover_harbor_tasks",
     "reward_payload_from_result",
     "run_harbor_eval",
+    "scoped_harbor_agent_import",
 ]

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -133,6 +133,16 @@ def test_task_discovery_and_taskset_loader_over_bundled_dataset() -> None:
     assert [t.id for t in loader.load(limit=5).tasks] == ["harbor/hello-world"]
 
 
+def test_discovery_fails_loudly_on_malformed_task(tmp_path: Path) -> None:
+    # A malformed task.toml raises a clear, path-named error rather than crashing
+    # cryptically or silently dropping the task (which would shrink eval coverage).
+    task_dir = tmp_path / "bad-task"
+    task_dir.mkdir()
+    (task_dir / "task.toml").write_text('[task]\nname = "oops')  # unterminated string
+    with pytest.raises(ValueError, match=r"malformed Harbor task config at .*bad-task"):
+        discover_harbor_tasks(tmp_path)
+
+
 def test_runtime_config_defaults_and_runner_requires_a_source() -> None:
     # Config holds only plain fields (importing the module never needs harbor).
     config = HarborRuntimeConfig(jobs_dir=Path("/tmp/jobs"))
@@ -176,6 +186,41 @@ async def test_native_runner_uses_job_dir_as_cache(tmp_path: Path) -> None:
     trials = await runner.run_tasks(tasks)
     assert [trial.task_id for trial in trials] == ["t"]
     assert trials[0].metadata["reward"] == 1.0
+
+
+def test_multiple_attempts_map_to_one_trial_each(tmp_path: Path) -> None:
+    # n_attempts > 1: Harbor writes one result.json per attempt, and each becomes a
+    # distinct trial for the same task id (so the summary can aggregate over attempts).
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    _write_trial(job_dir, "t__aaa", "t", reward=1.0)
+    _write_trial(job_dir, "t__bbb", "t", reward=0.0)
+    tasks = [AgentEvalTask(id="t", intent="x", inputs={"prompt": "p"}, metrics=[HarborRewardMetric()])]
+
+    trials = build_trials_from_job_dir(job_dir, tasks)
+    assert [trial.task_id for trial in trials] == ["t", "t"]
+    assert sorted(trial.metadata["reward"] for trial in trials) == [0.0, 1.0]
+
+
+def test_cache_is_attempt_and_success_aware(tmp_path: Path) -> None:
+    from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import _all_tasks_cached
+
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    tasks = [AgentEvalTask(id="t", intent="x", inputs={"prompt": "p"}, metrics=[HarborRewardMetric()])]
+
+    # One completed attempt: enough for n_attempts=1, not for n_attempts=2.
+    _write_trial(job_dir, "t__aaa", "t", reward=1.0)
+    assert _all_tasks_cached(job_dir, tasks, n_attempts=1) is True
+    assert _all_tasks_cached(job_dir, tasks, n_attempts=2) is False
+
+    # An errored attempt does not count, so the run is not served from a partial cache.
+    _write_trial(job_dir, "t__bbb", "t", reward=0.0, exception="NonZeroAgentExitCodeError")
+    assert _all_tasks_cached(job_dir, tasks, n_attempts=2) is False
+
+    # A second clean attempt satisfies n_attempts=2.
+    _write_trial(job_dir, "t__ccc", "t", reward=1.0)
+    assert _all_tasks_cached(job_dir, tasks, n_attempts=2) is True
 
 
 def test_scoped_agent_import_makes_wrapper_importable_then_cleans_up(tmp_path: Path) -> None:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
 import json
 import logging
+import sys
 from pathlib import Path
 
 import pytest
@@ -15,10 +17,12 @@ from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import (
     build_trials_from_job_dir,
     discover_harbor_tasks,
     reward_payload_from_result,
+    scoped_harbor_agent_import,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrialStatus
 from nemo_evaluator_sdk.metrics.utils import metric_type_name
+from pydantic import ValidationError
 
 _HELLO_WORLD_DATASET = Path(__file__).resolve().parents[2] / "examples" / "harbor" / "hello_world_dataset"
 
@@ -135,3 +139,24 @@ def test_runtime_config_defaults_and_runner_requires_a_source() -> None:
         HarborAgentTaskRunner()
     with pytest.raises(ValueError):
         HarborAgentTaskRunner(config=config)  # dataset_path missing
+
+
+def test_scoped_agent_import_makes_wrapper_importable_then_cleans_up(tmp_path: Path) -> None:
+    # A custom import_path agent requires agent_dir; the config rejects the half-spec.
+    with pytest.raises(ValidationError):
+        HarborRuntimeConfig(jobs_dir=tmp_path, agent_import_path="harbor_wrapper:WrappedAgent")
+
+    # Inside the scope the user's harbor_wrapper.py resolves under a synthetic package,
+    # and the yielded path preserves the :attribute suffix Harbor imports.
+    (tmp_path / "harbor_wrapper.py").write_text("class WrappedAgent:\n    value = 42\n")
+    with scoped_harbor_agent_import(tmp_path, "harbor_wrapper:WrappedAgent") as scoped_import:
+        module_name, _, attribute = scoped_import.partition(":")
+        assert attribute == "WrappedAgent"
+        module = importlib.import_module(module_name)
+        assert module.WrappedAgent.value == 42
+        package = module_name.rsplit(".", 1)[0]
+        assert package in sys.modules
+
+    # On exit the injected module and its synthetic package are gone from sys.modules.
+    assert module_name not in sys.modules
+    assert package not in sys.modules

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import importlib
 import json
 import logging
@@ -117,6 +118,10 @@ def test_task_discovery_and_taskset_loader_over_bundled_dataset() -> None:
     task = tasks[0]
     assert task.intent  # instruction.md content
     assert [metric_type_name(metric) for metric in task.metrics] == ["harbor_reward"]
+    # The dataset dir and task dir are stamped on the task so a native runner can
+    # recover them without a separate dataset_path argument.
+    assert task.metadata["harbor_dataset_path"] == str(_HELLO_WORLD_DATASET)
+    assert task.metadata["harbor_task_dir"] == str(_HELLO_WORLD_DATASET / "hello-world")
 
     # The loader wraps discovery as an AgentEvalTaskset and honors `limit`.
     loader = HarborTasksetLoader(_HELLO_WORLD_DATASET)
@@ -134,11 +139,43 @@ def test_runtime_config_defaults_and_runner_requires_a_source() -> None:
     assert config.agent_name == "oracle"
     assert config.reward_key == "reward"
 
-    # The runner rejects an under-specified construction rather than silently no-op.
+    # A fully under-specified construction is rejected up front.
     with pytest.raises(ValueError):
         HarborAgentTaskRunner()
+
+    # Native mode no longer needs dataset_path at construction; it is recovered from
+    # the tasks at run time. Tasks without that metadata (and no override) fail loudly
+    # when run (before Harbor is imported, so this needs no harbor install).
+    runner = HarborAgentTaskRunner(config=config)
     with pytest.raises(ValueError):
-        HarborAgentTaskRunner(config=config)  # dataset_path missing
+        asyncio.run(runner.run_tasks([AgentEvalTask(id="t", intent="x", inputs={})]))
+
+
+@pytest.mark.asyncio
+async def test_native_runner_uses_job_dir_as_cache(tmp_path: Path) -> None:
+    # A native run whose job_dir already covers every requested task is re-adapted,
+    # not re-run: run_job is never awaited, so Harbor is never imported here. This
+    # also exercises recovering the dataset dir from task metadata (no dataset_path).
+    jobs_dir = tmp_path / "jobs"
+    job_dir = jobs_dir / "cached-job"
+    job_dir.mkdir(parents=True)
+    _write_trial(job_dir, "t__aaa", "t", reward=1.0)
+
+    config = HarborRuntimeConfig(jobs_dir=jobs_dir, job_name="cached-job")
+    runner = HarborAgentTaskRunner(config=config)
+    tasks = [
+        AgentEvalTask(
+            id="t",
+            intent="x",
+            inputs={"instruction": "x"},
+            metrics=[HarborRewardMetric()],
+            metadata={"harbor_dataset_path": str(tmp_path)},
+        )
+    ]
+
+    trials = await runner.run_tasks(tasks)
+    assert [trial.task_id for trial in trials] == ["t"]
+    assert trials[0].metadata["reward"] == 1.0
 
 
 def test_scoped_agent_import_makes_wrapper_importable_then_cleans_up(tmp_path: Path) -> None:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -10,11 +10,17 @@ from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
 from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import (
     HarborAgentTaskRunner,
     HarborRewardMetric,
+    HarborRuntimeConfig,
+    HarborTasksetLoader,
     build_trials_from_job_dir,
+    discover_harbor_tasks,
     reward_payload_from_result,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrialStatus
+from nemo_evaluator_sdk.metrics.utils import metric_type_name
+
+_HELLO_WORLD_DATASET = Path(__file__).resolve().parents[2] / "examples" / "harbor" / "hello_world_dataset"
 
 
 def _write_trial(
@@ -97,3 +103,35 @@ def test_reward_with_no_matching_reward_key_is_partial_and_warns(tmp_path: Path,
     assert trials[0].metadata["reward"] is None
     assert trials[0].status == AgentEvalTrialStatus.PARTIAL
     assert "none matches reward_key" in caplog.text
+
+
+def test_task_discovery_and_taskset_loader_over_bundled_dataset() -> None:
+    # Discovery reads the bundled hello-world dataset directory the same way Harbor
+    # does: id comes from [task] name, and each task is scored by a reward metric.
+    tasks = discover_harbor_tasks(_HELLO_WORLD_DATASET)
+    assert [task.id for task in tasks] == ["harbor/hello-world"]
+    task = tasks[0]
+    assert task.intent  # instruction.md content
+    assert [metric_type_name(metric) for metric in task.metrics] == ["harbor_reward"]
+
+    # The loader wraps discovery as an AgentEvalTaskset and honors `limit`.
+    loader = HarborTasksetLoader(_HELLO_WORLD_DATASET)
+    assert loader.name == "harbor"
+    taskset = loader.load()
+    assert [t.id for t in taskset.tasks] == ["harbor/hello-world"]
+    assert taskset.metadata["harbor_dataset_path"] == str(_HELLO_WORLD_DATASET)
+    # A limit at/above the task count is a no-op (an empty taskset is invalid).
+    assert [t.id for t in loader.load(limit=5).tasks] == ["harbor/hello-world"]
+
+
+def test_runtime_config_defaults_and_runner_requires_a_source() -> None:
+    # Config holds only plain fields (importing the module never needs harbor).
+    config = HarborRuntimeConfig(jobs_dir=Path("/tmp/jobs"))
+    assert config.agent_name == "oracle"
+    assert config.reward_key == "reward"
+
+    # The runner rejects an under-specified construction rather than silently no-op.
+    with pytest.raises(ValueError):
+        HarborAgentTaskRunner()
+    with pytest.raises(ValueError):
+        HarborAgentTaskRunner(config=config)  # dataset_path missing

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -142,9 +142,11 @@ def test_runtime_config_defaults_and_runner_requires_a_source() -> None:
 
 
 def test_scoped_agent_import_makes_wrapper_importable_then_cleans_up(tmp_path: Path) -> None:
-    # A custom import_path agent requires agent_dir; the config rejects the half-spec.
+    # import_path without agent_dir is allowed (Harbor imports an installed module directly);
+    # only a dangling agent_dir (no import_path) is rejected.
+    HarborRuntimeConfig(jobs_dir=tmp_path, agent_import_path="mypkg.agent:WrappedAgent")
     with pytest.raises(ValidationError):
-        HarborRuntimeConfig(jobs_dir=tmp_path, agent_import_path="harbor_wrapper:WrappedAgent")
+        HarborRuntimeConfig(jobs_dir=tmp_path, agent_dir=tmp_path)
 
     # Inside the scope the user's harbor_wrapper.py resolves under a synthetic package,
     # and the yielded path preserves the :attribute suffix Harbor imports.

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime_e2e.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime_e2e.py
@@ -4,34 +4,29 @@
 """End-to-end test that the SDK runs Harbor's hello-world example natively.
 
 Unlike ``test_harbor_runtime.py`` (which adapts a fabricated job dir with no
-Docker), this drives a real Harbor job over the bundled ``hello_world_task``
-using the deterministic oracle agent, then scores it through the SDK. It needs
-both ``harbor`` installed and a working Docker daemon, and is skipped otherwise.
+Docker), this drives a real Harbor job over the bundled ``hello_world_dataset``
+using the deterministic oracle agent through the one-call ``run_harbor_eval``
+entry point, then checks the scores. It needs both ``harbor`` installed and a
+working Docker daemon, and is skipped otherwise.
 """
 
-import importlib.util
 import json
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
-from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
-from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import reward_payload_from_result
-from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig
+from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import (
+    HarborRuntimeConfig,
+    reward_payload_from_result,
+    run_harbor_eval,
+)
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrialStatus
 
 pytestmark = [pytest.mark.e2e, pytest.mark.slow, pytest.mark.skip_in_ci]
 
-_EXAMPLE = Path(__file__).resolve().parents[2] / "examples" / "harbor" / "run_harbor_example.py"
-
-
-def _load_example():
-    spec = importlib.util.spec_from_file_location("harbor_example", _EXAMPLE)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+_DATASET_DIR = Path(__file__).resolve().parents[2] / "examples" / "harbor" / "hello_world_dataset"
+_TASK_NAME = "harbor/hello-world"
 
 
 def _docker_available() -> bool:
@@ -46,30 +41,26 @@ async def test_sdk_runs_harbor_hello_world_natively(tmp_path: Path) -> None:
     if not _docker_available():
         pytest.skip("Docker daemon is required to run a Harbor job")
 
-    example = _load_example()
-    runner, tasks = example.build_hello_world_job_runner(tmp_path / "jobs")
-
-    result = await AgentEvaluator().run(
-        tasks=tasks,
-        target=runner,
-        config=AgentEvalRunConfig(write_dashboard=False),
-    )
+    # The whole caller side: a config and one call — no JobConfig, no harbor import.
+    jobs_dir = tmp_path / "jobs"
+    config = HarborRuntimeConfig(jobs_dir=jobs_dir, agent_name="oracle")
+    result = await run_harbor_eval(config, _DATASET_DIR)
 
     # The oracle agent writes hello.txt, so the verifier reward is 1.0 and the
     # trial completes cleanly through the SDK's Harbor adapter.
     assert len(result.trials) == 1
     trial = result.trials[0]
-    assert trial.task_id == example.HELLO_WORLD_TASK_NAME
+    assert trial.task_id == _TASK_NAME
     assert trial.status == AgentEvalTrialStatus.COMPLETED
     assert trial.metadata["reward"] == 1.0
 
     rewards = {score.task_id: score.outputs[0].value for score in result.scores if score.outputs}
-    assert rewards == {example.HELLO_WORLD_TASK_NAME: 1.0}
+    assert rewards == {_TASK_NAME: 1.0}
 
     # Harbor really wrote a per-trial result.json under the job dir.
-    trial_results = list((tmp_path / "jobs").glob("*/*/result.json"))
+    trial_results = list(jobs_dir.glob("*/*/result.json"))
     assert trial_results, "Harbor did not write a per-trial result.json"
-    assert json.loads(trial_results[0].read_text())["task_name"] == example.HELLO_WORLD_TASK_NAME
+    assert json.loads(trial_results[0].read_text())["task_name"] == _TASK_NAME
 
     # The optimizer-facing legacy payload reconstructs from the same result.
     payload = reward_payload_from_result(result)

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/harbor_runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/harbor_runtime.py
@@ -167,8 +167,11 @@ class HarborAgentTaskRunner:
       :func:`discover_harbor_tasks`), or from an explicit ``dataset_path``
       override, so it isn't repeated. ``task_names`` optionally restricts the run
       to a subset of tasks, and the ``config``'s ``job_dir`` doubles as a cache:
-      an existing run whose results already cover every requested task is
-      re-adapted instead of re-run (unless ``force_rerun`` is set).
+      an existing run whose results already cover every requested task (with
+      ``n_attempts`` completed, non-errored trials each) is re-adapted instead of
+      re-run (unless ``force_rerun`` is set). Caching only takes effect when a
+      stable ``job_name`` is set on the config — the default timestamped
+      ``job_name`` writes a fresh dir per run and never hits the cache.
     * **Injected / offline** — pass ``job_dir`` (and optionally a ``run_job``
       callback); ``run_job`` is awaited before the job dir is read, and
       ``run_job=None`` simply adapts an already-completed job dir.
@@ -208,12 +211,14 @@ class HarborAgentTaskRunner:
         :func:`discover_harbor_tasks`) unless a ``dataset_path`` override was given,
         so callers don't repeat it. ``job_dir`` doubles as a cache: the Harbor run
         is skipped and results are simply re-adapted when every requested task
-        already has a ``result.json`` there (unless ``force_rerun`` is set).
+        already has ``n_attempts`` completed, non-errored results there (unless
+        ``force_rerun`` is set). The cache only engages when the config pins a
+        stable ``job_name``; the default timestamped name never hits it.
         """
         if self._config is not None:
             dataset_path = self._dataset_path or _dataset_path_from_tasks(tasks)
             job_dir, run_job = _build_native_job(self._config, dataset_path, self._task_names)
-            if self._config.force_rerun or not _all_tasks_cached(job_dir, tasks):
+            if self._config.force_rerun or not _all_tasks_cached(job_dir, tasks, n_attempts=self._config.n_attempts):
                 await run_job()
             return build_trials_from_job_dir(job_dir, tasks, reward_key=self._reward_key)
 
@@ -236,23 +241,31 @@ def _dataset_path_from_tasks(tasks: Sequence[AgentEvalTask]) -> Path:
     )
 
 
-def _all_tasks_cached(job_dir: Path, tasks: Sequence[AgentEvalTask]) -> bool:
-    """Return True when every requested task already has a ``result.json`` under ``job_dir``.
+def _all_tasks_cached(job_dir: Path, tasks: Sequence[AgentEvalTask], *, n_attempts: int) -> bool:
+    """Return True when every requested task already has ``n_attempts`` completed results.
 
     Lets ``job_dir`` act as a cache so a native run whose results are all present
-    is re-adapted instead of re-run.
+    is re-adapted instead of re-run. The cache is **success-aware**: only trials
+    that finished without an ``exception_info`` count, and a task must have at
+    least ``n_attempts`` of them, so an interrupted, errored, or under-sampled run
+    is re-run rather than silently served from a partial cache. Caching only takes
+    effect when a stable ``job_name`` is set on the config; with the default
+    timestamped ``job_name`` every run writes a fresh dir and never hits the cache.
     """
     if not job_dir.is_dir():
         return False
-    present: set[str] = set()
+    counts: dict[str, int] = {}
     for result_path in job_dir.glob("*/result.json"):
         try:
-            name = json.loads(result_path.read_text()).get("task_name")
+            data = json.loads(result_path.read_text())
         except (json.JSONDecodeError, OSError):
             continue
+        if data.get("exception_info") is not None:
+            continue
+        name = data.get("task_name")
         if isinstance(name, str):
-            present.add(name)
-    return {task.id for task in tasks}.issubset(present)
+            counts[name] = counts.get(name, 0) + 1
+    return all(counts.get(task.id, 0) >= n_attempts for task in tasks)
 
 
 def _build_native_job(
@@ -272,9 +285,15 @@ def _build_native_job(
     job_dir = config.jobs_dir / job_name
 
     async def run_job() -> None:
-        from harbor.job import DatasetConfig, Job, JobConfig  # ty: ignore[unresolved-import]
-        from harbor.models.job.config import RetryConfig  # ty: ignore[unresolved-import]
-        from harbor.models.trial.config import AgentConfig, ArtifactConfig  # ty: ignore[unresolved-import]
+        try:
+            from harbor.job import DatasetConfig, Job, JobConfig  # ty: ignore[unresolved-import]
+            from harbor.models.job.config import RetryConfig  # ty: ignore[unresolved-import]
+            from harbor.models.trial.config import AgentConfig, ArtifactConfig  # ty: ignore[unresolved-import]
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "the native Harbor runtime needs `harbor`, which is not an SDK dependency "
+                '(it requires Python >=3.12). Install it separately: uv pip install "harbor>=0.16.1"'
+            ) from exc
 
         if config.force_rerun and job_dir.exists():
             shutil.rmtree(job_dir)
@@ -343,6 +362,12 @@ def scoped_harbor_agent_import(agent_dir: Path, import_path: str) -> Iterator[st
     On exit the injected ``sys.modules`` entries are removed. The mutation is
     guarded by a process-wide lock so concurrent runs don't corrupt import state;
     each run gets its own uniquely-named package so distinct agents never collide.
+
+    Only ``agent_dir`` (not ``sys.path``) is made importable, so a loose wrapper
+    must be self-contained: a single module, or one that reaches siblings via
+    relative imports (``from .helper import ...``). A wrapper that does an absolute
+    ``import helper`` of a sibling file won't resolve — install it as a package and
+    use the ``agent_dir``-less path instead.
     """
     module_name, sep, attribute = import_path.partition(":")
     module_name = module_name.strip().lstrip(".")
@@ -564,14 +589,26 @@ def discover_harbor_tasks(dataset_path: str | Path) -> list[AgentEvalTask]:
     with a ``task.toml`` is a task. The task id is read from ``[task] name`` so it
     matches the ``task_name`` Harbor writes into each trial's ``result.json``, and
     each task is scored by a :class:`HarborRewardMetric`.
+
+    Raises:
+        ValueError: if a task's ``task.toml`` or ``instruction.md`` is malformed or
+            unreadable — the offending path is named. A discovered task is never
+            silently dropped, since that would quietly shrink eval coverage.
     """
     dataset_path = Path(dataset_path)
     tasks: list[AgentEvalTask] = []
     for task_dir in _harbor_task_dirs(dataset_path):
-        config = tomllib.loads((task_dir / _TASK_CONFIG_FILENAME).read_text())
+        config_path = task_dir / _TASK_CONFIG_FILENAME
+        try:
+            config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+            raise ValueError(f"malformed Harbor task config at {config_path}: {exc}") from exc
         task_name = config.get("task", {}).get("name", task_dir.name)
         instruction_path = task_dir / "instruction.md"
-        intent = instruction_path.read_text().strip() if instruction_path.is_file() else task_name
+        try:
+            intent = instruction_path.read_text(encoding="utf-8").strip() if instruction_path.is_file() else task_name
+        except (OSError, UnicodeDecodeError) as exc:
+            raise ValueError(f"unreadable Harbor instruction at {instruction_path}: {exc}") from exc
         tasks.append(
             AgentEvalTask(
                 id=task_name,

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/harbor_runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/harbor_runtime.py
@@ -160,10 +160,15 @@ class HarborAgentTaskRunner:
 
     Two construction modes:
 
-    * **Native** — pass ``config`` (a :class:`HarborRuntimeConfig`) and
-      ``dataset_path``; the runtime builds and runs Harbor's ``JobConfig`` itself
-      (Harbor is imported lazily). ``task_names`` optionally restricts the run to
-      a subset of the dataset's tasks.
+    * **Native** — pass ``config`` (a :class:`HarborRuntimeConfig`); the runtime
+      builds and runs Harbor's ``JobConfig`` itself (Harbor is imported lazily).
+      The dataset directory is taken from the tasks handed to :meth:`run_tasks`
+      (each carries ``metadata['harbor_dataset_path']`` from
+      :func:`discover_harbor_tasks`), or from an explicit ``dataset_path``
+      override, so it isn't repeated. ``task_names`` optionally restricts the run
+      to a subset of tasks, and the ``config``'s ``job_dir`` doubles as a cache:
+      an existing run whose results already cover every requested task is
+      re-adapted instead of re-run (unless ``force_rerun`` is set).
     * **Injected / offline** — pass ``job_dir`` (and optionally a ``run_job``
       callback); ``run_job`` is awaited before the job dir is read, and
       ``run_job=None`` simply adapts an already-completed job dir.
@@ -182,26 +187,72 @@ class HarborAgentTaskRunner:
         run_job: RunJob | None = None,
         reward_key: str = DEFAULT_REWARD_KEY,
     ) -> None:
-        if config is not None:
-            if dataset_path is None:
-                raise ValueError("dataset_path is required when a HarborRuntimeConfig is given")
-            job_dir, run_job = _build_native_job(config, Path(dataset_path), task_names)
-            reward_key = config.reward_key
-        if job_dir is None:
-            raise ValueError("provide either config (+dataset_path) or an explicit job_dir")
-        self._job_dir = Path(job_dir)
+        if config is None and job_dir is None:
+            raise ValueError("provide either a HarborRuntimeConfig or an explicit job_dir")
+        self._config = config
+        self._dataset_path = Path(dataset_path) if dataset_path is not None else None
+        self._task_names = task_names
+        self._job_dir = Path(job_dir) if job_dir is not None else None
         self._run_job = run_job
-        self._reward_key = reward_key
+        self._reward_key = config.reward_key if config is not None else reward_key
 
     async def run_tasks(
         self,
         tasks: Sequence[AgentEvalTask],
         config: AgentEvalRunConfig | None = None,
     ) -> list[AgentEvalTrial]:
-        """Execute the Harbor job (if supplied) and return one trial per Harbor trial."""
+        """Run the Harbor job when needed, then return one trial per Harbor trial.
+
+        In native mode the dataset directory is recovered from the tasks (each
+        carries ``metadata['harbor_dataset_path']`` from
+        :func:`discover_harbor_tasks`) unless a ``dataset_path`` override was given,
+        so callers don't repeat it. ``job_dir`` doubles as a cache: the Harbor run
+        is skipped and results are simply re-adapted when every requested task
+        already has a ``result.json`` there (unless ``force_rerun`` is set).
+        """
+        if self._config is not None:
+            dataset_path = self._dataset_path or _dataset_path_from_tasks(tasks)
+            job_dir, run_job = _build_native_job(self._config, dataset_path, self._task_names)
+            if self._config.force_rerun or not _all_tasks_cached(job_dir, tasks):
+                await run_job()
+            return build_trials_from_job_dir(job_dir, tasks, reward_key=self._reward_key)
+
+        if self._job_dir is None:  # unreachable: __init__ guarantees config or job_dir
+            raise ValueError("no job_dir configured")
         if self._run_job is not None:
             await self._run_job()
         return build_trials_from_job_dir(self._job_dir, tasks, reward_key=self._reward_key)
+
+
+def _dataset_path_from_tasks(tasks: Sequence[AgentEvalTask]) -> Path:
+    """Recover the Harbor dataset dir stamped on tasks by :func:`discover_harbor_tasks`."""
+    for task in tasks:
+        stamped = task.metadata.get("harbor_dataset_path")
+        if isinstance(stamped, str) and stamped:
+            return Path(stamped)
+    raise ValueError(
+        "native Harbor run needs a dataset path: pass dataset_path, or build tasks with "
+        "discover_harbor_tasks/HarborTasksetLoader (which stamp metadata['harbor_dataset_path'])"
+    )
+
+
+def _all_tasks_cached(job_dir: Path, tasks: Sequence[AgentEvalTask]) -> bool:
+    """Return True when every requested task already has a ``result.json`` under ``job_dir``.
+
+    Lets ``job_dir`` act as a cache so a native run whose results are all present
+    is re-adapted instead of re-run.
+    """
+    if not job_dir.is_dir():
+        return False
+    present: set[str] = set()
+    for result_path in job_dir.glob("*/result.json"):
+        try:
+            name = json.loads(result_path.read_text()).get("task_name")
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(name, str):
+            present.add(name)
+    return {task.id for task in tasks}.issubset(present)
 
 
 def _build_native_job(
@@ -527,6 +578,7 @@ def discover_harbor_tasks(dataset_path: str | Path) -> list[AgentEvalTask]:
                 intent=intent,
                 inputs={"instruction": intent},
                 metrics=[HarborRewardMetric()],
+                metadata={"harbor_dataset_path": str(dataset_path), "harbor_task_dir": str(task_dir)},
             )
         )
     return tasks
@@ -586,7 +638,7 @@ async def run_harbor_eval(
     if metrics is not None:
         tasks = [task.model_copy(update={"metrics": list(metrics)}) for task in tasks]
 
-    runner = HarborAgentTaskRunner(config=config, dataset_path=dataset_path, task_names=task_names)
+    runner = HarborAgentTaskRunner(config=config, task_names=task_names)
     return await AgentEvaluator().run(
         tasks=tasks,
         target=runner,

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/harbor_runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/harbor_runtime.py
@@ -9,40 +9,124 @@ job directory. This runtime adapts that tree into SDK :class:`AgentEvalTrial`
 objects so an :class:`AgentEvaluator` can score and report Harbor runs through the
 same seam as any other runtime.
 
-The module is intentionally dependency-light: it does **not** import ``harbor``.
-Job *execution* is injected as the ``run_job`` callback (the caller owns Harbor's
-``JobConfig`` build, the import lock, and ``docker network prune`` cleanup), and
-trial *adaptation* only reads Harbor's on-disk ``result.json`` files. This mirrors
-how :class:`CallableAgentTaskRunner` stays free of any agent SDK, and matches the
-design note that Harbor-runtime concerns live with the caller, not the SDK.
+Two ways to drive it:
+
+* **Native** — pass a :class:`HarborRuntimeConfig` and a dataset directory; the
+  runtime builds Harbor's ``JobConfig`` and runs it itself. The one-call
+  :func:`run_harbor_eval` loads the tasks, runs, and scores, so caller code is a
+  couple of lines. ``harbor`` is imported lazily inside ``run_tasks`` (it is an
+  optional extra), so importing this module never requires Harbor. Custom
+  ``import_path`` agents are supported too: set ``agent_import_path`` and, for a
+  loose ``harbor_wrapper.py``, also ``agent_dir`` — the runtime then injects that
+  directory into ``sys.modules`` for the duration of the run and tears it down
+  after (see :func:`scoped_harbor_agent_import`). When ``agent_dir`` is omitted
+  (the module is already importable) the path is handed to Harbor's importer
+  unchanged, so nothing is imposed on how the agent is packaged.
+* **Injected / offline** — pass a ``job_dir`` (and optionally a ``run_job``
+  callback) to adapt an already-completed job dir or to run a caller-built job.
+
+Trial *adaptation* only ever reads Harbor's on-disk ``result.json`` files, so
+that half stays dependency-free regardless of how the job was produced.
 """
 
 from __future__ import annotations
 
+import contextlib
+import importlib.machinery
 import json
 import logging
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+import re
+import shutil
+import sys
+import threading
+import tomllib
+from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
+from datetime import datetime, timezone
 from pathlib import Path
+from types import ModuleType
 from typing import Any
+from uuid import uuid4
 
 from nemo_platform.beta.evaluator.agent_eval.results import AgentEvalResult
 from nemo_platform.beta.evaluator.agent_eval.scores import AgentEvalScoreStatus
-from nemo_platform.beta.evaluator.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+from nemo_platform.beta.evaluator.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask, AgentEvalTaskset
 from nemo_platform.beta.evaluator.agent_eval.trials import (
     AgentEvalTrial,
     AgentEvalTrialStatus,
     AgentOutput,
     standard_evidence_descriptors,
 )
-from nemo_platform.beta.evaluator.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
+from nemo_platform.beta.evaluator.metrics.protocol import Metric, MetricInput, MetricOutput, MetricOutputSpec, MetricResult
 from nemo_platform.beta.evaluator.values.evidence import CandidateEvidence
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 logger = logging.getLogger(__name__)
 
 # Default reward key inside Harbor's ``verifier_result.rewards`` mapping.
 DEFAULT_REWARD_KEY = "reward"
+# Filename that marks a directory as a Harbor task, and the template dir to skip.
+_TASK_CONFIG_FILENAME = "task.toml"
+_TASK_TEMPLATE_DIRNAME = "task_template"
+# Synthetic sys.modules root a custom ``import_path`` agent package is injected under.
+_AGENT_IMPORT_ROOT = "_nemo_evaluator_harbor_agents"
+# Guards the sys.modules mutation while injecting/removing scoped agent packages.
+_IMPORT_LOCK = threading.Lock()
 
 RunJob = Callable[[], Awaitable[None]]
+
+
+class HarborRuntimeConfig(BaseModel):
+    """Declarative config for running a Harbor job natively through the SDK.
+
+    Holds only plain/pydantic fields so importing this module never needs Harbor;
+    the fields are mapped onto Harbor's ``JobConfig`` lazily at run time.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    jobs_dir: Path = Field(description="Parent directory Harbor writes the ``<job_name>/`` results tree into.")
+    job_name: str | None = Field(default=None, description="Harbor job name; a timestamp is generated when omitted.")
+    agent_name: str | None = Field(
+        default="oracle",
+        description="Built-in Harbor agent to run (e.g. 'oracle'). Ignored when ``agent_import_path`` is set.",
+    )
+    agent_import_path: str | None = Field(
+        default=None,
+        description="Custom Harbor agent import path (e.g. 'harbor_wrapper:WrappedAgent'); overrides ``agent_name``.",
+    )
+    agent_dir: Path | None = Field(
+        default=None,
+        description=(
+            "Directory holding the module named by ``agent_import_path``. Set it for a loose "
+            "wrapper file (the SDK makes it importable); leave it unset when the module is "
+            "already importable (installed package), and Harbor imports it directly."
+        ),
+    )
+    agent_model_name: str | None = Field(default=None, description="Optional model slug passed to the Harbor agent.")
+    n_attempts: int = Field(default=1, ge=1, description="Number of attempts Harbor runs per task.")
+    n_concurrent_trials: int = Field(default=4, ge=1, description="Maximum concurrent Harbor trials.")
+    quiet: bool = Field(default=True, description="Suppress Harbor's trial progress displays.")
+    force_rerun: bool = Field(default=False, description="Delete an existing job dir before running.")
+    artifacts: list[str] = Field(default_factory=list, description="Harbor artifact sources to collect per trial.")
+    trace_dir: str | None = Field(
+        default=None,
+        description="Container path of agent traces to collect as the 'traces' artifact (e.g. '/app/traces').",
+    )
+    max_retries: int = Field(default=0, ge=0, description="Harbor per-trial retry attempts on transient failures.")
+    timeout_multiplier: float | None = Field(default=None, description="Global Harbor timeout multiplier.")
+    agent_timeout_multiplier: float | None = Field(default=None, description="Agent-phase timeout multiplier.")
+    verifier_timeout_multiplier: float | None = Field(default=None, description="Verifier-phase timeout multiplier.")
+    agent_setup_timeout_multiplier: float | None = Field(default=None, description="Agent-setup timeout multiplier.")
+    environment_build_timeout_multiplier: float | None = Field(
+        default=None, description="Environment-build timeout multiplier."
+    )
+    reward_key: str = Field(default=DEFAULT_REWARD_KEY, description="Key read from Harbor's rewards mapping.")
+
+    @model_validator(mode="after")
+    def _agent_dir_needs_import_path(self) -> HarborRuntimeConfig:
+        if self.agent_dir is not None and self.agent_import_path is None:
+            raise ValueError("agent_dir only applies to a custom agent_import_path")
+        return self
 
 
 class HarborRewardMetric:
@@ -74,20 +158,37 @@ class HarborRewardMetric:
 class HarborAgentTaskRunner:
     """An :class:`AgentTaskRunner` that runs a Harbor job, then adapts its results.
 
-    ``run_job`` executes the Harbor job (the caller builds the ``JobConfig`` and
-    owns any locking/cleanup); it is awaited once before the job directory is
-    read. Pass ``run_job=None`` to adapt an already-completed job directory
-    (offline re-scoring). ``job_dir`` is the directory Harbor writes its
-    per-trial ``<task>__<hash>/result.json`` files into.
+    Two construction modes:
+
+    * **Native** — pass ``config`` (a :class:`HarborRuntimeConfig`) and
+      ``dataset_path``; the runtime builds and runs Harbor's ``JobConfig`` itself
+      (Harbor is imported lazily). ``task_names`` optionally restricts the run to
+      a subset of the dataset's tasks.
+    * **Injected / offline** — pass ``job_dir`` (and optionally a ``run_job``
+      callback); ``run_job`` is awaited before the job dir is read, and
+      ``run_job=None`` simply adapts an already-completed job dir.
+
+    ``job_dir`` is the directory Harbor writes its per-trial
+    ``<task>__<hash>/result.json`` files into.
     """
 
     def __init__(
         self,
         *,
-        job_dir: str | Path,
+        config: HarborRuntimeConfig | None = None,
+        dataset_path: str | Path | None = None,
+        task_names: Sequence[str] | None = None,
+        job_dir: str | Path | None = None,
         run_job: RunJob | None = None,
         reward_key: str = DEFAULT_REWARD_KEY,
     ) -> None:
+        if config is not None:
+            if dataset_path is None:
+                raise ValueError("dataset_path is required when a HarborRuntimeConfig is given")
+            job_dir, run_job = _build_native_job(config, Path(dataset_path), task_names)
+            reward_key = config.reward_key
+        if job_dir is None:
+            raise ValueError("provide either config (+dataset_path) or an explicit job_dir")
         self._job_dir = Path(job_dir)
         self._run_job = run_job
         self._reward_key = reward_key
@@ -101,6 +202,144 @@ class HarborAgentTaskRunner:
         if self._run_job is not None:
             await self._run_job()
         return build_trials_from_job_dir(self._job_dir, tasks, reward_key=self._reward_key)
+
+
+def _build_native_job(
+    config: HarborRuntimeConfig,
+    dataset_path: Path,
+    task_names: Sequence[str] | None,
+) -> tuple[Path, RunJob]:
+    """Build a Harbor ``JobConfig`` from ``config`` and return ``(job_dir, run_job)``.
+
+    Harbor is imported inside ``run_job`` (not at module load) because it is an
+    optional extra. The job name is resolved up front so ``job_dir`` is known
+    without importing Harbor. When ``agent_import_path`` is set, ``run_job``
+    scopes the user's agent package into ``sys.modules`` for the run and removes
+    it afterwards (see :func:`scoped_harbor_agent_import`).
+    """
+    job_name = config.job_name or datetime.now(timezone.utc).strftime("%Y-%m-%d__%H-%M-%S__%f")
+    job_dir = config.jobs_dir / job_name
+
+    async def run_job() -> None:
+        from harbor.job import DatasetConfig, Job, JobConfig  # ty: ignore[unresolved-import]
+        from harbor.models.job.config import RetryConfig  # ty: ignore[unresolved-import]
+        from harbor.models.trial.config import AgentConfig, ArtifactConfig  # ty: ignore[unresolved-import]
+
+        if config.force_rerun and job_dir.exists():
+            shutil.rmtree(job_dir)
+
+        artifacts: list[str | ArtifactConfig] = list(config.artifacts)
+        if config.trace_dir is not None:
+            artifacts = [ArtifactConfig(source=config.trace_dir, destination="traces"), *artifacts]
+
+        timeout_kwargs = {
+            key: value
+            for key, value in {
+                "timeout_multiplier": config.timeout_multiplier,
+                "agent_timeout_multiplier": config.agent_timeout_multiplier,
+                "verifier_timeout_multiplier": config.verifier_timeout_multiplier,
+                "agent_setup_timeout_multiplier": config.agent_setup_timeout_multiplier,
+                "environment_build_timeout_multiplier": config.environment_build_timeout_multiplier,
+            }.items()
+            if value is not None
+        }
+
+        async def _create_and_run(agent: Any) -> None:
+            job_config = JobConfig(
+                job_name=job_name,
+                jobs_dir=config.jobs_dir,
+                n_attempts=config.n_attempts,
+                n_concurrent_trials=config.n_concurrent_trials,
+                quiet=config.quiet,
+                retry=RetryConfig(max_retries=config.max_retries),
+                artifacts=artifacts,
+                agents=[agent],
+                datasets=[DatasetConfig(path=dataset_path, task_names=list(task_names) if task_names else None)],
+                **timeout_kwargs,
+            )
+            job = await Job.create(job_config)
+            await job.run()
+
+        if config.agent_import_path is None:
+            await _create_and_run(AgentConfig(name=config.agent_name or "oracle", model_name=config.agent_model_name))
+        elif config.agent_dir is not None:
+            # Loose wrapper file: make its directory importable for the run.
+            agent_dir = config.agent_dir.expanduser().resolve()
+            with scoped_harbor_agent_import(agent_dir, config.agent_import_path) as scoped_import:
+                await _create_and_run(AgentConfig(import_path=scoped_import, model_name=config.agent_model_name))
+        else:
+            # Already-importable module (installed package): let Harbor import it directly.
+            await _create_and_run(AgentConfig(import_path=config.agent_import_path, model_name=config.agent_model_name))
+
+    return job_dir, run_job
+
+
+@contextlib.contextmanager
+def scoped_harbor_agent_import(agent_dir: Path, import_path: str) -> Iterator[str]:
+    """Make ``agent_dir`` importable under a unique synthetic package for the block.
+
+    Args:
+        agent_dir: directory containing the module referenced by ``import_path``.
+        import_path: Harbor agent path, ``"module"`` or ``"module:attribute"``.
+
+    Yields:
+        str: the rewritten import path Harbor should load (the module rooted under
+        the injected synthetic package, preserving any ``:attribute`` suffix).
+
+    Raises:
+        ValueError: if ``import_path`` has no module component.
+
+    On exit the injected ``sys.modules`` entries are removed. The mutation is
+    guarded by a process-wide lock so concurrent runs don't corrupt import state;
+    each run gets its own uniquely-named package so distinct agents never collide.
+    """
+    module_name, sep, attribute = import_path.partition(":")
+    module_name = module_name.strip().lstrip(".")
+    if not module_name:
+        raise ValueError("import_path must be 'module' or 'module:attribute'")
+    package = f"{_AGENT_IMPORT_ROOT}.{_safe_identifier(agent_dir.name)}_{uuid4().hex[:8]}"
+    with _IMPORT_LOCK:
+        _install_agent_package(package, agent_dir)
+    try:
+        scoped = f"{package}.{module_name}"
+        yield f"{scoped}:{attribute}" if sep else scoped
+    finally:
+        with _IMPORT_LOCK:
+            _uninstall_agent_package(package)
+
+
+def _safe_identifier(value: str) -> str:
+    """Turn an arbitrary directory name into a valid Python identifier."""
+    identifier = re.sub(r"\W+", "_", value).strip("_")
+    if not identifier:
+        return "agent"
+    return identifier if identifier[0].isalpha() or identifier[0] == "_" else f"_{identifier}"
+
+
+def _install_agent_package(package: str, agent_dir: Path) -> None:
+    """Register ``package`` (and its parents) in ``sys.modules`` rooted at ``agent_dir``."""
+    parts = package.split(".")
+    for idx in range(1, len(parts) + 1):
+        name = ".".join(parts[:idx])
+        if name not in sys.modules:
+            module = ModuleType(name)
+            module.__path__ = []  # namespace package; leaf __path__ is set below
+            module.__spec__ = importlib.machinery.ModuleSpec(name, loader=None, is_package=True)
+            sys.modules[name] = module
+            if idx > 1:
+                setattr(sys.modules[".".join(parts[: idx - 1])], parts[idx - 1], module)
+    sys.modules[package].__path__ = [str(agent_dir)]
+
+
+def _uninstall_agent_package(package: str) -> None:
+    """Remove ``package`` and any submodules imported through it from ``sys.modules``."""
+    for name in [n for n in sys.modules if n == package or n.startswith(f"{package}.")]:
+        sys.modules.pop(name, None)
+    parent, _, child = package.rpartition(".")
+    parent_module = sys.modules.get(parent)
+    if parent_module is not None:
+        with contextlib.suppress(AttributeError):
+            delattr(parent_module, child)
 
 
 def build_trials_from_job_dir(
@@ -256,6 +495,105 @@ def _token_measurements(agent_result: Any) -> dict[str, int | float]:
     return out
 
 
+def _harbor_task_dirs(dataset_path: Path) -> list[Path]:
+    """Return the Harbor task folders under ``dataset_path`` (or itself if it is one)."""
+    if (dataset_path / _TASK_CONFIG_FILENAME).is_file():
+        return [dataset_path]
+    return sorted(
+        path
+        for path in dataset_path.iterdir()
+        if path.is_dir() and path.name != _TASK_TEMPLATE_DIRNAME and (path / _TASK_CONFIG_FILENAME).is_file()
+    )
+
+
+def discover_harbor_tasks(dataset_path: str | Path) -> list[AgentEvalTask]:
+    """Build one :class:`AgentEvalTask` per Harbor task folder in ``dataset_path``.
+
+    Mirrors Harbor's own local-dataset discovery: every immediate subdirectory
+    with a ``task.toml`` is a task. The task id is read from ``[task] name`` so it
+    matches the ``task_name`` Harbor writes into each trial's ``result.json``, and
+    each task is scored by a :class:`HarborRewardMetric`.
+    """
+    dataset_path = Path(dataset_path)
+    tasks: list[AgentEvalTask] = []
+    for task_dir in _harbor_task_dirs(dataset_path):
+        config = tomllib.loads((task_dir / _TASK_CONFIG_FILENAME).read_text())
+        task_name = config.get("task", {}).get("name", task_dir.name)
+        instruction_path = task_dir / "instruction.md"
+        intent = instruction_path.read_text().strip() if instruction_path.is_file() else task_name
+        tasks.append(
+            AgentEvalTask(
+                id=task_name,
+                intent=intent,
+                inputs={"instruction": intent},
+                metrics=[HarborRewardMetric()],
+            )
+        )
+    return tasks
+
+
+class HarborTasksetLoader:
+    """Load a Harbor local-dataset directory as an :class:`AgentEvalTaskset`.
+
+    Implements the :class:`AgentEvalTasksetLoader` protocol so "dataset dir in →
+    tasks out" is a single call.
+    """
+
+    def __init__(self, dataset_path: str | Path, *, name: str = "harbor") -> None:
+        self._dataset_path = Path(dataset_path)
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def load(
+        self,
+        *,
+        source: str | Path | None = None,
+        limit: int | None = None,
+        evidence_dir: Path | None = None,
+    ) -> AgentEvalTaskset:
+        """Discover Harbor tasks under ``source`` (or the configured path) into a taskset."""
+        dataset_path = Path(source) if source is not None else self._dataset_path
+        tasks = discover_harbor_tasks(dataset_path)
+        if limit is not None:
+            tasks = tasks[:limit]
+        return AgentEvalTaskset(tasks=tasks, metadata={"harbor_dataset_path": str(dataset_path)})
+
+
+async def run_harbor_eval(
+    config: HarborRuntimeConfig,
+    dataset_path: str | Path,
+    *,
+    task_names: Sequence[str] | None = None,
+    metrics: Sequence[Metric] | None = None,
+    run_config: AgentEvalRunConfig | None = None,
+) -> AgentEvalResult:
+    """Run a Harbor dataset natively and score it — the minimal-plumbing entry point.
+
+    Loads the taskset from ``dataset_path``, runs Harbor via ``config``, and scores
+    through :class:`AgentEvaluator`. Tasks are scored by :class:`HarborRewardMetric`
+    unless ``metrics`` overrides them. Returns the scored :class:`AgentEvalResult`.
+    """
+    from nemo_platform.beta.evaluator.agent_eval.evaluator import AgentEvaluator
+
+    dataset_path = Path(dataset_path)
+    tasks = HarborTasksetLoader(dataset_path).load().tasks
+    if task_names is not None:
+        wanted = set(task_names)
+        tasks = [task for task in tasks if task.id in wanted]
+    if metrics is not None:
+        tasks = [task.model_copy(update={"metrics": list(metrics)}) for task in tasks]
+
+    runner = HarborAgentTaskRunner(config=config, dataset_path=dataset_path, task_names=task_names)
+    return await AgentEvaluator().run(
+        tasks=tasks,
+        target=runner,
+        config=run_config or AgentEvalRunConfig(write_dashboard=False),
+    )
+
+
 def reward_payload_from_result(
     result: AgentEvalResult,
     *,
@@ -302,6 +640,11 @@ __all__ = [
     "DEFAULT_REWARD_KEY",
     "HarborAgentTaskRunner",
     "HarborRewardMetric",
+    "HarborRuntimeConfig",
+    "HarborTasksetLoader",
     "build_trials_from_job_dir",
+    "discover_harbor_tasks",
     "reward_payload_from_result",
+    "run_harbor_eval",
+    "scoped_harbor_agent_import",
 ]


### PR DESCRIPTION
## Summary

Makes the NeMo Evaluator SDK run Harbor tasks **natively from a declarative config**, so callers no longer re-implement the Harbor plumbing (JobConfig build, `Job.create`/`job.run`, task discovery, and custom-agent import scoping). Targets `NemoOptimizeIntegration` (stacks on top of the experimental Harbor runtime in #544).

This PR delivers **Phase 1 and Phase 2** of the deep-integration plan as two atomic commits. Scope is **SDK-only** — NeMo Optimizer is untouched.

- **Phase 1** — config-driven native runtime for built-in, name-based Harbor agents.
- **Phase 2** — custom `import_path` wrapped-agent support (a user `harbor_wrapper.py`), with the `sys.modules` scoping owned by the SDK.

Minimal client-side plumbing is the acceptance criterion for both.

### Caller side is two lines (apart from imports)

```python
from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import (
    HarborRuntimeConfig, run_harbor_eval,
)

# built-in agent
config = HarborRuntimeConfig(jobs_dir=jobs_dir, agent_name="oracle")
result = await run_harbor_eval(config, "hello_world_dataset")  # loads tasks, runs, scores

# custom wrapped agent (Phase 2)
config = HarborRuntimeConfig(
    jobs_dir=jobs_dir,
    agent_dir="path/to/agent",              # dir holding harbor_wrapper.py
    agent_import_path="harbor_wrapper:WrappedAgent",
)
result = await run_harbor_eval(config, "hello_world_dataset")
```

### Phase 1 — config-driven native runtime

- **`HarborRuntimeConfig`** — declarative config (agent, attempts, concurrency, timeouts, artifacts) with plain/pydantic fields only, mapped onto Harbor's `JobConfig` lazily.
- **`HarborAgentTaskRunner`** — new **native** mode builds and runs the job itself; the existing **injected/offline** `job_dir` mode is preserved (back-compatible).
- **`HarborTasksetLoader` / `discover_harbor_tasks`** — "dataset dir → tasks" in one call (implements `AgentEvalTasksetLoader`).
- **`run_harbor_eval(config, dataset_path)`** — one-call entry point: load tasks, run, score with `HarborRewardMetric`.
- **Example** shrunk to the two-line native/optimizer path; README refreshed.

### Phase 2 — custom `import_path` agents in the SDK

- **`scoped_harbor_agent_import(agent_dir, import_path)`** — context manager that injects the user's agent package into `sys.modules` under a uniquely-named synthetic root for the duration of the run and tears it down after. Harbor resolves custom agents with a plain `importlib.import_module` (no `sys.path` handling of its own), so this fills the gap for directory-shape wrappers while leaving Harbor's mechanism intact.
- **Lock-guarded + collision-free** — the `sys.modules` mutation is guarded by a process-wide lock, and each run gets its own package name, so concurrent runs don't corrupt each other's import state. Callers never touch global import state.
- **`HarborRuntimeConfig.agent_dir`** added; `_build_native_job` resolves the job dir up front and builds/runs the `JobConfig` inside `run_job` so wrapped agents get the scoped import path.

### Design notes

- `harbor` is imported **lazily** inside `run_tasks` (never at module load), matching `FabricAgentRuntime`. Importing the SDK never requires Harbor.
- Harbor is intentionally **not** added to the locked deps: it requires Python >=3.12 while the workspace supports >=3.11, which makes the lock unsatisfiable (same reason `nemo_fabric` isn't locked). Install separately: `uv pip install "harbor>=0.16.1"`.
- The `result.json` → trial adapter (`build_trials_from_job_dir`) is unchanged in both phases.
- Plan step 2.2 (`docker network prune` + `n_concurrent_trials`↔`parallelism` reconcile) is intentionally omitted: the runtime runs a single Harbor job for all tasks (no double fan-out), and a global network prune is destructive on shared hosts.

## Test plan

- [x] `uv run --frozen pytest packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py` — 4 passed (adapter, discovery/loader/config, runner validation, and Phase-2 import scoping/cleanup + config validation; no Docker).
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run --frozen ty check` on changed files.
- [x] e2e (`test_harbor_runtime_e2e.py`) collects and skips cleanly without Harbor; runs `reward == 1.0` locally with Harbor + Docker.
```mermaid
flowchart TD
    U["User<br/>config = HarborRuntimeConfig(...)<br/>await run_harbor_eval(config, dataset_dir)"]

    subgraph ENTRY["Entry point"]
        RHE["run_harbor_eval(config, dataset_path,<br/>task_names?, metrics?, run_config?)"]
    end

    subgraph DISCOVER["1 - Task discovery (no Docker, no harbor import)"]
        LOAD["HarborTasksetLoader(dataset_path).load()"]
        DHT["discover_harbor_tasks(dataset_path)"]
        HTD["_harbor_task_dirs()<br/>find subdirs with task.toml"]
        PARSE["read task.toml + instruction.md<br/>(fail-loud on malformed)"]
        TASKS["list[AgentEvalTask]<br/>each: HarborRewardMetric +<br/>metadata[harbor_dataset_path/task_dir]"]
    end

    subgraph EVAL["2 - AgentEvaluator drives the runner"]
        AE["AgentEvaluator().run(tasks, target=runner, config)"]
        RT["HarborAgentTaskRunner.run_tasks(tasks)"]
    end

    subgraph RUN["3 - Native Harbor run (lazy harbor import)"]
        DSP["dataset_path = self._dataset_path<br/>or _dataset_path_from_tasks(tasks)"]
        BNJ["_build_native_job(config, dataset_path, task_names)<br/>returns (job_dir, run_job)"]
        CACHE{"force_rerun or<br/>not _all_tasks_cached(job_dir, tasks, n_attempts)?"}
        RJ["await run_job()"]
        HARBOR["import harbor -> build JobConfig<br/>(DatasetConfig, AgentConfig, RetryConfig, ArtifactConfig)<br/>Job.create() -> job.run()"]
        SCOPE["if agent_import_path + agent_dir:<br/>scoped_harbor_agent_import()<br/>(_install/_uninstall_agent_package)"]
        DISK[("job_dir/&lt;task&gt;__&lt;hash&gt;/result.json<br/>written by Harbor in Docker")]
    end

    subgraph ADAPT["4 - Adapt on-disk results (dependency-free)"]
        BTFJ["build_trials_from_job_dir(job_dir, tasks, reward_key)"]
        TFHR["_trial_from_harbor_result() per result.json"]
        HELP["_rewards_mapping() / _primary_reward()<br/>_exception_type() / _token_measurements()<br/>standard_evidence_descriptors()"]
        TRIALS["list[AgentEvalTrial]<br/>(status COMPLETED/PARTIAL, metadata.reward)"]
    end

    subgraph SCORE["5 - Scoring + result"]
        CS["HarborRewardMetric.compute_scores()<br/>reads reward off trial metadata"]
        RES["AgentEvalResult<br/>(scores, summary)"]
        PAY["reward_payload_from_result(result)<br/>-> legacy {reward, reward_details, exceptions}"]
    end

    U --> RHE --> LOAD --> DHT --> HTD --> PARSE --> TASKS
    RHE -->|"filter task_names / override metrics<br/>build HarborAgentTaskRunner(config)"| AE
    TASKS --> AE
    AE --> RT --> DSP --> BNJ --> CACHE
    CACHE -->|"yes: run"| RJ --> HARBOR
    HARBOR -.->|"custom agent"| SCOPE
    HARBOR --> DISK
    CACHE -->|"no: cache hit, skip run"| BTFJ
    RJ --> BTFJ
    DISK --> BTFJ --> TFHR --> HELP --> TRIALS
    TRIALS --> AE
    AE --> CS --> RES
    RES --> U
    RES -.->|"optimizer mode"| PAY -.-> U
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Harbor evaluation support via a one-call SDK entry point, including task discovery and dataset-driven loading.
  * Introduced Harbor runtime configuration and expanded runner capabilities for both native and offline/injected flows.
  * Added scoped custom-agent import support and improved cache-aware trial reuse with forced reruns.
* **Documentation**
  * Refreshed the Harbor example README with simplified setup, run modes, custom agent instructions, and troubleshooting updates.
* **Tests**
  * Expanded Harbor runtime unit and end-to-end coverage, including caching, multi-attempt behavior, and import scoping.
* **Packaging/Compatibility**
  * Documented Harbor runtime version requirements and lazy installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->