### PR TITLE
ci: squeeze disk space from the runner as much as possible

### DIFF
--- a/.github/actions/free-disk-space/action.yaml
+++ b/.github/actions/free-disk-space/action.yaml
@@ -5,6 +5,18 @@ description: >
   dependencies.
 
 inputs:
+  remove_python:
+    description: Remove /opt/hostedtoolcache/Python
+    required: false
+    default: "false"
+  remove_pypy:
+    description: Remove /opt/hostedtoolcache/PyPy
+    required: false
+    default: "false"
+  remove_node:
+    description: Remove /opt/hostedtoolcache/node
+    required: false
+    default: "false"
   remove_ruby:
     description: Remove /opt/hostedtoolcache/Ruby
     required: false
@@ -48,6 +60,15 @@ runs:
         sudo rm -rf /usr/local/lib/android || true
         sudo rm -rf /opt/ghc || true
         sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        if [ "${{ inputs.remove_python }}" = "true" ]; then
+          sudo rm -rf /opt/hostedtoolcache/Python || true
+        fi
+        if [ "${{ inputs.remove_pypy }}" = "true" ]; then
+          sudo rm -rf /opt/hostedtoolcache/PyPy || true
+        fi
+        if [ "${{ inputs.remove_node }}" = "true" ]; then
+          sudo rm -rf /opt/hostedtoolcache/node || true
+        fi
         if [ "${{ inputs.remove_ruby }}" = "true" ]; then
           sudo rm -rf /opt/hostedtoolcache/Ruby || true
         fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,11 +154,11 @@ jobs:
           prune_docker: "true"
 
       - name: Set up Docker Buildx
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker buildx create --name nmp-builder --driver docker-container --use
-          docker buildx inspect --bootstrap
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          name: nmp-builder
+          driver: docker-container
+          cleanup: true
 
       - name: Configure bake variables
         id: bake-vars
@@ -306,11 +306,11 @@ jobs:
           prune_docker: "true"
 
       - name: Set up Docker Buildx
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker buildx create --name nmp-builder --driver docker-container --use
-          docker buildx inspect --bootstrap
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          name: nmp-builder
+          driver: docker-container
+          cleanup: true
 
       - name: Configure bake variables
         shell: bash
@@ -365,6 +365,9 @@ jobs:
           remove_go: "true"
           remove_haskell: "true"
           remove_java: "true"
+          remove_node: "true"
+          remove_pypy: "true"
+          remove_python: "true"
           remove_ruby: "true"
           remove_swift: "true"
           prune_docker: "true"
@@ -378,11 +381,11 @@ jobs:
           du -sh /opt/hostedtoolcache/*
 
       - name: Set up Docker Buildx
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker buildx create --name nmp-builder --driver docker-container --use
-          docker buildx inspect --bootstrap
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          name: nmp-builder
+          driver: docker-container
+          cleanup: true
 
       - name: Configure bake variables
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -369,6 +369,14 @@ jobs:
           remove_swift: "true"
           prune_docker: "true"
 
+      - name: inspect disks
+        shell: bash
+        run: |
+          mount
+          df -h
+          ls -l /opt/hostedtoolcache
+          du -sh /opt/hostedtoolcache/*
+
       - name: Set up Docker Buildx
         shell: bash
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -372,14 +372,6 @@ jobs:
           remove_swift: "true"
           prune_docker: "true"
 
-      - name: inspect disks
-        shell: bash
-        run: |
-          mount
-          df -h
-          ls -l /opt/hostedtoolcache
-          du -sh /opt/hostedtoolcache/*
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the disk cleanup option set to let CI jobs remove Python, PyPy, and Node tool caches when needed.
  * Standardized Docker Buildx setup in CI using the managed setup action, simplifying build configuration.
* **Bug Fixes**
  * Improved build job consistency and cleanup behavior across multiple workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->