### PR TITLE
fix(studio): Add telemetry to example agents configs

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-build-agent/references/templates/agent.yml
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-build-agent/references/templates/agent.yml
@@ -15,6 +15,13 @@ llms:
     temperature: 0.0
     max_tokens: 1024
 
+general:
+  telemetry:
+    tracing:
+      nemo_files_trace:
+        _type: nemo_files
+        # workspace and agent_name are injected at deploy time
+
 workflow:
   _type: react_agent
   tool_names: [clock]

--- a/plugins/nemo-agents/examples/email-phishing-analyzer/src/nat_email_phishing_analyzer/email-phishing-agent.yml
+++ b/plugins/nemo-agents/examples/email-phishing-analyzer/src/nat_email_phishing_analyzer/email-phishing-agent.yml
@@ -40,3 +40,11 @@ workflow:
   # Use the LLM's native tool-calling API instead of NAT's text-mode ReAct regex
   # parser (see calculator-agent.yml for the rationale).
   use_native_tool_calling: true
+
+general:
+  telemetry:
+    tracing:
+      nemo_trace:
+        _type: nemo_files
+        # workspace and agent_name are injected at deploy time
+        batch_size: 128

--- a/plugins/nemo-agents/examples/hello_world.yaml
+++ b/plugins/nemo-agents/examples/hello_world.yaml
@@ -24,3 +24,11 @@ workflow:
    verbose: true
    # Retry up to 3 times
    parse_agent_response_max_retries: 3
+
+general:
+   telemetry:
+      tracing:
+         nemo_trace:
+            _type: nemo_files
+            # workspace and agent_name are injected at deploy time
+            batch_size: 128

--- a/web/packages/studio/public/sample-agents/calculator/agent.yml
+++ b/web/packages/studio/public/sample-agents/calculator/agent.yml
@@ -23,3 +23,10 @@ workflow:
   verbose: false
   parse_agent_response_max_retries: 3
   use_native_tool_calling: true
+general:
+  telemetry:
+    tracing:
+      nemo_trace:
+        _type: nemo_files
+        # workspace and agent_name are injected at deploy time
+        batch_size: 128

--- a/web/packages/studio/public/sample-agents/email-phishing-analyzer/agent.yml
+++ b/web/packages/studio/public/sample-agents/email-phishing-analyzer/agent.yml
@@ -29,3 +29,10 @@ workflow:
     After using the email_phishing_analyzer tool, your final answer MUST begin
     with a single-word verdict on its own line — exactly "phishing" or "benign" —
     followed by a brief one-sentence justification.
+general:
+  telemetry:
+    tracing:
+      nemo_trace:
+        _type: nemo_files
+        # workspace and agent_name are injected at deploy time
+        batch_size: 128


### PR DESCRIPTION
<img width="1728" height="956" alt="image" src="https://github.com/user-attachments/assets/0c2388d5-edf4-4058-ab3f-c6dcd9717c88" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled NeMo telemetry tracing for agent templates and built-in example configurations.
  * Added file-based tracing output (`nemo_files`) with configurable batching (`batch_size: 128`).
  * Applied the same tracing configuration across the build-agent template, examples, and Studio sample agents (with deploy-time injection of workspace and agent name).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->