### PR TITLE
refactor: decouple FilesetFileSystem from Starlette test internals and improve upload/download paths

### DIFF
--- a/packages/data_designer_nemo/src/data_designer_nemo/fileset_file_seed_reader.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/fileset_file_seed_reader.py
@@ -8,9 +8,6 @@ from data_designer.engine.resources.seed_reader import SeedReader
 from data_designer_nemo.fileset_file_seed_source import FilesetFileSeedSource
 from data_designer_nemo.sdk_translation import async_to_sync_sdk
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-from nemo_platform.filesets import FilesetFileSystem
-from nemo_platform_plugin.client.adapter import client_from_platform
-from nemo_platform_plugin.files.client import FilesClient
 
 workspace_cvar = ContextVar[str | None]("workspace_cvar", default=None)
 
@@ -28,11 +25,8 @@ class FilesetFileSeedReader(SeedReader[FilesetFileSeedSource]):
         if self._sdk is None:
             raise RuntimeError("FilesetFileSeedReader requires an injected NeMo Platform SDK")
 
-        files_client = client_from_platform(self._sdk, FilesClient)
-        filesystem = FilesetFileSystem(client=files_client)
-
         conn = duckdb.connect()
-        conn.register_filesystem(filesystem)
+        conn.register_filesystem(self._sdk.files.fsspec)
         return conn
 
     def get_dataset_uri(self) -> str:

--- a/packages/data_designer_nemo/src/data_designer_nemo/person_reader.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/person_reader.py
@@ -8,9 +8,6 @@ from data_designer_nemo.nemotron_personas import (
 )
 from data_designer_nemo.sdk_translation import async_to_sync_sdk
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-from nemo_platform.filesets import FilesetFileSystem
-from nemo_platform_plugin.client.adapter import client_from_platform
-from nemo_platform_plugin.files.client import FilesClient
 
 
 class FilesetsPersonReader(PersonReader):
@@ -20,15 +17,9 @@ class FilesetsPersonReader(PersonReader):
     top-level) or an :class:`AsyncNeMoPlatform` (API-process path, used
     from a worker thread under :func:`anyio.to_thread.run_sync`).
 
-    DuckDB calls into ``FilesetFileSystem`` synchronously, so the
-    underlying filesystem must be in fsspec's sync mode
-    (``asynchronous=False``) — fsspec then spins up its own daemon event
-    loop for sync→async bridging. ``FilesetFileSystem`` sets
-    ``asynchronous=True`` when given an ``AsyncFilesClient``, which would
-    break DuckDB. So when this reader is constructed with an async SDK we
-    rebuild a sync SDK, derive a sync ``FilesClient``, and hand *that* to
-    ``FilesetFileSystem``. Auth and identity propagate; fsspec stays in
-    sync mode.
+    DuckDB calls into the SDK fileset filesystem synchronously, so when this
+    reader is constructed with an async SDK we rebuild a sync SDK first. Auth
+    and identity propagate; fsspec stays in sync mode.
     """
 
     def __init__(self, sdk: NeMoPlatform | AsyncNeMoPlatform):
@@ -37,10 +28,8 @@ class FilesetsPersonReader(PersonReader):
         self._sdk = sdk
 
     def create_duckdb_connection(self) -> duckdb.DuckDBPyConnection:
-        files_client = client_from_platform(self._sdk, FilesClient)
-        filesystem = FilesetFileSystem(client=files_client)
         conn = duckdb.connect()
-        conn.register_filesystem(filesystem)
+        conn.register_filesystem(self._sdk.files.fsspec)
         return conn
 
     def get_dataset_uri(self, locale: str) -> str:

--- a/packages/filesets/src/filesets/filesystem/filesystem.py
+++ b/packages/filesets/src/filesets/filesystem/filesystem.py
@@ -6,17 +6,20 @@
 from __future__ import annotations
 
 import inspect
+import os
 from collections.abc import AsyncIterator, Coroutine, Iterator, Sequence
 from datetime import datetime, timezone
-from typing import Any, Literal, Protocol, TypedDict, TypeVar, overload, runtime_checkable
+from glob import has_magic
+from typing import Any, Literal, TypedDict, TypeVar, overload
 
 import anyio
 import fsspec.asyn
-import httpx
 from anyio import to_thread
 from fsspec.asyn import AbstractAsyncStreamedFile, AsyncFileSystem, _get_batch_size
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
+from fsspec.implementations.local import LocalFileSystem, make_path_posix, trailing_sep
 from fsspec.spec import AbstractBufferedFile
+from fsspec.utils import other_paths
 from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 from nemo_platform_plugin.files.types import FilesetFileOutput, ListFilesQueryParams
 
@@ -37,10 +40,8 @@ async def run_coros_in_chunks(
     We admit all work up front and use a CapacityLimiter so a new task can start
     as soon as any slot frees up, which keeps bulk downloads/uploads saturated.
 
-    We still monkey-patch fsspec's helper so inherited AsyncFileSystem bulk ops
-    benefit from AnyIO task-group cancellation. Running tasks are cancelled by
-    the task group; coroutine objects that were never entered are explicitly
-    closed in the outer finally block.
+    Running tasks are cancelled by the task group; coroutine objects that were
+    never entered are explicitly closed in the outer finally block.
     """
 
     if batch_size is None:
@@ -91,18 +92,6 @@ async def run_coros_in_chunks(
                 coro.close()
 
     return results
-
-
-@runtime_checkable
-class _AsyncTransportProvider(Protocol):
-    def create_async_transport(self) -> httpx.AsyncBaseTransport: ...
-
-
-def _create_async_transport(sync_client: httpx.Client) -> httpx.AsyncBaseTransport | None:
-    """Return an async transport when the sync client explicitly provides one."""
-    if isinstance(sync_client, _AsyncTransportProvider):
-        return sync_client.create_async_transport()
-    return None
 
 
 class FileInfo(TypedDict):
@@ -344,11 +333,12 @@ class FilesetFileSystem(AsyncFileSystem):
         self,
         *,
         client: FilesClient | AsyncFilesClient,
+        async_client: AsyncFilesClient | None = None,
         batch_size: int | None = None,
         blocksize: int | None = None,
         **kwargs,
     ):
-        async_client = self._ensure_async(client)
+        async_client = async_client or self._ensure_async(client)
         is_async = isinstance(client, AsyncFilesClient)
 
         if batch_size is None:
@@ -368,7 +358,6 @@ class FilesetFileSystem(AsyncFileSystem):
 
         import httpx
 
