### PR TITLE
feat(studio): Reintroduce Customization creation form

### DIFF
--- a/web/packages/sdk/vendored/customizer/api.ts
+++ b/web/packages/sdk/vendored/customizer/api.ts
@@ -18,7 +18,12 @@ import { customFetch } from '../../generated/fetchers/platform';
 import type { ErrorType } from '../../generated/fetchers/platform';
 import type { HTTPValidationError } from '../../generated/platform/schema';
 
-import type { CustomizationBackend, CustomizationJob } from './schema';
+import type {
+  AutomodelJobInput,
+  CustomizationBackend,
+  CustomizationJob,
+  UnslothJobInput,
+} from './schema';
 
 interface CustomizationCancelJobVariables {
   workspace: string;
@@ -76,6 +81,82 @@ export type CustomizationCancelJobMutationResult = NonNullable<
 >;
 
 export type CustomizationCancelJobMutationError = ErrorType<HTTPValidationError>;
+
+// ----- Create: automodel -----
+
+interface CustomizationCreateAutomodelJobVariables {
+  workspace: string;
+  data: AutomodelJobInput;
+}
+
+export const customizationCreateAutomodelJob = (
+  { workspace, data }: CustomizationCreateAutomodelJobVariables,
+  signal?: AbortSignal
+) => {
+  return customFetch<CustomizationJob>({
+    url: `/apis/customization/v2/workspaces/${encodeURIComponent(String(workspace))}/automodel/jobs`,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    data,
+    signal,
+  });
+};
+
+export const useCustomizationCreateAutomodelJob = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof customizationCreateAutomodelJob>>,
+    TError,
+    CustomizationCreateAutomodelJobVariables,
+    TContext
+  >;
+}) => {
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof customizationCreateAutomodelJob>>,
+    CustomizationCreateAutomodelJobVariables
+  > = (props) => customizationCreateAutomodelJob(props);
+  return useMutation({ mutationFn, ...options?.mutation });
+};
+
+// ----- Create: unsloth -----
+
+interface CustomizationCreateUnslothJobVariables {
+  workspace: string;
+  data: UnslothJobInput;
+}
+
+export const customizationCreateUnslothJob = (
+  { workspace, data }: CustomizationCreateUnslothJobVariables,
+  signal?: AbortSignal
+) => {
+  return customFetch<CustomizationJob>({
+    url: `/apis/customization/v2/workspaces/${encodeURIComponent(String(workspace))}/unsloth/jobs`,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    data,
+    signal,
+  });
+};
+
+export const useCustomizationCreateUnslothJob = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof customizationCreateUnslothJob>>,
+    TError,
+    CustomizationCreateUnslothJobVariables,
+    TContext
+  >;
+}) => {
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof customizationCreateUnslothJob>>,
+    CustomizationCreateUnslothJobVariables
+  > = (props) => customizationCreateUnslothJob(props);
+  return useMutation({ mutationFn, ...options?.mutation });
+};
 
 /**
  * @summary Cancel Job

--- a/web/packages/sdk/vendored/customizer/schema.ts
+++ b/web/packages/sdk/vendored/customizer/schema.ts
@@ -116,7 +116,15 @@ export interface AutomodelLoRAParams {
   dropout: number;
   merge: boolean;
   target_modules?: string[];
+  /** Module name patterns to exclude from LoRA (e.g. ['*.out_proj']). */
+  exclude_modules?: string[];
+  /** Use the optimized Triton LoRA kernel. Backend defaults to true. */
+  use_triton?: boolean;
 }
