### PR TITLE
ci: run Web typecheck when OpenAPI specs change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1176,7 +1176,8 @@ jobs:
     if: >
       !cancelled() && (
         github.event_name == 'workflow_dispatch' ||
-        needs.changes.outputs.web-studio == 'true'
+        needs.changes.outputs.web-studio == 'true' ||
+        needs.changes.outputs.openapi == 'true'
       )
     runs-on: ubuntu-latest
     defaults:
@@ -1192,9 +1193,9 @@ jobs:
         run: npm i -g corepack@0.31.0 && corepack enable pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Typecheck changed packages
+      - name: Typecheck web packages
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ needs.changes.outputs.openapi }}" != "true" ]; then
             git fetch origin "${{ github.base_ref }}" --depth=1
             pnpm --filter="...[origin/${{ github.base_ref }}]" run --parallel --if-present typecheck
           else


### PR DESCRIPTION
## Problem

A Python-only PR (#618) narrowed the intake `SpanEvaluationContext` schema, dropping `evaluation_run_id` / `evaluation_sha` / `metadata`. That regenerates the SDK types Studio consumes, breaking `nemo-studio-ui` typecheck — but **CI stayed green** and the break landed latently on `main`, only surfacing on the next PR to touch the studio package.

## Why it slipped through

The `Web typecheck` job was gated on the `web-studio` path filter (`web/**`) only:

```yaml
if: needs.changes.outputs.web-studio == 'true'
```

An OpenAPI-only change (`openapi/**`) touches no `web/` files → the job was **skipped**. And even when it runs on a PR, it scoped typecheck to *changed packages* (`--filter="...[origin/main]"`), which selects nothing for an OpenAPI-only diff. The `web-sdk-gen` job does run on `openapi` changes, but only typechecks the SDK package itself — never its Studio consumers.

## Fix

- Gate `web-typecheck` on `openapi == 'true'` in addition to `web-studio`.
- When OpenAPI changed, typecheck the **whole web workspace** instead of only changed packages (the SDK is regenerated on install via the root `postinstall` → `gen:all`, so the narrowed types are present).

Now a schema change that breaks a Studio consumer fails at merge time.

## Notes

Doesn't require a separate SDK-regen step: `pnpm install` already runs `postinstall: pnpm --filter @nemo/sdk gen:all`, which regenerates types from the current `openapi/ga/openapi.yaml` on every fresh CI checkout. Validated the workflow YAML parses. The companion consumer fix is #642.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI validation logic so web type checks run automatically when API specification changes are detected.
  * For relevant pull requests, the workflow now performs a full web workspace type check instead of the narrower “changed packages” approach, improving consistency and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->