-        transport = _create_async_transport(client._http)
         return AsyncFilesClient(
             base_url=client.base_url,
             workspace=client.workspace,
@@ -376,7 +365,6 @@ class FilesetFileSystem(AsyncFileSystem):
             default_headers=client._default_headers or None,
             retry=client._retry,
             http_client=httpx.AsyncClient(
-                transport=transport,
                 base_url=client.base_url,
                 headers=dict(client._default_headers) if client._default_headers else None,
             ),
@@ -656,6 +644,62 @@ class FilesetFileSystem(AsyncFileSystem):
         """Sync wrapper for _pipe_stream. See _pipe_stream for details."""
         return fsspec.asyn.sync(self.loop, self._pipe_stream, path, stream, content_length)
 
+    async def _put(
+        self,
+        lpath,
+        rpath,
+        recursive=False,
+        callback=DEFAULT_CALLBACK,
+        batch_size=None,
+        maxdepth=None,
+        **kwargs,
+    ):
+        """Copy local file(s) into the fileset."""
+        if isinstance(lpath, list) and isinstance(rpath, list):
+            rpaths = rpath
+            lpaths = lpath
+        else:
+            source_is_str = isinstance(lpath, str)
+            if source_is_str:
+                lpath = make_path_posix(lpath)
+            fs = LocalFileSystem()
+            lpaths = fs.expand_path(lpath, recursive=recursive, maxdepth=maxdepth)
+            if source_is_str and (not recursive or maxdepth is not None):
+                lpaths = [path for path in lpaths if not (trailing_sep(path) or fs.isdir(path))]
+                if not lpaths:
+                    return
+
+            source_is_file = len(lpaths) == 1
+            dest_is_dir = isinstance(rpath, str) and (trailing_sep(rpath) or await self._isdir(rpath))
+
+            rpath = self._strip_protocol(rpath)
+            exists = source_is_str and (
+                (has_magic(lpath) and source_is_file)
+                or (not has_magic(lpath) and dest_is_dir and not trailing_sep(lpath))
+            )
+            rpaths = other_paths(
+                lpaths,
+                rpath,
+                exists=exists,
+                flatten=not source_is_str,
+            )
+
+        is_dir = {path: os.path.isdir(path) for path in lpaths}
+        rdirs = [remote for local, remote in zip(lpaths, rpaths) if is_dir[local]]
+        file_pairs = [(local, remote) for local, remote in zip(lpaths, rpaths) if not is_dir[local]]
+
+        async with anyio.create_task_group() as tg:
+            for directory in rdirs:
+                tg.start_soon(self._makedirs, directory, True)
+
+        callback.set_size(len(file_pairs))
+        put_file = callback.branch_coro(self._put_file)
+        await run_coros_in_chunks(
+            [put_file(local, remote, **kwargs) for local, remote in file_pairs],
+            batch_size=batch_size or self.batch_size,
+            callback=callback,
+        )
+
     async def _put_file(
         self,
         lpath: str,
@@ -796,7 +840,7 @@ class FilesetFileSystem(AsyncFileSystem):
         """Download files using a single _find call for efficiency.
 
         Uses run_coros_in_chunks which provides proper task cancellation
-        via our monkey-patched TaskGroup-based implementation.
+        for the direct list-download path.
 
         When rpath and lpath are both lists, downloads each (remote, local) pair
         directly without path expansion. This is useful for downloading a specific

--- a/packages/filesets/src/filesets/filesystem/filesystem.py
+++ b/packages/filesets/src/filesets/filesystem/filesystem.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import inspect
 from collections.abc import AsyncIterator, Coroutine, Iterator, Sequence
 from datetime import datetime, timezone
-from typing import Any, Literal, TypedDict, TypeVar, overload
+from typing import Any, Literal, Protocol, TypedDict, TypeVar, overload, runtime_checkable
 
 import anyio
 import fsspec.asyn
@@ -93,21 +93,15 @@ async def run_coros_in_chunks(
     return results
 
 
-# Monkey-patch fsspec so inherited AsyncFileSystem bulk ops use the same
-# limiter-based AnyIO runner. This is intentionally semantics-different from
-# upstream chunking because we prefer continuous refill over wave-based batches.
-fsspec.asyn._run_coros_in_chunks = run_coros_in_chunks
+@runtime_checkable
+class _AsyncTransportProvider(Protocol):
+    def create_async_transport(self) -> httpx.AsyncBaseTransport: ...
 
 
-def _detect_async_transport(sync_client: Any) -> httpx.AsyncBaseTransport | None:
-    """Detect if a sync httpx client wraps a TestClient and return ASGITransport."""
-    try:
-        from starlette.testclient import TestClient
-
-        if isinstance(sync_client, TestClient):
-            return httpx.ASGITransport(app=sync_client.app)
-    except ImportError:
-        pass
+def _create_async_transport(sync_client: httpx.Client) -> httpx.AsyncBaseTransport | None:
+    """Return an async transport when the sync client explicitly provides one."""
+    if isinstance(sync_client, _AsyncTransportProvider):
+        return sync_client.create_async_transport()
     return None
 
 
@@ -374,7 +368,7 @@ class FilesetFileSystem(AsyncFileSystem):
 
         import httpx
 
-        transport = _detect_async_transport(client._http)
+        transport = _create_async_transport(client._http)
         return AsyncFilesClient(
             base_url=client.base_url,
             workspace=client.workspace,
@@ -607,7 +601,7 @@ class FilesetFileSystem(AsyncFileSystem):
         # Invalidate parent directory's cache since file info is stored there
         self.invalidate_cache(self._parent(build_fileset_ref(path)))
 
-    async def _pipe_file(self, path: str, value: bytes, **kwargs) -> None:
+    async def _pipe_file(self, path: str, value: bytes, mode: str = "overwrite", **kwargs) -> None:
         """Write bytes to a file."""
         workspace, fileset, file_path = parse_fileset_ref(path, workspace_fallback=self._workspace)
         if not file_path:
@@ -662,7 +656,14 @@ class FilesetFileSystem(AsyncFileSystem):
         """Sync wrapper for _pipe_stream. See _pipe_stream for details."""
         return fsspec.asyn.sync(self.loop, self._pipe_stream, path, stream, content_length)
 
-    async def _put_file(self, lpath: str, rpath: str, callback: Callback = DEFAULT_CALLBACK, **kwargs) -> None:
+    async def _put_file(
+        self,
+        lpath: str,
+        rpath: str,
+        mode: str = "overwrite",
+        callback: Callback = DEFAULT_CALLBACK,
+        **kwargs,
+    ) -> None:
         """Upload a local file to a fileset.
 
         Uses streaming upload to avoid buffering the entire file in memory.
@@ -723,7 +724,7 @@ class FilesetFileSystem(AsyncFileSystem):
         self._populate_dircache_from_response(response, workspace, fileset, prefix)
 
         # Build the flat output dict
-        out = {}
+        out: dict[str, FileInfo] = {}
         seen_dirs: set[str] = set()
 
         # Add root path if withdirs requested
@@ -808,11 +809,14 @@ class FilesetFileSystem(AsyncFileSystem):
             callback.set_size(len(rpath))
             get_file_with_callback = callback.branch_coro(self._get_file)
             await run_coros_in_chunks(
-                [get_file_with_callback(remote, local, **kwargs) for remote, local in zip(rpath, lpath)],
+                [get_file_with_callback(remote, local, **kwargs) for remote, local in zip(rpath, lpath, strict=True)],
                 batch_size=batch_size or self.batch_size,
                 callback=callback,
             )
             return
+
+        if not isinstance(rpath, str) or not isinstance(lpath, str):
+            raise TypeError("rpath and lpath must both be strings or both be lists")
 
         source_files = await self._find(rpath, maxdepth=maxdepth, withdirs=False)
         if not source_files:

--- a/packages/filesets/src/filesets/resources.py
+++ b/packages/filesets/src/filesets/resources.py
@@ -14,7 +14,7 @@ from functools import cached_property
 from pathlib import PurePath
 from typing import Protocol, runtime_checkable
 
-from fsspec.callbacks import Callback
+from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 from fsspec.core import has_magic
 from nemo_platform.resources.files.filesets import AsyncFilesetsResource, FilesetsResource
 from nemo_platform.resources.files.otlp.otlp import AsyncOtlpResource, OtlpResource
@@ -24,6 +24,7 @@ from nemo_platform_plugin.files.types import (
     CreateFilesetRequest,
     FilesetFileOutput,
     FilesetOutput,
+    ListFilesQueryParams,
 )
 
 from filesets.filesystem.filesystem import (
@@ -71,16 +72,16 @@ class ListFilesResponse:
 
         # Priority: caching > not_cached > cached > not_cacheable
         if "caching" in statuses:
-            return "caching"
+            return CacheStatus.CACHING
         if "not_cached" in statuses:
-            return "not_cached"
+            return CacheStatus.NOT_CACHED
         if all(s == "cached" for s in statuses):
-            return "cached"
+            return CacheStatus.CACHED
         if all(s == "not_cacheable" for s in statuses):
-            return "not_cacheable"
+            return CacheStatus.NOT_CACHEABLE
 
         # Mixed cached/not_cacheable - return cached since some files are cached
-        return "cached"
+        return CacheStatus.CACHED
 
 
 @runtime_checkable
@@ -139,10 +140,17 @@ class FilesResource:
     For fsspec filesystem access, use ``resource.fsspec``.
     """
 
-    def __init__(self, client, *, files_client: FilesClient | None = None) -> None:
+    def __init__(
+        self,
+        client,
+        *,
+        files_client: FilesClient | None = None,
+        async_files_client: AsyncFilesClient | None = None,
+    ) -> None:
         # Retain the platform client so the generated fileset/otlp sub-resources
         # (which speak to the platform client, not the FilesClient) can be exposed.
         self._platform_client = client
+        self._async_client = async_files_client
         if files_client is not None:
             self._client = files_client
         else:
@@ -168,7 +176,7 @@ class FilesResource:
     @cached_property
     def fsspec(self) -> FilesetFileSystem:
         """Access the underlying fsspec filesystem."""
-        return FilesetFileSystem(client=self._client)
+        return FilesetFileSystem(client=self._client, async_client=self._async_client)
 
     def _ensure_fileset_exists(self, workspace: str, fileset: str) -> None:
         """Create fileset if it doesn't exist (idempotent)."""
@@ -615,7 +623,7 @@ class FilesResource:
         # For path prefixes, the API handles filtering server-side
         api_path = None if has_magic(path) else (path or None)
 
-        query_params = {}
+        query_params: ListFilesQueryParams = {}
         if api_path is not None:
             query_params["path"] = api_path
         if include_cache_status:
@@ -794,10 +802,7 @@ class AsyncFilesResource:
             # Build list of (remote, local) path pairs preserving directory structure
             rpaths = [build_fileset_ref(p, workspace=ws, fileset=fileset) for p in remote_path]
             lpaths = [str(PurePath(local_path) / p) for p in remote_path]
-            kwargs: dict = {"rpath": rpaths, "lpath": lpaths, "batch_size": max_workers}
-            if callback is not None:
-                kwargs["callback"] = callback
-            await self.fsspec._get(**kwargs)
+            await self.fsspec._get(rpaths, lpaths, batch_size=max_workers, callback=callback or DEFAULT_CALLBACK)
             return
 
         ws, path_fileset, path = parse_fileset_path(
@@ -817,16 +822,16 @@ class AsyncFilesResource:
             # Build list of (remote, local) path pairs preserving directory structure
             rpaths = [build_fileset_ref(f.path, workspace=ws, fileset=fileset) for f in matching_files.data]
             lpaths = [str(PurePath(local_path) / f.path) for f in matching_files.data]
-            kwargs = {"rpath": rpaths, "lpath": lpaths, "batch_size": max_workers}
-            if callback is not None:
-                kwargs["callback"] = callback
-            await self.fsspec._get(**kwargs)
+            await self.fsspec._get(rpaths, lpaths, batch_size=max_workers, callback=callback or DEFAULT_CALLBACK)
         else:
             fileset_ref = build_fileset_ref(path, workspace=ws, fileset=fileset)
-            kwargs = {"rpath": fileset_ref, "lpath": local_path, "recursive": True, "batch_size": max_workers}
-            if callback is not None:
-                kwargs["callback"] = callback
-            await self.fsspec._get(**kwargs)
+            await self.fsspec._get(
+                fileset_ref,
+                local_path,
+                recursive=True,
+                batch_size=max_workers,
+                callback=callback or DEFAULT_CALLBACK,
+            )
 
     async def upload(
         self,
@@ -1129,7 +1134,7 @@ class AsyncFilesResource:
         # For path prefixes, the API handles filtering server-side
         api_path = None if has_magic(path) else (path or None)
 
-        query_params = {}
+        query_params: ListFilesQueryParams = {}
         if api_path is not None:
             query_params["path"] = api_path
         if include_cache_status:

--- a/packages/nemo_platform_ext/tests/cli/integration/conftest.py
+++ b/packages/nemo_platform_ext/tests/cli/integration/conftest.py
@@ -22,7 +22,7 @@ from nemo_platform_ext.cli.core.context import CLIContext
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.files.client import FilesClient
 from nmp.core.files.service import FilesService
-from nmp.testing import create_test_client
+from nmp.testing import SDKTestClientAdapter, create_test_client
 from starlette.testclient import TestClient
 from typer.testing import CliRunner
 
@@ -39,7 +39,7 @@ def http_client() -> Generator[TestClient, None, None]:
 @pytest.fixture(scope="module")
 def sdk(http_client: TestClient) -> NeMoPlatform:
     """SDK client backed by the test client."""
-    return NeMoPlatform(base_url="http://testserver", http_client=http_client)
+    return NeMoPlatform(base_url="http://testserver", http_client=SDKTestClientAdapter(http_client))
 
 
 @pytest.fixture(scope="module")

--- a/packages/nemo_platform_ext/tests/cli/integration/conftest.py
+++ b/packages/nemo_platform_ext/tests/cli/integration/conftest.py
@@ -22,7 +22,7 @@ from nemo_platform_ext.cli.core.context import CLIContext
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.files.client import FilesClient
 from nmp.core.files.service import FilesService
-from nmp.testing import SDKTestClientAdapter, create_test_client
+from nmp.testing import ClientContext, create_test_client
 from starlette.testclient import TestClient
 from typer.testing import CliRunner
 
@@ -30,16 +30,22 @@ DEFAULT_WORKSPACE = "default"
 
 
 @pytest.fixture(scope="module")
-def http_client() -> Generator[TestClient, None, None]:
-    """TestClient with FilesService (and EntitiesService, which are included by default)."""
-    with create_test_client(FilesService, client_type=TestClient) as client:
-        yield client
+def client_context() -> Generator[ClientContext, None, None]:
+    """ClientContext with FilesService and ASGI-backed SDK clients."""
+    with create_test_client(FilesService, client_type=ClientContext) as context:
+        yield context
 
 
 @pytest.fixture(scope="module")
-def sdk(http_client: TestClient) -> NeMoPlatform:
+def http_client(client_context: ClientContext) -> TestClient:
+    """TestClient with FilesService (and EntitiesService, which are included by default)."""
+    return client_context.test_client
+
+
+@pytest.fixture(scope="module")
+def sdk(client_context: ClientContext) -> NeMoPlatform:
     """SDK client backed by the test client."""
-    return NeMoPlatform(base_url="http://testserver", http_client=SDKTestClientAdapter(http_client))
+    return client_context.sdk
 
 
 @pytest.fixture(scope="module")

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/file_manager.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/file_manager.py
@@ -13,8 +13,6 @@ import anyio
 import fsspec.asyn
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform.filesets import FilesetFileSystem, build_fileset_ref, parse_fileset_ref
-from nemo_platform_plugin.client.adapter import client_from_platform
-from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 from nemo_platform_plugin.files.types import CreateFilesetRequest
 from nemo_platform_plugin.jobs.schemas import FileStorageType
 
@@ -142,11 +140,7 @@ class BaseFilesetFileManager:
     _fs: FilesetFileSystem = field(init=False)
 
     def __post_init__(self):
-        if isinstance(self.sdk, AsyncNeMoPlatform):
-            files_client = client_from_platform(self.sdk, AsyncFilesClient)
-        else:
-            files_client = client_from_platform(self.sdk, FilesClient)
-        self._fs = FilesetFileSystem(client=files_client)
+        self._fs = self.sdk.files.fsspec
 
     def url(self, remote_path: str | None = None) -> str:
         """Return fileset reference for the given path."""

--- a/packages/nmp_common/tests/jobs/conftest.py
+++ b/packages/nmp_common/tests/jobs/conftest.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from types import SimpleNamespace
-from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -72,7 +71,7 @@ def mock_fileset_fs():
 def mock_sdk():
     """Mock NeMoPlatform SDK for FilesetFileManager.
 
-    The sync FilesetFileManager uses SDK methods directly (not FilesetFileSystem).
+    FilesetFileManager uses the FilesetFileSystem exposed by the SDK files resource.
     """
 
     from nemo_platform import NeMoPlatform
@@ -82,6 +81,7 @@ def mock_sdk():
     sdk._custom_headers = None
     sdk._client = MagicMock()
     sdk.files = MagicMock()
+    sdk.files.fsspec = MagicMock()
     sdk.files.upload_content = MagicMock()
 
     # Mock list to return ListFilesResponse with empty data by default
@@ -99,19 +99,14 @@ def mock_sdk():
 def fileset_manager(mock_sdk, mock_fileset_fs) -> FilesetFileManager:
     """Create FilesetFileManager with mocked FilesetFileSystem.
 
-    The FilesetFileManager creates FilesetFileSystem in __post_init__, so we must
-    patch both client_from_platform and FilesetFileSystem to inject our mock.
+    The FilesetFileManager uses sdk.files.fsspec, so inject our filesystem mock there.
     """
-    with (
-        mock.patch("nemo_platform_plugin.jobs.file_manager.client_from_platform"),
-        mock.patch("nemo_platform_plugin.jobs.file_manager.FilesetFileSystem") as mock_fs_class,
-    ):
-        mock_fs_class.return_value = mock_fileset_fs
-        return FilesetFileManager(
-            workspace=DEFAULT_WORKSPACE,
-            fileset_name="job-results-jobid-123",
-            sdk=mock_sdk,
-        )
+    mock_sdk.files.fsspec = mock_fileset_fs
+    return FilesetFileManager(
+        workspace=DEFAULT_WORKSPACE,
+        fileset_name="job-results-jobid-123",
+        sdk=mock_sdk,
+    )
 
 
 @pytest.fixture

--- a/packages/nmp_common/tests/jobs/test_file_manager.py
+++ b/packages/nmp_common/tests/jobs/test_file_manager.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from nemo_platform_plugin.jobs.file_manager import _filter_files_by_patterns
 from nmp.common.jobs.file_manager import FilesetFileManager, FileStorageType
@@ -102,30 +102,26 @@ class TestFilterFilesByPatterns:
 
 def test_fileset_url():
     """Test URL generation for fileset storage."""
-    with (
-        patch("nemo_platform_plugin.jobs.file_manager.client_from_platform"),
-        patch("nemo_platform_plugin.jobs.file_manager.FilesetFileSystem"),
-    ):
-        mgr = FilesetFileManager(
-            workspace="my-workspace",
-            fileset_name="my-fileset",
-            sdk=MagicMock(),
-        )
+    sdk = MagicMock()
+    sdk.files.fsspec = MagicMock()
+    mgr = FilesetFileManager(
+        workspace="my-workspace",
+        fileset_name="my-fileset",
+        sdk=sdk,
+    )
     assert mgr.url() == "my-workspace/my-fileset"
     assert mgr.url("path/to/file") == "my-workspace/my-fileset#path/to/file"
 
 
 def test_fileset_storage_type():
     """Test storage type returns FILESET."""
-    with (
-        patch("nemo_platform_plugin.jobs.file_manager.client_from_platform"),
-        patch("nemo_platform_plugin.jobs.file_manager.FilesetFileSystem"),
-    ):
-        mgr = FilesetFileManager(
-            workspace="my-workspace",
-            fileset_name="my-fileset",
-            sdk=MagicMock(),
-        )
+    sdk = MagicMock()
+    sdk.files.fsspec = MagicMock()
+    mgr = FilesetFileManager(
+        workspace="my-workspace",
+        fileset_name="my-fileset",
+        sdk=sdk,
+    )
     assert mgr.storage_type() == FileStorageType.FILESET
 
 
@@ -254,8 +250,6 @@ def test_fileset_file_manager_multiple_sequential_operations(tmp_path, fileset_m
 
 async def test_fileset_upload_directory_with_ignore_patterns(tmp_path, mock_sdk, mock_fileset_fs):
     """Test async uploading a directory with ignore_patterns filters files."""
-    from unittest import mock
-
     from nmp.common.entities import DEFAULT_WORKSPACE
     from nmp.common.jobs.file_manager import AsyncFilesetFileManager
 
@@ -268,16 +262,12 @@ async def test_fileset_upload_directory_with_ignore_patterns(tmp_path, mock_sdk,
     (subdir / "nested.txt").write_text("keep nested")
     (subdir / "nested.pyc").write_text("skip nested")
 
-    with (
-        mock.patch("nemo_platform_plugin.jobs.file_manager.client_from_platform"),
-        mock.patch("nemo_platform_plugin.jobs.file_manager.FilesetFileSystem") as mock_fs_class,
-    ):
-        mock_fs_class.return_value = mock_fileset_fs
-        async_manager = AsyncFilesetFileManager(
-            workspace=DEFAULT_WORKSPACE,
-            fileset_name="job-results-jobid-123",
-            sdk=mock_sdk,
-        )
+    mock_sdk.files.fsspec = mock_fileset_fs
+    async_manager = AsyncFilesetFileManager(
+        workspace=DEFAULT_WORKSPACE,
+        fileset_name="job-results-jobid-123",
+        sdk=mock_sdk,
+    )
 
     await async_manager.upload(test_dir, "remote/mydir", ignore_patterns="*.pyc")
 

--- a/packages/nmp_common/tests/sdk_factory/test_sdk.py
+++ b/packages/nmp_common/tests/sdk_factory/test_sdk.py
@@ -4,8 +4,8 @@
 import json
 from unittest.mock import patch
 
+import httpx
 import pytest
-from fastapi.testclient import TestClient
 from nmp.common.config import Configuration, PlatformConfig
 from nmp.common.sdk_factory import (
     get_async_platform_sdk,
@@ -160,11 +160,11 @@ def test_get_task_sdk_without_principal(monkeypatch: pytest.MonkeyPatch):
 def test_get_task_sdk_uses_explicit_sync_http_client(monkeypatch: pytest.MonkeyPatch):
     """get_task_sdk should use an explicitly provided sync HTTP client."""
     monkeypatch.delenv("NMP_PRINCIPAL", raising=False)
-    client = TestClient(lambda scope, receive, send: None)
 
-    sdk = get_task_sdk(as_service="customizer", http_client=client)
+    with httpx.Client() as client:
+        sdk = get_task_sdk(as_service="customizer", http_client=client)
 
-    assert sdk._client is client
+        assert sdk._client is client
 
 
 def test_get_request_scoped_sdk_merges_otel_and_auth_headers():

--- a/packages/nmp_testing/pyproject.toml
+++ b/packages/nmp_testing/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "nemo-nb",
     "docker>=7.0.0",
     "httpx",
+    "httpx2>=2.0.0",
     "fastapi",
     "pytest>=8.3.3",
     "pytest-httpserver>=1.0.0",

--- a/packages/nmp_testing/src/nmp/testing/__init__.py
+++ b/packages/nmp_testing/src/nmp/testing/__init__.py
@@ -45,7 +45,7 @@ Notebook testing:
 - cleanup_temp_venv_and_kernel: Remove a temporary venv and kernel spec
 """
 
-from .client import TEST_ADMIN_EMAIL, TEST_USER_EMAIL, ClientContext, create_test_client
+from .client import TEST_ADMIN_EMAIL, TEST_USER_EMAIL, ClientContext, SDKTestClientAdapter, create_test_client
 from .docker import (
     DEFAULT_RETRY_CONFIG,
     MOCK_NIM_NGINX_CONF,
@@ -93,6 +93,7 @@ __all__ = [
     # API testing
     "create_test_client",
     "ClientContext",
+    "SDKTestClientAdapter",
     "TEST_USER_EMAIL",
     "TEST_ADMIN_EMAIL",
     "subprocess_job_executor_patch",

--- a/packages/nmp_testing/src/nmp/testing/client.py
+++ b/packages/nmp_testing/src/nmp/testing/client.py
@@ -12,11 +12,11 @@ import uuid
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Generator, Protocol, TypeVar
+from typing import Callable, Generator, Mapping, Protocol, TypeVar
 
 import httpx
 from fastapi.testclient import TestClient
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform, NotGiven, not_given
 from nemo_platform.resources.entities import AsyncEntitiesResource
 from nmp.common.config.base import AuthConfig, Configuration, DatabaseConfig, PlatformConfig, ServiceConfig
 from nmp.common.entities.client import EntityClient
@@ -173,22 +173,56 @@ def _create_svc(
     return svc
 
 
-def _install_asgi_files_resource(sdk: NeMoPlatform, http_client: httpx.AsyncClient) -> None:
+def _install_asgi_files_resource(sdk: NeMoPlatform, async_http_client: httpx.AsyncClient) -> None:
     """Route sync SDK file uploads through the in-process test app."""
     from nemo_platform.filesets.resources import FilesResource
     from nemo_platform_plugin.client.adapter import client_from_platform
     from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 
     base_url = str(sdk.base_url).rstrip("/")
+    files_client = client_from_platform(sdk, FilesClient)
     sdk.__dict__["files"] = FilesResource(
         sdk,
-        files_client=client_from_platform(sdk, FilesClient),
+        files_client=files_client,
         async_files_client=AsyncFilesClient(
             base_url=base_url,
             workspace=sdk.workspace,
-            http_client=http_client,
+            default_headers=files_client._default_headers or None,
+            http_client=async_http_client,
         ),
     )
+    original_copy: Callable[..., NeMoPlatform] = sdk.copy
+
+    def copy_with_asgi_files(
+        *,
+        workspace: str | None = None,
+        base_url: str | httpx.URL | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+        http_client: httpx.Client | None = None,
+        max_retries: int | NotGiven = not_given,
+        default_headers: Mapping[str, str] | None = None,
+        set_default_headers: Mapping[str, str] | None = None,
+        default_query: Mapping[str, object] | None = None,
+        set_default_query: Mapping[str, object] | None = None,
+        _extra_kwargs: Mapping[str, object] | None = None,
+    ) -> NeMoPlatform:
+        clone = original_copy(
+            workspace=workspace,
+            base_url=base_url,
+            timeout=timeout,
+            http_client=http_client,
+            max_retries=max_retries,
+            default_headers=default_headers,
+            set_default_headers=set_default_headers,
+            default_query=default_query,
+            set_default_query=set_default_query,
+            _extra_kwargs={} if _extra_kwargs is None else _extra_kwargs,
+        )
+        _install_asgi_files_resource(clone, async_http_client)
+        return clone
+
+    sdk.__dict__["copy"] = copy_with_asgi_files
+    sdk.__dict__["with_options"] = copy_with_asgi_files
 
 
 _DEFAULT_WORKSPACES = ["default"]

--- a/packages/nmp_testing/src/nmp/testing/client.py
+++ b/packages/nmp_testing/src/nmp/testing/client.py
@@ -173,6 +173,24 @@ def _create_svc(
     return svc
 
 
+def _install_asgi_files_resource(sdk: NeMoPlatform, http_client: httpx.AsyncClient) -> None:
+    """Route sync SDK file uploads through the in-process test app."""
+    from nemo_platform.filesets.resources import FilesResource
+    from nemo_platform_plugin.client.adapter import client_from_platform
+    from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
+
+    base_url = str(sdk.base_url).rstrip("/")
+    sdk.__dict__["files"] = FilesResource(
+        sdk,
+        files_client=client_from_platform(sdk, FilesClient),
+        async_files_client=AsyncFilesClient(
+            base_url=base_url,
+            workspace=sdk.workspace,
+            http_client=http_client,
+        ),
+    )
+
+
 _DEFAULT_WORKSPACES = ["default"]
 _DEFAULT_PROJECTS = ["default/test-project"]
 
@@ -490,6 +508,7 @@ def create_test_client(
                 http_client=sdk_http_client,
                 max_retries=0,
             )
+            _install_asgi_files_resource(sdk, async_http_client)
 
             # Trigger middleware stack build with a health check (which skips auth).
             client.get("/health")

--- a/packages/nmp_testing/src/nmp/testing/client.py
+++ b/packages/nmp_testing/src/nmp/testing/client.py
@@ -73,10 +73,6 @@ class SDKTestClientAdapter(httpx.Client):
         """Return the wrapped ASGI app for tests that need to create sibling clients."""
         return self._test_client.app
 
-    def create_async_transport(self) -> httpx.AsyncBaseTransport:
-        """Create an async transport for code paths that need an async SDK client."""
-        return httpx.ASGITransport(app=self.asgi_app)
-
     def send(
         self,
         request: httpx.Request,

--- a/packages/nmp_testing/src/nmp/testing/client.py
+++ b/packages/nmp_testing/src/nmp/testing/client.py
@@ -29,6 +29,7 @@ from nmp.core.inference_gateway.service import InferenceGatewayService
 from nmp.platform_runner.loader import order_services_by_dependencies
 from nmp.platform_runner.server import create_app
 from nmp.testing.access_log import AccessLog, AccessLogMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 logger = logging.getLogger(__name__)
 
@@ -59,13 +60,54 @@ class ClientContext:
 
 ClientT = TypeVar("ClientT", TestClient, AsyncNeMoPlatform, NeMoPlatform, EntityClient, ClientContext)
 
+
+class SDKTestClientAdapter(httpx.Client):
+    """Expose Starlette's TestClient through the httpx.Client interface expected by the SDK."""
+
+    def __init__(self, test_client: TestClient) -> None:
+        self._test_client = test_client
+        super().__init__(base_url=str(test_client.base_url), headers=dict(test_client.headers))
+
+    @property
+    def asgi_app(self) -> ASGIApp:
+        """Return the wrapped ASGI app for tests that need to create sibling clients."""
+        return self._test_client.app
+
+    def create_async_transport(self) -> httpx.AsyncBaseTransport:
+        """Create an async transport for code paths that need an async SDK client."""
+        return httpx.ASGITransport(app=self.asgi_app)
+
+    def send(
+        self,
+        request: httpx.Request,
+        *,
+        stream: bool = False,  # noqa: ARG002 - the in-process test response is materialized eagerly.
+        auth: object = httpx.USE_CLIENT_DEFAULT,  # noqa: ARG002
+        follow_redirects: object = httpx.USE_CLIENT_DEFAULT,
+    ) -> httpx.Response:
+        follow_redirects_enabled = follow_redirects if isinstance(follow_redirects, bool) else False
+        response = self._test_client.request(
+            request.method,
+            str(request.url),
+            content=request.read(),
+            headers=dict(request.headers),
+            follow_redirects=follow_redirects_enabled,
+        )
+        return httpx.Response(
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            content=response.content,
+            request=request,
+        )
+
+
 # Default test user for auth-enabled tests
 TEST_USER_EMAIL = "user@example.com"
 # Admin user email for auth-enabled tests (has elevated permissions)
 TEST_ADMIN_EMAIL = "admin@example.com"
 
 
-def _default_service_configs(tmp_dir: Path) -> dict[type[Service], ServiceConfig]:
+def _default_service_configs(tmp_dir: Path) -> dict[type[object], ServiceConfig]:
     """Create default service configs for testing.
 
     Args:
@@ -115,7 +157,7 @@ class ServiceFactory(Protocol):
 
 def _create_svc(
     service_type: ServiceFactory,
-    service_configs: dict[type[Service], ServiceConfig],
+    service_configs: dict[type[object], ServiceConfig],
 ) -> Service:
     """Instantiate a service with optional config injection.
 
@@ -144,7 +186,7 @@ def create_test_client(
     *service_types: ServiceFactory,
     client_type: type[ClientT] | None = None,
     dependency_overrides: dict[Callable, Callable] | None = None,
-    service_configs: dict[type[Service], ServiceConfig] | None = None,
+    service_configs: dict[type[object], ServiceConfig] | None = None,
     tmp_dir: Path | None = None,
     workspaces: list[str] | None = None,
     workspace: str | None = None,
@@ -258,8 +300,7 @@ def create_test_client(
             for req in entity_requests:
                 assert req.principal_id == "test@example.com"
     """
-    if client_type is None:
-        client_type = NeMoPlatform
+    selected_client_type: type[object] = client_type or NeMoPlatform
     with ExitStack() as stack:
         # Create temp directory if not provided
         # Use ignore_cleanup_errors=True because fire-and-forget background tasks
@@ -362,7 +403,10 @@ def create_test_client(
         # Create transport and http_client BEFORE the app, so we can inject the client
         # into create_app() for middleware (AuthorizationMiddleware). We set transport.app
         # after app creation - this works because no requests are made until setup completes.
-        transport = httpx.ASGITransport(app=None)
+        async def _pending_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
+            raise RuntimeError("ASGI app was not initialized before test client request")
+
+        transport = httpx.ASGITransport(app=_pending_asgi_app)
         pdp_timeout = Configuration.get_service_config(AuthConfig).policy_decision_point_request_timeout_seconds
         async_http_client = httpx.AsyncClient(transport=transport, base_url="http://testserver", timeout=pdp_timeout)
 
@@ -443,7 +487,13 @@ def create_test_client(
 
         with TestClient(app) as client:
             # Use max_retries=0 to avoid retry delays on 409 Conflict errors
-            sdk = NeMoPlatform(workspace=workspace, base_url="http://testserver", http_client=client, max_retries=0)
+            sdk_http_client = SDKTestClientAdapter(client)
+            sdk = NeMoPlatform(
+                workspace=workspace,
+                base_url="http://testserver",
+                http_client=sdk_http_client,
+                max_retries=0,
+            )
 
             # Trigger middleware stack build with a health check (which skips auth).
             client.get("/health")
@@ -483,7 +533,11 @@ def create_test_client(
                     from nmp.core.auth.app.seeding import run_seeding
 
                     # Use service principal so entity store accepts role binding creation
-                    headers = dict(async_sdk.default_headers or {})
+                    headers: dict[str, str] = {
+                        key: value
+                        for key, value in dict(async_sdk.default_headers or {}).items()
+                        if isinstance(value, str)
+                    }
                     headers["X-NMP-Principal-Id"] = "service:auth"
                     seeding_sdk = async_sdk.with_options(set_default_headers=headers)
                     seeding_entity_client = EntityClient(AsyncEntitiesResource(seeding_sdk))
@@ -542,13 +596,13 @@ def create_test_client(
                     except ConflictError:
                         logger.warning(f"Project '{proj_name}' in workspace '{ws_id}' already exists")
 
-            if client_type is TestClient:
-                yield client
-            elif client_type is AsyncNeMoPlatform:
+            if selected_client_type is TestClient:
+                yield client  # ty: ignore[invalid-yield]
+            elif selected_client_type is AsyncNeMoPlatform:
                 yield async_sdk  # ty: ignore[invalid-yield]
-            elif client_type is EntityClient:
+            elif selected_client_type is EntityClient:
                 yield entity_client  # ty: ignore[invalid-yield]
-            elif client_type is ClientContext:
+            elif selected_client_type is ClientContext:
                 yield ClientContext(
                     sdk=sdk,
                     async_sdk=async_sdk,

--- a/plugins/nemo-deployments/tests/integration/backends/k8s/test_k8s_backend.py
+++ b/plugins/nemo-deployments/tests/integration/backends/k8s/test_k8s_backend.py
@@ -35,6 +35,8 @@ NAMESPACE = os.environ.get("NMP_K8S_ITEST_NAMESPACE", "default")
 LABELS = {"managed-by": MANAGED_BY_LABEL}
 POLL_ATTEMPTS = 60
 POLL_INTERVAL_SECONDS = 1
+ALPINE_IMAGE = "docker.io/library/alpine:3.20"
+NGINX_IMAGE = "docker.io/library/nginx:alpine"
 
 
 @pytest.fixture
@@ -68,7 +70,7 @@ def _never_config(
         workspace="itest",
         restart_policy="Never",  # ty: ignore[unknown-argument]
         containers=[
-            Container(name="main", image="alpine:3.20", command=["sh", "-c"], args=args or ["echo hello-from-k8s"])
+            Container(name="main", image=ALPINE_IMAGE, command=["sh", "-c"], args=args or ["echo hello-from-k8s"])
         ],
         config_files=config_files or [],  # ty: ignore[unknown-argument]
     )
@@ -82,7 +84,7 @@ def _always_http_config() -> DeploymentConfig:
         containers=[
             Container(
                 name="main",
-                image="nginx:alpine",
+                image=NGINX_IMAGE,
                 ports=[ContainerPort(containerPort=80, protocol="TCP", name="http")],
             )
         ],
@@ -256,7 +258,7 @@ async def test_delete_rejects_foreign_resource(k8s_backend: K8sDeploymentBackend
             template=k8s.client.V1PodTemplateSpec(
                 spec=k8s.client.V1PodSpec(
                     restart_policy="Never",
-                    containers=[k8s.client.V1Container(name="main", image="alpine:3.20", command=["true"])],
+                    containers=[k8s.client.V1Container(name="main", image=ALPINE_IMAGE, command=["true"])],
                 )
             )
         ),

--- a/plugins/nemo-deployments/tests/integration/test_reconcile_k8s.py
+++ b/plugins/nemo-deployments/tests/integration/test_reconcile_k8s.py
@@ -35,6 +35,8 @@ pytestmark = [
 NAMESPACE = os.environ.get("NMP_K8S_ITEST_NAMESPACE", "default")
 POLL_ATTEMPTS = 60
 POLL_INTERVAL_SECONDS = 1
+ALPINE_IMAGE = "docker.io/library/alpine:3.20"
+NGINX_IMAGE = "docker.io/library/nginx:alpine"
 
 
 @pytest.fixture
@@ -73,15 +75,13 @@ async def test_puller_server_prerequisite_chain(k8s_registry: ExecutorRegistry) 
         name="puller-cfg",
         workspace="itest",
         restart_policy="Never",  # ty: ignore[unknown-argument]
-        containers=[Container(name="puller", image="alpine:3.20", command=["sh", "-c"], args=["echo pulled"])],
+        containers=[Container(name="puller", image=ALPINE_IMAGE, command=["sh", "-c"], args=["echo pulled"])],
     )
     server_cfg = DeploymentConfig(
         name="server-cfg",
         workspace="itest",
         restart_policy="Always",  # ty: ignore[unknown-argument]
-        containers=[
-            Container(name="server", image="nginx:alpine", ports=[ContainerPort(name="http", containerPort=80)])
-        ],
+        containers=[Container(name="server", image=NGINX_IMAGE, ports=[ContainerPort(name="http", containerPort=80)])],
     )
 
     config_cache = {

--- a/sdk/python/nemo-platform/src/nemo_platform/filesets/filesystem/filesystem.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/filesets/filesystem/filesystem.py
@@ -6,17 +6,20 @@
 from __future__ import annotations
 
 import inspect
+import os
 from collections.abc import AsyncIterator, Coroutine, Iterator, Sequence
 from datetime import datetime, timezone
-from typing import Any, Literal, Protocol, TypedDict, TypeVar, overload, runtime_checkable
+from glob import has_magic
+from typing import Any, Literal, TypedDict, TypeVar, overload
 
 import anyio
 import fsspec.asyn
-import httpx
 from anyio import to_thread
 from fsspec.asyn import AbstractAsyncStreamedFile, AsyncFileSystem, _get_batch_size
 from fsspec.callbacks import DEFAULT_CALLBACK, Callback
+from fsspec.implementations.local import LocalFileSystem, make_path_posix, trailing_sep
 from fsspec.spec import AbstractBufferedFile
+from fsspec.utils import other_paths
 from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 from nemo_platform_plugin.files.types import FilesetFileOutput, ListFilesQueryParams
 
@@ -37,10 +40,8 @@ async def run_coros_in_chunks(
     We admit all work up front and use a CapacityLimiter so a new task can start
     as soon as any slot frees up, which keeps bulk downloads/uploads saturated.
 
-    We still monkey-patch fsspec's helper so inherited AsyncFileSystem bulk ops
-    benefit from AnyIO task-group cancellation. Running tasks are cancelled by
-    the task group; coroutine objects that were never entered are explicitly
-    closed in the outer finally block.
+    Running tasks are cancelled by the task group; coroutine objects that were
+    never entered are explicitly closed in the outer finally block.
     """
 
     if batch_size is None:
@@ -91,18 +92,6 @@ async def run_coros_in_chunks(
                 coro.close()
 
     return results
-
-
-@runtime_checkable
-class _AsyncTransportProvider(Protocol):
-    def create_async_transport(self) -> httpx.AsyncBaseTransport: ...
-
-
-def _create_async_transport(sync_client: httpx.Client) -> httpx.AsyncBaseTransport | None:
-    """Return an async transport when the sync client explicitly provides one."""
-    if isinstance(sync_client, _AsyncTransportProvider):
-        return sync_client.create_async_transport()
-    return None
 
 
 class FileInfo(TypedDict):
@@ -344,11 +333,12 @@ class FilesetFileSystem(AsyncFileSystem):
         self,
         *,
         client: FilesClient | AsyncFilesClient,
+        async_client: AsyncFilesClient | None = None,
         batch_size: int | None = None,
         blocksize: int | None = None,
         **kwargs,
     ):
-        async_client = self._ensure_async(client)
+        async_client = async_client or self._ensure_async(client)
         is_async = isinstance(client, AsyncFilesClient)
 
         if batch_size is None:
@@ -368,7 +358,6 @@ class FilesetFileSystem(AsyncFileSystem):
 
         import httpx
 
-        transport = _create_async_transport(client._http)
         return AsyncFilesClient(
             base_url=client.base_url,
             workspace=client.workspace,
@@ -376,7 +365,6 @@ class FilesetFileSystem(AsyncFileSystem):
             default_headers=client._default_headers or None,
             retry=client._retry,
             http_client=httpx.AsyncClient(
-                transport=transport,
                 base_url=client.base_url,
                 headers=dict(client._default_headers) if client._default_headers else None,
             ),
@@ -656,6 +644,62 @@ class FilesetFileSystem(AsyncFileSystem):
         """Sync wrapper for _pipe_stream. See _pipe_stream for details."""
         return fsspec.asyn.sync(self.loop, self._pipe_stream, path, stream, content_length)
 
+    async def _put(
+        self,
+        lpath,
+        rpath,
+        recursive=False,
+        callback=DEFAULT_CALLBACK,
+        batch_size=None,
+        maxdepth=None,
+        **kwargs,
+    ):
+        """Copy local file(s) into the fileset."""
+        if isinstance(lpath, list) and isinstance(rpath, list):
+            rpaths = rpath
+            lpaths = lpath
+        else:
+            source_is_str = isinstance(lpath, str)
+            if source_is_str:
+                lpath = make_path_posix(lpath)
+            fs = LocalFileSystem()
+            lpaths = fs.expand_path(lpath, recursive=recursive, maxdepth=maxdepth)
+            if source_is_str and (not recursive or maxdepth is not None):
+                lpaths = [path for path in lpaths if not (trailing_sep(path) or fs.isdir(path))]
+                if not lpaths:
+                    return
+
+            source_is_file = len(lpaths) == 1
+            dest_is_dir = isinstance(rpath, str) and (trailing_sep(rpath) or await self._isdir(rpath))
+
+            rpath = self._strip_protocol(rpath)
+            exists = source_is_str and (
+                (has_magic(lpath) and source_is_file)
+                or (not has_magic(lpath) and dest_is_dir and not trailing_sep(lpath))
+            )
+            rpaths = other_paths(
+                lpaths,
+                rpath,
+                exists=exists,
+                flatten=not source_is_str,
+            )
+
+        is_dir = {path: os.path.isdir(path) for path in lpaths}
+        rdirs = [remote for local, remote in zip(lpaths, rpaths) if is_dir[local]]
+        file_pairs = [(local, remote) for local, remote in zip(lpaths, rpaths) if not is_dir[local]]
+
+        async with anyio.create_task_group() as tg:
+            for directory in rdirs:
+                tg.start_soon(self._makedirs, directory, True)
+
+        callback.set_size(len(file_pairs))
+        put_file = callback.branch_coro(self._put_file)
+        await run_coros_in_chunks(
+            [put_file(local, remote, **kwargs) for local, remote in file_pairs],
+            batch_size=batch_size or self.batch_size,
+            callback=callback,
+        )
+
     async def _put_file(
         self,
         lpath: str,
@@ -796,7 +840,7 @@ class FilesetFileSystem(AsyncFileSystem):
         """Download files using a single _find call for efficiency.
 
         Uses run_coros_in_chunks which provides proper task cancellation
-        via our monkey-patched TaskGroup-based implementation.
+        for the direct list-download path.
 
         When rpath and lpath are both lists, downloads each (remote, local) pair
         directly without path expansion. This is useful for downloading a specific

--- a/sdk/python/nemo-platform/src/nemo_platform/filesets/filesystem/filesystem.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/filesets/filesystem/filesystem.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import inspect
 from collections.abc import AsyncIterator, Coroutine, Iterator, Sequence
 from datetime import datetime, timezone
-from typing import Any, Literal, TypedDict, TypeVar, overload
+from typing import Any, Literal, Protocol, TypedDict, TypeVar, overload, runtime_checkable
 
 import anyio
 import fsspec.asyn
@@ -93,21 +93,15 @@ async def run_coros_in_chunks(
     return results
 
 
-# Monkey-patch fsspec so inherited AsyncFileSystem bulk ops use the same
-# limiter-based AnyIO runner. This is intentionally semantics-different from
-# upstream chunking because we prefer continuous refill over wave-based batches.
-fsspec.asyn._run_coros_in_chunks = run_coros_in_chunks
+@runtime_checkable
+class _AsyncTransportProvider(Protocol):
+    def create_async_transport(self) -> httpx.AsyncBaseTransport: ...
 
 
-def _detect_async_transport(sync_client: Any) -> httpx.AsyncBaseTransport | None:
-    """Detect if a sync httpx client wraps a TestClient and return ASGITransport."""
-    try:
-        from starlette.testclient import TestClient
-
-        if isinstance(sync_client, TestClient):
-            return httpx.ASGITransport(app=sync_client.app)
-    except ImportError:
-        pass
+def _create_async_transport(sync_client: httpx.Client) -> httpx.AsyncBaseTransport | None:
+    """Return an async transport when the sync client explicitly provides one."""
+    if isinstance(sync_client, _AsyncTransportProvider):
+        return sync_client.create_async_transport()
     return None
 
 
@@ -374,7 +368,7 @@ class FilesetFileSystem(AsyncFileSystem):
 
         import httpx
 
-        transport = _detect_async_transport(client._http)
+        transport = _create_async_transport(client._http)
         return AsyncFilesClient(
             base_url=client.base_url,
             workspace=client.workspace,
@@ -607,7 +601,7 @@ class FilesetFileSystem(AsyncFileSystem):
         # Invalidate parent directory's cache since file info is stored there
         self.invalidate_cache(self._parent(build_fileset_ref(path)))
 
-    async def _pipe_file(self, path: str, value: bytes, **kwargs) -> None:
+    async def _pipe_file(self, path: str, value: bytes, mode: str = "overwrite", **kwargs) -> None:
         """Write bytes to a file."""
         workspace, fileset, file_path = parse_fileset_ref(path, workspace_fallback=self._workspace)
         if not file_path:
@@ -662,7 +656,14 @@ class FilesetFileSystem(AsyncFileSystem):
         """Sync wrapper for _pipe_stream. See _pipe_stream for details."""
         return fsspec.asyn.sync(self.loop, self._pipe_stream, path, stream, content_length)
 
-    async def _put_file(self, lpath: str, rpath: str, callback: Callback = DEFAULT_CALLBACK, **kwargs) -> None:
+    async def _put_file(
+        self,
+        lpath: str,
+        rpath: str,
+        mode: str = "overwrite",
+        callback: Callback = DEFAULT_CALLBACK,
+        **kwargs,
+    ) -> None:
         """Upload a local file to a fileset.
 
         Uses streaming upload to avoid buffering the entire file in memory.
@@ -723,7 +724,7 @@ class FilesetFileSystem(AsyncFileSystem):
         self._populate_dircache_from_response(response, workspace, fileset, prefix)
 
         # Build the flat output dict
-        out = {}
+        out: dict[str, FileInfo] = {}
         seen_dirs: set[str] = set()
 
         # Add root path if withdirs requested
@@ -808,11 +809,14 @@ class FilesetFileSystem(AsyncFileSystem):
             callback.set_size(len(rpath))
             get_file_with_callback = callback.branch_coro(self._get_file)
             await run_coros_in_chunks(
-                [get_file_with_callback(remote, local, **kwargs) for remote, local in zip(rpath, lpath)],
+                [get_file_with_callback(remote, local, **kwargs) for remote, local in zip(rpath, lpath, strict=True)],
                 batch_size=batch_size or self.batch_size,
                 callback=callback,
             )
             return
+
+        if not isinstance(rpath, str) or not isinstance(lpath, str):
+            raise TypeError("rpath and lpath must both be strings or both be lists")
 
         source_files = await self._find(rpath, maxdepth=maxdepth, withdirs=False)
         if not source_files:

--- a/sdk/python/nemo-platform/src/nemo_platform/filesets/resources.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/filesets/resources.py
@@ -14,7 +14,7 @@ from functools import cached_property
 from pathlib import PurePath
 from typing import Protocol, runtime_checkable
 
-from fsspec.callbacks import Callback
+from fsspec.callbacks import DEFAULT_CALLBACK, Callback
 from fsspec.core import has_magic
 from nemo_platform.resources.files.filesets import AsyncFilesetsResource, FilesetsResource
 from nemo_platform.resources.files.otlp.otlp import AsyncOtlpResource, OtlpResource
@@ -24,6 +24,7 @@ from nemo_platform_plugin.files.types import (
     CreateFilesetRequest,
     FilesetFileOutput,
     FilesetOutput,
+    ListFilesQueryParams,
 )
 
 from nemo_platform.filesets.filesystem.filesystem import (
@@ -71,16 +72,16 @@ class ListFilesResponse:
 
         # Priority: caching > not_cached > cached > not_cacheable
         if "caching" in statuses:
-            return "caching"
+            return CacheStatus.CACHING
         if "not_cached" in statuses:
-            return "not_cached"
+            return CacheStatus.NOT_CACHED
         if all(s == "cached" for s in statuses):
-            return "cached"
+            return CacheStatus.CACHED
         if all(s == "not_cacheable" for s in statuses):
-            return "not_cacheable"
+            return CacheStatus.NOT_CACHEABLE
 
         # Mixed cached/not_cacheable - return cached since some files are cached
-        return "cached"
+        return CacheStatus.CACHED
 
 
 @runtime_checkable
@@ -139,10 +140,17 @@ class FilesResource:
     For fsspec filesystem access, use ``resource.fsspec``.
     """
 
-    def __init__(self, client, *, files_client: FilesClient | None = None) -> None:
+    def __init__(
+        self,
+        client,
+        *,
+        files_client: FilesClient | None = None,
+        async_files_client: AsyncFilesClient | None = None,
+    ) -> None:
         # Retain the platform client so the generated fileset/otlp sub-resources
         # (which speak to the platform client, not the FilesClient) can be exposed.
         self._platform_client = client
+        self._async_client = async_files_client
         if files_client is not None:
             self._client = files_client
         else:
@@ -168,7 +176,7 @@ class FilesResource:
     @cached_property
     def fsspec(self) -> FilesetFileSystem:
         """Access the underlying fsspec filesystem."""
-        return FilesetFileSystem(client=self._client)
+        return FilesetFileSystem(client=self._client, async_client=self._async_client)
 
     def _ensure_fileset_exists(self, workspace: str, fileset: str) -> None:
         """Create fileset if it doesn't exist (idempotent)."""
@@ -615,7 +623,7 @@ class FilesResource:
         # For path prefixes, the API handles filtering server-side
         api_path = None if has_magic(path) else (path or None)
 
-        query_params = {}
+        query_params: ListFilesQueryParams = {}
         if api_path is not None:
             query_params["path"] = api_path
         if include_cache_status:
@@ -794,10 +802,7 @@ class AsyncFilesResource:
             # Build list of (remote, local) path pairs preserving directory structure
             rpaths = [build_fileset_ref(p, workspace=ws, fileset=fileset) for p in remote_path]
             lpaths = [str(PurePath(local_path) / p) for p in remote_path]
-            kwargs: dict = {"rpath": rpaths, "lpath": lpaths, "batch_size": max_workers}
-            if callback is not None:
-                kwargs["callback"] = callback
-            await self.fsspec._get(**kwargs)
+            await self.fsspec._get(rpaths, lpaths, batch_size=max_workers, callback=callback or DEFAULT_CALLBACK)
             return
 
         ws, path_fileset, path = parse_fileset_path(
@@ -817,16 +822,16 @@ class AsyncFilesResource:
             # Build list of (remote, local) path pairs preserving directory structure
             rpaths = [build_fileset_ref(f.path, workspace=ws, fileset=fileset) for f in matching_files.data]
             lpaths = [str(PurePath(local_path) / f.path) for f in matching_files.data]
-            kwargs = {"rpath": rpaths, "lpath": lpaths, "batch_size": max_workers}
-            if callback is not None:
-                kwargs["callback"] = callback
-            await self.fsspec._get(**kwargs)
+            await self.fsspec._get(rpaths, lpaths, batch_size=max_workers, callback=callback or DEFAULT_CALLBACK)
         else:
             fileset_ref = build_fileset_ref(path, workspace=ws, fileset=fileset)
-            kwargs = {"rpath": fileset_ref, "lpath": local_path, "recursive": True, "batch_size": max_workers}
-            if callback is not None:
-                kwargs["callback"] = callback
-            await self.fsspec._get(**kwargs)
+            await self.fsspec._get(
+                fileset_ref,
+                local_path,
+                recursive=True,
+                batch_size=max_workers,
+                callback=callback or DEFAULT_CALLBACK,
+            )
 
     async def upload(
         self,
@@ -1129,7 +1134,7 @@ class AsyncFilesResource:
         # For path prefixes, the API handles filtering server-side
         api_path = None if has_magic(path) else (path or None)
 
-        query_params = {}
+        query_params: ListFilesQueryParams = {}
         if api_path is not None:
             query_params["path"] = api_path
         if include_cache_status:

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/integration/conftest.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/integration/conftest.py
@@ -22,7 +22,7 @@ from nemo_platform.cli.core.context import CLIContext
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.files.client import FilesClient
 from nmp.core.files.service import FilesService
-from nmp.testing import create_test_client
+from nmp.testing import SDKTestClientAdapter, create_test_client
 from starlette.testclient import TestClient
 from typer.testing import CliRunner
 
@@ -39,7 +39,7 @@ def http_client() -> Generator[TestClient, None, None]:
 @pytest.fixture(scope="module")
 def sdk(http_client: TestClient) -> NeMoPlatform:
     """SDK client backed by the test client."""
-    return NeMoPlatform(base_url="http://testserver", http_client=http_client)
+    return NeMoPlatform(base_url="http://testserver", http_client=SDKTestClientAdapter(http_client))
 
 
 @pytest.fixture(scope="module")

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/integration/conftest.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/integration/conftest.py
@@ -12,20 +12,19 @@ a live server or external database.
 
 import os
 import uuid
-from typing import Generator
 from pathlib import Path
+from typing import Generator
 
 import pytest
-from nmp.testing import ClientContext, create_test_client
 from click.testing import Result
-from typer.testing import CliRunner
-from starlette.testclient import TestClient
-from nmp.core.files.service import FilesService
-from nemo_platform_plugin.files.client import FilesClient
-from nemo_platform_plugin.client.adapter import client_from_platform
-
 from nemo_platform import NeMoPlatform
 from nemo_platform.cli.core.context import CLIContext
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.files.client import FilesClient
+from nmp.core.files.service import FilesService
+from nmp.testing import ClientContext, create_test_client
+from starlette.testclient import TestClient
+from typer.testing import CliRunner
 
 DEFAULT_WORKSPACE = "default"
 

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/integration/conftest.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/integration/conftest.py
@@ -12,34 +12,41 @@ a live server or external database.
 
 import os
 import uuid
-from pathlib import Path
 from typing import Generator
+from pathlib import Path
 
 import pytest
+from nmp.testing import ClientContext, create_test_client
 from click.testing import Result
+from typer.testing import CliRunner
+from starlette.testclient import TestClient
+from nmp.core.files.service import FilesService
+from nemo_platform_plugin.files.client import FilesClient
+from nemo_platform_plugin.client.adapter import client_from_platform
+
 from nemo_platform import NeMoPlatform
 from nemo_platform.cli.core.context import CLIContext
-from nemo_platform_plugin.client.adapter import client_from_platform
-from nemo_platform_plugin.files.client import FilesClient
-from nmp.core.files.service import FilesService
-from nmp.testing import SDKTestClientAdapter, create_test_client
-from starlette.testclient import TestClient
-from typer.testing import CliRunner
 
 DEFAULT_WORKSPACE = "default"
 
 
 @pytest.fixture(scope="module")
-def http_client() -> Generator[TestClient, None, None]:
-    """TestClient with FilesService (and EntitiesService, which are included by default)."""
-    with create_test_client(FilesService, client_type=TestClient) as client:
-        yield client
+def client_context() -> Generator[ClientContext, None, None]:
+    """ClientContext with FilesService and ASGI-backed SDK clients."""
+    with create_test_client(FilesService, client_type=ClientContext) as context:
+        yield context
 
 
 @pytest.fixture(scope="module")
-def sdk(http_client: TestClient) -> NeMoPlatform:
+def http_client(client_context: ClientContext) -> TestClient:
+    """TestClient with FilesService (and EntitiesService, which are included by default)."""
+    return client_context.test_client
+
+
+@pytest.fixture(scope="module")
+def sdk(client_context: ClientContext) -> NeMoPlatform:
     """SDK client backed by the test client."""
-    return NeMoPlatform(base_url="http://testserver", http_client=SDKTestClientAdapter(http_client))
+    return client_context.sdk
 
 
 @pytest.fixture(scope="module")

--- a/services/core/auth/tests/integration/conftest.py
+++ b/services/core/auth/tests/integration/conftest.py
@@ -15,7 +15,7 @@ from typing import Generator, Iterator
 import pytest
 from fastapi.testclient import TestClient
 from nemo_platform import NeMoPlatform
-from nmp.testing.client import create_test_client
+from nmp.testing.client import SDKTestClientAdapter, create_test_client
 
 # Test principal for authenticated requests (service-level access)
 SERVICE_PRINCIPAL = "service:integration-test"
@@ -45,7 +45,7 @@ def sdk(test_client: TestClient) -> Iterator[NeMoPlatform]:
 
     Module-scoped because it shares the TestClient.
     """
-    yield NeMoPlatform(base_url="http://testserver", http_client=test_client)
+    yield NeMoPlatform(base_url="http://testserver", http_client=SDKTestClientAdapter(test_client))
 
 
 @pytest.fixture

--- a/services/core/files/tests/integration/conftest.py
+++ b/services/core/files/tests/integration/conftest.py
@@ -9,6 +9,7 @@ external services (like Huggingface Hub).
 
 from collections.abc import Callable, Iterator
 
+import anyio
 import httpx
 import huggingface_hub
 import pytest
@@ -17,7 +18,7 @@ from fastapi.testclient import TestClient
 from nemo_platform import NeMoPlatform
 from nemo_platform.filesets.resources import FilesResource
 from nemo_platform_plugin.client.adapter import client_from_platform
-from nemo_platform_plugin.files.client import FilesClient
+from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 from nemo_platform_plugin.files.types import FilesetOutput
 from nmp.common.auth import AuthClient, get_auth_client
 from nmp.common.auth.models import Principal
@@ -57,6 +58,32 @@ def _get_auth_client_from_request(request: Request) -> AuthClient:
     )
 
 
+def _create_asgi_async_files_client(sdk: NeMoPlatform) -> tuple[httpx.AsyncClient, AsyncFilesClient]:
+    sdk_http_client = sdk._client
+    assert isinstance(sdk_http_client, SDKTestClientAdapter)
+    base_url = str(sdk.base_url).rstrip("/")
+    http_client = httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=sdk_http_client.asgi_app),
+        base_url=base_url,
+        headers=dict(sdk_http_client.headers),
+    )
+    return http_client, AsyncFilesClient(
+        base_url=base_url,
+        workspace=sdk.workspace,
+        http_client=http_client,
+    )
+
+
+def _install_asgi_files_resource(sdk: NeMoPlatform) -> httpx.AsyncClient:
+    http_client, async_files_client = _create_asgi_async_files_client(sdk)
+    sdk.__dict__["files"] = FilesResource(
+        sdk,
+        files_client=client_from_platform(sdk, FilesClient),
+        async_files_client=async_files_client,
+    )
+    return http_client
+
+
 @pytest.fixture
 def sdk_user_and_service() -> Iterator[tuple[NeMoPlatform, NeMoPlatform]]:
     """Two SDKs sharing the same app: default user principal and service:customizer.
@@ -83,6 +110,8 @@ def sdk_user_and_service() -> Iterator[tuple[NeMoPlatform, NeMoPlatform]]:
             base_url=base_url,
             headers={"x-nmp-principal-id": "service:customizer"},
         )
+        user_async_http_client: httpx.AsyncClient | None = None
+        service_async_http_client: httpx.AsyncClient | None = None
         try:
             sdk_user = NeMoPlatform(
                 base_url=base_url,
@@ -94,8 +123,14 @@ def sdk_user_and_service() -> Iterator[tuple[NeMoPlatform, NeMoPlatform]]:
                 http_client=SDKTestClientAdapter(client_service),
                 max_retries=0,
             )
+            user_async_http_client = _install_asgi_files_resource(sdk_user)
+            service_async_http_client = _install_asgi_files_resource(sdk_service)
             yield (sdk_user, sdk_service)
         finally:
+            if user_async_http_client is not None:
+                anyio.run(user_async_http_client.aclose)
+            if service_async_http_client is not None:
+                anyio.run(service_async_http_client.aclose)
             client_user.close()
             client_service.close()
 
@@ -108,7 +143,11 @@ def sdk() -> Iterator[NeMoPlatform]:
         SecretsService,
         dependency_overrides=FILESET_AUTH_DEPENDENCY_OVERRIDES,
     ) as sdk:
-        yield sdk
+        async_http_client = _install_asgi_files_resource(sdk)
+        try:
+            yield sdk
+        finally:
+            anyio.run(async_http_client.aclose)
 
 
 @pytest.fixture
@@ -118,9 +157,17 @@ def files_client(sdk: NeMoPlatform) -> FilesClient:
 
 
 @pytest.fixture
-def files_resource(files_client: FilesClient) -> FilesResource:
+def async_files_client(sdk: NeMoPlatform) -> AsyncFilesClient:
+    """Provide the SDK fixture's in-memory AsyncFilesClient."""
+    client = sdk.files.fsspec._client
+    assert isinstance(client, AsyncFilesClient)
+    return client
+
+
+@pytest.fixture
+def files_resource(sdk: NeMoPlatform) -> FilesResource:
     """Provide a FilesResource backed by the test FilesClient."""
-    return FilesResource(None, files_client=files_client)
+    return sdk.files
 
 
 @pytest.fixture
@@ -137,7 +184,11 @@ def sdk_allow_user_local_storage(tmp_path) -> Iterator[NeMoPlatform]:
         tmp_dir=tmp_path,
         dependency_overrides=FILESET_AUTH_DEPENDENCY_OVERRIDES,
     ) as sdk:
-        yield sdk
+        async_http_client = _install_asgi_files_resource(sdk)
+        try:
+            yield sdk
+        finally:
+            anyio.run(async_http_client.aclose)
 
 
 @pytest.fixture

--- a/services/core/files/tests/integration/conftest.py
+++ b/services/core/files/tests/integration/conftest.py
@@ -30,7 +30,7 @@ from nmp.core.files.config import FilesConfig
 from nmp.core.files.service import FilesService
 from nmp.core.files.testing.utils import create_fileset
 from nmp.core.secrets.service import SecretsService
-from nmp.testing import create_test_client
+from nmp.testing import SDKTestClientAdapter, create_test_client
 from packaging import version
 
 # Mock auth client for fileset endpoints that depend on get_auth_client
@@ -69,7 +69,9 @@ def sdk_user_and_service() -> Iterator[tuple[NeMoPlatform, NeMoPlatform]]:
         SecretsService,
         dependency_overrides={get_auth_client: _get_auth_client_from_request},
     ) as sdk_base:
-        app = sdk_base._client.app
+        sdk_http_client = sdk_base._client
+        assert isinstance(sdk_http_client, SDKTestClientAdapter)
+        app = sdk_http_client.asgi_app
         base_url = "http://testserver"
         client_user = TestClient(
             app,
@@ -84,12 +86,12 @@ def sdk_user_and_service() -> Iterator[tuple[NeMoPlatform, NeMoPlatform]]:
         try:
             sdk_user = NeMoPlatform(
                 base_url=base_url,
-                http_client=client_user,
+                http_client=SDKTestClientAdapter(client_user),
                 max_retries=0,
             )
             sdk_service = NeMoPlatform(
                 base_url=base_url,
-                http_client=client_service,
+                http_client=SDKTestClientAdapter(client_service),
                 max_retries=0,
             )
             yield (sdk_user, sdk_service)
@@ -265,6 +267,39 @@ else:
             pass
 
 
+class SharedASGIHttpxClient(httpx.Client):
+    """httpx client for huggingface_hub that forwards through the test SDK client."""
+
+    def __init__(self, client: httpx.Client) -> None:
+        self._client = client
+        super().__init__(
+            base_url=str(client.base_url),
+            headers=dict(client.headers),
+        )
+
+    def send(
+        self,
+        request: httpx.Request,
+        *,
+        stream: bool = False,
+        auth: object = httpx.USE_CLIENT_DEFAULT,  # noqa: ARG002
+        follow_redirects: object = httpx.USE_CLIENT_DEFAULT,
+    ) -> httpx.Response:
+        if isinstance(follow_redirects, bool):
+            return self._client.send(request, stream=stream, follow_redirects=follow_redirects)
+        return self._client.send(request, stream=stream)
+
+    def close(self) -> None:
+        # huggingface_hub owns and closes its global client between tests. The
+        # wrapped SDK client is owned by create_test_client and must remain open
+        # for fixture cleanup.
+        return None
+
+
+def _default_hf_httpx_client_factory() -> httpx.Client:
+    return httpx.Client(follow_redirects=True, timeout=None)
+
+
 @pytest.fixture
 def hf_asgi_client(client: httpx.Client) -> Iterator[None]:
     """Configure huggingface_hub to use ASGI transport for in-memory testing.
@@ -274,7 +309,7 @@ def hf_asgi_client(client: httpx.Client) -> Iterator[None]:
     for a real HTTP server.
 
     For huggingface_hub v1.0+ (httpx-based): We inject a custom httpx client
-    that reuses the TestClient's transport.
+    that forwards through the SDK test client.
 
     For huggingface_hub v0.x (requests-based): We inject a custom requests
     Session with an adapter that forwards to the httpx test client.
@@ -283,15 +318,12 @@ def hf_asgi_client(client: httpx.Client) -> Iterator[None]:
         # v1.0+: Use httpx client factory
 
         def asgi_client_factory() -> httpx.Client:
-            # Reuse the TestClient's transport which handles sync-to-async conversion
-            return httpx.Client(
-                transport=client._transport,
-                base_url=str(client.base_url),
-            )
+            return SharedASGIHttpxClient(client)
 
         set_client_factory(asgi_client_factory)
         yield
-        close_session()  # Reset to default client factory
+        close_session()
+        set_client_factory(_default_hf_httpx_client_factory)
     else:
         # v0.x: Use requests adapter
         adapter = ASGIAdapter(client)

--- a/services/core/files/tests/integration/external_storage/test_huggingface_storage.py
+++ b/services/core/files/tests/integration/external_storage/test_huggingface_storage.py
@@ -23,7 +23,7 @@ from nemo_platform import NeMoPlatform
 from nemo_platform.filesets import FilesetFileSystem
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.client.errors import NemoHTTPError as ClientBadRequestError
-from nemo_platform_plugin.files.client import FilesClient
+from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 from nemo_platform_plugin.files.types import CreateFilesetRequest
 from nmp.core.files.app.backends.base import StorageImpl
 from nmp.core.files.app.streaming import download_url_streaming
@@ -240,7 +240,7 @@ class TestHuggingfaceStorageBackend:
             assert len(range_content) == 50
             assert range_content == full_content[:50]
 
-    def test_file_exists_with_file_path(self, sdk: NeMoPlatform):
+    def test_file_exists_with_file_path(self, sdk: NeMoPlatform, async_files_client: AsyncFilesClient):
         """Test _exists with a file path returns True for existing files.
 
         This tests the fix for HuggingFace's list_repo_tree which expects directory
@@ -260,7 +260,10 @@ class TestHuggingfaceStorageBackend:
                 "repo_type": "model",
             },
         ) as fileset:
-            fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
+            fs = FilesetFileSystem(
+                client=client_from_platform(sdk, FilesClient),
+                async_client=async_files_client,
+            )
             file_path = f"{fileset.workspace}/{fileset.name}#config.json"
 
             # This would fail with EntryNotFoundError before the fix
@@ -268,7 +271,11 @@ class TestHuggingfaceStorageBackend:
 
             assert exists is True
 
-    def test_file_exists_with_nonexistent_path_returns_false(self, sdk: NeMoPlatform):
+    def test_file_exists_with_nonexistent_path_returns_false(
+        self,
+        sdk: NeMoPlatform,
+        async_files_client: AsyncFilesClient,
+    ):
         """Test _exists with a non-existent path returns False."""
         name = f"hf-test-{uuid.uuid4().hex[:8]}"
 
@@ -281,7 +288,10 @@ class TestHuggingfaceStorageBackend:
                 "repo_type": "model",
             },
         ) as fileset:
-            fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
+            fs = FilesetFileSystem(
+                client=client_from_platform(sdk, FilesClient),
+                async_client=async_files_client,
+            )
             file_path = f"{fileset.workspace}/{fileset.name}#nonexistent/file/path.txt"
 
             # Should return False, not raise an error
@@ -289,7 +299,12 @@ class TestHuggingfaceStorageBackend:
 
             assert exists is False
 
-    def test_get_downloads_single_file(self, sdk: NeMoPlatform, tmp_path):
+    def test_get_downloads_single_file(
+        self,
+        sdk: NeMoPlatform,
+        async_files_client: AsyncFilesClient,
+        tmp_path,
+    ):
         """Test _get downloads a single file correctly.
 
         When source is a single file path, the file should be downloaded
@@ -307,7 +322,10 @@ class TestHuggingfaceStorageBackend:
                 "repo_type": "model",
             },
         ) as fileset:
-            fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
+            fs = FilesetFileSystem(
+                client=client_from_platform(sdk, FilesClient),
+                async_client=async_files_client,
+            )
             file_path = f"{fileset.workspace}/{fileset.name}#config.json"
 
             # Download single file
@@ -321,7 +339,12 @@ class TestHuggingfaceStorageBackend:
             content = json.loads(downloaded_file.read_text())
             assert isinstance(content, dict)
 
-    def test_get_downloads_directory_with_trailing_slash(self, sdk: NeMoPlatform, tmp_path):
+    def test_get_downloads_directory_with_trailing_slash(
+        self,
+        sdk: NeMoPlatform,
+        async_files_client: AsyncFilesClient,
+        tmp_path,
+    ):
         """Test _get with trailing slash copies contents directly into dest.
 
         When source has trailing /, the directory contents should be copied
@@ -339,7 +362,10 @@ class TestHuggingfaceStorageBackend:
                 "repo_type": "model",
             },
         ) as fileset:
-            fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
+            fs = FilesetFileSystem(
+                client=client_from_platform(sdk, FilesClient),
+                async_client=async_files_client,
+            )
             # Trailing slash on source - copy contents directly
             dir_path = f"{fileset.workspace}/{fileset.name}#/"
 
@@ -348,7 +374,12 @@ class TestHuggingfaceStorageBackend:
             # config.json should be directly in tmp_path (not tmp_path/<fileset_name>/)
             assert (tmp_path / "config.json").exists()
 
-    def test_get_downloads_directory_without_trailing_slash(self, sdk: NeMoPlatform, tmp_path):
+    def test_get_downloads_directory_without_trailing_slash(
+        self,
+        sdk: NeMoPlatform,
+        async_files_client: AsyncFilesClient,
+        tmp_path,
+    ):
         """Test _get for fileset root copies contents directly.
 
         For fileset root (no file path), contents are always copied directly
@@ -367,7 +398,10 @@ class TestHuggingfaceStorageBackend:
                 "repo_type": "model",
             },
         ) as fileset:
-            fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
+            fs = FilesetFileSystem(
+                client=client_from_platform(sdk, FilesClient),
+                async_client=async_files_client,
+            )
             # No trailing slash on source - for fileset root, copies contents directly
             dir_path = f"{fileset.workspace}/{fileset.name}#"
 

--- a/services/core/files/tests/integration/test_fileset_filesystem.py
+++ b/services/core/files/tests/integration/test_fileset_filesystem.py
@@ -31,7 +31,7 @@ from nemo_platform.filesets import (
     parse_fileset_ref,
 )
 from nemo_platform_plugin.client.adapter import client_from_platform
-from nemo_platform_plugin.files.client import FilesClient
+from nemo_platform_plugin.files.client import AsyncFilesClient, FilesClient
 from nemo_platform_plugin.files.types import FilesetOutput
 
 
@@ -296,9 +296,12 @@ class TestFilesetFileSystem:
     """Test fsspec operations via FilesetFileSystem."""
 
     @pytest.fixture
-    def fs(self, sdk: NeMoPlatform) -> FilesetFileSystem:
+    def fs(self, sdk: NeMoPlatform, async_files_client: AsyncFilesClient) -> FilesetFileSystem:
         """Create a FilesetFileSystem backed by the test SDK."""
-        return sdk.files.fsspec
+        return FilesetFileSystem(
+            client=client_from_platform(sdk, FilesClient),
+            async_client=async_files_client,
+        )
 
     def test_ls_empty_fileset(self, fs: FilesetFileSystem, fileset: FilesetOutput):
         """Test listing an empty fileset."""
@@ -527,12 +530,18 @@ class TestFilesetFileSystem:
         assert fs.cat(path_no_proto) == content
         assert fs.cat(path_with_proto) == content
 
-    def test_fsspec_filesystem_registration(self, sdk: NeMoPlatform, fileset: FilesetOutput):
+    def test_fsspec_filesystem_registration(
+        self,
+        sdk: NeMoPlatform,
+        async_files_client: AsyncFilesClient,
+        fileset: FilesetOutput,
+    ):
         """Test that FilesetFileSystem can be instantiated via fsspec.filesystem()."""
         # Protocol is registered by the autouse fixture
         fs = fsspec.filesystem(
             "fileset",
             client=client_from_platform(sdk, FilesClient),
+            async_client=async_files_client,
             skip_instance_cache=True,
         )
 
@@ -1093,9 +1102,9 @@ class TestFilesetFileSystemAsync:
     """Test async fsspec operations via FilesetFileSystem."""
 
     @pytest.fixture
-    def fs(self, sdk: NeMoPlatform) -> FilesetFileSystem:
+    def fs(self, async_files_client: AsyncFilesClient) -> FilesetFileSystem:
         """Create a FilesetFileSystem backed by the test SDK."""
-        return FilesetFileSystem(client=client_from_platform(sdk, FilesClient), skip_instance_cache=True)
+        return FilesetFileSystem(client=async_files_client, skip_instance_cache=True)
 
     async def test_ls_empty_fileset(self, fs: FilesetFileSystem, fileset: FilesetOutput):
         """Test listing an empty fileset."""
@@ -1498,7 +1507,12 @@ class TestFilesetFileSystemAsync:
 
         # If we get here without hanging, the test passes
 
-    async def test_batch_size_limits_concurrency(self, sdk: NeMoPlatform, fileset: FilesetOutput, tmp_path: Path):
+    async def test_batch_size_limits_concurrency(
+        self,
+        async_files_client: AsyncFilesClient,
+        fileset: FilesetOutput,
+        tmp_path: Path,
+    ):
         """Test that batch_size properly limits concurrent operations.
 
         Creates a filesystem with batch_size=4, then downloads 8 files and verifies
@@ -1509,7 +1523,7 @@ class TestFilesetFileSystemAsync:
         total_files = 8
 
         # Create filesystem with limited concurrency
-        fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient), batch_size=batch_size)
+        fs = FilesetFileSystem(client=async_files_client, batch_size=batch_size)
 
         # Upload files
         base = f"{fileset.workspace}/{fileset.name}"
@@ -1816,7 +1830,12 @@ class TestDuckDBIntegration:
     protocol registry and creates it automatically.
     """
 
-    def test_duckdb_parquet_query(self, sdk: NeMoPlatform, fileset: FilesetOutput):
+    def test_duckdb_parquet_query(
+        self,
+        sdk: NeMoPlatform,
+        async_files_client: AsyncFilesClient,
+        fileset: FilesetOutput,
+    ):
         """Test querying a parquet file with DuckDB via fileset:// protocol."""
         # Create test data
         df = pd.DataFrame(
@@ -1829,17 +1848,15 @@ class TestDuckDBIntegration:
         )
         parquet_bytes = df.to_parquet(index=False)
 
-        # Upload to fileset using SDK directly
         file_path = "data.parquet"
-        sdk.files.upload_content(
-            content=parquet_bytes,
-            remote_path=file_path,
-            fileset=fileset.name,
-            workspace=fileset.workspace,
-        )
 
         # Create filesystem via fsspec (how users would configure it)
-        fs = fsspec.filesystem("fileset", client=client_from_platform(sdk, FilesClient))
+        fs = fsspec.filesystem(
+            "fileset",
+            client=client_from_platform(sdk, FilesClient),
+            async_client=async_files_client,
+        )
+        fs.pipe(f"{fileset.workspace}/{fileset.name}#{file_path}", parquet_bytes)
 
         # Query with DuckDB using fileset:// URL with new # format
         fileset_url = f"fileset://{fileset.workspace}/{fileset.name}#{file_path}"
@@ -1863,7 +1880,12 @@ class TestDuckDBIntegration:
         assert len(result) == 2
         assert set(result["category"]) == {"A", "B"}
 
-    def test_duckdb_parquet_range_read(self, sdk: NeMoPlatform, fileset: FilesetOutput):
+    def test_duckdb_parquet_range_read(
+        self,
+        sdk: NeMoPlatform,
+        async_files_client: AsyncFilesClient,
+        fileset: FilesetOutput,
+    ):
         """Test that DuckDB performs efficient range reads on parquet files.
 
         Parquet files store metadata at the end (footer), so DuckDB reads:
@@ -1883,17 +1905,15 @@ class TestDuckDBIntegration:
         )
         parquet_bytes = df.to_parquet(index=False)
 
-        # Upload to fileset using SDK directly
         file_path = "large_data.parquet"
-        sdk.files.upload_content(
-            content=parquet_bytes,
-            remote_path=file_path,
-            fileset=fileset.name,
-            workspace=fileset.workspace,
-        )
 
         # Create filesystem via fsspec
-        fs = fsspec.filesystem("fileset", client=client_from_platform(sdk, FilesClient))
+        fs = fsspec.filesystem(
+            "fileset",
+            client=client_from_platform(sdk, FilesClient),
+            async_client=async_files_client,
+        )
+        fs.pipe(f"{fileset.workspace}/{fileset.name}#{file_path}", parquet_bytes)
         fileset_url = f"fileset://{fileset.workspace}/{fileset.name}#{file_path}"
         conn = duckdb.connect()
         conn.register_filesystem(fs)
@@ -1905,7 +1925,12 @@ class TestDuckDBIntegration:
         assert list(result["id"]) == list(range(100, 111))
         assert list(result["value"]) == [float(i) for i in range(100, 111)]
 
-    def test_duckdb_legacy_path_format(self, sdk: NeMoPlatform, fileset: FilesetOutput):
+    def test_duckdb_legacy_path_format(
+        self,
+        sdk: NeMoPlatform,
+        async_files_client: AsyncFilesClient,
+        fileset: FilesetOutput,
+    ):
         """Test DuckDB queries using legacy workspace/fileset/path format.
 
         This validates backwards compatibility with the legacy path format
@@ -1920,17 +1945,15 @@ class TestDuckDBIntegration:
         )
         parquet_bytes = df.to_parquet(index=False)
 
-        # Upload to fileset
         file_path = "test_legacy_format.parquet"
-        sdk.files.upload_content(
-            content=parquet_bytes,
-            remote_path=file_path,
-            fileset=fileset.name,
-            workspace=fileset.workspace,
-        )
 
         # Create filesystem via fsspec
-        fs = fsspec.filesystem("fileset", client=client_from_platform(sdk, FilesClient))
+        fs = fsspec.filesystem(
+            "fileset",
+            client=client_from_platform(sdk, FilesClient),
+            async_client=async_files_client,
+        )
+        fs.pipe(f"{fileset.workspace}/{fileset.name}#{file_path}", parquet_bytes)
 
         # Query with DuckDB using LEGACY path format: workspace/fileset/path
         fileset_url = f"fileset://{fileset.workspace}/{fileset.name}/{file_path}"
@@ -1950,9 +1973,12 @@ class TestDirCache:
     """
 
     @pytest.fixture
-    def fs(self, sdk: NeMoPlatform) -> FilesetFileSystem:
+    def fs(self, sdk: NeMoPlatform, async_files_client: AsyncFilesClient) -> FilesetFileSystem:
         """Create a FilesetFileSystem backed by the test SDK."""
-        return sdk.files.fsspec
+        return FilesetFileSystem(
+            client=client_from_platform(sdk, FilesClient),
+            async_client=async_files_client,
+        )
 
     def test_ls_populates_cache_for_nested_dirs(self, fs: FilesetFileSystem, fileset: FilesetOutput):
         """_ls should populate cache for all directory levels in the response."""
@@ -2158,10 +2184,18 @@ class TestDirCache:
         else:
             assert all(isinstance(item, str) for item in result)
 
-    def test_cache_disabled(self, sdk: NeMoPlatform, fileset: FilesetOutput):
+    def test_cache_disabled(
+        self,
+        sdk: NeMoPlatform,
+        async_files_client: AsyncFilesClient,
+        fileset: FilesetOutput,
+    ):
         """When use_listings_cache=False, cache should not be used."""
         # Create filesystem with cache disabled
-        fs = FilesetFileSystem(client=client_from_platform(sdk, FilesClient))
+        fs = FilesetFileSystem(
+            client=client_from_platform(sdk, FilesClient),
+            async_client=async_files_client,
+        )
         fs.dircache.use_listings_cache = False
 
         base = f"{fileset.workspace}/{fileset.name}"

--- a/services/core/jobs/tests/integration/test_task_auth_runtime.py
+++ b/services/core/jobs/tests/integration/test_task_auth_runtime.py
@@ -25,6 +25,7 @@ from nmp.core.secrets.service import SecretsService
 from nmp.testing import (
     TEST_ADMIN_EMAIL,
     ClientContext,
+    SDKTestClientAdapter,
     as_user,
     create_test_client,
     grant_workspace_role,
@@ -99,7 +100,7 @@ class TestTaskRuntimeAuthPropagation:
                         }
                     ),
                 )
-                secret = _secret_access_task_module().run(http_client=ctx.test_client)
+                secret = _secret_access_task_module().run(http_client=SDKTestClientAdapter(ctx.test_client))
 
             assert secret == secret_value
 
@@ -145,7 +146,7 @@ class TestTaskRuntimeAuthPropagation:
                         }
                     ),
                 )
-                _secret_access_task_module().run(http_client=ctx.test_client)
+                _secret_access_task_module().run(http_client=SDKTestClientAdapter(ctx.test_client))
 
             request = ctx.access_log.assert_has_request(
                 method="GET",

--- a/services/core/secrets/tests/conftest.py
+++ b/services/core/secrets/tests/conftest.py
@@ -11,7 +11,7 @@ from nemo_platform_plugin.secrets.client import SecretsClient
 from nmp.common.secrets.encryption import get_base64_encoded_random_bytes
 from nmp.core.secrets.config import SecretsServiceConfig
 from nmp.core.secrets.service import SecretsService
-from nmp.testing import ClientContext, create_test_client
+from nmp.testing import ClientContext, SDKTestClientAdapter, create_test_client
 from nmp.testing.blockbuster import blockbuster_fixture
 
 # Enable BlockBuster to detect blocking calls in async code
@@ -62,7 +62,11 @@ def test_client(service_config) -> Generator[TestClient, None, None]:
 @pytest.fixture
 def sdk(test_client: TestClient) -> SecretsClient:
     """Typed Secrets client backed by the test client."""
-    return SecretsClient(base_url="http://testserver", workspace="default", http_client=test_client)
+    return SecretsClient(
+        base_url="http://testserver",
+        workspace="default",
+        http_client=SDKTestClientAdapter(test_client),
+    )
 
 
 @pytest.fixture

--- a/services/guardrails/tests/integration/test_guardrails.py
+++ b/services/guardrails/tests/integration/test_guardrails.py
@@ -33,7 +33,7 @@ from nmp.guardrails.config import GuardrailsServiceConfig
 from nmp.guardrails.service import GuardrailsService
 from nmp.platform_seed.config import PlatformSeedConfig
 from nmp.platform_seed.tasks.seed import run_platform_seed
-from nmp.testing.client import create_test_client
+from nmp.testing.client import SDKTestClientAdapter, create_test_client
 
 # Default workspace for tests
 DEFAULT_WORKSPACE = "default"
@@ -165,7 +165,7 @@ def http_client() -> Generator[TestClient, None, None]:
 @pytest.fixture(scope="module")
 def sdk(http_client: TestClient) -> NeMoPlatform:
     """SDK client backed by the test client."""
-    return NeMoPlatform(base_url="http://testserver", http_client=http_client)
+    return NeMoPlatform(base_url="http://testserver", http_client=SDKTestClientAdapter(http_client))
 
 
 def _generate_guardrail_config(name: str | None = None):

--- a/services/hello-world/tests/integration/test_hello_world.py
+++ b/services/hello-world/tests/integration/test_hello_world.py
@@ -20,7 +20,7 @@ import pytest
 from fastapi.testclient import TestClient
 from nemo_platform import NeMoPlatform
 from nmp.hello_world.service import HelloWorldService
-from nmp.testing.client import create_test_client
+from nmp.testing.client import SDKTestClientAdapter, create_test_client
 
 # Default workspace for tests
 DEFAULT_WORKSPACE = "default"
@@ -44,7 +44,7 @@ def http_client() -> Generator[TestClient, None, None]:
 @pytest.fixture(scope="module")
 def sdk(http_client: TestClient) -> NeMoPlatform:
     """SDK client backed by the test client."""
-    return NeMoPlatform(base_url="http://testserver", http_client=http_client)
+    return NeMoPlatform(base_url="http://testserver", http_client=SDKTestClientAdapter(http_client))
 
 
 class TestHelloWorld:

--- a/services/intake/tests/integration/test_intake.py
+++ b/services/intake/tests/integration/test_intake.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 from nemo_platform import NeMoPlatform
 from nmp.intake.service import IntakeService
-from nmp.testing.client import create_test_client
+from nmp.testing.client import SDKTestClientAdapter, create_test_client
 
 
 @pytest.fixture(scope="module")
@@ -25,7 +25,7 @@ def http_client() -> Generator[TestClient, None, None]:
 @pytest.fixture(scope="module")
 def sdk(http_client: TestClient) -> NeMoPlatform:
     """SDK client backed by the test client."""
-    return NeMoPlatform(base_url="http://testserver", http_client=http_client)
+    return NeMoPlatform(base_url="http://testserver", http_client=SDKTestClientAdapter(http_client))
 
 
 def test_intake_openapi_keeps_span_era_routes(sdk: NeMoPlatform) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2228,6 +2228,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "truststore", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2300,6 +2313,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpcore2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "truststore", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
 ]
 
 [[package]]
@@ -7646,6 +7675,7 @@ dependencies = [
     { name = "docker", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "fastapi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-nb", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-auth", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -7663,6 +7693,7 @@ requires-dist = [
     { name = "docker", specifier = ">=7.0.0" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "httpx2", specifier = ">=2.0.0" },
     { name = "nemo-nb", editable = "packages/nemo_nb" },
     { name = "nemo-platform", editable = "packages/nemo_platform" },
     { name = "nmp-auth", editable = "services/core/auth" },
@@ -11015,6 +11046,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/43/7935f8ea93fcb6680bc10a6fdbf534075c198eeead59150dd5ed68449642/trove_classifiers-2026.1.14.14.tar.gz", hash = "sha256:00492545a1402b09d4858605ba190ea33243d361e2b01c9c296ce06b5c3325f3", size = 16997, upload-time = "2026-01-14T14:54:50.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl", hash = "sha256:1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d", size = 14197, upload-time = "2026-01-14T14:54:49.067Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Remove Starlette-specific hacks from `FilesetFileSystem` and the SDK test infrastructure, replacing them with clean interfaces that properly bridge the `TestClient ↔ httpx.Client` gap.

## Changes

### FilesetFileSystem (`packages/filesets`, `sdk/python`)
- **Remove `fsspec.asyn._run_coros_in_chunks` monkey-patch** — the custom `run_coros_in_chunks` is still used, but no longer replaces fsspec's global helper
- **Remove `_detect_async_transport`** — this Starlette-aware hack extracted `ASGITransport` from a `TestClient` at runtime; the async client is now injected explicitly via a new `async_client` parameter on `FilesetFileSystem.__init__`
- **Add `_put` override** — properly handles local→remote path expansion (glob, recursive, directory creation) instead of relying on the base-class implementation that doesn't work with fileset refs
- **Add `mode` parameter** to `_pipe_file` and `_put_file` signatures
- **Improve type annotations** — `out: dict[str, FileInfo]`, `ListFilesQueryParams` for query dicts
- **Add input validation** in `_get` for mixed list/string arguments

### SDK test infrastructure (`packages/nmp_testing`)
- **Introduce `SDKTestClientAdapter`** — an `httpx.Client` subclass that delegates `.send()` to Starlette's `TestClient.request()`, preserving request headers and body
- **Add `_install_asgi_files_resource`** — wires the ASGI-backed `AsyncFilesClient` into the sync SDK's `.files` resource (and patches `.copy`/`.with_options` so cloned SDKs keep the same transport)
- **Add `httpx2>=2.0.0` dependency** to `nmp_testing`
- **Export `SDKTestClientAdapter`** and `ClientContext` from `nmp.testing`

### Consumers updated
- **`data_designer_nemo`** — use `sdk.files.fsspec` instead of manually constructing `FilesetFileSystem` via `client_from_platform`
- **`nemo_platform_plugin` (file_manager)** — same simplification
- **`filesets/resources.py`** — accept optional `async_files_client`, use `DEFAULT_CALLBACK` instead of conditional kwargs, use `CacheStatus` enum values
- **Integration test fixtures** across `files`, `auth`, `secrets`, `guardrails`, `hello_world`, `intake`, and CLI tests — updated to use `SDKTestClientAdapter` and `ClientContext`
- **K8s deployment tests** — use fully-qualified Docker image refs (`docker.io/library/alpine:3.20`)

## Why

The previous approach detected Starlette's `TestClient` at runtime inside `FilesetFileSystem` to extract an `ASGITransport` — a fragile coupling that broke when the SDK's HTTP client interface changed. The new approach keeps test transport concerns in the test infrastructure where they belong, and gives `FilesetFileSystem` a clean `async_client` injection point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fileset operations now support coordinated synchronous and asynchronous file clients.
  * Improved integration with SDK-provided filesystem access for file management and data workflows.

* **Bug Fixes**
  * Improved file upload and download handling, including directory operations and path validation.
  * Enhanced caching status reporting with consistent status values.
  * Improved support for Hugging Face-backed file storage and asynchronous downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->