### PR TITLE
ci: cleanup job for nightly GHCR packages as well as CI ones

### DIFF
--- a/.github/scripts/cleanup-ghcr-ci-images.sh
+++ b/.github/scripts/cleanup-ghcr-ci-images.sh
@@ -27,18 +27,33 @@ date_utc() {
 cutoff="$(date_utc "${STALE_HOURS} hours ago")"
 
 # GitHub's package version API exposes updated_at, not a separate last-pulled timestamp.
-# These are the docker-cpu images published by .github/workflows/ci.yaml.
-images=(
-  "nmp-api"
-  "nmp-core"
-  "nmp-cpu-tasks"
-)
+# Containers use nightly-<timestamp>. Existing Helm charts use
+# <semver>-night-<timestamp>; the release workflow currently emits -nightly-.
+nightly_tag_pattern='^(nightly-[0-9]{14}|[0-9]+[.][0-9]+[.][0-9]+-(night|nightly)-[0-9]{14})$'
 
-echo "Scanning ghcr.io/${owner}/${repo} image versions last updated before ${cutoff}"
+case "${CLEANUP_SCOPE:-ci}" in
+  ci)
+    tag_filter="select(((.metadata.container.tags // []) | any(test(\"${nightly_tag_pattern}\"))) | not)"
+    ;;
+  nightly-release)
+    tag_filter="select((.metadata.container.tags // []) | any(test(\"${nightly_tag_pattern}\")))"
+    ;;
+  *)
+    echo "cleanup_scope must be ci or nightly-release, got: ${CLEANUP_SCOPE}" >&2
+    exit 1
+    ;;
+esac
+
+echo "Scanning ${CLEANUP_SCOPE:-ci} package versions last updated before ${cutoff}"
 echo "dry_run=${DRY_RUN}"
 
 total_deleted=0
 total_candidates=0
+
+find_packages() {
+  gh api --paginate "/orgs/${owner}/packages?package_type=container&per_page=100" \
+    | jq -r --arg prefix "${repo}/" '.[] | select(.name | startswith($prefix)) | .name'
+}
 
 url_encode() {
   jq -nr --arg value "$1" '$value|@uri'
@@ -51,6 +66,7 @@ find_stale_versions() {
     .[] |
     select(.updated_at != null and .updated_at < \"${cutoff}\") |
     select(((.metadata.container.tags // []) | index(\"latest\")) | not) |
+    ${tag_filter} |
     [.id, .name, .updated_at, ((.metadata.container.tags // []) | join(\",\"))] |
     @tsv
   "
@@ -58,8 +74,18 @@ find_stale_versions() {
   gh api --paginate "${endpoint}/versions?per_page=100" --jq "${jq_filter}"
 }
 
-for image in "${images[@]}"; do
-  package_name="${repo}/${image}"
+api_error="$(mktemp)"
+if ! package_names="$(find_packages 2>"${api_error}")"; then
+  cat "${api_error}" >&2
+  exit 1
+fi
+
+if [ -z "${package_names}" ]; then
+  echo "No GHCR packages found under ${owner}/${repo}/."
+  exit 0
+fi
+
+while IFS= read -r package_name; do
   encoded_package_name="$(url_encode "${package_name}")"
   endpoint="/orgs/${owner}/packages/container/${encoded_package_name}"
 
@@ -102,7 +128,7 @@ for image in "${images[@]}"; do
   done <<< "${stale_versions}"
 
   echo "::endgroup::"
-done
+done <<< "${package_names}"
 
 echo "Stale candidates: ${total_candidates}"
 echo "Deleted versions: ${total_deleted}"

--- a/.github/workflows/ghcr-cleanup.yaml
+++ b/.github/workflows/ghcr-cleanup.yaml
@@ -1,16 +1,16 @@
-name: Cleanup GHCR CI Images
+name: Cleanup GHCR Packages
 
 on:
   schedule:
     - cron: "43 4 * * *"
   workflow_dispatch:
     inputs:
-      dry_run:
+      dry-run:
         description: Log stale GHCR package versions without deleting them.
         required: false
         type: boolean
         default: false
-      stale_hours:
+      stale-hours:
         description: Delete versions last updated more than this many hours ago.
         required: false
         type: number
@@ -23,15 +23,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  cleanup:
+  cleanup-ci:
     name: Delete stale GHCR CI image versions
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     env:
-      DRY_RUN: ${{ inputs.dry_run || 'false' }}
-      STALE_HOURS: ${{ inputs.stale_hours || '24' }}
+      DRY_RUN: ${{ inputs['dry-run'] || 'false' }}
+      STALE_HOURS: ${{ inputs['stale-hours'] || '24' }}
+      CLEANUP_SCOPE: ci
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -39,6 +40,28 @@ jobs:
           persist-credentials: false
 
       - name: Delete stale package versions
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/cleanup-ghcr-ci-images.sh
+
+  cleanup-nightly-releases:
+    name: Delete GHCR nightly release versions older than 90 days
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      DRY_RUN: ${{ inputs['dry-run'] || 'false' }}
+      STALE_HOURS: "2160"
+      CLEANUP_SCOPE: nightly-release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Delete stale nightly release versions
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The nightly containers need cleanup and differentiation so they aren't deleted every 24 hours.
This should make the scheduled cleanup job selective enough to do a 90 day cleanup on nightlies and aggressively remove CI containers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated cleanup for stale nightly release container versions.
  * Container cleanup now discovers applicable packages automatically and supports separate CI and nightly-release scopes.
  * Added configurable cleanup inputs for dry-run mode and stale-version age.

* **Bug Fixes**
  * Improved handling of missing packages, empty results, and API errors during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->