### PR TITLE
fix(studio): drop removed SpanEvaluationContext fields to fix Web typecheck

### DIFF
--- a/web/packages/studio/src/components/IntakeDetail/IntakeComponents/spanKeyValues.test.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/IntakeComponents/spanKeyValues.test.tsx
@@ -21,7 +21,7 @@ describe('spanKeyValues', () => {
         ...span!,
         usage_details: {},
         cost_details: {},
-        evaluation_context: { metadata: {} },
+        evaluation_context: {},
       },
       { workspace: 'default' }
     );

--- a/web/packages/studio/src/util/intakeTelemetry.ts
+++ b/web/packages/studio/src/util/intakeTelemetry.ts
@@ -76,18 +76,11 @@ export const getEvaluationContextSummary = (
   context: SpanEvaluationContext | null | undefined
 ): string => {
   if (!context) return EMPTY_VALUE;
-  return context.evaluation_run_id || context.evaluation_id || context.test_case_id || EMPTY_VALUE;
+  return context.evaluation_id || context.test_case_id || EMPTY_VALUE;
 };
 
 export const hasEvaluationContext = (context: SpanEvaluationContext | null | undefined): boolean =>
-  Boolean(
-    context &&
-    (context.evaluation_id ||
-      context.evaluation_sha ||
-      context.evaluation_run_id ||
-      context.test_case_id ||
-      (context.metadata && Object.keys(context.metadata).length > 0))
-  );
+  Boolean(context && (context.evaluation_id || context.test_case_id));
 
 export const compareSpansByStartedAt = (a: Span, b: Span): number => {
   const aStartedAt = Date.parse(a.started_at);


### PR DESCRIPTION
## Summary

The `CI / Web typecheck` job is red: the generated SDK type `SpanEvaluationContext` only exposes `evaluation_id` and `test_case_id`, but Studio code still references three fields that were removed from the schema — `evaluation_run_id`, `evaluation_sha`, and `metadata`.

## Changes

- `src/util/intakeTelemetry.ts` — drop the stale field refs from `getEvaluationContextSummary` and `hasEvaluationContext`; keep `evaluation_id` / `test_case_id`.
- `src/components/IntakeDetail/IntakeComponents/spanKeyValues.test.tsx` — `evaluation_context: { metadata: {} }` → `{}` (still exercises the empty-context path).

## Verification

- `pnpm --filter nemo-studio-ui typecheck` (tsc) — clean
- `pnpm --filter nemo-studio-ui typecheck:go` (tsgo, CI/pre-push variant) — clean
- `pnpm --filter nemo-studio-ui test src/components/IntakeDetail/IntakeComponents/spanKeyValues.test.tsx` — 7/7 pass

Note: `packages/sdk/generated/` is gitignored and regenerated in CI, so if the API is later changed to re-add these fields, the consumers can be restored instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation context handling when metadata is absent.
  * Updated evaluation summaries to use evaluation or test case identifiers.
  * Prevented unsupported context fields from being treated as valid evaluation context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->