### PR TITLE
fix(studio): prevent blank UserPopover when no auth profile

### DIFF
--- a/web/packages/studio/src/components/UserPopover/index.test.tsx
+++ b/web/packages/studio/src/components/UserPopover/index.test.tsx
@@ -161,6 +161,22 @@ describe('UserPopover', () => {
     expect(screen.queryByText('Report a Trace')).not.toBeInTheDocument();
   });
 
+  it('should render a non-clickable avatar when no profile and telemetry disabled', async () => {
+    vi.resetModules();
+    vi.doMock('@studio/constants/environment', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@studio/constants/environment')>();
+      return {
+        ...actual,
+        TELEMETRY_ENABLED: false,
+      };
+    });
+    mockUseAuthProfile.mockReturnValue(undefined);
+    const { UserPopover: UserPopoverEmpty } = await import('@studio/components/UserPopover');
+    renderWithRouter(<UserPopoverEmpty />);
+
+    expect(screen.queryByTestId('nv-dropdown-trigger')).not.toBeInTheDocument();
+  });
+
   it('should open trace modal when "Report a Trace" is clicked', async () => {
     renderWithRouter(<UserPopover />);
 

--- a/web/packages/studio/src/components/UserPopover/index.test.tsx
+++ b/web/packages/studio/src/components/UserPopover/index.test.tsx
@@ -175,6 +175,7 @@ describe('UserPopover', () => {
     renderWithRouter(<UserPopoverEmpty />);
 
     expect(screen.queryByTestId('nv-dropdown-trigger')).not.toBeInTheDocument();
+    expect(screen.getByText('N')).toBeInTheDocument();
   });
 
   it('should open trace modal when "Report a Trace" is clicked', async () => {

--- a/web/packages/studio/src/components/UserPopover/index.tsx
+++ b/web/packages/studio/src/components/UserPopover/index.tsx
@@ -26,6 +26,10 @@ export const UserPopover = () => {
   const profile = useAuthProfile();
   const auth = useAuth();
 
+  if (!profile && !TELEMETRY_ENABLED) {
+    return <Avatar fallback="N" />;
+  }
+
   return (
     <>
       <DropdownRoot defaultOpen={false}>
@@ -40,7 +44,7 @@ export const UserPopover = () => {
           </Button>
         </DropdownTrigger>
         <DropdownContent align="end" className="w-[300px] mt-[8px]" density="spacious">
-          {typeof profile?.workspace === 'string' && (
+          {profile && (
             <DropdownHeading>
               <Text fontSize="14" kind="label/bold/sm" className="text-center w-full">
                 {profile.email}


### PR DESCRIPTION
## Summary

Opening the user menu (`UserPopover`) with no menu content rendered an empty dropdown. This happens in the local-dev / auth-disabled configuration (`VITE_AUTH_AUTHORITY`/`VITE_AUTH_CLIENT_ID` empty, telemetry off): `profile` is `undefined` and every conditional child of `DropdownContent` evaluates false → blank popover.

## Changes

- Hide the email heading when there is no profile (unauthenticated).
- Render a plain, non-clickable `Avatar` (no `DropdownRoot`/trigger) when there is no profile **and** telemetry is disabled — nothing to show, so the avatar no longer opens an empty popover.

## Verification

`pnpm --filter nemo-studio-ui test src/components/UserPopover/index.test.tsx` → 14/14 pass.

Linear: ASTD-296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the user menu behavior when no authenticated profile is available and telemetry is disabled.
  - Shows a simple fallback avatar instead of rendering dropdown UI in this scenario.
  - Ensures dropdown content and related headings appear whenever an authenticated profile exists.

- **Tests**
  - Added a focused UserPopover test covering the no-profile, telemetry-disabled case and verifying the fallback avatar renders while dropdown UI is hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->