### PR TITLE
fix(intake): require explicit ATIF span end times

### DIFF
--- a/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
+++ b/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
@@ -10,7 +10,6 @@ dedicated span column for them. That includes agent tool definitions,
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Any
@@ -124,9 +123,8 @@ def _trajectory_tree_to_spans(
         if subagent.trajectory_id is not None
     }
     expanded_subagent_ids: set[str] = set()
-    evaluator_ended_at = _evaluator_ended_at(trajectory)
     for index, step in enumerate(trajectory.steps):
-        step_ended_at = _step_ended_at(trajectory.steps, index, evaluator_ended_at)
+        step_ended_at = _step_ended_at(step)
         step_span = _step_to_span(
             workspace=workspace,
             default_session_id=trace_session_id,
@@ -154,7 +152,6 @@ def _trajectory_tree_to_spans(
                 step_index=index,
                 tool_index=tool_index,
                 tool_call=tool_call,
-                step_ended_at=step_ended_at,
                 ingested_at=ingested_at,
             )
             for tool_index, tool_call in enumerate(_step_tool_calls(step))
@@ -383,7 +380,6 @@ def _tool_call_to_span(
     step_index: int,
     tool_index: int,
     tool_call: AtifToolCall,
-    step_ended_at: datetime | None,
     ingested_at: datetime,
 ) -> IntakeSpan:
     """Map one ATIF tool call to a span under its owning step."""
@@ -414,7 +410,6 @@ def _tool_call_to_span(
     )
     invocation_started_at, invocation_ended_at = _invocation_window(tool_call.extra)
     tool_started_at = invocation_started_at or _step_started_at(step, step_index, ingested_at)
-    tool_ended_at = invocation_ended_at or step_ended_at
     return IntakeSpan(
         workspace=workspace,
         session_id=default_session_id,
@@ -426,7 +421,7 @@ def _tool_call_to_span(
         name=tool_call.function_name,
         status=SpanStatus.ERROR if _tool_result_is_error(step, result) else SpanStatus.SUCCESS,
         start_time=tool_started_at,
-        end_time=_clamped_end(tool_started_at, tool_ended_at),
+        end_time=_clamped_end(tool_started_at, invocation_ended_at),
         attributes_string=attribute_bags.string,
         attributes_number=attribute_bags.number,
         attributes_bool=attribute_bags.boolean,
@@ -942,18 +937,14 @@ def _step_started_at(step: AtifStep, index: int, ingested_at: datetime) -> datet
     return invocation_started_at or _timestamp(step) or (ingested_at + timedelta(milliseconds=index))
 
 
-def _step_ended_at(steps: Sequence[AtifStep], index: int, evaluator_ended_at: datetime | None) -> datetime | None:
-    """Step end: explicit invocation end, else the next timed step's start,
-    else (for the trailing steps) the verifier's finish. A step's own timestamp
-    is never used as its end — unknown stays None rather than zero-duration."""
-    _, invocation_ended_at = _invocation_window(steps[index].extra)
-    if invocation_ended_at is not None:
-        return invocation_ended_at
-    for later_step in steps[index + 1 :]:
-        later_started_at = _invocation_window(later_step.extra)[0] or _timestamp(later_step)
-        if later_started_at is not None:
-            return later_started_at
-    return evaluator_ended_at
+def _step_ended_at(step: AtifStep) -> datetime | None:
+    """Return only a producer-supplied invocation end.
+
+    Step timestamps and adjacent steps establish ordering, not duration. An
+    absent invocation end therefore remains absent instead of being inferred
+    from a sibling step or evaluator timestamp.
+    """
+    return _invocation_window(step.extra)[1]
 
 
 def _clamped_end(start_time: datetime, end_time: datetime | None) -> datetime | None:

--- a/services/intake/tests/test_atif_v17.py
+++ b/services/intake/tests/test_atif_v17.py
@@ -916,7 +916,7 @@ def test_atif_mapping_drops_root_end_time_before_root_start_time() -> None:
     assert root.end_time is None
 
 
-def test_atif_mapping_infers_step_end_from_next_timed_step_and_verifier_finish() -> None:
+def test_atif_mapping_does_not_infer_step_or_tool_ends() -> None:
     base = datetime(2026, 6, 1, tzinfo=timezone.utc)
     trajectory = _timed_trajectory(
         [
@@ -945,11 +945,15 @@ def test_atif_mapping_infers_step_end_from_next_timed_step_and_verifier_finish()
     user = next(span for span in spans if span.name == "user-1")
     step = next(span for span in spans if span.name == "sample-agent" and span.kind == SpanKind.LLM)
     tool = next(span for span in spans if span.name == "bash")
+    root = next(span for span in spans if span.name == "sample-agent" and span.kind == SpanKind.AGENT)
 
-    assert user.end_time == base + timedelta(seconds=5)
-    assert step.end_time == base + timedelta(seconds=60)
+    assert user.start_time == base
+    assert user.end_time is None
+    assert step.start_time == base + timedelta(seconds=5)
+    assert step.end_time is None
     assert tool.start_time == step.start_time
-    assert tool.end_time == step.end_time
+    assert tool.end_time is None
+    assert root.end_time == base + timedelta(seconds=60)
 
 
 def test_atif_mapping_leaves_end_time_none_when_underivable() -> None:
@@ -988,13 +992,54 @@ def test_atif_mapping_leaves_end_time_none_when_underivable() -> None:
     llm_steps = [span for span in spans if span.name == "sample-agent" and span.kind == SpanKind.LLM]
     last = llm_steps[-1]
 
-    # Malformed invocation blocks never fail ingest and never fabricate ends:
-    # earlier steps end at agent-3's invocation start (the next timed step),
-    # while agent-3's own out-of-order end (end < start) is dropped, not clamped.
-    assert user.end_time == base + timedelta(seconds=10)
-    assert tool.end_time == base + timedelta(seconds=10)
+    # Malformed invocation blocks never fail ingest and never fabricate ends
+    # from later steps. The out-of-order explicit end is also dropped.
+    assert user.end_time is None
+    assert tool.end_time is None
     assert last.start_time == base + timedelta(seconds=10)
     assert last.end_time is None
+
+
+def test_atif_mapping_tool_end_requires_explicit_tool_invocation_end() -> None:
+    base = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    trajectory = _timed_trajectory(
+        [
+            {
+                "step_id": 1,
+                "source": "agent",
+                "message": "working",
+                "extra": {
+                    "invocation": {
+                        "start_timestamp": base.timestamp() + 10,
+                        "end_timestamp": base.timestamp() + 40,
+                    }
+                },
+                "tool_calls": [
+                    {
+                        "tool_call_id": "call-1",
+                        "function_name": "bash",
+                        "extra": {
+                            "invocation": {
+                                "start_timestamp": base.timestamp() + 12,
+                            }
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+
+    spans = trajectory_to_spans(
+        workspace="default",
+        trajectory=trajectory,
+        ingested_at=base,
+    )
+    step = next(span for span in spans if span.name == "sample-agent" and span.kind == SpanKind.LLM)
+    tool = next(span for span in spans if span.name == "bash")
+
+    assert step.end_time == base + timedelta(seconds=40)
+    assert tool.start_time == base + timedelta(seconds=12)
+    assert tool.end_time is None
 
 
 def test_atif_mapping_end_time_none_when_no_timing_exists_at_all() -> None:


### PR DESCRIPTION
## Summary

- preserve ATIF step start timestamps for ordering
- stop inferring step ends from later steps or evaluator timestamps
- stop inheriting tool ends from their owning step
- continue deriving trajectory bounds from all explicit tree timestamps

## Why

Adjacent ATIF timestamps establish ordering, not duration. Inferring child end times creates false latency, especially for concurrent calls and producers that only know one invocation boundary. Child latency is now present only when the producer supplies an explicit invocation end.

## Verification

- `uv run --frozen pytest services/intake/tests/test_atif_v17.py -v` (24 passed)
- `uv run --frozen pytest services/intake/tests/integration/spans/test_atif_ingest.py -q` (18 passed)
- `uv run pre-commit run -a` (passed)

Commit includes DCO sign-off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected span timing so step and tool end times are recorded only when explicitly provided by the invocation.
  * Prevented inferred end times based on later steps, evaluator completion, or parent-step timing.
  * Preserved root span end times based on verifier completion.
  * Improved handling of missing, malformed, or out-of-order timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->