### PR TITLE
ci: allow flexibility for the root of wasm build action

### DIFF
--- a/.github/actions/build-policy-wasm/action.yaml
+++ b/.github/actions/build-policy-wasm/action.yaml
@@ -10,4 +10,6 @@ runs:
   steps:
     - name: Build policy WASM
       shell: bash
-      run: ./script/build_policy_wasm.sh
+      env:
+        REPO_ROOT: ${{ github.action_path }}/../../..
+      run: "${REPO_ROOT}/script/build_policy_wasm.sh"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by ensuring the policy WebAssembly build script is located correctly regardless of the action’s execution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->