### PR TITLE
feat(studio): Add column fields for samplers

### DIFF
--- a/web/packages/studio/src/components/ColumnConfigPanel/index.tsx
+++ b/web/packages/studio/src/components/ColumnConfigPanel/index.tsx
@@ -1,5 +1,230 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { ColumnConfigPanel } from '@studio/components/ColumnConfigPanel/ColumnConfigPanel';
-export type { ColumnConfigPanelProps } from '@studio/components/ColumnConfigPanel/ColumnConfigPanel';
+import { SamplerType } from '@nemo/sdk/generated/data-designer/schema';
+import {
+  Banner,
+  Button,
+  Flex,
+  FormField,
+  SelectContent,
+  SelectItem,
+  SelectListbox,
+  SelectRoot,
+  SelectTrigger,
+  Stack,
+  Switch,
+  Text,
+  TextArea,
+  TextInput,
+} from '@nvidia/foundations-react-core';
+import { ICON_COLOR_CLASS } from '@studio/components/AddColumnPalette/constants';
+import { CardIconBadge } from '@studio/components/common/SelectableCard';
+import {
+  type BuilderColumn,
+  type ColumnField,
+  getColumnFields,
+  validateColumnName,
+} from '@studio/routes/DataDesignerJobBuildRoute/columns';
+import { Trash2, X } from 'lucide-react';
+import type { FC } from 'react';
+
+/** Renders one config field as the appropriate control, wrapped in a `FormField`. */
+const FieldControl: FC<{
+  field: ColumnField;
+  value: string;
+  onChange: (value: string) => void;
+}> = ({ field, value, onChange }) => {
+  const control = () => {
+    switch (field.kind) {
+      case 'textarea':
+        return (
+          <TextArea
+            value={value}
+            onValueChange={onChange}
+            placeholder={field.placeholder}
+            resizeable="auto"
+          />
+        );
+      case 'select':
+        return (
+          <SelectRoot value={value || undefined} onValueChange={onChange}>
+            <SelectTrigger className="w-full" placeholder="Select…" />
+            <SelectContent className="w-(--radix-popper-anchor-width)">
+              <SelectListbox>
+                {field.options?.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectListbox>
+            </SelectContent>
+          </SelectRoot>
+        );
+      case 'number':
+        return (
+          <TextInput
+            value={value}
+            onValueChange={onChange}
+            placeholder={field.placeholder}
+            attributes={{ Input: { type: 'number', inputMode: 'decimal' } }}
+          />
+        );
+      default:
+        return <TextInput value={value} onValueChange={onChange} placeholder={field.placeholder} />;
+    }
+  };
+
+  // A boolean toggle reads better as an inline switch than a stacked FormField control.
+  if (field.kind === 'switch') {
+    return (
+      <FormField slotLabel={field.label} slotInfo={field.helperText}>
+        <Switch
+          checked={value === 'true'}
+          onCheckedChange={(checked) => onChange(checked ? 'true' : 'false')}
+        />
+      </FormField>
+    );
+  }
+
+  return (
+    <FormField slotLabel={field.label} required={field.required} slotInfo={field.helperText}>
+      {control()}
+    </FormField>
+  );
+};
+
+export interface ColumnConfigPanelProps {
+  /** The column currently being edited. */
+  column: BuilderColumn;
+  /** Names used by other columns, for the uniqueness check. */
+  takenNames: Set<string>;
+  /** Fired live as the user edits the name or any field. */
+  onChange: (patch: { name?: string; values?: Record<string, string> }) => void;
+  /** Removes this column from the canvas. */
+  onRemove: () => void;
+  /** Closes the panel (deselects the column). */
+  onClose: () => void;
+}
+
+/**
+ * Setup note shown for the managed `person` sampler. Unlike the other samplers, it reads
+ * from downloaded Nemotron Personas datasets, so it fails at preview/build time (with
+ * "Failed to access Nemotron personas filesets") until those are available for the locale.
+ */
+const PersonSamplerNote: FC = () => (
+  <Banner kind="inline" status="info" title="Requires a managed dataset">
+    <Text kind="body/regular/sm">
+      The person sampler reads from downloaded Nemotron Personas datasets. Before it can preview or
+      build:
+    </Text>
+    <ol className="list-decimal pl-density-lg">
+      <li>
+        Download the Nemotron Personas dataset for your locale into the Data Designer service's
+        managed assets directory.
+      </li>
+      <li>
+        Set <Text kind="body/bold/sm">Locale</Text> below to a supported value (e.g. en_US, en_IN,
+        fr_FR, ja_JP, ko_KR, pt_BR).
+      </li>
+    </ol>
+    <Text kind="body/regular/sm">
+      Without the managed dataset, use a different sampler for local previews.
+    </Text>
+  </Banner>
+);
+
+/**
+ * Right-hand config panel for the selected column on the build canvas.
+ *
+ * Renders as an inline pane (not an overlay) so the canvas stays visible while editing.
+ * Edits are applied live via {@link ColumnConfigPanelProps.onChange} — as the user types
+ * Jinja2 `{{ column_name }}` references, the canvas re-derives its dependency edges. The
+ * fields shown are derived from the column type via {@link getColumnFields}.
+ */
+export const ColumnConfigPanel: FC<ColumnConfigPanelProps> = ({
+  column,
+  takenNames,
+  onChange,
+  onRemove,
+  onClose,
+}) => {
+  const { option, name, values } = column;
+  const { icon: Icon, label, description, color } = option;
+  const fields = getColumnFields(option);
+  const nameError = validateColumnName(name, takenNames);
+
+  const setValue = (key: string, value: string) =>
+    onChange({ values: { ...values, [key]: value } });
+
+  return (
+    <aside
+      aria-label={`Configure ${label} column`}
+      className="flex h-full w-full flex-col bg-surface-base"
+    >
+      <Flex
+        align="start"
+        justify="between"
+        gap="density-md"
+        className="shrink-0 border-b border-base p-density-lg"
+      >
+        <Flex align="center" gap="density-sm" className="min-w-0">
+          <CardIconBadge>
+            <Icon size={16} className={ICON_COLOR_CLASS[color]} aria-hidden />
+          </CardIconBadge>
+          <Stack gap="density-xxs" className="min-w-0">
+            <Text kind="body/bold/md" className="truncate">
+              {label}
+            </Text>
+            <Text kind="body/regular/xs" className="text-secondary truncate">
+              {description}
+            </Text>
+          </Stack>
+        </Flex>
+        <Button
+          kind="tertiary"
+          color="neutral"
+          size="small"
+          aria-label="Close column config"
+          onClick={onClose}
+        >
+          <X size={16} aria-hidden />
+        </Button>
+      </Flex>
+
+      <Stack gap="density-lg" padding="density-lg" className="min-h-0 flex-1 overflow-y-auto">
+        {option.samplerType === SamplerType.person && <PersonSamplerNote />}
+        <FormField
+          slotLabel="Column name"
+          required
+          slotInfo="Other columns reference this via {{ name }}."
+          status={name && nameError ? 'error' : undefined}
+          slotError={name ? (nameError ?? undefined) : undefined}
+        >
+          <TextInput
+            value={name}
+            onValueChange={(value) => onChange({ name: value })}
+            placeholder="e.g. topic"
+            attributes={{ Input: { 'aria-label': 'Column name' } }}
+          />
+        </FormField>
+
+        {fields.map((field) => (
+          <FieldControl
+            key={field.key}
+            field={field}
+            value={values[field.key] ?? ''}
+            onChange={(value) => setValue(field.key, value)}
+          />
+        ))}
+      </Stack>
+
+      <Flex align="center" justify="start" className="shrink-0 border-t border-base p-density-lg">
+        <Button kind="tertiary" color="danger" size="small" onClick={onRemove}>
+          <Trash2 size={16} aria-hidden />
+          Remove column
+        </Button>
+      </Flex>
+    </aside>
+  );
+};

--- a/web/packages/studio/src/components/CreateFilesetStart/constants.ts
+++ b/web/packages/studio/src/components/CreateFilesetStart/constants.ts
@@ -1,8 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { FILESET_TEMPLATES } from '@studio/components/CreateFilesetStart/templates';
 import type { StartOption } from '@studio/components/CreateFilesetStart/types';
 import { LayoutGrid, Plus, Sparkles } from 'lucide-react';
+
+/** "N recipe(s)" badge label, kept in sync with the number of authored templates. */
+const RECIPE_COUNT_LABEL = `${FILESET_TEMPLATES.length} ${
+  FILESET_TEMPLATES.length === 1 ? 'recipe' : 'recipes'
+}`;
 
 /**
  * The "How do you want to start?" tiles, in display order. Only "Build from scratch"
@@ -22,7 +28,7 @@ export const START_OPTIONS: StartOption[] = [
     title: 'Start from a template',
     description: 'Pick a ready-made recipe for SFT, classification, RAG eval, tool-use and more.',
     icon: LayoutGrid,
-    tag: { label: '8 recipes', color: 'blue', kind: 'outline' },
+    tag: { label: RECIPE_COUNT_LABEL, color: 'blue', kind: 'outline' },
     enabled: true,
   },
   {

--- a/web/packages/studio/src/components/CreateFilesetStart/templates.ts
+++ b/web/packages/studio/src/components/CreateFilesetStart/templates.ts
@@ -4,7 +4,7 @@
 import { SamplerType } from '@nemo/sdk/generated/data-designer/schema';
 import type { FilesetTemplate } from '@studio/components/CreateFilesetStart/types';
 import { DEFAULT_BUILD_MODEL_NAME } from '@studio/constants/constants';
-import { GraduationCap } from 'lucide-react';
+import { FlaskConical, GraduationCap } from 'lucide-react';
 
 /**
  * The ready-made recipes shown as cards in the secondary area when "Start from a
@@ -49,6 +49,96 @@ export const FILESET_TEMPLATES: FilesetTemplate[] = [
       },
     ],
     models: [{ alias: 'default', model: DEFAULT_BUILD_MODEL_NAME }],
+  },
+  {
+    id: 'sampler-showcase',
+    title: 'All samplers (showcase)',
+    description:
+      'A column for each previewable sampler sub-type — UUID, category, subcategory, uniform, gaussian, Bernoulli, Bernoulli mixture, binomial, Poisson, scipy, datetime, and timedelta — seeded with valid params for QA.',
+    icon: FlaskConical,
+    tag: { label: 'Showcase', color: 'green', kind: 'outline' },
+    columns: [
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.uuid,
+        name: 'uuid_id',
+        values: { prefix: 'user-', short_form: 'true', uppercase: 'false' },
+      },
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.category,
+        name: 'category_topic',
+        values: { values: 'science, technology, arts', weights: '3, 2, 1' },
+      },
+      {
+        // Parent-category reference → draws an edge from `category_topic`.
+        columnType: 'sampler',
+        samplerType: SamplerType.subcategory,
+        name: 'subcategory_topic',
+        values: {
+          category: 'category_topic',
+          values:
+            '{ "science": ["physics", "biology"], "technology": ["ai", "systems"], "arts": ["music", "painting"] }',
+        },
+      },
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.uniform,
+        name: 'uniform_score',
+        values: { low: '0', high: '1', decimal_places: '3' },
+      },
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.gaussian,
+        name: 'gaussian_measure',
+        values: { mean: '100', stddev: '15', decimal_places: '2' },
+      },
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.bernoulli,
+        name: 'bernoulli_flag',
+        values: { p: '0.3' },
+      },
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.bernoulli_mixture,
+        name: 'bernoulli_mixture_value',
+        values: { p: '0.5', dist_name: 'norm', dist_params: '{ "loc": 10, "scale": 2 }' },
+      },
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.binomial,
+        name: 'binomial_successes',
+        values: { n: '10', p: '0.5' },
+      },
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.poisson,
+        name: 'poisson_events',
+        values: { mean: '4' },
+      },
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.scipy,
+        name: 'scipy_sample',
+        values: { dist_name: 'beta', dist_params: '{ "a": 2, "b": 5 }', decimal_places: '3' },
+      },
+      // The managed `person` sampler is intentionally omitted: it requires downloaded
+      // Nemotron Personas datasets, so it can't preview in environments without them.
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.datetime,
+        name: 'created_at',
+        values: { start: '2020-01-01', end: '2024-01-01', unit: 'D' },
+      },
+      {
+        // Reference-datetime column → draws an edge from `created_at`.
+        columnType: 'sampler',
+        samplerType: SamplerType.timedelta,
+        name: 'shipped_after',
+        values: { dt_min: '1', dt_max: '30', reference_column_name: 'created_at', unit: 'D' },
+      },
+    ],
   },
 ];
 

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.test.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.test.ts
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { SamplerType } from '@nemo/sdk/generated/data-designer/schema';
 import { COLUMN_TYPE_GROUPS } from '@studio/components/AddColumnPalette/constants';
 import type { ColumnTypeOption } from '@studio/components/AddColumnPalette/types';
+import { FILESET_TEMPLATES } from '@studio/components/CreateFilesetStart/templates';
 import {
   type BuilderColumn,
   buildColumnsFromTemplate,
@@ -183,51 +185,163 @@ describe('sampler columns', () => {
     expect(validateColumns(columns)).toContainEqual(expect.stringContaining('Categories'));
   });
 
-  it('serializes binomial params as numbers', () => {
-    const columns = [column('a', 'returns', 'sampler', { n: '10', p: '0.1' }, 'binomial')];
-
-    expect(buildDataDesignerConfig(columns).columns[0]).toEqual({
-      name: 'returns',
-      column_type: 'sampler',
-      sampler_type: 'binomial',
-      params: { n: 10, p: 0.1 },
-    });
-  });
-
-  it('serializes boolean and JSON params for their SDK types', () => {
+  it('coerces numeric sampler params to numbers', () => {
     const columns = [
       column(
         'a',
-        'dist',
+        'score',
         'sampler',
-        { dist_name: 'norm', dist_params: '{ "loc": 0, "scale": 1 }', p: '0.5' },
-        'bernoulli_mixture'
+        { mean: '1.5', stddev: '0.25', decimal_places: '2' },
+        'gaussian'
       ),
-      column('b', 'ids', 'sampler', { short_form: 'true' }, 'uuid'),
     ];
 
-    const built = buildDataDesignerConfig(columns);
-    expect(built.columns[0]).toMatchObject({
-      params: { p: 0.5, dist_name: 'norm', dist_params: { loc: 0, scale: 1 } },
+    expect(buildDataDesignerConfig(columns).columns[0]).toEqual({
+      name: 'score',
+      column_type: 'sampler',
+      sampler_type: 'gaussian',
+      params: { mean: 1.5, stddev: 0.25, decimal_places: 2 },
     });
-    expect(built.columns[1]).toMatchObject({ params: { short_form: true } });
   });
 
-  it('flags non-numeric and malformed-JSON sampler params', () => {
+  it('serializes boolean switches and a numeric weight list', () => {
+    const uuid = column('a', 'id', 'sampler', { short_form: 'true', uppercase: 'false' }, 'uuid');
+    const category = column(
+      'b',
+      'domain',
+      'sampler',
+      { values: 'a, b, c', weights: '3, 1, 1' },
+      'category'
+    );
+
+    const built = buildDataDesignerConfig([uuid, category]).columns;
+    expect(built[0]).toMatchObject({ params: { short_form: 'true', uppercase: 'false' } });
+    expect(built[1]).toMatchObject({ params: { values: ['a', 'b', 'c'], weights: [3, 1, 1] } });
+  });
+
+  it('parses JSON sampler params (subcategory mapping)', () => {
     const columns = [
-      column('a', 'returns', 'sampler', { n: 'not-a-number', p: '0.1' }, 'binomial'),
       column(
-        'b',
-        'dist',
+        'a',
+        'sub',
         'sampler',
-        { dist_name: 'norm', dist_params: '{ bad', p: '0.5' },
-        'bernoulli_mixture'
+        { category: 'domain', values: '{ "sci": ["physics"], "art": ["music"] }' },
+        'subcategory'
       ),
     ];
 
-    const errors = validateColumns(columns);
-    expect(errors).toContainEqual(expect.stringContaining('Number of trials'));
-    expect(errors).toContainEqual(expect.stringContaining('Distribution params'));
+    expect(buildDataDesignerConfig(columns).columns[0]).toMatchObject({
+      params: { category: 'domain', values: { sci: ['physics'], art: ['music'] } },
+    });
+  });
+
+  it('draws edges from sampler column-name references (subcategory parent, timedelta reference)', () => {
+    const columns = [
+      column('a', 'domain', 'sampler', { values: 'x, y' }, 'category'),
+      column(
+        'b',
+        'sub',
+        'sampler',
+        { category: 'domain', values: '{ "x": ["x1"] }' },
+        'subcategory'
+      ),
+      column('c', 'created', 'sampler', { start: '2020-01-01', end: '2024-01-01' }, 'datetime'),
+      column(
+        'd',
+        'shipped',
+        'sampler',
+        { dt_min: '1', dt_max: '30', reference_column_name: 'created' },
+        'timedelta'
+      ),
+    ];
+
+    const { edges } = buildGraph(columns);
+    expect(edges).toContainEqual({ source: 'a', target: 'b' });
+    expect(edges).toContainEqual({ source: 'c', target: 'd' });
+  });
+
+  it('flags malformed numeric and JSON sampler params', () => {
+    const badNumber = column('a', 'x', 'sampler', { p: 'not-a-number' }, 'bernoulli');
+    const badJson = column(
+      'b',
+      'y',
+      'sampler',
+      { dist_name: 'beta', dist_params: '{ oops' },
+      'scipy'
+    );
+
+    expect(validateColumns([badNumber])).toContainEqual(
+      expect.stringContaining('must be a number')
+    );
+    expect(validateColumns([badJson])).toContainEqual(
+      expect.stringContaining('must be valid JSON')
+    );
+  });
+
+  it('accepts a fully-specified numeric sampler as submittable', () => {
+    const columns = [column('a', 'trials', 'sampler', { n: '10', p: '0.5' }, 'binomial')];
+
+    expect(validateColumns(columns)).toEqual([]);
+  });
+});
+
+describe('sampler-showcase template', () => {
+  const showcase = FILESET_TEMPLATES.find((t) => t.id === 'sampler-showcase');
+  if (!showcase) throw new Error('sampler-showcase template is missing');
+
+  it('covers every previewable sampler sub-type in the palette', () => {
+    // The managed `person` sampler is intentionally excluded — it needs downloaded
+    // Nemotron Personas datasets and can't preview without them.
+    const excluded = new Set<string | undefined>([SamplerType.person]);
+    const samplerTypesInPalette = COLUMN_TYPE_GROUPS.flatMap((g) => g.options)
+      .filter((o) => o.columnType === 'sampler')
+      .map((o) => o.samplerType)
+      .filter((t) => !excluded.has(t));
+    const covered = new Set(showcase.columns.map((c) => c.samplerType));
+    for (const samplerType of samplerTypesInPalette) {
+      expect(covered).toContain(samplerType);
+    }
+    expect(covered.has(SamplerType.person)).toBe(false);
+  });
+
+  it('validates clean and builds a config for every sampler', () => {
+    const columns = buildColumnsFromTemplate(showcase.columns);
+    expect(columns).toHaveLength(showcase.columns.length);
+    expect(validateColumns(columns)).toEqual([]);
+
+    const built = buildDataDesignerConfig(columns).columns;
+    // Every emitted config is a sampler with a params object.
+    for (const config of built) {
+      expect(config).toMatchObject({ column_type: 'sampler' });
+      expect((config as { params?: unknown }).params).toBeTypeOf('object');
+    }
+  });
+
+  it('wires the two intended sampler dependency edges', () => {
+    const columns = buildColumnsFromTemplate(showcase.columns);
+    const { edges } = buildGraph(columns);
+    const idOf = (name: string) => columns.find((c) => c.name === name)?.id;
+
+    expect(edges).toContainEqual({
+      source: idOf('category_topic'),
+      target: idOf('subcategory_topic'),
+    });
+    expect(edges).toContainEqual({ source: idOf('created_at'), target: idOf('shipped_after') });
+  });
+
+  it('coerces representative params to their SDK types', () => {
+    const columns = buildColumnsFromTemplate(showcase.columns);
+    const built = buildDataDesignerConfig(columns).columns as unknown as Array<{
+      sampler_type: string;
+      params: Record<string, unknown>;
+    }>;
+    const paramsFor = (t: SamplerType) => built.find((c) => c.sampler_type === t)?.params;
+
+    expect(paramsFor(SamplerType.uuid)).toMatchObject({ short_form: 'true', uppercase: 'false' });
+    expect(paramsFor(SamplerType.category)).toMatchObject({ weights: [3, 2, 1] });
+    expect(paramsFor(SamplerType.binomial)).toMatchObject({ n: 10, p: 0.5 });
+    expect(paramsFor(SamplerType.scipy)).toMatchObject({ dist_params: { a: 2, b: 5 } });
+    expect(paramsFor(SamplerType.timedelta)).toMatchObject({ dt_min: 1, dt_max: 30 });
   });
 });
 

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.ts
@@ -1,7 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type DataDesignerConfig, SamplerType } from '@nemo/sdk/generated/data-designer/schema';
+import {
+  type DataDesignerConfig,
+  DatetimeSamplerParamsUnit,
+  PersonSamplerParamsSex,
+  SamplerType,
+  TimeDeltaSamplerParamsUnit,
+} from '@nemo/sdk/generated/data-designer/schema';
 import { COLUMN_TYPE_GROUPS } from '@studio/components/AddColumnPalette/constants';
 import type {
   AddColumnSelection,
@@ -24,7 +30,14 @@ export type FieldReference =
   /** Value is a comma-separated list of column names. */
   | 'list';
 
-export type FieldKind = 'text' | 'textarea' | 'select';
+/** Input control kind for a column config field. */
+export type FieldKind = 'text' | 'textarea' | 'select' | 'number' | 'switch';
+
+/**
+ * How a field's string value is serialized into the SDK column config. Defaults to a plain
+ * string; sampler params commonly need numbers, booleans, JSON objects, or numeric lists.
+ */
+export type FieldDataType = 'string' | 'number' | 'boolean' | 'json' | 'number-list';
 
 export interface ColumnField {
   /** Key into {@link BuilderColumn.values} and the eventual SDK config. */
@@ -48,6 +61,11 @@ export interface ColumnField {
    * Used by sampler params whose SDK types are non-string (see PARAM_FIELDS_BY_SAMPLER_TYPE).
    */
   valueType?: 'number' | 'boolean' | 'json';
+  /**
+   * How the string value is coerced for the SDK config (number, boolean, JSON, numeric list).
+   * Defaults to `'string'`. Also drives validation (numbers must parse, JSON must be well-formed).
+   */
+  dataType?: FieldDataType;
 }
 
 /** Not yet the SDK column config — that's produced by {@link buildDataDesignerConfig}. */
@@ -218,6 +236,86 @@ const BOOL_OPTIONS = [
   { label: 'No', value: 'false' },
 ] as const;
 
+/** `p` (probability of success) field, shared by the Bernoulli-family samplers. */
+const probabilityField = (helperText: string): ColumnField => ({
+  key: 'p',
+  label: 'Probability of success (p)',
+  kind: 'number',
+  dataType: 'number',
+  required: true,
+  placeholder: '0.0 – 1.0',
+  helperText,
+});
+
+/** Optional `decimal_places` rounding field, shared by the continuous distributions. */
+const DECIMAL_PLACES_FIELD: ColumnField = {
+  key: 'decimal_places',
+  label: 'Decimal places (optional)',
+  kind: 'number',
+  dataType: 'number',
+  placeholder: 'e.g. 2',
+  helperText: 'Round sampled values to this many decimal places.',
+};
+
+/** `dist_name` / `dist_params` fields, shared by the Scipy and Bernoulli-mixture samplers. */
+const DIST_NAME_FIELD: ColumnField = {
+  key: 'dist_name',
+  label: 'Distribution name',
+  kind: 'text',
+  required: true,
+  placeholder: 'e.g. beta, gamma, expon',
+  helperText: 'A scipy.stats distribution name.',
+};
+
+const DIST_PARAMS_FIELD: ColumnField = {
+  key: 'dist_params',
+  label: 'Distribution parameters (JSON)',
+  kind: 'textarea',
+  dataType: 'json',
+  required: true,
+  placeholder: '{ "a": 2, "b": 5 }',
+  helperText: 'JSON object of parameters for the scipy.stats distribution.',
+};
+
+/** `locale` / `sex` / `city` / `age_range` fields shared by the two Person samplers. */
+const PERSON_SHARED_FIELDS: ColumnField[] = [
+  {
+    key: 'locale',
+    label: 'Locale (optional)',
+    kind: 'text',
+    placeholder: 'e.g. en_US',
+    helperText: 'Language and geographic region to sample from.',
+  },
+  {
+    key: 'sex',
+    label: 'Sex (optional)',
+    kind: 'select',
+    options: asOptions(Object.values(PersonSamplerParamsSex)),
+    helperText: 'Restrict sampling to a single sex.',
+  },
+  {
+    key: 'city',
+    label: 'City (optional)',
+    kind: 'text',
+    list: true,
+    placeholder: 'e.g. San Jose, Austin',
+    helperText: 'Comma-separated city names to restrict to.',
+  },
+  {
+    key: 'age_range',
+    label: 'Age range (optional)',
+    kind: 'text',
+    dataType: 'number-list',
+    placeholder: 'e.g. 18, 65',
+    helperText: 'Two comma-separated ages: min, max.',
+  },
+];
+
+/**
+ * Sampler sub-type-specific fields, collected into the sampler config's required `params`
+ * object (see `SamplerColumnConfig`). Every sampler sub-type surfaced in the palette is
+ * listed; sub-types with no builder-editable params map to an empty array.
+ */
 const PARAM_FIELDS_BY_SAMPLER_TYPE: Partial<Record<SamplerType, ColumnField[]>> = {
   [SamplerType.uuid]: [
     {
@@ -254,6 +352,14 @@ const PARAM_FIELDS_BY_SAMPLER_TYPE: Partial<Record<SamplerType, ColumnField[]>> 
       placeholder: 'science, technology, history, arts, business',
       helperText: 'Comma-separated values to sample from.',
     },
+    {
+      key: 'weights',
+      label: 'Weights (optional)',
+      kind: 'text',
+      dataType: 'number-list',
+      placeholder: 'e.g. 3, 1, 1, 2',
+      helperText: 'Comma-separated weights, one per category, in order.',
+    },
   ],
   [SamplerType.subcategory]: [
     {
@@ -263,176 +369,106 @@ const PARAM_FIELDS_BY_SAMPLER_TYPE: Partial<Record<SamplerType, ColumnField[]>> 
       required: true,
       reference: 'single',
       placeholder: 'Name of the parent category column',
-      helperText: 'The category column each subcategory value depends on.',
+      helperText: 'The category column this subcategory is conditioned on.',
     },
     {
       key: 'values',
       label: 'Subcategory values (JSON)',
       kind: 'textarea',
+      dataType: 'json',
       required: true,
-      valueType: 'json',
-      placeholder: '{ "science": ["physics", "chemistry"], "arts": ["music", "film"] }',
-      helperText: 'JSON mapping each parent value to a list of subcategory values.',
+      placeholder: '{ "science": ["physics", "biology"], "arts": ["music"] }',
+      helperText: 'JSON mapping each parent value to its list of subcategory values.',
     },
   ],
   [SamplerType.uniform]: [
     {
       key: 'low',
       label: 'Low',
-      kind: 'text',
+      kind: 'number',
+      dataType: 'number',
       required: true,
-      valueType: 'number',
-      helperText: 'Lower bound of the range (inclusive).',
+      placeholder: 'Lower bound (inclusive)',
+      helperText: 'Lower bound of the range.',
     },
     {
       key: 'high',
       label: 'High',
-      kind: 'text',
+      kind: 'number',
+      dataType: 'number',
       required: true,
-      valueType: 'number',
-      helperText: 'Upper bound of the range (must be greater than low).',
+      placeholder: 'Upper bound',
+      helperText: 'Upper bound of the range (must exceed low).',
     },
-    {
-      key: 'decimal_places',
-      label: 'Decimal places (optional)',
-      kind: 'text',
-      valueType: 'number',
-      helperText: 'Round sampled values to this many decimals.',
-    },
+    DECIMAL_PLACES_FIELD,
   ],
   [SamplerType.gaussian]: [
-    { key: 'mean', label: 'Mean', kind: 'text', required: true, valueType: 'number' },
+    {
+      key: 'mean',
+      label: 'Mean',
+      kind: 'number',
+      dataType: 'number',
+      required: true,
+      placeholder: 'Center of the distribution',
+      helperText: 'Mean (center) of the distribution.',
+    },
     {
       key: 'stddev',
       label: 'Standard deviation',
-      kind: 'text',
+      kind: 'number',
+      dataType: 'number',
       required: true,
-      valueType: 'number',
-      helperText: 'Must be positive.',
+      placeholder: 'Spread of the distribution',
+      helperText: 'Standard deviation; must be positive.',
     },
-    {
-      key: 'decimal_places',
-      label: 'Decimal places (optional)',
-      kind: 'text',
-      valueType: 'number',
-      helperText: 'Round sampled values to this many decimals.',
-    },
+    DECIMAL_PLACES_FIELD,
   ],
-  [SamplerType.bernoulli]: [
-    {
-      key: 'p',
-      label: 'Probability of success (p)',
-      kind: 'text',
-      required: true,
-      valueType: 'number',
-      helperText: 'Between 0 and 1.',
-    },
-  ],
+  [SamplerType.bernoulli]: [probabilityField('Probability of sampling 1 (0.0 – 1.0).')],
   [SamplerType.bernoulli_mixture]: [
-    {
-      key: 'p',
-      label: 'Mixture probability (p)',
-      kind: 'text',
-      required: true,
-      valueType: 'number',
-      helperText: 'Between 0 and 1; otherwise the sample is 0.',
-    },
-    {
-      key: 'dist_name',
-      label: 'Distribution name',
-      kind: 'text',
-      required: true,
-      placeholder: 'e.g. norm, gamma, expon',
-      helperText: 'A scipy.stats distribution name.',
-    },
-    {
-      key: 'dist_params',
-      label: 'Distribution params (JSON)',
-      kind: 'textarea',
-      required: true,
-      valueType: 'json',
-      placeholder: '{ "loc": 0, "scale": 1 }',
-      helperText: 'JSON parameters for the distribution.',
-    },
+    probabilityField('Probability of sampling from the mixture distribution (0.0 – 1.0).'),
+    DIST_NAME_FIELD,
+    DIST_PARAMS_FIELD,
   ],
   [SamplerType.binomial]: [
     {
       key: 'n',
       label: 'Number of trials (n)',
-      kind: 'text',
+      kind: 'number',
+      dataType: 'number',
       required: true,
-      valueType: 'number',
-      helperText: 'Positive integer.',
+      placeholder: 'e.g. 10',
+      helperText: 'Number of independent trials; a positive integer.',
     },
-    {
-      key: 'p',
-      label: 'Probability of success (p)',
-      kind: 'text',
-      required: true,
-      valueType: 'number',
-      helperText: 'Between 0 and 1.',
-    },
+    probabilityField('Probability of success on each trial (0.0 – 1.0).'),
   ],
   [SamplerType.poisson]: [
     {
       key: 'mean',
       label: 'Mean (rate λ)',
-      kind: 'text',
+      kind: 'number',
+      dataType: 'number',
       required: true,
-      valueType: 'number',
-      helperText: 'Must be positive.',
+      placeholder: 'e.g. 4',
+      helperText: 'Mean number of events per interval; must be positive.',
     },
   ],
-  [SamplerType.scipy]: [
-    {
-      key: 'dist_name',
-      label: 'Distribution name',
-      kind: 'text',
-      required: true,
-      placeholder: 'e.g. beta, gamma, lognorm',
-      helperText: 'A scipy.stats distribution name.',
-    },
-    {
-      key: 'dist_params',
-      label: 'Distribution params (JSON)',
-      kind: 'textarea',
-      required: true,
-      valueType: 'json',
-      placeholder: '{ "a": 2, "b": 5 }',
-      helperText: 'JSON parameters for the distribution.',
-    },
-    {
-      key: 'decimal_places',
-      label: 'Decimal places (optional)',
-      kind: 'text',
-      valueType: 'number',
-      helperText: 'Round sampled values to this many decimals.',
-    },
-  ],
+  [SamplerType.scipy]: [DIST_NAME_FIELD, DIST_PARAMS_FIELD, DECIMAL_PLACES_FIELD],
   [SamplerType.person]: [
-    {
-      key: 'locale',
-      label: 'Locale (optional)',
-      kind: 'text',
-      placeholder: 'e.g. en_US',
-      helperText: 'Managed persona locale (e.g. en_US, ja_JP).',
-    },
-    { key: 'sex', label: 'Sex (optional)', kind: 'select', options: asOptions(['Male', 'Female']) },
-    {
-      key: 'city',
-      label: 'Cities (optional)',
-      kind: 'text',
-      list: true,
-      placeholder: 'comma,separated,cities',
-      helperText: 'Comma-separated city filter.',
-    },
+    ...PERSON_SHARED_FIELDS,
     {
       key: 'with_synthetic_personas',
-      label: 'Synthetic personas (optional)',
-      kind: 'select',
-      valueType: 'boolean',
-      options: BOOL_OPTIONS,
-      helperText: 'Append persona trait columns to each person.',
+      label: 'Include synthetic personas',
+      kind: 'switch',
+      dataType: 'boolean',
+      helperText: 'Append synthetic persona columns (locale-dependent).',
+    },
+    {
+      key: 'select_field_values',
+      label: 'Field-value filters (JSON, optional)',
+      kind: 'textarea',
+      dataType: 'json',
+      placeholder: '{ "occupation": ["engineer", "teacher"] }',
+      helperText: 'JSON mapping managed-dataset fields to allowed values.',
     },
   ],
   [SamplerType.datetime]: [
@@ -449,33 +485,35 @@ const PARAM_FIELDS_BY_SAMPLER_TYPE: Partial<Record<SamplerType, ColumnField[]>> 
       label: 'End',
       kind: 'text',
       required: true,
-      placeholder: 'e.g. 2025-01-01',
+      placeholder: 'e.g. 2024-01-01',
       helperText: 'Exclusive upper bound.',
     },
     {
       key: 'unit',
       label: 'Unit (optional)',
       kind: 'select',
-      options: asOptions(['Y', 'M', 'D', 'h', 'm', 's']),
-      helperText: 'Sampling granularity (defaults to days).',
+      options: asOptions(Object.values(DatetimeSamplerParamsUnit)),
+      helperText: 'Sampling granularity (Y, M, D, h, m, s). Defaults to D.',
     },
   ],
   [SamplerType.timedelta]: [
     {
       key: 'dt_min',
       label: 'Minimum delta',
-      kind: 'text',
+      kind: 'number',
+      dataType: 'number',
       required: true,
-      valueType: 'number',
-      helperText: 'Non-negative and less than the maximum.',
+      placeholder: 'e.g. 1',
+      helperText: 'Minimum time-delta (inclusive, non-negative).',
     },
     {
       key: 'dt_max',
       label: 'Maximum delta',
-      kind: 'text',
+      kind: 'number',
+      dataType: 'number',
       required: true,
-      valueType: 'number',
-      helperText: 'Greater than the minimum.',
+      placeholder: 'e.g. 30',
+      helperText: 'Maximum time-delta (exclusive, greater than the minimum).',
     },
     {
       key: 'reference_column_name',
@@ -484,14 +522,14 @@ const PARAM_FIELDS_BY_SAMPLER_TYPE: Partial<Record<SamplerType, ColumnField[]>> 
       required: true,
       reference: 'single',
       placeholder: 'Name of an existing datetime column',
-      helperText: 'The datetime column each delta is added to.',
+      helperText: 'The delta is added to values from this column.',
     },
     {
       key: 'unit',
       label: 'Unit (optional)',
       kind: 'select',
-      options: asOptions(['D', 'h', 'm', 's']),
-      helperText: 'Time unit for the deltas (defaults to days).',
+      options: asOptions(Object.values(TimeDeltaSamplerParamsUnit)),
+      helperText: 'Delta unit (D, h, m, s). Defaults to D.',
     },
   ],
 };
@@ -627,15 +665,39 @@ export const validateColumnName = (name: string, takenNames: Set<string>): strin
   return null;
 };
 
