### PR TITLE
feat(studio): agent eval fileset descriptions, reusable eval configs

### DIFF
--- a/web/packages/common/src/components/DatasetFileSelect/ControlledDatasetFileSelect.tsx
+++ b/web/packages/common/src/components/DatasetFileSelect/ControlledDatasetFileSelect.tsx
@@ -9,6 +9,7 @@ import { parseFilesetLocation } from '@nemo/common/src/components/DatasetFileSel
 import { parseFilesetUrl } from '@nemo/common/src/components/DatasetFileSelect/utils';
 import type { FileListItem } from '@nemo/common/src/components/FileList';
 import type { UseControllerComponentProps } from '@nemo/common/src/utils/types';
+import type { FilesetPurpose } from '@nemo/sdk/generated/platform/schema';
 import { FormField } from '@nvidia/foundations-react-core';
 import { FC, useMemo } from 'react';
 import { useController } from 'react-hook-form';
@@ -32,6 +33,15 @@ interface ControlledDatasetFileSelectProps extends UseControllerComponentProps {
   /** Inline-only: skip the "Add" button and commit on selection; also hides
    *  the file list rendered below the picker. */
   autoCommit?: boolean;
+  /** Fileset ``purpose`` the picker lists. Defaults to ``'dataset'``; pass
+   *  ``'generic'`` to browse non-dataset filesets. */
+  filesetPurpose?: FilesetPurpose;
+  /** Label for the fileset picker. Defaults to ``'Dataset'``. */
+  datasetLabel?: string;
+  /** When true, selecting a fileset auto-selects the first root-level file
+   *  matching ``acceptedFileTypes`` (pairs with ``autoCommit``). No-op when no
+   *  such file exists. */
+  autoSelectFirstAcceptable?: boolean;
   /**
    * Callback fired when a file is selected. Useful for custom validation or processing.
    * Called with the selected file info, or null when file is cleared.
@@ -73,6 +83,9 @@ export const ControlledDatasetFileSelect: FC<ControlledDatasetFileSelectProps> =
   listLabel,
   inline,
   autoCommit,
+  filesetPurpose,
+  datasetLabel,
+  autoSelectFirstAcceptable,
 }) => {
   const {
     field: { onChange, value },
@@ -131,6 +144,9 @@ export const ControlledDatasetFileSelect: FC<ControlledDatasetFileSelectProps> =
         listLabel={listLabel}
         inline={inline}
         autoCommit={autoCommit}
+        filesetPurpose={filesetPurpose}
+        datasetLabel={datasetLabel}
+        autoSelectFirstAcceptable={autoSelectFirstAcceptable}
       />
     </FormField>
   );

--- a/web/packages/common/src/components/DatasetFileSelect/ControlledDatasetFileSelect.tsx
+++ b/web/packages/common/src/components/DatasetFileSelect/ControlledDatasetFileSelect.tsx
@@ -33,14 +33,11 @@ interface ControlledDatasetFileSelectProps extends UseControllerComponentProps {
   /** Inline-only: skip the "Add" button and commit on selection; also hides
    *  the file list rendered below the picker. */
   autoCommit?: boolean;
-  /** Fileset ``purpose`` the picker lists. Defaults to ``'dataset'``; pass
-   *  ``'generic'`` to browse non-dataset filesets. */
+  /** Fileset ``purpose`` the picker lists. Defaults to ``'dataset'``. */
   filesetPurpose?: FilesetPurpose;
   /** Label for the fileset picker. Defaults to ``'Dataset'``. */
   datasetLabel?: string;
-  /** When true, selecting a fileset auto-selects the first root-level file
-   *  matching ``acceptedFileTypes`` (pairs with ``autoCommit``). No-op when no
-   *  such file exists. */
+  /** Auto-select the first root-level accepted file on fileset selection. */
   autoSelectFirstAcceptable?: boolean;
   /**
    * Callback fired when a file is selected. Useful for custom validation or processing.

--- a/web/packages/common/src/components/DatasetFileSelect/DatasetFileSelect.tsx
+++ b/web/packages/common/src/components/DatasetFileSelect/DatasetFileSelect.tsx
@@ -10,6 +10,7 @@ import { FileList, FileListItem } from '@nemo/common/src/components/FileList';
 import { UploadModal } from '@nemo/common/src/components/UploadModal/index';
 import { InlineUploadPicker } from '@nemo/common/src/components/UploadModal/InlineUploadPicker';
 import type { SubmitUploadType } from '@nemo/common/src/components/UploadModal/types';
+import type { FilesetPurpose } from '@nemo/sdk/generated/platform/schema';
 import { SidePanel, Stack, Text } from '@nvidia/foundations-react-core';
 import { FolderOpen } from 'lucide-react';
 import { FC, useEffect, useMemo, useRef, useState } from 'react';
@@ -49,6 +50,15 @@ interface DatasetFileSelectProps {
    *  selects a file. Also hides the post-commit file list since the parent
    *  form already reflects the selection. */
   autoCommit?: boolean;
+  /** Fileset ``purpose`` the picker lists. Defaults to ``'dataset'``; pass
+   *  ``'generic'`` to browse non-dataset filesets. */
+  filesetPurpose?: FilesetPurpose;
+  /** Label for the fileset picker. Defaults to ``'Dataset'``. */
+  datasetLabel?: string;
+  /** When true, selecting a fileset auto-selects the first root-level file
+   *  matching ``acceptedFileTypes`` (pairs with ``autoCommit``). No-op when no
+   *  such file exists. */
+  autoSelectFirstAcceptable?: boolean;
 }
 
 /**
@@ -77,6 +87,9 @@ export const DatasetFileSelect: FC<DatasetFileSelectProps> = ({
   listLabel,
   inline = false,
   autoCommit = false,
+  filesetPurpose,
+  datasetLabel,
+  autoSelectFirstAcceptable,
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -198,6 +211,9 @@ export const DatasetFileSelect: FC<DatasetFileSelectProps> = ({
             invalidFileMode={invalidFileMode}
             onSubmit={handleModalSubmit}
             autoCommit={autoCommit}
+            filesetPurpose={filesetPurpose}
+            datasetLabel={datasetLabel}
+            autoSelectFirstAcceptable={autoSelectFirstAcceptable}
           />
         ) : (
           <DatasetFileSelectButton

--- a/web/packages/common/src/components/DatasetFileSelect/DatasetFileSelect.tsx
+++ b/web/packages/common/src/components/DatasetFileSelect/DatasetFileSelect.tsx
@@ -50,14 +50,11 @@ interface DatasetFileSelectProps {
    *  selects a file. Also hides the post-commit file list since the parent
    *  form already reflects the selection. */
   autoCommit?: boolean;
-  /** Fileset ``purpose`` the picker lists. Defaults to ``'dataset'``; pass
-   *  ``'generic'`` to browse non-dataset filesets. */
+  /** Fileset ``purpose`` the picker lists. Defaults to ``'dataset'``. */
   filesetPurpose?: FilesetPurpose;
   /** Label for the fileset picker. Defaults to ``'Dataset'``. */
   datasetLabel?: string;
-  /** When true, selecting a fileset auto-selects the first root-level file
-   *  matching ``acceptedFileTypes`` (pairs with ``autoCommit``). No-op when no
-   *  such file exists. */
+  /** Auto-select the first root-level accepted file on fileset selection. */
   autoSelectFirstAcceptable?: boolean;
 }
 

--- a/web/packages/common/src/components/UploadModal/Context/useUploadModalReducer.ts
+++ b/web/packages/common/src/components/UploadModal/Context/useUploadModalReducer.ts
@@ -46,15 +46,11 @@ export type UploadModalState = {
    *  picker in ``autoCommit`` mode where uploading new files would race with
    *  the user editing the dataset name. Defaults to ``true``. */
   allowNewDataset: boolean;
-  /** Fileset ``purpose`` the picker lists (and creates). Defaults to
-   *  ``'dataset'``; set to ``'generic'`` to browse non-dataset filesets. */
+  /** Fileset ``purpose`` the picker lists. Defaults to ``'dataset'``. */
   filesetPurpose?: FilesetPurpose;
-  /** Label for the fileset picker (``slotLabel`` / placeholder / heading).
-   *  Defaults to ``'Dataset'``. */
+  /** Label for the fileset picker. Defaults to ``'Dataset'``. */
   datasetLabel?: string;
-  /** When true, selecting a fileset auto-selects the first root-level file
-   *  whose extension is in ``acceptableFileTypes`` (used with ``autoCommit``
-   *  to skip the manual file pick). No-op when the fileset has no such file. */
+  /** Auto-select the first root-level accepted file on fileset selection. */
   autoSelectFirstAcceptable?: boolean;
   errors: Record<string, string>;
 };

--- a/web/packages/common/src/components/UploadModal/Context/useUploadModalReducer.ts
+++ b/web/packages/common/src/components/UploadModal/Context/useUploadModalReducer.ts
@@ -12,6 +12,7 @@
 
 import { UploadFile, UploadDataset } from '@nemo/common/src/components/UploadModal/types';
 import { sanitizeFilenameForDatasetName } from '@nemo/common/src/components/UploadModal/utils';
+import type { FilesetPurpose } from '@nemo/sdk/generated/platform/schema';
 import { useReducer } from 'react';
 
 /**
@@ -45,6 +46,16 @@ export type UploadModalState = {
    *  picker in ``autoCommit`` mode where uploading new files would race with
    *  the user editing the dataset name. Defaults to ``true``. */
   allowNewDataset: boolean;
