### PR TITLE
fix(docker): scope Docker cleanup and labels by controller owner

### DIFF
--- a/services/core/jobs/src/nmp/core/jobs/app/constants.py
+++ b/services/core/jobs/src/nmp/core/jobs/app/constants.py
@@ -9,6 +9,7 @@ JOB_STEP_NAME_LABEL = "nmp.nvidia.com/job_step_name"
 JOB_STEP_ID_LABEL = "nmp.nvidia.com/job_step_id"
 JOB_TASK_ID_LABEL = "nmp.nvidia.com/job_task_id"
 JOB_USES_PERSISTENT_STORAGE_LABEL = "nmp.nvidia.com/uses_persistent_storage"
+JOB_CONTROLLER_INSTANCE_ID_LABEL = "nmp.nvidia.com/jobs_controller_instance_id"
 
 JOB_TYPE_LABEL = "nmp.nvidia.com/job_type"
 JOB_TYPE_JOB = "job"

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
@@ -253,6 +253,7 @@ class DockerJobBackend(JobBackend[ProviderT, DockerJobExecutionProfileConfig], G
                 f"{JOB_MANAGED_BY_LABEL}={JOB_MANAGED_BY_JOBS_CONTROLLER}",
                 f"{JOB_CONTROLLER_INSTANCE_ID_LABEL}={self._jobs_controller_instance_id}",
                 f"{JOB_EXECUTION_BACKEND_LABEL}={self.BACKEND_NAME}",
+                f"{JOB_EXECUTION_PROFILE_LABEL}={self._profile_name}",
             ]
         }
 

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
+import hashlib
 import io
 import json
 import logging
@@ -21,7 +22,7 @@ from docker.models.containers import Container
 from docker.types import LogConfig, Mount
 from nemo_platform.types.jobs import PlatformJobStepWithContext
 from nmp.common.auth import AuthContext
