### PR TITLE
fix(intake): preserve ATIF trajectory semantics

### DIFF
--- a/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
+++ b/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
@@ -357,7 +357,7 @@ def _step_to_span(
         external_span_id=external_span_id,
         external_parent_span_id=external_parent_span_id,
         kind=_step_kind(step),
-        name=f"{step.source}-{step.step_id}",
+        name=(default_agent_name if isinstance(step, AtifStepAgent) else f"{step.source}-{step.step_id}"),
         status=SpanStatus.SUCCESS,
         start_time=step_started_at,
         end_time=_clamped_end(step_started_at, step_ended_at),

--- a/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
+++ b/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
@@ -840,17 +840,21 @@ def _trajectory_output(trajectory: AtifTrajectory) -> str | None:
 
 
 def _trajectory_has_error(trajectory: AtifTrajectory) -> bool:
-    """Return whether a trajectory or any embedded descendant has an error."""
-    for current, _identity, _depth in _trajectory_tree(trajectory):
-        for step in current.steps:
-            if not isinstance(step, AtifStepAgent):
-                continue
-            observation = _step_observation(step)
-            if observation is None:
-                continue
-            for result in observation.results:
-                if _tool_result_is_error(step, result):
-                    return True
+    """Return whether this trajectory directly contains a tool error.
+
+    Embedded trajectories map to independent AGENT spans. Their errors remain
+    visible on those spans and in the trace error count, but must not change the
+    status of a parent trajectory that successfully delegated and recovered.
+    """
+    for step in trajectory.steps:
+        if not isinstance(step, AtifStepAgent):
+            continue
+        observation = _step_observation(step)
+        if observation is None:
+            continue
+        for result in observation.results:
+            if _tool_result_is_error(step, result):
+                return True
     return False
 
 

--- a/services/intake/tests/integration/spans/test_atif_ingest.py
+++ b/services/intake/tests/integration/spans/test_atif_ingest.py
@@ -263,18 +263,30 @@ def test_atif_ingest_expands_embedded_subagent_trajectory_into_the_parent_trace(
     )
     assert spans_response.status_code == 200, spans_response.text
     spans = spans_response.json()["data"]
-    spans_by_name = {span["name"]: span for span in spans}
+    root = next(span for span in spans if span["name"] == "orchestrator" and span["kind"] == "AGENT")
+    delegation = next(span for span in spans if span["name"] == "orchestrator" and span["kind"] == "LLM")
+    worker = next(span for span in spans if span["name"] == "worker-agent" and span["kind"] == "AGENT")
+    worker_step = next(span for span in spans if span["name"] == "worker-agent" and span["kind"] == "LLM")
+    user_step = next(span for span in spans if span["name"] == "user-1")
 
     assert len(spans) == 5
-    assert set(spans_by_name) == {"orchestrator", "agent-1", "worker-agent", "user-1", "agent-2"}
+    assert sorted(span["name"] for span in spans) == [
+        "orchestrator",
+        "orchestrator",
+        "user-1",
+        "worker-agent",
+        "worker-agent",
+    ]
     assert {span["trace_id"] for span in spans} == {session_id}
     assert {span["session_id"] for span in spans} == {session_id}
-    assert spans_by_name["agent-1"]["parent_span_id"] == spans_by_name["orchestrator"]["span_id"]
-    assert spans_by_name["worker-agent"]["parent_span_id"] == spans_by_name["agent-1"]["span_id"]
-    assert spans_by_name["user-1"]["parent_span_id"] == spans_by_name["worker-agent"]["span_id"]
-    assert spans_by_name["agent-2"]["parent_span_id"] == spans_by_name["worker-agent"]["span_id"]
-    assert spans_by_name["orchestrator"]["started_at"] == _span_started_at(root_started_at)
-    assert spans_by_name["orchestrator"]["ended_at"] == _span_ended_at(subagent_ended_at)
+    assert delegation["parent_span_id"] == root["span_id"]
+    assert delegation["agent_name"] == "orchestrator"
+    assert worker["parent_span_id"] == delegation["span_id"]
+    assert user_step["parent_span_id"] == worker["span_id"]
+    assert worker_step["parent_span_id"] == worker["span_id"]
+    assert worker_step["agent_name"] == "worker-agent"
+    assert root["started_at"] == _span_started_at(root_started_at)
+    assert root["ended_at"] == _span_ended_at(subagent_ended_at)
 
 
 def test_atif_ingest_rejects_subagent_tree_over_configured_depth(shallow_atif_client: TestClient):
@@ -486,18 +498,22 @@ def test_atif_ingest_accepts_example_trajectory_and_reconstructs_read_side_data(
     spans = spans_response.json()["data"]
     assert len(spans) == 7
     spans_by_name = {span["name"]: span for span in spans}
+    assert [span["name"] for span in spans].count("sample-agent") == 3
     assert set(spans_by_name) == {
         "sample-agent",
         "user-1",
-        "agent-2",
         "Bash",
-        "agent-3",
         "subagent-subagents/subagent-session-1.json",
         "harbor.verifier",
     }
     assert {span["session_id"] for span in spans} == {"d074dfb7-3691-443c-b137-720d75e40afa"}
 
-    trajectory = spans_by_name["sample-agent"]
+    trajectory = next(span for span in spans if span["name"] == "sample-agent" and span["kind"] == "AGENT")
+    agent_steps = sorted(
+        (span for span in spans if span["name"] == "sample-agent" and span["kind"] == "LLM"),
+        key=lambda span: span["started_at"],
+    )
+    llm_step, final_agent_step = agent_steps
     assert trajectory["kind"] == "AGENT"
     assert trajectory["source"] == "atif"
     assert trajectory["status"] == "error"
@@ -529,7 +545,7 @@ def test_atif_ingest_accepts_example_trajectory_and_reconstructs_read_side_data(
     assert trajectory["ended_at"] == _span_ended_at(verifier_finished_at)
 
     for span in spans:
-        if span["name"] == "sample-agent":
+        if span["span_id"] == trajectory["span_id"]:
             continue
         assert "evaluation_context" not in span
 
@@ -587,8 +603,9 @@ def test_atif_ingest_accepts_example_trajectory_and_reconstructs_read_side_data(
     assert user_step["parent_span_id"] == trajectory["span_id"]
     assert user_step["input"] == body["steps"][0]["message"]
 
-    llm_step = spans_by_name["agent-2"]
     assert llm_step["kind"] == "LLM"
+    assert llm_step["name"] == body["agent"]["name"]
+    assert llm_step["agent_name"] == body["agent"]["name"]
     assert llm_step["parent_span_id"] == trajectory["span_id"]
     assert llm_step["status"] == "success"
     assert "error_message" not in llm_step
@@ -615,12 +632,12 @@ def test_atif_ingest_accepts_example_trajectory_and_reconstructs_read_side_data(
 
     subagent_step = spans_by_name["subagent-subagents/subagent-session-1.json"]
     assert subagent_step["kind"] == "AGENT"
-    assert subagent_step["parent_span_id"] == spans_by_name["agent-3"]["span_id"]
+    assert subagent_step["parent_span_id"] == final_agent_step["span_id"]
     assert subagent_step["trace_id"] == body["session_id"]
     assert json.loads(subagent_step["input"]) == subagent_ref
     assert json.loads(subagent_step["output"]) == subagent_observation
 
-    agent_step_response = client.get(f"/apis/intake/v2/workspaces/default/spans/{spans_by_name['agent-3']['span_id']}")
+    agent_step_response = client.get(f"/apis/intake/v2/workspaces/default/spans/{final_agent_step['span_id']}")
     assert agent_step_response.status_code == 200, agent_step_response.text
     agent_step = agent_step_response.json()
     assert agent_step["kind"] == "LLM"

--- a/services/intake/tests/test_atif_v17.py
+++ b/services/intake/tests/test_atif_v17.py
@@ -247,8 +247,10 @@ def test_atif_v17_embedded_subagents_expand_recursively_in_the_parent_trace() ->
     assert not any(span.name == "subagent-subagents/review-trajectory.json" for span in spans)
     assert root.start_time == datetime(2026, 5, 18, 10, tzinfo=timezone.utc)
     assert root.end_time == datetime(2026, 5, 18, 10, 0, 8, tzinfo=timezone.utc)
-    assert root.status == SpanStatus.ERROR
-    assert research.status == SpanStatus.ERROR
+    # A descendant tool error stays on the trajectory that emitted it. Parent
+    # trajectories successfully delegated, so their AGENT spans remain healthy.
+    assert root.status == SpanStatus.SUCCESS
+    assert research.status == SpanStatus.SUCCESS
     assert review.status == SpanStatus.ERROR
 
     root_raw = json.loads(root.attributes_string["atif.raw"])
@@ -679,7 +681,7 @@ def test_atif_mapping_uses_root_cost_when_step_metrics_have_tokens_only() -> Non
     assert child_response.cost_total_usd is None
 
 
-def test_atif_mapping_populates_root_content_and_rolls_child_errors() -> None:
+def test_atif_mapping_marks_trajectory_error_for_own_tool_error() -> None:
     trajectory = AtifTrajectory.model_validate(
         {
             "schema_version": "ATIF-v1.7",

--- a/services/intake/tests/test_atif_v17.py
+++ b/services/intake/tests/test_atif_v17.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import pytest
 from nmp.intake.spans.api.spans_schemas import Span
-from nmp.intake.spans.domain import SpanStatus
+from nmp.intake.spans.domain import SpanKind, SpanStatus
 from nmp.intake.spans.ingest.atif import AtifIngestRequest
 from nmp.intake.spans.ingest.atif_domain import (
     AtifAgent,
@@ -227,11 +227,13 @@ def test_atif_v17_embedded_subagents_expand_recursively_in_the_parent_trace() ->
 
     root = next(span for span in spans if span.name == "root-agent")
     root_delegation = next(
-        span for span in spans if span.name == "agent-2" and span.external_parent_span_id == root.external_span_id
+        span for span in spans if span.name == "root-agent" and span.external_parent_span_id == root.external_span_id
     )
     research = next(span for span in spans if span.name == "research-agent")
     research_delegation = next(
-        span for span in spans if span.name == "agent-2" and span.external_parent_span_id == research.external_span_id
+        span
+        for span in spans
+        if span.name == "research-agent" and span.external_parent_span_id == research.external_span_id
     )
     review = next(span for span in spans if span.name == "review-agent")
     external_ref = next(span for span in spans if span.name == "subagent-subagents/external-trajectory.json")
@@ -324,7 +326,7 @@ def test_atif_v17_timestamp_free_subagent_starts_at_delegating_step() -> None:
         trajectory=trajectory,
         ingested_at=ingested_at,
     )
-    delegation = next(span for span in spans if span.name == "agent-2")
+    delegation = next(span for span in spans if span.name == "root-agent" and span.kind == SpanKind.LLM)
     worker = next(span for span in spans if span.name == "worker-agent")
     worker_step = next(
         span for span in spans if span.name == "user-1" and span.external_parent_span_id == worker.external_span_id
@@ -589,7 +591,9 @@ def test_atif_mapping_uses_root_final_metrics_when_steps_have_no_metrics() -> No
     )
 
     root_response = Span.from_domain(spans[0])
-    child_response = Span.from_domain(next(span for span in spans if span.name == "agent-2"))
+    child_response = Span.from_domain(
+        next(span for span in spans if span.name == "sample-agent" and span.kind == SpanKind.LLM)
+    )
     assert root_response.input_tokens == 10
     assert root_response.output_tokens == 5
     assert root_response.cached_tokens == 2
@@ -629,7 +633,9 @@ def test_atif_mapping_does_not_duplicate_final_metrics_when_step_metrics_exist()
     )
 
     root_response = Span.from_domain(spans[0])
-    child_response = Span.from_domain(next(span for span in spans if span.name == "agent-2"))
+    child_response = Span.from_domain(
+        next(span for span in spans if span.name == "sample-agent" and span.kind == SpanKind.LLM)
+    )
     assert root_response.input_tokens is None
     assert root_response.output_tokens is None
     assert root_response.cost_total_usd is None
@@ -670,7 +676,9 @@ def test_atif_mapping_uses_root_cost_when_step_metrics_have_tokens_only() -> Non
     )
 
     root_response = Span.from_domain(spans[0])
-    child_response = Span.from_domain(next(span for span in spans if span.name == "agent-2"))
+    child_response = Span.from_domain(
+        next(span for span in spans if span.name == "sample-agent" and span.kind == SpanKind.LLM)
+    )
     assert root_response.input_tokens is None
     assert root_response.output_tokens is None
     assert root_response.cached_tokens is None
@@ -833,7 +841,7 @@ def test_atif_mapping_uses_invocation_timing_for_step_and_tool_spans() -> None:
         ingested_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
     )
     root = next(span for span in spans if span.name == "sample-agent")
-    step = next(span for span in spans if span.name == "agent-1")
+    step = next(span for span in spans if span.name == "sample-agent" and span.kind == SpanKind.LLM)
     tool = next(span for span in spans if span.name == "bash")
 
     assert step.start_time == base + timedelta(seconds=10)
@@ -935,7 +943,7 @@ def test_atif_mapping_infers_step_end_from_next_timed_step_and_verifier_finish()
         ingested_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
     )
     user = next(span for span in spans if span.name == "user-1")
-    step = next(span for span in spans if span.name == "agent-2")
+    step = next(span for span in spans if span.name == "sample-agent" and span.kind == SpanKind.LLM)
     tool = next(span for span in spans if span.name == "bash")
 
     assert user.end_time == base + timedelta(seconds=5)
@@ -977,7 +985,8 @@ def test_atif_mapping_leaves_end_time_none_when_underivable() -> None:
     )
     user = next(span for span in spans if span.name == "user-1")
     tool = next(span for span in spans if span.name == "bash")
-    last = next(span for span in spans if span.name == "agent-3")
+    llm_steps = [span for span in spans if span.name == "sample-agent" and span.kind == SpanKind.LLM]
+    last = llm_steps[-1]
 
     # Malformed invocation blocks never fail ingest and never fabricate ends:
     # earlier steps end at agent-3's invocation start (the next timed step),
@@ -1006,4 +1015,8 @@ def test_atif_mapping_end_time_none_when_no_timing_exists_at_all() -> None:
         trajectory=trajectory,
         ingested_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
     )
-    assert all(span.end_time is None for span in spans if span.name in {"user-1", "agent-2", "bash"})
+    assert all(
+        span.end_time is None
+        for span in spans
+        if span.name in {"user-1", "bash"} or (span.name == "sample-agent" and span.kind == SpanKind.LLM)
+    )


### PR DESCRIPTION
## Summary

- scope ATIF trajectory status to tool errors emitted directly by that trajectory
- keep descendant failures on their owning TOOL and AGENT spans without poisoning successful parents
- name agent/LLM step spans from the standard `trajectory.agent.name` field instead of synthetic `agent-N` labels
- preserve trace-level error counts and stable span IDs

## Why

ATIF recursively expanded subagents into independent spans, but `_trajectory_has_error` recursively scanned the same subtree for every parent. One recoverable tool failure therefore marked every ancestor, including a successful campaign root, as `error`.

Agent steps also discarded the standard ATIF agent name when constructing their display names, even though the same value was already retained in the semantic `agent_name` attribute. Span names are labels rather than identifiers, so duplicate agent names are valid; stable span IDs retain step identity.

## Validation

- `uv run --frozen pytest services/intake/tests/test_atif_v17.py -q` — 23 passed
- `uv run --frozen pytest services/intake/tests/integration/spans/test_atif_ingest.py -q` — 18 passed
- focused Ruff and diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ATIF trajectory span error propagation so tool errors inside embedded sub-trajectories no longer incorrectly mark the parent trajectory as failed.
  * Improved span naming for agent steps to use a default agent label, keeping non-agent step naming unchanged.
  * Ensured parent trajectories report success when only embedded/child trajectories encounter errors, while still failing for the parent’s own tool-step errors.
* **Tests**
  * Updated ATIF v17 and ingest integration tests to locate spans using span kind and relationships rather than prior step-name placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->