-const isValidJson = (value: string): boolean => {
-  try {
-    JSON.parse(value);
-    return true;
-  } catch {
-    return false;
+/**
+ * Reports why a filled-in field value is malformed for its {@link ColumnField.dataType}
+ * (bad number, invalid JSON, non-numeric list entry), or `null` if it is well-formed.
+ * `output_format` is treated as JSON regardless of its declared type.
+ */
+const fieldValueError = (field: ColumnField, value: string): string | null => {
+  const isJson = field.dataType === 'json' || field.key === 'output_format';
+  if (isJson) {
+    try {
+      JSON.parse(value);
+    } catch {
+      return `${field.label} must be valid JSON.`;
+    }
+    return null;
   }
+  if (field.dataType === 'number' && !Number.isFinite(Number(value))) {
+    return `${field.label} must be a number.`;
+  }
+  if (
+    field.dataType === 'number-list' &&
+    splitList(value).some((v) => !Number.isFinite(Number(v)))
+  ) {
+    return `${field.label} must be a comma-separated list of numbers.`;
+  }
+  return null;
 };
 
+/**
+ * Validates every column is ready to submit: unique, well-formed names; every field
+ * marked `required` in {@link getColumnFields} filled in; and typed fields (numbers, JSON,
+ * numeric lists) parse. Returns one human-readable message per problem found, or an
+ * empty array if the recipe is submittable.
+ */
 export const validateColumns = (columns: BuilderColumn[]): string[] => {
   if (columns.length === 0) return ['Add at least one column before creating the job.'];
 
@@ -650,20 +712,12 @@ export const validateColumns = (columns: BuilderColumn[]): string[] => {
 
     for (const field of getColumnFields(column.option)) {
       const value = column.values[field.key]?.trim();
-      if (field.required && !value) {
-        errors.push(`${label}: ${field.label} is required.`);
+      if (!value) {
+        if (field.required) errors.push(`${label}: ${field.label} is required.`);
         continue;
       }
-      if (!value) continue;
-      if (field.key === 'output_format' && !isValidJson(value)) {
-        errors.push(`${label}: ${field.label} must be valid JSON.`);
-      }
-      if (field.valueType === 'number' && !Number.isFinite(Number(value))) {
-        errors.push(`${label}: ${field.label} must be a number.`);
-      }
-      if (field.valueType === 'json' && !isValidJson(value)) {
-        errors.push(`${label}: ${field.label} must be valid JSON.`);
-      }
+      const valueError = fieldValueError(field, value);
+      if (valueError) errors.push(`${label}: ${valueError}`);
     }
   }
   return errors;
@@ -676,18 +730,23 @@ const splitList = (value: string): string[] =>
     .map((entry) => entry.trim())
     .filter(Boolean);
 
-/** Coerces a (non-empty) string field value into its SDK config form per {@link ColumnField}. */
+/**
+ * Coerces a field's trimmed string value into the type the SDK config expects, per the
+ * field's {@link ColumnField.dataType} (and the legacy `list` / `reference: 'list'` flags).
+ * Assumes the value is non-empty and already validated by {@link validateColumns}.
+ */
 const serializeFieldValue = (field: ColumnField, value: string): unknown => {
-  if (field.list) return splitList(value);
-  switch (field.valueType) {
+  switch (field.dataType) {
     case 'number':
       return Number(value);
     case 'boolean':
       return value === 'true';
     case 'json':
       return JSON.parse(value);
+    case 'number-list':
+      return splitList(value).map(Number);
     default:
-      return value;
+      return field.list || field.reference === 'list' ? splitList(value) : value;
   }
 };
 
@@ -725,13 +784,8 @@ const toColumnConfig = (column: BuilderColumn): Record<string, unknown> => {
   for (const field of getColumnFields(column.option)) {
     const value = column.values[field.key]?.trim();
     if (!value) continue;
-    if (field.key === 'output_format') {
-      config[field.key] = JSON.parse(value);
-    } else if (field.reference === 'list' || field.list) {
-      config[field.key] = splitList(value);
-    } else {
-      config[field.key] = value;
-    }
+    config[field.key] =
+      field.key === 'output_format' ? JSON.parse(value) : serializeFieldValue(field, value);
   }
   return config;
 };


### PR DESCRIPTION
Adds column definitions and config panel for editing column fields

<img width="269" height="671" alt="Screenshot 2026-07-14 at 10 41 32 AM" src="https://github.com/user-attachments/assets/17983475-393e-4154-93c2-54c46d56af09" />


Signed-off-by: Sean Teramae <steramae@nvidia.com>