-from nmp.common.config import get_platform_config
+from nmp.common.config import get_platform_config, nmp_user_data_dir
 from nmp.common.docker.gpu_pool import GPUAllocationError
 from nmp.common.jobs.constants import (
     CONFIG_TASK_STORAGE_PATH_ENVVAR,
@@ -46,6 +47,7 @@ from nmp.common.observability import start_span_with_ctx
 from nmp.common.resources import SharedResourceManager
 from nmp.core.jobs.app.constants import (
     JOB_ATTEMPT_ID_LABEL,
+    JOB_CONTROLLER_INSTANCE_ID_LABEL,
     JOB_EXECUTION_BACKEND_LABEL,
     JOB_EXECUTION_PROFILE_LABEL,
     JOB_ID_LABEL,
@@ -115,9 +117,19 @@ NEMO_JOBS_DEFAULT_DOCKER_NETWORK = os.getenv("NEMO_JOBS_DEFAULT_DOCKER_NETWORK",
 # Timeout for stopping Docker containers gracefully with SIGTERM before SIGKILL is sent.
 # Default is 30 seconds which matches the Kubernetes default grace period for pod termination.
 DOCKER_STOP_TIMEOUT = int(os.getenv("NEMO_JOBS_DEFAULT_DOCKER_STOP_TIMEOUT", "30"))
+NMP_JOBS_DOCKER_OWNER_ID_ENVVAR = "NMP_JOBS_DOCKER_OWNER_ID"
 
 
 ProviderT = TypeVar("ProviderT", bound=ExecutionProviderT)
+
+
+def _resolve_jobs_controller_instance_id() -> str:
+    configured = os.getenv(NMP_JOBS_DOCKER_OWNER_ID_ENVVAR)
+    if configured:
+        return configured
+
+    owner_source = f"nmp-data-dir:{nmp_user_data_dir().expanduser().resolve()}"
+    return hashlib.sha256(owner_source.encode("utf-8")).hexdigest()[:32]
 
 
 @dataclass(frozen=True, slots=True)
@@ -192,6 +204,7 @@ class DockerJobBackend(JobBackend[ProviderT, DockerJobExecutionProfileConfig], G
     BACKEND_NAME: str = "docker"
 
     def init(self) -> None:
+        self._jobs_controller_instance_id = _resolve_jobs_controller_instance_id()
         self._container_start_admission = threading.BoundedSemaphore(DOCKER_CONTAINER_START_WORKERS)
         self._container_run_threadpool = ThreadPoolExecutor(max_workers=DOCKER_CONTAINER_START_WORKERS)
         self._client = docker.from_env(timeout=180)
@@ -218,6 +231,30 @@ class DockerJobBackend(JobBackend[ProviderT, DockerJobExecutionProfileConfig], G
         """Return True if the container has the jobs-controller managed-by label."""
         labels = getattr(container, "labels", None) or {}
         return labels.get(JOB_MANAGED_BY_LABEL) == JOB_MANAGED_BY_JOBS_CONTROLLER
+
+    def _base_controller_labels(self) -> dict[str, str]:
+        return {
+            JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+            JOB_CONTROLLER_INSTANCE_ID_LABEL: self._jobs_controller_instance_id,
+            JOB_EXECUTION_BACKEND_LABEL: self.BACKEND_NAME,
+            JOB_EXECUTION_PROFILE_LABEL: self._profile_name,
+        }
+
+    def _is_container_owned_by_this_controller(self, container: Container) -> bool:
+        labels = getattr(container, "labels", None) or {}
+        return (
+            labels.get(JOB_MANAGED_BY_LABEL) == JOB_MANAGED_BY_JOBS_CONTROLLER
+            and labels.get(JOB_CONTROLLER_INSTANCE_ID_LABEL) == self._jobs_controller_instance_id
+        )
+
+    def _cleanup_container_filters(self) -> dict[str, list[str]]:
+        return {
+            "label": [
+                f"{JOB_MANAGED_BY_LABEL}={JOB_MANAGED_BY_JOBS_CONTROLLER}",
+                f"{JOB_CONTROLLER_INSTANCE_ID_LABEL}={self._jobs_controller_instance_id}",
+                f"{JOB_EXECUTION_BACKEND_LABEL}={self.BACKEND_NAME}",
+            ]
+        }
 
     def job_storage_subpath(self, workspace: str, job: str) -> str:
         return f"jobs/{workspace}/{job}"
@@ -282,12 +319,10 @@ fi
         volumes = {storage_config.volume_name: {"bind": "/vol", "mode": "rw"}}
 
         labels = {
+            **self._base_controller_labels(),
             JOB_WORKSPACE_ID_LABEL: workspace,
             JOB_ID_LABEL: job,
-            JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
             JOB_TYPE_LABEL: JOB_TYPE_STORAGE_CLEANUP,
-            JOB_EXECUTION_BACKEND_LABEL: self.BACKEND_NAME,
-            JOB_EXECUTION_PROFILE_LABEL: self._profile_name,
         }
         container_args = {
             "name": f"job-cleanup-{workspace}-{job}-{uuid.uuid4().hex[:8]}",
@@ -334,11 +369,14 @@ fi
             self.cleanup_container(container)
 
     def cleanup_container(self, container: Container) -> None:
-        """Remove a Docker container. Only removes containers managed by the jobs controller."""
-        if not self._is_container_managed_by_jobs_controller(container):
+        """Remove a Docker container. Only removes containers owned by this jobs controller."""
+        if not self._is_container_owned_by_this_controller(container):
             logger.warning(
-                "Skipping container remove (not managed by jobs-controller)",
-                extra={"container_id": container.id[:16] if container.id else "unknown"},
+                "Skipping container remove (not owned by this jobs-controller)",
+                extra={
+                    "container_id": container.id[:16] if container.id else "unknown",
+                    "owner_label": (getattr(container, "labels", None) or {}).get(JOB_CONTROLLER_INSTANCE_ID_LABEL),
+                },
             )
             return
         try:
@@ -722,6 +760,7 @@ chmod -R 777 {job_vol}/{storage_subpath}
         )
 
         labels = {
+            **self._base_controller_labels(),
             JOB_WORKSPACE_ID_LABEL: step.workspace,
             JOB_ID_LABEL: step.job,
             JOB_ATTEMPT_ID_LABEL: step.attempt_id,
@@ -730,10 +769,7 @@ chmod -R 777 {job_vol}/{storage_subpath}
             # because parallelism is not supported.
             JOB_TASK_ID_LABEL: task_id,
             JOB_STEP_ID_LABEL: step.id,
-            JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
             JOB_TYPE_LABEL: JOB_TYPE_JOB,
-            JOB_EXECUTION_BACKEND_LABEL: self.BACKEND_NAME,
-            JOB_EXECUTION_PROFILE_LABEL: self._profile_name,
         }
 
         # Mark container if it uses persistent storage so we can clean it up later
@@ -1201,10 +1237,13 @@ chmod -R 777 {job_vol}/{storage_subpath}
         status_details = {"message": message}
         error_details = {"message": message}
 
-        if not self._is_container_managed_by_jobs_controller(container):
+        if not self._is_container_owned_by_this_controller(container):
             logger.warning(
-                "Skipping container kill (not managed by jobs-controller)",
-                extra={"container_name": container.name},
+                "Skipping container kill (not owned by this jobs-controller)",
+                extra={
+                    "container_name": container.name,
+                    "owner_label": (getattr(container, "labels", None) or {}).get(JOB_CONTROLLER_INSTANCE_ID_LABEL),
+                },
             )
             return JobUpdate(
                 status=PlatformJobStatus.ERROR.value,
@@ -1276,14 +1315,17 @@ chmod -R 777 {job_vol}/{storage_subpath}
                 error_details={"message": "Container not found while stopping container"},
             )
         else:
-            if not self._is_container_managed_by_jobs_controller(container):
+            if not self._is_container_owned_by_this_controller(container):
                 logger.warning(
-                    "Skipping container stop (not managed by jobs-controller)",
-                    extra={"container_name": container.name},
+                    "Skipping container stop (not owned by this jobs-controller)",
+                    extra={
+                        "container_name": container.name,
+                        "owner_label": (getattr(container, "labels", None) or {}).get(JOB_CONTROLLER_INSTANCE_ID_LABEL),
+                    },
                 )
                 return JobUpdate(
                     status=PlatformJobStatus.ERROR,
-                    error_details={"message": "Container not managed by jobs controller"},
+                    error_details={"message": "Container not owned by this jobs controller"},
                 )
             try:
                 logger.debug(
@@ -1503,12 +1545,21 @@ chmod -R 777 {job_vol}/{storage_subpath}
     def cleanup_steps(self):
         containers = self._client.containers.list(
             all=True,
-            filters={"label": JOB_MANAGED_BY_LABEL},
+            filters=self._cleanup_container_filters(),
             ignore_removed=True,
         )
         for container in containers:
             try:
-                if container.labels.get(JOB_MANAGED_BY_LABEL) != JOB_MANAGED_BY_JOBS_CONTROLLER:
+                if not self._is_container_owned_by_this_controller(container):
+                    logger.debug(
+                        "Skipping Docker cleanup for unowned job container",
+                        extra={
+                            "container_name": getattr(container, "name", None),
+                            "owner_label": (getattr(container, "labels", None) or {}).get(
+                                JOB_CONTROLLER_INSTANCE_ID_LABEL
+                            ),
+                        },
+                    )
                     continue
                 if container.labels.get(JOB_TYPE_LABEL) != JOB_TYPE_JOB:
                     continue

--- a/services/core/jobs/tests/controllers/test_docker_backend.py
+++ b/services/core/jobs/tests/controllers/test_docker_backend.py
@@ -22,6 +22,7 @@ from nmp.common.jobs.constants import (
 from nmp.common.jobs.schemas import PlatformJobStatus
 from nmp.core.jobs.api.v2.jobs.schemas import PlatformJobStepWithContext
 from nmp.core.jobs.app.constants import (
+    JOB_CONTROLLER_INSTANCE_ID_LABEL,
     JOB_EXECUTION_BACKEND_LABEL,
     JOB_EXECUTION_PROFILE_LABEL,
     JOB_ID_LABEL,
@@ -32,6 +33,7 @@ from nmp.core.jobs.app.constants import (
     JOB_TASK_ID_LABEL,
     JOB_TYPE_JOB,
     JOB_TYPE_LABEL,
+    JOB_TYPE_STORAGE_CLEANUP,
     JOB_USES_PERSISTENT_STORAGE_LABEL,
     JOB_WORKSPACE_ID_LABEL,
 )
@@ -58,6 +60,21 @@ from nmp.core.jobs.controllers.backends.docker import (
 )
 from nmp.core.jobs.controllers.backends.exceptions import ResourceAllocationError, SchedulingDeferred
 from pydantic import ValidationError
+
+TEST_JOBS_CONTROLLER_INSTANCE_ID = "test-owner"
+
+
+@pytest.fixture(autouse=True)
+def docker_owner_id(monkeypatch):
+    monkeypatch.setenv("NMP_JOBS_DOCKER_OWNER_ID", TEST_JOBS_CONTROLLER_INSTANCE_ID)
+
+
+def owned_container_labels(labels: dict) -> dict:
+    return {
+        **labels,
+        JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
+    }
 
 
 @pytest.fixture
@@ -92,6 +109,8 @@ def docker_client_mock(monkeypatch):
         # Patch containers.create to return a mock with .wait() returning success by default
         def create_container_mock(*args, **kwargs):
             container = MagicMock()
+            container.id = kwargs.get("name", "mock-container-id")
+            container.labels = kwargs.get("labels", {})
             # By default, .wait() returns success
             container.wait.return_value = {"StatusCode": 0}
             container.put_archive.return_value = None
@@ -223,6 +242,7 @@ def test_docker_job_schedule(docker_job, docker_client_mock, test_job_step):
 
     # Verify execution profile labels on job container
     assert "labels" in kwargs
+    assert kwargs["labels"][JOB_CONTROLLER_INSTANCE_ID_LABEL] == TEST_JOBS_CONTROLLER_INSTANCE_ID
     assert kwargs["labels"][JOB_EXECUTION_BACKEND_LABEL] == "docker"
     assert kwargs["labels"][JOB_EXECUTION_PROFILE_LABEL] == "default"
 
@@ -292,6 +312,7 @@ def test_docker_job_with_persistence_schedule(docker_job, docker_client_mock, te
 
     # Verify execution profile labels on job container
     assert "labels" in kwargs
+    assert kwargs["labels"][JOB_CONTROLLER_INSTANCE_ID_LABEL] == TEST_JOBS_CONTROLLER_INSTANCE_ID
     assert kwargs["labels"][JOB_EXECUTION_BACKEND_LABEL] == "docker"
     assert kwargs["labels"][JOB_EXECUTION_PROFILE_LABEL] == "default"
 
@@ -391,13 +412,14 @@ def test_docker_job_sync_pausing_sigterm(docker_job, docker_client_mock, test_jo
     container_mock.status = "exited"
     container_mock.attrs = {"State": {"ExitCode": 0}}  # SIGTERM will set exit code 0 if exited gracefully
     task_id = uuid.uuid4().hex
-    container_mock.labels = {
-        JOB_WORKSPACE_ID_LABEL: test_job_step.workspace,
-        JOB_ID_LABEL: test_job_step.job,
-        JOB_STEP_NAME_LABEL: test_job_step.name,
-        JOB_TASK_ID_LABEL: task_id,
-        JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
-    }
+    container_mock.labels = owned_container_labels(
+        {
+            JOB_WORKSPACE_ID_LABEL: test_job_step.workspace,
+            JOB_ID_LABEL: test_job_step.job,
+            JOB_STEP_NAME_LABEL: test_job_step.name,
+            JOB_TASK_ID_LABEL: task_id,
+        }
+    )
     # Clear side_effect so return_value takes precedence
     docker_client_mock.containers.get.side_effect = None
     docker_client_mock.containers.get.return_value = container_mock
@@ -418,13 +440,14 @@ def test_docker_job_sync_cancelling_sigterm(docker_job, docker_client_mock, test
     container_mock.status = "exited"
     container_mock.attrs = {"State": {"ExitCode": 0}}  # SIGTERM will set exit code 0 if exited gracefully
     task_id = uuid.uuid4().hex
-    container_mock.labels = {
-        JOB_WORKSPACE_ID_LABEL: test_job_step.workspace,
-        JOB_ID_LABEL: test_job_step.job,
-        JOB_STEP_NAME_LABEL: test_job_step.name,
-        JOB_TASK_ID_LABEL: task_id,
-        JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
-    }
+    container_mock.labels = owned_container_labels(
+        {
+            JOB_WORKSPACE_ID_LABEL: test_job_step.workspace,
+            JOB_ID_LABEL: test_job_step.job,
+            JOB_STEP_NAME_LABEL: test_job_step.name,
+            JOB_TASK_ID_LABEL: task_id,
+        }
+    )
     # Clear side_effect so return_value takes precedence
     docker_client_mock.containers.get.side_effect = None
     docker_client_mock.containers.get.return_value = container_mock
@@ -446,13 +469,14 @@ def test_docker_job_sync_cancelling_sigkill(docker_job, docker_client_mock, test
     container_mock.status = "exited"
     container_mock.attrs = {"State": {"ExitCode": 137}}  # SIGKILL will set exit code 137
     task_id = uuid.uuid4().hex
-    container_mock.labels = {
-        JOB_WORKSPACE_ID_LABEL: test_job_step.workspace,
-        JOB_ID_LABEL: test_job_step.job,
-        JOB_STEP_NAME_LABEL: test_job_step.name,
-        JOB_TASK_ID_LABEL: task_id,
-        JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
-    }
+    container_mock.labels = owned_container_labels(
+        {
+            JOB_WORKSPACE_ID_LABEL: test_job_step.workspace,
+            JOB_ID_LABEL: test_job_step.job,
+            JOB_STEP_NAME_LABEL: test_job_step.name,
+            JOB_TASK_ID_LABEL: task_id,
+        }
+    )
     # Clear side_effect so return_value takes precedence
     docker_client_mock.containers.get.side_effect = None
     docker_client_mock.containers.get.return_value = container_mock
@@ -898,6 +922,7 @@ def test_gpu_cleanup_on_job_completion(mock_nmp_client, docker_client_mock):
         JOB_STEP_ID_LABEL: step.id,
         JOB_TASK_ID_LABEL: task_id,
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
         JOB_TYPE_LABEL: JOB_TYPE_JOB,
     }
 
@@ -999,6 +1024,7 @@ def test_gpu_cleanup_on_job_error(mock_nmp_client, docker_client_mock):
         JOB_STEP_ID_LABEL: step.id,
         JOB_TASK_ID_LABEL: task_id,
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
         JOB_TYPE_LABEL: JOB_TYPE_JOB,
     }
 
@@ -1395,6 +1421,7 @@ def test_cleanup_steps_by_ttl(docker_job, docker_client_mock, test_job_step, cle
         JOB_STEP_NAME_LABEL: "test-step",
         JOB_TASK_ID_LABEL: "task-success",
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
         JOB_TYPE_LABEL: JOB_TYPE_JOB,
     }
 
@@ -1413,6 +1440,7 @@ def test_cleanup_steps_by_ttl(docker_job, docker_client_mock, test_job_step, cle
         JOB_STEP_NAME_LABEL: "test-step",
         JOB_TASK_ID_LABEL: "task-killed",
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
         JOB_TYPE_LABEL: JOB_TYPE_JOB,
     }
 
@@ -1431,6 +1459,7 @@ def test_cleanup_steps_by_ttl(docker_job, docker_client_mock, test_job_step, cle
         JOB_STEP_NAME_LABEL: "test-step",
         JOB_TASK_ID_LABEL: "task-error",
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
         JOB_TYPE_LABEL: JOB_TYPE_JOB,
     }
 
@@ -1449,6 +1478,7 @@ def test_cleanup_steps_by_ttl(docker_job, docker_client_mock, test_job_step, cle
         JOB_STEP_NAME_LABEL: "test-step",
         JOB_TASK_ID_LABEL: "task-old-error",
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
         JOB_TYPE_LABEL: JOB_TYPE_JOB,
     }
 
@@ -1464,6 +1494,7 @@ def test_cleanup_steps_by_ttl(docker_job, docker_client_mock, test_job_step, cle
         JOB_STEP_NAME_LABEL: "test-step",
         JOB_TASK_ID_LABEL: "task-running",
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
         JOB_TYPE_LABEL: JOB_TYPE_JOB,
     }
 
@@ -1487,9 +1518,17 @@ def test_cleanup_steps_by_ttl(docker_job, docker_client_mock, test_job_step, cle
     # Run cleanup
     docker_job.cleanup_steps()
 
-    # Verify containers.list was called with the correct filter (managed_by to find job controller containers)
+    # Verify containers.list was called with owner-scoped filters.
     docker_client_mock.containers.list.assert_called_once_with(
-        all=True, filters={"label": JOB_MANAGED_BY_LABEL}, ignore_removed=True
+        all=True,
+        filters={
+            "label": [
+                f"{JOB_MANAGED_BY_LABEL}={JOB_MANAGED_BY_JOBS_CONTROLLER}",
+                f"{JOB_CONTROLLER_INSTANCE_ID_LABEL}={TEST_JOBS_CONTROLLER_INSTANCE_ID}",
+                f"{JOB_EXECUTION_BACKEND_LABEL}=docker",
+            ]
+        },
+        ignore_removed=True,
     )
 
     if cleanup_completed_jobs_immediately:
@@ -1537,6 +1576,67 @@ def test_cleanup_steps_by_ttl(docker_job, docker_client_mock, test_job_step, cle
     mock_network.disconnect.assert_any_call(mock_container_killed)
     mock_network.disconnect.assert_any_call(mock_container_error)
     mock_network.disconnect.assert_any_call(mock_container_old_error)
+
+
+def test_cleanup_steps_skips_different_owner_container_before_jobs_api_check(docker_job, docker_client_mock):
+    other_owner = MagicMock()
+    other_owner.name = "other-owner-container"
+    other_owner.id = "other-owner-container-id"
+    other_owner.status = "exited"
+    other_owner.attrs = {
+        "State": {"ExitCode": 0, "FinishedAt": datetime.datetime.now(datetime.UTC).isoformat()},
+        "NetworkSettings": {"Networks": {"host": {}}},
+    }
+    other_owner.labels = {
+        JOB_WORKSPACE_ID_LABEL: "default",
+        JOB_ID_LABEL: "other-job",
+        JOB_STEP_NAME_LABEL: "other-step",
+        JOB_TASK_ID_LABEL: "other-task",
+        JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: "other-owner",
+        JOB_TYPE_LABEL: JOB_TYPE_JOB,
+    }
+    docker_client_mock.containers.list.return_value = [other_owner]
+    docker_job.check_step_is_terminal = MagicMock(return_value=True)
+
+    docker_job.cleanup_steps()
+
+    docker_job.check_step_is_terminal.assert_not_called()
+    other_owner.remove.assert_not_called()
+
+
+def test_cleanup_steps_skips_legacy_container_without_owner_label(docker_job, docker_client_mock):
+    legacy = MagicMock()
+    legacy.name = "legacy-container"
+    legacy.id = "legacy-container-id"
+    legacy.status = "exited"
+    legacy.attrs = {
+        "State": {"ExitCode": 0, "FinishedAt": datetime.datetime.now(datetime.UTC).isoformat()},
+        "NetworkSettings": {"Networks": {"host": {}}},
+    }
+    legacy.labels = {
+        JOB_WORKSPACE_ID_LABEL: "default",
+        JOB_ID_LABEL: "legacy-job",
+        JOB_STEP_NAME_LABEL: "legacy-step",
+        JOB_TASK_ID_LABEL: "legacy-task",
+        JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_TYPE_LABEL: JOB_TYPE_JOB,
+    }
+    docker_client_mock.containers.list.return_value = [legacy]
+    docker_job.check_step_is_terminal = MagicMock(return_value=True)
+
+    docker_job.cleanup_steps()
+
+    docker_job.check_step_is_terminal.assert_not_called()
+    legacy.remove.assert_not_called()
+
+
+def test_cleanup_job_persistent_storage_labels_cleanup_container_owner(docker_job, docker_client_mock):
+    docker_job.cleanup_job_persistent_storage("default", "job-owner-test")
+
+    cleanup_args = docker_client_mock.containers.create.call_args[1]
+    assert cleanup_args["labels"][JOB_CONTROLLER_INSTANCE_ID_LABEL] == TEST_JOBS_CONTROLLER_INSTANCE_ID
+    assert cleanup_args["labels"][JOB_TYPE_LABEL] == JOB_TYPE_STORAGE_CLEANUP
 
 
 def test_created_step_does_not_ttl_before_backend_acceptance(docker_job, docker_client_mock, test_job_step):
@@ -1610,7 +1710,7 @@ def test_cleanup_pending_created_container_by_ttl(docker_job, docker_client_mock
     test_job_step.created_at = old_timestamp
     test_job_step.updated_at = old_timestamp
 
-    # Create a mock container that the sync method will find (with managed-by label so we kill it)
+    # Create a mock container that the sync method will find (with owner labels so we kill it)
     container_mock = MagicMock()
     container_mock.id = "16-character-uid"
     container_mock.status = "created"
@@ -1620,6 +1720,7 @@ def test_cleanup_pending_created_container_by_ttl(docker_job, docker_client_mock
         JOB_STEP_NAME_LABEL: test_job_step.name,
         JOB_TASK_ID_LABEL: task_id,
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
     }
 
     # Mock containers.get to return our container
@@ -1667,6 +1768,7 @@ def test_pending_running_container_preempts_before_active_ttl(docker_job, docker
         JOB_STEP_NAME_LABEL: test_job_step.name,
         JOB_TASK_ID_LABEL: task_id,
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
     }
     container_mock.attrs = {"State": {"Status": "running", "Running": True}, "HostConfig": {}}
     docker_client_mock.containers.get.side_effect = None
@@ -1697,6 +1799,7 @@ def test_pending_exited_container_preempts_before_active_ttl(docker_job, docker_
         JOB_STEP_NAME_LABEL: test_job_step.name,
         JOB_TASK_ID_LABEL: task_id,
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
     }
     container_mock.attrs = {"State": {"Status": "exited", "ExitCode": 0}, "HostConfig": {}}
     docker_client_mock.containers.get.side_effect = None
@@ -1721,7 +1824,7 @@ def test_cleanup_active_by_ttl(docker_job, docker_client_mock, test_job_step):
     old_timestamp = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=ttl_seconds + 3600)
     test_job_step.created_at = old_timestamp
 
-    # Create a mock container that the sync method will find (with managed-by label so we kill it)
+    # Create a mock container that the sync method will find (with owner labels so we kill it)
     container_mock = MagicMock()
     container_mock.id = "16-character-uid"
     container_mock.status = "running"
@@ -1731,6 +1834,7 @@ def test_cleanup_active_by_ttl(docker_job, docker_client_mock, test_job_step):
         JOB_STEP_NAME_LABEL: test_job_step.name,
         JOB_TASK_ID_LABEL: task_id,
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
     }
 
     # Mock containers.get to return our container
@@ -1787,6 +1891,7 @@ def test_ttl_enforcement_handles_409_when_kill_races_with_stopped_container(
         JOB_STEP_NAME_LABEL: test_job_step.name,
         JOB_TASK_ID_LABEL: task_id,
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
     }
 
     # Mock container.kill() to raise APIError with 409 status (container already stopped)
@@ -1825,7 +1930,7 @@ def test_sync_stop_container_already_stopped(docker_job, docker_client_mock, tes
     # Set the step to CANCELLING status (which triggers sync_stop_container)
     test_job_step.status = PlatformJobStatus.CANCELLING
 
-    # Create a mock container that's already stopped (with managed-by label so we attempt stop)
+    # Create a mock container that's already stopped (with owner labels so we attempt stop)
     container_mock = MagicMock()
     container_mock.id = "16-character-uid"
     container_mock.name = "job-test-job-id-test-step"
@@ -1837,6 +1942,7 @@ def test_sync_stop_container_already_stopped(docker_job, docker_client_mock, tes
         JOB_STEP_NAME_LABEL: test_job_step.name,
         JOB_TASK_ID_LABEL: task_id,
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
     }
 
     # Mock container.stop() to raise APIError with 409 status (container already stopped)
@@ -1872,8 +1978,8 @@ def test_sync_stop_container_already_stopped(docker_job, docker_client_mock, tes
     )
 
 
-def test_sync_stop_container_skips_when_not_managed_by_jobs_controller(docker_job, docker_client_mock, test_job_step):
-    """sync_stop_container must not call container.stop() if the container is not managed by jobs-controller."""
+def test_sync_stop_container_skips_when_not_owned_by_jobs_controller(docker_job, docker_client_mock, test_job_step):
+    """sync_stop_container must not call container.stop() if the container is not owned by this controller."""
     test_job_step.status = PlatformJobStatus.CANCELLING
 
     container_mock = MagicMock()
@@ -1889,7 +1995,7 @@ def test_sync_stop_container_skips_when_not_managed_by_jobs_controller(docker_jo
 
     container_mock.stop.assert_not_called()
     assert result.status == PlatformJobStatus.ERROR.value
-    assert "not managed" in result.error_details.get("message", "")
+    assert "not owned" in result.error_details.get("message", "")
 
 
 # ============================================================================
@@ -2081,6 +2187,7 @@ def test_cleanup_single_container_checks_job_terminal_before_persistent_storage_
         JOB_TASK_ID_LABEL: "task-success",
         JOB_USES_PERSISTENT_STORAGE_LABEL: "true",
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
     }
 
     # Mock volume operations
@@ -2139,6 +2246,7 @@ def test_cleanup_single_container_without_persistent_storage_label(docker_job, d
         JOB_ID_LABEL: "test-job-id",
         JOB_TASK_ID_LABEL: "task-no-storage",
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
         # No JOB_USES_PERSISTENT_STORAGE_LABEL
     }
 
@@ -2182,6 +2290,7 @@ def test_cleanup_single_container_step_terminal_but_job_has_more_steps(docker_jo
         JOB_TASK_ID_LABEL: "task-step1",
         JOB_USES_PERSISTENT_STORAGE_LABEL: "true",
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
     }
 
     # Mock volume operations
@@ -2253,6 +2362,7 @@ def test_cleanup_steps_with_multi_step_job_only_first_step_complete(docker_job, 
         JOB_TASK_ID_LABEL: "task-step1",
         JOB_USES_PERSISTENT_STORAGE_LABEL: "true",
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
         JOB_TYPE_LABEL: JOB_TYPE_JOB,
     }
 
@@ -2269,6 +2379,7 @@ def test_cleanup_steps_with_multi_step_job_only_first_step_complete(docker_job, 
         JOB_TASK_ID_LABEL: "task-step2",
         JOB_USES_PERSISTENT_STORAGE_LABEL: "true",
         JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
         JOB_TYPE_LABEL: JOB_TYPE_JOB,
     }
 

--- a/services/core/jobs/tests/controllers/test_docker_backend.py
+++ b/services/core/jobs/tests/controllers/test_docker_backend.py
@@ -1526,6 +1526,7 @@ def test_cleanup_steps_by_ttl(docker_job, docker_client_mock, test_job_step, cle
                 f"{JOB_MANAGED_BY_LABEL}={JOB_MANAGED_BY_JOBS_CONTROLLER}",
                 f"{JOB_CONTROLLER_INSTANCE_ID_LABEL}={TEST_JOBS_CONTROLLER_INSTANCE_ID}",
                 f"{JOB_EXECUTION_BACKEND_LABEL}=docker",
+                f"{JOB_EXECUTION_PROFILE_LABEL}=default",
             ]
         },
         ignore_removed=True,


### PR DESCRIPTION
## Summary

Prevents multiple Docker-backend jobs controllers from interfering with each other by scoping container lifecycle operations (cleanup, stop, kill) to the owning controller instance.

## Changes

- **Controller instance ID label**: Each controller stamps containers with a `nmp.nvidia.com/jobs_controller_instance_id` label derived from `NMP_JOBS_DOCKER_OWNER_ID` env var (if set) or a SHA-256 hash of the resolved data directory path.
- **Owner-scoped operations**: `cleanup_container`, `sync_stop_container`, and `sync_kill_container` now check `_is_container_owned_by_this_controller()` instead of only checking the `managed-by` label. Containers belonging to a different controller instance or legacy containers without an owner label are skipped.
- **Scoped cleanup filters**: `cleanup_steps` passes owner-scoped Docker label filters (`managed-by`, `controller-instance-id`, `backend`, `profile`) so the Docker daemon only returns containers relevant to this controller.
- **Consolidated base labels**: A `_base_controller_labels()` helper provides the common label set (`managed-by`, `controller-instance-id`, `backend`, `profile`) used by both job containers and storage-cleanup containers, reducing duplication.
- **Tests**: Added dedicated tests for cross-owner and legacy-container skip behavior, owner label assertions on storage-cleanup containers, and updated existing tests to include the new label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker-managed jobs are now tracked with a controller-instance label, so stop, kill, and cleanup actions only affect containers owned by the current controller.
  * Cleanup flows now skip legacy or foreign containers more reliably, reducing accidental interruption of unrelated workloads.
  * Persistent-storage cleanup jobs now carry the same ownership metadata, improving consistency across job lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->