+
+export type AutomodelAttnImplementation = 'sdpa' | 'flash_attention_2' | 'eager';
+export type AutomodelOptimizerAlgo = 'Adam' | 'AdamW';
+export type AutomodelLrDecayStyle = 'cosine' | 'linear' | 'constant';
 
 export interface AutomodelDatasetSpec {
   /** Training fileset as 'name' or 'workspace/name'. */
@@ -130,6 +138,8 @@ export interface AutomodelTrainingSpec {
   finetuning_type: AutomodelFinetuningType;
   lora?: AutomodelLoRAParams;
   max_seq_length: number;
+  /** Attention kernel implementation. Backend defaults to 'sdpa'. */
+  attn_implementation?: AutomodelAttnImplementation;
   /** Model precision for training. Auto-detected from the checkpoint when unset. */
   precision?: Precision;
   execution_profile?: string;
@@ -152,6 +162,8 @@ export interface AutomodelBatchSpec {
   global_batch_size: number;
   micro_batch_size: number;
   sequence_packing: boolean;
+  /** Max samples sampled to estimate packing. Backend defaults to 1000. */
+  sequence_packing_max_samples?: number;
 }
 
 export interface AutomodelOptimizerSpec {
@@ -161,6 +173,12 @@ export interface AutomodelOptimizerSpec {
   adam_beta1: number;
   adam_beta2: number;
   warmup_steps: number;
+  /** Adam/AdamW epsilon. Backend defaults to 1e-8. */
+  adam_eps?: number;
+  /** Optimizer algorithm. Backend defaults to 'Adam'. */
+  optimizer?: AutomodelOptimizerAlgo;
+  /** Learning-rate decay schedule. Backend defaults to 'cosine'. */
+  lr_decay_style?: AutomodelLrDecayStyle;
 }
 
 /** Distributed training parallelism configuration (automodel). */
@@ -222,7 +240,12 @@ export interface ModelLoadSpec {
   dtype: UnslothModelDtype;
   trust_remote_code: boolean;
   device_map?: ModelLoadSpecDeviceMap;
+  /** RoPE scaling config passed through to the HF model loader. */
+  rope_scaling?: { [key: string]: unknown } | null;
 }
+
+/** LoRA weight-initialization scheme (unsloth/PEFT). `true` = PEFT default. */
+export type UnslothInitLoraWeights = boolean | 'gaussian' | 'pissa' | 'olora' | 'loftq';
 
 /** LoRA adapter configuration (unsloth). */
 export interface UnslothLoRAParams {
@@ -233,6 +256,18 @@ export interface UnslothLoRAParams {
   bias: UnslothLoRABias;
   use_rslora: boolean;
   random_state: number;
+  /** Use DoRA (weight-decomposed LoRA). Backend defaults to false. */
+  use_dora?: boolean;
+  /** LoftQ quantization config for LoRA init. */
+  loftq_config?: { [key: string]: unknown } | null;
+  /** Extra modules to train and save fully (beyond the adapter). */
+  modules_to_save?: string[] | null;
+  /** Restrict LoRA to specific transformer layer indices. */
+  layers_to_transform?: number | number[] | null;
+  /** Layer-replication ranges for depth up-scaling. */
+  layer_replication?: number[][] | null;
+  /** LoRA weight init scheme. Backend defaults to true (PEFT default). */
+  init_lora_weights?: UnslothInitLoraWeights;
 }
 
 export interface UnslothDatasetSpec {
@@ -261,6 +296,8 @@ export interface UnslothScheduleSpec {
   save_steps?: number;
   eval_steps?: number;
   seed: number;
+  /** Extra kwargs forwarded to the LR scheduler. */
+  lr_scheduler_kwargs?: { [key: string]: unknown } | null;
 }
 
 export interface UnslothBatchSpec {
@@ -272,6 +309,18 @@ export interface UnslothOptimizerSpec {
   learning_rate: number;
   weight_decay: number;
   optim: UnslothOptim;
+  /** Adam/AdamW beta1. Backend defaults to 0.9. */
+  adam_beta1?: number;
+  /** Adam/AdamW beta2. Backend defaults to 0.999. */
+  adam_beta2?: number;
+  /** Adam/AdamW epsilon. Backend defaults to 1e-8. */
+  adam_epsilon?: number;
+  /** Gradient-clipping max norm. Backend defaults to 1.0. */
+  max_grad_norm?: number;
+  /** Label smoothing for cross-entropy. Backend defaults to 0.0 (disabled). */
+  label_smoothing_factor?: number;
+  /** NEFTune embedding-noise alpha. null disables. */
+  neftune_noise_alpha?: number | null;
 }
 
 /** Single-node hardware configuration (unsloth). */
@@ -299,6 +348,52 @@ export interface UnslothJobSpec {
   integrations?: IntegrationsSpec;
   output: UnslothOutputResponse;
   deployment_config?: string | DeploymentParams;
+}
+
+// ===================================================================================
+// Create-request input types (not yet generated; inlined alongside the response types)
+// ===================================================================================
+
+/** Output artifact request used in create-job bodies. */
+export interface OutputRequest {
+  name?: string;
+  description?: string;
+}
+
+/** Automodel create-job request body (wrapped in the platform job envelope). */
+export interface AutomodelJobInput {
+  name?: string;
+  description?: string;
+  spec: {
+    model: string;
+    dataset: AutomodelDatasetSpec;
+    training: Omit<AutomodelTrainingSpec, 'execution_profile'> & { execution_profile?: string };
+    schedule?: Partial<AutomodelScheduleSpec>;
+    batch?: Partial<AutomodelBatchSpec>;
+    optimizer?: Partial<AutomodelOptimizerSpec>;
+    parallelism?: Partial<ParallelismSpec>;
+    // Automodel requires `name` whenever an output object is present.
+    output?: OutputRequest & { name: string };
+    integrations?: IntegrationsSpec;
+  };
+}
+
+/** Unsloth create-job request body (wrapped in the platform job envelope). */
+export interface UnslothJobInput {
+  name?: string;
+  description?: string;
+  spec: {
+    model: Omit<ModelLoadSpec, 'device_map'> & { device_map?: ModelLoadSpecDeviceMap };
+    dataset: UnslothDatasetSpec;
+    training?: Omit<UnslothTrainingSpec, 'training_type'> & { training_type?: 'sft' };
+    schedule?: Partial<UnslothScheduleSpec>;
+    batch?: Partial<UnslothBatchSpec>;
+    optimizer?: Partial<UnslothOptimizerSpec>;
+    hardware?: Partial<HardwareSpec>;
+    output?: OutputRequest & { save_method?: UnslothSaveMethod };
+    integrations?: IntegrationsSpec;
+    deployment_config?: string | DeploymentParams;
+  };
 }
 
 // ===================================================================================

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -96,11 +96,6 @@ export const datasetFileContentQueryOptions = ({
       } else {
         const start = range ? range[0] : 0;
         const end = range ? range[1] : FILE_PREVIEW_MAX_BYTES - 1;
-        // A size-capped preview (no explicit range, file larger than the cap) is
-        // sliced at a raw byte boundary and almost always ends mid-line. Trim
-        // back to the last newline so callers only ever see complete lines —
-        // otherwise a truncated trailing fragment reads as invalid JSON/JSONL
-        // (e.g., the customizer dataset format check) or renders a partial row.
         const isSizeCappedPreview =
           range === undefined && fileSize !== null && fileSize > FILE_PREVIEW_MAX_BYTES;
         const needsRange = range !== undefined || isSizeCappedPreview;

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -96,15 +96,26 @@ export const datasetFileContentQueryOptions = ({
       } else {
         const start = range ? range[0] : 0;
         const end = range ? range[1] : FILE_PREVIEW_MAX_BYTES - 1;
-        const needsRange =
-          range !== undefined || (fileSize !== null && fileSize > FILE_PREVIEW_MAX_BYTES);
+        // A size-capped preview (no explicit range, file larger than the cap) is
+        // sliced at a raw byte boundary and almost always ends mid-line. Trim
+        // back to the last newline so callers only ever see complete lines —
+        // otherwise a truncated trailing fragment reads as invalid JSON/JSONL
+        // (e.g., the customizer dataset format check) or renders a partial row.
+        const isSizeCappedPreview =
+          range === undefined && fileSize !== null && fileSize > FILE_PREVIEW_MAX_BYTES;
+        const needsRange = range !== undefined || isSizeCappedPreview;
         const blob = await customFetch<Blob>({
           url: fileUrl,
           method: 'GET',
           responseType: 'blob',
           ...(needsRange ? { headers: { Range: `bytes=${start}-${end}` } } : {}),
         });
-        return blob.text();
+        const text = await blob.text();
+        if (isSizeCappedPreview) {
+          const lastNewline = text.lastIndexOf('\n');
+          return lastNewline >= 0 ? text.slice(0, lastNewline + 1) : text;
+        }
+        return text;
       }
     },
   });

--- a/web/packages/studio/src/components/CustomizeModelModal/index.test.tsx
+++ b/web/packages/studio/src/components/CustomizeModelModal/index.test.tsx
@@ -5,7 +5,7 @@ import { CustomizeModelModal } from '@studio/components/CustomizeModelModal';
 import { CUSTOMIZATION_METHODS } from '@studio/components/CustomizeModelModal/constants';
 import { ROUTES } from '@studio/constants/routes';
 import { workspace1 } from '@studio/mocks/entity-store/projects';
-import { getClaudeCodeChatRoute, getPromptTuningFormRoute } from '@studio/routes/utils';
+import { getNewCustomizationJobRoute, getPromptTuningFormRoute } from '@studio/routes/utils';
 import { LOCATION_DISPLAY_TEST_ID } from '@studio/tests/util/constants';
 import { LocationDisplay } from '@studio/tests/util/LocationDisplay';
 import { TestProviders } from '@studio/tests/util/TestProviders';
@@ -43,7 +43,7 @@ const renderModal = ({
           />
         ),
       },
-      { path: getClaudeCodeChatRoute(workspace1.workspace), element: <LocationDisplay /> },
+      { path: getNewCustomizationJobRoute(workspace1.workspace), element: <LocationDisplay /> },
       { path: getPromptTuningFormRoute(workspace1.workspace), element: <LocationDisplay /> },
     ],
     {
@@ -98,12 +98,12 @@ describe('CustomizeModelModal', () => {
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
-  it('navigates to the Code Agent when fine-tuned is selected and Continue is clicked', async () => {
+  it('navigates to the new customization form when fine-tuned is selected and Continue is clicked', async () => {
     const user = userEvent.setup();
     renderModal();
     await user.click(screen.getByRole('button', { name: 'Continue' }));
     const location = (await screen.findByTestId(LOCATION_DISPLAY_TEST_ID)).textContent;
-    expect(location).toEqual(getClaudeCodeChatRoute(workspace1.workspace));
+    expect(location).toEqual(getNewCustomizationJobRoute(workspace1.workspace));
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 

--- a/web/packages/studio/src/components/CustomizeModelModal/index.tsx
+++ b/web/packages/studio/src/components/CustomizeModelModal/index.tsx
@@ -21,8 +21,7 @@ import {
   CUSTOMIZATION_METHODS,
   CustomizationMethod,
 } from '@studio/components/CustomizeModelModal/constants';
-import type { ClaudeCodeChatRouteState } from '@studio/routes/agents/ClaudeCodeChatRoute/types';
-import { getClaudeCodeChatRoute, getPromptTuningFormRoute } from '@studio/routes/utils';
+import { getNewCustomizationJobRoute, getPromptTuningFormRoute } from '@studio/routes/utils';
 import { FC, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -34,12 +33,6 @@ interface CustomizeModelModalProps {
   canPromptTune?: boolean;
   modelRef?: string;
 }
-
-/** Build the guided fine-tuning prompt the Code Agent starts from. */
-const buildFineTunePrompt = (modelRef?: string): string =>
-  `Use the nemo-customizer skill to fine-tune ${
-    modelRef ? `the base model \`${modelRef}\`` : 'a model'
-  }. Help me choose a dataset and training configuration, then launch and monitor the customization job.`;
 
 export const CustomizeModelModal: FC<CustomizeModelModalProps> = ({
   open,
@@ -61,9 +54,7 @@ export const CustomizeModelModal: FC<CustomizeModelModalProps> = ({
   const handleContinue = () => {
     onClose();
     if (selectedMethod === 'fine-tuned') {
-      // Fine-tuning is run through the Code Agent, seeded with a guided prompt.
-      const state: ClaudeCodeChatRouteState = { initialPrompt: buildFineTunePrompt(modelRef) };
-      navigate(getClaudeCodeChatRoute(workspace), { state });
+      navigate(getNewCustomizationJobRoute(workspace, { model: modelRef }));
       return;
     }
     navigate(getPromptTuningFormRoute(workspace, { model: modelRef }));

--- a/web/packages/studio/src/components/NewCustomizationForm/BackendSelectionSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/BackendSelectionSection.tsx
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RadioCard } from '@nemo/common/src/components/RadioCard';
+import { RadioGroupRoot, Stack, Text } from '@nvidia/foundations-react-core';
+import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { useFormContext } from 'react-hook-form';
+
+const BACKENDS = [
+  {
+    value: 'automodel' as const,
+    title: 'Automodel',
+    description:
+      'Multi-GPU distributed training. Supports SFT and knowledge distillation with LoRA or full-weight fine-tuning.',
+  },
+  {
+    value: 'unsloth' as const,
+    title: 'Unsloth',
+    description:
+      'Single-GPU, memory-efficient training via 4-bit quantization. Ideal for smaller hardware with fast iteration.',
+  },
+];
+
+export const BackendSelectionSection = () => {
+  const { watch, setValue, formState } = useFormContext<CustomizationFormFields>();
+  const backend = watch('backend');
+  const disabled = formState.isSubmitting;
+
+  return (
+    <FormSection title="Training Backend">
+      <RadioGroupRoot
+        name="backend"
+        value={backend}
+        onValueChange={(v) =>
+          setValue('backend', v as CustomizationFormFields['backend'], { shouldValidate: false })
+        }
+        className="w-full"
+        disabled={disabled}
+      >
+        <Stack gap="density-md">
+          {BACKENDS.map((b) => (
+            <RadioCard
+              key={b.value}
+              value={b.value}
+              label={<Text kind="body/bold/lg">{b.title}</Text>}
+              description={
+                <Text kind="body/regular/md" color="secondary">
+                  {b.description}
+                </Text>
+              }
+              labelSide="left"
+            />
+          ))}
+        </Stack>
+      </RadioGroupRoot>
+    </FormSection>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/ComputeResourcesSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ComputeResourcesSection.tsx
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledSliderWithTextInput } from '@nemo/common/src/components/form/ControlledSliderWithTextInput';
+import { ControlledSwitch } from '@nemo/common/src/components/form/ControlledSwitch';
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionRoot,
+  AccordionTrigger,
+  Stack,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
+import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { useFormContext } from 'react-hook-form';
+
+const AutomodelParallelism = ({ disabled }: { disabled: boolean }) => {
+  const { control } = useFormContext<CustomizationFormFields>();
+  return (
+    <Stack gap="density-lg">
+      <ControlledSliderWithTextInput
+        useControllerProps={{ name: 'automodel.parallelism.num_nodes', control }}
+        formFieldProps={{ slotLabel: 'Nodes' }}
+        defaultValue={1}
+        min={1}
+        max={16}
+        step={1}
+        disabled={disabled}
+      />
+      <ControlledSliderWithTextInput
+        useControllerProps={{ name: 'automodel.parallelism.num_gpus_per_node', control }}
+        formFieldProps={{ slotLabel: 'GPUs per Node' }}
+        defaultValue={1}
+        min={1}
+        max={8}
+        step={1}
+        disabled={disabled}
+      />
+      <AccordionRoot multiple>
+        <AccordionItem value="advanced-parallelism" className="border-b-0">
+          <AccordionTrigger>
+            <Text kind="label/bold/md">Advanced Parallelism</Text>
+          </AccordionTrigger>
+          <AccordionContent>
+            <Stack gap="density-md" className="pt-density-md">
+              <ControlledSliderWithTextInput
+                useControllerProps={{ name: 'automodel.parallelism.tensor_parallel_size', control }}
+                formFieldProps={{ slotLabel: 'Tensor Parallel Size' }}
+                defaultValue={1}
+                min={1}
+                max={8}
+                step={1}
+                disabled={disabled}
+              />
+              <ControlledSliderWithTextInput
+                useControllerProps={{
+                  name: 'automodel.parallelism.pipeline_parallel_size',
+                  control,
+                }}
+                formFieldProps={{ slotLabel: 'Pipeline Parallel Size' }}
+                defaultValue={1}
+                min={1}
+                max={8}
+                step={1}
+                disabled={disabled}
+              />
+              <ControlledSliderWithTextInput
+                useControllerProps={{
+                  name: 'automodel.parallelism.context_parallel_size',
+                  control,
+                }}
+                formFieldProps={{ slotLabel: 'Context Parallel Size' }}
+                defaultValue={1}
+                min={1}
+                max={8}
+                step={1}
+                disabled={disabled}
+              />
+              <ControlledSwitch
+                useControllerProps={{ name: 'automodel.parallelism.sequence_parallel', control }}
+                formFieldProps={{ slotLabel: 'Sequence Parallel', labelPosition: 'left' }}
+                disabled={disabled}
+              />
+            </Stack>
+          </AccordionContent>
+        </AccordionItem>
+      </AccordionRoot>
+    </Stack>
+  );
+};
+
+const UnslothHardware = ({ disabled }: { disabled: boolean }) => {
+  const { control } = useFormContext<CustomizationFormFields>();
+  return (
+    <Stack gap="density-lg">
+      <ControlledTextInput
+        useControllerProps={{ name: 'unsloth.hardware.gpus', control }}
+        label="GPU Indices"
+        placeholder="0  or  0,1"
+        disabled={disabled}
+      />
+      <ControlledJsonInput
+        useControllerProps={{ name: 'unsloth.deployment_config', control }}
+        formFieldProps={{ slotLabel: 'Deployment Config (name or JSON)' }}
+        placeholder='"my-config"  or  { "gpu": 1 }'
+        disabled={disabled}
+      />
+    </Stack>
+  );
+};
+
+export const ComputeResourcesSection = () => {
+  const { watch, formState } = useFormContext<CustomizationFormFields>();
+  const backend = watch('backend');
+  const disabled = formState.isSubmitting;
+
+  return (
+    <FormSection title="Compute Resources">
+      {backend === 'automodel' ? (
+        <AutomodelParallelism disabled={disabled} />
+      ) : (
+        <UnslothHardware disabled={disabled} />
+      )}
+    </FormSection>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/ControlledJsonInput.test.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ControlledJsonInput.test.tsx
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
+import { render, screen } from '@studio/tests/util/render';
+import userEvent from '@testing-library/user-event';
+import { FC } from 'react';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
+
+interface FormShape {
+  cfg?: unknown;
+}
+
+const Spy: FC = () => {
+  const value = useWatch<FormShape>({ name: 'cfg' });
+  return <div data-testid="value">{value === undefined ? 'UNDEFINED' : JSON.stringify(value)}</div>;
+};
+
+const Harness: FC = () => {
+  const methods = useForm<FormShape>({ defaultValues: { cfg: undefined } });
+  return (
+    <FormProvider {...methods}>
+      <ControlledJsonInput
+        useControllerProps={{ name: 'cfg', control: methods.control }}
+        formFieldProps={{ slotLabel: 'Config' }}
+      />
+      <Spy />
+    </FormProvider>
+  );
+};
+
+const typeInto = async (user: ReturnType<typeof userEvent.setup>, text: string) => {
+  const box = screen.getByRole('textbox', { name: /config/i });
+  await user.clear(box);
+  await user.type(box, text);
+  return box;
+};
+
+describe('ControlledJsonInput', () => {
+  it('writes parsed JSON objects to the field', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    // `[` and `{` are special chars for user.type; escape by wrapping in braces.
+    await typeInto(user, '{{ "a": 1 }');
+    expect(screen.getByTestId('value')).toHaveTextContent('{"a":1}');
+  });
+
+  it('parses a bare JSON string (for str-or-object fields like deployment_config)', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await typeInto(user, '"my-config"');
+    expect(screen.getByTestId('value')).toHaveTextContent('my-config');
+  });
+
+  it('clears the field to undefined when emptied', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await typeInto(user, '"x"');
+    expect(screen.getByTestId('value')).toHaveTextContent('x');
+    await user.clear(screen.getByRole('textbox', { name: /config/i }));
+    expect(screen.getByTestId('value')).toHaveTextContent('UNDEFINED');
+  });
+
+  it('shows an error and does not update the field on invalid JSON', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await typeInto(user, '{{ not json');
+    expect(screen.getByText('Invalid JSON')).toBeInTheDocument();
+    expect(screen.getByTestId('value')).toHaveTextContent('UNDEFINED');
+  });
+});

--- a/web/packages/studio/src/components/NewCustomizationForm/ControlledJsonInput.test.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ControlledJsonInput.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
-import { render, screen } from '@studio/tests/util/render';
+import { act, render, screen, waitFor } from '@studio/tests/util/render';
 import userEvent from '@testing-library/user-event';
 import { FC } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
@@ -16,8 +16,9 @@ const Spy: FC = () => {
   return <div data-testid="value">{value === undefined ? 'UNDEFINED' : JSON.stringify(value)}</div>;
 };
 
-const Harness: FC = () => {
+const Harness: FC<{ onReady?: (setValue: (v: unknown) => void) => void }> = ({ onReady }) => {
   const methods = useForm<FormShape>({ defaultValues: { cfg: undefined } });
+  onReady?.((v) => methods.setValue('cfg', v));
   return (
     <FormProvider {...methods}>
       <ControlledJsonInput
@@ -67,5 +68,19 @@ describe('ControlledJsonInput', () => {
     await typeInto(user, '{{ not json');
     expect(screen.getByText('Invalid JSON')).toBeInTheDocument();
     expect(screen.getByTestId('value')).toHaveTextContent('UNDEFINED');
+  });
+
+  it('resyncs the text box when the field is changed externally', async () => {
+    let setValue: (v: unknown) => void = () => {};
+    render(<Harness onReady={(fn) => (setValue = fn)} />);
+
+    // The box starts empty; an external setValue must be reflected in the text.
+    await act(async () => setValue({ b: 2 }));
+    const box = screen.getByRole('textbox', { name: /config/i });
+    await waitFor(() => expect(box).toHaveValue(JSON.stringify({ b: 2 }, null, 2)));
+
+    // Clearing the field externally empties the box.
+    await act(async () => setValue(undefined));
+    await waitFor(() => expect(box).toHaveValue(''));
   });
 });

--- a/web/packages/studio/src/components/NewCustomizationForm/ControlledJsonInput.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ControlledJsonInput.tsx
@@ -3,7 +3,7 @@
 
 import type { UseControllerComponentProps } from '@nemo/common/src/types';
 import { FormField, TextArea } from '@nvidia/foundations-react-core';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useController } from 'react-hook-form';
 
 interface Props extends UseControllerComponentProps {
@@ -34,6 +34,31 @@ export const ControlledJsonInput = ({
     value == null ? '' : JSON.stringify(value, null, 2)
   );
   const [parseError, setParseError] = useState<string>();
+
+  // Re-sync the local text when `value` changes from OUTSIDE this input (e.g. a
+  // form reset or an external setValue). We keep the box untouched when its text
+  // already represents `value` (idle, or our own edit whose onChange set it) or
+  // is a mid-edit invalid fragment — so typing and cursor position are never
+  // disturbed.
+  const textRef = useRef(text);
+  textRef.current = text;
+  useEffect(() => {
+    const trimmed = textRef.current.trim();
+    if (!trimmed) {
+      if (value != null) setText(JSON.stringify(value, null, 2));
+      return;
+    }
+    let current: unknown;
+    try {
+      current = JSON.parse(trimmed);
+    } catch {
+      return; // invalid mid-edit text — don't clobber it
+    }
+    if (JSON.stringify(current) !== JSON.stringify(value)) {
+      setText(value == null ? '' : JSON.stringify(value, null, 2));
+      setParseError(undefined);
+    }
+  }, [value]);
 
   const handleChange = (next: string) => {
     setText(next);

--- a/web/packages/studio/src/components/NewCustomizationForm/ControlledJsonInput.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ControlledJsonInput.tsx
@@ -12,13 +12,6 @@ interface Props extends UseControllerComponentProps {
   disabled?: boolean;
 }
 
-/**
- * Raw-JSON editor bound to a form field. Parses on change: valid JSON is written
- * to the field (as the parsed value — object, array, string, etc.), an empty box
- * clears it to `undefined`, and invalid JSON shows an inline error without
- * corrupting the stored value. Used for the customizer's free-form / nested
- * config fields (rope_scaling, loftq_config, layer_replication, …).
- */
 export const ControlledJsonInput = ({
   useControllerProps,
   formFieldProps,
@@ -35,11 +28,6 @@ export const ControlledJsonInput = ({
   );
   const [parseError, setParseError] = useState<string>();
 
-  // Re-sync the local text when `value` changes from OUTSIDE this input (e.g. a
-  // form reset or an external setValue). We keep the box untouched when its text
-  // already represents `value` (idle, or our own edit whose onChange set it) or
-  // is a mid-edit invalid fragment — so typing and cursor position are never
-  // disturbed.
   const textRef = useRef(text);
   textRef.current = text;
   useEffect(() => {

--- a/web/packages/studio/src/components/NewCustomizationForm/ControlledJsonInput.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ControlledJsonInput.tsx
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { UseControllerComponentProps } from '@nemo/common/src/types';
+import { FormField, TextArea } from '@nvidia/foundations-react-core';
+import { useState } from 'react';
+import { useController } from 'react-hook-form';
+
+interface Props extends UseControllerComponentProps {
+  label?: string;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Raw-JSON editor bound to a form field. Parses on change: valid JSON is written
+ * to the field (as the parsed value — object, array, string, etc.), an empty box
+ * clears it to `undefined`, and invalid JSON shows an inline error without
+ * corrupting the stored value. Used for the customizer's free-form / nested
+ * config fields (rope_scaling, loftq_config, layer_replication, …).
+ */
+export const ControlledJsonInput = ({
+  useControllerProps,
+  formFieldProps,
+  label,
+  placeholder,
+  disabled,
+}: Props) => {
+  const {
+    field: { value, onChange, onBlur, disabled: fieldDisabled },
+  } = useController(useControllerProps);
+
+  const [text, setText] = useState<string>(() =>
+    value == null ? '' : JSON.stringify(value, null, 2)
+  );
+  const [parseError, setParseError] = useState<string>();
+
+  const handleChange = (next: string) => {
+    setText(next);
+    const trimmed = next.trim();
+    if (!trimmed) {
+      setParseError(undefined);
+      onChange(undefined);
+      return;
+    }
+    try {
+      onChange(JSON.parse(trimmed));
+      setParseError(undefined);
+    } catch {
+      setParseError('Invalid JSON');
+    }
+  };
+
+  return (
+    <FormField
+      slotLabel={label}
+      slotError={parseError ?? ''}
+      status={parseError ? 'error' : undefined}
+      {...formFieldProps}
+    >
+      <TextArea
+        value={text}
+        onValueChange={handleChange}
+        onBlur={onBlur}
+        disabled={disabled || fieldDisabled}
+        placeholder={placeholder}
+      />
+    </FormField>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/FormSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/FormSection.tsx
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Stack, Text } from '@nvidia/foundations-react-core';
+import type { FC, ReactNode } from 'react';
+
+interface FormSectionProps {
+  title: string;
+  description?: ReactNode;
+  children: ReactNode;
+}
+
+export const FormSection: FC<FormSectionProps> = ({ title, description, children }) => (
+  <Stack gap="density-md">
+    <Stack gap="density-sm" className="pb-density-xl">
+      <Text kind="body/bold/lg">{title}</Text>
+      {description && <Text kind="body/regular/md">{description}</Text>}
+    </Stack>
+    {children}
+  </Stack>
+);

--- a/web/packages/studio/src/components/NewCustomizationForm/GeneralParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/GeneralParametersSection.tsx
@@ -1,0 +1,321 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
+import { ControlledSliderWithTextInput } from '@nemo/common/src/components/form/ControlledSliderWithTextInput';
+import { ControlledSwitch } from '@nemo/common/src/components/form/ControlledSwitch';
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionRoot,
+  AccordionTrigger,
+  Stack,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
+import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { useFormContext } from 'react-hook-form';
+
+export const GeneralParametersSection = () => {
+  const { control, watch, formState } = useFormContext<CustomizationFormFields>();
+  const backend = watch('backend');
+  const disabled = formState.isSubmitting;
+
+  if (backend === 'automodel') {
+    return (
+      <FormSection title="Training Parameters">
+        <Stack gap="density-lg">
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'automodel.schedule.epochs', control }}
+            formFieldProps={{ slotLabel: 'Epochs' }}
+            defaultValue={1}
+            min={1}
+            max={100}
+            step={1}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'automodel.optimizer.learning_rate', control }}
+            formFieldProps={{ slotLabel: 'Learning Rate' }}
+            defaultValue={5e-6}
+            min={1e-6}
+            max={1e-3}
+            step={1e-6}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'automodel.batch.global_batch_size', control }}
+            formFieldProps={{ slotLabel: 'Global Batch Size' }}
+            defaultValue={8}
+            min={1}
+            max={256}
+            step={1}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'automodel.training.max_seq_length', control }}
+            formFieldProps={{ slotLabel: 'Max Sequence Length' }}
+            defaultValue={2048}
+            min={128}
+            max={131072}
+            step={128}
+            disabled={disabled}
+          />
+          <ControlledSwitch
+            useControllerProps={{ name: 'automodel.batch.sequence_packing', control }}
+            formFieldProps={{ slotLabel: 'Sequence Packing', labelPosition: 'left' }}
+            disabled={disabled}
+          />
+          <AccordionRoot multiple>
+            <AccordionItem value="advanced" className="border-b-0">
+              <AccordionTrigger>
+                <Text kind="label/bold/md">Advanced</Text>
+              </AccordionTrigger>
+              <AccordionContent>
+                <Stack gap="density-md" className="pt-density-md">
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'automodel.batch.micro_batch_size', control }}
+                    formFieldProps={{ slotLabel: 'Micro Batch Size' }}
+                    defaultValue={1}
+                    min={1}
+                    max={64}
+                    step={1}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'automodel.optimizer.warmup_steps', control }}
+                    formFieldProps={{ slotLabel: 'Warmup Steps' }}
+                    defaultValue={0}
+                    min={0}
+                    max={1000}
+                    step={1}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'automodel.optimizer.weight_decay', control }}
+                    formFieldProps={{ slotLabel: 'Weight Decay' }}
+                    defaultValue={0.01}
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'automodel.optimizer.min_learning_rate', control }}
+                    formFieldProps={{ slotLabel: 'Min Learning Rate' }}
+                    defaultValue={0}
+                    min={0}
+                    max={1e-3}
+                    step={1e-6}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'automodel.optimizer.adam_eps', control }}
+                    formFieldProps={{ slotLabel: 'Adam Epsilon' }}
+                    defaultValue={1e-8}
+                    min={1e-10}
+                    max={1e-6}
+                    step={1e-10}
+                    disabled={disabled}
+                  />
+                  <ControlledSelect
+                    useControllerProps={{ name: 'automodel.optimizer.optimizer', control }}
+                    formFieldProps={{ slotLabel: 'Optimizer' }}
+                    items={[
+                      { value: 'Adam', children: 'Adam' },
+                      { value: 'AdamW', children: 'AdamW' },
+                    ]}
+                    disabled={disabled}
+                  />
+                  <ControlledSelect
+                    useControllerProps={{ name: 'automodel.optimizer.lr_decay_style', control }}
+                    formFieldProps={{ slotLabel: 'LR Decay Style' }}
+                    items={[
+                      { value: 'cosine', children: 'Cosine' },
+                      { value: 'linear', children: 'Linear' },
+                      { value: 'constant', children: 'Constant' },
+                    ]}
+                    disabled={disabled}
+                  />
+                  <ControlledSelect
+                    useControllerProps={{ name: 'automodel.training.attn_implementation', control }}
+                    formFieldProps={{ slotLabel: 'Attention Implementation' }}
+                    items={[
+                      { value: 'sdpa', children: 'SDPA' },
+                      { value: 'flash_attention_2', children: 'FlashAttention 2' },
+                      { value: 'eager', children: 'Eager' },
+                    ]}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{
+                      name: 'automodel.batch.sequence_packing_max_samples',
+                      control,
+                    }}
+                    formFieldProps={{ slotLabel: 'Sequence Packing Max Samples' }}
+                    defaultValue={1000}
+                    min={1}
+                    max={10000}
+                    step={1}
+                    disabled={disabled}
+                  />
+                </Stack>
+              </AccordionContent>
+            </AccordionItem>
+          </AccordionRoot>
+        </Stack>
+      </FormSection>
+    );
+  }
+
+  return (
+    <FormSection title="Training Parameters">
+      <Stack gap="density-lg">
+        <ControlledSliderWithTextInput
+          useControllerProps={{ name: 'unsloth.schedule.epochs', control }}
+          formFieldProps={{ slotLabel: 'Epochs' }}
+          defaultValue={1}
+          min={1}
+          max={100}
+          step={1}
+          disabled={disabled}
+        />
+        <ControlledSliderWithTextInput
+          useControllerProps={{ name: 'unsloth.optimizer.learning_rate', control }}
+          formFieldProps={{ slotLabel: 'Learning Rate' }}
+          defaultValue={2e-4}
+          min={1e-6}
+          max={1e-3}
+          step={1e-6}
+          disabled={disabled}
+        />
+        <ControlledSliderWithTextInput
+          useControllerProps={{ name: 'unsloth.batch.per_device_train_batch_size', control }}
+          formFieldProps={{ slotLabel: 'Per-Device Batch Size' }}
+          defaultValue={1}
+          min={1}
+          max={64}
+          step={1}
+          disabled={disabled}
+        />
+        <ControlledSliderWithTextInput
+          useControllerProps={{ name: 'unsloth.model.max_seq_length', control }}
+          formFieldProps={{ slotLabel: 'Max Sequence Length' }}
+          defaultValue={2048}
+          min={128}
+          max={131072}
+          step={128}
+          disabled={disabled}
+        />
+        <AccordionRoot multiple>
+          <AccordionItem value="advanced">
+            <AccordionTrigger>
+              <Text kind="label/bold/md">Advanced</Text>
+            </AccordionTrigger>
+            <AccordionContent>
+              <Stack gap="density-md" className="pt-density-md">
+                <ControlledSliderWithTextInput
+                  useControllerProps={{
+                    name: 'unsloth.batch.gradient_accumulation_steps',
+                    control,
+                  }}
+                  formFieldProps={{ slotLabel: 'Gradient Accumulation Steps' }}
+                  defaultValue={1}
+                  min={1}
+                  max={64}
+                  step={1}
+                  disabled={disabled}
+                />
+                <ControlledSliderWithTextInput
+                  useControllerProps={{ name: 'unsloth.schedule.warmup_steps', control }}
+                  formFieldProps={{ slotLabel: 'Warmup Steps' }}
+                  defaultValue={0}
+                  min={0}
+                  max={1000}
+                  step={1}
+                  disabled={disabled}
+                />
+                <ControlledSliderWithTextInput
+                  useControllerProps={{ name: 'unsloth.optimizer.weight_decay', control }}
+                  formFieldProps={{ slotLabel: 'Weight Decay' }}
+                  defaultValue={0}
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  disabled={disabled}
+                />
+                <ControlledSliderWithTextInput
+                  useControllerProps={{ name: 'unsloth.optimizer.adam_beta1', control }}
+                  formFieldProps={{ slotLabel: 'Adam Beta1' }}
+                  defaultValue={0.9}
+                  min={0}
+                  max={1}
+                  step={0.001}
+                  disabled={disabled}
+                />
+                <ControlledSliderWithTextInput
+                  useControllerProps={{ name: 'unsloth.optimizer.adam_beta2', control }}
+                  formFieldProps={{ slotLabel: 'Adam Beta2' }}
+                  defaultValue={0.999}
+                  min={0}
+                  max={1}
+                  step={0.001}
+                  disabled={disabled}
+                />
+                <ControlledSliderWithTextInput
+                  useControllerProps={{ name: 'unsloth.optimizer.adam_epsilon', control }}
+                  formFieldProps={{ slotLabel: 'Adam Epsilon' }}
+                  defaultValue={1e-8}
+                  min={1e-10}
+                  max={1e-6}
+                  step={1e-10}
+                  disabled={disabled}
+                />
+                <ControlledSliderWithTextInput
+                  useControllerProps={{ name: 'unsloth.optimizer.max_grad_norm', control }}
+                  formFieldProps={{ slotLabel: 'Max Gradient Norm' }}
+                  defaultValue={1}
+                  min={0}
+                  max={10}
+                  step={0.1}
+                  disabled={disabled}
+                />
+                <ControlledSliderWithTextInput
+                  useControllerProps={{ name: 'unsloth.optimizer.label_smoothing_factor', control }}
+                  formFieldProps={{ slotLabel: 'Label Smoothing Factor' }}
+                  defaultValue={0}
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  disabled={disabled}
+                />
+                <ControlledSliderWithTextInput
+                  useControllerProps={{ name: 'unsloth.optimizer.neftune_noise_alpha', control }}
+                  formFieldProps={{ slotLabel: 'NEFTune Noise Alpha' }}
+                  defaultValue={0}
+                  min={0}
+                  max={20}
+                  step={1}
+                  disabled={disabled}
+                />
+                <ControlledJsonInput
+                  useControllerProps={{ name: 'unsloth.schedule.lr_scheduler_kwargs', control }}
+                  formFieldProps={{ slotLabel: 'LR Scheduler Kwargs (JSON)' }}
+                  placeholder='{ "num_cycles": 1 }'
+                  disabled={disabled}
+                />
+                <ControlledJsonInput
+                  useControllerProps={{ name: 'unsloth.model.rope_scaling', control }}
+                  formFieldProps={{ slotLabel: 'RoPE Scaling (JSON)' }}
+                  placeholder='{ "type": "linear", "factor": 2.0 }'
+                  disabled={disabled}
+                />
+              </Stack>
+            </AccordionContent>
+          </AccordionItem>
+        </AccordionRoot>
+      </Stack>
+    </FormSection>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/LoraParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/LoraParametersSection.tsx
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledSliderWithTextInput } from '@nemo/common/src/components/form/ControlledSliderWithTextInput';
+import { ControlledSwitch } from '@nemo/common/src/components/form/ControlledSwitch';
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionRoot,
+  AccordionTrigger,
+  FormField,
+  SelectContent,
+  SelectItem,
+  SelectListbox,
+  SelectRoot,
+  SelectTrigger,
+  Stack,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
+import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { useFormContext } from 'react-hook-form';
+
+const INIT_LORA_WEIGHTS_OPTIONS = [
+  { label: 'Default (true)', value: 'true' },
+  { label: 'Off (false)', value: 'false' },
+  { label: 'Gaussian', value: 'gaussian' },
+  { label: 'PiSSA', value: 'pissa' },
+  { label: 'OLoRA', value: 'olora' },
+  { label: 'LoftQ', value: 'loftq' },
+];
+
+const RANK_VALUES = [1, 2, 4, 8, 16, 32, 64, 128, 256];
+
+const BIAS_OPTIONS = [
+  { label: 'None', value: 'none' },
+  { label: 'All', value: 'all' },
+  { label: 'LoRA Only', value: 'lora_only' },
+];
+
+export const LoraParametersSection = () => {
+  const { control, watch, setValue, formState } = useFormContext<CustomizationFormFields>();
+  const backend = watch('backend');
+  const disabled = formState.isSubmitting;
+
+  if (backend === 'automodel') {
+    const rank = watch('automodel.training.lora.rank') ?? 16;
+    return (
+      <FormSection title="LoRA Parameters">
+        <Stack gap="density-lg">
+          <FormField slotLabel="Rank">
+            {() => (
+              <SelectRoot
+                value={String(rank)}
+                onValueChange={(v: string) =>
+                  setValue('automodel.training.lora.rank', Number(v), { shouldValidate: true })
+                }
+                disabled={disabled}
+              >
+                <SelectTrigger placeholder="Select rank" aria-label="Rank" />
+                <SelectContent>
+                  <SelectListbox>
+                    {RANK_VALUES.map((v) => (
+                      <SelectItem key={v} value={String(v)}>
+                        {v}
+                      </SelectItem>
+                    ))}
+                  </SelectListbox>
+                </SelectContent>
+              </SelectRoot>
+            )}
+          </FormField>
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'automodel.training.lora.alpha', control }}
+            formFieldProps={{ slotLabel: 'Alpha' }}
+            defaultValue={32}
+            min={1}
+            max={512}
+            step={1}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'automodel.training.lora.dropout', control }}
+            formFieldProps={{ slotLabel: 'Dropout' }}
+            defaultValue={0}
+            min={0}
+            max={1}
+            step={0.01}
+            disabled={disabled}
+          />
+          <ControlledSwitch
+            useControllerProps={{ name: 'automodel.training.lora.merge', control }}
+            formFieldProps={{ slotLabel: 'Merge weights after training', labelPosition: 'left' }}
+            disabled={disabled}
+          />
+          <AccordionRoot multiple>
+            <AccordionItem value="advanced-lora" className="border-b-0">
+              <AccordionTrigger>
+                <Text kind="label/bold/md">Advanced</Text>
+              </AccordionTrigger>
+              <AccordionContent>
+                <Stack gap="density-md" className="pt-density-md">
+                  <ControlledSwitch
+                    useControllerProps={{ name: 'automodel.training.lora.use_triton', control }}
+                    formFieldProps={{ slotLabel: 'Use Triton kernel', labelPosition: 'left' }}
+                    disabled={disabled}
+                  />
+                  <ControlledJsonInput
+                    useControllerProps={{
+                      name: 'automodel.training.lora.exclude_modules',
+                      control,
+                    }}
+                    formFieldProps={{ slotLabel: 'Exclude Modules (JSON array)' }}
+                    placeholder='["*.out_proj"]'
+                    disabled={disabled}
+                  />
+                </Stack>
+              </AccordionContent>
+            </AccordionItem>
+          </AccordionRoot>
+        </Stack>
+      </FormSection>
+    );
+  }
+
+  const rank = watch('unsloth.training.lora.rank') ?? 16;
+  const bias = watch('unsloth.training.lora.bias') ?? 'none';
+  const initLoraWeights = watch('unsloth.training.lora.init_lora_weights') ?? true;
+
+  return (
+    <FormSection title="LoRA Parameters">
+      <Stack gap="density-lg">
+        <FormField slotLabel="Rank">
+          {() => (
+            <SelectRoot
+              value={String(rank)}
+              onValueChange={(v: string) =>
+                setValue('unsloth.training.lora.rank', Number(v), { shouldValidate: true })
+              }
+              disabled={disabled}
+            >
+              <SelectTrigger placeholder="Select rank" aria-label="Rank" />
+              <SelectContent>
+                <SelectListbox>
+                  {RANK_VALUES.map((v) => (
+                    <SelectItem key={v} value={String(v)}>
+                      {v}
+                    </SelectItem>
+                  ))}
+                </SelectListbox>
+              </SelectContent>
+            </SelectRoot>
+          )}
+        </FormField>
+        <ControlledSliderWithTextInput
+          useControllerProps={{ name: 'unsloth.training.lora.alpha', control }}
+          formFieldProps={{ slotLabel: 'Alpha' }}
+          defaultValue={16}
+          min={1}
+          max={512}
+          step={1}
+          disabled={disabled}
+        />
+        <ControlledSliderWithTextInput
+          useControllerProps={{ name: 'unsloth.training.lora.dropout', control }}
+          formFieldProps={{ slotLabel: 'Dropout' }}
+          defaultValue={0}
+          min={0}
+          max={1}
+          step={0.01}
+          disabled={disabled}
+        />
+        <AccordionRoot multiple>
+          <AccordionItem value="advanced-lora" className="border-b-0">
+            <AccordionTrigger>
+              <Text kind="label/bold/md">Advanced</Text>
+            </AccordionTrigger>
+            <AccordionContent>
+              <Stack gap="density-md" className="pt-density-md">
+                <FormField slotLabel="Bias">
+                  {() => (
+                    <SelectRoot
+                      value={bias}
+                      onValueChange={(v: string) =>
+                        setValue('unsloth.training.lora.bias', v as 'none' | 'all' | 'lora_only', {
+                          shouldValidate: true,
+                        })
+                      }
+                      disabled={disabled}
+                    >
+                      <SelectTrigger placeholder="Select bias" aria-label="Bias" />
+                      <SelectContent>
+                        <SelectListbox>
+                          {BIAS_OPTIONS.map((opt) => (
+                            <SelectItem key={opt.value} value={opt.value}>
+                              {opt.label}
+                            </SelectItem>
+                          ))}
+                        </SelectListbox>
+                      </SelectContent>
+                    </SelectRoot>
+                  )}
+                </FormField>
+                <ControlledSwitch
+                  useControllerProps={{ name: 'unsloth.training.lora.use_rslora', control }}
+                  formFieldProps={{
+                    slotLabel: 'Use rsLoRA (rank-stabilized)',
+                    labelPosition: 'left',
+                  }}
+                  disabled={disabled}
+                />
+                <ControlledSwitch
+                  useControllerProps={{ name: 'unsloth.training.lora.use_dora', control }}
+                  formFieldProps={{ slotLabel: 'Use DoRA', labelPosition: 'left' }}
+                  disabled={disabled}
+                />
+                <FormField slotLabel="Init LoRA Weights">
+                  {() => (
+                    <SelectRoot
+                      value={String(initLoraWeights)}
+                      onValueChange={(v: string) =>
+                        setValue(
+                          'unsloth.training.lora.init_lora_weights',
+                          v === 'true' ? true : v === 'false' ? false : (v as 'gaussian'),
+                          { shouldValidate: false }
+                        )
+                      }
+                      disabled={disabled}
+                    >
+                      <SelectTrigger
+                        placeholder="Select init scheme"
+                        aria-label="Init LoRA Weights"
+                      />
+                      <SelectContent>
+                        <SelectListbox>
+                          {INIT_LORA_WEIGHTS_OPTIONS.map((opt) => (
+                            <SelectItem key={opt.value} value={opt.value}>
+                              {opt.label}
+                            </SelectItem>
+                          ))}
+                        </SelectListbox>
+                      </SelectContent>
+                    </SelectRoot>
+                  )}
+                </FormField>
+                <ControlledJsonInput
+                  useControllerProps={{ name: 'unsloth.training.lora.modules_to_save', control }}
+                  formFieldProps={{ slotLabel: 'Modules to Save (JSON array)' }}
+                  placeholder='["lm_head", "embed_tokens"]'
+                  disabled={disabled}
+                />
+                <ControlledJsonInput
+                  useControllerProps={{ name: 'unsloth.training.lora.loftq_config', control }}
+                  formFieldProps={{ slotLabel: 'LoftQ Config (JSON)' }}
+                  placeholder='{ "loftq_bits": 4 }'
+                  disabled={disabled}
+                />
+                <ControlledJsonInput
+                  useControllerProps={{
+                    name: 'unsloth.training.lora.layers_to_transform',
+                    control,
+                  }}
+                  formFieldProps={{ slotLabel: 'Layers to Transform (JSON)' }}
+                  placeholder="[0, 1, 2] or 5"
+                  disabled={disabled}
+                />
+                <ControlledJsonInput
+                  useControllerProps={{ name: 'unsloth.training.lora.layer_replication', control }}
+                  formFieldProps={{ slotLabel: 'Layer Replication (JSON)' }}
+                  placeholder="[[0, 8], [4, 12]]"
+                  disabled={disabled}
+                />
+              </Stack>
+            </AccordionContent>
+          </AccordionItem>
+        </AccordionRoot>
+      </Stack>
+    </FormSection>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/ModelSelectionSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ModelSelectionSection.tsx
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useModelsFromWorkspace } from '@nemo/common/src/api/models/useModelsFromWorkspace';
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { ModelSelectV2 } from '@nemo/common/src/components/ModelSelectV2';
+import type { ModelSelection } from '@nemo/common/src/components/ModelSelectV2';
+import { FormField, Stack } from '@nvidia/foundations-react-core';
+import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { useController, useFormContext } from 'react-hook-form';
+
+export const ModelSelectionSection = () => {
+  const workspace = useWorkspaceFromPath();
+  const { control, watch, formState } = useFormContext<CustomizationFormFields>();
+  const backend = watch('backend');
+  const disabled = formState.isSubmitting;
+
+  const modelFieldName = backend === 'automodel' ? 'automodel.model' : 'unsloth.model.name';
+
+  const { field: modelField, fieldState: modelFieldState } = useController({
+    control,
+    name: modelFieldName,
+  });
+
+  const { groups, isFetching } = useModelsFromWorkspace({ workspace });
+
+  const selectedValue: ModelSelection | null = modelField.value
+    ? { model: modelField.value as string }
+    : null;
+
+  const handleModelChange = (selection: ModelSelection) => {
+    modelField.onChange(selection.model);
+  };
+
+  return (
+    <FormSection title="Model">
+      <Stack gap="density-md">
+        <FormField
+          slotLabel="Base Model"
+          required
+          status={modelFieldState.error ? 'error' : undefined}
+          slotError={modelFieldState.error?.message}
+        >
+          <ModelSelectV2
+            groups={groups}
+            loading={isFetching}
+            value={selectedValue}
+            onValueChange={handleModelChange}
+            disabled={disabled}
+            hideAdapters
+            fullWidth
+          />
+        </FormField>
+        <ControlledTextInput
+          useControllerProps={{ name: 'outputName', control }}
+          label="Output Model Name"
+          required
+          disabled={disabled}
+        />
+        <ControlledTextInput
+          useControllerProps={{ name: 'description', control }}
+          label="Description"
+          disabled={disabled}
+        />
+      </Stack>
+    </FormSection>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/ModelSelectionSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ModelSelectionSection.tsx
@@ -3,8 +3,7 @@
 
 import { useModelsFromWorkspace } from '@nemo/common/src/api/models/useModelsFromWorkspace';
 import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
-import { ModelSelectV2 } from '@nemo/common/src/components/ModelSelectV2';
-import type { ModelSelection } from '@nemo/common/src/components/ModelSelectV2';
+import { ModelSelectV2, type ModelSelection } from '@nemo/common/src/components/ModelSelectV2';
 import { FormField, Stack } from '@nvidia/foundations-react-core';
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';

--- a/web/packages/studio/src/components/NewCustomizationForm/TrainingMethodSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/TrainingMethodSection.tsx
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { RadioCard } from '@nemo/common/src/components/RadioCard';
+import { RadioGroupRoot, Stack, Text } from '@nvidia/foundations-react-core';
+import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { useFormContext } from 'react-hook-form';
+
+const AUTOMODEL_FINETUNING_TYPES = [
+  { value: 'lora', title: 'LoRA', description: 'Low-rank adapter — fewer parameters, less VRAM.' },
+  {
+    value: 'lora_merged',
+    title: 'LoRA (Merged)',
+    description: 'LoRA weights merged into base at the end.',
+  },
+  { value: 'all_weights', title: 'Full Weights', description: 'Train all model parameters.' },
+] as const;
+
+const UNSLOTH_FINETUNING_TYPES = [
+  { value: 'lora', title: 'LoRA', description: 'Low-rank adapter — fewer parameters, less VRAM.' },
+  { value: 'all_weights', title: 'Full Weights', description: 'Train all model parameters.' },
+] as const;
+
+const AUTOMODEL_TRAINING_TYPES = [
+  {
+    value: 'sft',
+    title: 'SFT',
+    description: 'Supervised fine-tuning on instruction/response pairs.',
+  },
+  {
+    value: 'distillation',
+    title: 'Distillation',
+    description: 'Learn from a larger teacher model.',
+  },
+] as const;
+
+export const TrainingMethodSection = () => {
+  const { watch, setValue, control, formState } = useFormContext<CustomizationFormFields>();
+  const backend = watch('backend');
+  const disabled = formState.isSubmitting;
+
+  const finetuningType =
+    backend === 'automodel'
+      ? watch('automodel.training.finetuning_type')
+      : watch('unsloth.training.finetuning_type');
+
+  const trainingType = backend === 'automodel' ? watch('automodel.training.training_type') : null;
+
+  const finetuningOptions =
+    backend === 'automodel' ? AUTOMODEL_FINETUNING_TYPES : UNSLOTH_FINETUNING_TYPES;
+
+  const handleFinetuningChange = (value: string) => {
+    if (backend === 'automodel') {
+      setValue(
+        'automodel.training.finetuning_type',
+        value as CustomizationFormFields['automodel']['training']['finetuning_type'],
+        { shouldValidate: true }
+      );
+    } else {
+      setValue('unsloth.training.finetuning_type', value as 'lora' | 'all_weights', {
+        shouldValidate: true,
+      });
+    }
+  };
+
+  return (
+    <FormSection title="Training Method">
+      <Stack gap="density-xl">
+        <Stack gap="density-md">
+          <Text kind="label/bold/md">Fine-tuning Type</Text>
+          <RadioGroupRoot
+            name="finetuningType"
+            value={finetuningType ?? ''}
+            onValueChange={handleFinetuningChange}
+            className="w-full"
+            disabled={disabled}
+          >
+            <Stack gap="density-sm">
+              {finetuningOptions.map((opt) => (
+                <RadioCard
+                  key={opt.value}
+                  value={opt.value}
+                  label={<Text kind="body/bold/md">{opt.title}</Text>}
+                  description={
+                    <Text kind="body/regular/md" color="secondary">
+                      {opt.description}
+                    </Text>
+                  }
+                  labelSide="left"
+                />
+              ))}
+            </Stack>
+          </RadioGroupRoot>
+        </Stack>
+
+        {backend === 'automodel' && (
+          <Stack gap="density-md">
+            <Text kind="label/bold/md">Training Type</Text>
+            <RadioGroupRoot
+              name="trainingType"
+              value={trainingType ?? 'sft'}
+              onValueChange={(v) =>
+                setValue('automodel.training.training_type', v as 'sft' | 'distillation', {
+                  shouldValidate: true,
+                })
+              }
+              className="w-full"
+              disabled={disabled}
+            >
+              <Stack gap="density-sm">
+                {AUTOMODEL_TRAINING_TYPES.map((opt) => (
+                  <RadioCard
+                    key={opt.value}
+                    value={opt.value}
+                    label={<Text kind="body/bold/md">{opt.title}</Text>}
+                    description={
+                      <Text kind="body/regular/md" color="secondary">
+                        {opt.description}
+                      </Text>
+                    }
+                    labelSide="left"
+                  />
+                ))}
+              </Stack>
+            </RadioGroupRoot>
+            {trainingType === 'distillation' && (
+              <ControlledTextInput
+                useControllerProps={{ name: 'automodel.training.teacher_model', control }}
+                label="Teacher Model"
+                placeholder="workspace/model-name"
+                required
+                disabled={disabled}
+              />
+            )}
+          </Stack>
+        )}
+      </Stack>
+    </FormSection>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/index.test.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/index.test.tsx
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ROUTE_PARAMS } from '@studio/constants/routes';
+import {
+  CustomizationDatasetValidationResult,
+  useCustomizationDatasetValidation,
+} from '@studio/hooks/useCustomizationDatasetValidation';
+import { mockUseParams } from '@studio/tests/util/mockUseParams';
+import { renderRoute, screen, waitFor } from '@studio/tests/util/render';
+import userEvent from '@testing-library/user-event';
+
+const mutateAutomodel = vi.fn();
+const mutateUnsloth = vi.fn();
+
+vi.mock('@nemo/sdk/vendored/customizer/api', () => ({
+  useCustomizationCreateAutomodelJob: () => ({ mutateAsync: mutateAutomodel, isPending: false }),
+  useCustomizationCreateUnslothJob: () => ({ mutateAsync: mutateUnsloth, isPending: false }),
+}));
+
+vi.mock('@studio/hooks/useCustomizationDatasetValidation', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@studio/hooks/useCustomizationDatasetValidation')>();
+  return { ...actual, useCustomizationDatasetValidation: vi.fn() };
+});
+
+const emptyValidation: CustomizationDatasetValidationResult = {
+  isPending: false,
+  discoveryError: null,
+  format: { ok: true, fileErrors: [] },
+  schema: null,
+  schemaExpectedCopy: '',
+  schemaMismatchedFiles: [],
+  schemaShape: '',
+  completeness: { ok: true, skipped: false, errors: [] },
+  encoding: { ok: true, fileErrors: [] },
+  hasTraining: false,
+  hasValidation: false,
+  autoSplitNotice: false,
+  training: [],
+  validation: [],
+  trainingRowCount: 0,
+  validationRowCount: 0,
+};
+
+// Imported after the mocks are registered.
+import { NewCustomizationForm } from '@studio/components/NewCustomizationForm';
+
+describe('NewCustomizationForm', () => {
+  beforeEach(() => {
+    mutateAutomodel.mockReset();
+    mutateUnsloth.mockReset();
+    mockUseParams({ [ROUTE_PARAMS.workspace]: 'default' });
+    vi.mocked(useCustomizationDatasetValidation).mockReturnValue(emptyValidation);
+  });
+
+  it('defaults to the automodel backend and shows its compute controls', async () => {
+    renderRoute(<NewCustomizationForm workspace="default" />);
+    // Automodel exposes multi-GPU parallelism ("GPUs per Node"), not raw indices.
+    expect(await screen.findByText('GPUs per Node')).toBeInTheDocument();
+    expect(screen.queryByText('GPU Indices')).not.toBeInTheDocument();
+  });
+
+  it('swaps to unsloth-specific controls when the unsloth backend is selected', async () => {
+    const user = userEvent.setup();
+    renderRoute(<NewCustomizationForm workspace="default" />);
+
+    await user.click(await screen.findByRole('radio', { name: /Unsloth/i }));
+
+    // Unsloth exposes single-node GPU indices; automodel parallelism disappears.
+    expect(await screen.findByText('GPU Indices')).toBeInTheDocument();
+    expect(screen.queryByText('GPUs per Node')).not.toBeInTheDocument();
+  });
+
+  it('shows the validation banner and does not submit when required fields are missing', async () => {
+    const user = userEvent.setup();
+    renderRoute(<NewCustomizationForm workspace="default" />);
+
+    await user.click(await screen.findByRole('button', { name: /Start Fine-Tuning/i }));
+
+    expect(await screen.findByText(/Please fix the following errors/i)).toBeInTheDocument();
+    expect(mutateAutomodel).not.toHaveBeenCalled();
+    expect(mutateUnsloth).not.toHaveBeenCalled();
+  });
+
+  it('does not block submit on the inactive backend (only the active one is validated)', async () => {
+    // Regression guard: switching to unsloth must not surface stale automodel errors.
+    const user = userEvent.setup();
+    renderRoute(<NewCustomizationForm workspace="default" />);
+
+    await user.click(await screen.findByRole('radio', { name: /Unsloth/i }));
+    await user.click(await screen.findByRole('button', { name: /Start Fine-Tuning/i }));
+
+    // The errors shown must be about the unsloth fields, never automodel ones.
+    const banner = await screen.findByText(/Please fix the following errors/i);
+    expect(banner.textContent).not.toMatch(/automodel/i);
+    await waitFor(() => expect(mutateAutomodel).not.toHaveBeenCalled());
+  });
+});

--- a/web/packages/studio/src/components/NewCustomizationForm/index.test.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/index.test.tsx
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// vi.mock calls below are hoisted by vitest, so this import still resolves the mocks.
+import { NewCustomizationForm } from '@studio/components/NewCustomizationForm';
 import { ROUTE_PARAMS } from '@studio/constants/routes';
 import {
   CustomizationDatasetValidationResult,
@@ -42,9 +44,6 @@ const emptyValidation: CustomizationDatasetValidationResult = {
   trainingRowCount: 0,
   validationRowCount: 0,
 };
-
-// Imported after the mocks are registered.
-import { NewCustomizationForm } from '@studio/components/NewCustomizationForm';
 
 describe('NewCustomizationForm', () => {
   beforeEach(() => {

--- a/web/packages/studio/src/components/NewCustomizationForm/index.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/index.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
 import {
   useCustomizationCreateAutomodelJob,
   useCustomizationCreateUnslothJob,
@@ -32,11 +32,10 @@ import {
   customizationFormSchema,
   formToAutomodelCreate,
   formToUnslothCreate,
+  type CustomizationFormFields,
 } from '@studio/util/forms/customization';
-import type { CustomizationFormFields } from '@studio/util/forms/customization';
 import { FC, useEffect, useMemo, useRef, useState } from 'react';
-import type { FieldErrors, Resolver } from 'react-hook-form';
-import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import { type FieldErrors, FormProvider, type Resolver, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
 interface NewCustomizationFormProps {
@@ -87,8 +86,7 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
     control: form.control,
     name: 'unsloth.training.finetuning_type',
   });
-  const finetuningType =
-    backend === 'automodel' ? automodelFinetuningType : unslothFinetuningType;
+  const finetuningType = backend === 'automodel' ? automodelFinetuningType : unslothFinetuningType;
   const isLora = finetuningType === 'lora' || finetuningType === 'lora_merged';
 
   const { mutateAsync: createAutomodel, isPending: isPendingAutomodel } =
@@ -104,17 +102,18 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
       },
     });
 
-  const { mutateAsync: createUnsloth, isPending: isPendingUnsloth } = useCustomizationCreateUnslothJob({
-    mutation: {
-      onSuccess: (job) => {
-        toast.success('Fine-tuning job started');
-        navigate(getWorkspaceCustomizationJobDetailsRoute(workspace, job.name));
+  const { mutateAsync: createUnsloth, isPending: isPendingUnsloth } =
+    useCustomizationCreateUnslothJob({
+      mutation: {
+        onSuccess: (job) => {
+          toast.success('Fine-tuning job started');
+          navigate(getWorkspaceCustomizationJobDetailsRoute(workspace, job.name));
+        },
+        onError: (error: Error) => {
+          toast.error(getErrorMessage(error, 'Failed to create fine-tuning job'));
+        },
       },
-      onError: (error: Error) => {
-        toast.error(getErrorMessage(error, 'Failed to create fine-tuning job'));
-      },
-    },
-  });
+    });
 
   const isPending = isPendingAutomodel || isPendingUnsloth;
 

--- a/web/packages/studio/src/components/NewCustomizationForm/index.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/index.tsx
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import {
+  useCustomizationCreateAutomodelJob,
+  useCustomizationCreateUnslothJob,
+} from '@nemo/sdk/vendored/customizer/api';
+import {
+  Banner,
+  Button,
+  Divider,
+  Flex,
+  PageHeader,
+  Panel,
+  Stack,
+} from '@nvidia/foundations-react-core';
+import { getErrorMessage } from '@studio/api/common/utils';
+import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { CustomizationFilesetSelect } from '@studio/components/customizer/CustomizationFilesetSelect';
+import { BackendSelectionSection } from '@studio/components/NewCustomizationForm/BackendSelectionSection';
+import { ComputeResourcesSection } from '@studio/components/NewCustomizationForm/ComputeResourcesSection';
+import { GeneralParametersSection } from '@studio/components/NewCustomizationForm/GeneralParametersSection';
+import { LoraParametersSection } from '@studio/components/NewCustomizationForm/LoraParametersSection';
+import { ModelSelectionSection } from '@studio/components/NewCustomizationForm/ModelSelectionSection';
+import { TrainingMethodSection } from '@studio/components/NewCustomizationForm/TrainingMethodSection';
+import { getWorkspaceCustomizationJobDetailsRoute } from '@studio/routes/utils';
+import {
+  FORM_DEFAULTS,
+  customizationFormSchema,
+  formToAutomodelCreate,
+  formToUnslothCreate,
+} from '@studio/util/forms/customization';
+import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { FC, useEffect, useMemo, useRef, useState } from 'react';
+import type { FieldErrors, Resolver } from 'react-hook-form';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+interface NewCustomizationFormProps {
+  workspace: string;
+  initialModel?: string;
+}
+
+export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
+  workspace,
+  initialModel,
+}) => {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const errorBannerRef = useRef<HTMLDivElement>(null);
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+
+  const defaultValues = useMemo<CustomizationFormFields>(
+    () => ({
+      ...FORM_DEFAULTS,
+      outputName: generateDefaultName(),
+      automodel: { ...FORM_DEFAULTS.automodel, model: initialModel ?? '' },
+      unsloth: {
+        ...FORM_DEFAULTS.unsloth,
+        model: { ...FORM_DEFAULTS.unsloth.model, name: initialModel ?? '' },
+      },
+    }),
+    [initialModel]
+  );
+
+  const form = useForm<CustomizationFormFields>({
+    // The form type is vendored-driven (nested specs are Partial), while the
+    // schema validates those params as required (defaults always supply them).
+    // That variance is safe here, so cast the resolver to the form's field type.
+    resolver: zodResolver(customizationFormSchema) as unknown as Resolver<CustomizationFormFields>,
+    defaultValues,
+    mode: 'onChange',
+    // Keep field values when a section unmounts (e.g. switching backend or
+    // collapsing an accordion) so the form state stays complete.
+    shouldUnregister: false,
+  });
+
+  const backend = useWatch({ control: form.control, name: 'backend' });
+  const automodelFinetuningType = useWatch({
+    control: form.control,
+    name: 'automodel.training.finetuning_type',
+  });
+  const unslothFinetuningType = useWatch({
+    control: form.control,
+    name: 'unsloth.training.finetuning_type',
+  });
+  const finetuningType =
+    backend === 'automodel' ? automodelFinetuningType : unslothFinetuningType;
+  const isLora = finetuningType === 'lora' || finetuningType === 'lora_merged';
+
+  const { mutateAsync: createAutomodel, isPending: isPendingAutomodel } =
+    useCustomizationCreateAutomodelJob({
+      mutation: {
+        onSuccess: (job) => {
+          toast.success('Fine-tuning job started');
+          navigate(getWorkspaceCustomizationJobDetailsRoute(workspace, job.name));
+        },
+        onError: (error: Error) => {
+          toast.error(getErrorMessage(error, 'Failed to create fine-tuning job'));
+        },
+      },
+    });
+
+  const { mutateAsync: createUnsloth, isPending: isPendingUnsloth } = useCustomizationCreateUnslothJob({
+    mutation: {
+      onSuccess: (job) => {
+        toast.success('Fine-tuning job started');
+        navigate(getWorkspaceCustomizationJobDetailsRoute(workspace, job.name));
+      },
+      onError: (error: Error) => {
+        toast.error(getErrorMessage(error, 'Failed to create fine-tuning job'));
+      },
+    },
+  });
+
+  const isPending = isPendingAutomodel || isPendingUnsloth;
+
+  const onSubmit = async (fields: CustomizationFormFields) => {
+    setValidationErrors([]);
+    // Await the mutation so react-hook-form keeps formState.isSubmitting true
+    // (and the sections disabled) for the whole request, not just validation.
+    try {
+      if (fields.backend === 'automodel') {
+        await createAutomodel({ workspace, data: formToAutomodelCreate(fields) });
+      } else {
+        await createUnsloth({ workspace, data: formToUnslothCreate(fields) });
+      }
+    } catch {
+      // Failure is surfaced by the mutation's onError toast; swallow here so
+      // react-hook-form clears isSubmitting and re-enables the form.
+    }
+  };
+
+  // Surface validation failures instead of silently blocking submit. Collects
+  // the leaf error messages from the (deeply nested) RHF error tree.
+  const onInvalid = (formErrors: FieldErrors<CustomizationFormFields>) => {
+    const messages: string[] = [];
+    const collect = (node: unknown) => {
+      if (!node || typeof node !== 'object') return;
+      if ('message' in node && typeof (node as { message?: unknown }).message === 'string') {
+        messages.push((node as { message: string }).message);
+        return;
+      }
+      Object.values(node as Record<string, unknown>).forEach(collect);
+    };
+    collect(formErrors);
+    setValidationErrors(
+      messages.length ? Array.from(new Set(messages)) : ['Please complete the required fields.']
+    );
+  };
+
+  useEffect(() => {
+    if (validationErrors.length > 0) {
+      errorBannerRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [validationErrors]);
+
+  return (
+    <AccessibleTitle title="Fine-tune a Model">
+      <Stack className="h-full" gap="density-2xl" padding="density-2xl">
+        <PageHeader
+          slotHeading="Fine-tune a Model"
+          slotDescription="Select a model, choose your data, set your parameters and start training in seconds."
+        />
+        <FormProvider {...form}>
+          <form
+            className="w-full"
+            aria-label="Fine-tune a Model"
+            // Validation is handled by React Hook Form + Zod. Disable native
+            // constraint validation so the browser doesn't try (and fail) to
+            // focus hidden `required` controls like ModelSelectV2's filter input.
+            noValidate
+            onSubmit={form.handleSubmit(onSubmit, onInvalid)}
+          >
+            <Stack className="overflow-auto" gap="density-2xl" padding="density-2xl">
+              <Flex align="center" justify="center" className="w-full">
+                <Panel
+                  className="max-w-3xl h-full overflow-auto"
+                  elevation="high"
+                  density="standard"
+                  slotFooter={
+                    <Flex className="w-full justify-end gap-2">
+                      <Button type="submit" disabled={isPending} color="brand">
+                        {isPending ? 'Starting…' : 'Start Fine-Tuning'}
+                      </Button>
+                    </Flex>
+                  }
+                >
+                  <Stack gap="density-2xl">
+                    <BackendSelectionSection />
+                    <Divider />
+                    <ModelSelectionSection />
+                    <Divider />
+                    <TrainingMethodSection />
+                    <Divider />
+                    <CustomizationFilesetSelect disabled={isPending} />
+                    <Divider />
+                    <GeneralParametersSection />
+                    {isLora && (
+                      <>
+                        <Divider />
+                        <LoraParametersSection />
+                      </>
+                    )}
+                    <Divider />
+                    <ComputeResourcesSection />
+                    {validationErrors.length > 0 && (
+                      <Banner kind="inline" ref={errorBannerRef} status="error">
+                        Please fix the following errors: {validationErrors.join(', ')}
+                      </Banner>
+                    )}
+                  </Stack>
+                </Panel>
+              </Flex>
+            </Stack>
+          </form>
+        </FormProvider>
+      </Stack>
+    </AccessibleTitle>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/index.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/index.tsx
@@ -66,14 +66,9 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
   );
 
   const form = useForm<CustomizationFormFields>({
-    // The form type is vendored-driven (nested specs are Partial), while the
-    // schema validates those params as required (defaults always supply them).
-    // That variance is safe here, so cast the resolver to the form's field type.
     resolver: zodResolver(customizationFormSchema) as unknown as Resolver<CustomizationFormFields>,
     defaultValues,
     mode: 'onChange',
-    // Keep field values when a section unmounts (e.g. switching backend or
-    // collapsing an accordion) so the form state stays complete.
     shouldUnregister: false,
   });
 
@@ -119,22 +114,15 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
 
   const onSubmit = async (fields: CustomizationFormFields) => {
     setValidationErrors([]);
-    // Await the mutation so react-hook-form keeps formState.isSubmitting true
-    // (and the sections disabled) for the whole request, not just validation.
-    try {
-      if (fields.backend === 'automodel') {
-        await createAutomodel({ workspace, data: formToAutomodelCreate(fields) });
-      } else {
-        await createUnsloth({ workspace, data: formToUnslothCreate(fields) });
-      }
-    } catch {
-      // Failure is surfaced by the mutation's onError toast; swallow here so
-      // react-hook-form clears isSubmitting and re-enables the form.
+    if (fields.backend === 'automodel') {
+      await createAutomodel({ workspace, data: formToAutomodelCreate(fields) }).catch(
+        () => undefined
+      );
+    } else {
+      await createUnsloth({ workspace, data: formToUnslothCreate(fields) }).catch(() => undefined);
     }
   };
 
-  // Surface validation failures instead of silently blocking submit. Collects
-  // the leaf error messages from the (deeply nested) RHF error tree.
   const onInvalid = (formErrors: FieldErrors<CustomizationFormFields>) => {
     const messages: string[] = [];
     const collect = (node: unknown) => {
@@ -168,9 +156,6 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
           <form
             className="w-full"
             aria-label="Fine-tune a Model"
-            // Validation is handled by React Hook Form + Zod. Disable native
-            // constraint validation so the browser doesn't try (and fail) to
-            // focus hidden `required` controls like ModelSelectV2's filter input.
             noValidate
             onSubmit={form.handleSubmit(onSubmit, onInvalid)}
           >

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/AutoSplitNotice.test.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/AutoSplitNotice.test.tsx
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AutoSplitNotice } from '@studio/components/customizer/CustomizationFilesetSelect/FileValidationPanel/AutoSplitNotice';
+import { render, screen } from '@testing-library/react';
+
+describe('AutoSplitNotice', () => {
+  it('omits the row-count breakdown when training is empty', () => {
+    render(<AutoSplitNotice trainingRowCount={0} />);
+    expect(screen.queryByText(/examples will be used for training/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/examples will be used for validation/)).not.toBeInTheDocument();
+  });
+
+  it('renders 90% / 10% split with comma-formatted counts', () => {
+    // 1000 -> validation = round(1000 * 0.1) = 100, training = 900
+    render(<AutoSplitNotice trainingRowCount={1000} />);
+    expect(screen.getByText('90% (900) examples will be used for training.')).toBeInTheDocument();
+    expect(screen.getByText('10% (100) examples will be used for validation.')).toBeInTheDocument();
+  });
+
+  it('formats large counts with thousands separators', () => {
+    // 12000 chosen for unambiguous rounding (12000 * 0.1 = 1200 exactly).
+    // Both numbers are large enough to exercise the comma separator.
+    render(<AutoSplitNotice trainingRowCount={12000} />);
+    expect(
+      screen.getByText('90% (10,800) examples will be used for training.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('10% (1,200) examples will be used for validation.')
+    ).toBeInTheDocument();
+  });
+
+  it('rounds the validation count to the nearest integer', () => {
+    // 7 -> validation = round(0.7) = 1 ; training = 6
+    render(<AutoSplitNotice trainingRowCount={7} />);
+    expect(screen.getByText('90% (6) examples will be used for training.')).toBeInTheDocument();
+    expect(screen.getByText('10% (1) examples will be used for validation.')).toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/AutoSplitNotice.test.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/AutoSplitNotice.test.tsx
@@ -19,8 +19,6 @@ describe('AutoSplitNotice', () => {
   });
 
   it('formats large counts with thousands separators', () => {
-    // 12000 chosen for unambiguous rounding (12000 * 0.1 = 1200 exactly).
-    // Both numbers are large enough to exercise the comma separator.
     render(<AutoSplitNotice trainingRowCount={12000} />);
     expect(
       screen.getByText('90% (10,800) examples will be used for training.')

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/AutoSplitNotice.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/AutoSplitNotice.tsx
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flex, Stack, Text } from '@nvidia/foundations-react-core';
+import { CUSTOMIZER_AUTO_VAL_SPLIT_RATIO } from '@studio/constants/customization';
+import { Info } from 'lucide-react';
+import { FC } from 'react';
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+const percentFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  maximumFractionDigits: 0,
+});
+
+export interface AutoSplitNoticeProps {
+  trainingRowCount: number;
+}
+
+export const AutoSplitNotice: FC<AutoSplitNoticeProps> = ({ trainingRowCount }) => {
+  const validationCount = Math.round(trainingRowCount * CUSTOMIZER_AUTO_VAL_SPLIT_RATIO);
+  const trainingCount = trainingRowCount - validationCount;
+  const trainingPct = percentFormatter.format(1 - CUSTOMIZER_AUTO_VAL_SPLIT_RATIO);
+  const validationPct = percentFormatter.format(CUSTOMIZER_AUTO_VAL_SPLIT_RATIO);
+
+  // Per design spec: neutral, not blue/info. Top + bottom borders only (no
+  // left/right borders, no background fill) so the notice reads as a quiet
+  // contextual aside rather than an alert.
+  return (
+    <Flex
+      align="start"
+      gap="density-md"
+      className="border-y border-base py-density-md text-fg-subdued"
+    >
+      <Info width={16} height={16} className="mt-1 flex-shrink-0" />
+      <Stack gap="density-xs">
+        <Text kind="body/regular/md">
+          No Validation Data found. Training data will be automatically split.
+        </Text>
+        {trainingRowCount > 0 && (
+          <>
+            <Text kind="body/regular/sm">
+              {trainingPct} ({numberFormatter.format(trainingCount)}) examples will be used for
+              training.
+            </Text>
+            <Text kind="body/regular/sm">
+              {validationPct} ({numberFormatter.format(validationCount)}) examples will be used for
+              validation.
+            </Text>
+          </>
+        )}
+      </Stack>
+    </Flex>
+  );
+};

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/ChecklistRow.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/ChecklistRow.tsx
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flex, Text } from '@nvidia/foundations-react-core';
+import { AlertTriangle, CheckCircle2, XCircle } from 'lucide-react';
+import { FC, ReactNode } from 'react';
+
+// Validation rows are strictly binary: pass (green check), warn (yellow triangle),
+// or fail (red X). Anything we can't actually evaluate is hidden by the panel
+// rather than rendered as a third "neutral" state — that was confusing in
+// practice ("did we pass? did we fail?").
+export type ChecklistStatus = 'ok' | 'warning' | 'fail';
+
+const StatusIcon: FC<{ status: ChecklistStatus }> = ({ status }) => {
+  if (status === 'ok')
+    return <CheckCircle2 width={16} height={16} className="text-feedback-success" />;
+  if (status === 'warning')
+    return <AlertTriangle width={16} height={16} className="text-feedback-warning" />;
+  return <XCircle width={16} height={16} className="text-feedback-danger" />;
+};
+
+export interface ChecklistRowProps {
+  status: ChecklistStatus;
+  label: ReactNode;
+}
+
+export const ChecklistRow: FC<ChecklistRowProps> = ({ status, label }) => (
+  <Flex align="center" gap="density-sm">
+    <StatusIcon status={status} />
+    <Text kind="body/regular/md">{label}</Text>
+  </Flex>
+);

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/PatternsTooltip.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/PatternsTooltip.tsx
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flex, Stack, Text, Tooltip } from '@nvidia/foundations-react-core';
+import { tooltipClassName } from '@studio/styles/common';
+import { HelpCircle } from 'lucide-react';
+import { FC } from 'react';
+
+const PatternsTooltipContent: FC = () => (
+  <div className={tooltipClassName}>
+    <Stack gap="density-xs">
+      <Text kind="label/bold/sm">Customizer file discovery</Text>
+      <Text kind="body/regular/sm">
+        Both <code>.jsonl</code> and <code>.json</code> are accepted everywhere below.
+      </Text>
+      <Text kind="body/regular/sm">
+        <strong>Training (required):</strong> any <code>.jsonl</code>/<code>.json</code> inside{' '}
+        <code>train/</code> or <code>training/</code>, OR root files whose names start with{' '}
+        <code>train</code> or <code>training</code>.
+      </Text>
+      <Text kind="body/regular/sm">
+        <strong>Validation (optional):</strong> any <code>.jsonl</code>/<code>.json</code> inside{' '}
+        <code>val/</code>, <code>validation/</code>, or <code>dev/</code>, OR root files whose names
+        start with <code>val</code>, <code>validation</code>, or <code>dev</code>.
+      </Text>
+      <Text kind="body/regular/sm">
+        If nothing else matches, root-level <code>.jsonl</code> files (only) are claimed as training
+        and auto-split 10% for validation.
+      </Text>
+    </Stack>
+  </div>
+);
+
+export interface PatternsTooltipTriggerProps {
+  label?: string;
+}
+
+export const PatternsTooltipTrigger: FC<PatternsTooltipTriggerProps> = ({
+  label = 'Why are no files matching?',
+}) => (
+  <Tooltip slotContent={<PatternsTooltipContent />} side="top">
+    <Flex align="center" gap="density-sm" className="cursor-help text-fg-subdued">
+      <HelpCircle width={16} height={16} />
+      <Text kind="body/regular/md">{label}</Text>
+    </Flex>
+  </Tooltip>
+);

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/SchemaBlock.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/SchemaBlock.tsx
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CodeSnippet, Stack, Text } from '@nvidia/foundations-react-core';
+import { FC } from 'react';
+
+export interface SchemaBlockProps {
+  /**
+   * TypeScript-shaped string describing the inferred row schema (with nested
+   * objects/arrays expanded). Empty string when nothing was detected — the
+   * block hides itself in that case.
+   */
+  schemaShape: string;
+}
+
+export const SchemaBlock: FC<SchemaBlockProps> = ({ schemaShape }) => {
+  if (!schemaShape) return null;
+  return (
+    <Stack gap="density-sm">
+      <Text kind="label/bold/sm">Schema</Text>
+      <CodeSnippet kind="block" language="typescript" value={schemaShape} />
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/index.test.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/index.test.tsx
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { FileValidationPanel } from '@studio/components/customizer/CustomizationFilesetSelect/FileValidationPanel';
+import type { CustomizationDatasetValidationResult } from '@studio/hooks/useCustomizationDatasetValidation';
+import { CUSTOMIZER_SCHEMA_LABELS } from '@studio/util/customizerSchema';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Build a baseline-pass validation result. Individual tests override the one
+ * field they care about so each test exercises a single visible branch.
+ */
+const buildValidation = (
+  overrides: Partial<CustomizationDatasetValidationResult> = {}
+): CustomizationDatasetValidationResult => ({
+  isPending: false,
+  discoveryError: null,
+  format: { ok: true, fileErrors: [] },
+  schema: {
+    variant: 'sft-prompt-completion',
+    label: CUSTOMIZER_SCHEMA_LABELS['sft-prompt-completion'],
+  },
+  schemaExpectedCopy: 'Must contain messages (chat) or prompt and completion.',
+  schemaMismatchedFiles: [],
+  schemaShape: '{\n  prompt: string,\n  completion: string,\n}',
+  completeness: { ok: true, skipped: false, errors: [] },
+  encoding: { ok: true, fileErrors: [] },
+  hasTraining: true,
+  hasValidation: true,
+  autoSplitNotice: false,
+  training: [],
+  validation: [],
+  trainingRowCount: 100,
+  validationRowCount: 20,
+  ...overrides,
+});
+
+describe('FileValidationPanel', () => {
+  describe('overriding states (supersede the checklist)', () => {
+    it('renders a load-error banner when discovery itself failed', () => {
+      render(
+        <FileValidationPanel
+          validation={buildValidation({ discoveryError: new Error('Network down') })}
+        />
+      );
+      expect(screen.getByText(/Could not list files in this dataset/)).toBeInTheDocument();
+      expect(screen.getByText(/Network down/)).toBeInTheDocument();
+      // Checklist label should NOT be rendered.
+      expect(screen.queryByText('File Validation')).not.toBeInTheDocument();
+    });
+
+    it('renders a spinner while validation is pending', () => {
+      render(
+        <FileValidationPanel
+          validation={buildValidation({ isPending: true, hasTraining: false })}
+        />
+      );
+      expect(screen.getByText('Validating dataset files...')).toBeInTheDocument();
+      expect(screen.queryByText('File Validation')).not.toBeInTheDocument();
+    });
+
+    it('renders nothing when no training files are present', () => {
+      const { container } = render(
+        <FileValidationPanel validation={buildValidation({ hasTraining: false })} />
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('checklist (happy path)', () => {
+    it('renders all rows green when every check passes', () => {
+      render(<FileValidationPanel validation={buildValidation()} />);
+      expect(screen.getByText('File Validation')).toBeInTheDocument();
+      expect(screen.getByText(/Format: Single line JSONL is valid/)).toBeInTheDocument();
+      expect(
+        screen.getByText(`Schema: ${CUSTOMIZER_SCHEMA_LABELS['sft-prompt-completion']}`)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Encoding: UTF-8 encoding/)).toBeInTheDocument();
+      expect(screen.getByText(/Completeness: No empty or null values/)).toBeInTheDocument();
+    });
+  });
+
+  describe('format row', () => {
+    it('renders sample error message when one or more files failed format/fetch', () => {
+      const validation = buildValidation({
+        format: {
+          ok: false,
+          fileErrors: [
+            { path: 'training/bad.jsonl', error: 'Failed to download file: 404' },
+            { path: 'training/other.jsonl', error: 'parse error at line 3' },
+          ],
+        },
+      });
+      render(<FileValidationPanel validation={validation} />);
+      expect(
+        screen.getByText(/Found 2 files with errors \(e\.g\. training\/bad\.jsonl/)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Failed to download file: 404/)).toBeInTheDocument();
+    });
+  });
+
+  describe('schema row', () => {
+    it('renders warning when no file matched any customizer shape', () => {
+      const validation = buildValidation({
+        schema: null,
+        schemaShape: '',
+        schemaMismatchedFiles: [],
+      });
+      render(<FileValidationPanel validation={validation} />);
+      expect(
+        screen.getByText(
+          /Schema: Does not match\. Must contain messages \(chat\) or prompt and completion\./
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('renders fail when some files matched but others did not', () => {
+      const validation = buildValidation({
+        schemaMismatchedFiles: ['training/odd.jsonl'],
+      });
+      render(<FileValidationPanel validation={validation} />);
+      expect(
+        screen.getByText(
+          new RegExp(`Schema: ${CUSTOMIZER_SCHEMA_LABELS['sft-prompt-completion']}, but 1 file`)
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByText(/training\/odd\.jsonl/)).toBeInTheDocument();
+    });
+  });
+
+  describe('encoding row', () => {
+    it('renders the offending file path when a single file fails', () => {
+      const validation = buildValidation({
+        encoding: { ok: false, fileErrors: [{ path: 'training/utf16.jsonl' }] },
+      });
+      render(<FileValidationPanel validation={validation} />);
+      expect(
+        screen.getByText(/Encoding: training\/utf16\.jsonl is not valid UTF-8/)
+      ).toBeInTheDocument();
+    });
+
+    it('renders a count + sample path when multiple files fail', () => {
+      const validation = buildValidation({
+        encoding: {
+          ok: false,
+          fileErrors: [{ path: 'training/utf16.jsonl' }, { path: 'validation/utf16.jsonl' }],
+        },
+      });
+      render(<FileValidationPanel validation={validation} />);
+      expect(
+        screen.getByText(/Encoding: 2 files are not valid UTF-8 \(e\.g\. training\/utf16\.jsonl\)/)
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to a generic message when encoding.ok is false but fileErrors is empty', () => {
+      // Defensive: the hook can in principle produce ok=false with no
+      // fileErrors (e.g. perFile.length !== allFiles.length). The panel
+      // must not crash on errors[0].
+      const validation = buildValidation({
+        encoding: { ok: false, fileErrors: [] },
+      });
+      render(<FileValidationPanel validation={validation} />);
+      expect(screen.getByText(/Encoding: UTF-8 encoding check failed/)).toBeInTheDocument();
+    });
+  });
+
+  describe('completeness row', () => {
+    it('renders fail with first offending row', () => {
+      const validation = buildValidation({
+        completeness: {
+          ok: false,
+          skipped: false,
+          errors: [{ path: 'training/bad.jsonl', row: 3, message: 'rejected is missing or empty' }],
+        },
+      });
+      render(<FileValidationPanel validation={validation} />);
+      expect(
+        screen.getByText(
+          /Completeness: Found 1 row with empty or missing required fields \(e\.g\. training\/bad\.jsonl:3 — rejected is missing or empty\)/
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('hides the completeness row entirely when the check was skipped', () => {
+      // We don't know what to require when format failed or schema didn't
+      // match, so we drop the row instead of rendering a third ambiguous
+      // status. The whole panel keeps a strict pass/fail/warn convention.
+      const validation = buildValidation({
+        format: { ok: false, fileErrors: [{ path: 'a.jsonl', error: 'bad' }] },
+        schema: null,
+        schemaShape: '',
+        completeness: { ok: false, skipped: true, errors: [] },
+      });
+      render(<FileValidationPanel validation={validation} />);
+      expect(screen.queryByText(/Completeness:/)).not.toBeInTheDocument();
+    });
+
+    it('falls back to a generic message when completeness fails with no specific errors', () => {
+      // Defensive: shouldn't happen given today's invariants, but guard
+      // ensures we never crash on errors[0] if the invariant changes.
+      const validation = buildValidation({
+        completeness: { ok: false, skipped: false, errors: [] },
+      });
+      render(<FileValidationPanel validation={validation} />);
+      expect(screen.getByText(/Completeness: Completeness check failed/)).toBeInTheDocument();
+    });
+  });
+
+  describe('auto-split notice', () => {
+    it('renders the info banner with split stats when validation is missing', () => {
+      const validation = buildValidation({
+        hasValidation: false,
+        autoSplitNotice: true,
+        validationRowCount: 0,
+        trainingRowCount: 1000,
+      });
+      render(<FileValidationPanel validation={validation} />);
+      expect(
+        screen.getByText('No Validation Data found. Training data will be automatically split.')
+      ).toBeInTheDocument();
+      expect(screen.getByText(/90% \(900\)/)).toBeInTheDocument();
+      expect(screen.getByText(/10% \(100\)/)).toBeInTheDocument();
+    });
+
+    it('omits the info banner when validation files are present', () => {
+      render(<FileValidationPanel validation={buildValidation()} />);
+      expect(
+        screen.queryByText('No Validation Data found. Training data will be automatically split.')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('schema preview', () => {
+    it('renders the inferred field shape as a typescript code block', () => {
+      const { container } = render(<FileValidationPanel validation={buildValidation()} />);
+      expect(screen.getByText('Schema')).toBeInTheDocument();
+      // CodeSnippet renders the value into a <pre>/<code> block; check the keys exist.
+      expect(container.textContent).toContain('prompt: string');
+      expect(container.textContent).toContain('completion: string');
+    });
+
+    it('omits the schema block when no shape was inferred', () => {
+      render(<FileValidationPanel validation={buildValidation({ schemaShape: '' })} />);
+      expect(screen.queryByText('Schema')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/index.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/FileValidationPanel/index.tsx
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Banner, Block, Flex, Spinner, Stack, Text } from '@nvidia/foundations-react-core';
+import { AutoSplitNotice } from '@studio/components/customizer/CustomizationFilesetSelect/FileValidationPanel/AutoSplitNotice';
+import {
+  ChecklistRow,
+  ChecklistStatus,
+} from '@studio/components/customizer/CustomizationFilesetSelect/FileValidationPanel/ChecklistRow';
+import { SchemaBlock } from '@studio/components/customizer/CustomizationFilesetSelect/FileValidationPanel/SchemaBlock';
+import { CustomizationDatasetValidationResult } from '@studio/hooks/useCustomizationDatasetValidation';
+import { FC } from 'react';
+
+export interface FileValidationPanelProps {
+  validation: CustomizationDatasetValidationResult;
+}
+
+export const FileValidationPanel: FC<FileValidationPanelProps> = ({ validation }) => {
+  const {
+    isPending,
+    discoveryError,
+    format,
+    schema,
+    schemaExpectedCopy,
+    schemaMismatchedFiles,
+    schemaShape,
+    completeness,
+    encoding,
+    hasTraining,
+    autoSplitNotice,
+    trainingRowCount,
+  } = validation;
+
+  // Discovery (file-listing) failure is distinct from "the dataset is empty".
+  // Render an explicit load error so users don't think their data is bad.
+  if (discoveryError) {
+    return (
+      <Banner kind="inline" status="error">
+        Could not list files in this dataset: {discoveryError.message || 'unknown error'}. Pick the
+        dataset again or try once more.
+      </Banner>
+    );
+  }
+
+  if (isPending) {
+    return (
+      <Flex align="center" gap="density-sm" className="py-density-md">
+        <Spinner size="small" description="Validating dataset files..." />
+      </Flex>
+    );
+  }
+
+  // No-training error supersedes the rest of the checklist.
+  if (!hasTraining) {
+    return null;
+  }
+
+  const formatStatus: ChecklistStatus = format.ok ? 'ok' : 'fail';
+  const formatLabel = format.ok ? (
+    'Single line JSONL is valid'
+  ) : format.fileErrors.length === 0 ? (
+    'Format check failed'
+  ) : (
+    <>
+      Found {format.fileErrors.length} file
+      {format.fileErrors.length === 1 ? '' : 's'} with errors (e.g. {format.fileErrors[0].path} —{' '}
+      {format.fileErrors[0].error})
+    </>
+  );
+
+  // Schema check fails when:
+  //   - no file matched a recognized customizer shape (warning), OR
+  //   - some files matched but others didn't / used a different variant (fail).
+  // Customizer would still reject the latter at training time, so the panel
+  // can't silently treat the first match as authoritative.
+  const schemaHasMismatches = schemaMismatchedFiles.length > 0;
+  const schemaStatus: ChecklistStatus = !schema ? 'warning' : schemaHasMismatches ? 'fail' : 'ok';
+  const schemaLabel = !schema ? (
+    <>Does not match. {schemaExpectedCopy}</>
+  ) : schemaHasMismatches ? (
+    <>
+      {schema.label}, but {schemaMismatchedFiles.length} file
+      {schemaMismatchedFiles.length === 1 ? '' : 's'} do not match (e.g. {schemaMismatchedFiles[0]}
+      ).
+    </>
+  ) : (
+    <>{schema.label}</>
+  );
+
+  return (
+    <Stack gap="density-lg">
+      {autoSplitNotice && <AutoSplitNotice trainingRowCount={trainingRowCount} />}
+
+      {/* File Validation + Schema preview share a subdued grouped surface
+          per design spec — visually distinct from the auto-split notice
+          (which lives on the form's main surface). bg-surface-sunken matches
+          the recessed look used elsewhere in the app for inset content. */}
+      <Block className="bg-surface-sunken rounded-lg" padding="density-lg">
+        <Stack gap="density-lg">
+          <Stack gap="density-sm">
+            <Text kind="label/bold/sm">File Validation</Text>
+            <ChecklistRow status={formatStatus} label={<>Format: {formatLabel}</>} />
+            <ChecklistRow status={schemaStatus} label={<>Schema: {schemaLabel}</>} />
+            <ChecklistRow
+              status={encoding.ok ? 'ok' : 'fail'}
+              label={
+                <>
+                  Encoding:{' '}
+                  {encoding.ok
+                    ? 'UTF-8 encoding (not UTF-16 or other encodings)'
+                    : encoding.fileErrors.length === 0
+                      ? 'UTF-8 encoding check failed'
+                      : encoding.fileErrors.length === 1
+                        ? `${encoding.fileErrors[0].path} is not valid UTF-8`
+                        : `${encoding.fileErrors.length} files are not valid UTF-8 (e.g. ${encoding.fileErrors[0].path})`}
+                </>
+              }
+            />
+            {/* Completeness only renders when it could be evaluated. When
+                format failed or schema didn't match (skipped=true) we don't
+                know what to require, so hiding the row is honest — better
+                than a third "neutral" state. */}
+            {!completeness.skipped && (
+              <ChecklistRow
+                status={completeness.ok ? 'ok' : 'fail'}
+                label={
+                  <>
+                    Completeness:{' '}
+                    {completeness.ok
+                      ? 'No empty or null values in required fields'
+                      : completeness.errors.length === 0
+                        ? 'Completeness check failed'
+                        : `Found ${completeness.errors.length} row${
+                            completeness.errors.length === 1 ? '' : 's'
+                          } with empty or missing required fields (e.g. ${completeness.errors[0].path}:${completeness.errors[0].row} — ${completeness.errors[0].message})`}
+                  </>
+                }
+              />
+            )}
+            {/* Length is intentionally not rendered here — we don't run a
+                tokenizer client-side. Customizer enforces context-window limits
+                at training time; surfacing a row we can't actually evaluate
+                would be misleading. */}
+            {/* Naming was previously rendered here ("Training and validation
+                sets are separate and representative") but its check (namingOk
+                = hasTraining) was redundant with the no-training error banner
+                above and the label promised verifications we don't and can't
+                run. Dropped to keep the panel honest. */}
+          </Stack>
+
+          <SchemaBlock schemaShape={schemaShape} />
+        </Stack>
+      </Block>
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.test.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.test.tsx
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CustomizationFilesetSelect } from '@studio/components/customizer/CustomizationFilesetSelect';
+import { ROUTE_PARAMS } from '@studio/constants/routes';
+import {
+  CustomizationDatasetValidationResult,
+  useCustomizationDatasetValidation,
+} from '@studio/hooks/useCustomizationDatasetValidation';
+import { datasets } from '@studio/mocks/datasets';
+import { mockUseParams } from '@studio/tests/util/mockUseParams';
+import { renderRoute, screen, waitFor } from '@studio/tests/util/render';
+import type { CustomizerSchemaVariant } from '@studio/util/customizerSchema';
+import { FORM_DEFAULTS, type CustomizationFormFields } from '@studio/util/forms/customization';
+import userEvent from '@testing-library/user-event';
+import { FC, ReactNode } from 'react';
+import { FieldPath, FormProvider, useForm, useWatch } from 'react-hook-form';
+
+vi.mock('@studio/hooks/useCustomizationDatasetValidation', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@studio/hooks/useCustomizationDatasetValidation')>();
+  return { ...actual, useCustomizationDatasetValidation: vi.fn() };
+});
+
+const mockValidation = vi.mocked(useCustomizationDatasetValidation);
+
+const buildValidation = (
+  overrides: Partial<CustomizationDatasetValidationResult> = {}
+): CustomizationDatasetValidationResult => ({
+  isPending: false,
+  discoveryError: null,
+  format: { ok: true, fileErrors: [] },
+  schema: { variant: 'sft-prompt-completion', label: 'SFT prompt/completion' },
+  schemaExpectedCopy: 'Must contain messages (chat) or prompt and completion.',
+  schemaMismatchedFiles: [],
+  schemaShape: '',
+  completeness: { ok: true, skipped: false, errors: [] },
+  encoding: { ok: true, fileErrors: [] },
+  hasTraining: true,
+  hasValidation: true,
+  autoSplitNotice: false,
+  training: [],
+  validation: [],
+  trainingRowCount: 100,
+  validationRowCount: 20,
+  ...overrides,
+});
+
+const withVariant = (variant: CustomizerSchemaVariant): CustomizationDatasetValidationResult =>
+  buildValidation({ schema: { variant, label: variant } });
+
+/** Renders a form field's current value so tests can assert what the picker wrote. */
+const FieldSpy: FC<{ name: FieldPath<CustomizationFormFields> }> = ({ name }) => {
+  const value = useWatch<CustomizationFormFields>({ name });
+  return <div data-testid={`spy:${name}`}>{String(value ?? '')}</div>;
+};
+
+/** Wraps the picker in a real RHF context seeded from the production defaults. */
+const Harness: FC<{
+  children: ReactNode;
+  overrides?: Partial<CustomizationFormFields>;
+}> = ({ children, overrides }) => {
+  const methods = useForm<CustomizationFormFields>({
+    defaultValues: { ...FORM_DEFAULTS, ...overrides },
+  });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+const firstFileset = datasets.data[0]!;
+const firstRef = `${firstFileset.workspace}/${firstFileset.name}`;
+
+describe('CustomizationFilesetSelect', () => {
+  beforeEach(() => {
+    mockUseParams({ [ROUTE_PARAMS.workspace]: 'default' });
+    mockValidation.mockReturnValue(buildValidation());
+  });
+
+  it('writes the picked fileset reference into automodel.dataset.training', async () => {
+    const user = userEvent.setup();
+    renderRoute(
+      <Harness overrides={{ backend: 'automodel' }}>
+        <CustomizationFilesetSelect />
+        <FieldSpy name="automodel.dataset.training" />
+      </Harness>
+    );
+
+    const trigger = await screen.findByRole('combobox', { name: /dataset/i });
+    await user.click(trigger);
+    await user.click(await screen.findByRole('option', { name: firstFileset.name ?? '' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('spy:automodel.dataset.training')).toHaveTextContent(firstRef)
+    );
+  });
+
+  it('writes the picked fileset reference into unsloth.dataset.path', async () => {
+    const user = userEvent.setup();
+    renderRoute(
+      <Harness overrides={{ backend: 'unsloth' }}>
+        <CustomizationFilesetSelect />
+        <FieldSpy name="unsloth.dataset.path" />
+      </Harness>
+    );
+
+    const trigger = await screen.findByRole('combobox', { name: /dataset/i });
+    await user.click(trigger);
+    await user.click(await screen.findByRole('option', { name: firstFileset.name ?? '' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('spy:unsloth.dataset.path')).toHaveTextContent(firstRef)
+    );
+  });
+
+  it('opens the create-fileset modal when New Dataset is selected', async () => {
+    const user = userEvent.setup();
+    renderRoute(
+      <Harness overrides={{ backend: 'automodel' }}>
+        <CustomizationFilesetSelect />
+      </Harness>
+    );
+
+    const trigger = await screen.findByRole('combobox', { name: /dataset/i });
+    await user.click(trigger);
+    await user.click(await screen.findByRole('option', { name: 'New Dataset' }));
+
+    expect(await screen.findByText('Create New Dataset')).toBeInTheDocument();
+  });
+
+  it('surfaces the no-training-files error when the selected dataset has none', async () => {
+    mockValidation.mockReturnValue(buildValidation({ hasTraining: false }));
+    renderRoute(
+      <Harness
+        overrides={{
+          backend: 'automodel',
+          automodel: { ...FORM_DEFAULTS.automodel, dataset: { training: firstRef } },
+        }}
+      >
+        <CustomizationFilesetSelect />
+      </Harness>
+    );
+
+    expect(
+      await screen.findByText(/No training files were found in this dataset/)
+    ).toBeInTheDocument();
+  });
+
+  describe('apply_chat_template auto-detection (unsloth)', () => {
+    it('enables the chat template for chat/messages datasets', async () => {
+      mockValidation.mockReturnValue(withVariant('sft-chat'));
+      renderRoute(
+        <Harness
+          overrides={{
+            backend: 'unsloth',
+            unsloth: {
+              ...FORM_DEFAULTS.unsloth,
+              dataset: {
+                ...FORM_DEFAULTS.unsloth.dataset,
+                path: firstRef,
+                apply_chat_template: false,
+              },
+            },
+          }}
+        >
+          <CustomizationFilesetSelect />
+          <FieldSpy name="unsloth.dataset.apply_chat_template" />
+        </Harness>
+      );
+
+      await waitFor(() =>
+        expect(screen.getByTestId('spy:unsloth.dataset.apply_chat_template')).toHaveTextContent(
+          'true'
+        )
+      );
+    });
+
+    it('disables the chat template for prompt-completion datasets', async () => {
+      mockValidation.mockReturnValue(withVariant('sft-prompt-completion'));
+      renderRoute(
+        <Harness
+          overrides={{
+            backend: 'unsloth',
+            unsloth: {
+              ...FORM_DEFAULTS.unsloth,
+              dataset: {
+                ...FORM_DEFAULTS.unsloth.dataset,
+                path: firstRef,
+                apply_chat_template: true,
+              },
+            },
+          }}
+        >
+          <CustomizationFilesetSelect />
+          <FieldSpy name="unsloth.dataset.apply_chat_template" />
+        </Harness>
+      );
+
+      await waitFor(() =>
+        expect(screen.getByTestId('spy:unsloth.dataset.apply_chat_template')).toHaveTextContent(
+          'false'
+        )
+      );
+    });
+  });
+});

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.tsx
@@ -46,7 +46,6 @@ import { useController, useFormContext, useWatch } from 'react-hook-form';
 
 const NEW_DATASET_VALUE = '__new_dataset__';
 
-/** Form path that holds the selected training-fileset reference, per backend. */
 type DatasetFieldName = 'automodel.dataset.training' | 'unsloth.dataset.path';
 
 export interface CustomizationFilesetSelectProps {
@@ -60,8 +59,6 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
   const { control, setValue } = useFormContext<CustomizationFormFields>();
   const backend = useWatch({ control, name: 'backend' });
 
-  // Both backends take a fileset reference string; the field path and the
-  // training objective (which drives schema validation) differ by backend.
   const fieldName: DatasetFieldName =
     backend === 'automodel' ? 'automodel.dataset.training' : 'unsloth.dataset.path';
   const automodelTrainingType = useWatch({ control, name: 'automodel.training.training_type' });
@@ -78,10 +75,6 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
     isFetching,
     error,
   } = useListFilesets(workspace, {
-    // Pull the largest page the backend allows for client-side filtering.
-    // The filesets endpoint caps page_size at 100 (validates with 422 on
-    // larger values — DEFAULT_LARGE_PAGE_SIZE = 1000 fails). Once server-side
-    // search lands, drop this and paginate properly.
     page_size: 100,
     sort: 'created_at',
     filter: { purpose: 'dataset' },
@@ -89,8 +82,6 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
   const filesets = useMemo(() => filesetsResponse?.data ?? [], [filesetsResponse?.data]);
   const dropdownDisabled = isPending || isFetching || !!error;
 
-  // The stored value is an entity reference ('workspace/name' or 'name'); split
-  // it back into parts so we can retrieve the fileset and build its URN.
   const selectedParts = selectedRef ? getPartsFromReference(selectedRef) : undefined;
   const filesetURN =
     selectedParts?.workspace && selectedParts?.name
@@ -111,10 +102,6 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
   });
   const { training, validation: validationFiles } = validation;
 
-  // Unsloth SFT needs the chat template applied for messages datasets, otherwise
-  // there's no text column to train on and SFTTrainer raises "You must specify a
-  // formatting_func". Drive the flag off the detected schema: chat → render via
-  // the tokenizer's template; prompt/text → leave the raw text field as-is.
   const detectedVariant = validation.schema?.variant;
   useEffect(() => {
     if (backend !== 'unsloth' || !detectedVariant) return;
@@ -141,7 +128,6 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
 
   const selectedDropdownValue = (selectedRef as string) ?? '';
 
-  // File preview state and content fetching
   const {
     previewFile,
     previewContent,
@@ -151,8 +137,6 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
     clearPreview,
   } = useFilePreview();
 
-  // FileList items: training files first, then validation files. The
-  // FileValidationPanel handles error/info banners separately.
   const filesetFiles = useMemo<FileListItem[]>(() => {
     if (fetchFilesetStatus !== 'success') return [];
     return [...training, ...validationFiles].map((file) => ({
@@ -191,9 +175,6 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
         }
         status={fieldError || hasMissingTrainingFiles ? 'error' : undefined}
       >
-        {/* Compound Select form (rather than `<Select items={...}>`) so the
-            per-item className on the New Dataset row is honored — the items
-            array drops className silently. */}
         <SelectRoot
           value={selectedDropdownValue}
           onValueChange={handleSelectChange}
@@ -220,7 +201,6 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
                 </SelectItem>
               );
             })}
-            {/* Visually offsets the create-new action from the dataset list. */}
             <SelectItem className="border-t border-base" value={NEW_DATASET_VALUE}>
               New Dataset
             </SelectItem>
@@ -261,11 +241,6 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
         <FileList files={filesetFiles} allowDelete={false} onPreviewFile={setPreviewFile} />
       )}
 
-      {/* Always visible. Sits between the matched files list (above) and the
-          auto-split + File Validation sections (below) so users can read the
-          discovery rules right where they need them. When no fileset is
-          selected yet, the file list is absent and the tooltip naturally sits
-          right below the dropdown. */}
       <PatternsTooltipTrigger
         label={hasMissingTrainingFiles ? undefined : 'How are files matched within the Dataset?'}
       />
@@ -307,11 +282,6 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
           modal
           className="max-w-[960px] w-full"
         >
-          {/* Use the same CodeEditor the Fileset browser uses for previews —
-              it virtualizes content so multi-MB JSONL files render without
-              freezing the browser. The lightweight FileContentPreview from
-              @nemo/common runs Shiki on the entire string and hangs above
-              ~1 MB. */}
           {previewError ? (
             <div className="flex h-full items-center justify-center text-red-600">
               Error loading file: {previewError.message}

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.tsx
@@ -5,8 +5,8 @@ import { CodeEditor } from '@nemo/common/src/components/CodeEditor';
 import { ContentType } from '@nemo/common/src/components/CodeEditor/constants';
 import { useFilePreview } from '@nemo/common/src/components/DatasetFileSelect/hooks/useFilePreview';
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
-import { ControlledSwitch } from '@nemo/common/src/components/form/ControlledSwitch';
 import { FileList, FileListItem } from '@nemo/common/src/components/FileList';
+import { ControlledSwitch } from '@nemo/common/src/components/form/ControlledSwitch';
 import {
   getEntityReference,
   getPartsFromReference,

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.tsx
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CodeEditor } from '@nemo/common/src/components/CodeEditor';
+import { ContentType } from '@nemo/common/src/components/CodeEditor/constants';
+import { useFilePreview } from '@nemo/common/src/components/DatasetFileSelect/hooks/useFilePreview';
+import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
+import { ControlledSwitch } from '@nemo/common/src/components/form/ControlledSwitch';
+import { FileList, FileListItem } from '@nemo/common/src/components/FileList';
+import {
+  getEntityReference,
+  getPartsFromReference,
+  getURNFromNamedEntityRef,
+} from '@nemo/common/src/namedEntity';
+import {
+  useFilesListFilesets as useListFilesets,
+  useFilesRetrieveFileset,
+} from '@nemo/sdk/generated/platform/api';
+import { FilesetOutput as Fileset } from '@nemo/sdk/generated/platform/schema';
+import {
+  Anchor,
+  Block,
+  Button,
+  FormField,
+  SelectContent,
+  SelectItem,
+  SelectRoot,
+  SelectTrigger,
+  SidePanel,
+  Stack,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { CustomizationFilesetCreateModal } from '@studio/components/CustomizationFilesetCreateModal';
+import { FileValidationPanel } from '@studio/components/customizer/CustomizationFilesetSelect/FileValidationPanel';
+import { PatternsTooltipTrigger } from '@studio/components/customizer/CustomizationFilesetSelect/FileValidationPanel/PatternsTooltip';
+import { Loading } from '@studio/components/Layouts/Loading';
+import { LINK_DOCS_FINE_TUNE_DATASET_FORMAT_REQUIREMENTS } from '@studio/constants/links';
+import { useCustomizationDatasetValidation } from '@studio/hooks/useCustomizationDatasetValidation';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import type { TrainingType } from '@studio/util/customizerSchema';
+import { inferJsonContentType, isJsonFile } from '@studio/util/files';
+import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { Database, FolderOpen } from 'lucide-react';
+import { FC, useEffect, useMemo, useState } from 'react';
+import { useController, useFormContext, useWatch } from 'react-hook-form';
+
+const NEW_DATASET_VALUE = '__new_dataset__';
+
+/** Form path that holds the selected training-fileset reference, per backend. */
+type DatasetFieldName = 'automodel.dataset.training' | 'unsloth.dataset.path';
+
+export interface CustomizationFilesetSelectProps {
+  disabled?: boolean;
+}
+
+export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = ({ disabled }) => {
+  const workspace = useWorkspaceFromPath();
+  const [openModal, setOpenModal] = useState<'create' | undefined>();
+
+  const { control, setValue } = useFormContext<CustomizationFormFields>();
+  const backend = useWatch({ control, name: 'backend' });
+
+  // Both backends take a fileset reference string; the field path and the
+  // training objective (which drives schema validation) differ by backend.
+  const fieldName: DatasetFieldName =
+    backend === 'automodel' ? 'automodel.dataset.training' : 'unsloth.dataset.path';
+  const automodelTrainingType = useWatch({ control, name: 'automodel.training.training_type' });
+  const trainingType: TrainingType = backend === 'automodel' ? automodelTrainingType : 'sft';
+
+  const {
+    field: { value: selectedRef, onChange: setSelectedRef, onBlur },
+    fieldState: { error: fieldError },
+  } = useController({ control, name: fieldName });
+
+  const {
+    data: filesetsResponse,
+    isPending,
+    isFetching,
+    error,
+  } = useListFilesets(workspace, {
+    // Pull the largest page the backend allows for client-side filtering.
+    // The filesets endpoint caps page_size at 100 (validates with 422 on
+    // larger values — DEFAULT_LARGE_PAGE_SIZE = 1000 fails). Once server-side
+    // search lands, drop this and paginate properly.
+    page_size: 100,
+    sort: 'created_at',
+    filter: { purpose: 'dataset' },
+  });
+  const filesets = useMemo(() => filesetsResponse?.data ?? [], [filesetsResponse?.data]);
+  const dropdownDisabled = isPending || isFetching || !!error;
+
+  // The stored value is an entity reference ('workspace/name' or 'name'); split
+  // it back into parts so we can retrieve the fileset and build its URN.
+  const selectedParts = selectedRef ? getPartsFromReference(selectedRef) : undefined;
+  const filesetURN =
+    selectedParts?.workspace && selectedParts?.name
+      ? getURNFromNamedEntityRef({ workspace: selectedParts.workspace, name: selectedParts.name })
+      : undefined;
+
+  const {
+    data: fileset,
+    status: fetchFilesetStatus,
+    refetch: refetchFileset,
+  } = useFilesRetrieveFileset(selectedParts?.workspace ?? '', selectedParts?.name ?? '', {
+    query: { enabled: !!(selectedParts?.workspace && selectedParts?.name) },
+  });
+
+  const validation = useCustomizationDatasetValidation({
+    fileset: filesetURN,
+    trainingType,
+  });
+  const { training, validation: validationFiles } = validation;
+
+  // Unsloth SFT needs the chat template applied for messages datasets, otherwise
+  // there's no text column to train on and SFTTrainer raises "You must specify a
+  // formatting_func". Drive the flag off the detected schema: chat → render via
+  // the tokenizer's template; prompt/text → leave the raw text field as-is.
+  const detectedVariant = validation.schema?.variant;
+  useEffect(() => {
+    if (backend !== 'unsloth' || !detectedVariant) return;
+    setValue('unsloth.dataset.apply_chat_template', detectedVariant === 'sft-chat', {
+      shouldValidate: false,
+    });
+  }, [backend, detectedVariant, setValue]);
+
+  const onCreate = (createdFileset: Fileset) => {
+    setSelectedRef(getEntityReference(createdFileset));
+    setOpenModal(undefined);
+  };
+
+  const handleSelectChange = (value: string) => {
+    if (value === NEW_DATASET_VALUE) {
+      setOpenModal('create');
+      return;
+    }
+    const picked = filesets.find((f) => getEntityReference(f) === value);
+    if (picked) {
+      setSelectedRef(getEntityReference(picked));
+    }
+  };
+
+  const selectedDropdownValue = (selectedRef as string) ?? '';
+
+  // File preview state and content fetching
+  const {
+    previewFile,
+    previewContent,
+    isLoadingPreview,
+    previewError,
+    setPreviewFile,
+    clearPreview,
+  } = useFilePreview();
+
+  // FileList items: training files first, then validation files. The
+  // FileValidationPanel handles error/info banners separately.
+  const filesetFiles = useMemo<FileListItem[]>(() => {
+    if (fetchFilesetStatus !== 'success') return [];
+    return [...training, ...validationFiles].map((file) => ({
+      path: file.path,
+      dataset: fileset ?? undefined,
+      rowCount: file.rowCount,
+    }));
+  }, [training, validationFiles, fileset, fetchFilesetStatus]);
+
+  const hasMissingTrainingFiles =
+    !validation.hasTraining && !validation.isPending && selectedDropdownValue;
+
+  return (
+    <Stack gap="density-2xl">
+      <Text kind="body/bold/lg">Training Data</Text>
+      <Text kind="body/regular/md">
+        Datasets should be in JSONL format and split into separate, representative training and
+        validation sets. For formatting guidelines, refer to the{' '}
+        <Anchor
+          href={LINK_DOCS_FINE_TUNE_DATASET_FORMAT_REQUIREMENTS}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Dataset Format Requirements
+        </Anchor>
+        .
+      </Text>
+
+      <FormField
+        slotLabel="Dataset"
+        slotError={
+          fieldError?.message ??
+          (hasMissingTrainingFiles
+            ? 'No training files were found in this dataset. Customizer needs at least one training file to start fine-tuning.'
+            : undefined)
+        }
+        status={fieldError || hasMissingTrainingFiles ? 'error' : undefined}
+      >
+        {/* Compound Select form (rather than `<Select items={...}>`) so the
+            per-item className on the New Dataset row is honored — the items
+            array drops className silently. */}
+        <SelectRoot
+          value={selectedDropdownValue}
+          onValueChange={handleSelectChange}
+          onOpenChange={(open) => {
+            if (!open) onBlur();
+          }}
+          disabled={disabled || dropdownDisabled}
+        >
+          <SelectTrigger
+            aria-label="dataset-select"
+            placeholder="Select a dataset"
+            slotStart={
+              selectedDropdownValue && selectedDropdownValue !== NEW_DATASET_VALUE ? (
+                <Database width={16} height={16} className="text-fg-subdued" />
+              ) : undefined
+            }
+          />
+          <SelectContent>
+            {filesets.map((f) => {
+              const ref = getEntityReference(f);
+              return (
+                <SelectItem key={ref} value={ref}>
+                  {f.name ?? ''}
+                </SelectItem>
+              );
+            })}
+            {/* Visually offsets the create-new action from the dataset list. */}
+            <SelectItem className="border-t border-base" value={NEW_DATASET_VALUE}>
+              New Dataset
+            </SelectItem>
+          </SelectContent>
+        </SelectRoot>
+      </FormField>
+
+      {backend === 'unsloth' && (
+        <ControlledSwitch
+          useControllerProps={{ name: 'unsloth.dataset.apply_chat_template', control }}
+          formFieldProps={{
+            slotLabel: 'Apply chat template',
+            labelPosition: 'left',
+            slotInfo:
+              "Render each row's messages with the tokenizer's chat template. Auto-enabled for chat datasets; turn off for datasets that already have a plain text column.",
+          }}
+          disabled={disabled}
+        />
+      )}
+
+      {fetchFilesetStatus === 'pending' && selectedParts?.name && (
+        <Block paddingX="density-md">
+          <Loading description="Dataset loading..." />
+        </Block>
+      )}
+
+      {fetchFilesetStatus === 'error' && (
+        <Block paddingX="density-md">
+          <ErrorMessage
+            header="Loading Error"
+            message="This dataset was unable to load. Please try again."
+            slotFooter={<Button onClick={() => refetchFileset()}>Retry</Button>}
+          />
+        </Block>
+      )}
+
+      {fetchFilesetStatus === 'success' && filesetFiles.length > 0 && (
+        <FileList files={filesetFiles} allowDelete={false} onPreviewFile={setPreviewFile} />
+      )}
+
+      {/* Always visible. Sits between the matched files list (above) and the
+          auto-split + File Validation sections (below) so users can read the
+          discovery rules right where they need them. When no fileset is
+          selected yet, the file list is absent and the tooltip naturally sits
+          right below the dropdown. */}
+      <PatternsTooltipTrigger
+        label={hasMissingTrainingFiles ? undefined : 'How are files matched within the Dataset?'}
+      />
+      {fetchFilesetStatus === 'success' && <FileValidationPanel validation={validation} />}
+
+      {openModal === 'create' && (
+        <CustomizationFilesetCreateModal
+          open
+          onClose={() => setOpenModal(undefined)}
+          onFilesetCreated={onCreate}
+        />
+      )}
+
+      {previewFile && (
+        <SidePanel
+          slotHeading={
+            <div className="flex gap-2 items-center">
+              <FolderOpen />
+              {previewFile.dataset
+                ? `${previewFile.dataset.workspace}/${previewFile.dataset.name}/${previewFile.path}`
+                : previewFile.path}
+            </div>
+          }
+          side="right"
+          open
+          onOpenChange={clearPreview}
+          onEscapeKeyDown={(e) => {
+            e.preventDefault();
+            clearPreview();
+          }}
+          onPointerDownOutside={(e) => {
+            e.preventDefault();
+            clearPreview();
+          }}
+          attributes={{
+            SidePanelHeading: { className: 'font-normal' },
+          }}
+          bordered
+          modal
+          className="max-w-[960px] w-full"
+        >
+          {/* Use the same CodeEditor the Fileset browser uses for previews —
+              it virtualizes content so multi-MB JSONL files render without
+              freezing the browser. The lightweight FileContentPreview from
+              @nemo/common runs Shiki on the entire string and hangs above
+              ~1 MB. */}
+          {previewError ? (
+            <div className="flex h-full items-center justify-center text-red-600">
+              Error loading file: {previewError.message}
+            </div>
+          ) : isLoadingPreview ? (
+            <div className="flex h-full items-center justify-center">
+              <span>Loading content...</span>
+            </div>
+          ) : (
+            <div className="h-full">
+              <CodeEditor
+                content={previewContent ?? ''}
+                contentType={
+                  isJsonFile(inferJsonContentType(previewFile.path))
+                    ? ContentType.JSON
+                    : ContentType.TEXT
+                }
+                readOnly
+              />
+            </div>
+          )}
+        </SidePanel>
+      )}
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/constants/routes.ts
+++ b/web/packages/studio/src/constants/routes.ts
@@ -56,6 +56,7 @@ export const ROUTES = {
     jobs: `/workspaces/:${P.workspace}/jobs`,
     jobDetail: `/workspaces/:${P.workspace}/jobs/:${P.jobName}`,
     promptTuningForm: `/workspaces/:${P.workspace}/customizations/prompt-tuned/new`,
+    newCustomizationJob: `/workspaces/:${P.workspace}/customizations/fine-tuned/new`,
     baseModels: `/workspaces/:${P.workspace}/base-models`,
     /** Base models list with a specific model panel open (model name in path) */
     baseModelsModel: `/workspaces/:${P.workspace}/base-models/:${P.modelName}`,

--- a/web/packages/studio/src/hooks/useCustomizationDatasetValidation/encodingQuery.ts
+++ b/web/packages/studio/src/hooks/useCustomizationDatasetValidation/encodingQuery.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { filesDownloadFile } from '@nemo/sdk/generated/platform/api';
+import { queryOptions } from '@tanstack/react-query';
+
+export interface FileEncodingResult {
+  ok: boolean;
+}
+
+interface DatasetFileEncodingParams {
+  workspace: string;
+  name: string;
+  path: string;
+}
+
+/**
+ * Strict UTF-8 validation for a single fileset file.
+ *
+ * Runs in parallel with `datasetFileContentQueryOptions` (which uses lossy
+ * `Blob.text()` decoding for backwards compatibility with non-validation
+ * consumers). Customizer's training pipeline opens every file with
+ * encoding="utf-8" and Python's default 'strict' error mode, so non-UTF-8
+ * input fails the training job with UnicodeDecodeError. We catch that here
+ * pre-submit by using `TextDecoder('utf-8', { fatal: true })`, which throws
+ * on the same byte sequences Python's strict UTF-8 decoder would reject.
+ *
+ * Note: this fetches the file a second time alongside the content query.
+ * Worth living with for now to keep the blast radius inside the customizer
+ * fine-tuning form. Folding the strict decode into
+ * `datasetFileContentQueryOptions` itself (and removing this query) is
+ * tracked as a follow-up.
+ */
+export const datasetFileEncodingQueryOptions = ({
+  workspace,
+  name,
+  path,
+}: DatasetFileEncodingParams) =>
+  queryOptions<FileEncodingResult>({
+    staleTime: Infinity,
+    queryKey: ['fileset-encoding-utf8', workspace, name, path],
+    queryFn: async () => {
+      const blob = await filesDownloadFile(workspace, name, path);
+      if (!blob) {
+        throw new Error('Invalid response while downloading file for encoding check');
+      }
+      const buffer = await blob.arrayBuffer();
+      try {
+        new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+        return { ok: true };
+      } catch {
+        // The browser's TextDecoder error string is implementation-specific
+        // and not user-friendly ("Failed to execute 'decode' on 'TextDecoder'").
+        // Drop it on the floor — the panel only needs to know pass/fail and
+        // surfaces the offending file path itself.
+        return { ok: false };
+      }
+    },
+  });

--- a/web/packages/studio/src/hooks/useCustomizationDatasetValidation/encodingQuery.ts
+++ b/web/packages/studio/src/hooks/useCustomizationDatasetValidation/encodingQuery.ts
@@ -15,21 +15,10 @@ interface DatasetFileEncodingParams {
 }
 
 /**
- * Strict UTF-8 validation for a single fileset file.
- *
- * Runs in parallel with `datasetFileContentQueryOptions` (which uses lossy
- * `Blob.text()` decoding for backwards compatibility with non-validation
- * consumers). Customizer's training pipeline opens every file with
- * encoding="utf-8" and Python's default 'strict' error mode, so non-UTF-8
- * input fails the training job with UnicodeDecodeError. We catch that here
- * pre-submit by using `TextDecoder('utf-8', { fatal: true })`, which throws
- * on the same byte sequences Python's strict UTF-8 decoder would reject.
- *
- * Note: this fetches the file a second time alongside the content query.
- * Worth living with for now to keep the blast radius inside the customizer
- * fine-tuning form. Folding the strict decode into
- * `datasetFileContentQueryOptions` itself (and removing this query) is
- * tracked as a follow-up.
+ * Strict UTF-8 validation for a fileset file. Customizer training decodes files
+ * with Python's strict UTF-8, so we reject the same bytes pre-submit via
+ * `TextDecoder('utf-8', { fatal: true })`. Fetches the file a second time;
+ * folding this into the content query is a follow-up.
  */
 export const datasetFileEncodingQueryOptions = ({
   workspace,

--- a/web/packages/studio/src/hooks/useCustomizationDatasetValidation/index.test.tsx
+++ b/web/packages/studio/src/hooks/useCustomizationDatasetValidation/index.test.tsx
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import {
+  type CustomizationDatasetValidationResult,
+  useCustomizationDatasetValidation,
+} from '@studio/hooks/useCustomizationDatasetValidation';
+import { server } from '@studio/mocks/node';
+import { TestProviders } from '@studio/tests/util/TestProviders';
+import { render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { FC } from 'react';
+
+/**
+ * Shape we serialize from the hook into the DOM. JSON-stringified so each
+ * test asserts only the field it cares about with regex / textContent checks.
+ */
+interface HarnessSnapshot {
+  isPending: boolean;
+  formatOk: boolean;
+  formatFileErrorPaths: string[];
+  schemaVariant: string | null;
+  schemaMismatchedFiles: string[];
+  encodingOk: boolean;
+  encodingFileErrorPaths: string[];
+  completenessOk: boolean;
+  completenessSkipped: boolean;
+  completenessErrorCount: number;
+  trainingRowCount: number;
+  validationRowCount: number;
+  hasTraining: boolean;
+}
+
+const snapshot = (r: CustomizationDatasetValidationResult): HarnessSnapshot => ({
+  isPending: r.isPending,
+  formatOk: r.format.ok,
+  formatFileErrorPaths: r.format.fileErrors.map((e) => e.path),
+  schemaVariant: r.schema?.variant ?? null,
+  schemaMismatchedFiles: r.schemaMismatchedFiles,
+  encodingOk: r.encoding.ok,
+  encodingFileErrorPaths: r.encoding.fileErrors.map((e) => e.path),
+  completenessOk: r.completeness.ok,
+  completenessSkipped: r.completeness.skipped,
+  completenessErrorCount: r.completeness.errors.length,
+  trainingRowCount: r.trainingRowCount,
+  validationRowCount: r.validationRowCount,
+  hasTraining: r.hasTraining,
+});
+
+interface HarnessProps {
+  fileset: string;
+  trainingType: 'sft' | 'dpo';
+  sampleLimit?: number;
+}
+
+const HookHarness: FC<HarnessProps> = ({ fileset, trainingType, sampleLimit }) => {
+  const result = useCustomizationDatasetValidation({ fileset, trainingType, sampleLimit });
+  return <span data-testid="snapshot">{JSON.stringify(snapshot(result))}</span>;
+};
+
+/** Helper: read the latest snapshot from the harness DOM node. */
+const readSnapshot = (): HarnessSnapshot =>
+  JSON.parse(screen.getByTestId('snapshot').textContent ?? '{}');
+
+/** Wait until the validation has resolved (isPending === false). */
+const waitForResolved = async (): Promise<HarnessSnapshot> => {
+  await waitFor(() => {
+    expect(readSnapshot().isPending).toBe(false);
+  });
+  return readSnapshot();
+};
+
+/**
+ * Build the four msw overrides needed to drive a single fileset under test:
+ *  - list filesets (the validation hook doesn't call this; fileset retrieval does)
+ *  - list fileset files (returns the discovered file paths)
+ *  - HEAD per file (200)
+ *  - GET (download) per file (returns the content for that specific path)
+ *
+ * `contents` maps file path -> UTF-8 string body returned by the GET handler.
+ */
+const setupFilesetMock = (
+  workspace: string,
+  name: string,
+  files: { path: string; size: number }[],
+  contents: Record<string, string>
+) => {
+  const filesetUrl = `${PLATFORM_BASE_URL}/apis/files/v2/workspaces/${workspace}/filesets/${name}`;
+  server.use(
+    http.get(`${filesetUrl}/files`, () =>
+      HttpResponse.json({
+        data: files.map((f) => ({ ...f, file_ref: `ref-${f.path}` })),
+        pagination: {
+          page: 1,
+          page_size: 100,
+          current_page_size: files.length,
+          total_pages: 1,
+          total_results: files.length,
+        },
+      })
+    ),
+    http.head(`${filesetUrl}/-/*`, () => new HttpResponse(null, { status: 200 })),
+    http.get(`${filesetUrl}/-/*`, ({ request }) => {
+      const url = new URL(request.url);
+      // Path is everything after /-/
+      const match = url.pathname.match(/\/-\/(.+)$/);
+      const filePath = match ? decodeURIComponent(match[1]) : '';
+      const body = contents[filePath];
+      if (body === undefined) return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(body, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      });
+    })
+  );
+};
+
+const FILESET_URN = 'fileset://test-workspace/test-fileset';
+
+describe('useCustomizationDatasetValidation', () => {
+  describe('happy path', () => {
+    it('format-pass + schema=sft-prompt-completion when content is well-formed', async () => {
+      const lines = Array.from({ length: 5 }, (_, i) =>
+        JSON.stringify({ prompt: `q${i}`, completion: `a${i}` })
+      ).join('\n');
+      setupFilesetMock(
+        'test-workspace',
+        'test-fileset',
+        [{ path: 'training/data.jsonl', size: lines.length }],
+        { 'training/data.jsonl': lines }
+      );
+
+      render(
+        <TestProviders>
+          <HookHarness fileset={FILESET_URN} trainingType="sft" />
+        </TestProviders>
+      );
+
+      const result = await waitForResolved();
+      expect(result.formatOk).toBe(true);
+      expect(result.schemaVariant).toBe('sft-prompt-completion');
+      expect(result.schemaMismatchedFiles).toEqual([]);
+      expect(result.completenessOk).toBe(true);
+      expect(result.encodingOk).toBe(true);
+      expect(result.trainingRowCount).toBe(5);
+      expect(result.hasTraining).toBe(true);
+    });
+
+    it('detects schema=sft-chat when rows have a messages array', async () => {
+      const line = JSON.stringify({
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'hello' },
+        ],
+      });
+      setupFilesetMock(
+        'test-workspace',
+        'test-fileset',
+        [{ path: 'training/chat.jsonl', size: line.length }],
+        { 'training/chat.jsonl': `${line}\n${line}` }
+      );
+
+      render(
+        <TestProviders>
+          <HookHarness fileset={FILESET_URN} trainingType="sft" />
+        </TestProviders>
+      );
+
+      const result = await waitForResolved();
+      expect(result.schemaVariant).toBe('sft-chat');
+    });
+  });
+
+  describe('schema-not-detected', () => {
+    it('returns null schema and skips completeness when no SFT shape matches', async () => {
+      const line = JSON.stringify({ foo: 'bar', baz: 'qux' });
+      setupFilesetMock(
+        'test-workspace',
+        'test-fileset',
+        [{ path: 'training/odd.jsonl', size: line.length }],
+        { 'training/odd.jsonl': `${line}\n${line}` }
+      );
+
+      render(
+        <TestProviders>
+          <HookHarness fileset={FILESET_URN} trainingType="sft" />
+        </TestProviders>
+      );
+
+      const result = await waitForResolved();
+      expect(result.schemaVariant).toBeNull();
+      // Schema mismatched files lists files where format passed but schema didn't.
+      expect(result.schemaMismatchedFiles).toEqual(['training/odd.jsonl']);
+      expect(result.completenessSkipped).toBe(true);
+    });
+  });
+
+  describe('sampleLimit', () => {
+    /**
+     * Build content with 60 valid prompt-completion rows and one malformed
+     * line at row index 60 (the 61st line). Format check should:
+     *   - sampleLimit=0 (default): scan everything → fail
+     *   - sampleLimit=10: only scan first 10 lines → pass
+     * This pins that sampleLimit actually bounds the scan and that the
+     * default really walks the full file.
+     */
+    const buildContentWithMalformedPastFifty = () => {
+      const valid = Array.from({ length: 60 }, (_, i) =>
+        JSON.stringify({ prompt: `q${i}`, completion: `a${i}` })
+      );
+      const malformed = '{not valid json';
+      return [...valid, malformed].join('\n');
+    };
+
+    it('default sampleLimit=0 walks the full file and catches a malformed row past 50', async () => {
+      const content = buildContentWithMalformedPastFifty();
+      setupFilesetMock(
+        'test-workspace',
+        'test-fileset',
+        [{ path: 'training/data.jsonl', size: content.length }],
+        { 'training/data.jsonl': content }
+      );
+
+      render(
+        <TestProviders>
+          <HookHarness fileset={FILESET_URN} trainingType="sft" />
+        </TestProviders>
+      );
+
+      const result = await waitForResolved();
+      expect(result.formatOk).toBe(false);
+      expect(result.formatFileErrorPaths).toEqual(['training/data.jsonl']);
+    });
+
+    it('sampleLimit=10 truncates the scan so the malformed past-50 row is not reached', async () => {
+      const content = buildContentWithMalformedPastFifty();
+      setupFilesetMock(
+        'test-workspace',
+        'test-fileset',
+        [{ path: 'training/data.jsonl', size: content.length }],
+        { 'training/data.jsonl': content }
+      );
+
+      render(
+        <TestProviders>
+          <HookHarness fileset={FILESET_URN} trainingType="sft" sampleLimit={10} />
+        </TestProviders>
+      );
+
+      const result = await waitForResolved();
+      expect(result.formatOk).toBe(true);
+      expect(result.schemaVariant).toBe('sft-prompt-completion');
+      // Row count still reflects the full file, not the sample.
+      expect(result.trainingRowCount).toBe(61);
+    });
+  });
+
+  // Encoding test (non-UTF-8 input flagged as failure) intentionally omitted
+  // here: jsdom + blob-polyfill don't preserve raw binary bytes through Blob/
+  // arrayBuffer round-trips, so a non-UTF-8 fixture decodes as if it were
+  // valid. The encoding query itself uses `TextDecoder('utf-8', { fatal: true })`
+  // — a standard browser API — and is verified manually with the UTF-16 BOM
+  // fixture in tmp/training-utf16.jsonl.
+});

--- a/web/packages/studio/src/hooks/useCustomizationDatasetValidation/index.ts
+++ b/web/packages/studio/src/hooks/useCustomizationDatasetValidation/index.ts
@@ -4,7 +4,6 @@
 import { validateFileFormat } from '@nemo/common/src/utils/fileValidation';
 import type { FilesetFileOutput } from '@nemo/sdk/generated/platform/schema';
 import { datasetFileContentQueryOptions } from '@studio/api/datasets/useDatasetFileContent';
-import type { TrainingType } from '@studio/util/customizerSchema';
 import {
   datasetFileEncodingQueryOptions,
   type FileEncodingResult,
@@ -13,6 +12,7 @@ import { parseFilesetUri } from '@studio/hooks/useCustomizationFiles/utils';
 import { useDatasetFileDiscovery } from '@studio/hooks/useDatasetFileDiscovery';
 import {
   type CustomizerSchemaDetection,
+  type TrainingType,
   detectCustomizerSchema,
   expectedSchemaCopy,
   inferRowSchema,

--- a/web/packages/studio/src/hooks/useCustomizationDatasetValidation/index.ts
+++ b/web/packages/studio/src/hooks/useCustomizationDatasetValidation/index.ts
@@ -136,16 +136,7 @@ export interface CustomizationDatasetValidationResult {
     ok: boolean;
     fileErrors: EncodingFileError[];
   };
-  /**
-   * Inferred field shape from the first row of the first successfully detected
-   * file: list of [key, jsType] tuples (e.g. [["prompt", "string"], ...]).
-   */
-  /**
-   * TypeScript-shaped string describing the inferred schema of the first
-   * recognized row, with nested objects/arrays expanded so users can verify
-   * the full structure — not just see "object". Empty when nothing was
-   * detected; callers should hide the preview block in that case.
-   */
+  /** TS-shaped string of the first recognized row's inferred schema; empty when none. */
   schemaShape: string;
   hasTraining: boolean;
   hasValidation: boolean;
@@ -297,15 +288,9 @@ const validateOne = async (
 };
 
 /**
- * Downloads the content of every training/validation file in a fileset and runs:
- *   - Format check via validateFileFormat from @nemo/common (line-by-line JSONL parse)
- *   - Strict customizer-aligned schema detection via detectCustomizerSchema, scoped
- *     to the currently selected training type (SFT vs DPO have different rules,
- *     mirroring services/customizer/.../schemas.py discriminators)
- *
- * Reuses the existing JSONL parser in @nemo/common; do NOT duplicate it here.
- *
- * sampleLimit defaults to 0 (parse every line). Positive values truncate the sample.
+ * Downloads every training/validation file in a fileset and runs format, schema
+ * (scoped to the training type), encoding, and completeness checks.
+ * sampleLimit defaults to 0 (parse every line); positive values truncate.
  */
 export const useCustomizationDatasetValidation = ({
   fileset,

--- a/web/packages/studio/src/hooks/useCustomizationDatasetValidation/index.ts
+++ b/web/packages/studio/src/hooks/useCustomizationDatasetValidation/index.ts
@@ -1,0 +1,461 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { validateFileFormat } from '@nemo/common/src/utils/fileValidation';
+import type { FilesetFileOutput } from '@nemo/sdk/generated/platform/schema';
+import { datasetFileContentQueryOptions } from '@studio/api/datasets/useDatasetFileContent';
+import type { TrainingType } from '@studio/util/customizerSchema';
+import {
+  datasetFileEncodingQueryOptions,
+  type FileEncodingResult,
+} from '@studio/hooks/useCustomizationDatasetValidation/encodingQuery';
+import { parseFilesetUri } from '@studio/hooks/useCustomizationFiles/utils';
+import { useDatasetFileDiscovery } from '@studio/hooks/useDatasetFileDiscovery';
+import {
+  type CustomizerSchemaDetection,
+  detectCustomizerSchema,
+  expectedSchemaCopy,
+  inferRowSchema,
+  validateRowCompleteness,
+} from '@studio/util/customizerSchema';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+export interface FileValidationError {
+  path: string;
+  error: string;
+}
+
+export interface CompletenessError {
+  /** Fileset-relative path of the offending file. */
+  path: string;
+  /** 1-based row index for human display. */
+  row: number;
+  /** Short description of the missing/empty field. */
+  message: string;
+}
+
+export interface EncodingFileError {
+  path: string;
+}
+
+/**
+ * SDK file output decorated with the per-file row count this hook computes
+ * during validation. rowCount is undefined while validation is in flight or
+ * when validation skipped the file (e.g., format check failed).
+ */
+export interface AnnotatedFilesetFile extends FilesetFileOutput {
+  rowCount?: number;
+}
+
+/** Per-file completeness check results are capped to keep the UI fast. */
+const MAX_COMPLETENESS_ERRORS_PER_FILE = 10;
+
+/**
+ * Cap concurrent per-file fetch+validate operations. Each file kicks off two
+ * requests (content + strict UTF-8 encoding check) plus buffers a full
+ * arrayBuffer transiently — without a cap, a 100-file fileset would issue
+ * 200 concurrent requests and could buffer hundreds of MB. Browser HTTP/1.1
+ * pools cap at ~6 per origin anyway, so high parallelism just queues without
+ * benefit. 4 leaves headroom for other in-flight queries on the page.
+ */
+const PER_FILE_VALIDATION_CONCURRENCY = 4;
+
+/**
+ * Run an async worker over an items array with bounded concurrency, preserving
+ * input order in the result. Equivalent to Promise.all(items.map(worker)) but
+ * with at most `concurrency` workers active at any time.
+ */
+const runWithConcurrency = async <T, R>(
+  items: T[],
+  worker: (item: T) => Promise<R>,
+  concurrency: number
+): Promise<R[]> => {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const runOne = async (): Promise<void> => {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      results[i] = await worker(items[i]);
+    }
+  };
+  const lanes = Array.from({ length: Math.min(concurrency, items.length) }, runOne);
+  await Promise.all(lanes);
+  return results;
+};
+
+export interface CustomizationDatasetValidationResult {
+  isPending: boolean;
+  /**
+   * Non-null when the fileset's file listing itself failed (network/API/perms).
+   * Callers should render a retryable load error instead of any of the other
+   * checks — the rest of the result is meaningless when discovery failed.
+   */
+  discoveryError: Error | null;
+  /** Format check across every discovered file. */
+  format: {
+    ok: boolean;
+    fileErrors: FileValidationError[];
+  };
+  /**
+   * Strict customizer-aligned schema detection across discovered files. Set
+   * from the FIRST file that matched; null when no file matched.
+   */
+  schema: CustomizerSchemaDetection | null;
+  /**
+   * Human-readable description of the keys customizer expects for the active
+   * training type, surfaced in the "Schema does not match" copy.
+   */
+  schemaExpectedCopy: string;
+  /**
+   * Files that parsed cleanly but whose first row did not match any
+   * customizer-recognized shape, OR matched a different variant than
+   * `schema.variant`. Customizer would reject these at training time, so the
+   * panel must surface them rather than silently relying on the first match.
+   */
+  schemaMismatchedFiles: string[];
+  /**
+   * Completeness check (no empty/null values in required fields). Skipped when
+   * format failed or the schema didn't match — we don't know what to require
+   * in those cases.
+   */
+  completeness: {
+    /** True when the check ran and found no errors. */
+    ok: boolean;
+    /** True when the check was skipped (format failed or schema didn't match). */
+    skipped: boolean;
+    /** Per-file errors, capped at MAX_COMPLETENESS_ERRORS_PER_FILE per file. */
+    errors: CompletenessError[];
+  };
+  /**
+   * Strict UTF-8 encoding check across every discovered file. Uses
+   * `TextDecoder('utf-8', { fatal: true })` on raw bytes, which throws on the
+   * same input customizer's Python `open(encoding="utf-8")` would reject.
+   */
+  encoding: {
+    ok: boolean;
+    fileErrors: EncodingFileError[];
+  };
+  /**
+   * Inferred field shape from the first row of the first successfully detected
+   * file: list of [key, jsType] tuples (e.g. [["prompt", "string"], ...]).
+   */
+  /**
+   * TypeScript-shaped string describing the inferred schema of the first
+   * recognized row, with nested objects/arrays expanded so users can verify
+   * the full structure — not just see "object". Empty when nothing was
+   * detected; callers should hide the preview block in that case.
+   */
+  schemaShape: string;
+  hasTraining: boolean;
+  hasValidation: boolean;
+  /** Show "customizer will auto-split 10%" notice. */
+  autoSplitNotice: boolean;
+  /**
+   * Discovered training files, each annotated with its non-empty row count.
+   * The count is undefined while validation is pending or the file was
+   * skipped — consumers should fall back to "no count yet" rendering.
+   */
+  training: AnnotatedFilesetFile[];
+  /** Discovered validation files, decorated the same way as training. */
+  validation: AnnotatedFilesetFile[];
+  /** Total non-empty rows across all training files (for auto-split stats). */
+  trainingRowCount: number;
+  /** Total non-empty rows across all validation files. */
+  validationRowCount: number;
+}
+
+interface UseCustomizationDatasetValidationOptions {
+  fileset?: string;
+  /**
+   * Currently-selected training type from the form. Schema rules differ:
+   * SFT accepts messages or prompt+completion; DPO accepts the four preference
+   * shapes. Customizer applies the same training-type-aware discrimination.
+   */
+  trainingType: TrainingType;
+  /**
+   * Cap on the number of lines parsed per file. 0 (default) means parse every
+   * line of every file. Positive values truncate the sample, useful for
+   * lightweight pre-flight callers.
+   */
+  sampleLimit?: number;
+}
+
+interface PerFileValidation {
+  file: FilesetFileOutput;
+  error: string | null;
+  schema: CustomizerSchemaDetection | null;
+  firstRow: Record<string, unknown> | null;
+  /** Non-empty line count from the full content (independent of sampleLimit). */
+  rowCount: number;
+  /**
+   * Completeness errors collected for this file, capped at
+   * MAX_COMPLETENESS_ERRORS_PER_FILE. Empty when the schema didn't detect
+   * (we can't check) or when every row is complete.
+   */
+  completenessErrors: CompletenessError[];
+  /** Strict UTF-8 check result for this file's raw bytes. */
+  encoding: FileEncodingResult;
+}
+
+const buildSampleFile = (path: string, content: string, sampleLimit: number): File => {
+  const text = sampleLimit > 0 ? content.split('\n').slice(0, sampleLimit).join('\n') : content;
+  return new File([text], path, { type: 'application/x-ndjson' });
+};
+
+const countRows = (content: string): number =>
+  content.split('\n').filter((line) => line.trim().length > 0).length;
+
+/**
+ * Iterate every non-empty line of JSONL content and call the visitor with the
+ * parsed row. Returns true if all lines parsed; false on a parse error (caller
+ * already runs validateFileFormat which would catch this, so this should only
+ * happen if line counts diverge).
+ */
+const forEachParsedRow = (
+  content: string,
+  visitor: (row: Record<string, unknown>, index: number) => 'stop' | void
+): void => {
+  let index = 0;
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const result = visitor(parsed as Record<string, unknown>, index);
+        if (result === 'stop') return;
+      }
+    } catch {
+      return;
+    }
+    index += 1;
+  }
+};
+
+const validateOne = async (
+  file: FilesetFileOutput,
+  content: string,
+  encoding: FileEncodingResult,
+  sampleLimit: number,
+  trainingType: TrainingType
+): Promise<PerFileValidation> => {
+  const rowCount = countRows(content);
+  const sample = buildSampleFile(file.path, content, sampleLimit);
+  const formatResult = await validateFileFormat(sample);
+  if (!formatResult.isValid || !formatResult.format) {
+    return {
+      file,
+      error: formatResult.error ?? 'File is not valid JSON or JSONL',
+      schema: null,
+      firstRow: null,
+      rowCount,
+      completenessErrors: [],
+      encoding,
+    };
+  }
+
+  let firstRow: Record<string, unknown> | null = null;
+  let schema: CustomizerSchemaDetection | null = null;
+  const completenessErrors: CompletenessError[] = [];
+
+  // Honor sampleLimit for the completeness scan as well, so lightweight
+  // callers don't quietly walk every line of every file. Schema detection
+  // only reads the first row regardless, so truncation is safe for it too.
+  // rowCount above stays computed off the full content — that field exposes
+  // true file size for the auto-split stats, independent of sample mode.
+  const sampledContent =
+    sampleLimit > 0 ? content.split('\n').slice(0, sampleLimit).join('\n') : content;
+
+  forEachParsedRow(sampledContent, (row, index) => {
+    if (firstRow === null) {
+      firstRow = row;
+      schema = detectCustomizerSchema(row, trainingType);
+    }
+    // Skip completeness when the schema didn't match — we don't know what to
+    // require. The Schema check already surfaces a warning.
+    if (schema === null) return 'stop';
+
+    const message = validateRowCompleteness(row, schema.variant);
+    if (message !== null) {
+      completenessErrors.push({ path: file.path, row: index + 1, message });
+      if (completenessErrors.length >= MAX_COMPLETENESS_ERRORS_PER_FILE) {
+        return 'stop';
+      }
+    }
+  });
+
+  return {
+    file,
+    error: null,
+    schema,
+    firstRow,
+    rowCount,
+    completenessErrors,
+    encoding,
+  };
+};
+
+/**
+ * Downloads the content of every training/validation file in a fileset and runs:
+ *   - Format check via validateFileFormat from @nemo/common (line-by-line JSONL parse)
+ *   - Strict customizer-aligned schema detection via detectCustomizerSchema, scoped
+ *     to the currently selected training type (SFT vs DPO have different rules,
+ *     mirroring services/customizer/.../schemas.py discriminators)
+ *
+ * Reuses the existing JSONL parser in @nemo/common; do NOT duplicate it here.
+ *
+ * sampleLimit defaults to 0 (parse every line). Positive values truncate the sample.
+ */
+export const useCustomizationDatasetValidation = ({
+  fileset,
+  trainingType,
+  sampleLimit = 0,
+}: UseCustomizationDatasetValidationOptions): CustomizationDatasetValidationResult => {
+  const { workspace, name } = parseFilesetUri(fileset ?? '');
+  const queryClient = useQueryClient();
+  const {
+    training,
+    validation,
+    isPending: isDiscoveryPending,
+    error: discoveryError,
+  } = useDatasetFileDiscovery({ fileset });
+
+  const allFiles = [...training, ...validation];
+  const paths = allFiles.map((f) => f.path);
+  const enabled = !!workspace && !!name && allFiles.length > 0;
+
+  const { data, isPending: isValidationPending } = useQuery({
+    enabled,
+    // Sort paths in the key so a backend reorder of the same files doesn't
+    // change the key and spuriously refetch the whole validation pass.
+    // allFiles below stays in the original order so per-file iteration
+    // behavior is unchanged.
+    queryKey: [
+      'customization-dataset-validation',
+      workspace,
+      name,
+      trainingType,
+      sampleLimit,
+      [...paths].sort(),
+    ] as const,
+    queryFn: async () => {
+      const perFile = await runWithConcurrency<FilesetFileOutput, PerFileValidation>(
+        allFiles,
+        async (file): Promise<PerFileValidation> => {
+          try {
+            // Fetch lossy text + strict UTF-8 check in parallel for THIS
+            // file (two requests per file). The outer concurrency cap
+            // bounds how many files run at once. Folding the strict decode
+            // into datasetFileContentQueryOptions is tracked as a follow-up.
+            const [content, encoding] = await Promise.all([
+              queryClient.ensureQueryData(
+                datasetFileContentQueryOptions({ workspace, name, path: file.path })
+              ),
+              queryClient.ensureQueryData(
+                datasetFileEncodingQueryOptions({ workspace, name, path: file.path })
+              ),
+            ]);
+            return await validateOne(file, content, encoding, sampleLimit, trainingType);
+          } catch (err) {
+            // A single file failing to download (404, network blip, fileset
+            // shifting underneath us) shouldn't poison the whole validation —
+            // surface it on this file's row and let the rest be validated.
+            const message = err instanceof Error ? err.message : 'Failed to download file';
+            return {
+              file,
+              error: `Failed to download file: ${message}`,
+              schema: null,
+              firstRow: null,
+              rowCount: 0,
+              completenessErrors: [],
+              // Don't double-count this in the encoding row — the format/error
+              // row already carries the download failure for this file.
+              encoding: { ok: true },
+            };
+          }
+        },
+        PER_FILE_VALIDATION_CONCURRENCY
+      );
+      return perFile;
+    },
+  });
+
+  const perFile = data ?? [];
+  const fileErrors: FileValidationError[] = perFile
+    .filter((r) => r.error !== null)
+    .map((r) => ({ path: r.file.path, error: r.error as string }));
+  const formatOk = enabled && fileErrors.length === 0 && perFile.length === allFiles.length;
+  const firstDetected = perFile.find((r) => r.schema !== null) ?? null;
+
+  const hasTraining = training.length > 0;
+  const hasValidation = validation.length > 0;
+
+  // Decorate the discovered files with their per-file row counts so consumers
+  // get one annotated array instead of having to merge a parallel path->count
+  // map. rowCount is undefined for any file whose validation hasn't resolved
+  // yet (or was skipped because format failed).
+  const rowCountsByPath: Record<string, number> = Object.fromEntries(
+    perFile.map((r) => [r.file.path, r.rowCount])
+  );
+  const annotate = (file: FilesetFileOutput): AnnotatedFilesetFile => ({
+    ...file,
+    rowCount: rowCountsByPath[file.path],
+  });
+  const annotatedTraining = training.map(annotate);
+  const annotatedValidation = validation.map(annotate);
+
+  const trainingPaths = new Set(training.map((f) => f.path));
+  const trainingRowCount = perFile
+    .filter((r) => trainingPaths.has(r.file.path))
+    .reduce((sum, r) => sum + r.rowCount, 0);
+  const validationRowCount = perFile
+    .filter((r) => !trainingPaths.has(r.file.path))
+    .reduce((sum, r) => sum + r.rowCount, 0);
+
+  const schema = firstDetected?.schema ?? null;
+  // A file mismatches when its format check passed but its first row either
+  // didn't match any customizer shape OR matched a different variant than the
+  // one we're treating as "the" schema. Customizer's per-file Pydantic
+  // validation would reject these at training time.
+  const schemaMismatchedFiles = perFile
+    .filter(
+      (r) =>
+        r.error === null &&
+        (r.schema === null || (schema !== null && r.schema?.variant !== schema.variant))
+    )
+    .map((r) => r.file.path);
+  const completenessErrors = perFile.flatMap((r) => r.completenessErrors);
+  const completenessSkipped = !formatOk || schema === null;
+  const completeness = {
+    ok: !completenessSkipped && completenessErrors.length === 0,
+    skipped: completenessSkipped,
+    errors: completenessErrors,
+  };
+  const encodingFileErrors: EncodingFileError[] = perFile
+    .filter((r) => !r.encoding.ok)
+    .map((r) => ({ path: r.file.path }));
+  const encoding = {
+    ok: enabled && encodingFileErrors.length === 0 && perFile.length === allFiles.length,
+    fileErrors: encodingFileErrors,
+  };
+
+  return {
+    isPending: isDiscoveryPending || (enabled && isValidationPending),
+    discoveryError,
+    format: { ok: formatOk, fileErrors },
+    schema,
+    schemaExpectedCopy: expectedSchemaCopy(trainingType),
+    schemaMismatchedFiles,
+    schemaShape: inferRowSchema(firstDetected?.firstRow ?? null),
+    completeness,
+    encoding,
+    hasTraining,
+    hasValidation,
+    autoSplitNotice: hasTraining && !hasValidation,
+    training: annotatedTraining,
+    validation: annotatedValidation,
+    trainingRowCount,
+    validationRowCount,
+  };
+};

--- a/web/packages/studio/src/routes/NewCustomizationRoute/index.tsx
+++ b/web/packages/studio/src/routes/NewCustomizationRoute/index.tsx
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NewCustomizationForm } from '@studio/components/NewCustomizationForm';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { getWorkspaceCustomizationJobListRoute } from '@studio/routes/utils';
+import { useSearchParams } from 'react-router-dom';
+
+export const NewCustomizationRoute = () => {
+  const workspace = useWorkspaceFromPath();
+  const [searchParams] = useSearchParams();
+  const initialModel = searchParams.get('model') ?? undefined;
+
+  useBreadcrumbs({
+    items: [
+      {
+        href: getWorkspaceCustomizationJobListRoute(workspace),
+        slotLabel: 'Models',
+      },
+      {
+        slotLabel: 'New Fine-Tuned Model',
+      },
+    ],
+  });
+
+  return <NewCustomizationForm workspace={workspace} initialModel={initialModel} />;
+};

--- a/web/packages/studio/src/routes/groups/customizationRoutes.tsx
+++ b/web/packages/studio/src/routes/groups/customizationRoutes.tsx
@@ -7,6 +7,11 @@ import { gateCustomizationRoutes } from '@studio/routes/utils';
 import { lazy } from 'react';
 import type { RouteObject } from 'react-router-dom';
 
+const NewCustomizationRoute = lazy(() =>
+  import('@studio/routes/NewCustomizationRoute/index').then((module) => ({
+    default: module.NewCustomizationRoute,
+  }))
+);
 const PromptTuningFormRoute = lazy(() =>
   import('@studio/routes/PromptTuningFormRoute/index').then((module) => ({
     default: module.PromptTuningFormRoute,
@@ -24,6 +29,11 @@ const CustomizationJobDetailsRoute = lazy(() =>
 );
 
 export const customizationRoutes: RouteObject[] = gateCustomizationRoutes([
+  {
+    path: ROUTES.workspace.newCustomizationJob,
+    element: <NewCustomizationRoute />,
+    errorElement: <ErrorPanel title="Customizer" />,
+  },
   {
     path: ROUTES.workspace.promptTuningForm,
     element: <PromptTuningFormRoute />,

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -343,6 +343,14 @@ export const getPromptTuningFormRoute = (workspace: string, options?: { model?: 
   return basePath;
 };
 
+export const getNewCustomizationJobRoute = (workspace: string, options?: { model?: string }) => {
+  const basePath = generatePath(ROUTES.workspace.newCustomizationJob, { workspace });
+  if (options?.model) {
+    return `${basePath}?model=${encodeURIComponent(options.model)}`;
+  }
+  return basePath;
+};
+
 export const getNewFilesetRoute = (workspace: string) => {
   return generatePath(ROUTES.workspace.filesetNew, { workspace });
 };

--- a/web/packages/studio/src/util/customizerSchema.test.ts
+++ b/web/packages/studio/src/util/customizerSchema.test.ts
@@ -1,0 +1,413 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  CUSTOMIZER_SCHEMA_LABELS,
+  detectCustomizerSchema,
+  expectedSchemaCopy,
+  inferRowSchema,
+  validateRowCompleteness,
+} from '@studio/util/customizerSchema';
+
+describe('detectCustomizerSchema', () => {
+  describe('SFT', () => {
+    it('detects messages (chat) when first message has a role', () => {
+      const row = {
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'hello' },
+        ],
+      };
+      expect(detectCustomizerSchema(row, 'sft')).toEqual({
+        variant: 'sft-chat',
+        label: CUSTOMIZER_SCHEMA_LABELS['sft-chat'],
+      });
+    });
+
+    it('detects prompt + completion', () => {
+      const row = { prompt: 'capital of France?', completion: 'Paris' };
+      expect(detectCustomizerSchema(row, 'sft')).toEqual({
+        variant: 'sft-prompt-completion',
+        label: CUSTOMIZER_SCHEMA_LABELS['sft-prompt-completion'],
+      });
+    });
+
+    it('rejects DPO-shaped rows under SFT', () => {
+      const row = { prompt: 'p', chosen: 'c', rejected: 'r' };
+      // BinaryPreference is a DPO shape; SFT rules accept prompt+completion only.
+      // The SFT detector only sees prompt and falls through.
+      expect(detectCustomizerSchema(row, 'sft')).toBeNull();
+    });
+
+    it('rejects rows that match no SFT shape', () => {
+      expect(detectCustomizerSchema({ foo: 'bar' }, 'sft')).toBeNull();
+    });
+
+    it('rejects empty messages array (no first message to verify role)', () => {
+      expect(detectCustomizerSchema({ messages: [] }, 'sft')).toBeNull();
+    });
+
+    it('rejects messages array whose first item has no role field', () => {
+      expect(detectCustomizerSchema({ messages: [{ content: 'hi' }] }, 'sft')).toBeNull();
+    });
+
+    it('returns null for null input', () => {
+      expect(detectCustomizerSchema(null, 'sft')).toBeNull();
+    });
+  });
+
+  describe('DPO', () => {
+    it('detects native PreferenceDataset (context + completions)', () => {
+      const row = {
+        context: [{ role: 'user', content: 'hi' }],
+        completions: [{ rank: 0, completion: [{ role: 'assistant', content: 'hello' }] }],
+      };
+      expect(detectCustomizerSchema(row, 'dpo')).toEqual({
+        variant: 'dpo-preference',
+        label: CUSTOMIZER_SCHEMA_LABELS['dpo-preference'],
+      });
+    });
+
+    it('detects HelpSteer3 by overall_preference field', () => {
+      const row = {
+        context: 'explain quantum',
+        response1: 'a',
+        response2: 'b',
+        overall_preference: -2,
+      };
+      expect(detectCustomizerSchema(row, 'dpo')).toEqual({
+        variant: 'dpo-helpsteer3',
+        label: CUSTOMIZER_SCHEMA_LABELS['dpo-helpsteer3'],
+      });
+    });
+
+    it('detects Tulu3 when chosen is a list of messages', () => {
+      const row = {
+        chosen: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'hello' },
+        ],
+        rejected: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'go away' },
+        ],
+      };
+      expect(detectCustomizerSchema(row, 'dpo')).toEqual({
+        variant: 'dpo-tulu3',
+        label: CUSTOMIZER_SCHEMA_LABELS['dpo-tulu3'],
+      });
+    });
+
+    it('falls back to BinaryPreference when chosen/rejected are strings', () => {
+      const row = { prompt: 'capital?', chosen: 'Paris', rejected: 'London' };
+      expect(detectCustomizerSchema(row, 'dpo')).toEqual({
+        variant: 'dpo-binary-preference',
+        label: CUSTOMIZER_SCHEMA_LABELS['dpo-binary-preference'],
+      });
+    });
+
+    it('rejects SFT prompt+completion under DPO', () => {
+      expect(detectCustomizerSchema({ prompt: 'a', completion: 'b' }, 'dpo')).toBeNull();
+    });
+
+    it('rejects rows that match no DPO shape', () => {
+      expect(detectCustomizerSchema({ foo: 'bar' }, 'dpo')).toBeNull();
+    });
+  });
+});
+
+describe('validateRowCompleteness', () => {
+  describe('sft-prompt-completion', () => {
+    it('passes when prompt and completion are non-empty strings', () => {
+      expect(
+        validateRowCompleteness({ prompt: 'p', completion: 'c' }, 'sft-prompt-completion')
+      ).toBeNull();
+    });
+
+    it('flags empty prompt', () => {
+      expect(
+        validateRowCompleteness({ prompt: '', completion: 'c' }, 'sft-prompt-completion')
+      ).toMatch(/prompt is missing or empty/);
+    });
+
+    it('flags empty completion', () => {
+      expect(
+        validateRowCompleteness({ prompt: 'p', completion: '' }, 'sft-prompt-completion')
+      ).toMatch(/completion is missing or empty/);
+    });
+
+    it('flags missing completion key', () => {
+      expect(validateRowCompleteness({ prompt: 'p' }, 'sft-prompt-completion')).toMatch(
+        /completion is missing or empty/
+      );
+    });
+  });
+
+  describe('sft-chat', () => {
+    it('passes when every message has role + content', () => {
+      const row = {
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'hello' },
+        ],
+      };
+      expect(validateRowCompleteness(row, 'sft-chat')).toBeNull();
+    });
+
+    it('passes when content is missing but tool_calls is non-empty', () => {
+      const row = {
+        messages: [
+          { role: 'assistant', tool_calls: [{ type: 'function', function: { name: 'x' } }] },
+        ],
+      };
+      expect(validateRowCompleteness(row, 'sft-chat')).toBeNull();
+    });
+
+    it('flags an empty messages array', () => {
+      expect(validateRowCompleteness({ messages: [] }, 'sft-chat')).toMatch(
+        /messages must be a non-empty array/
+      );
+    });
+
+    it('flags a message missing role', () => {
+      expect(validateRowCompleteness({ messages: [{ content: 'hi' }] }, 'sft-chat')).toMatch(
+        /messages\[0\]\.role is missing or empty/
+      );
+    });
+
+    it('flags a message missing all of content/thinking/tool_calls', () => {
+      expect(validateRowCompleteness({ messages: [{ role: 'user' }] }, 'sft-chat')).toMatch(
+        /must have non-empty content, thinking, or tool_calls/
+      );
+    });
+
+    it('flags a message that has BOTH content and thinking (backend rejects)', () => {
+      // services/customizer/.../schemas.py:292 — SFTChatMessage validator
+      // rejects messages with both fields populated. Studio must mirror that
+      // so users see the failure pre-submit instead of at training time.
+      const row = {
+        messages: [{ role: 'assistant', content: 'answer', thinking: 'reasoning' }],
+      };
+      expect(validateRowCompleteness(row, 'sft-chat')).toMatch(
+        /cannot have both content and thinking/
+      );
+    });
+  });
+
+  describe('dpo-binary-preference', () => {
+    it('passes for non-empty prompt/chosen/rejected strings', () => {
+      expect(
+        validateRowCompleteness(
+          { prompt: 'p', chosen: 'c', rejected: 'r' },
+          'dpo-binary-preference'
+        )
+      ).toBeNull();
+    });
+
+    it('passes when prompt is a non-empty list of messages', () => {
+      expect(
+        validateRowCompleteness(
+          {
+            prompt: [{ role: 'user', content: 'hi' }],
+            chosen: 'c',
+            rejected: 'r',
+          },
+          'dpo-binary-preference'
+        )
+      ).toBeNull();
+    });
+
+    it('flags empty rejected', () => {
+      expect(
+        validateRowCompleteness({ prompt: 'p', chosen: 'c', rejected: '' }, 'dpo-binary-preference')
+      ).toMatch(/rejected is missing or empty/);
+    });
+
+    it('flags non-string non-array prompt', () => {
+      expect(
+        validateRowCompleteness({ prompt: 42, chosen: 'c', rejected: 'r' }, 'dpo-binary-preference')
+      ).toMatch(/prompt must be a non-empty string or list of messages/);
+    });
+  });
+
+  describe('dpo-tulu3', () => {
+    it('passes for non-empty chosen/rejected message lists', () => {
+      const row = {
+        chosen: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'hello' },
+        ],
+        rejected: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'go away' },
+        ],
+      };
+      expect(validateRowCompleteness(row, 'dpo-tulu3')).toBeNull();
+    });
+
+    it('flags empty chosen list', () => {
+      const row = {
+        chosen: [],
+        rejected: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'go away' },
+        ],
+      };
+      expect(validateRowCompleteness(row, 'dpo-tulu3')).toMatch(
+        /chosen: messages must be a non-empty array/
+      );
+    });
+  });
+
+  describe('dpo-preference', () => {
+    it('flags missing context', () => {
+      expect(validateRowCompleteness({ completions: [{ rank: 0 }] }, 'dpo-preference')).toMatch(
+        /context: messages must be a non-empty array/
+      );
+    });
+
+    it('flags empty completions', () => {
+      const row = {
+        context: [{ role: 'user', content: 'hi' }],
+        completions: [],
+      };
+      expect(validateRowCompleteness(row, 'dpo-preference')).toMatch(
+        /completions must be a non-empty array/
+      );
+    });
+  });
+
+  describe('dpo-helpsteer3', () => {
+    it('passes for valid HelpSteer3 row', () => {
+      const row = {
+        context: 'explain quantum',
+        response1: 'a',
+        response2: 'b',
+        overall_preference: 0,
+      };
+      expect(validateRowCompleteness(row, 'dpo-helpsteer3')).toBeNull();
+    });
+
+    it('flags non-numeric overall_preference', () => {
+      const row = {
+        context: 'explain quantum',
+        response1: 'a',
+        response2: 'b',
+        overall_preference: 'high',
+      };
+      expect(validateRowCompleteness(row, 'dpo-helpsteer3')).toMatch(
+        /overall_preference must be a number/
+      );
+    });
+
+    it('flags empty response1', () => {
+      const row = {
+        context: 'explain quantum',
+        response1: '',
+        response2: 'b',
+        overall_preference: 0,
+      };
+      expect(validateRowCompleteness(row, 'dpo-helpsteer3')).toMatch(
+        /response1 is missing or empty/
+      );
+    });
+  });
+});
+
+describe('CUSTOMIZER_SCHEMA_LABELS', () => {
+  it('pins the user-facing label for every variant', () => {
+    // Update intentionally: canonical names were chosen for the panel checklist
+    // ("Schema: Chat Completion" rather than "Schema: messages (chat)"). Bumping
+    // these values is a UX decision — fail this test loudly to force a review.
+    expect(CUSTOMIZER_SCHEMA_LABELS).toEqual({
+      'sft-chat': 'Chat Completion',
+      'sft-prompt-completion': 'Completion',
+      'dpo-preference': 'Preference',
+      'dpo-helpsteer3': 'HelpSteer3',
+      'dpo-tulu3': 'Tulu3',
+      'dpo-binary-preference': 'Binary Preference',
+    });
+  });
+});
+
+describe('expectedSchemaCopy', () => {
+  it('returns DPO copy for dpo training', () => {
+    expect(expectedSchemaCopy('dpo')).toMatch(/chosen and rejected/);
+  });
+
+  it('returns SFT copy for sft training', () => {
+    expect(expectedSchemaCopy('sft')).toMatch(/messages.*prompt and completion/);
+  });
+});
+
+describe('inferRowSchema', () => {
+  it('returns empty string for null input', () => {
+    expect(inferRowSchema(null)).toBe('');
+  });
+
+  it('renders flat primitive types', () => {
+    expect(inferRowSchema({ prompt: 'hi', score: 1, ok: true })).toBe(
+      ['{', '  prompt: string,', '  score: number,', '  ok: boolean,', '}'].join('\n')
+    );
+  });
+
+  it('renders null values as the literal `null`', () => {
+    expect(inferRowSchema({ trace: null })).toBe(['{', '  trace: null,', '}'].join('\n'));
+  });
+
+  it('expands nested objects so the structure is fully visible', () => {
+    expect(inferRowSchema({ answers: { value: 'x', score: 1 } })).toBe(
+      ['{', '  answers: {', '    value: string,', '    score: number,', '  },', '}'].join('\n')
+    );
+  });
+
+  it('expands arrays of objects (e.g. messages) into multi-line form', () => {
+    const row = {
+      messages: [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'hello' },
+      ],
+    };
+    expect(inferRowSchema(row)).toBe(
+      [
+        '{',
+        '  messages: [',
+        '    {',
+        '      role: string,',
+        '      content: string,',
+        '    },',
+        '  ],',
+        '}',
+      ].join('\n')
+    );
+  });
+
+  it('uses single-line form for arrays of primitives', () => {
+    expect(inferRowSchema({ tags: ['a', 'b', 'c'] })).toBe(
+      ['{', '  tags: [string],', '}'].join('\n')
+    );
+  });
+
+  it('renders empty containers as `{}` and `[]` rather than recursing', () => {
+    expect(inferRowSchema({ extras: {}, neg_doc: [] })).toBe(
+      ['{', '  extras: {},', '  neg_doc: [],', '}'].join('\n')
+    );
+  });
+
+  it('uses the FIRST element to represent heterogeneous arrays', () => {
+    // Documented limitation: schema-mismatch row catches the broader case.
+    expect(inferRowSchema({ rows: [{ a: 1 }, { b: 'x' }] as Array<Record<string, unknown>> })).toBe(
+      ['{', '  rows: [', '    {', '      a: number,', '    },', '  ],', '}'].join('\n')
+    );
+  });
+
+  it('caps recursion depth so degenerate inputs do not loop', () => {
+    // Depth cap is 8; build a 12-deep nested object and assert the deepest
+    // layers collapse to `unknown` rather than running away.
+    let nested: Record<string, unknown> = { v: 'leaf' };
+    for (let i = 0; i < 12; i++) {
+      nested = { wrap: nested };
+    }
+    expect(inferRowSchema(nested)).toContain('unknown');
+  });
+});

--- a/web/packages/studio/src/util/customizerSchema.ts
+++ b/web/packages/studio/src/util/customizerSchema.ts
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Strict, customizer-aligned schema detection for fine-tuning datasets.
+ *
+ * Mirrors services/customizer/src/nmp/customizer/tasks/training/datasets/schemas.py
+ * (get_sft_dataset_discriminator and get_preference_dataset_discriminator).
+ *
+ * Common's detectFileStructure is too permissive for this purpose — it accepts
+ * synonyms like "question"/"answer" and recurses to find a "messages"-like array.
+ * Customizer requires literal top-level keys, so studio mirrors that exactly.
+ */
+/**
+ * Training objective used to pick the expected dataset schema. Mirrors the
+ * customizer backend's supported objectives (SFT, DPO, distillation). Owned
+ * here so schema detection has no dependency on form-layer constants.
+ */
+export type TrainingType = 'sft' | 'dpo' | 'distillation';
+
+export type CustomizerSchemaVariant =
+  /** SFT chat format: {"messages": [{"role": "...", ...}]} */
+  | 'sft-chat'
+  /** SFT prompt-completion: {"prompt": "...", "completion": "..."} */
+  | 'sft-prompt-completion'
+  /** DPO native: {"context": [...], "completions": [...]} */
+  | 'dpo-preference'
+  /** DPO HelpSteer3: {"overall_preference": ..., ...} */
+  | 'dpo-helpsteer3'
+  /** DPO Tulu3: {"chosen": [msgs], "rejected": [msgs]} */
+  | 'dpo-tulu3'
+  /** DPO BinaryPreference: {"prompt": "...", "chosen": "...", "rejected": "..."} */
+  | 'dpo-binary-preference';
+
+/**
+ * Single source of truth for the user-facing label of each detected schema.
+ * Tests reference this map directly so a label change can never drift between
+ * source and assertions, and the panel renders `CUSTOMIZER_SCHEMA_LABELS[variant]`
+ * rather than carrying the string on every detection result.
+ */
+export const CUSTOMIZER_SCHEMA_LABELS: Record<CustomizerSchemaVariant, string> = {
+  'sft-chat': 'Chat Completion',
+  'sft-prompt-completion': 'Completion',
+  'dpo-preference': 'Preference',
+  'dpo-helpsteer3': 'HelpSteer3',
+  'dpo-tulu3': 'Tulu3',
+  'dpo-binary-preference': 'Binary Preference',
+};
+
+export interface CustomizerSchemaDetection {
+  variant: CustomizerSchemaVariant;
+  /** Friendly label for the panel checklist row, sourced from CUSTOMIZER_SCHEMA_LABELS. */
+  label: string;
+}
+
+const detection = (variant: CustomizerSchemaVariant): CustomizerSchemaDetection => ({
+  variant,
+  label: CUSTOMIZER_SCHEMA_LABELS[variant],
+});
+
+const isMessageList = (value: unknown): boolean => {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  const first = value[0];
+  return typeof first === 'object' && first !== null && 'role' in (first as object);
+};
+
+const detectSft = (row: Record<string, unknown>): CustomizerSchemaDetection | null => {
+  // Chat: literal top-level "messages" with role on first item.
+  if (isMessageList(row.messages)) return detection('sft-chat');
+  // Prompt-completion: literal "prompt" + "completion".
+  if ('prompt' in row && 'completion' in row) return detection('sft-prompt-completion');
+  return null;
+};
+
+const detectDpo = (row: Record<string, unknown>): CustomizerSchemaDetection | null => {
+  // Native PreferenceDataset: context + completions.
+  if ('context' in row && 'completions' in row) return detection('dpo-preference');
+  // HelpSteer3: overall_preference score.
+  if ('overall_preference' in row) return detection('dpo-helpsteer3');
+  // Tulu3: chosen/rejected as message lists. Must be checked before binary
+  // (binary also has chosen/rejected, but as strings).
+  if ('chosen' in row && 'rejected' in row && isMessageList(row.chosen)) {
+    return detection('dpo-tulu3');
+  }
+  // BinaryPreference: prompt + chosen + rejected (typically as strings).
+  if ('prompt' in row && 'chosen' in row && 'rejected' in row) {
+    return detection('dpo-binary-preference');
+  }
+  return null;
+};
+
+/**
+ * Strictly detect which customizer-recognized schema a sample row matches,
+ * scoped to the currently selected training type. Returns null when none of
+ * the type-specific shapes match — caller should render an error.
+ *
+ * Distillation isn't exposed in the new-model UI; if it ever is, it shares
+ * SFT's schema rules in customizer.
+ */
+export const detectCustomizerSchema = (
+  row: Record<string, unknown> | null,
+  trainingType: TrainingType
+): CustomizerSchemaDetection | null => {
+  if (!row) return null;
+  if (trainingType === 'dpo') return detectDpo(row);
+  return detectSft(row);
+};
+
+/**
+ * Human-readable description of the keys customizer expects for a given
+ * training type, used for the "Schema does not match" copy.
+ */
+export const expectedSchemaCopy = (trainingType: TrainingType): string => {
+  if (trainingType === 'dpo') {
+    return 'Must contain chosen and rejected columns (or context + completions, or overall_preference).';
+  }
+  return 'Must contain messages (chat) or prompt and completion.';
+};
+
+// Encoding validation lives in the customizer validation hook, not here — it
+// uses TextDecoder('utf-8', { fatal: true }) on raw bytes and runs as its own
+// TanStack query (see useCustomizationDatasetValidation/encodingQuery.ts).
+
+const SCHEMA_PREVIEW_INDENT = '  ';
+/** Cap recursion to keep degenerate inputs (deep/cyclic JSON) from looping. */
+const SCHEMA_PREVIEW_MAX_DEPTH = 8;
+
+/**
+ * Render a JSON value as a TypeScript-shaped string, recursing into nested
+ * objects and arrays so the schema preview shows the full structure rather
+ * than collapsing everything to "object".
+ *
+ * Heterogeneous arrays use the FIRST element's shape as representative —
+ * matches how customizer's discriminator validates per-row.
+ */
+const renderInferredType = (value: unknown, depth: number): string => {
+  if (depth > SCHEMA_PREVIEW_MAX_DEPTH) return 'unknown';
+  if (value === null) return 'null';
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]';
+    const inner = renderInferredType(value[0], depth + 1);
+    if (inner.includes('\n')) {
+      const open = SCHEMA_PREVIEW_INDENT.repeat(depth + 1);
+      const close = SCHEMA_PREVIEW_INDENT.repeat(depth);
+      return `[\n${open}${inner},\n${close}]`;
+    }
+    return `[${inner}]`;
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return '{}';
+    const open = SCHEMA_PREVIEW_INDENT.repeat(depth + 1);
+    const close = SCHEMA_PREVIEW_INDENT.repeat(depth);
+    const lines = entries
+      .map(([key, v]) => `${open}${key}: ${renderInferredType(v, depth + 1)},`)
+      .join('\n');
+    return `{\n${lines}\n${close}}`;
+  }
+  return typeof value;
+};
+
+/**
+ * Build a TypeScript-like schema preview string from a parsed JSON row.
+ * Returns an empty string when the row is missing — callers that render the
+ * preview should treat empty as "nothing to show" and skip the block.
+ */
+export const inferRowSchema = (row: Record<string, unknown> | null): string => {
+  if (!row) return '';
+  return renderInferredType(row, 0);
+};
+
+const isNonEmptyString = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
+
+const isNonEmptyArray = (v: unknown): v is unknown[] => Array.isArray(v) && v.length > 0;
+
+const validateChatMessages = (messages: unknown): string | null => {
+  if (!isNonEmptyArray(messages)) return 'messages must be a non-empty array';
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (typeof msg !== 'object' || msg === null) {
+      return `messages[${i}] is not an object`;
+    }
+    const m = msg as Record<string, unknown>;
+    if (!isNonEmptyString(m.role)) {
+      return `messages[${i}].role is missing or empty`;
+    }
+    // Backend SFTChatMessage validator (services/customizer/.../schemas.py:292)
+    // rejects messages with BOTH content and thinking — they're mutually
+    // exclusive. Use key presence (not just non-empty) to match the backend's
+    // `is not None` semantics.
+    const contentPresent = m.content !== undefined && m.content !== null;
+    const thinkingPresent = m.thinking !== undefined && m.thinking !== null;
+    if (contentPresent && thinkingPresent) {
+      return `messages[${i}] cannot have both content and thinking (mutually exclusive)`;
+    }
+    const hasContent = isNonEmptyString(m.content);
+    const hasThinking = isNonEmptyString(m.thinking);
+    const hasToolCalls = isNonEmptyArray(m.tool_calls);
+    if (!hasContent && !hasThinking && !hasToolCalls) {
+      return `messages[${i}] must have non-empty content, thinking, or tool_calls`;
+    }
+  }
+  return null;
+};
+
+/**
+ * Per-variant required-field check on a single parsed row. Returns null when
+ * the row is complete enough for customizer to use, or a short human-readable
+ * message naming the first offending field. Mirrors the spirit of the Pydantic
+ * validators in services/customizer/.../schemas.py without re-implementing
+ * every edge case (we cover the common "missing key" / "empty value" cases the
+ * pre-flight panel needs to flag).
+ */
+export const validateRowCompleteness = (
+  row: Record<string, unknown>,
+  variant: CustomizerSchemaVariant
+): string | null => {
+  switch (variant) {
+    case 'sft-chat':
+      return validateChatMessages(row.messages);
+
+    case 'sft-prompt-completion':
+      if (!isNonEmptyString(row.prompt)) return 'prompt is missing or empty';
+      if (!isNonEmptyString(row.completion)) return 'completion is missing or empty';
+      return null;
+
+    case 'dpo-binary-preference': {
+      // prompt can be a string OR a list of chat messages.
+      if (typeof row.prompt === 'string') {
+        if (!isNonEmptyString(row.prompt)) return 'prompt is empty';
+      } else if (Array.isArray(row.prompt)) {
+        const msgError = validateChatMessages(row.prompt);
+        if (msgError) return `prompt: ${msgError}`;
+      } else {
+        return 'prompt must be a non-empty string or list of messages';
+      }
+      if (!isNonEmptyString(row.chosen)) return 'chosen is missing or empty';
+      if (!isNonEmptyString(row.rejected)) return 'rejected is missing or empty';
+      return null;
+    }
+
+    case 'dpo-tulu3': {
+      const chosenError = validateChatMessages(row.chosen);
+      if (chosenError) return `chosen: ${chosenError}`;
+      const rejectedError = validateChatMessages(row.rejected);
+      if (rejectedError) return `rejected: ${rejectedError}`;
+      return null;
+    }
+
+    case 'dpo-preference': {
+      const contextError = validateChatMessages(row.context);
+      if (contextError) return `context: ${contextError}`;
+      if (!isNonEmptyArray(row.completions)) return 'completions must be a non-empty array';
+      return null;
+    }
+
+    case 'dpo-helpsteer3': {
+      if (typeof row.context === 'string') {
+        if (!isNonEmptyString(row.context)) return 'context is empty';
+      } else if (Array.isArray(row.context)) {
+        const msgError = validateChatMessages(row.context);
+        if (msgError) return `context: ${msgError}`;
+      } else {
+        return 'context must be a non-empty string or list of messages';
+      }
+      if (!isNonEmptyString(row.response1)) return 'response1 is missing or empty';
+      if (!isNonEmptyString(row.response2)) return 'response2 is missing or empty';
+      if (typeof row.overall_preference !== 'number') {
+        return 'overall_preference must be a number';
+      }
+      return null;
+    }
+  }
+};

