### PR TITLE
feat(studio): More templates and visual fixes

### DIFF
--- a/web/packages/studio/src/components/CreateFilesetStart/StartOptionDetail.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/StartOptionDetail.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Divider, Flex, Stack, Text } from '@nvidia/foundations-react-core';
+import { Divider, Flex, Grid, Stack, Text } from '@nvidia/foundations-react-core';
 import { TemplateCard } from '@studio/components/CreateFilesetStart/TemplateCard';
 import { FILESET_TEMPLATES } from '@studio/components/CreateFilesetStart/templates';
 import type {
@@ -66,7 +66,7 @@ export const StartOptionDetail: FC<StartOptionDetailProps> = ({
 }) => {
   const content =
     option.id === 'template' ? (
-      <Flex gap="density-md" className="w-full flex-wrap">
+      <Grid colMinWidth="260px" gap="density-md">
         {FILESET_TEMPLATES.map((template) => (
           <TemplateCard
             key={template.id}
@@ -75,7 +75,7 @@ export const StartOptionDetail: FC<StartOptionDetailProps> = ({
             onSelect={() => onSelectTemplate(template.id)}
           />
         ))}
-      </Flex>
+      </Grid>
     ) : (
       DETAIL_CONTENT[option.id]
     );

--- a/web/packages/studio/src/components/CreateFilesetStart/TemplateCard.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/TemplateCard.tsx
@@ -22,7 +22,7 @@ export const TemplateCard: FC<TemplateCardProps> = ({ template, selected, onSele
       type="button"
       onClick={onSelect}
       aria-pressed={selected}
-      className={`flex h-[200px] min-w-[260px] flex-1 flex-col items-start gap-3 rounded-md border bg-surface-raised p-5 text-left transition focus-visible:border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#76b900] ${stateClasses}`}
+      className={`flex h-[200px] min-w-[260px] flex-1 flex-col items-start gap-3 overflow-hidden rounded-md border bg-surface-raised p-5 text-left transition focus-visible:border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#76b900] ${stateClasses}`}
     >
       <Flex
         align="center"
@@ -32,11 +32,15 @@ export const TemplateCard: FC<TemplateCardProps> = ({ template, selected, onSele
         <Icon size={20} className="text-primary" aria-hidden />
       </Flex>
 
-      <Stack gap="density-xs">
+      <Stack gap="density-xs" className="min-h-0">
         <Text kind="body/bold/md" className="text-primary">
           {template.title}
         </Text>
-        <Text kind="body/regular/sm" className="text-secondary">
+        <Text
+          kind="body/regular/sm"
+          className="line-clamp-3 text-secondary"
+          title={template.description}
+        >
           {template.description}
         </Text>
       </Stack>

--- a/web/packages/studio/src/components/CreateFilesetStart/templates.ts
+++ b/web/packages/studio/src/components/CreateFilesetStart/templates.ts
@@ -4,7 +4,16 @@
 import { SamplerType } from '@nemo/sdk/generated/data-designer/schema';
 import type { FilesetTemplate } from '@studio/components/CreateFilesetStart/types';
 import { DEFAULT_BUILD_MODEL_NAME } from '@studio/constants/constants';
-import { FlaskConical, GraduationCap } from 'lucide-react';
+import {
+  Braces,
+  Code2,
+  FlaskConical,
+  GraduationCap,
+  ImageIcon,
+  Scale,
+  SearchCode,
+  SquareFunction,
+} from 'lucide-react';
 
 /**
  * The ready-made recipes shown as cards in the secondary area when "Start from a
@@ -139,6 +148,282 @@ export const FILESET_TEMPLATES: FilesetTemplate[] = [
         values: { dt_min: '1', dt_max: '30', reference_column_name: 'created_at', unit: 'D' },
       },
     ],
+  },
+  {
+    id: 'code-generation',
+    title: 'Code generation + validation (Python)',
+    description:
+      'Python coding challenges with LLM-generated solutions and automatic code validation: exercises a sampled topic, an LLM task description, a code answer, and a pass/fail validation column.',
+    icon: Code2,
+    tag: { label: 'Fine-tuning', color: 'green', kind: 'outline' },
+    columns: [
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.category,
+        name: 'topic',
+        values: {
+          values:
+            'sorting algorithms, string manipulation, file I/O, data structures, recursion, decorators, generators, async I/O',
+        },
+      },
+      {
+        columnType: 'llm-text',
+        name: 'task',
+        values: {
+          prompt:
+            'Write a clear, self-contained Python coding challenge about {{ topic }}. State what the function should do and give one example input/output pair. Return only the problem statement.',
+          model_alias: 'default',
+        },
+      },
+      {
+        columnType: 'llm-code',
+        name: 'solution',
+        values: {
+          prompt:
+            'Solve the following Python coding challenge. Return only the code — no prose, no markdown fences.\n\n{{ task }}',
+          model_alias: 'default',
+          code_lang: 'python',
+        },
+      },
+      {
+        columnType: 'validation',
+        name: 'is_valid',
+        values: {
+          target_columns: 'solution',
+          validator_type: 'code',
+          validator_params: '{ "code_lang": "python" }',
+        },
+      },
+    ],
+    models: [{ alias: 'default', model: DEFAULT_BUILD_MODEL_NAME }],
+  },
+  {
+    id: 'structured-extraction',
+    title: 'Structured data extraction',
+    description:
+      'Free-form text paired with its structured JSON representation — for training extraction and information-retrieval models. An LLM writes a description; a second call extracts it into a typed schema.',
+    icon: Braces,
+    tag: { label: 'Fine-tuning', color: 'purple', kind: 'outline' },
+    columns: [
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.category,
+        name: 'entity_type',
+        values: {
+          values: 'product, company, research paper, recipe, event, film',
+        },
+      },
+      {
+        columnType: 'llm-text',
+        name: 'description',
+        values: {
+          prompt:
+            'Write a realistic, detailed description of a {{ entity_type }} — include concrete names, dates, and figures. Return only the description.',
+          model_alias: 'default',
+        },
+      },
+      {
+        columnType: 'llm-structured',
+        name: 'structured',
+        values: {
+          prompt:
+            'Extract the key attributes from the following {{ entity_type }} description:\n\n{{ description }}\n\nReturn the attributes as a JSON object.',
+          model_alias: 'default',
+          output_format:
+            '{ "type": "object", "properties": { "name": { "type": "string" }, "attributes": { "type": "object" } }, "required": ["name", "attributes"] }',
+        },
+      },
+    ],
+    models: [{ alias: 'default', model: DEFAULT_BUILD_MODEL_NAME }],
+  },
+  {
+    id: 'preference-pairs',
+    title: 'Preference pairs (reward modeling)',
+    description:
+      'An instruction with a high-quality chosen answer, a lower-quality rejected answer, and an LLM judge score — for DPO fine-tuning and reward model training.',
+    icon: Scale,
+    tag: { label: 'Alignment', color: 'yellow', kind: 'outline' },
+    columns: [
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.category,
+        name: 'topic',
+        values: {
+          values: 'science, history, philosophy, mathematics, literature, technology, ethics',
+        },
+      },
+      {
+        columnType: 'llm-text',
+        name: 'instruction',
+        values: {
+          prompt:
+            'Write a challenging, open-ended question about {{ topic }} that requires an explanatory answer. Return only the question.',
+          model_alias: 'default',
+        },
+      },
+      {
+        columnType: 'llm-text',
+        name: 'chosen',
+        values: {
+          prompt: 'Answer the following question accurately and thoroughly:\n\n{{ instruction }}',
+          model_alias: 'default',
+        },
+      },
+      {
+        columnType: 'llm-text',
+        name: 'rejected',
+        values: {
+          prompt:
+            'Give a brief, vague, or slightly inaccurate answer to the following question — do not correct yourself:\n\n{{ instruction }}',
+          model_alias: 'default',
+        },
+      },
+      {
+        columnType: 'llm-judge',
+        name: 'quality_score',
+        values: {
+          prompt:
+            'On a scale of 1–5 (1 = very poor, 5 = excellent), rate the quality of the following answer.\n\nQuestion: {{ instruction }}\nAnswer: {{ chosen }}\n\nReturn only the integer score.',
+          model_alias: 'default',
+        },
+      },
+    ],
+    models: [{ alias: 'default', model: DEFAULT_BUILD_MODEL_NAME }],
+  },
+  {
+    id: 'semantic-search',
+    title: 'Semantic search dataset',
+    description:
+      'Query–passage pairs with vector embeddings for retrieval, RAG evaluation, and semantic similarity benchmarks. Requires an embedding model configured under the "embedder" alias.',
+    icon: SearchCode,
+    tag: { label: 'Retrieval', color: 'blue', kind: 'outline' },
+    columns: [
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.category,
+        name: 'domain',
+        values: {
+          values: 'science, technology, health, finance, culture, sports',
+        },
+      },
+      {
+        columnType: 'llm-text',
+        name: 'passage',
+        values: {
+          prompt:
+            'Write a factual, self-contained paragraph about a specific topic within {{ domain }}. Return only the paragraph.',
+          model_alias: 'default',
+        },
+      },
+      {
+        columnType: 'llm-text',
+        name: 'query',
+        values: {
+          prompt:
+            'Write a short search query that a user might type to retrieve the following passage:\n\n{{ passage }}\n\nReturn only the query.',
+          model_alias: 'default',
+        },
+      },
+      {
+        columnType: 'embedding',
+        name: 'passage_embedding',
+        values: {
+          target_column: 'passage',
+          model_alias: 'embedder',
+        },
+      },
+    ],
+    models: [
+      { alias: 'default', model: DEFAULT_BUILD_MODEL_NAME },
+      { alias: 'embedder', model: 'nvidia/nv-embedqa-e5-v5' },
+    ],
+  },
+  {
+    id: 'expression-transforms',
+    title: 'Expression transforms (no LLM)',
+    description:
+      'Derived columns computed via Jinja2 expressions — full-name concatenation, score banding into letter grades. No LLM calls; previews instantly.',
+    icon: SquareFunction,
+    tag: { label: 'Transform', color: 'teal', kind: 'outline' },
+    columns: [
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.category,
+        name: 'first_name',
+        values: { values: 'Alice, Bob, Carol, Dave, Eve, Frank, Grace, Hank' },
+      },
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.category,
+        name: 'last_name',
+        values: { values: 'Smith, Jones, Williams, Brown, Davis, Miller' },
+      },
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.uniform,
+        name: 'score',
+        values: { low: '0', high: '100', decimal_places: '1' },
+      },
+      {
+        columnType: 'expression',
+        name: 'full_name',
+        values: {
+          expr: '{{ first_name }} {{ last_name }}',
+        },
+      },
+      {
+        columnType: 'expression',
+        name: 'grade',
+        values: {
+          expr: '{% if score|float >= 90 %}A{% elif score|float >= 80 %}B{% elif score|float >= 70 %}C{% elif score|float >= 60 %}D{% else %}F{% endif %}',
+          dtype: 'str',
+        },
+      },
+    ],
+  },
+  {
+    id: 'image-generation',
+    title: 'Image generation dataset',
+    description:
+      'Text-to-image pairs: sampled visual style and subject, an LLM-crafted descriptive prompt, and the generated image. Requires an image model configured under the "image_model" alias.',
+    icon: ImageIcon,
+    tag: { label: 'Multimodal', color: 'purple', kind: 'outline' },
+    columns: [
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.category,
+        name: 'style',
+        values: {
+          values: 'photorealistic, watercolor, oil painting, digital art, pencil sketch',
+        },
+      },
+      {
+        columnType: 'sampler',
+        samplerType: SamplerType.category,
+        name: 'subject',
+        values: {
+          values: 'mountain landscape, city skyline, forest path, ocean sunset, snowy village',
+        },
+      },
+      {
+        columnType: 'llm-text',
+        name: 'prompt_text',
+        values: {
+          prompt:
+            'Write a vivid, detailed image generation prompt for a {{ style }} depiction of: {{ subject }}. Include lighting, mood, and composition details. Return only the prompt.',
+          model_alias: 'default',
+        },
+      },
+      {
+        columnType: 'image',
+        name: 'generated_image',
+        values: {
+          prompt: '{{ prompt_text }}',
+          model_alias: 'image_model',
+        },
+      },
+    ],
+    models: [{ alias: 'default', model: DEFAULT_BUILD_MODEL_NAME }, { alias: 'image_model' }],
   },
 ];
 

--- a/web/packages/studio/src/components/CreateFilesetStart/templates.ts
+++ b/web/packages/studio/src/components/CreateFilesetStart/templates.ts
@@ -9,7 +9,6 @@ import {
   Code2,
   FlaskConical,
   GraduationCap,
-  ImageIcon,
   Scale,
   SearchCode,
   SquareFunction,
@@ -380,50 +379,6 @@ export const FILESET_TEMPLATES: FilesetTemplate[] = [
         },
       },
     ],
-  },
-  {
-    id: 'image-generation',
-    title: 'Image generation dataset',
-    description:
-      'Text-to-image pairs: sampled visual style and subject, an LLM-crafted descriptive prompt, and the generated image. Requires an image model configured under the "image_model" alias.',
-    icon: ImageIcon,
-    tag: { label: 'Multimodal', color: 'purple', kind: 'outline' },
-    columns: [
-      {
-        columnType: 'sampler',
-        samplerType: SamplerType.category,
-        name: 'style',
-        values: {
-          values: 'photorealistic, watercolor, oil painting, digital art, pencil sketch',
-        },
-      },
-      {
-        columnType: 'sampler',
-        samplerType: SamplerType.category,
-        name: 'subject',
-        values: {
-          values: 'mountain landscape, city skyline, forest path, ocean sunset, snowy village',
-        },
-      },
-      {
-        columnType: 'llm-text',
-        name: 'prompt_text',
-        values: {
-          prompt:
-            'Write a vivid, detailed image generation prompt for a {{ style }} depiction of: {{ subject }}. Include lighting, mood, and composition details. Return only the prompt.',
-          model_alias: 'default',
-        },
-      },
-      {
-        columnType: 'image',
-        name: 'generated_image',
-        values: {
-          prompt: '{{ prompt_text }}',
-          model_alias: 'image_model',
-        },
-      },
-    ],
-    models: [{ alias: 'default', model: DEFAULT_BUILD_MODEL_NAME }, { alias: 'image_model' }],
   },
 ];
 

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.ts
@@ -208,6 +208,16 @@ const FIELDS_BY_COLUMN_TYPE: Record<NonNullable<DataDesignerColumnType>, ColumnF
       required: true,
       options: asOptions(['code', 'local_callable', 'remote']),
     },
+    {
+      key: 'validator_params',
+      label: 'Validator params (JSON)',
+      kind: 'textarea',
+      dataType: 'json',
+      required: true,
+      placeholder: '{ "code_lang": "python" }',
+      helperText:
+        'Parameters for the chosen validator. For "code": { "code_lang": "python" }. For "remote": { "url": "https://…" }.',
+    },
   ],
   'seed-dataset': [],
   custom: [
@@ -792,12 +802,13 @@ const toColumnConfig = (column: BuilderColumn): Record<string, unknown> => {
 
 export const buildDataDesignerConfig = (
   columns: BuilderColumn[],
-  models: BuilderModel[] = []
+  models: BuilderModel[] = [],
+  servedModelNames: Map<string, string> = new Map()
 ): DataDesignerConfig => {
   const config: DataDesignerConfig = {
     columns: columns.map(toColumnConfig) as unknown as DataDesignerConfig['columns'],
   };
-  const modelConfigs = buildModelConfigs(models);
+  const modelConfigs = buildModelConfigs(models, servedModelNames);
   if (modelConfigs) config.model_configs = modelConfigs;
   return config;
 };

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useAllModels } from '@nemo/common/src/api/models/useModels';
+import { DEFAULT_LARGE_PAGE_SIZE } from '@nemo/common/src/constants/api';
 import { groupModelsByWorkspace } from '@nemo/common/src/utils/models';
 import { useDataDesignerCreateJob } from '@nemo/sdk/generated/data-designer/api';
+import { useModelsListProviders } from '@nemo/sdk/generated/platform/api';
 import { Flex, Stack, Text } from '@nvidia/foundations-react-core';
 import { getErrorMessage } from '@studio/api/common/utils';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
@@ -20,7 +22,10 @@ import {
   buildDataDesignerConfig,
   validateColumns,
 } from '@studio/routes/DataDesignerJobBuildRoute/columns';
-import { validateModels } from '@studio/routes/DataDesignerJobBuildRoute/models';
+import {
+  buildServedModelNames,
+  validateModels,
+} from '@studio/routes/DataDesignerJobBuildRoute/models';
 import { useJobBuilder } from '@studio/routes/DataDesignerJobBuildRoute/useJobBuilder';
 import {
   getDataDesignerJobDetailsRoute,
@@ -73,6 +78,16 @@ export const DataDesignerJobBuildRoute: FC = () => {
   const modelsSettled = !isLoadingModels && !hasNextPage && !isFetchingNextPage;
 
   const builder = useJobBuilder(template, modelGroups, modelsSettled);
+  const { data: providersPage } = useModelsListProviders(
+    workspace,
+    { page_size: DEFAULT_LARGE_PAGE_SIZE },
+    { query: {} }
+  );
+  const servedModelNames = useMemo(
+    () => buildServedModelNames(providersPage?.data ?? []),
+    [providersPage?.data]
+  );
+
   const { columns, models } = builder;
 
   const [name, setName] = useState(() => template?.id ?? 'untitled-dataset');
@@ -99,9 +114,9 @@ export const DataDesignerJobBuildRoute: FC = () => {
   const getCurrentConfig = useCallback(
     () =>
       validateColumns(columns).length === 0 && validateModels(models).length === 0
-        ? buildDataDesignerConfig(columns, models)
+        ? buildDataDesignerConfig(columns, models, servedModelNames)
         : undefined,
-    [columns, models]
+    [columns, models, servedModelNames]
   );
   const { previewLogs, isPreviewing, runPreview } = usePreview({
     workspace,
@@ -126,7 +141,10 @@ export const DataDesignerJobBuildRoute: FC = () => {
         workspace,
         data: {
           name,
-          spec: { num_records: Number(rows), config: buildDataDesignerConfig(columns, models) },
+          spec: {
+            num_records: Number(rows),
+            config: buildDataDesignerConfig(columns, models, servedModelNames),
+          },
         },
       });
       if (created?.name) {

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/models.test.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/models.test.ts
@@ -222,9 +222,9 @@ describe('buildModelConfigs', () => {
       {
         alias: 'default',
         model: 'openai/gpt-4o-mini',
+        provider: '',
         inference_parameters: {
           generation_type: 'chat-completion',
-          provider: '',
           max_tokens: 1024,
         },
       },
@@ -248,6 +248,7 @@ describe('buildModelConfigs', () => {
         alias: 'default',
         model: 'nvidia/llama-3.3-nemotron-super-49b-v1.5',
         inference_parameters: { generation_type: 'chat-completion', max_tokens: 1024 },
+        provider: '',
       },
     ]);
   });

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/models.test.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/models.test.ts
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ModelWorkspaceGroup } from '@nemo/common/src/api/models/useModels';
+import type { ModelProvider } from '@nemo/sdk/generated/platform/schema';
 import {
   type BuilderModel,
   buildModelConfigs,
   buildModelsFromTemplate,
+  buildServedModelNames,
   builderModelFromSelection,
   defaultModelAlias,
   firstAvailableModel,
+  modelIdForModel,
   providerForModel,
   resolveTemplateModel,
   validateModelAlias,
@@ -39,7 +42,7 @@ describe('providerForModel', () => {
         { workspace: 'steramae', name: 'gpt-oss', model_providers: ['steramae/build'] },
         {
           workspace: 'steramae',
-          name: 'nvidia-llama-3-3-nemotron-super-49b-v1',
+          name: 'nvidia-llama-3-3-nemotron-super-49b-v1-5',
           model_providers: ['steramae/build'],
         },
         { workspace: 'steramae', name: 'no-provider' },
@@ -65,8 +68,8 @@ describe('providerForModel', () => {
   });
 
   it('resolveTemplateModel prefers a model matching the name across workspaces', () => {
-    expect(resolveTemplateModel(groups, 'nvidia-llama-3-3-nemotron-super-49b-v1')).toEqual({
-      model: 'steramae/nvidia-llama-3-3-nemotron-super-49b-v1',
+    expect(resolveTemplateModel(groups, 'nvidia-llama-3-3-nemotron-super-49b-v1-5')).toEqual({
+      model: 'steramae/nvidia-llama-3-3-nemotron-super-49b-v1-5',
       provider: 'steramae/build',
     });
   });
@@ -84,6 +87,53 @@ describe('providerForModel', () => {
       provider: 'steramae/build',
     });
     expect(resolveTemplateModel([], 'anything')).toBeNull();
+  });
+});
+
+describe('buildServedModelNames / modelIdForModel', () => {
+  const providers = [
+    {
+      workspace: 'steramae',
+      name: 'build',
+      served_models: [
+        {
+          model_entity_id: 'steramae/nvidia-llama-3-3-nemotron-super-49b-v1-5',
+          served_model_name: 'nvidia/llama-3.3-nemotron-super-49b-v1.5',
+        },
+        { model_entity_id: 'steramae/gpt-oss', served_model_name: 'openai/gpt-oss-120b' },
+      ],
+    },
+    {
+      // A second provider re-serving the same entity: the first mapping wins.
+      workspace: 'steramae',
+      name: 'other',
+      served_models: [
+        {
+          model_entity_id: 'steramae/nvidia-llama-3-3-nemotron-super-49b-v1-5',
+          served_model_name: 'ignored/duplicate',
+        },
+      ],
+    },
+  ] as unknown as ModelProvider[];
+
+  it('maps each served model_entity_id (URN) to its served_model_name, first mapping winning', () => {
+    const names = buildServedModelNames(providers);
+    expect(names.get('steramae/nvidia-llama-3-3-nemotron-super-49b-v1-5')).toBe(
+      'nvidia/llama-3.3-nemotron-super-49b-v1.5'
+    );
+    expect(names.get('steramae/gpt-oss')).toBe('openai/gpt-oss-120b');
+  });
+
+  it('modelIdForModel resolves the URN to the served model name', () => {
+    const names = buildServedModelNames(providers);
+    expect(names.size).toBe(2);
+    expect(modelIdForModel(names, 'steramae/nvidia-llama-3-3-nemotron-super-49b-v1-5')).toBe(
+      'nvidia/llama-3.3-nemotron-super-49b-v1.5'
+    );
+  });
+
+  it('modelIdForModel falls back to the URN when no mapping is found', () => {
+    expect(modelIdForModel(new Map(), 'steramae/unknown')).toBe('steramae/unknown');
   });
 });
 
@@ -167,9 +217,38 @@ describe('buildModelConfigs', () => {
     expect(buildModelConfigs([])).toBeUndefined();
   });
 
-  it('omits empty optional fields and inference parameters', () => {
+  it('omits empty optional fields but always includes inference parameters with defaults', () => {
     expect(buildModelConfigs([model({ provider: '' })])).toEqual([
-      { alias: 'default', model: 'openai/gpt-4o-mini', provider: '' },
+      {
+        alias: 'default',
+        model: 'openai/gpt-4o-mini',
+        inference_parameters: {
+          generation_type: 'chat-completion',
+          provider: '',
+          max_tokens: 1024,
+        },
+      },
+    ]);
+  });
+
+  it('resolves the model URN to the provider-facing served model name when given', () => {
+    const servedModelNames = new Map([
+      [
+        'steramae/nvidia-llama-3-3-nemotron-super-49b-v1-5',
+        'nvidia/llama-3.3-nemotron-super-49b-v1.5',
+      ],
+    ]);
+    expect(
+      buildModelConfigs(
+        [model({ model: 'steramae/nvidia-llama-3-3-nemotron-super-49b-v1-5', provider: '' })],
+        servedModelNames
+      )
+    ).toEqual([
+      {
+        alias: 'default',
+        model: 'nvidia/llama-3.3-nemotron-super-49b-v1.5',
+        inference_parameters: { generation_type: 'chat-completion', max_tokens: 1024 },
+      },
     ]);
   });
 

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/models.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/models.ts
@@ -3,12 +3,13 @@
 
 import type { ModelWorkspaceGroup } from '@nemo/common/src/api/models/useModels';
 import type { ModelSelection } from '@nemo/common/src/components/ModelSelectV2/types';
+import { MAX_COMPLETION_TOKENS_DEFAULT } from '@nemo/common/src/constants/inferenceParameters';
 import { getURNFromNamedEntityRef } from '@nemo/common/src/namedEntity';
 import type {
   ChatCompletionInferenceParams,
   ModelConfig,
 } from '@nemo/sdk/generated/data-designer/schema';
-import type { InferenceParams } from '@nemo/sdk/generated/platform/schema';
+import type { InferenceParams, ModelProvider } from '@nemo/sdk/generated/platform/schema';
 import type { TemplateModelSpec } from '@studio/components/CreateFilesetStart/types';
 
 /** Mirrors the SDK ModelConfig shape; `alias` is what LLM columns reference via `model_alias`. */
@@ -39,7 +40,26 @@ export const providerForModel = (modelGroups: ModelWorkspaceGroup[], model: stri
   return '';
 };
 
-/** First platform model (with resolved provider), used to auto-fill a template's model. */
+export const buildServedModelNames = (providers: ModelProvider[]): Map<string, string> => {
+  const servedModelNames = new Map<string, string>();
+  for (const provider of providers) {
+    for (const served of provider.served_models ?? []) {
+      if (served.model_entity_id && !servedModelNames.has(served.model_entity_id)) {
+        servedModelNames.set(served.model_entity_id, served.served_model_name);
+      }
+    }
+  }
+  return servedModelNames;
+};
+
+export const modelIdForModel = (servedModelNames: Map<string, string>, model: string): string =>
+  servedModelNames.get(model) || model;
+
+/**
+ * The first platform model (with its resolved provider) from the model list, used to
+ * auto-fill a template's model so the recipe can be previewed without picking one by
+ * hand. Returns null when no models are available.
+ */
 export const firstAvailableModel = (
   modelGroups: ModelWorkspaceGroup[]
 ): { model: string; provider: string } | null => {
@@ -135,25 +155,28 @@ export const validateModels = (models: BuilderModel[]): string[] => {
   return errors;
 };
 
-const toModelConfig = (model: BuilderModel): ModelConfig => {
+const toModelConfig = (model: BuilderModel, servedModelNames: Map<string, string>): ModelConfig => {
   const config: ModelConfig = {
     alias: model.alias.trim(),
-    model: model.model.trim(),
+    model: modelIdForModel(servedModelNames, model.model.trim()),
     provider: model.provider.trim(),
   };
   if (model.provider.trim()) config.provider = model.provider.trim();
 
   const { temperature, top_p, max_tokens } = model.inferenceParams;
-  const inference: ChatCompletionInferenceParams = {};
+  const inference: ChatCompletionInferenceParams = {
+    generation_type: 'chat-completion',
+    max_tokens: max_tokens ?? MAX_COMPLETION_TOKENS_DEFAULT,
+  };
   if (temperature !== undefined) inference.temperature = temperature;
   if (top_p !== undefined) inference.top_p = top_p;
-  if (max_tokens !== undefined) inference.max_tokens = max_tokens;
-  if (Object.keys(inference).length > 0) {
-    config.inference_parameters = { generation_type: 'chat-completion', ...inference };
-  }
+  config.inference_parameters = inference;
   return config;
 };
 
 /** Returns undefined when there are no models so the key is omitted from the config. */
-export const buildModelConfigs = (models: BuilderModel[]): ModelConfig[] | undefined =>
-  models.length > 0 ? models.map(toModelConfig) : undefined;
+export const buildModelConfigs = (
+  models: BuilderModel[],
+  servedModelNames: Map<string, string> = new Map()
+): ModelConfig[] | undefined =>
+  models.length > 0 ? models.map((model) => toModelConfig(model, servedModelNames)) : undefined;


### PR DESCRIPTION
Add templates
<img width="1128" height="479" alt="Screenshot 2026-07-13 at 4 04 08 PM" src="https://github.com/user-attachments/assets/1b480977-a231-4699-bbbd-2e4e3c1ae193" />


Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new fileset templates (code generation/validation, structured data extraction, reward modeling, semantic search, and expression transforms).
  * Added validator parameter configuration with JSON guidance.
  * Improved Data Designer job building by incorporating served model names and applying default inference settings when generating model configs.

* **UI Improvements**
  * Updated template selection to use a grid layout for better responsiveness.
  * Enhanced template cards by clipping overflow, improving description sizing, and truncating long descriptions with hover/title support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->