### PR TITLE
refactor(studio): use useSyncExternalStore in useLocalStorage

### DIFF
--- a/web/packages/studio/src/util/hooks/useLocalStorage.test.ts
+++ b/web/packages/studio/src/util/hooks/useLocalStorage.test.ts
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useLocalStorage } from '@studio/util/hooks/useLocalStorage';
+import { renderHook, act } from '@testing-library/react';
+
+describe('useLocalStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns default value when no stored value exists', () => {
+    const { result } = renderHook(() => useLocalStorage('test-key', 'default'));
+    expect(result.current[0]).toBe('default');
+  });
+
+  it('returns undefined when no default and no stored value', () => {
+    const { result } = renderHook(() => useLocalStorage('test-key'));
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('reads existing value from localStorage', () => {
+    localStorage.setItem('test-key', JSON.stringify('stored-value'));
+    const { result } = renderHook(() => useLocalStorage('test-key', 'default'));
+    expect(result.current[0]).toBe('stored-value');
+  });
+
+  it('setValue updates state and localStorage', () => {
+    const { result } = renderHook(() => useLocalStorage<string>('test-key', 'initial'));
+
+    act(() => {
+      result.current[1]('updated');
+    });
+
+    expect(result.current[0]).toBe('updated');
+    expect(localStorage.getItem('test-key')).toBe(JSON.stringify('updated'));
+  });
+
+  it('deleteValue removes from state and localStorage', () => {
+    localStorage.setItem('test-key', JSON.stringify('to-delete'));
+    const { result } = renderHook(() => useLocalStorage<string>('test-key', 'default'));
+
+    expect(result.current[0]).toBe('to-delete');
+
+    act(() => {
+      result.current[2]();
+    });
+
+    // With no stored value, the snapshot falls back to the default.
+    expect(result.current[0]).toBe('default');
+    expect(localStorage.getItem('test-key')).toBeNull();
+  });
+
+  it('handles objects as values', () => {
+    const obj = { name: 'test', count: 42 };
+    const { result } = renderHook(() => useLocalStorage<typeof obj>('obj-key'));
+
+    act(() => {
+      result.current[1](obj);
+    });
+
+    expect(result.current[0]).toEqual(obj);
+    expect(JSON.parse(localStorage.getItem('obj-key')!)).toEqual(obj);
+  });
+
+  it('falls back to default when localStorage has invalid JSON', () => {
+    localStorage.setItem('bad-key', 'not-json{');
+
+    // SyntaxError from JSON.parse is caught → returns defaultValue
+    const { result } = renderHook(() => useLocalStorage('bad-key', 'fallback'));
+
+    expect(result.current[0]).toBe('fallback');
+  });
+
+  it('reacts to storage events from other tabs', () => {
+    const { result } = renderHook(() => useLocalStorage<string>('test-key', 'default'));
+    expect(result.current[0]).toBe('default');
+
+    act(() => {
+      // Simulate another tab writing the key. `storage` events don't touch this tab's
+      // localStorage automatically, so set the value first.
+      localStorage.setItem('test-key', JSON.stringify('from-other-tab'));
+      window.dispatchEvent(new StorageEvent('storage', { key: 'test-key' }));
+    });
+
+    expect(result.current[0]).toBe('from-other-tab');
+  });
+
+  it('keeps two hooks on the same key in sync within a tab', () => {
+    const { result: a } = renderHook(() => useLocalStorage<string>('shared', 'default'));
+    const { result: b } = renderHook(() => useLocalStorage<string>('shared', 'default'));
+
+    act(() => {
+      a.current[1]('written-by-a');
+    });
+
+    expect(a.current[0]).toBe('written-by-a');
+    expect(b.current[0]).toBe('written-by-a');
+  });
+
+  it('returns a stable reference across re-renders when the value is unchanged', () => {
+    localStorage.setItem('obj-key', JSON.stringify({ a: 1 }));
+    const { result, rerender } = renderHook(() => useLocalStorage<{ a: number }>('obj-key'));
+
+    const first = result.current[0];
+    rerender();
+    expect(result.current[0]).toBe(first);
+  });
+
+  it('does not loop when the default value is a fresh reference each render', () => {
+    // A callsite passing an inline `[]` produces a new default reference every render.
+    // The snapshot must stay stable to avoid the "getSnapshot should be cached" loop.
+    const { result, rerender } = renderHook(() => useLocalStorage<string[]>('missing-key', []));
+
+    const first = result.current[0];
+    rerender();
+    expect(result.current[0]).toBe(first);
+    expect(result.current[0]).toEqual([]);
+  });
+});