--- a/web/packages/studio/src/util/forms/customization.test.ts
+++ b/web/packages/studio/src/util/forms/customization.test.ts
@@ -8,7 +8,6 @@ import {
   formToUnslothCreate,
   type CustomizationFormFields,
 } from '@studio/util/forms/customization';
-import { describe, expect, it } from 'vitest';
 
 // Deep-clone the defaults so per-test mutations (e.g. flipping finetuning_type)
 // never leak through shared nested references into FORM_DEFAULTS or other tests.

--- a/web/packages/studio/src/util/forms/customization.test.ts
+++ b/web/packages/studio/src/util/forms/customization.test.ts
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  FORM_DEFAULTS,
+  customizationFormSchema,
+  formToAutomodelCreate,
+  formToUnslothCreate,
+  type CustomizationFormFields,
+} from '@studio/util/forms/customization';
+import { describe, expect, it } from 'vitest';
+
+// Deep-clone the defaults so per-test mutations (e.g. flipping finetuning_type)
+// never leak through shared nested references into FORM_DEFAULTS or other tests.
+/** A fully-valid automodel form value (model + training dataset filled). */
+const validAutomodel = (): CustomizationFormFields => {
+  const data = structuredClone(FORM_DEFAULTS);
+  data.backend = 'automodel';
+  data.outputName = 'my-output';
+  data.automodel.model = 'default/llama-3.1-8b';
+  data.automodel.dataset = { training: 'default/train-ds' };
+  return data;
+};
+
+/** A fully-valid unsloth form value (model + path filled). */
+const validUnsloth = (): CustomizationFormFields => {
+  const data = structuredClone(FORM_DEFAULTS);
+  data.backend = 'unsloth';
+  data.outputName = 'my-output';
+  data.unsloth.model.name = 'default/qwen3-1.7b';
+  data.unsloth.dataset.path = 'default/train-ds';
+  return data;
+};
+
+const messages = (data: CustomizationFormFields): string[] => {
+  const result = customizationFormSchema.safeParse(data);
+  return result.success ? [] : result.error.issues.map((i) => i.message);
+};
+
+describe('customizationFormSchema', () => {
+  it('accepts a valid automodel form', () => {
+    expect(customizationFormSchema.safeParse(validAutomodel()).success).toBe(true);
+  });
+
+  it('accepts a valid unsloth form', () => {
+    expect(customizationFormSchema.safeParse(validUnsloth()).success).toBe(true);
+  });
+
+  it('requires an output model name', () => {
+    const data = { ...validAutomodel(), outputName: '' };
+    expect(messages(data)).toContain('Output model name is required');
+  });
+
+  describe('active-backend-only validation', () => {
+    // Regression: the form keeps both sub-objects in state; switching backend
+    // unmounts the other backend's fields. Only the selected backend must be valid.
+    it('ignores an empty automodel subtree when unsloth is selected', () => {
+      const data = validUnsloth();
+      data.automodel = {
+        ...data.automodel,
+        model: '',
+        dataset: { training: '' },
+      };
+      expect(customizationFormSchema.safeParse(data).success).toBe(true);
+    });
+
+    it('ignores an empty unsloth subtree when automodel is selected', () => {
+      const data = validAutomodel();
+      data.unsloth = {
+        ...data.unsloth,
+        model: { ...data.unsloth.model, name: '' },
+        dataset: { ...data.unsloth.dataset, path: '' },
+      };
+      expect(customizationFormSchema.safeParse(data).success).toBe(true);
+    });
+  });
+
+  describe('automodel required fields', () => {
+    it('requires a model', () => {
+      const data = validAutomodel();
+      data.automodel.model = '';
+      expect(messages(data)).toContain('Please select a model');
+    });
+
+    it('requires a training dataset', () => {
+      const data = validAutomodel();
+      data.automodel.dataset.training = '';
+      expect(messages(data)).toContain('Training dataset is required');
+    });
+
+    it('requires a teacher model for distillation', () => {
+      const data = validAutomodel();
+      data.automodel.training.training_type = 'distillation';
+      data.automodel.training.teacher_model = '';
+      expect(messages(data)).toContain('Teacher model is required for distillation');
+    });
+
+    it('does not require a teacher model for sft', () => {
+      const data = validAutomodel();
+      data.automodel.training.training_type = 'sft';
+      data.automodel.training.teacher_model = '';
+      expect(customizationFormSchema.safeParse(data).success).toBe(true);
+    });
+  });
+
+  describe('unsloth required fields', () => {
+    it('requires a model', () => {
+      const data = validUnsloth();
+      data.unsloth.model.name = '';
+      expect(messages(data)).toContain('Please select a model');
+    });
+
+    it('requires a training dataset path', () => {
+      const data = validUnsloth();
+      data.unsloth.dataset.path = '';
+      expect(messages(data)).toContain('Training dataset is required');
+    });
+  });
+});
+
+describe('formToAutomodelCreate', () => {
+  it('maps output name and description onto the job and spec.output', () => {
+    const data = validAutomodel();
+    data.description = 'my desc';
+    const result = formToAutomodelCreate(data);
+    expect(result.name).toBe('my-output');
+    expect(result.description).toBe('my desc');
+    expect(result.spec.output).toEqual({ name: 'my-output', description: 'my desc' });
+  });
+
+  it('omits blank job name/description but always sets the required spec.output.name', () => {
+    // The top-level job name is omitted when blank, but automodel requires
+    // spec.output.name, so it carries the (validation-guaranteed non-empty)
+    // output name verbatim.
+    const data = validAutomodel();
+    data.outputName = '';
+    data.description = '';
+    const result = formToAutomodelCreate(data);
+    expect(result.name).toBeUndefined();
+    expect(result.description).toBeUndefined();
+    expect(result.spec.output).toEqual({ name: '', description: undefined });
+  });
+
+  it('keeps lora params for lora finetuning', () => {
+    const data = validAutomodel();
+    data.automodel.training.finetuning_type = 'lora';
+    expect(formToAutomodelCreate(data).spec.training.lora).toBeDefined();
+  });
+
+  it('keeps lora params for lora_merged finetuning', () => {
+    const data = validAutomodel();
+    data.automodel.training.finetuning_type = 'lora_merged';
+    expect(formToAutomodelCreate(data).spec.training.lora).toBeDefined();
+  });
+
+  it('drops lora params for all_weights finetuning', () => {
+    const data = validAutomodel();
+    data.automodel.training.finetuning_type = 'all_weights';
+    expect(formToAutomodelCreate(data).spec.training.lora).toBeUndefined();
+  });
+
+  it('sends the backend-default use_triton flag for lora runs', () => {
+    // Backend defaults use_triton to true; the form must not silently send false.
+    const spec = formToAutomodelCreate(validAutomodel()).spec;
+    expect(spec.training.lora?.use_triton).toBe(true);
+  });
+
+  it('seeds the backend-default enum knobs so the UI matches the backend', () => {
+    const spec = formToAutomodelCreate(validAutomodel()).spec;
+    expect(spec.training.attn_implementation).toBe('sdpa');
+    expect(spec.optimizer?.optimizer).toBe('Adam');
+    expect(spec.optimizer?.lr_decay_style).toBe('cosine');
+  });
+
+  it('passes through advanced automodel fields set on the form', () => {
+    const data = validAutomodel();
+    data.automodel.batch = {
+      ...data.automodel.batch!,
+      sequence_packing_max_samples: 500,
+    };
+    data.automodel.training.lora = {
+      ...data.automodel.training.lora!,
+      exclude_modules: ['*.out_proj'],
+    };
+    const spec = formToAutomodelCreate(data).spec;
+    expect(spec.batch?.sequence_packing_max_samples).toBe(500);
+    expect(spec.training.lora?.exclude_modules).toEqual(['*.out_proj']);
+  });
+
+  it('includes teacher_model only for distillation', () => {
+    const distill = validAutomodel();
+    distill.automodel.training.training_type = 'distillation';
+    distill.automodel.training.teacher_model = 'default/teacher';
+    expect(formToAutomodelCreate(distill).spec.training.teacher_model).toBe('default/teacher');
+
+    const sft = validAutomodel();
+    sft.automodel.training.training_type = 'sft';
+    sft.automodel.training.teacher_model = 'default/teacher'; // stale value from a prior distillation selection
+    expect(formToAutomodelCreate(sft).spec.training.teacher_model).toBeUndefined();
+  });
+});
+
+describe('formToUnslothCreate', () => {
+  it('always supplies the fixed dataset fields the UI does not expose', () => {
+    const spec = formToUnslothCreate(validUnsloth()).spec;
+    expect(spec.dataset.text_field).toBe('text');
+    expect(spec.dataset.packing).toBe(false);
+    expect(spec.training?.use_gradient_checkpointing).toBe('unsloth');
+  });
+
+  it('preserves the detected apply_chat_template flag', () => {
+    const data = validUnsloth();
+    data.unsloth.dataset.apply_chat_template = true;
+    expect(formToUnslothCreate(data).spec.dataset.apply_chat_template).toBe(true);
+  });
+
+  it('omits gpus when blank', () => {
+    const data = validUnsloth();
+    data.unsloth.hardware = { ...data.unsloth.hardware!, gpus: '' };
+    expect(formToUnslothCreate(data).spec.hardware?.gpus).toBeUndefined();
+  });
+
+  it('keeps gpus when provided', () => {
+    const data = validUnsloth();
+    data.unsloth.hardware = { ...data.unsloth.hardware!, gpus: '0,1' };
+    expect(formToUnslothCreate(data).spec.hardware?.gpus).toBe('0,1');
+  });
+
+  it('keeps lora params for lora finetuning', () => {
+    const data = validUnsloth();
+    data.unsloth.training!.finetuning_type = 'lora';
+    expect(formToUnslothCreate(data).spec.training?.lora).toBeDefined();
+  });
+
+  it('drops lora params for all_weights finetuning', () => {
+    const data = validUnsloth();
+    data.unsloth.training!.finetuning_type = 'all_weights';
+    expect(formToUnslothCreate(data).spec.training?.lora).toBeUndefined();
+  });
+
+  it('disables quantization for all_weights finetuning', () => {
+    // The unsloth backend rejects finetuning_type='all_weights' with 4-bit/8-bit
+    // loading, so the mapper must force both off for full-weight runs.
+    const data = validUnsloth();
+    data.unsloth.training!.finetuning_type = 'all_weights';
+    data.unsloth.model.load_in_4bit = true;
+    const spec = formToUnslothCreate(data).spec;
+    expect(spec.model.load_in_4bit).toBe(false);
+    expect(spec.model.load_in_8bit).toBe(false);
+  });
+
+  it('keeps quantization for lora finetuning', () => {
+    const data = validUnsloth();
+    data.unsloth.training!.finetuning_type = 'lora';
+    data.unsloth.model.load_in_4bit = true;
+    expect(formToUnslothCreate(data).spec.model.load_in_4bit).toBe(true);
+  });
+});