+  /** Fileset ``purpose`` the picker lists (and creates). Defaults to
+   *  ``'dataset'``; set to ``'generic'`` to browse non-dataset filesets. */
+  filesetPurpose?: FilesetPurpose;
+  /** Label for the fileset picker (``slotLabel`` / placeholder / heading).
+   *  Defaults to ``'Dataset'``. */
+  datasetLabel?: string;
+  /** When true, selecting a fileset auto-selects the first root-level file
+   *  whose extension is in ``acceptableFileTypes`` (used with ``autoCommit``
+   *  to skip the manual file pick). No-op when the fileset has no such file. */
+  autoSelectFirstAcceptable?: boolean;
   errors: Record<string, string>;
 };
 

--- a/web/packages/common/src/components/UploadModal/DatasetUploader/Select.test.tsx
+++ b/web/packages/common/src/components/UploadModal/DatasetUploader/Select.test.tsx
@@ -3,7 +3,10 @@
 
 import { UploadModalProvider } from '@nemo/common/src/components/UploadModal/Context/UploadModalProvider';
 import { useUploadModalContext } from '@nemo/common/src/components/UploadModal/Context/useUploadModalContext';
-import { UploadModalState } from '@nemo/common/src/components/UploadModal/Context/useUploadModalReducer';
+import {
+  uploadModalInitialState,
+  UploadModalState,
+} from '@nemo/common/src/components/UploadModal/Context/useUploadModalReducer';
 import { DatasetSelect } from '@nemo/common/src/components/UploadModal/DatasetUploader/Select';
 import { filesListFilesetFiles, useFilesListFilesets } from '@nemo/sdk/generated/platform/api';
 import { FilesetOutput } from '@nemo/sdk/generated/platform/schema';
@@ -57,7 +60,7 @@ const ContextReader = ({
   return null;
 };
 
-const createWrapper = () => {
+const createWrapper = (initialState?: Partial<UploadModalState>) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -65,10 +68,14 @@ const createWrapper = () => {
   });
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>
-      <UploadModalProvider>{children}</UploadModalProvider>
+      <UploadModalProvider initialState={{ ...uploadModalInitialState, ...initialState }}>
+        {children}
+      </UploadModalProvider>
     </QueryClientProvider>
   );
 };
