### PR TITLE
ci: wire the real release deployment signal

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -755,6 +755,8 @@ jobs:
     name: Signal deployment
     needs: [plan-release, stage-helm, poll-final-release]
     if: >-
+      !cancelled() &&
+      needs.poll-final-release.result == 'success' &&
       needs.plan-release.outputs.include_helm == 'true' &&
       needs.plan-release.outputs.dry_run != 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -751,8 +751,8 @@ jobs:
             helm cm-push "${CHART_PACKAGE}" nemo-platform
           fi
 
-  dispatch-release-deployment:
-    name: Dispatch release deployment
+  signal-deployment:
+    name: Signal deployment
     needs: [plan-release, stage-helm, poll-final-release]
     if: >-
       needs.plan-release.outputs.include_helm == 'true' &&
@@ -1048,16 +1048,6 @@ jobs:
             --title "${RELEASE_TAG}" \
             --generate-notes \
             "${notes_range[@]}"
-
-  signal-deployment:
-    name: Signal deployment
-    needs: [plan-release, poll-final-release]
-    if: >-
-      needs.poll-final-release.result == 'success' &&
-      needs.plan-release.outputs.dry_run != 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "::notice::Placeholder - signal the completed release"
 
   notify-end:
     name: Notify release result

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -95,10 +95,10 @@ America/Los_Angeles.
    GitHub release and tag at the selected SHA. GitHub generates the release
    notes from the previous numeric SemVer tag. Subset releases do not create a
    GitHub release or tag.
-
-The deployment-signalling job is currently a placeholder. A successful poll
-means the selected artifacts are public; it does not yet mean a deployment was
-created by this workflow.
+8. After polling succeeds, releases that include the Helm chart dispatch a
+   deployment signal to the configured internal release repository. The
+   downstream workflow creates a pending GitHub Deployment, and the deployment
+   controller completes it independently. Releases without Helm skip this step.
 
 ## Publication destinations
 


### PR DESCRIPTION
The [nightly run](https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/29345313121) showed **Signal deployment** as skipped. That looked like the real deployment handoff, but inspection revealed it was still an echo-only placeholder; the actual dispatch lived in a separate job with a different name.

Consolidating those jobs exposed the reason both had skipped: nightlies intentionally skip stable-only release registration, and GitHub propagates that skipped state through dependent jobs unless they explicitly evaluate their own status. Artifact polling already handled that case and succeeded, but deployment signaling did not.

This PR makes the real dispatch the single `signal-deployment` job. It now runs only when the workflow was not cancelled, artifact polling succeeded, Helm was selected, and the run is not a dry run. The final notification therefore observes the job that actually performs the handoff.

| Release state | Deployment signal |
|---|---|
| Nightly or stable; polling succeeded; Helm selected | Dispatch `create-release-deployment` with the source SHA, cadence, release label, and Helm version |
| Nightly skipped stable-only registration | Dispatch still runs after successful polling |
| Polling failed or the run was cancelled | Skip |
| Helm not selected or dry run | Skip |

The downstream workflow remains responsible for creating the pending GitHub Deployment and completing it independently.

## Evidence

- `actionlint .github/workflows/release.yaml` passes.
- No live release or nightly was triggered while validating this change.

Linear: [AIREINF-267 — Create the deployment workflow](https://linear.app/nvidia/issue/AIREINF-267/create-the-deployment-workflow)