--- a/web/packages/studio/src/util/forms/customization.ts
+++ b/web/packages/studio/src/util/forms/customization.ts
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AutomodelJobInput, UnslothJobInput } from '@nemo/sdk/vendored/customizer/schema';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Form shape — the vendored create-request specs are the source of truth. The
+// spec fields are nested under their backend key so the type stays structurally
+// identical to what the API expects. No separate mapper interface needed; submit
+// just reads f.automodel / f.unsloth directly.
+// ---------------------------------------------------------------------------
+
+export interface CustomizationFormFields {
+  backend: 'automodel' | 'unsloth';
+  /** Output model / adapter name (maps to job.name AND spec.output.name) */
+  outputName: string;
+  description: string;
+  automodel: AutomodelJobInput['spec'];
+  unsloth: UnslothJobInput['spec'];
+}
+
+// ---------------------------------------------------------------------------
+// Default values
+// ---------------------------------------------------------------------------
+
+const UNSLOTH_DEFAULT_TARGET_MODULES = [
+  'q_proj',
+  'k_proj',
+  'v_proj',
+  'o_proj',
+  'gate_proj',
+  'up_proj',
+  'down_proj',
+];
+
+export const FORM_DEFAULTS: CustomizationFormFields = {
+  backend: 'automodel',
+  outputName: '',
+  description: '',
+  automodel: {
+    model: '',
+    dataset: { training: '' },
+    training: {
+      training_type: 'sft',
+      finetuning_type: 'lora',
+      lora: { rank: 16, alpha: 32, dropout: 0, merge: false, use_triton: true },
+      max_seq_length: 2048,
+      attn_implementation: 'sdpa',
+    },
+    schedule: { epochs: 1 },
+    batch: { global_batch_size: 8, micro_batch_size: 1, sequence_packing: false },
+    optimizer: {
+      learning_rate: 5e-6,
+      weight_decay: 0.01,
+      warmup_steps: 0,
+      adam_beta1: 0.9,
+      adam_beta2: 0.999,
+      optimizer: 'Adam',
+      lr_decay_style: 'cosine',
+    },
+    parallelism: {
+      num_nodes: 1,
+      num_gpus_per_node: 1,
+      tensor_parallel_size: 1,
+      pipeline_parallel_size: 1,
+      context_parallel_size: 1,
+      sequence_parallel: false,
+    },
+  },
+  unsloth: {
+    model: {
+      name: '',
+      max_seq_length: 2048,
+      load_in_4bit: true,
+      load_in_8bit: false,
+      dtype: 'auto',
+      trust_remote_code: false,
+    },
+    dataset: {
+      path: '',
+      text_field: 'text',
+      apply_chat_template: false,
+      packing: false,
+    },
+    training: {
+      training_type: 'sft',
+      finetuning_type: 'lora',
+      lora: {
+        rank: 16,
+        alpha: 16,
+        dropout: 0,
+        target_modules: UNSLOTH_DEFAULT_TARGET_MODULES,
+        bias: 'none',
+        use_rslora: false,
+        random_state: 3407,
+        init_lora_weights: true,
+      },
+      use_gradient_checkpointing: 'unsloth',
+    },
+    schedule: {
+      epochs: 1,
+      warmup_steps: 0,
+      lr_scheduler_type: 'linear',
+      logging_steps: 1,
+      seed: 3407,
+    },
+    batch: { per_device_train_batch_size: 1, gradient_accumulation_steps: 1 },
+    optimizer: { learning_rate: 2e-4, weight_decay: 0, optim: 'adamw_8bit' },
+    hardware: { precision: 'bf16' },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Zod schema — validates only the fields the form actually touches.
+// Deep-nested optional fields not shown in the UI are left unchecked.
+//
+// Each backend's spec is its own schema. The top-level schema validates ONLY
+// the selected backend (see the superRefine below): the form keeps both
+// sub-objects in state, and switching backends unmounts the other backend's
+// field controllers — so its values are stale/absent and must not gate submit.
+// ---------------------------------------------------------------------------
+
+const automodelSpecSchema = z
+  .object({
+    model: z.string().min(1, 'Please select a model'),
+    dataset: z.object({
+      training: z.string().min(1, 'Training dataset is required'),
+      validation: z.string().optional(),
+    }),
+    training: z.object({
+      training_type: z.enum(['sft', 'distillation']),
+      finetuning_type: z.enum(['lora', 'all_weights', 'lora_merged']),
+      max_seq_length: z.number().int().positive(),
+      teacher_model: z.string().optional(),
+      lora: z
+        .object({
+          rank: z.number().int().positive(),
+          alpha: z.number().int().positive(),
+          dropout: z.number().min(0).max(1),
+          merge: z.boolean(),
+        })
+        .optional(),
+    }),
+    schedule: z.object({ epochs: z.number().int().positive() }).optional(),
+    batch: z
+      .object({
+        global_batch_size: z.number().int().positive(),
+        micro_batch_size: z.number().int().positive(),
+        sequence_packing: z.boolean(),
+      })
+      .optional(),
+    optimizer: z
+      .object({
+        learning_rate: z.number().positive(),
+        weight_decay: z.number().min(0),
+        warmup_steps: z.number().int().min(0),
+        adam_beta1: z.number(),
+        adam_beta2: z.number(),
+        min_learning_rate: z.number().min(0).optional(),
+      })
+      .optional(),
+    parallelism: z
+      .object({
+        num_nodes: z.number().int().positive(),
+        num_gpus_per_node: z.number().int().positive(),
+        tensor_parallel_size: z.number().int().positive(),
+        pipeline_parallel_size: z.number().int().positive(),
+        context_parallel_size: z.number().int().positive(),
+        sequence_parallel: z.boolean(),
+      })
+      .optional(),
+  })
+  .superRefine((spec, ctx) => {
+    if (spec.training.training_type === 'distillation' && !spec.training.teacher_model) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Teacher model is required for distillation',
+        path: ['training', 'teacher_model'],
+      });
+    }
+  });
+
+const unslothSpecSchema = z.object({
+  model: z.object({
+    name: z.string().min(1, 'Please select a model'),
+    max_seq_length: z.number().int().positive(),
+    load_in_4bit: z.boolean(),
+    load_in_8bit: z.boolean(),
+    dtype: z.enum(['auto', 'bfloat16', 'float16', 'float32']),
+    trust_remote_code: z.boolean(),
+  }),
+  dataset: z.object({
+    path: z.string().min(1, 'Training dataset is required'),
+    validation_path: z.string().optional(),
+  }),
+  training: z
+    .object({
+      finetuning_type: z.enum(['lora', 'all_weights']),
+      lora: z
+        .object({
+          rank: z.number().int().positive(),
+          alpha: z.number().int().positive(),
+          dropout: z.number().min(0).max(1),
+          target_modules: z.array(z.string()),
+          bias: z.enum(['none', 'all', 'lora_only']),
+          use_rslora: z.boolean(),
+          random_state: z.number().int(),
+        })
+        .optional(),
+    })
+    .optional(),
+  schedule: z
+    .object({
+      epochs: z.number().int().positive(),
+      warmup_steps: z.number().int().min(0),
+      lr_scheduler_type: z.enum([
+        'linear',
+        'cosine',
+        'constant',
+        'constant_with_warmup',
+        'cosine_with_restarts',
+      ]),
+      logging_steps: z.number().int().positive(),
+      seed: z.number().int(),
+    })
+    .optional(),
+  batch: z
+    .object({
+      per_device_train_batch_size: z.number().int().positive(),
+      gradient_accumulation_steps: z.number().int().positive(),
+    })
+    .optional(),
+  optimizer: z
+    .object({
+      learning_rate: z.number().positive(),
+      weight_decay: z.number().min(0),
+      optim: z.enum(['adamw_torch', 'adamw_torch_fused', 'adamw_8bit', 'paged_adamw_8bit', 'sgd']),
+    })
+    .optional(),
+  hardware: z
+    .object({ gpus: z.string().optional(), precision: z.enum(['bf16', 'fp16']) })
+    .optional(),
+});
+
+export const customizationFormSchema = z
+  .object({
+    backend: z.enum(['automodel', 'unsloth']),
+    outputName: z.string().min(1, 'Output model name is required'),
+    description: z.string(),
+    // Validated conditionally in the superRefine — only the active backend.
+    automodel: z.unknown(),
+    unsloth: z.unknown(),
+  })
+  .superRefine((data, ctx) => {
+    const spec = data.backend === 'automodel' ? automodelSpecSchema : unslothSpecSchema;
+    const value = data.backend === 'automodel' ? data.automodel : data.unsloth;
+    const result = spec.safeParse(value);
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        ctx.addIssue({ ...issue, path: [data.backend, ...issue.path] });
+      }
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Submit helpers — the form keeps every sub-object populated (so values survive
+// backend/mode switches), so each mapper strips config that doesn't apply to the
+// selected mode rather than leaking stale values into the payload.
+// ---------------------------------------------------------------------------
+
+export const formToAutomodelCreate = (f: CustomizationFormFields): AutomodelJobInput => {
+  const { training } = f.automodel;
+  const usesLora =
+    training.finetuning_type === 'lora' || training.finetuning_type === 'lora_merged';
+  const isDistillation = training.training_type === 'distillation';
+  return {
+    name: f.outputName || undefined,
+    description: f.description || undefined,
+    spec: {
+      ...f.automodel,
+      training: {
+        ...training,
+        // LoRA params only apply to LoRA finetuning; teacher model only to
+        // distillation. Omit otherwise so switching modes can't leak stale config.
+        lora: usesLora ? training.lora : undefined,
+        teacher_model: isDistillation ? training.teacher_model || undefined : undefined,
+      },
+      // Automodel requires output.name; outputName is validated non-empty.
+      output: { name: f.outputName, description: f.description || undefined },
+    },
+  };
+};
+
+export const formToUnslothCreate = (f: CustomizationFormFields): UnslothJobInput => {
+  const { training } = f.unsloth;
+  const usesLora = training?.finetuning_type === 'lora';
+  return {
+    name: f.outputName || undefined,
+    description: f.description || undefined,
+    spec: {
+      ...f.unsloth,
+      // Full-weight (all_weights) training cannot quantize — the backend rejects
+      // finetuning_type='all_weights' with 4-bit/8-bit loading. Force them off
+      // (these flags aren't UI-exposed, so the mapper is the right place).
+      model: usesLora
+        ? f.unsloth.model
+        : { ...f.unsloth.model, load_in_4bit: false, load_in_8bit: false },
+      // Omit `gpus` when blank so "empty" consistently means "unset" (backend
+      // picks devices), whether the field was left untouched or typed-then-cleared.
+      hardware: { ...f.unsloth.hardware, gpus: f.unsloth.hardware?.gpus || undefined },
+      // LoRA params only apply to LoRA finetuning — drop them for full-weight runs.
+      training: training && { ...training, lora: usesLora ? training.lora : undefined },
+      output: { name: f.outputName || undefined, description: f.description || undefined },
+    },
+  };
+};

--- a/web/packages/studio/src/util/forms/customization.ts
+++ b/web/packages/studio/src/util/forms/customization.ts
@@ -4,25 +4,13 @@
 import type { AutomodelJobInput, UnslothJobInput } from '@nemo/sdk/vendored/customizer/schema';
 import { z } from 'zod';
 
-// ---------------------------------------------------------------------------
-// Form shape — the vendored create-request specs are the source of truth. The
-// spec fields are nested under their backend key so the type stays structurally
-// identical to what the API expects. No separate mapper interface needed; submit
-// just reads f.automodel / f.unsloth directly.
-// ---------------------------------------------------------------------------
-
 export interface CustomizationFormFields {
   backend: 'automodel' | 'unsloth';
-  /** Output model / adapter name (maps to job.name AND spec.output.name) */
   outputName: string;
   description: string;
   automodel: AutomodelJobInput['spec'];
   unsloth: UnslothJobInput['spec'];
 }
-
-// ---------------------------------------------------------------------------
-// Default values
-// ---------------------------------------------------------------------------
 
 const UNSLOTH_DEFAULT_TARGET_MODULES = [
   'q_proj',
@@ -110,16 +98,6 @@ export const FORM_DEFAULTS: CustomizationFormFields = {
     hardware: { precision: 'bf16' },
   },
 };
-
-// ---------------------------------------------------------------------------
-// Zod schema — validates only the fields the form actually touches.
-// Deep-nested optional fields not shown in the UI are left unchecked.
-//
-// Each backend's spec is its own schema. The top-level schema validates ONLY
-// the selected backend (see the superRefine below): the form keeps both
-// sub-objects in state, and switching backends unmounts the other backend's
-// field controllers — so its values are stale/absent and must not gate submit.
-// ---------------------------------------------------------------------------
 
 const automodelSpecSchema = z
   .object({
@@ -248,7 +226,6 @@ export const customizationFormSchema = z
     backend: z.enum(['automodel', 'unsloth']),
     outputName: z.string().min(1, 'Output model name is required'),
     description: z.string(),
-    // Validated conditionally in the superRefine — only the active backend.
     automodel: z.unknown(),
     unsloth: z.unknown(),
   })
@@ -263,12 +240,6 @@ export const customizationFormSchema = z
     }
   });
 