+
+const filesetFile = (path: string) => ({ path, file_ref: `ref-${path}` });
 
 describe('DatasetSelect', () => {
   const user = userEvent.setup();
@@ -180,6 +187,54 @@ describe('DatasetSelect', () => {
     expect(contextState?.dataset?.type === 'existing' && contextState.dataset.dataset.name).toBe(
       'dataset1'
     );
+  });
+
+  it('auto-selects the first root-level accepted file when autoSelectFirstAcceptable is set', async () => {
+    vi.mocked(filesListFilesetFiles).mockResolvedValueOnce({
+      data: [filesetFile('smaller_test.csv'), filesetFile('email_phishing_analyzer-eval.yml')],
+    } as Awaited<ReturnType<typeof filesListFilesetFiles>>);
+
+    let contextState: UploadModalState | undefined;
+    render(
+      <>
+        <DatasetSelect project="test-project" />
+        <ContextReader onContextChange={(state) => (contextState = state)} />
+      </>,
+      { wrapper: createWrapper({ autoSelectFirstAcceptable: true, acceptableFileTypes: ['.yml'] }) }
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByRole('option', { name: 'dataset1' }));
+
+    await waitFor(() => {
+      expect(contextState?.selectedFiles).toHaveLength(1);
+    });
+    expect((contextState?.selectedFiles[0]?.file as { path?: string }).path).toBe(
+      'email_phishing_analyzer-eval.yml'
+    );
+  });
+
+  it('selects nothing when no root-level accepted file exists', async () => {
+    vi.mocked(filesListFilesetFiles).mockResolvedValueOnce({
+      data: [filesetFile('smaller_test.csv'), filesetFile('nested/config.yml')],
+    } as Awaited<ReturnType<typeof filesListFilesetFiles>>);
+
+    let contextState: UploadModalState | undefined;
+    render(
+      <>
+        <DatasetSelect project="test-project" />
+        <ContextReader onContextChange={(state) => (contextState = state)} />
+      </>,
+      { wrapper: createWrapper({ autoSelectFirstAcceptable: true, acceptableFileTypes: ['.yml'] }) }
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByRole('option', { name: 'dataset1' }));
+
+    await waitFor(() => {
+      expect(contextState?.dataset?.type).toBe('existing');
+    });
+    expect(contextState?.selectedFiles).toHaveLength(0);
   });
 
   it('includes "New Dataset" option', async () => {

--- a/web/packages/common/src/components/UploadModal/DatasetUploader/Select.tsx
+++ b/web/packages/common/src/components/UploadModal/DatasetUploader/Select.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { getFileExtension } from '@nemo/common/src/components/DatasetFileSelect/utils';
 import { useUploadModalContext } from '@nemo/common/src/components/UploadModal/Context/useUploadModalContext';
 import { getExistingFileId } from '@nemo/common/src/components/UploadModal/utils';
 import { getEntityReference } from '@nemo/common/src/namedEntity';
@@ -26,7 +27,9 @@ const filesetToOption = (fileset: FilesetOutput) => ({
 
 export const DatasetSelect: FC<Props> = ({ project, disabled, error }) => {
   const [state, dispatch] = useUploadModalContext();
-  const { dataset, allowNewDataset } = state;
+  const { dataset, allowNewDataset, acceptableFileTypes, autoSelectFirstAcceptable } = state;
+  const purpose = state.filesetPurpose ?? 'dataset';
+  const label = state.datasetLabel ?? 'Dataset';
 
   // Extract workspace from project (project format is "workspace/name" or just "workspace")
   const workspace = project.includes('/') ? project.split('/')[0] : project;
@@ -43,7 +46,7 @@ export const DatasetSelect: FC<Props> = ({ project, disabled, error }) => {
      */
     page_size: 100, // v2 API max is 100
     sort: 'created_at',
-    filter: { purpose: 'dataset' },
+    filter: { purpose },
   });
 
   const filesets = useMemo(() => filesetsResponse?.data ?? [], [filesetsResponse]);
@@ -67,14 +70,23 @@ export const DatasetSelect: FC<Props> = ({ project, disabled, error }) => {
       try {
         const filesResponse = await filesListFilesetFiles(fileset.workspace, fileset.name);
         const filesetFiles = filesResponse.data ?? [];
-        dispatch({
-          type: 'SET_FILES',
-          payload: filesetFiles.map((file) => ({
-            id: getExistingFileId(file),
-            type: 'existing',
-            file,
-          })),
-        });
+        const uploadFiles = filesetFiles.map(
+          (file) => ({ id: getExistingFileId(file), type: 'existing', file }) as const
+        );
+        dispatch({ type: 'SET_FILES', payload: uploadFiles });
+        // Optionally skip the manual file pick: auto-select the first root-level
+        // file whose extension is accepted. The reducer already auto-selects a
+        // lone file, so only act when there's more than one (otherwise we'd
+        // toggle the reducer's selection back off).
+        if (autoSelectFirstAcceptable && uploadFiles.length > 1) {
+          const target = uploadFiles.find((f) => {
+            const path = f.file.path;
+            if (path.includes('/')) return false; // root-level only
+            const ext = getFileExtension(path)?.toLowerCase();
+            return !!ext && acceptableFileTypes.includes(ext);
+          });
+          if (target) dispatch({ type: 'TOGGLE_FILE_SELECTION', payload: target });
+        }
         dispatch({ type: 'SET_FETCHING', payload: false });
       } catch (error) {
         console.error('Error fetching dataset files', error);
@@ -100,7 +112,7 @@ export const DatasetSelect: FC<Props> = ({ project, disabled, error }) => {
 
   return (
     <FormField
-      slotLabel="Dataset"
+      slotLabel={label}
       slotError={
         <Flex gap="density-md" align="center">
           <CircleAlert className="text-feedback-danger" />
@@ -135,14 +147,14 @@ export const DatasetSelect: FC<Props> = ({ project, disabled, error }) => {
                 ]
               : []),
             {
-              slotHeading: 'Existing Datasets',
+              slotHeading: `Existing ${label}s`,
               attributes: { MenuHeading: { className: 'hidden', 'aria-hidden': true } },
               items: datasetOptions,
             },
           ]}
           value={selectedDatasetOption}
           onValueChange={handleDatasetSelect}
-          placeholder="Select a dataset"
+          placeholder={`Select a ${label.toLowerCase()}`}
         />
       )}
     </FormField>

--- a/web/packages/common/src/components/UploadModal/DatasetUploader/Select.tsx
+++ b/web/packages/common/src/components/UploadModal/DatasetUploader/Select.tsx
@@ -74,16 +74,15 @@ export const DatasetSelect: FC<Props> = ({ project, disabled, error }) => {
           (file) => ({ id: getExistingFileId(file), type: 'existing', file }) as const
         );
         dispatch({ type: 'SET_FILES', payload: uploadFiles });
-        // Optionally skip the manual file pick: auto-select the first root-level
-        // file whose extension is accepted. The reducer already auto-selects a
-        // lone file, so only act when there's more than one (otherwise we'd
-        // toggle the reducer's selection back off).
+        // Auto-select the first root-level accepted file (only when >1, since
+        // the reducer already auto-selects a lone file).
         if (autoSelectFirstAcceptable && uploadFiles.length > 1) {
+          const allowed = acceptableFileTypes.map((t) => t.toLowerCase());
           const target = uploadFiles.find((f) => {
             const path = f.file.path;
-            if (path.includes('/')) return false; // root-level only
+            if (path.includes('/')) return false;
             const ext = getFileExtension(path)?.toLowerCase();
-            return !!ext && acceptableFileTypes.includes(ext);
+            return !!ext && allowed.includes(ext);
           });
           if (target) dispatch({ type: 'TOGGLE_FILE_SELECTION', payload: target });
         }

--- a/web/packages/common/src/components/UploadModal/InlineUploadPicker.tsx
+++ b/web/packages/common/src/components/UploadModal/InlineUploadPicker.tsx
@@ -22,6 +22,9 @@ type InlineUploadPickerProps = Pick<
   | 'acceptableFileSize'
   | 'invalidFileMode'
   | 'allowNewDataset'
+  | 'filesetPurpose'
+  | 'datasetLabel'
+  | 'autoSelectFirstAcceptable'
 > & {
   /** Called once the picked / uploaded file is committed. */
   onSubmit: (data: SubmitUploadType) => void;
@@ -148,6 +151,9 @@ export const InlineUploadPicker: FC<InlineUploadPickerProps> = ({
   acceptableFileSize,
   invalidFileMode,
   allowNewDataset,
+  filesetPurpose,
+  datasetLabel,
+  autoSelectFirstAcceptable,
   onSubmit,
   addButtonText = 'Add file',
   autoCommit = false,
@@ -168,6 +174,10 @@ export const InlineUploadPicker: FC<InlineUploadPickerProps> = ({
       acceptableFileSize: acceptableFileSize ?? uploadModalInitialState.acceptableFileSize,
       invalidFileMode: invalidFileMode ?? uploadModalInitialState.invalidFileMode,
       allowNewDataset: effectiveAllowNewDataset,
+      filesetPurpose: filesetPurpose ?? uploadModalInitialState.filesetPurpose,
+      datasetLabel: datasetLabel ?? uploadModalInitialState.datasetLabel,
+      autoSelectFirstAcceptable:
+        autoSelectFirstAcceptable ?? uploadModalInitialState.autoSelectFirstAcceptable,
     }),
     [
       allowMultipleFileSelection,
@@ -175,6 +185,9 @@ export const InlineUploadPicker: FC<InlineUploadPickerProps> = ({
       acceptableFileSize,
       invalidFileMode,
       effectiveAllowNewDataset,
+      filesetPurpose,
+      datasetLabel,
+      autoSelectFirstAcceptable,
     ]
   );
   return (

--- a/web/packages/common/src/components/UploadModal/SimpleFilesTable.tsx
+++ b/web/packages/common/src/components/UploadModal/SimpleFilesTable.tsx
@@ -62,8 +62,6 @@ export const SimpleFilesTable = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [files, allowedExtensions, invalidFileMode]);
 
-  // Only nudge about disabled files while the user hasn't yet landed on a valid
-  // selection — once a supported file is picked, the hint is just noise.
   const hasValidSelection = selectedFiles.some((file) => isFileAllowed(file));
   const disabledFilesMessage =
     invalidFileMode === 'disable' &&
@@ -115,8 +113,6 @@ export const SimpleFilesTable = () => {
       col.accessor('name', { header: 'Name' }),
       col.accessor('size', {
         header: 'Size',
-        // Fixed-width column (proper DataView API: an explicit ``size`` marks
-        // the column as non-auto-sized). File sizes are short.
         size: 120,
         cell: (ctx) => formatFileSize(ctx.getValue()),
       }),
@@ -136,13 +132,7 @@ export const SimpleFilesTable = () => {
 
   return (
     <Stack className="min-h-0 flex-1 w-full" gap="density-md">
-      {/* The virtualized table sizes columns to their measured content and caps
-          each cell's max-width there, so the row never fills its container.
-          Pin the widths ourselves (``tr>*`` hits both header th and body td, so
-          they stay aligned): column 3 (Size) is a fixed 120px, and column 2
-          (Name) takes width:100% to absorb the leftover space — the classic
-          auto-table fill trick. max-w-none lifts the measured cap so Name can
-          actually grow. Column 1 is the 40px radio. */}
+      {/* Name column fills the row; Size (col 3) is pinned to 120px. */}
       <div className="border border-base rounded-md overflow-hidden [&_tr>*:nth-child(2)]:w-full! [&_tr>*:nth-child(2)]:max-w-none! [&_tr>*:nth-child(3)]:w-[120px]! [&_tr>*:nth-child(3)]:min-w-[120px]! [&_tr>*:nth-child(3)]:max-w-[120px]!">
         <RadioGroupRoot
           name="simple-files-table"

--- a/web/packages/common/src/components/UploadModal/SimpleFilesTable.tsx
+++ b/web/packages/common/src/components/UploadModal/SimpleFilesTable.tsx
@@ -62,9 +62,13 @@ export const SimpleFilesTable = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [files, allowedExtensions, invalidFileMode]);
 
+  // Only nudge about disabled files while the user hasn't yet landed on a valid
+  // selection — once a supported file is picked, the hint is just noise.
+  const hasValidSelection = selectedFiles.some((file) => isFileAllowed(file));
   const disabledFilesMessage =
     invalidFileMode === 'disable' &&
     allowedExtensions.size > 0 &&
+    !hasValidSelection &&
     visibleFiles.some((file) => !isFileAllowed(file))
       ? `Only ${acceptableFileTypes.join(', ')} files can be selected. Upload a supported file or choose a different fileset.`
       : null;
@@ -111,6 +115,9 @@ export const SimpleFilesTable = () => {
       col.accessor('name', { header: 'Name' }),
       col.accessor('size', {
         header: 'Size',
+        // Fixed-width column (proper DataView API: an explicit ``size`` marks
+        // the column as non-auto-sized). File sizes are short.
+        size: 120,
         cell: (ctx) => formatFileSize(ctx.getValue()),
       }),
     ],
@@ -129,7 +136,14 @@ export const SimpleFilesTable = () => {
 
   return (
     <Stack className="min-h-0 flex-1 w-full" gap="density-md">
-      <div className="border border-base rounded-md overflow-hidden">
+      {/* The virtualized table sizes columns to their measured content and caps
+          each cell's max-width there, so the row never fills its container.
+          Pin the widths ourselves (``tr>*`` hits both header th and body td, so
+          they stay aligned): column 3 (Size) is a fixed 120px, and column 2
+          (Name) takes width:100% to absorb the leftover space — the classic
+          auto-table fill trick. max-w-none lifts the measured cap so Name can
+          actually grow. Column 1 is the 40px radio. */}
+      <div className="border border-base rounded-md overflow-hidden [&_tr>*:nth-child(2)]:w-full! [&_tr>*:nth-child(2)]:max-w-none! [&_tr>*:nth-child(3)]:w-[120px]! [&_tr>*:nth-child(3)]:min-w-[120px]! [&_tr>*:nth-child(3)]:max-w-[120px]!">
         <RadioGroupRoot
           name="simple-files-table"
           value={selectedFiles[0]?.id ?? ''}

--- a/web/packages/common/src/components/UploadModal/types.ts
+++ b/web/packages/common/src/components/UploadModal/types.ts
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { FilesetFileOutput, FilesetOutput } from '@nemo/sdk/generated/platform/schema';
+import {
+  FilesetFileOutput,
+  FilesetOutput,
+  FilesetPurpose,
+} from '@nemo/sdk/generated/platform/schema';
 import {
   ModalContent,
   ModalHeading,
@@ -62,6 +66,15 @@ export interface UploadModalProps {
   /** When false, the dataset picker hides the "Create new dataset" option.
    *  Defaults to ``true`` (legacy behaviour). */
   allowNewDataset?: boolean;
+  /** Fileset ``purpose`` the picker lists. Defaults to ``'dataset'``; pass
+   *  ``'generic'`` to browse non-dataset filesets. */
+  filesetPurpose?: FilesetPurpose;
+  /** Label for the fileset picker. Defaults to ``'Dataset'``. */
+  datasetLabel?: string;
+  /** When true, selecting a fileset auto-selects the first root-level file
+   *  matching ``acceptableFileTypes`` (pairs with ``autoCommit`` to skip the
+   *  manual file pick). No-op when no such file exists. */
+  autoSelectFirstAcceptable?: boolean;
   attributes?: {
     ModalRoot?: React.ComponentProps<typeof ModalRoot>;
     ModalContent?: React.ComponentProps<typeof ModalContent>;

--- a/web/packages/common/src/components/UploadModal/types.ts
+++ b/web/packages/common/src/components/UploadModal/types.ts
@@ -66,14 +66,11 @@ export interface UploadModalProps {
   /** When false, the dataset picker hides the "Create new dataset" option.
    *  Defaults to ``true`` (legacy behaviour). */
   allowNewDataset?: boolean;
-  /** Fileset ``purpose`` the picker lists. Defaults to ``'dataset'``; pass
-   *  ``'generic'`` to browse non-dataset filesets. */
+  /** Fileset ``purpose`` the picker lists. Defaults to ``'dataset'``. */
   filesetPurpose?: FilesetPurpose;
   /** Label for the fileset picker. Defaults to ``'Dataset'``. */
   datasetLabel?: string;
-  /** When true, selecting a fileset auto-selects the first root-level file
-   *  matching ``acceptableFileTypes`` (pairs with ``autoCommit`` to skip the
-   *  manual file pick). No-op when no such file exists. */
+  /** Auto-select the first root-level accepted file on fileset selection. */
   autoSelectFirstAcceptable?: boolean;
   attributes?: {
     ModalRoot?: React.ComponentProps<typeof ModalRoot>;

--- a/web/packages/common/src/utils/generateDefaultName.ts
+++ b/web/packages/common/src/utils/generateDefaultName.ts
@@ -29,3 +29,11 @@ export const generateDefaultName = ({
     style: 'lowerCase',
   });
 };
+
+/**
+ * Suggests a short, memorable, semantically-meaningless name for a reusable
+ * eval config (e.g. "wise-pretzel"). Two words (adjective-animal) keep it
+ * readable in a dropdown while staying valid as a fileset name.
+ */
+export const generateEvalConfigName = (): string =>
+  generateDefaultName({ dictionaries: [adjectives, animals], length: 2 });

--- a/web/packages/common/src/utils/generateDefaultName.ts
+++ b/web/packages/common/src/utils/generateDefaultName.ts
@@ -29,11 +29,3 @@ export const generateDefaultName = ({
     style: 'lowerCase',
   });
 };
-
-/**
- * Suggests a short, memorable, semantically-meaningless name for a reusable
- * eval config (e.g. "wise-pretzel"). Two words (adjective-animal) keep it
- * readable in a dropdown while staying valid as a fileset name.
- */
-export const generateEvalConfigName = (): string =>
-  generateDefaultName({ dictionaries: [adjectives, animals], length: 2 });

--- a/web/packages/studio/public/sample-agents/email-phishing-analyzer/eval.yml
+++ b/web/packages/studio/public/sample-agents/email-phishing-analyzer/eval.yml
@@ -20,7 +20,7 @@ llms:
 eval:
   general:
     max_concurrency: 4
-    output_dir: eval/agent
+    output_dir: .
     dataset:
       _type: csv
       file_path: smaller_test.csv

--- a/web/packages/studio/src/components/DatasetsTable/columns.tsx
+++ b/web/packages/studio/src/components/DatasetsTable/columns.tsx
@@ -67,6 +67,11 @@ export function makeDatasetsTableColumns({
         header: 'Name',
         enableSorting: enableFilters,
         size: 175,
+        cell({ row }) {
+          const name = row.original?.name;
+          // Wrap long fileset names to multiple lines instead of truncating.
+          return name ? <Text className="whitespace-normal break-all">{name}</Text> : null;
+        },
       }),
       accessor((row) => getStorageBackend(row.storage), {
         id: 'storage_type',
@@ -129,8 +134,9 @@ export function makeDatasetsTableColumns({
         size: 200,
         cell({ row }) {
           const path = getStoragePath(row.original?.storage);
+          // Wrap long paths to multiple lines instead of truncating.
           return path ? (
-            <Text className="truncate" title={path}>
+            <Text className="whitespace-normal break-all" title={path}>
               {path}
             </Text>
           ) : null;

--- a/web/packages/studio/src/components/DatasetsTable/columns.tsx
+++ b/web/packages/studio/src/components/DatasetsTable/columns.tsx
@@ -69,7 +69,6 @@ export function makeDatasetsTableColumns({
         size: 175,
         cell({ row }) {
           const name = row.original?.name;
-          // Wrap long fileset names to multiple lines instead of truncating.
           return name ? <Text className="whitespace-normal break-all">{name}</Text> : null;
         },
       }),
@@ -134,7 +133,6 @@ export function makeDatasetsTableColumns({
         size: 200,
         cell({ row }) {
           const path = getStoragePath(row.original?.storage);
-          // Wrap long paths to multiple lines instead of truncating.
           return path ? (
             <Text className="whitespace-normal break-all" title={path}>
               {path}

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationsListRoute.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationsListRoute.test.tsx
@@ -21,7 +21,7 @@ describe('AgentEvaluationsListRoute', () => {
   it('renders the page header and submit button', async () => {
     renderList();
     expect(await screen.findByText('Agent Evaluations')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'New evaluation' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run Evaluation' })).toBeInTheDocument();
   });
 
   it('shows the empty state when no eval jobs are returned (default mock)', async () => {

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationsListRoute.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationsListRoute.tsx
@@ -120,8 +120,8 @@ export const AgentEvaluationsListRoute: FC = () => {
           slotHeading="Agent Evaluations"
           slotDescription="Evaluation jobs run against deployed agents — submitted by the optimizer apply flow or directly via the evaluate-agent job API."
           slotActions={
-            <Button kind="primary" onClick={() => setSubmitOpen(true)}>
-              New evaluation
+            <Button kind="primary" color="brand" onClick={() => setSubmitOpen(true)}>
+              Run Evaluation
             </Button>
           }
         />

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal.tsx
@@ -8,7 +8,6 @@ import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSel
 import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
 import { FormModal, type FormModalProps } from '@nemo/common/src/components/FormModal';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
-import { generateEvalConfigName } from '@nemo/common/src/utils/generateDefaultName';
 import { customFetch } from '@nemo/sdk/generated/fetchers/platform';
 import { filesCreateFileset } from '@nemo/sdk/generated/platform/api';
 import { SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
@@ -29,6 +28,7 @@ import {
   CREATE_NEW,
   evalOutputDescription,
   evaluateRequestBody,
+  generateEvalConfigName,
   generateOutputFilesetName,
   MODE_DEFAULT,
   MODE_FILESET,
@@ -67,8 +67,22 @@ const submitEvaluationSchema = z
   })
   .superRefine((data, ctx) => {
     if (data.evalConfig !== CREATE_NEW) return;
-    if (data.mode === MODE_DEFAULT && !data.newName.trim()) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Name is required', path: ['newName'] });
+    if (data.mode === MODE_DEFAULT) {
+      // newName becomes the fileset name — enforce the platform naming rules.
+      const name = data.newName.trim();
+      if (!name) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Name is required',
+          path: ['newName'],
+        });
+      } else if (!/^[a-zA-Z0-9_.-]+$/.test(name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Use only letters, digits, dots, hyphens, and underscores',
+          path: ['newName'],
+        });
+      }
     }
     if (data.mode === MODE_FILESET && !parseFilesetLocation(data.datasetFile ?? '')?.objectPath) {
       ctx.addIssue({
@@ -83,8 +97,7 @@ type SubmitEvaluationFormData = z.infer<typeof submitEvaluationSchema>;
 
 const makeDefaultValues = (agent?: string): SubmitEvaluationFormData => ({
   agent: agent ?? '',
-  // Default to create so a first-time agent goes straight to the create form;
-  // existing configs are still one click away in the dropdown.
+  // Default to create; existing configs are one click away in the dropdown.
   evalConfig: CREATE_NEW,
   newName: generateEvalConfigName(),
   mode: MODE_DEFAULT,
@@ -143,9 +156,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   } = useMutation({
     mutationFn: async (spec: SubmitSpec) => {
       if (spec.seedSources) {
-        // Create mode (example): fetch the selected example's eval assets on
-        // demand and seed them into the new eval-config fileset so the user
-        // doesn't have to pre-upload anything.
+        // Seed the selected example's eval assets into the new config fileset.
         const files: EvalSeedFile[] = await Promise.all(
           spec.seedSources.map(async (source) => ({
             path: source.path,
@@ -161,9 +172,8 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
           'Agent Evaluation Config'
         );
       }
-      // Pre-create the per-run output fileset so we can stamp a description on
-      // it. The eval job uploads with fileset_auto_create=True, which no-ops
-      // once the fileset exists — so the description we set here persists.
+      // Pre-create the output fileset so it carries a description; the job's
+      // auto-create no-ops once it exists. Best-effort — never block submission.
       const outputFileset = generateOutputFilesetName(spec.agent);
       try {
         await filesCreateFileset(workspace, {
@@ -172,8 +182,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
           purpose: 'generic',
         });
       } catch {
-        // Best-effort: if this fails, the job still auto-creates the output
-        // fileset (without a description). Don't block submission.
+        // Job still auto-creates the fileset (without a description).
       }
       const body = evaluateRequestBody(spec, outputFileset);
       const res = await customFetch<{ name?: string }>({
@@ -215,9 +224,8 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const mode = useWatch({ control, name: 'mode' });
   const selectedAgent = useWatch({ control, name: 'agent' });
 
-  // Existing eval configs for the selected agent: distinct eval-config
-  // filesets from that agent's prior jobs, each mapped to the eval-config YAML
-  // it ran (needed to re-run against the same file).
+  // Existing eval configs for the agent: distinct config filesets from prior
+  // jobs, mapped to the YAML each ran.
   const existingConfigs = useMemo(() => {
     const map = new Map<string, string>();
     const agentKey = bareName(selectedAgent);
@@ -249,10 +257,8 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     if (matchedKey) setValue('exampleKey', matchedKey);
   }, [selectedAgent, setValue]);
 
-  // Preselect the latest existing eval config for the agent (jobs are sorted
-  // newest-first, so the first key is the most recent), falling back to create
-  // when the agent has none. Ref-guarded to run once per agent so it seeds the
-  // default without overriding the user's later manual pick.
+  // Preselect the latest existing config for the agent (else create). Ref-guarded
+  // to run once per agent so it doesn't override the user's later manual pick.
   const autoSelectedAgentRef = useRef<string | null>(null);
   useEffect(() => {
     if (!open) {

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal.tsx
@@ -5,84 +5,88 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { ControlledDatasetFileSelect } from '@nemo/common/src/components/DatasetFileSelect/ControlledDatasetFileSelect';
 import { parseFilesetLocation } from '@nemo/common/src/components/DatasetFileSelect/parseFilesetLocation';
 import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
 import { FormModal, type FormModalProps } from '@nemo/common/src/components/FormModal';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import { generateEvalConfigName } from '@nemo/common/src/utils/generateDefaultName';
 import { customFetch } from '@nemo/sdk/generated/fetchers/platform';
-import { Block, RadioGroup, Stack, Text } from '@nvidia/foundations-react-core';
+import { filesCreateFileset } from '@nemo/sdk/generated/platform/api';
+import { SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
 import { fetchSampleText } from '@studio/api/agents/fetchSampleText';
 import { type Agent } from '@studio/components/dataViews/AgentsDataView';
 import { PLATFORM_BASE_URL } from '@studio/constants/environment';
 import {
   DEFAULT_SAMPLE_AGENT_KEY,
-  getSampleAgent,
   SAMPLE_AGENTS,
   sampleAgentKeyForAgentName,
 } from '@studio/constants/sampleAgents';
 import {
+  fetchAgentEvalJobs,
+  type AgentEvalJob,
+} from '@studio/routes/agents/AgentEvaluationsRoute/api';
+import {
+  buildSubmitSpec,
+  CREATE_NEW,
+  evalOutputDescription,
+  evaluateRequestBody,
+  generateOutputFilesetName,
+  MODE_DEFAULT,
+  MODE_FILESET,
+  type SubmitSpec,
+} from '@studio/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec';
+import {
   ensureEvalConfigFileset,
   type EvalSeedFile,
 } from '@studio/routes/agents/AgentSuggestionsRoute/api';
-import {
-  evalFilesetForAgent,
-  evalOutputFilesetFor,
-} from '@studio/routes/agents/AgentSuggestionsRoute/utils';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { type FC, useEffect } from 'react';
+import { type FC, useEffect, useMemo, useRef } from 'react';
 import { type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { z } from 'zod';
 
-const MODE_DEFAULT = 'default';
-const MODE_FILESET = 'fileset';
-
 const EVAL_CONFIG_MODE_ITEMS = [
-  { value: MODE_DEFAULT, children: 'Use example evaluation config' },
-  { value: MODE_FILESET, children: 'Select or upload a config file from a fileset' },
+  { value: MODE_DEFAULT, children: 'Use Example' },
+  { value: MODE_FILESET, children: 'Choose Fileset' },
 ];
 
-const contentTypeForFile = (name: string): string => {
-  if (name.endsWith('.json')) return 'application/json';
-  if (name.endsWith('.csv')) return 'text/csv';
-  return 'application/yaml';
+/** Strip an optional ``workspace/`` prefix so agent references compare by name. */
+const bareName = (value?: string | null): string | null => {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return value.includes('/') ? (value.split('/').pop() ?? null) : value;
 };
-
-/** Basename of a public asset path — the flat name it's seeded as in the fileset. */
-const fileNameOf = (path: string): string => path.slice(path.lastIndexOf('/') + 1);
 
 const submitEvaluationSchema = z
   .object({
     agent: z.string().min(1, 'Agent is required'),
+    // Existing eval-config fileset to reuse, or CREATE_NEW to make one.
+    evalConfig: z.string().min(1, 'Select or create an eval config'),
+    // Create-mode fields (only enforced when evalConfig === CREATE_NEW).
+    newName: z.string(),
     mode: z.enum([MODE_DEFAULT, MODE_FILESET]),
     exampleKey: z.string(),
     datasetFile: z.string().nullable(),
   })
-  .refine(
-    (data) =>
-      data.mode !== MODE_FILESET ||
-      (typeof data.datasetFile === 'string' &&
-        !!parseFilesetLocation(data.datasetFile)?.objectPath),
-    {
-      message: 'Pick an eval YAML inside an existing fileset',
-      path: ['datasetFile'],
+  .superRefine((data, ctx) => {
+    if (data.evalConfig !== CREATE_NEW) return;
+    if (data.mode === MODE_DEFAULT && !data.newName.trim()) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Name is required', path: ['newName'] });
     }
-  );
+    if (data.mode === MODE_FILESET && !parseFilesetLocation(data.datasetFile ?? '')?.objectPath) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Pick an eval YAML inside an existing fileset',
+        path: ['datasetFile'],
+      });
+    }
+  });
 
 type SubmitEvaluationFormData = z.infer<typeof submitEvaluationSchema>;
 
-const SUFFIX_LENGTH = 5;
-const SUFFIX_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
-
-/** Mirrors the optimizer's randomSiblingSuffix so this surface looks the
- *  same; isolated copy so the form doesn't reach into utils.ts internals. */
-const randomSuffix = (): string => {
-  const bytes = new Uint8Array(SUFFIX_LENGTH);
-  crypto.getRandomValues(bytes);
-  let out = '';
-  for (const b of bytes) out += SUFFIX_ALPHABET[b % SUFFIX_ALPHABET.length];
-  return out;
-};
-
 const makeDefaultValues = (agent?: string): SubmitEvaluationFormData => ({
   agent: agent ?? '',
+  // Default to create so a first-time agent goes straight to the create form;
+  // existing configs are still one click away in the dropdown.
+  evalConfig: CREATE_NEW,
+  newName: generateEvalConfigName(),
   mode: MODE_DEFAULT,
   // Auto-match the example to the agent it was created from (by name prefix),
   // falling back to the first example for non-example agents.
@@ -99,24 +103,6 @@ interface SubmitEvaluationModalProps extends Pick<FormModalProps, 'open' | 'onCl
   agent?: string;
   /** Called after a successful submission with the new job's name. */
   onSubmitted?: (jobName: string) => void;
-}
-
-interface EvalSeedSource {
-  /** Flat filename seeded into the fileset. */
-  path: string;
-  /** Public asset path fetched on demand for the file's content. */
-  assetPath: string;
-  type: string;
-}
-
-interface SubmitSpec {
-  agent: string;
-  evalConfig: string;
-  evalConfigFileset: string;
-  /** When set, fetch each source and seed it into ``evalConfigFileset`` before
-   *  POSTing to ``/jobs/evaluate``. Omitted when the user picks an existing
-   *  fileset since we shouldn't overwrite their files. */
-  seedSources?: EvalSeedSource[];
 }
 
 export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
@@ -142,6 +128,13 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     enabled: open && !agentProp,
   });
 
+  // Prior eval jobs — the source for the "existing eval config" dropdown.
+  const { data: jobs = [], isLoading: isJobsLoading } = useQuery({
+    queryKey: ['agent-eval-jobs', workspace],
+    queryFn: ({ signal }) => fetchAgentEvalJobs(workspace, signal),
+    enabled: open,
+  });
+
   const {
     mutateAsync: submitEvaluation,
     error: submitError,
@@ -150,9 +143,9 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   } = useMutation({
     mutationFn: async (spec: SubmitSpec) => {
       if (spec.seedSources) {
-        // Default mode: fetch the selected example's eval assets on demand and
-        // seed them into the per-agent eval-config fileset so the user doesn't
-        // have to pre-upload anything.
+        // Create mode (example): fetch the selected example's eval assets on
+        // demand and seed them into the new eval-config fileset so the user
+        // doesn't have to pre-upload anything.
         const files: EvalSeedFile[] = await Promise.all(
           spec.seedSources.map(async (source) => ({
             path: source.path,
@@ -164,19 +157,25 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
           workspace,
           spec.evalConfigFileset,
           new AbortController().signal,
-          files
+          files,
+          'Agent Evaluation Config'
         );
       }
-      const body = {
-        spec: {
-          agent: spec.agent,
-          eval_config: spec.evalConfig,
-          eval_config_fileset: spec.evalConfigFileset,
-          // Auto-generated per submission so re-running for the same agent
-          // doesn't 409 on an existing output fileset.
-          output: `${evalOutputFilesetFor(spec.agent)}-${randomSuffix()}`,
-        },
-      };
+      // Pre-create the per-run output fileset so we can stamp a description on
+      // it. The eval job uploads with fileset_auto_create=True, which no-ops
+      // once the fileset exists — so the description we set here persists.
+      const outputFileset = generateOutputFilesetName(spec.agent);
+      try {
+        await filesCreateFileset(workspace, {
+          name: outputFileset,
+          description: evalOutputDescription(spec),
+          purpose: 'generic',
+        });
+      } catch {
+        // Best-effort: if this fails, the job still auto-creates the output
+        // fileset (without a description). Don't block submission.
+      }
+      const body = evaluateRequestBody(spec, outputFileset);
       const res = await customFetch<{ name?: string }>({
         url: `/apis/agents/v2/workspaces/${encodeURIComponent(workspace)}/jobs/evaluate`,
         method: 'POST',
@@ -212,14 +211,60 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     reValidateMode: 'onChange',
   });
 
+  const evalConfig = useWatch({ control, name: 'evalConfig' });
   const mode = useWatch({ control, name: 'mode' });
   const selectedAgent = useWatch({ control, name: 'agent' });
+
+  // Existing eval configs for the selected agent: distinct eval-config
+  // filesets from that agent's prior jobs, each mapped to the eval-config YAML
+  // it ran (needed to re-run against the same file).
+  const existingConfigs = useMemo(() => {
+    const map = new Map<string, string>();
+    const agentKey = bareName(selectedAgent);
+    if (!agentKey) return map;
+    for (const job of jobs as AgentEvalJob[]) {
+      if (bareName(job.spec.agent) !== agentKey) continue;
+      const fileset = job.spec.eval_config_fileset;
+      if (typeof fileset === 'string' && fileset.length > 0 && !map.has(fileset)) {
+        map.set(fileset, job.spec.eval_config ?? '');
+      }
+    }
+    return map;
+  }, [jobs, selectedAgent]);
+
+  const evalConfigItems = useMemo(
+    () => [
+      ...Array.from(existingConfigs.keys()).map((fileset) => ({
+        value: fileset,
+        children: fileset,
+      })),
+      { value: CREATE_NEW, children: '+ Create new eval config' },
+    ],
+    [existingConfigs]
+  );
 
   // When the chosen agent maps to a known example, auto-select its eval config.
   useEffect(() => {
     const matchedKey = sampleAgentKeyForAgentName(selectedAgent);
     if (matchedKey) setValue('exampleKey', matchedKey);
   }, [selectedAgent, setValue]);
+
+  // Preselect the latest existing eval config for the agent (jobs are sorted
+  // newest-first, so the first key is the most recent), falling back to create
+  // when the agent has none. Ref-guarded to run once per agent so it seeds the
+  // default without overriding the user's later manual pick.
+  const autoSelectedAgentRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!open) {
+      autoSelectedAgentRef.current = null;
+      return;
+    }
+    if (isJobsLoading || !selectedAgent) return;
+    if (autoSelectedAgentRef.current === selectedAgent) return;
+    autoSelectedAgentRef.current = selectedAgent;
+    const latest = existingConfigs.keys().next().value;
+    setValue('evalConfig', latest ?? CREATE_NEW);
+  }, [open, isJobsLoading, selectedAgent, existingConfigs, setValue]);
 
   useEffect(() => {
     resetForm(makeDefaultValues(agentProp));
@@ -242,44 +287,8 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   };
 
   const onSubmit: SubmitHandler<SubmitEvaluationFormData> = async (formData) => {
-    let spec: SubmitSpec;
-    if (formData.mode === MODE_FILESET) {
-      // Schema refine guarantees ``datasetFile`` parses to a fileset reference
-      // with a non-empty ``objectPath`` before reaching this point.
-      const parsed = parseFilesetLocation(formData.datasetFile!)!;
-      spec = {
-        agent: formData.agent,
-        evalConfig: parsed.objectPath,
-        evalConfigFileset: parsed.name,
-      };
-    } else {
-      const example = getSampleAgent(formData.exampleKey);
-      // Namespace the seeded config per example. The {agent}-eval fileset is
-      // shared and ensureEvalConfigFileset skips existing files, so seeding every
-      // example as a bare "eval.yml" would make the first-seeded config stick when
-      // switching examples on the same agent. (Datasets already have distinct
-      // basenames.)
-      const evalConfigName = `${example.key}-${fileNameOf(example.evalConfigPath)}`;
-      spec = {
-        agent: formData.agent,
-        evalConfig: evalConfigName,
-        evalConfigFileset: evalFilesetForAgent(formData.agent),
-        seedSources: [
-          {
-            path: evalConfigName,
-            assetPath: example.evalConfigPath,
-            type: contentTypeForFile(example.evalConfigPath),
-          },
-          {
-            path: fileNameOf(example.evalDataPath),
-            assetPath: example.evalDataPath,
-            type: contentTypeForFile(example.evalDataPath),
-          },
-        ],
-      };
-    }
     try {
-      await submitEvaluation(spec);
+      await submitEvaluation(buildSubmitSpec(formData, existingConfigs));
     } catch {
       // Error rendered via errorText prop.
     }
@@ -292,16 +301,19 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
         ? 'An error occurred'
         : undefined;
 
+  const isCreating = evalConfig === CREATE_NEW;
+
   return (
     <FormModal
       open={open}
       onClose={resetAndClose}
-      title="Run Evaluation"
+      title="Run Agent Evaluation"
       submitButtonText="Submit"
       onSubmit={handleSubmit(onSubmit)}
       disabled={isPending}
       loading={isPending}
       errorText={errorMessage}
+      className="w-[690px]! max-w-[95vw]!"
     >
       <Stack gap="density-xl">
         {agentProp ? (
@@ -321,53 +333,79 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
             }}
           />
         )}
-        <Block>
-          <Text kind="label/bold/sm" color="secondary">
-            Evaluation config
-          </Text>
-          <RadioGroup
-            name="eval-config-mode"
-            value={mode}
-            onValueChange={(v) => {
-              setValue('mode', v as typeof MODE_DEFAULT | typeof MODE_FILESET, {
-                shouldValidate: false,
-              });
-              clearErrors('datasetFile');
-            }}
-            items={EVAL_CONFIG_MODE_ITEMS}
-          />
-        </Block>
-        {mode === MODE_DEFAULT ? (
-          <ControlledSelect
-            useControllerProps={{ control, name: 'exampleKey' }}
-            items={SAMPLE_AGENTS.map((example) => ({
-              value: example.key,
-              children: example.label,
-            }))}
-            formFieldProps={{
-              slotLabel: 'Example',
-              slotError: errors.exampleKey?.message,
-            }}
-          />
-        ) : null}
-        {mode === MODE_FILESET ? (
-          <ControlledDatasetFileSelect
-            useControllerProps={{
-              control,
-              name: 'datasetFile',
-              rules: { required: 'Pick an eval YAML inside an existing fileset' },
-            }}
-            acceptedFileTypes={['.yml', '.yaml']}
-            invalidFileMode="disable"
-            setError={(error) => setError('datasetFile', error)}
-            clearError={() => clearErrors('datasetFile')}
-            workspace={workspace}
-            inline
-            autoCommit
-            formFieldProps={{
-              slotError: errors.datasetFile?.message,
-            }}
-          />
+        {selectedAgent ? (
+          <Stack gap="density-xl">
+            <Text kind="label/bold/sm" color="secondary">
+              Eval Config
+            </Text>
+            <ControlledSelect
+              useControllerProps={{ control, name: 'evalConfig' }}
+              loading={isJobsLoading}
+              items={evalConfigItems}
+              formFieldProps={{
+                slotError: errors.evalConfig?.message,
+              }}
+            />
+            {isCreating && (
+              <>
+                <SegmentedControl
+                  className="w-full [&_button]:flex-1"
+                  value={mode}
+                  onValueChange={(v) => {
+                    setValue('mode', v as typeof MODE_DEFAULT | typeof MODE_FILESET, {
+                      shouldValidate: false,
+                    });
+                    clearErrors('datasetFile');
+                  }}
+                  items={EVAL_CONFIG_MODE_ITEMS}
+                />
+                {mode === MODE_DEFAULT ? (
+                  <>
+                    <ControlledSelect
+                      useControllerProps={{ control, name: 'exampleKey' }}
+                      items={SAMPLE_AGENTS.map((example) => ({
+                        value: example.key,
+                        children: example.label,
+                      }))}
+                      formFieldProps={{
+                        slotLabel: 'Example',
+                        slotError: errors.exampleKey?.message,
+                      }}
+                    />
+                    <ControlledTextInput
+                      useControllerProps={{ control, name: 'newName' }}
+                      selectOnFocus
+                      formFieldProps={{
+                        slotLabel: 'New Fileset Name',
+                        slotError: errors.newName?.message,
+                      }}
+                    />
+                  </>
+                ) : (
+                  <ControlledDatasetFileSelect
+                    useControllerProps={{
+                      control,
+                      name: 'datasetFile',
+                      rules: { required: 'Pick an eval YAML inside an existing fileset' },
+                    }}
+                    acceptedFileTypes={['.yml', '.yaml']}
+                    invalidFileMode="disable"
+                    setError={(error) => setError('datasetFile', error)}
+                    clearError={() => clearErrors('datasetFile')}
+                    workspace={workspace}
+                    inline
+                    autoCommit
+                    autoSelectFirstAcceptable
+                    filesetPurpose="generic"
+                    datasetLabel="Fileset"
+                    formFieldProps={{
+                      slotError: errors.datasetFile?.message,
+                    }}
+                  />
+                )}
+              </>
+            )}
+          </Stack>
         ) : null}
       </Stack>
     </FormModal>

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.test.ts
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.test.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SAMPLE_AGENTS } from '@studio/constants/sampleAgents';
+import {
+  buildSubmitSpec,
+  CREATE_NEW,
+  evalOutputDescription,
+  evaluateRequestBody,
+  generateOutputFilesetName,
+} from '@studio/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec';
+
+const baseForm = {
+  agent: 'my-agent',
+  evalConfig: CREATE_NEW,
+  newName: '',
+  mode: 'default' as const,
+  exampleKey: SAMPLE_AGENTS[0].key,
+  datasetFile: null as string | null,
+};
+
+describe('buildSubmitSpec', () => {
+  it('reuses an existing eval config untouched (no seed sources)', () => {
+    const existing = new Map([['wise-pretzel', 'analyzer-eval.yml']]);
+    const spec = buildSubmitSpec({ ...baseForm, evalConfig: 'wise-pretzel' }, existing);
+
+    expect(spec).toEqual({
+      agent: 'my-agent',
+      evalConfig: 'analyzer-eval.yml',
+      evalConfigFileset: 'wise-pretzel',
+    });
+    expect(spec.seedSources).toBeUndefined();
+  });
+
+  it('creates a new slug fileset and seeds the example config + dataset', () => {
+    const spec = buildSubmitSpec(
+      { ...baseForm, evalConfig: CREATE_NEW, mode: 'default', newName: '  wise-pretzel  ' },
+      new Map()
+    );
+
+    // Trimmed slug becomes the eval-config fileset (also the output target).
+    expect(spec.evalConfigFileset).toBe('wise-pretzel');
+    expect(spec.evalConfig.startsWith(`${SAMPLE_AGENTS[0].key}-`)).toBe(true);
+    expect(spec.seedSources).toHaveLength(2);
+  });
+
+  it("reuses the picked file's own fileset when creating from a fileset YAML", () => {
+    const spec = buildSubmitSpec(
+      {
+        ...baseForm,
+        evalConfig: CREATE_NEW,
+        mode: 'fileset',
+        datasetFile: 'default/my-fs#eval.yml',
+      },
+      new Map()
+    );
+
+    expect(spec.evalConfigFileset).toBe('my-fs');
+    expect(spec.evalConfig).toBe('eval.yml');
+    expect(spec.seedSources).toBeUndefined();
+  });
+});
+
+describe('generateOutputFilesetName', () => {
+  it('mints a fresh per-run <agent>-eval-out-<random> name', () => {
+    const a = generateOutputFilesetName('my-agent');
+    const b = generateOutputFilesetName('my-agent');
+    expect(a).toMatch(/^my-agent-eval-out-[a-z0-9]{5}$/);
+    expect(a).not.toBe(b); // random suffix differs per call
+  });
+});
+
+describe('evalOutputDescription', () => {
+  it('describes the agent and eval-config fileset', () => {
+    expect(
+      evalOutputDescription({
+        agent: 'my-agent',
+        evalConfig: 'eval.yml',
+        evalConfigFileset: 'wise-pretzel',
+      })
+    ).toBe('Agent Evaluation output, agent: my-agent, config: wise-pretzel');
+  });
+});
+
+describe('evaluateRequestBody', () => {
+  it('sends the chosen eval-config fileset and the given per-run output fileset', () => {
+    const body = evaluateRequestBody(
+      { agent: 'my-agent', evalConfig: 'eval.yml', evalConfigFileset: 'wise-pretzel' },
+      'my-agent-eval-out-ab3d9'
+    );
+
+    expect(body.spec.eval_config).toBe('eval.yml');
+    expect(body.spec.eval_config_fileset).toBe('wise-pretzel');
+    // Output is a distinct per-run fileset, not the config fileset.
+    expect(body.spec.output).toBe('my-agent-eval-out-ab3d9');
+    expect(body.spec.output).not.toBe(body.spec.eval_config_fileset);
+  });
+});

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.ts
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { parseFilesetLocation } from '@nemo/common/src/components/DatasetFileSelect/parseFilesetLocation';
+import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
 import { getSampleAgent } from '@studio/constants/sampleAgents';
 import { evalOutputFilesetFor } from '@studio/routes/agents/AgentSuggestionsRoute/utils';
 
@@ -10,6 +11,9 @@ export const MODE_FILESET = 'fileset';
 
 /** Sentinel ``evalConfig`` value that switches the form into create mode. */
 export const CREATE_NEW = '__create_new__';
+
+/** Suggested name for a new eval config (e.g. "wise-blue"). */
+export const generateEvalConfigName = (): string => generateDefaultName({ length: 2 });
 
 /** Form values the eval-submit modal collects. */
 export interface SubmitEvaluationFormValues {
@@ -34,9 +38,8 @@ export interface SubmitSpec {
   agent: string;
   evalConfig: string;
   evalConfigFileset: string;
-  /** When set, fetch each source and seed it into ``evalConfigFileset`` before
-   *  POSTing to ``/jobs/evaluate``. Omitted when reusing an existing eval
-   *  config (or an existing fileset) since we shouldn't overwrite files. */
+  /** Files to seed into ``evalConfigFileset`` before submitting. Omitted when
+   *  reusing an existing config. */
   seedSources?: EvalSeedSource[];
 }
 
@@ -49,15 +52,8 @@ export const contentTypeForFile = (name: string): string => {
 /** Basename of a public asset path — the flat name it's seeded as in the fileset. */
 export const fileNameOf = (path: string): string => path.slice(path.lastIndexOf('/') + 1);
 
-/**
- * Builds the eval-job spec from the form. Three branches:
- * - reuse an existing eval config → reference its fileset untouched (no seed);
- * - create from an existing fileset's YAML → that fileset becomes the config
- *   fileset (no seed);
- * - create from an example → seed the example into a new slug fileset.
- *
- * ``existingConfigs`` maps an eval-config fileset to the YAML it last ran.
- */
+/** Builds the eval-job spec from the form (reuse existing config, pick a
+ *  fileset YAML, or seed an example into a new fileset). */
 export const buildSubmitSpec = (
   formData: SubmitEvaluationFormValues,
   existingConfigs: Map<string, string>
@@ -70,9 +66,7 @@ export const buildSubmitSpec = (
     };
   }
   if (formData.mode === MODE_FILESET) {
-    // Schema refine guarantees ``datasetFile`` parses to a fileset reference
-    // with a non-empty ``objectPath`` before reaching this point. The picked
-    // file's own fileset becomes the eval-config fileset.
+    // datasetFile is validated by the schema refine before we get here.
     const parsed = parseFilesetLocation(formData.datasetFile!)!;
     return {
       agent: formData.agent,
@@ -81,9 +75,8 @@ export const buildSubmitSpec = (
     };
   }
   const example = getSampleAgent(formData.exampleKey);
-  // Namespace the seeded config per example so switching examples on the same
-  // fileset doesn't make the first-seeded config stick (datasets already have
-  // distinct basenames).
+  // Namespace the config per example so switching examples doesn't reuse the
+  // first-seeded config.
   const evalConfigName = `${example.key}-${fileNameOf(example.evalConfigPath)}`;
   return {
     agent: formData.agent,
@@ -107,8 +100,7 @@ export const buildSubmitSpec = (
 const OUTPUT_SUFFIX_LENGTH = 5;
 const OUTPUT_SUFFIX_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
-/** Random 5-char suffix so re-running for the same agent doesn't 409 on an
- *  existing output fileset. */
+/** Random 5-char suffix so re-runs don't 409 on an existing output fileset. */
 const randomSuffix = (): string => {
   const bytes = new Uint8Array(OUTPUT_SUFFIX_LENGTH);
   crypto.getRandomValues(bytes);
@@ -117,20 +109,15 @@ const randomSuffix = (): string => {
   return out;
 };
 
-/** Fresh per-run output fileset name (``<agent>-eval-out-<random>``) so re-runs
- *  never collide. Generated once per submission and reused for both the
- *  pre-create (to stamp a description) and the job spec's ``output``. */
+/** Fresh per-run output fileset name (``<agent>-eval-out-<random>``). */
 export const generateOutputFilesetName = (agent: string): string =>
   `${evalOutputFilesetFor(agent)}-${randomSuffix()}`;
 
-/** Human-readable description stamped on the eval output fileset at create
- *  time (the eval job's auto-create is a no-op once the fileset exists, so the
- *  description persists). */
+/** Description stamped on the eval output fileset. */
 export const evalOutputDescription = (spec: SubmitSpec): string =>
   `Agent Evaluation output, agent: ${spec.agent}, config: ${spec.evalConfigFileset}`;
 
-/** POST body for ``/jobs/evaluate``. ``output`` is the pre-created per-run
- *  fileset name from {@link generateOutputFilesetName}. */
+/** POST body for ``/jobs/evaluate``. */
 export const evaluateRequestBody = (spec: SubmitSpec, output: string) => ({
   spec: {
     agent: spec.agent,

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.ts
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.ts
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { parseFilesetLocation } from '@nemo/common/src/components/DatasetFileSelect/parseFilesetLocation';
+import { getSampleAgent } from '@studio/constants/sampleAgents';
+import { evalOutputFilesetFor } from '@studio/routes/agents/AgentSuggestionsRoute/utils';
+
+export const MODE_DEFAULT = 'default';
+export const MODE_FILESET = 'fileset';
+
+/** Sentinel ``evalConfig`` value that switches the form into create mode. */
+export const CREATE_NEW = '__create_new__';
+
+/** Form values the eval-submit modal collects. */
+export interface SubmitEvaluationFormValues {
+  agent: string;
+  /** Existing eval-config fileset to reuse, or CREATE_NEW to make one. */
+  evalConfig: string;
+  newName: string;
+  mode: typeof MODE_DEFAULT | typeof MODE_FILESET;
+  exampleKey: string;
+  datasetFile: string | null;
+}
+
+export interface EvalSeedSource {
+  /** Flat filename seeded into the fileset. */
+  path: string;
+  /** Public asset path fetched on demand for the file's content. */
+  assetPath: string;
+  type: string;
+}
+
+export interface SubmitSpec {
+  agent: string;
+  evalConfig: string;
+  evalConfigFileset: string;
+  /** When set, fetch each source and seed it into ``evalConfigFileset`` before
+   *  POSTing to ``/jobs/evaluate``. Omitted when reusing an existing eval
+   *  config (or an existing fileset) since we shouldn't overwrite files. */
+  seedSources?: EvalSeedSource[];
+}
+
+export const contentTypeForFile = (name: string): string => {
+  if (name.endsWith('.json')) return 'application/json';
+  if (name.endsWith('.csv')) return 'text/csv';
+  return 'application/yaml';
+};
+
+/** Basename of a public asset path — the flat name it's seeded as in the fileset. */
+export const fileNameOf = (path: string): string => path.slice(path.lastIndexOf('/') + 1);
+
+/**
+ * Builds the eval-job spec from the form. Three branches:
+ * - reuse an existing eval config → reference its fileset untouched (no seed);
+ * - create from an existing fileset's YAML → that fileset becomes the config
+ *   fileset (no seed);
+ * - create from an example → seed the example into a new slug fileset.
+ *
+ * ``existingConfigs`` maps an eval-config fileset to the YAML it last ran.
+ */
+export const buildSubmitSpec = (
+  formData: SubmitEvaluationFormValues,
+  existingConfigs: Map<string, string>
+): SubmitSpec => {
+  if (formData.evalConfig !== CREATE_NEW) {
+    return {
+      agent: formData.agent,
+      evalConfig: existingConfigs.get(formData.evalConfig) ?? '',
+      evalConfigFileset: formData.evalConfig,
+    };
+  }
+  if (formData.mode === MODE_FILESET) {
+    // Schema refine guarantees ``datasetFile`` parses to a fileset reference
+    // with a non-empty ``objectPath`` before reaching this point. The picked
+    // file's own fileset becomes the eval-config fileset.
+    const parsed = parseFilesetLocation(formData.datasetFile!)!;
+    return {
+      agent: formData.agent,
+      evalConfig: parsed.objectPath,
+      evalConfigFileset: parsed.name,
+    };
+  }
+  const example = getSampleAgent(formData.exampleKey);
+  // Namespace the seeded config per example so switching examples on the same
+  // fileset doesn't make the first-seeded config stick (datasets already have
+  // distinct basenames).
+  const evalConfigName = `${example.key}-${fileNameOf(example.evalConfigPath)}`;
+  return {
+    agent: formData.agent,
+    evalConfig: evalConfigName,
+    evalConfigFileset: formData.newName.trim(),
+    seedSources: [
+      {
+        path: evalConfigName,
+        assetPath: example.evalConfigPath,
+        type: contentTypeForFile(example.evalConfigPath),
+      },
+      {
+        path: fileNameOf(example.evalDataPath),
+        assetPath: example.evalDataPath,
+        type: contentTypeForFile(example.evalDataPath),
+      },
+    ],
+  };
+};
+
+const OUTPUT_SUFFIX_LENGTH = 5;
+const OUTPUT_SUFFIX_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+/** Random 5-char suffix so re-running for the same agent doesn't 409 on an
+ *  existing output fileset. */
+const randomSuffix = (): string => {
+  const bytes = new Uint8Array(OUTPUT_SUFFIX_LENGTH);
+  crypto.getRandomValues(bytes);
+  let out = '';
+  for (const b of bytes) out += OUTPUT_SUFFIX_ALPHABET[b % OUTPUT_SUFFIX_ALPHABET.length];
+  return out;
+};
+
+/** Fresh per-run output fileset name (``<agent>-eval-out-<random>``) so re-runs
+ *  never collide. Generated once per submission and reused for both the
+ *  pre-create (to stamp a description) and the job spec's ``output``. */
+export const generateOutputFilesetName = (agent: string): string =>
+  `${evalOutputFilesetFor(agent)}-${randomSuffix()}`;
+
+/** Human-readable description stamped on the eval output fileset at create
+ *  time (the eval job's auto-create is a no-op once the fileset exists, so the
+ *  description persists). */
+export const evalOutputDescription = (spec: SubmitSpec): string =>
+  `Agent Evaluation output, agent: ${spec.agent}, config: ${spec.evalConfigFileset}`;
+
+/** POST body for ``/jobs/evaluate``. ``output`` is the pre-created per-run
+ *  fileset name from {@link generateOutputFilesetName}. */
+export const evaluateRequestBody = (spec: SubmitSpec, output: string) => ({
+  spec: {
+    agent: spec.agent,
+    eval_config: spec.evalConfig,
+    eval_config_fileset: spec.evalConfigFileset,
+    output,
+  },
+});

--- a/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/api.ts
+++ b/web/packages/studio/src/routes/agents/AgentSuggestionsRoute/api.ts
@@ -243,7 +243,8 @@ export const ensureEvalConfigFileset = async (
   workspace: string,
   fileset: string,
   signal: AbortSignal,
-  files: EvalSeedFile[] = defaultEvalSeedFiles()
+  files: EvalSeedFile[] = defaultEvalSeedFiles(),
+  description?: string
 ): Promise<void> => {
   let existingPaths = new Set<string>();
   try {
@@ -253,7 +254,7 @@ export const ensureEvalConfigFileset = async (
     if (isCanceledError(err)) throw err;
     if (!isNotFoundError(err)) throw err;
     try {
-      await filesCreateFileset(workspace, { name: fileset }, signal);
+      await filesCreateFileset(workspace, { name: fileset, description }, signal);
     } catch (createErr) {
       if (isCanceledError(createErr)) throw createErr;
       // 409 is fine — a parallel apply already created it.


### PR DESCRIPTION
### Agent Eval: create new config from example

<img width="710" height="505" alt="Screenshot 2026-07-13 at 1 06 08 PM" src="https://github.com/user-attachments/assets/332e906d-ef57-4e5e-82ac-32199ae70974" />


### Agent Eval: create new config from existing fileset

<img width="706" height="691" alt="Screenshot 2026-07-13 at 1 06 17 PM" src="https://github.com/user-attachments/assets/88374b5e-2550-4e5f-9051-fba7ddfdf346" />


### Agent Eval: reuse existing agent eval config


<img width="709" height="304" alt="Screenshot 2026-07-13 at 1 05 57 PM" src="https://github.com/user-attachments/assets/f847ac52-600f-4ba7-b813-70bf680736a9" />


### Agent Eval: the 3 Filesets that are created, 2 now have descriptions


<img width="1463" height="430" alt="Screenshot 2026-07-13 at 1 10 15 PM" src="https://github.com/user-attachments/assets/34916e7f-151a-48fb-a39e-62471d1252da" />


  **Run Agent Evaluation modal** (`SubmitEvaluationModal.tsx`, new `submitEvaluationSpec.ts`)
  - New **Eval Config** dropdown: reuse an existing config (derived from the agent's prior
  eval jobs) or **Create new eval config**. Preselects the latest config for the selected
  agent.
  - The Eval Config subsection only appears once an agent is selected (auto-selected when
  opened from the agent side panel).
  - Segmented control **Use Example** / **Choose Fileset** (replaces the radio group).
  - **Use Example**: pre-fills a suggested `adjective-animal` fileset name
  (`generateEvalConfigName`), editable ("New Fileset Name").
  - **Choose Fileset**: fileset picker filtered to `purpose=generic`, labelled "Fileset",
  **auto-selects the first root-level `.yml`/`.yaml`** so you don't have to drill in.
  - Spec-building extracted to a pure, unit-tested module (`buildSubmitSpec`,
  `evaluateRequestBody`, `generateOutputFilesetName`, `evalOutputDescription`).

  **Fileset descriptions** (no plugin change)
  - **Output fileset**: Studio now pre-creates the per-run output fileset with a description
  — `Agent Evaluation output, agent: <agent>, config: <config-fileset>`. The job's
  `fileset_auto_create` no-ops on existence, so the description sticks. Best-effort (never
  blocks submission).
  - **Eval config fileset**: created with description `Agent Evaluation Config` (via
  `ensureEvalConfigFileset`, only when Studio actually creates it).

  **Output layout** (`sample-agents/email-phishing-analyzer/eval.yml`)
  - `output_dir: eval/agent` → `output_dir: .` so eval artifacts land at the output fileset
  root instead of a nested `eval/agent/` subfolder.

  **Filesets list** (`DatasetsTable/columns.tsx`)
  - **Name** and **Path** columns now **wrap** to multiple lines instead of truncating.

  **Shared UploadModal / file picker** (`packages/common/.../UploadModal`,
  `DatasetFileSelect`)
  - Added opt-in props threaded through the picker: `filesetPurpose`, `datasetLabel`,
  `autoSelectFirstAcceptable`. All default to today's behavior (backward compatible).
  - `SimpleFilesTable`: Name column now fills the row width while Size stays a fixed 120px
  (fixes a width-distribution issue in the virtualized table); the "only `.yml`/`.yaml` can
  be selected" hint is suppressed once a valid file is selected. Still virtualized.

  **List route CTA** (`AgentEvaluationsListRoute.tsx`)
  - "New evaluation" → **"Run Evaluation"** (brand-green primary button).

  ### Out of scope / not in this PR
  - No `plugins/nemo-agents` changes.
  - Output nesting under the eval-config fileset (dropped — needs a plugin change).
  - Internal `job-fileset-*` clutter in the Filesets list (tracked separately).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced upload flow with purpose-specific file filtering, configurable dataset labeling, and an option to automatically select the first acceptable root-level file.
  * Improved agent evaluation setup with smarter eval-config selection/creation and automatic preparation of run output.
  * Changed the evaluation action button to **“Run Evaluation”**.
* **Bug Fixes**
  * Selection warning now only shows when no valid (allowed) file is selected.
* **UI Improvements**
  * Dataset names/paths now wrap instead of truncating.
  * File table columns now use more consistent sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->