### PR TITLE
ci: authenticate nightly GHCR polling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,9 +123,9 @@ env:
   RELEASE_HELM_REGISTRY: nvcr.io/0921617854601259/nemo-platform
   RELEASE_NIGHTLY_WHEEL_INDEX: https://pypi.nvidia.com
   RELEASE_STABLE_WHEEL_INDEX: https://pypi.org/simple
+  # Nightly GHCR readiness checks authenticate with the repository GITHUB_TOKEN.
   RELEASE_NIGHTLY_CONTAINER_REGISTRY: ghcr.io/nvidia-nemo/nemo-platform
   RELEASE_STABLE_CONTAINER_REGISTRY: nvcr.io/nvidia/nemo-platform
-  # Make this package public in GitHub Packages after its first push.
   RELEASE_NIGHTLY_HELM_OCI_REGISTRY: oci://ghcr.io/nvidia-nemo/nemo-platform
   # Stable charts must be promoted from RELEASE_HELM_REGISTRY before polling.
   RELEASE_STABLE_HELM_REPOSITORY: https://helm.ngc.nvidia.com/nvidia/nemo-platform
@@ -801,6 +801,7 @@ jobs:
     timeout-minutes: 240
     permissions:
       contents: read
+      packages: read
     env:
       POLL_INTERVAL_SECONDS: "30"
     steps:
@@ -848,8 +849,8 @@ jobs:
             echo "Found ${package}==${WHEEL_VERSION}"
           done < <(jq -r '.[]' <<< "${WHEEL_IDS}")
 
-      # Both final container registries are public, so this check deliberately
-      # uses docker manifest inspect without credentials.
+      # Stable containers are public. Nightly GHCR containers require the
+      # repository GITHUB_TOKEN.
       - name: Wait for selected containers in the final registry
         if: >-
           needs.plan-release.outputs.has_containers == 'true' &&
@@ -858,12 +859,19 @@ jobs:
         env:
           CONTAINER_IDS: ${{ needs.plan-release.outputs.container_ids }}
           CONTAINER_TAG: ${{ needs.plan-release.outputs.release_label }}
+          GHCR_TOKEN: ${{ github.token }}
+          RELEASE_TYPE: ${{ needs.plan-release.outputs.release_type }}
           CONTAINER_REGISTRY: >-
             ${{ needs.plan-release.outputs.release_type == 'nightly' &&
             env.RELEASE_NIGHTLY_CONTAINER_REGISTRY ||
             env.RELEASE_STABLE_CONTAINER_REGISTRY }}
         run: |
           set -euo pipefail
+
+          if [[ "${RELEASE_TYPE}" == "nightly" ]]; then
+            printf '%s' "${GHCR_TOKEN}" | docker login ghcr.io \
+              --username "${GITHUB_ACTOR}" --password-stdin
+          fi
 
           while IFS= read -r container_id; do
             ref="${CONTAINER_REGISTRY}/${container_id}:${CONTAINER_TAG}"
@@ -874,8 +882,8 @@ jobs:
             echo "Found ${ref}"
           done < <(jq -r '.[]' <<< "${CONTAINER_IDS}")
 
-      # Both final Helm chart locations are public, so this check deliberately
-      # uses Helm without registry credentials.
+      # The stable Helm repository is public. Nightly GHCR charts require the
+      # repository GITHUB_TOKEN.
       - name: Wait for Helm chart in the final registry
         if: >-
           needs.plan-release.outputs.include_helm == 'true' &&
@@ -885,12 +893,15 @@ jobs:
           RELEASE_TYPE: ${{ needs.plan-release.outputs.release_type }}
           CHART_ID: ${{ env.RELEASE_HELM_ID }}
           CHART_VERSION: ${{ needs.stage-helm.outputs.chart_version }}
+          GHCR_TOKEN: ${{ github.token }}
           NIGHTLY_HELM_OCI_REGISTRY: ${{ env.RELEASE_NIGHTLY_HELM_OCI_REGISTRY }}
           STABLE_HELM_REPOSITORY: ${{ env.RELEASE_STABLE_HELM_REPOSITORY }}
         run: |
           set -euo pipefail
 
           if [[ "${RELEASE_TYPE}" == "nightly" ]]; then
+            printf '%s' "${GHCR_TOKEN}" | helm registry login ghcr.io \
+              --username "${GITHUB_ACTOR}" --password-stdin
             chart_ref="${NIGHTLY_HELM_OCI_REGISTRY}/${CHART_ID}"
             chart_is_available() {
               helm show chart "${chart_ref}" --version "${CHART_VERSION}" >/dev/null 2>&1


### PR DESCRIPTION
The nightly release run successfully pushed wheels, containers, and the Helm chart, but final artifact polling never got past the first GHCR container. The poll was anonymous because nightly GHCR artifacts were expected to be public; these packages are currently private, so `docker manifest inspect` received `denied` and retried as though the artifact had not arrived.

This PR gives only the final polling job `packages: read` and authenticates Docker and Helm with the repository's built-in `GITHUB_TOKEN` for nightly runs. Stable container and Helm polling remains anonymous, and no PAT or new secret is introduced.

## Human attention needed

- **Decision:** accept authenticated GHCR availability as the nightly readiness contract while public access is tracked separately in [AIREINF-269](https://linear.app/nvidia/issue/AIREINF-269/request-that-we-can-make-our-pre-release-containers-public)
- **Read carefully:** the job-level package permission and the two nightly-only registry logins
- **Safe to skim:** comment updates describing nightly versus stable access
- **Proof:** `actionlint`, `act workflow_dispatch --list`, and `git diff --check` pass locally; the [failed nightly poll](https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/29298618095/job/86977532472) reproduced the anonymous `denied` response after the container build had pushed successfully
- **Biggest risk:** each private container package must grant the `nemo-platform` repository Actions read access; a fresh nightly is still required to prove that package-side configuration end to end

## Rollout

Merge this change, then start a fresh nightly from `main`. Rerunning the existing workflow would reuse its original workflow revision and would not exercise this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly release readiness checks by authenticating access to container images and Helm charts.
  * Added the required package-read permissions for nightly artifact validation.
  * Preserved existing behavior for stable release checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->