--- a/web/packages/studio/src/util/hooks/useLocalStorage.ts
+++ b/web/packages/studio/src/util/hooks/useLocalStorage.ts
@@ -1,27 +1,87 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useSyncExternalStore } from 'react';
+
+// The browser `storage` event only fires in *other* tabs, so it can't notify the writing tab.
+// We dispatch this custom event on every local write to keep the current tab reactive too.
+const LOCAL_STORAGE_EVENT = 'nemo-studio:local-storage';
+
+const notify = (key: string) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.dispatchEvent(new CustomEvent(LOCAL_STORAGE_EVENT, { detail: key }));
+};
+
+const subscribe = (key: string, callback: () => void) => {
+  const onStorage = (e: StorageEvent) => {
+    // `e.key` is null when storage is cleared, in which case every key may have changed.
+    if (e.key === null || e.key === key) {
+      callback();
+    }
+  };
+  const onLocal = (e: Event) => {
+    if ((e as CustomEvent<string>).detail === key) {
+      callback();
+    }
+  };
+  window.addEventListener('storage', onStorage);
+  window.addEventListener(LOCAL_STORAGE_EVENT, onLocal);
+  return () => {
+    window.removeEventListener('storage', onStorage);
+    window.removeEventListener(LOCAL_STORAGE_EVENT, onLocal);
+  };
+};
 
 export const useLocalStorage = <T>(key: string, defaultValue?: T) => {
-  const [storedValue, setStoredValue] = useState<T | undefined>(() => {
-    if (typeof window === 'undefined') {
-      return defaultValue;
+  // Freeze the default to the first render's reference. `useSyncExternalStore` compares snapshots
+  // with `Object.is`, so returning a fresh inline default (e.g. `[]`) on every render would loop.
+  // This also matches the previous lazy-`useState` semantics, where the default was read once.
+  const defaultValueRef = useRef(defaultValue);
+
+  // Cache the parsed value so a snapshot returns a stable reference until the raw string changes.
+  const cache = useRef<{ raw: string | null; value: T | undefined }>({
+    raw: null,
+    value: defaultValueRef.current,
+  });
+
+  const getSnapshot = useCallback((): T | undefined => {
+    let raw: string | null;
+    try {
+      raw = window.localStorage.getItem(key);
+    } catch {
+      return defaultValueRef.current;
+    }
+    if (raw === null) {
+      return defaultValueRef.current;
+    }
+    if (cache.current.raw === raw) {
+      return cache.current.value;
     }
     try {
-      const item = window.localStorage.getItem(key);
-      return item ? JSON.parse(item) : defaultValue;
+      const parsed = JSON.parse(raw) as T;
+      cache.current = { raw, value: parsed };
+      return parsed;
     } catch {
-      return defaultValue;
+      return defaultValueRef.current;
     }
-  });
+  }, [key]);
+
+  const getServerSnapshot = useCallback(() => defaultValueRef.current, []);
+
+  const storedValue = useSyncExternalStore(
+    useCallback((callback: () => void) => subscribe(key, callback), [key]),
+    getSnapshot,
+    getServerSnapshot
+  );
 
   const setValue = useCallback(
     (value: T) => {
-      setStoredValue(value);
       try {
         if (typeof window !== 'undefined') {
           window.localStorage.setItem(key, JSON.stringify(value));
+          notify(key);
         }
       } catch {
         // do nothing
@@ -31,10 +91,10 @@ export const useLocalStorage = <T>(key: string, defaultValue?: T) => {
   );
 
   const deleteValue = useCallback(() => {
-    setStoredValue(undefined);
     try {
       if (typeof window !== 'undefined') {
         window.localStorage.removeItem(key);
+        notify(key);
       }
     } catch {
       // do nothing


### PR DESCRIPTION
## Summary

Rewrites `useLocalStorage` (`web/packages/studio/src/util/hooks/useLocalStorage.ts`) to use React 18's `useSyncExternalStore` instead of `useState` + a lazy initializer. The public API — `[value, setValue, deleteValue]` — is unchanged, so no callsites needed edits.

Resolves ASTD-272.

## What changed

- **Cross-tab reactivity** — subscribes to the `storage` event, so a write in another tab now re-renders this tab.
- **Same-tab reactivity** — the `storage` event only fires in *other* tabs, so `setValue`/`deleteValue` also dispatch a custom `nemo-studio:local-storage` event. Two hooks on the same key in one tab now stay in sync (previously each had its own isolated `useState`).
- **SSR** — the old `typeof window === 'undefined'` guard is replaced by the `getServerSnapshot` parameter.

### Two correctness details `useSyncExternalStore` forces

`useSyncExternalStore` compares snapshots with `Object.is`:

1. The parsed value is cached against the raw string, so an unchanged value returns a stable reference instead of a fresh `JSON.parse` result each render.
2. The default is frozen to the first render's reference (via a ref). Two callsites (`ExperimentGroupDataView`, `useRecentWorkspaces`) pass an inline `[]`, a new reference every render — returning that directly would trigger React's "getSnapshot should be cached" infinite loop. Freezing it also matches the old lazy-`useState` "read the default once" semantics.

### Minor behavior change

After `deleteValue`, the value now falls back to the default rather than `undefined`. For callsites without a default this is identical (`undefined` either way); for those with one it's arguably more correct.

## Testing

- Added `useLocalStorage.test.ts` (11 tests) — mirrors the sibling `useSessionStorage.test.ts` plus new cases for cross-tab `storage` events, same-tab sync, and stable snapshot references.
- `typecheck`, `lint`, the new tests, and the `ThemeSwitch` callsite test all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local storage state synchronization across multiple hook instances and browser tabs.
  * Updates and deletions now reflect immediately in the current tab.
  * Added more robust fallback behavior for missing or invalid stored data.
  * Prevented unnecessary re-renders and update loops when default values change by reference.
* **Tests**
  * Added a comprehensive test suite for the local storage hook, including cross-tab updates, JSON parsing, defaults, deletions, and referential stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->