-// ---------------------------------------------------------------------------
-// Submit helpers — the form keeps every sub-object populated (so values survive
-// backend/mode switches), so each mapper strips config that doesn't apply to the
-// selected mode rather than leaking stale values into the payload.
-// ---------------------------------------------------------------------------
-
 export const formToAutomodelCreate = (f: CustomizationFormFields): AutomodelJobInput => {
   const { training } = f.automodel;
   const usesLora =
@@ -281,12 +252,9 @@ export const formToAutomodelCreate = (f: CustomizationFormFields): AutomodelJobI
       ...f.automodel,
       training: {
         ...training,
-        // LoRA params only apply to LoRA finetuning; teacher model only to
-        // distillation. Omit otherwise so switching modes can't leak stale config.
         lora: usesLora ? training.lora : undefined,
         teacher_model: isDistillation ? training.teacher_model || undefined : undefined,
       },
-      // Automodel requires output.name; outputName is validated non-empty.
       output: { name: f.outputName, description: f.description || undefined },
     },
   };
@@ -300,16 +268,10 @@ export const formToUnslothCreate = (f: CustomizationFormFields): UnslothJobInput
     description: f.description || undefined,
     spec: {
       ...f.unsloth,
-      // Full-weight (all_weights) training cannot quantize — the backend rejects
-      // finetuning_type='all_weights' with 4-bit/8-bit loading. Force them off
-      // (these flags aren't UI-exposed, so the mapper is the right place).
       model: usesLora
         ? f.unsloth.model
         : { ...f.unsloth.model, load_in_4bit: false, load_in_8bit: false },
-      // Omit `gpus` when blank so "empty" consistently means "unset" (backend
-      // picks devices), whether the field was left untouched or typed-then-cleared.
       hardware: { ...f.unsloth.hardware, gpus: f.unsloth.hardware?.gpus || undefined },
-      // LoRA params only apply to LoRA finetuning — drop them for full-weight runs.
       training: training && { ...training, lora: usesLora ? training.lora : undefined },
       output: { name: f.outputName || undefined, description: f.description || undefined },
     },


### PR DESCRIPTION

<img width="2008" height="1323" alt="image" src="https://github.com/user-attachments/assets/d69286e5-bec0-4e93-a7dc-0cff0d5327e5" />
<img width="2008" height="1324" alt="image" src="https://github.com/user-attachments/assets/f4eae384-7692-4c73-a014-4030329d70de" />
<img width="2008" height="1321" alt="image" src="https://github.com/user-attachments/assets/2917357e-dbfa-402f-91db-5aa333d69f01" />
<img width="2007" height="1324" alt="image" src="https://github.com/user-attachments/assets/942b53ef-a7d7-49aa-8c91-a957522f9c02" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new fine-tuning job creation flow with Automodel and Unsloth backend selection, model/training/LoRA/compute sections, and a dedicated “new job” route.
  * Introduced enhanced dataset validation feedback (format, schema, UTF-8 encoding, completeness) with schema preview and improved fileset selection UI.
  * Updated the SDK to support creating Automodel and Unsloth customization jobs.
* **Bug Fixes**
  * Improved dataset text previews to avoid showing truncated mid-line fragments.
* **Tests**
  * Expanded coverage for the new customization workflow, routing, dataset validation, and related UI components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->