### PR TITLE
feat(insights): Move the insights-powered analysis into the platform repo

### DIFF
--- a/.github/actions/insights-intake-stack/action.yml
+++ b/.github/actions/insights-intake-stack/action.yml
@@ -1,0 +1,10 @@
+name: insights-intake-stack
+description: Self-contained Intake (ClickHouse + auth,entities,intake) on :8080 over $RUNNER_TEMP/state
+runs:
+  using: composite
+  steps:
+    - name: Start ClickHouse + platform services
+      shell: bash
+      run: >-
+        uv run --no-project python
+        nemo-platform/plugins/nemo-insights/testbed/eval/stack.py

--- a/.github/actions/insights-testbed-prep/action.yml
+++ b/.github/actions/insights-testbed-prep/action.yml
@@ -1,0 +1,23 @@
+name: insights-testbed-prep
+description: uv + dependency sync + tau2 data check + judge model repoint
+inputs:
+  install-tau2:
+    description: Also uv-sync tau2-bench and verify its data (needed to RUN tau2, not to analyze)
+    default: "true"
+  sync-insights:
+    description: uv-sync the optional insights group; disable only for stack-only jobs
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      with:
+        working-directory: nemo-platform
+    - name: Sync + judge repoint
+      shell: bash
+      run: >-
+        uv run --no-project python
+        nemo-platform/plugins/nemo-insights/testbed/eval/prep.py
+        --sync-insights=${{ inputs.sync-insights }}
+        --install-tau2=${{ inputs.install-tau2 }}

--- a/.github/workflows/insights-testbed.yml
+++ b/.github/workflows/insights-testbed.yml
@@ -52,7 +52,7 @@ jobs:
     permissions: { contents: read }
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with: { path: nemo-platform }
+        with: { path: nemo-platform, persist-credentials: false }
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           working-directory: nemo-platform
@@ -67,7 +67,7 @@ jobs:
       subjects: ${{ steps.resolve.outputs.subjects }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with: { path: nemo-platform }
+        with: { path: nemo-platform, persist-credentials: false }
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           working-directory: nemo-platform
@@ -84,12 +84,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with: { path: nemo-platform }
+        with: { path: nemo-platform, persist-credentials: false }
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: sierra-research/tau2-bench
           ref: ${{ env.TAU2_BENCH_REF }}
           path: tau2-bench
+          persist-credentials: false
       - uses: ./nemo-platform/.github/actions/insights-testbed-prep
         with: { install-tau2: "false", sync-insights: "false" }
       - uses: ./nemo-platform/.github/actions/insights-intake-stack
@@ -119,12 +120,13 @@ jobs:
         run: |
           [ -n "$INFERENCE_API_KEY" ] || { echo "secret INFERENCE_API_KEY is not set"; exit 1; }
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with: { path: nemo-platform }
+        with: { path: nemo-platform, persist-credentials: false }
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: sierra-research/tau2-bench
           ref: ${{ env.TAU2_BENCH_REF }}
           path: tau2-bench
+          persist-credentials: false
       - uses: ./nemo-platform/.github/actions/insights-testbed-prep
       - uses: ./nemo-platform/.github/actions/insights-intake-stack
       - name: Run subjects (tau2 -> ingest -> insights)
@@ -194,12 +196,13 @@ jobs:
       - name: Require secrets
         run: '[ -n "$INFERENCE_API_KEY" ] || { echo "secret INFERENCE_API_KEY is not set"; exit 1; }'
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with: { path: nemo-platform }
+        with: { path: nemo-platform, persist-credentials: false }
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: sierra-research/tau2-bench
           ref: ${{ env.TAU2_BENCH_REF }}
           path: tau2-bench
+          persist-credentials: false
       - uses: ./nemo-platform/.github/actions/insights-testbed-prep
         with: { install-tau2: "false" }
       - uses: ./nemo-platform/.github/actions/insights-intake-stack

--- a/.github/workflows/insights-testbed.yml
+++ b/.github/workflows/insights-testbed.yml
@@ -175,14 +175,15 @@ jobs:
 
   analyze:
     needs: plan
-    # PR gate: on `pull_request` events, only run with the `run-insights` label. Every
-    # other trigger (workflow_dispatch, any future dispatch-like event) is gated on
-    # mode alone, matching stack-check/produce above.
+    # PR gate: run only when `run-insights` is applied, not again on every
+    # synchronize event. Remove and reapply the label to request another run.
+    # Dispatch-like events remain gated on mode alone.
     if: >-
       needs.plan.outputs.mode == 'analyze' &&
       (github.event_name != 'pull_request' ||
-       (github.event.pull_request.head.repo.full_name == github.repository &&
-        contains(github.event.pull_request.labels.*.name, 'run-insights')))
+       (github.event.action == 'labeled' &&
+        github.event.label.name == 'run-insights' &&
+        github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions: { contents: read }

--- a/.github/workflows/insights-testbed.yml
+++ b/.github/workflows/insights-testbed.yml
@@ -1,0 +1,210 @@
+name: insights-testbed
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "What to run"
+        type: choice
+        options: [produce, analyze, stack-check]
+        default: analyze
+      subjects:
+        description: "Comma-separated testbed subjects"
+        type: string
+        default: tau2-airline
+      state:
+        description: "Empty = each subject's state.lock pin"
+        type: string
+        default: ""
+      num_tasks:
+        description: "Override subject num_tasks (empty = testbeds.toml value)"
+        type: string
+        default: ""
+      num_trials:
+        description: "Override subject num_trials (empty = testbeds.toml value)"
+        type: string
+        default: ""
+      publish_state:
+        description: "produce only: upload the new state version to the testbed-state release"
+        type: boolean
+        default: true
+      reason:
+        description: "produce only: why this fixture exists (one line for the release catalog)"
+        type: string
+        default: ""
+  pull_request:
+    types: [opened, synchronize, labeled]
+    paths:
+      - "plugins/nemo-insights/**"
+      - ".github/workflows/insights-testbed.yml"
+      - ".github/actions/insights-intake-stack/**"
+      - ".github/actions/insights-testbed-prep/**"
+
+env:
+  OPENAI_API_BASE: ${{ vars.OPENAI_API_BASE || 'https://inference-api.nvidia.com' }}
+  TAU2_JUDGE_LLM: ${{ vars.TAU2_JUDGE_LLM || 'openai/nvidia/nvidia/evals-nemotron-ultra' }}
+  TAU2_BENCH_REF: 8ebb7499622fc2be9b9d510d6f7a7653461f4f29
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.resolve.outputs.mode }}
+      subjects: ${{ steps.resolve.outputs.subjects }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with: { path: nemo-platform }
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          working-directory: nemo-platform
+      - id: resolve
+        env:
+          INPUT_MODE: ${{ inputs.mode }}
+          INPUT_SUBJECTS: ${{ inputs.subjects }}
+        run: uv run --no-project python nemo-platform/plugins/nemo-insights/testbed/eval/plan.py
+
+  stack-check:
+    needs: plan
+    if: needs.plan.outputs.mode == 'stack-check'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with: { path: nemo-platform }
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: sierra-research/tau2-bench
+          ref: ${{ env.TAU2_BENCH_REF }}
+          path: tau2-bench
+      - uses: ./nemo-platform/.github/actions/insights-testbed-prep
+        with: { install-tau2: "false", sync-insights: "false" }
+      - uses: ./nemo-platform/.github/actions/insights-intake-stack
+      - name: Verify stack end-to-end
+        run: uv run --no-project python nemo-platform/plugins/nemo-insights/testbed/eval/stack.py --verify
+      - name: Platform log on failure
+        if: failure()
+        run: tail -100 "$RUNNER_TEMP/platform.log" || true
+
+  produce:
+    needs: plan
+    # produce is EXPLICIT-ONLY: a human dispatches it (e.g. after a tau2-bench or agent
+    # change warrants a new fixture). It must never fire from PRs, pushes, or any
+    # future automatic trigger — hence the hard event gate on top of the mode check.
+    if: needs.plan.outputs.mode == 'produce' && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    concurrency: { group: testbed-state-produce, cancel-in-progress: false }
+    permissions: { contents: write }   # release asset upload
+    env:
+      GH_TOKEN: ${{ github.token }}
+      INFERENCE_API_KEY: ${{ secrets.INFERENCE_API_KEY }}
+      # Same gateway key; litellm/tau2 read it under the OpenAI-conventional name.
+      OPENAI_API_KEY: ${{ secrets.INFERENCE_API_KEY }}
+    steps:
+      - name: Require secrets
+        run: |
+          [ -n "$INFERENCE_API_KEY" ] || { echo "secret INFERENCE_API_KEY is not set"; exit 1; }
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with: { path: nemo-platform }
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: sierra-research/tau2-bench
+          ref: ${{ env.TAU2_BENCH_REF }}
+          path: tau2-bench
+      - uses: ./nemo-platform/.github/actions/insights-testbed-prep
+      - uses: ./nemo-platform/.github/actions/insights-intake-stack
+      - name: Run subjects (tau2 -> ingest -> insights)
+        working-directory: nemo-platform/plugins/nemo-insights
+        env:
+          SUBJECTS: ${{ needs.plan.outputs.subjects }}
+          NUM_TASKS: ${{ inputs.num_tasks }}
+          NUM_TRIALS: ${{ inputs.num_trials }}
+        run: uv run --project ../.. python testbed/eval/run_subjects.py
+      - name: Snapshot state
+        if: always()
+        working-directory: nemo-platform/plugins/nemo-insights
+        env:
+          SUBJECTS_JSON: ${{ needs.plan.outputs.subjects }}
+          # NUM_TASKS / NUM_TRIALS / REASON feed the manifest's CI-lineage fields.
+          NUM_TASKS: ${{ inputs.num_tasks }}
+          NUM_TRIALS: ${{ inputs.num_trials }}
+          REASON: ${{ inputs.reason }}
+        run: uv run --project ../.. python -m testbed snapshot --subjects-json "$SUBJECTS_JSON" --base http://localhost:8080 -o "$RUNNER_TEMP/bundles/candidate.tar.zst"
+      - name: Round-trip fidelity guard
+        working-directory: nemo-platform/plugins/nemo-insights
+        # Re-ingest the candidate into scratch workspaces on the in-job stack, re-export,
+        # doc-diff; any mismatch fails the job before the candidate can be published.
+        # platform-root auto-resolves to the containing nemo-platform checkout.
+        run: uv run --project ../.. python -m testbed roundtrip "$RUNNER_TEMP/bundles/candidate.tar.zst" --base http://localhost:8080
+      - name: Upload state artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          # run_attempt suffix: upload-artifact@v4 409s on duplicate names within a
+          # run, which would fail this always() step on a re-run and block publish.
+          name: state-candidate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/bundles/candidate.tar.zst
+          if-no-files-found: warn
+      - name: Publish to testbed-state release
+        if: success() && inputs.publish_state
+        working-directory: nemo-platform/plugins/nemo-insights
+        env:
+          REASON: ${{ inputs.reason }}
+        # --no-verify: the round-trip fidelity guard already ran as its own step above.
+        run: uv run --project ../.. python -m testbed publish "$RUNNER_TEMP/bundles/candidate.tar.zst" --reason "$REASON" --no-verify
+      - name: Platform log on failure
+        if: failure()
+        run: tail -200 "$RUNNER_TEMP/platform.log" || true
+
+  analyze:
+    needs: plan
+    # PR gate: on `pull_request` events, only run with the `run-insights` label. Every
+    # other trigger (workflow_dispatch, any future dispatch-like event) is gated on
+    # mode alone, matching stack-check/produce above.
+    if: >-
+      needs.plan.outputs.mode == 'analyze' &&
+      (github.event_name != 'pull_request' ||
+       (github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'run-insights')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions: { contents: read }
+    strategy:
+      fail-fast: false
+      matrix:
+        subject: ${{ fromJSON(needs.plan.outputs.subjects) }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      INFERENCE_API_KEY: ${{ secrets.INFERENCE_API_KEY }}
+    steps:
+      - name: Require secrets
+        run: '[ -n "$INFERENCE_API_KEY" ] || { echo "secret INFERENCE_API_KEY is not set"; exit 1; }'
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with: { path: nemo-platform }
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: sierra-research/tau2-bench
+          ref: ${{ env.TAU2_BENCH_REF }}
+          path: tau2-bench
+      - uses: ./nemo-platform/.github/actions/insights-testbed-prep
+        with: { install-tau2: "false" }
+      - uses: ./nemo-platform/.github/actions/insights-intake-stack
+      - name: Generate insights
+        working-directory: nemo-platform/plugins/nemo-insights
+        env:
+          SUBJECT: ${{ matrix.subject }}
+          STATE: ${{ inputs.state }}
+        # Empty STATE = bare analyze = the subject's state.lock pin (the
+        # reproducible default); a non-empty ref overrides it via --state.
+        run: |
+          uv run --project ../.. python -m testbed analyze "$SUBJECT" ${STATE:+--state "$STATE"} --summary-md "$GITHUB_STEP_SUMMARY"
+          cat "testbed/tmp/insights_${SUBJECT}.yaml"
+      - name: Upload insights
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: insights-${{ matrix.subject }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: nemo-platform/plugins/nemo-insights/testbed/tmp/insights_${{ matrix.subject }}.yaml
+      - name: Platform log on failure
+        if: failure()
+        run: tail -200 "$RUNNER_TEMP/platform.log" || true

--- a/.github/workflows/insights-testbed.yml
+++ b/.github/workflows/insights-testbed.yml
@@ -46,6 +46,20 @@ env:
   TAU2_BENCH_REF: 8ebb7499622fc2be9b9d510d6f7a7653461f4f29
 
 jobs:
+  plugin-tests:
+    name: Insights plugin tests
+    runs-on: ubuntu-latest
+    permissions: { contents: read }
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with: { path: nemo-platform }
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          working-directory: nemo-platform
+      - name: Run plugin tests
+        working-directory: nemo-platform
+        run: uv run --frozen --group insights pytest -q plugins/nemo-insights/tests
+
   plan:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/insights-testbed.yml
+++ b/.github/workflows/insights-testbed.yml
@@ -41,7 +41,6 @@ on:
       - ".github/actions/insights-testbed-prep/**"
 
 env:
-  OPENAI_API_BASE: ${{ vars.OPENAI_API_BASE || 'https://inference-api.nvidia.com' }}
   TAU2_JUDGE_LLM: ${{ vars.TAU2_JUDGE_LLM || 'openai/nvidia/nvidia/evals-nemotron-ultra' }}
   TAU2_BENCH_REF: 8ebb7499622fc2be9b9d510d6f7a7653461f4f29
 
@@ -112,13 +111,15 @@ jobs:
     permissions: { contents: write }   # release asset upload
     env:
       GH_TOKEN: ${{ github.token }}
-      INFERENCE_API_KEY: ${{ secrets.INFERENCE_API_KEY }}
+      INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_KEY }}
       # Same gateway key; litellm/tau2 read it under the OpenAI-conventional name.
-      OPENAI_API_KEY: ${{ secrets.INFERENCE_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.NVIDIA_INFERENCE_KEY }}
+      OPENAI_API_BASE: ${{ secrets.NVIDIA_INFERENCE_URL }}
     steps:
       - name: Require secrets
         run: |
-          [ -n "$INFERENCE_API_KEY" ] || { echo "secret INFERENCE_API_KEY is not set"; exit 1; }
+          [ -n "$INFERENCE_API_KEY" ] || { echo "secret NVIDIA_INFERENCE_KEY is not set"; exit 1; }
+          [ -n "$OPENAI_API_BASE" ] || { echo "secret NVIDIA_INFERENCE_URL is not set"; exit 1; }
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { path: nemo-platform, persist-credentials: false }
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -191,10 +192,10 @@ jobs:
         subject: ${{ fromJSON(needs.plan.outputs.subjects) }}
     env:
       GH_TOKEN: ${{ github.token }}
-      INFERENCE_API_KEY: ${{ secrets.INFERENCE_API_KEY }}
+      INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_KEY }}
     steps:
       - name: Require secrets
-        run: '[ -n "$INFERENCE_API_KEY" ] || { echo "secret INFERENCE_API_KEY is not set"; exit 1; }'
+        run: '[ -n "$INFERENCE_API_KEY" ] || { echo "secret NVIDIA_INFERENCE_KEY is not set"; exit 1; }'
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { path: nemo-platform, persist-credentials: false }
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/plugins/nemo-insights/README.md
+++ b/plugins/nemo-insights/README.md
@@ -1,0 +1,56 @@
+# NeMo Insights
+
+Optional NeMo Platform plugin for analyzing agent telemetry and persisting actionable insights.
+
+## Install from the monorepo
+
+```bash
+uv sync --group insights
+```
+
+The plugin is intentionally not part of `enabled-plugins`.
+
+## CLI
+
+```bash
+uv run nemo insights analyze \
+  --agent research-agent \
+  --workspace default \
+  --base-url http://localhost:8080
+
+uv run nemo insights analysis enable --agent research-agent
+uv run nemo insights analysis status
+uv run nemo insights analysis disable --agent research-agent
+```
+
+`--base-url` defaults to `NMP_BASE_URL`, then `http://localhost:8080`.
+
+## API and SDK
+
+The service is mounted under:
+
+```text
+/apis/insights/v2/workspaces/{workspace}
+```
+
+The plugin SDK is available as `client.insights`, including:
+
+- `client.insights.insights`
+- `client.insights.analysis_configs`
+- `client.insights.analysis_run_statuses`
+
+## Configuration
+
+Periodic analysis settings use the `NEMO_INSIGHTS_` environment prefix. For example:
+
+```bash
+export NEMO_INSIGHTS_ANALYST_FREQUENCY=daily
+export NEMO_INSIGHTS_ANALYST_TIMEZONE=America/Denver
+```
+
+## Development
+
+```bash
+uv run pytest plugins/nemo-insights/tests
+uv run ruff check plugins/nemo-insights
+```

--- a/plugins/nemo-insights/README.md
+++ b/plugins/nemo-insights/README.md
@@ -51,7 +51,7 @@ export NEMO_INSIGHTS_ANALYST_TIMEZONE=America/Denver
 ## Development
 
 ```bash
-uv run pytest plugins/nemo-insights/tests
+uv run --group insights pytest plugins/nemo-insights/tests
 uv run ruff check plugins/nemo-insights
 ```
 

--- a/plugins/nemo-insights/README.md
+++ b/plugins/nemo-insights/README.md
@@ -54,3 +54,8 @@ export NEMO_INSIGHTS_ANALYST_TIMEZONE=America/Denver
 uv run pytest plugins/nemo-insights/tests
 uv run ruff check plugins/nemo-insights
 ```
+
+## Testbed
+
+The analyst-only testbed is in [`testbed/`](testbed/). It can replay pinned
+Intake traces or run Tau2 benchmarks before invoking `nemo insights analyze`.

--- a/plugins/nemo-insights/examples/insight-example.yaml
+++ b/plugins/nemo-insights/examples/insight-example.yaml
@@ -1,0 +1,76 @@
+insights:
+- id: insight-b3adbc1b909843cf83dfd35a4bfa5e3d
+  workspace: default
+  title: Spurious refusal on benign terminal-bench tasks
+  agent: codex
+  description: 'Failure mode: codex aborts a task by emitting the canned refusal "I''m
+    sorry, but I cannot assist with that request." as its final assistant message,
+    scoring 0 on the task verifier. Affected component: the final LLM/assistant
+    turn (model aws/anthropic/bedrock-claude-opus-4-6 under the codex harness) — the
+    refusal appears AFTER the agent has already begun work (2–5 shell_command/update_plan
+    calls), not at the outset. Trigger conditions: entirely benign coding/ops prompts
+    — constraint scheduling, generating a [regex, replacement] JSON file, implementing
+    a headless terminal interface. The same task ids pass in other trials, so the
+    refusal is non-deterministic. Hypothesis: an over-aggressive safety/instruction-following
+    layer mis-classifies these benign tasks as disallowed and short-circuits an in-progress
+    trajectory.'
+  status: open
+  trace_refs:
+  - constraints-scheduling-xhsKy3g
+  - regex-chess-HfzhtaZ
+  - headless-terminal-DzYqtUy
+  created_at: '2026-06-05T22:28:00.691135+00:00'
+  updated_at: '2026-06-05T22:28:00.691135+00:00'
+- id: insight-c0bbadce52c34656a0e61b215142f291
+  workspace: default
+  title: Declares success against self-authored tests that don't meet the real spec
+  agent: codex
+  description: 'Failure mode: codex finishes with a confident completion claim — "The
+    implementation is complete and all tests pass", "I have successfully implemented...",
+    "passes the required tests" — yet the task verifier scores 0. Affected component:
+    the agent''s self-verification step. In the trajectories it writes and runs its
+    OWN tests (e.g. `Rscript -e ''source("ars.R"); test()''`) and treats their passing
+    as task completion, instead of validating against the task''s stated acceptance
+    criteria. Trigger conditions: open-ended implementation tasks where the agent
+    can author its own tests (adaptive-rejection-sampler fails 5/6 trials this way;
+    also SAM cell-segmentation, regex-chess, Raman fitting, mailman setup). Hypothesis:
+    the agent anchors on self-invented success criteria and never reconciles them
+    with the real spec, producing overconfident but incorrect completions.'
+  status: open
+  trace_refs:
+  - adaptive-rejection-sampler-sCQXPuA
+  - adaptive-rejection-sampler-qYLBFwo
+  - adaptive-rejection-sampler-Fgeag3m
+  - sam-cell-seg-XVe4VSi
+  - regex-chess-mbr83he
+  - raman-fitting-4TkuEBg
+  - mailman-Aw7evCn
+  created_at: '2026-06-05T22:28:00.691135+00:00'
+  updated_at: '2026-06-05T22:28:00.691135+00:00'
+- id: insight-78d54712121d416192b9aa04bc78d375
+  workspace: default
+  title: Trajectory truncated mid-debugging on long environment-heavy tasks
+  agent: codex
+  description: 'Failure mode: on long-horizon, environment-heavy tasks the codex trajectory
+    terminates with its last recorded action being a shell_command and no closing
+    completion summary; the task verifier scores 0. The final tool output frequently
+    still shows a live failure (segfault exit 139, gcc/compile errors, exit 1 tracebacks,
+    or ''No SSH banner after 60s''), i.e. the solution was never finalized. Affected
+    component: the agent loop / step-budget — this end-on-tool-call-without-summary
+    pattern occurs in ~56% of failures vs ~11% of passes, and the affected runs cluster
+    at high tool-call counts (50+: qemu, path-tracing, make-mips, protein-assembly).
+    Trigger conditions: tasks involving builds, emulation, ML training/setup, or long
+    iterative debugging (qemu+ssh boot, custom compressor, MIPS interpreter, Caffe
+    CIFAR-10 build, path-tracing reverse-engineering). Hypothesis: the agent exhausts
+    its turn/step budget (or is cut off) before converging, leaving a broken solution
+    and never delivering or verifying a result.'
+  status: open
+  trace_refs:
+  - qemu-alpine-ssh-Z9EtcT7
+  - write-compressor-U9gsqTF
+  - path-tracing-reverse-XKeZn2P
+  - make-mips-interpreter-vgGbWQh
+  - caffe-cifar-10-mZcR43P
+  - polyglot-c-py-jcceToH
+  created_at: '2026-06-05T22:28:00.691135+00:00'
+  updated_at: '2026-06-05T22:28:00.691135+00:00'

--- a/plugins/nemo-insights/examples/research-agent/.gitignore
+++ b/plugins/nemo-insights/examples/research-agent/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+__pycache__/
+*.pyc
+.env
+.DS_Store
+.ruff_cache/
+tmp/

--- a/plugins/nemo-insights/examples/research-agent/README.md
+++ b/plugins/nemo-insights/examples/research-agent/README.md
@@ -1,0 +1,119 @@
+# research-agent
+
+A minimal research agent built on the [NVIDIA NeMo Agent Toolkit (NAT)](https://github.com/NVIDIA/NeMo-Agent-Toolkit): a [Tavily](https://tavily.com/) search tool wired into a ReAct agent backed by an NVIDIA NIM-hosted LLM.
+
+The workflow is declared in [`workflow.yml`](./workflow.yml); `main.py` is a thin wrapper that loads `.env` and invokes NAT's Python API.
+
+## Setup
+
+```bash
+cp .env.example .env   # fill in NVIDIA_API_KEY and TAVILY_API_KEY
+uv sync
+```
+
+## Run
+
+Via the Python wrapper:
+
+```bash
+uv run main.py "What did NVIDIA announce at GTC 2026?"
+```
+
+Or directly via the NAT CLI (equivalent):
+
+```bash
+uv run nat run --config_file workflow.yml --input "What did NVIDIA announce at GTC 2026?"
+```
+
+## Customize
+
+Edit `workflow.yml` to swap the model, change the search depth, or tweak the system prompt. To list every knob NAT exposes for a given component type:
+
+```bash
+uv run nat info components -t llm_provider -q nim
+uv run nat info components -t function    -q tavily_internet_search
+```
+
+## Run on NeMo Platform
+
+This example uses local paths to the monorepo's `nemo-platform`, `nemo-platform-plugin`, and `nemo-insights-plugin` packages. Run `uv sync` from this directory to create its standalone environment.
+
+### Start services
+
+From this directory:
+
+```bash
+set -a && source .env && set +a   # exposes NVIDIA_API_KEY / TAVILY_API_KEY
+uv run nemo services run          # boots 18 services on :8080 — leave running
+```
+
+Confirm the plugin loaded: `nemo plugins list` should include `insights`, and the startup banner should list the `insights` service.
+
+### Start ClickHouse (for the `intake` service)
+
+The platform's `intake` service persists spans/traces in ClickHouse, and `nemo services run` does not bring it up. Without it, every `/apis/intake/v2/...` route returns `503 ClickHouse spans storage unavailable`, and the OTLP trace exporter in [`workflow.yml`](./workflow.yml) will fail to land traces.
+
+The quickest fix is to run a single ClickHouse container on the default port (`8123`):
+
+```bash
+docker run -d --name nemo-clickhouse \
+  -p 8123:8123 -p 9000:9000 \
+  clickhouse/clickhouse-server:24.3
+```
+
+`intake` looks for ClickHouse at `http://localhost:8123` by default; override with `NMP_INTAKE_CLICKHOUSE_URL` if you're pointing at a remote instance. Verify with:
+
+```bash
+curl -s http://localhost:8123/ping                                           # -> Ok.
+curl -s http://localhost:8080/apis/intake/v2/workspaces/default/traces       # -> 200 with JSON
+```
+
+Tear it down with `docker rm -f nemo-clickhouse` when you're done.
+
+### Configure a provider
+
+In a second shell, register the NVIDIA Build provider and pick a default model:
+
+```bash
+set -a && source .env && set +a
+uv run nemo setup --auto
+```
+
+### Register the workflow as an agent
+
+`workflow.yml` is a valid NAT config and is accepted by the platform as-is. The model name must be the platform-registered entity ID (lowercase, hyphenated) — list available IDs with `uv run nemo models list`.
+
+```bash
+uv run nemo agents create --name research-agent \
+  --agent-config workflow.yml \
+  --description "Tavily-powered research agent"
+uv run nemo agents deploy --agent research-agent
+```
+
+`deploy` blocks until the container reaches `running` and prints the deployment endpoint.
+
+### Chat with the deployed agent
+
+```bash
+uv run nemo agents invoke --agent research-agent \
+  --input "What did NVIDIA announce at GTC 2026?"
+```
+
+The response is an OpenAI-style chat completion. Inference goes through the platform's gateway, and Tavily search is invoked from inside the agent container.
+
+### Inspect and tear down
+
+```bash
+uv run nemo agents list
+uv run nemo agents deployments list
+uv run nemo agents logs --agent research-agent
+
+echo y | uv run nemo agents undeploy --agent research-agent
+echo y | uv run nemo agents delete   research-agent
+```
+
+### Gotchas
+
+- **Model name format.** NAT YAML accepts the `meta/llama-3.3-70b-instruct` style for direct NIM calls, but when the agent runs under the platform, NIM calls are routed through the inference gateway, which validates names as lowercase letters/digits/hyphens (2–63 chars). Use the hyphenated entity ID from `nemo models list` (e.g. `meta-llama-3-3-70b-instruct`).
+- **Undeploy / delete prompt.** No `--yes` flag on this build — pipe `echo y |` for non-interactive use.
+- **Editing `workflow.yml`.** The platform stores the YAML at create time. After edits, `undeploy` + `delete` + `create` + `deploy` to pick them up.

--- a/plugins/nemo-insights/examples/research-agent/main.py
+++ b/plugins/nemo-insights/examples/research-agent/main.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal research agent powered by NAT and Tavily.
+
+Thin wrapper around `nat run`: loads .env, then executes the workflow defined in
+`workflow.yml` via NAT's Python API. The same workflow can be invoked directly
+with:
+
+    nat run --config_file workflow.yml --input "..."
+"""
+
+import asyncio
+import pathlib
+import sys
+from contextvars import ContextVar
+
+from dotenv import load_dotenv
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.tracers.context import register_configure_hook
+from nat.plugins.langchain.callback_handler import LangchainProfilerHandler
+from nat.runtime.loader import load_workflow
+
+CONFIG_FILE = pathlib.Path(__file__).parent / "workflow.yml"
+
+_NAT_PROFILER_HANDLER: ContextVar[BaseCallbackHandler | None] = ContextVar("nat_profiler_handler", default=None)
+register_configure_hook(_NAT_PROFILER_HANDLER, inheritable=True)
+
+
+async def run(query: str) -> str:
+    async with load_workflow(CONFIG_FILE) as workflow:
+        _NAT_PROFILER_HANDLER.set(LangchainProfilerHandler())
+        async with workflow.run(query) as runner:
+            return await runner.result(to_type=str)
+
+
+def main() -> None:
+    load_dotenv()
+
+    query = " ".join(sys.argv[1:]).strip() or input("Research query: ").strip()
+    if not query:
+        print("No query provided.", file=sys.stderr)
+        sys.exit(1)
+
+    output = asyncio.run(run(query))
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/nemo-insights/examples/research-agent/pyproject.toml
+++ b/plugins/nemo-insights/examples/research-agent/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "research-agent"
+version = "0.1.0"
+description = "Minimal Tavily-powered research agent built on the NVIDIA NeMo Agent Toolkit (NAT)."
+requires-python = ">=3.12,<3.14"
+dependencies = [
+    "nvidia-nat[langchain]>=1.6.0",
+    "opentelemetry-exporter-otlp>=1.30",
+    "opentelemetry-proto>=1.30",
+    "python-dotenv>=1.0.1",
+    "nemo-platform[services]",
+    "nemo-insights-plugin",
+    "dataclasses-json>=0.6.7",
+]
+
+[project.scripts]
+research-agent = "main:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.4",
+    "clickhouse-connect>=0.8",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "e2e: real end-to-end test that starts services and hits real LLM APIs (opt-in via NMP_INSIGHTS_E2E=1).",
+]
+
+[tool.uv.sources]
+nemo-insights-plugin = { path = "../..", editable = true }
+nemo-platform = { path = "../../../../packages/nemo_platform", editable = true }
+nemo-platform-plugin = { path = "../../../../packages/nemo_platform_plugin", editable = true }

--- a/plugins/nemo-insights/examples/research-agent/tests/test_analyst_e2e.py
+++ b/plugins/nemo-insights/examples/research-agent/tests/test_analyst_e2e.py
@@ -1,0 +1,473 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end integration test for the analyst agent.
+
+This exercises the whole loop against *real* services and *real* LLM APIs:
+
+1. Start ClickHouse (auto-provisioned via the platform's docker helper).
+2. Start the NeMo Platform (``nemo services run``) with Intake + Insights.
+3. Clear all spans for the test project.
+4. Run the research agent on three questions (concurrently) so it logs
+   traces to Intake.
+5. Run the analyst agent (``nemo insights analyze``).
+6. Assert the analyst created at least one Insight.
+
+Required setup (the test is **opt-in** because it costs real tokens and needs
+Docker):
+
+- ``NMP_INSIGHTS_E2E=1`` — opt in; otherwise the test skips.
+- ``NVIDIA_API_KEY`` and ``TAVILY_API_KEY`` — for the research agent's NIM
+  model + Tavily search. Read from the example's ``.env`` (or the shell).
+- ``INFERENCE_API_KEY`` — the ``sk-...`` NVIDIA Inference Gateway virtual key
+  for the analyst's Claude Opus (served over the Anthropic wire format). The
+  analyst's LLM ``base_url`` is pinned in
+  :mod:`nemo_insights_plugin.analyst.agent`, so no base-url override is
+  required.
+- Docker — required to auto-start ClickHouse if one isn't already at
+  ``NMP_INTAKE_CLICKHOUSE_URL`` (default ``http://localhost:8123``). A missing
+  Docker daemon fails the test.
+
+Optional overrides: ``NMP_INSIGHTS_E2E_PORT`` (default ``18080``),
+``NEMO_PLATFORM_DIR`` (default ``~/code/nemo-platform``, where the ClickHouse
+helper script lives), and ``NMP_INTAKE_CLICKHOUSE_{URL,USER,PASSWORD,DATABASE}``.
+
+Run it from the example's venv so every dependency
+(``nemo-platform[services]``, the NAT langchain provider, and the Insights
+plugin) is present::
+
+    cd examples/research-agent
+    NMP_INSIGHTS_E2E=1 uv run pytest tests/test_analyst_e2e.py -s
+
+The test is isolated from any platform you already have running: it binds a
+dedicated port, uses a throwaway ``NMP_DATA_DIR``, and scopes all data to the
+``research-agent-e2e-test`` project so it never touches real ``research-agent``
+spans or Insights.
+"""
+
+import asyncio
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+from nemo_insights_plugin.analyst.observability import (
+    ANALYST_OBSERVABILITY_AGENT_NAME,
+    ANALYST_OBSERVABILITY_ENV,
+)
+
+# Scope every artifact this test produces to a dedicated project/agent name so
+# it is non-destructive to the real `research-agent` data.
+TEST_AGENT = "research-agent-e2e-test"
+WORKSPACE = "default"
+
+EXAMPLE_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = EXAMPLE_DIR.parent.parent
+TMP_DIR = EXAMPLE_DIR / "tmp"
+
+QUESTIONS = [
+    "Who won the 2025 Nobel Prize in Physics?",
+    "What were the main findings of the 2025 ICLR best-paper award?",
+    "List three open-source vector databases and one differentiator each.",
+]
+
+PORT = int(os.environ.get("NMP_INSIGHTS_E2E_PORT", "18080"))
+BASE_URL = f"http://127.0.0.1:{PORT}"
+CLICKHOUSE_URL = os.environ.get("NMP_INTAKE_CLICKHOUSE_URL", "http://localhost:8123")
+CLICKHOUSE_USER = os.environ.get("NMP_INTAKE_CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = os.environ.get("NMP_INTAKE_CLICKHOUSE_PASSWORD", "")
+CLICKHOUSE_DB = os.environ.get("NMP_INTAKE_CLICKHOUSE_DATABASE", "intake")
+PLATFORM_DIR = Path(os.environ.get("NEMO_PLATFORM_DIR", str(Path.home() / "code" / "nemo-platform")))
+
+MIN_TRACES = 3
+SERVER_START_TIMEOUT_S = 180
+SPAN_VISIBLE_TIMEOUT_S = 120
+
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.environ.get("NMP_INSIGHTS_E2E") != "1",
+        reason="opt-in only; set NMP_INSIGHTS_E2E=1 to run the real end-to-end test",
+    ),
+]
+
+
+def _load_dotenv(path: Path) -> dict[str, str]:
+    """Parse the example's ``.env`` into a dict (no external dependency)."""
+    env: dict[str, str] = {}
+    if not path.exists():
+        return env
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        env[key.strip()] = value.strip().strip('"').strip("'")
+    return env
+
+
+def _subprocess_env() -> dict[str, str]:
+    """Shell env + example ``.env``, plus the test's service/ClickHouse pins."""
+    env = dict(os.environ)
+    env.update(_load_dotenv(EXAMPLE_DIR / ".env"))
+    env.update(
+        {
+            "NMP_INTAKE_CLICKHOUSE_URL": CLICKHOUSE_URL,
+            "NMP_INTAKE_CLICKHOUSE_USER": CLICKHOUSE_USER,
+            "NMP_INTAKE_CLICKHOUSE_PASSWORD": CLICKHOUSE_PASSWORD,
+            "NMP_INTAKE_CLICKHOUSE_DATABASE": CLICKHOUSE_DB,
+        }
+    )
+    return env
+
+
+# The `nemo` / `nat` console-script wrappers are not reliably written into the
+# venv (a `uv sync` that reverts an editable install can drop them), but their
+# entry-point callables are always importable. Invoke those directly so the
+# test does not depend on the script wrappers existing on disk.
+_CLI_CALLABLES = {
+    "nemo": ("nemo_platform.cli.app", "cli"),
+    "nat": ("nat.cli.main", "run_cli"),
+}
+
+
+def _cli_cmd(name: str, *args: str) -> list[str]:
+    """Build a command that runs CLI *name* via its entry-point callable."""
+    module, func = _CLI_CALLABLES[name]
+    return [sys.executable, "-c", f"from {module} import {func}; {func}()", *args]
+
+
+def _require_keys() -> None:
+    env = _subprocess_env()
+    missing = [key for key in ("NVIDIA_API_KEY", "TAVILY_API_KEY", "INFERENCE_API_KEY") if not env.get(key)]
+    if missing:
+        pytest.skip(f"missing required API keys: {', '.join(missing)}")
+
+
+# --------------------------------------------------------------------------- #
+# ClickHouse                                                                   #
+# --------------------------------------------------------------------------- #
+def _clickhouse_reachable() -> bool:
+    try:
+        resp = httpx.get(f"{CLICKHOUSE_URL}/ping", timeout=2.0)
+        return resp.status_code == 200
+    except httpx.HTTPError:
+        return False
+
+
+@pytest.fixture(scope="module")
+def clickhouse() -> None:
+    """Ensure ClickHouse is up, auto-starting it via the platform's docker helper.
+
+    Per the test contract, a missing Docker daemon is a hard failure (not a
+    skip) once the suite is opted into.
+    """
+    if _clickhouse_reachable():
+        return
+
+    if shutil.which("docker") is None:
+        pytest.fail("Docker is required to start ClickHouse for the e2e test, but `docker` was not found")
+
+    script = PLATFORM_DIR / "services" / "intake" / "scripts" / "spans" / "run_clickhouse.sh"
+    if not script.exists():
+        pytest.fail(
+            f"ClickHouse helper script not found at {script}; set NEMO_PLATFORM_DIR to your nemo-platform checkout"
+        )
+
+    result = subprocess.run(["bash", str(script)], capture_output=True, text=True)
+    if result.returncode != 0:
+        pytest.fail(f"Failed to start ClickHouse via {script}:\n{result.stdout}\n{result.stderr}")
+
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        if _clickhouse_reachable():
+            return
+        time.sleep(1.0)
+    pytest.fail("ClickHouse did not become reachable after starting the container")
+
+
+def _clear_spans_for_project() -> None:
+    """Delete all spans for the test project directly in ClickHouse.
+
+    Intake exposes no span-delete HTTP route, and the spans table is keyed on
+    the `project.name` attribute, so we issue a synchronous ALTER ... DELETE.
+    The schema is lazily created by Intake on first span query, so this is a
+    no-op (table-missing) on a brand-new database.
+    """
+    import clickhouse_connect
+
+    parsed = urlparse(CLICKHOUSE_URL)
+    client = clickhouse_connect.get_client(
+        host=parsed.hostname or "localhost",
+        port=parsed.port or 8123,
+        username=CLICKHOUSE_USER,
+        password=CLICKHOUSE_PASSWORD,
+        database=CLICKHOUSE_DB,
+    )
+    try:
+        client.command(
+            "ALTER TABLE spans DELETE WHERE attributes_string['project.name'] = "
+            "{project:String} SETTINGS mutations_sync=2",
+            parameters={"project": TEST_AGENT},
+        )
+    except Exception as exc:  # noqa: BLE001 - table may not exist yet on a fresh DB
+        if "doesn't exist" not in str(exc) and "UNKNOWN_TABLE" not in str(exc):
+            raise
+    finally:
+        client.close()
+
+
+# --------------------------------------------------------------------------- #
+# Platform server                                                             #
+# --------------------------------------------------------------------------- #
+def _server_ready() -> bool:
+    """True once both the Intake span route and the Insights route are live."""
+    try:
+        spans = httpx.get(
+            f"{BASE_URL}/apis/intake/v2/workspaces/{WORKSPACE}/spans",
+            params={"page_size": 1},
+            timeout=3.0,
+        )
+        insights = httpx.get(
+            f"{BASE_URL}/apis/insights/v2/workspaces/{WORKSPACE}/insights",
+            params={"page_size": 1},
+            timeout=3.0,
+        )
+    except httpx.HTTPError:
+        return False
+    return spans.status_code == 200 and insights.status_code == 200
+
+
+@pytest.fixture(scope="module")
+def platform_server(clickhouse: None) -> Iterator[str]:  # noqa: ARG001 - ordering dep
+    """Start `nemo services run` on a dedicated port with isolated storage."""
+    TMP_DIR.mkdir(exist_ok=True)
+    data_dir = TMP_DIR / "e2e-nmp-data"
+    log_path = TMP_DIR / "e2e_platform_server.log"
+
+    env = _subprocess_env()
+    # Isolate entity/Insight storage from any platform already running locally.
+    env["NMP_DATA_DIR"] = str(data_dir)
+
+    log = open(log_path, "w")
+    proc = subprocess.Popen(
+        _cli_cmd("nemo", "services", "run", "--host", "127.0.0.1", "--port", str(PORT)),
+        cwd=str(EXAMPLE_DIR),
+        env=env,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+    try:
+        deadline = time.monotonic() + SERVER_START_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                log.flush()
+                pytest.fail(
+                    f"platform server exited early (code {proc.returncode}); see {log_path}\n"
+                    + log_path.read_text()[-2000:]
+                )
+            if _server_ready():
+                break
+            time.sleep(2.0)
+        else:
+            pytest.fail(f"platform server not ready after {SERVER_START_TIMEOUT_S}s; see {log_path}")
+        yield BASE_URL
+    finally:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            proc.wait(timeout=30)
+        except (ProcessLookupError, subprocess.TimeoutExpired):
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        log.close()
+
+
+# --------------------------------------------------------------------------- #
+# SDK helpers (reuse the Insights plugin's own client/preflight code)         #
+# --------------------------------------------------------------------------- #
+def _count_traces() -> int:
+    from nemo_insights_plugin.analyst.analyst_backend import make_analyst_backend
+    from nemo_insights_plugin.client import make_client
+
+    async def _run() -> int:
+        client = make_client(BASE_URL)
+        backend = make_analyst_backend(client=client, insights_output=None)
+        try:
+            return await backend.count_agent_sessions(agent=TEST_AGENT, workspace=WORKSPACE)
+        finally:
+            await client.close()
+
+    return asyncio.run(_run())
+
+
+def _list_insight_ids() -> list[str]:
+    from nemo_insights_plugin.client import make_client
+
+    async def _run() -> list[str]:
+        client = make_client(BASE_URL)
+        try:
+            page = await client.insights.insights.list_insights(workspace=WORKSPACE, agent=TEST_AGENT, page_size=100)
+        finally:
+            await client.close()
+        return [insight.id for insight in page.data]
+
+    return asyncio.run(_run())
+
+
+def _delete_insights(insight_ids: list[str]) -> None:
+    from nemo_insights_plugin.client import make_client
+
+    async def _run() -> None:
+        client = make_client(BASE_URL)
+        try:
+            for insight_id in insight_ids:
+                await client.insights.insights.delete(workspace=WORKSPACE, insight_id=insight_id)
+        finally:
+            await client.close()
+
+    asyncio.run(_run())
+
+
+# --------------------------------------------------------------------------- #
+# Research-agent workflow templating                                          #
+# --------------------------------------------------------------------------- #
+def _write_research_workflow() -> Path:
+    """Copy the example workflow, re-scoping it to the test project + port."""
+    source = (EXAMPLE_DIR / "workflow.yml").read_text()
+    templated = source.replace("http://localhost:8080", BASE_URL).replace("research-agent", TEST_AGENT)
+    TMP_DIR.mkdir(exist_ok=True)
+    out = TMP_DIR / "e2e_research_workflow.yml"
+    out.write_text(templated)
+    return out
+
+
+def _run_research_agents_parallel(workflow: Path, questions: list[str]) -> None:
+    """Run every research-agent question concurrently (each is its own process).
+
+    Distinct invocations get distinct trace/session ids, so running them in
+    parallel only changes wall-clock time, not the resulting span data.
+    """
+    env = _subprocess_env()
+    with ThreadPoolExecutor(max_workers=len(questions)) as pool:
+        futures = {
+            pool.submit(
+                subprocess.run,
+                _cli_cmd("nat", "run", "--config_file", str(workflow), "--input", q),
+                cwd=str(EXAMPLE_DIR),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            ): q
+            for q in questions
+        }
+        failures: list[str] = []
+        for future, question in futures.items():
+            result = future.result()
+            if result.returncode != 0:
+                failures.append(f"research agent failed for {question!r}:\n{result.stdout}\n{result.stderr}")
+    assert not failures, "\n\n".join(failures)
+
+
+def _wait_for_traces(minimum: int, timeout_s: int) -> int:
+    deadline = time.monotonic() + timeout_s
+    count = 0
+    while time.monotonic() < deadline:
+        count = _count_traces()
+        if count >= minimum:
+            return count
+        time.sleep(3.0)
+    return count
+
+
+def _wait_for_analyst_spans(timeout_s: int) -> list[dict]:
+    deadline = time.monotonic() + timeout_s
+    spans: list[dict] = []
+    while time.monotonic() < deadline:
+        response = httpx.get(
+            f"{BASE_URL}/apis/intake/v2/workspaces/{WORKSPACE}/spans",
+            params={
+                "filter[agent_name]": ANALYST_OBSERVABILITY_AGENT_NAME,
+                "page_size": 100,
+            },
+            timeout=3.0,
+        )
+        if response.status_code == 200:
+            spans = response.json()["data"]
+            if spans:
+                return spans
+        time.sleep(3.0)
+    return spans
+
+
+# --------------------------------------------------------------------------- #
+# The test                                                                    #
+# --------------------------------------------------------------------------- #
+def test_analyst_creates_insight_end_to_end(platform_server: str) -> None:  # noqa: ARG001
+    _require_keys()
+
+    # 1. Clean slate: drop any spans + Insights left by a previous run.
+    _clear_spans_for_project()
+    _delete_insights(_list_insight_ids())
+    assert _list_insight_ids() == []
+
+    # 2. Exercise the research agent (questions run concurrently) so Intake
+    #    accumulates traces.
+    workflow = _write_research_workflow()
+    _run_research_agents_parallel(workflow, QUESTIONS)
+
+    # 3. Traces must be queryable before the analyst's preflight gate passes.
+    trace_count = _wait_for_traces(MIN_TRACES, SPAN_VISIBLE_TIMEOUT_S)
+    assert trace_count >= MIN_TRACES, f"expected >= {MIN_TRACES} traces for {TEST_AGENT}, saw {trace_count}"
+
+    # 4. Run the analyst.
+    analyst_env = _subprocess_env()
+    analyst_env[ANALYST_OBSERVABILITY_ENV] = "1"
+    result = subprocess.run(
+        _cli_cmd(
+            "nemo",
+            "insights",
+            "analyze",
+            "--agent",
+            TEST_AGENT,
+            "--workspace",
+            WORKSPACE,
+            "--base-url",
+            BASE_URL,
+        ),
+        cwd=str(EXAMPLE_DIR),
+        env=analyst_env,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, f"analyst failed:\n{result.stdout}\n{result.stderr}"
+
+    # 5. The analyst must have persisted at least one Insight.
+    insight_ids = _list_insight_ids()
+    assert len(insight_ids) >= 1, (
+        f"analyst created no Insights for {TEST_AGENT}.\n"
+        f"--- analyst stdout ---\n{result.stdout}\n--- analyst stderr ---\n{result.stderr}"
+    )
+
+    # 6. The analyst's own Pydantic AI spans should be queryable in Intake.
+    analyst_spans = _wait_for_analyst_spans(SPAN_VISIBLE_TIMEOUT_S)
+    assert analyst_spans, (
+        f"expected Intake spans for {ANALYST_OBSERVABILITY_AGENT_NAME}; "
+        f"--- analyst stdout ---\n{result.stdout}\n--- analyst stderr ---\n{result.stderr}"
+    )
+    assert {span["agent_name"] for span in analyst_spans} == {ANALYST_OBSERVABILITY_AGENT_NAME}
+    assert all(span["session_id"] for span in analyst_spans)

--- a/plugins/nemo-insights/examples/research-agent/workflow.yml
+++ b/plugins/nemo-insights/examples/research-agent/workflow.yml
@@ -1,0 +1,54 @@
+# NAT (NVIDIA NeMo Agent Toolkit) workflow for the research agent.
+#
+# Run with:
+#   nat run --config_file workflow.yml --input "What did NVIDIA announce at GTC 2026?"
+#
+# Requires NVIDIA_API_KEY and TAVILY_API_KEY in the environment (or .env).
+
+general:
+  telemetry:
+    tracing:
+      intake:
+        _type: otelcollector
+        endpoint: http://localhost:8080/apis/intake/v2/workspaces/default/ingest/otlp/v1/traces
+        project: research-agent
+        # NAT's otelcollector exporter only emits `service.name` by default,
+        # which Intake does not map to either `project` or `agent_name`. Setting
+        # these resource attributes explicitly makes the spans queryable by the
+        # analyst's `agent_name` / `project` filters.
+        resource_attributes:
+          gen_ai.agent.name: research-agent
+          project.name: research-agent
+        batch_size: 10
+        flush_interval: 1.0
+
+functions:
+  tavily_search:
+    _type: tavily_internet_search
+    max_results: 5
+    search_depth: basic
+
+llms:
+  nim_llm:
+    _type: nim
+    # Direct NIM model name (slash/dot form), so `uv run main.py` hits NIM
+    # at integrate.api.nvidia.com directly. When deploying through
+    # nemo-platform (`nemo agents deploy`), swap to the lowercase-hyphenated
+    # platform entity ID (e.g. `meta-llama-3-3-70b-instruct`) — the platform
+    # inference gateway validates names against that format. List entity IDs
+    # with `nemo models list`.
+    model_name: meta/llama-3.3-70b-instruct
+    temperature: 0.0
+    max_tokens: 1024
+
+workflow:
+  _type: react_agent
+  tool_names: [tavily_search]
+  llm_name: nim_llm
+  verbose: false
+  parse_agent_response_max_retries: 3
+  additional_instructions: >-
+    You are a concise research assistant. Use the tavily_internet_search tool to
+    gather up-to-date information, then synthesize a clear, well-cited answer.
+    Always include source URLs inline as markdown links. Be very brief. Only one
+    search call allowed.

--- a/plugins/nemo-insights/pyproject.toml
+++ b/plugins/nemo-insights/pyproject.toml
@@ -47,5 +47,5 @@ pythonpath = ["src", "."]
 testpaths = ["tests"]
 
 [tool.uv.sources]
-nemo-platform = { path = "../../packages/nemo_platform", editable = true }
-nemo-platform-plugin = { path = "../../packages/nemo_platform_plugin", editable = true }
+nemo-platform = { workspace = true }
+nemo-platform-plugin = { workspace = true }

--- a/plugins/nemo-insights/pyproject.toml
+++ b/plugins/nemo-insights/pyproject.toml
@@ -1,0 +1,51 @@
+[project]
+name = "nemo-insights-plugin"
+version = "0.1.0"
+description = "Agent telemetry analysis and persistent insights for NeMo Platform."
+requires-python = ">=3.11,<3.15"
+dependencies = [
+  "fastapi>=0.115",
+  "genai-prices==0.0.62",
+  "httpx",
+  "nemo-platform",
+  "nemo-platform-plugin",
+  "opentelemetry-exporter-otlp>=1.42.1",
+  "opentelemetry-sdk>=1.42.1",
+  "pydantic>=2.10.6",
+  "pydantic-ai-harness[code-mode]==0.3.0",
+  "pydantic-ai-slim[anthropic]==1.105.0",
+  "pyyaml>=6.0.3",
+  "typer>=0.20.0",
+  "tzdata==2026.2",
+]
+
+[project.entry-points."nemo.cli"]
+insights = "nemo_insights_plugin.cli:InsightsCLI"
+
+[project.entry-points."nemo.services"]
+insights = "nemo_insights_plugin.service:InsightsService"
+
+[project.entry-points."nemo.controllers"]
+insights-analysis = "nemo_insights_plugin.controller:InsightsAnalysisController"
+
+[project.entry-points."nemo.jobs"]
+"insights.analyze-job" = "nemo_insights_plugin.jobs.analyze:AnalyzeJob"
+
+[project.entry-points."nemo.sdk"]
+insights = "nemo_insights_plugin.sdk:insights_sdk_resources"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/nemo_insights_plugin"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["src", "."]
+testpaths = ["tests"]
+
+[tool.uv.sources]
+nemo-platform = { path = "../../packages/nemo_platform", editable = true }
+nemo-platform-plugin = { path = "../../packages/nemo_platform_plugin", editable = true }

--- a/plugins/nemo-insights/src/nemo_insights_plugin/_perms.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/_perms.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed permissions for Insights HTTP resources."""
+
+from nemo_platform_plugin.authz import PermissionSet, perm
+
+
+class InsightPerms(PermissionSet, namespace="insights.insights"):
+    CREATE = perm("Create insights")
+    LIST = perm("List insights")
+    READ = perm("Read insights")
+    UPDATE = perm("Update insights")
+    DELETE = perm("Delete insights")
+
+
+class AnalysisConfigPerms(PermissionSet, namespace="insights.analysis-configs"):
+    ENABLE = perm("Enable periodic analysis")
+    DISABLE = perm("Disable periodic analysis")
+    LIST = perm("List periodic analysis configuration")
+    READ = perm("Read periodic analysis configuration")
+    UPDATE = perm("Update periodic analysis configuration")
+
+
+class AnalysisRunStatusPerms(PermissionSet, namespace="insights.analysis-run-statuses"):
+    LIST = perm("List analysis run status")
+    READ = perm("Read analysis run status")
+    UPDATE = perm("Update analysis run status")

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/agent.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/agent.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The NeMo Insights analyst agent, built on Pydantic AI.
+
+The analyst inspects recent traces from a target agent, identifies failure
+patterns and performance regressions, and reports actionable Insights. It is a
+Pydantic AI :class:`~pydantic_ai.Agent` with a fixed persona (``INSTRUCTIONS``)
+and read-only tools for observability data.
+
+Rather than mutating platform state mid-run through a series of write tools,
+the analyst gathers evidence with its read tools and then emits a single
+:class:`~nemo_insights_plugin.analyst.result.AnalystResult` as its typed
+output. Producing that result ends the run and hands the entire change-set
+(new insights and updates) back to the CLI, which is the only component
+that persists.
+
+The result is delivered via ``PromptedOutput`` rather than a tool call:
+Anthropic rejects extended thinking and tool-based output in the same request,
+and the analyst keeps adaptive thinking on for reasoning quality, so the
+change-set is returned as a final structured message validated against the
+``AnalystResult`` schema.
+
+The analyst's persona, task, the agent-under-test name, and the optional AUT
+spec are all formatted into the instructions by ``build_analyst_agent``; the
+run is seeded with only the minimal ``KICKOFF`` user turn (the Anthropic
+Messages API requires a non-empty ``messages`` array). The per-run config the
+tools need is carried in :class:`~nemo_insights_plugin.analyst.deps.AnalystDeps`.
+Workspace and base URL aren't in the instructions because the tools are already
+scoped to them via ``AnalystDeps``.
+"""
+
+import os
+from typing import Any
+
+from nemo_insights_plugin.analyst.deps import AnalystDeps
+from nemo_insights_plugin.analyst.functions.annotations import (
+    fetch_annotations,
+    get_annotation,
+)
+from nemo_insights_plugin.analyst.functions.insights import list_insights
+from nemo_insights_plugin.analyst.functions.spans import (
+    fetch_scores,
+    fetch_spans,
+    get_span,
+)
+from nemo_insights_plugin.analyst.observability import (
+    ANALYST_OBSERVABILITY_AGENT_NAME,
+    AnalystObservability,
+)
+from nemo_insights_plugin.analyst.result import AnalystResult
+from pydantic_ai import Agent, PromptedOutput
+from pydantic_ai.capabilities import Instrumentation
+from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
+from pydantic_ai.providers.anthropic import AnthropicProvider
+from pydantic_ai_harness import CodeMode
+
+# The analyst runs on Claude Opus 4.8, but reached over the native Anthropic
+# Messages wire format rather than Anthropic's own endpoint: NVIDIA's Inference
+# Gateway (a LiteLLM proxy) exposes ``/v1/messages`` and authenticates with the
+# gateway virtual key in ``INFERENCE_API_KEY``. The Anthropic SDK appends
+# ``/v1/messages`` to the base URL, so we point it at the gateway root.
+DEFAULT_MODEL = "aws/anthropic/bedrock-claude-opus-4-8"
+INFERENCE_GATEWAY_BASE_URL = "https://inference-api.nvidia.com"
+# Extended thinking effort. Opus 4.8 only accepts adaptive thinking with an
+# ``output_config.effort`` level (it rejects the older fixed ``budget_tokens``
+# form). We set these explicitly because the gateway-aliased model name hides
+# the model identity from Pydantic AI's profile-based inference.
+THINKING_EFFORT = "medium"
+MAX_TOKENS = 16000
+
+# Safety cap on model requests per run so a misbehaving loop cannot spin
+# forever. Each tool-calling round is one request, so this bounds the analyst
+# to roughly this many tool-use steps.
+MAX_REQUESTS = 50
+
+# ---------------------------------------------------------------------------
+# Analyst persona + task + methodology, derived from docs/prd-por.md.
+#
+# This is the system prompt (Pydantic AI "instructions") and the only prompt
+# the analyst gets — there is no separate user-message brief. ``{agent}`` is
+# formatted in by ``build_analyst_agent`` and the optional AUT spec is appended
+# as the final paragraph. Pydantic AI owns the tool catalog and JSON
+# tool-calling protocol, so this text covers only the analyst's persona,
+# principles, and method — it deliberately does not document the tools or
+# restate any output format.
+#
+# This is v0 — untuned against real traces; treat early output as preliminary.
+# ---------------------------------------------------------------------------
+INSTRUCTIONS = """
+You are the Analyst agent for the NeMo Insights plugin. Analyze recent
+production and evaluation traces from the agent under test (AUT),
+**{agent}**, and file Insights for the highest-impact failure patterns
+you find. An Insight is a named, persistent description of a recurring
+problem in the AUT, scoped specifically enough to act on and generally
+enough to recur. Insights are the unit of work the rest of the
+optimization loop runs on, so the bar on signal-to-noise is high: a
+noisy Insight burns developer trust and is worse than no Insight at all.
+
+## Operating principles
+
+1. Quality over quantity. Two precise, well-evidenced Insights beat
+   ten vague ones. Insights such as "Retrieval is
+   failing" or "The agent is slow" are underspecified and not useful.
+2. Traces are receipts. Every Insight must cite the specific Intake
+   trace IDs you used as evidence so a developer can audit your
+   reasoning and build regression tests. A trace id is the ``trace_id``
+   carried on the evidence spans (not the ``session_id`` you grouped
+   by). Aim for at least three representative traces per Insight before
+   filing.
+3. Find the sweet spot between specific and general. A good
+   description names the failure mode, the affected tool or model
+   call and the conditions that trigger it. Avoid descriptions that only fit a single input.
+4. Do not duplicate. Check existing Insights for the AUT before
+   filing a new one. If you find new evidence for an existing open
+   Insight, append it to that Insight rather than creating a
+   near-duplicate.
+5. Prioritize by impact. Negative end-user and developer feedback
+   ranks highest, then explicit error-status spans, then evaluator
+   regressions, then latency or cost outliers, then divergence from
+   the agent's described intent. Issues that are more widespread and occur in many different sessions are higher impact than those that occur in one session.
+
+## Method
+
+1. Scope to the AUT through spans and fan out across sessions first.
+   Intake traces cannot be filtered by agent — only spans carry the
+   agent identity — so there is no agent-scoped trace tool. Spans can be
+   filtered by ``agent_name``, so anchor your survey on spans scoped to
+   **{agent}** (the span tools default to this agent). The AUT's work is
+   organized into sessions (one ``session_id`` per end-to-end run), so
+   begin with ``fetch_spans`` grouped by ``session_id`` (pass
+   ``group_by="session_id"``) to recover the AUT's sessions in one shot and
+   survey **many** of them — looking at 100 sessions is far more
+   informative than 100 spans drawn from 2 sessions, especially in this
+   initial exploration phase. Only pull a flat span list (``fetch_spans``
+   without ``group_by``) once you have specific sessions worth opening up, and
+   try to scope the spans you retrieve to the impactful ones.
+2. Start with feedback: it is the strongest signal of a real problem.
+   Pull negative end-user and developer feedback first, then fan out
+   over the AUT's sessions with ``fetch_spans`` grouped by
+   ``session_id``, looking for errors, outliers, and clusters of similar
+   failures across as many sessions as you can.
+3. Drill into the spans behind each candidate cluster: take the
+   ``session_id`` (or ``trace_id``) of an interesting session and call
+   ``fetch_spans`` with that filter (or ``get_span`` for one span) to
+   find the actual LLM and tool calls where the root cause lives.
+   Correlate feedback to its session via the session or trace id.
+4. Check the existing Insights for the agent so you know which of your
+   findings are new and which extend an Insight that already exists.
+
+## Reporting your findings
+
+When your analysis is complete, report everything in one
+final ``analyst_result`` with your full change-set:
+
+- ``new_insights``: Insights that do not already exist. Give each a
+  short, human-readable title (a sentence naming the failure, e.g.
+  'Retrieval drops relevant context near the token limit'), a
+  description covering failure mode + affected component and
+  the trace IDs as evidence.
+- ``updated_insights``: new evidence — trace refs
+  for Insights that already exist. Reference the target Insight by its
+  ``id`` from the ``list_insights`` output (e.g.
+  'insight-5Q2LoF8z8M9JZxZsHwJKNn'), not by its name. Appending evidence
+  is the only change allowed on an existing Insight (you cannot rename,
+  re-describe, or restatus it). Use this instead of re-filing a
+  near-duplicate of an existing Insight.
+
+Producing the result ends the run, so gather all your evidence first
+and emit one complete, well-evidenced change-set. If you found
+nothing worth filing, return empty lists and say so in the summary.
+
+Notes:
+- Do not refer to the AUT agent as the AUT in the insights you create. The developer is not familiar with this vocabulary.
+"""
+
+
+AGENT_SPEC_HEADER = """
+## Agent Spec
+
+Use this as the contract for what the agent is supposed to do, what
+success looks like, and what behavior should be flagged as divergence.
+Flag agent divergence from the spec. The spec was authored by the
+developer of the application and should be considered the purpose and goals.
+"""
+
+KICKOFF = (
+    "Analyze recent traces for the agent under test and file Insights for the highest-impact failure patterns you find."
+)
+
+
+def build_analyst_agent(
+    agent: str,
+    agent_spec: str | None = None,
+    observability: AnalystObservability | None = None,
+) -> Agent[AnalystDeps, AnalystResult]:
+    """Build the analyst :class:`~pydantic_ai.Agent`.
+
+    Args:
+        agent: Name of the agent under test, formatted into the instructions.
+        agent_spec: Optional spec describing the agent under test. When given,
+            it is appended as the final paragraph of the instructions (under
+            ``AGENT_SPEC_HEADER``) so the analyst can flag divergence from it.
+        observability: Optional Pydantic AI OTel instrumentation for dogfooding
+            analyst self-observability.
+    """
+    instructions = INSTRUCTIONS.format(agent=agent)
+    if agent_spec and agent_spec.strip():
+        instructions = f"{instructions}\n{AGENT_SPEC_HEADER}\n\n{agent_spec.strip()}\n"
+    capabilities: list[Any] = [CodeMode()]
+    if observability is not None:
+        capabilities.append(Instrumentation(settings=observability.instrumentation_settings))
+    return Agent(
+        AnthropicModel(
+            DEFAULT_MODEL,
+            provider=AnthropicProvider(
+                api_key=os.environ["INFERENCE_API_KEY"],
+                base_url=INFERENCE_GATEWAY_BASE_URL,
+            ),
+        ),
+        deps_type=AnalystDeps,
+        name=ANALYST_OBSERVABILITY_AGENT_NAME,
+        instructions=instructions,
+        metadata=observability.metadata if observability else None,
+        output_type=PromptedOutput(
+            AnalystResult,
+            name="analyst_result",
+            description=(
+                "The complete set of insights from this analysis. Emit this once, at the end; it ends the run."
+            ),
+        ),
+        model_settings=AnthropicModelSettings(
+            max_tokens=MAX_TOKENS,
+            anthropic_thinking={"type": "adaptive"},
+            anthropic_effort=THINKING_EFFORT,
+        ),
+        # Code mode (Pydantic AI Harness) collapses the analyst's read tools
+        # into a single sandboxed ``run_code`` tool, so the model orchestrates
+        # multi-step trace triage in one Python program instead of dozens of
+        # serial tool-call round-trips.
+        capabilities=capabilities,
+        tools=[
+            fetch_spans,
+            get_span,
+            fetch_scores,
+            fetch_annotations,
+            get_annotation,
+            list_insights,
+        ],
+    )

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
@@ -1,0 +1,532 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Data-access backend for the analyst's tools and final change-set.
+
+Every tool talks to the platform through one :class:`AnalystBackend`, built
+once per run by the CLI and shared via ``AnalystDeps`` instead of threading a
+raw SDK client around. The backend owns the SDK client and exposes:
+
+- read-only Intake queries (spans, span groups, feedback annotations, and a
+  span-rollup session count),
+- ``list_insights`` so the analyst can see what already exists, and
+- ``persist_result``: the single write entry point that takes the analyst's
+  :class:`~nemo_insights_plugin.analyst.result.AnalystResult` and stores it.
+
+Intake reads (spans, span groups, annotations, session count) always hit the
+live platform. Insight listing and result persistence vary by backend, because the
+target deployment may not have the Insights plugin installed.
+:class:`RemoteAnalystBackend` lists insights via the plugin API and persists the
+result as Insight rows via the plugin API.
+:class:`LocalAnalystBackend` lists from and persists to a local YAML file
+(``--insights-file-output``), merging each run's change-set into the file rather
+than overwriting it. :func:`make_analyst_backend` picks one. The client's
+lifecycle is owned by the caller (the CLI), so the backend never closes it.
+"""
+
+import uuid
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import yaml
+from nemo_insights_plugin.analyst.result import AnalystResult
+from nemo_insights_plugin.entities import Insight, InsightStatus
+from nemo_insights_plugin.schema import InsightPage
+from nemo_platform import AsyncNeMoPlatform, omit
+from nemo_platform_plugin.schema import PaginationData
+
+
+class InsightNotFoundError(Exception):
+    """No insight with the given id exists in the workspace."""
+
+
+def _dump(item) -> dict:
+    """Serialize one SDK model to a plain JSON-able dict (drop null fields)."""
+    return item.model_dump(mode="json", exclude_none=True)
+
+
+def _union_refs(existing: list[str] | None, new: list[str] | None) -> list[str]:
+    """Append *new* refs to *existing*, de-duplicating and preserving order."""
+    merged = list(existing or [])
+    seen = set(merged)
+    for ref in new or []:
+        if ref not in seen:
+            merged.append(ref)
+            seen.add(ref)
+    return merged
+
+
+async def _drain(paginator, *, limit: int) -> tuple[list, bool]:
+    """Pull up to *limit* items across pages; return ``(items, truncated)``.
+
+    ``truncated`` is True when the stream still had more items than *limit*,
+    so the model knows it is looking at a capped view and can narrow its
+    filter or raise the limit.
+    """
+    items: list = []
+    truncated = False
+    async for item in paginator:
+        if len(items) >= limit:
+            truncated = True
+            break
+        items.append(item)
+    return items, truncated
+
+
+def _page_size_for(limit: int) -> int:
+    """Per-page size for a drain: big enough to minimize round-trips."""
+    return max(1, min(limit, 100))
+
+
+def _merge_since_filter(filter_obj: dict | None, *, since: datetime | None) -> dict | None:
+    """Return *filter_obj* with an enforced ``started_at >= since`` lower bound."""
+    return _merge_datetime_lower_bound(filter_obj, key="started_at", since=since)
+
+
+def _merge_created_since_filter(filter_obj: dict | None, *, since: datetime | None) -> dict | None:
+    """Return *filter_obj* with an enforced ``created_at >= since`` lower bound."""
+    return _merge_datetime_lower_bound(filter_obj, key="created_at", since=since)
+
+
+def _merge_datetime_lower_bound(filter_obj: dict | None, *, key: str, since: datetime | None) -> dict | None:
+    if since is None:
+        return filter_obj
+
+    merged: dict = dict(filter_obj or {})
+    existing = merged.get(key)
+    lower_bound = since.isoformat()
+    if isinstance(existing, dict):
+        existing = dict(existing)
+        current = existing.get("gte")
+        if current is None or str(current) < lower_bound:
+            existing["gte"] = lower_bound
+        merged[key] = existing
+    else:
+        merged[key] = {"gte": lower_bound}
+    return merged
+
+
+def _merge_eval_filter(filter_obj: dict | None, *, evaluation_id: str | None) -> dict | None:
+    """AND-pin the run scope onto a span filter.
+
+    Mirrors ``_merge_since_filter``: a set ``evaluation_id`` is forced onto every
+    read (overwriting any model-supplied value), so a run-scoped analyst never
+    reads across runs that share a workspace. ``None`` is a no-op.
+    """
+    if evaluation_id is None:
+        return filter_obj
+    merged: dict = dict(filter_obj or {})
+    merged["evaluation_id"] = evaluation_id
+    return merged
+
+
+class AnalystBackend(ABC):
+    """Read-only Intake access (shared) plus pluggable result persistence.
+
+    The read surface is a thin, uniform pass-through over the Intake SDK: every
+    list method takes the raw Intake ``filter`` dict and ``sort`` field and
+    drains pages up to ``limit``, and there are get-by-id and evaluator-score
+    primitives. The analyst composes these in ``run_code`` rather than relying
+    on a wide catalog of narrow tools. Reads always hit the live platform, even
+    in local insights mode.
+    """
+
+    def __init__(self, client: AsyncNeMoPlatform) -> None:
+        self.client = client
+
+    # -- reads: always against the live platform -------------------------- #
+
+    async def count_agent_sessions(
+        self,
+        *,
+        agent: str,
+        workspace: str,
+        since: datetime | None = None,
+        evaluation_id: str | None = None,
+    ) -> int:
+        """Count distinct sessions (the agent's "traces") via the span rollup.
+
+        Intake has no agent-scoped trace count — only spans carry the agent
+        identity — so a "trace" is one distinct ``session_id`` among the agent's
+        spans. This rolls those spans up server-side with :meth:`list_span_groups`
+        and reports the full distinct-group ``total``.
+        """
+        groups = await self.list_span_groups(
+            workspace=workspace,
+            filter={"agent_name": agent},
+            group_by="session_id",
+            limit=1,
+            since=since,
+            evaluation_id=evaluation_id,
+        )
+        return groups["total"]
+
+    async def list_spans(
+        self,
+        *,
+        workspace: str,
+        filter: dict | None,
+        sort: str,
+        mode: str,
+        limit: int,
+        since: datetime | None = None,
+        evaluation_id: str | None = None,
+    ) -> dict:
+        effective_filter = _merge_eval_filter(_merge_since_filter(filter, since=since), evaluation_id=evaluation_id)
+        paginator = self.client.intake.spans.list(
+            workspace=workspace,
+            page_size=_page_size_for(limit),
+            sort=cast(Any, sort),
+            filter=cast(Any, effective_filter) or omit,
+            mode=cast(Any, mode),
+        )
+        items, truncated = await _drain(paginator, limit=limit)
+        return {
+            "spans": [_dump(s) for s in items],
+            "count": len(items),
+            "truncated": truncated,
+        }
+
+    async def list_span_groups(
+        self,
+        *,
+        workspace: str,
+        filter: dict | None,
+        group_by: str = "session_id",
+        sort: str = "-span_count",
+        limit: int,
+        since: datetime | None = None,
+        evaluation_id: str | None = None,
+    ) -> dict:
+        """Group matching spans server-side and return the group rows.
+
+        Each row is ``{"group": {<by-field>: value, ...}, "span_count": int}``.
+        Grouping by ``session_id`` recovers the AUT's distinct sessions (its
+        "traces") in a single request, so a wide survey fans out across many
+        sessions instead of burning the budget on the spans of a few. ``total``
+        is the server's full group count; ``truncated`` means more groups
+        matched than were returned on this page.
+        """
+        effective_filter = _merge_eval_filter(_merge_since_filter(filter, since=since), evaluation_id=evaluation_id)
+        page_size = max(1, min(limit, 1000))
+        page = await self.client.intake.spans.groups.list(
+            workspace=workspace,
+            by=group_by,
+            page=1,
+            page_size=page_size,
+            filter=cast(Any, effective_filter or omit),
+            sort=cast(Any, sort),
+        )
+        groups = [_dump(g) for g in page.data]
+        total = page.pagination.total_results if page.pagination is not None else len(groups)
+        return {
+            "groups": groups,
+            "grouped_by": group_by,
+            "count": len(groups),
+            "total": total,
+            "truncated": total > len(groups),
+        }
+
+    async def list_annotations(
+        self,
+        *,
+        workspace: str,
+        filter: dict | None,
+        sort: str,
+        limit: int,
+        since: datetime | None = None,
+    ) -> dict:
+        effective_filter = _merge_created_since_filter(filter, since=since)
+        paginator = self.client.intake.annotations.list(
+            workspace=workspace,
+            page_size=_page_size_for(limit),
+            sort=cast(Any, sort),
+            filter=cast(Any, effective_filter) or omit,
+        )
+        items, truncated = await _drain(paginator, limit=limit)
+        return {
+            "annotations": [_dump(a) for a in items],
+            "count": len(items),
+            "truncated": truncated,
+        }
+
+    async def get_span(self, *, workspace: str, span_id: str) -> dict:
+        span = await self.client.intake.spans.retrieve(span_id, workspace=workspace)
+        return _dump(span)
+
+    async def get_annotation(self, *, workspace: str, annotation_id: str) -> dict:
+        annotation = await self.client.intake.annotations.retrieve(annotation_id, workspace=workspace)
+        return _dump(annotation)
+
+    async def list_scores(self, *, workspace: str, span_id: str) -> dict:
+        results = await self.client.intake.spans.evaluator_results.list(span_id, workspace=workspace)
+        return {
+            "evaluator_results": [_dump(r) for r in results],
+            "count": len(results),
+        }
+
+    # -- insight read + result persistence: varies by backend ------------- #
+
+    @abstractmethod
+    async def list_insights(
+        self,
+        *,
+        workspace: str,
+        page: int,
+        page_size: int,
+        agent: str | None,
+        status: InsightStatus | None,
+    ) -> InsightPage:
+        """List existing insights so the analyst can dedupe its findings.
+
+        The remote backend lists from the Insights plugin API; the local
+        backend lists from its YAML file, since the target deployment may not
+        have the plugin installed.
+        """
+        ...
+
+    @abstractmethod
+    async def persist_result(self, *, workspace: str, agent: str, result: AnalystResult) -> str:
+        """Persist the analyst's whole change-set and return a printable report.
+
+        The shape on disk/in the store is the backend's concern; callers hand
+        over the storage-agnostic :class:`AnalystResult` and get back the text
+        the CLI prints (the model's summary followed by a line-item log).
+        """
+        ...
+
+
+class RemoteAnalystBackend(AnalystBackend):
+    """Persist insights via the Insights plugin API.
+
+    Translates the SDK's HTTP 404 on an update into the backend-neutral
+    not-found error so the persistence logic doesn't depend on ``httpx``
+    semantics.
+    """
+
+    @property
+    def _insights(self):
+        return self.client.insights.insights
+
+    async def list_insights(
+        self,
+        *,
+        workspace: str,
+        page: int,
+        page_size: int,
+        agent: str | None,
+        status: InsightStatus | None,
+    ) -> InsightPage:
+        return await self._insights.list_insights(
+            workspace=workspace,
+            page=page,
+            page_size=page_size,
+            agent=agent,
+            status=status,
+        )
+
+    async def persist_result(self, *, workspace: str, agent: str, result: AnalystResult) -> str:
+        """Replay the change-set: insights into the DB.
+
+        New insights are created with their evidence; the store auto-assigns a
+        unique slug name and an id. Existing insights are referenced by id —
+        only trace refs are appended.
+        """
+        lines: list[str] = []
+
+        for new in result.new_insights:
+            created = await self._create(
+                workspace=workspace,
+                title=new.title,
+                agent=agent,
+                description=new.description,
+                status=new.status,
+                trace_refs=new.trace_refs or None,
+            )
+            lines.append(f"- created: {new.title} [{created.id}] ({len(new.trace_refs)} trace refs)")
+
+        for upd in result.updated_insights:
+            try:
+                if upd.trace_refs:
+                    await self._add_trace_refs(
+                        workspace=workspace,
+                        insight_id=upd.id,
+                        trace_refs=upd.trace_refs,
+                    )
+            except InsightNotFoundError:
+                lines.append(f"- skipped (insight not found): {upd.id}")
+                continue
+            lines.append(f"- updated: {upd.id} ({len(upd.trace_refs)} trace refs)")
+
+        if not lines:
+            lines.append("- no insights created or updated")
+
+        return f"{result.summary}\n\n" + "\n".join(lines)
+
+    async def _create(
+        self,
+        *,
+        workspace: str,
+        title: str,
+        agent: str,
+        description: str,
+        status: InsightStatus,
+        trace_refs: list[str] | None,
+    ) -> Insight:
+        return await self._insights.create(
+            workspace=workspace,
+            title=title,
+            agent=agent,
+            description=description,
+            status=status,
+            trace_refs=_union_refs(None, trace_refs),
+        )
+
+    async def _add_trace_refs(self, *, workspace: str, insight_id: str, trace_refs: list[str]) -> Insight:
+        try:
+            current = await self._insights.get(workspace=workspace, insight_id=insight_id)
+            return await self._insights.update(
+                workspace=workspace,
+                insight_id=insight_id,
+                trace_refs=_union_refs(current.trace_refs, trace_refs),
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                raise InsightNotFoundError(insight_id) from exc
+            raise
+
+
+def _generate_local_insight_id() -> str:
+    """Mint a path-safe, unique insight id for offline mode.
+
+    Mirrors the remote store's ``insight-<suffix>`` shape so file records look
+    like what the platform would assign; the suffix is a uuid4 hex rather than
+    the store's base58 encoding (no extra dependency), which is still unique.
+    """
+    return f"insight-{uuid.uuid4().hex}"
+
+
+def _record_to_insight(record: dict) -> Insight:
+    """Rebuild an :class:`Insight` (id/timestamps included) from a file record.
+
+    A record is an :class:`Insight` JSON-able dump; any keys not on the entity
+    are ignored by Pydantic during validation.
+    """
+    insight = Insight.model_validate(record)
+    insight._id = record.get("id") or None
+    for attr, key in (("_created_at", "created_at"), ("_updated_at", "updated_at")):
+        raw = record.get(key)
+        setattr(insight, attr, datetime.fromisoformat(raw) if raw else None)
+    return insight
+
+
+class LocalAnalystBackend(AnalystBackend):
+    """Persist the analyst's result to a local YAML file (offline mode).
+
+    For running against a deployment that hosts observability data but does not
+    have the Insights plugin installed: reads of traces/spans/annotations still
+    hit the live platform, but insights are both listed from and written to the
+    file. The file accumulates across runs — ``persist_result`` merges the new
+    change-set into whatever the file already holds rather than overwriting it,
+    so re-running the analyst against the same file folds new evidence into
+    existing insights instead of dropping prior work.
+
+    File shape: ``{"insights": [<Insight record>, ...]}`` — each record is the
+    stored entity.
+    """
+
+    def __init__(self, *, client: AsyncNeMoPlatform, path: Path) -> None:
+        super().__init__(client)
+        self.path = path
+
+    def _read_records(self) -> list[dict]:
+        if not self.path.exists():
+            return []
+        raw = yaml.safe_load(self.path.read_text()) or {}
+        return list(raw.get("insights", []))
+
+    def _write_records(self, records: list[dict]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(yaml.safe_dump({"insights": records}, sort_keys=False, allow_unicode=True))
+
+    async def persist_result(self, *, workspace: str, agent: str, result: AnalystResult) -> str:
+        records = self._read_records()
+        by_id = {(r.get("workspace"), r.get("id")): r for r in records}
+        now = datetime.now(timezone.utc).isoformat()
+        lines: list[str] = []
+
+        for new in result.new_insights:
+            insight_id = _generate_local_insight_id()
+            record = {
+                "id": insight_id,
+                "workspace": workspace,
+                "title": new.title,
+                "agent": agent,
+                "description": new.description,
+                "status": new.status.value,
+                "trace_refs": list(new.trace_refs),
+                "created_at": now,
+                "updated_at": now,
+            }
+            records.append(record)
+            by_id[(workspace, insight_id)] = record
+            lines.append(f"- created: {new.title} [{insight_id}] ({len(new.trace_refs)} trace refs)")
+
+        for upd in result.updated_insights:
+            existing = by_id.get((workspace, upd.id))
+            if existing is None:
+                lines.append(f"- skipped (insight not found): {upd.id}")
+                continue
+            existing["trace_refs"] = _union_refs(existing.get("trace_refs"), upd.trace_refs)
+            existing["updated_at"] = now
+            lines.append(f"- updated: {upd.id} ({len(upd.trace_refs)} trace refs)")
+
+        if not lines:
+            lines.append("- no insights created or updated")
+
+        self._write_records(records)
+        return f"{result.summary}\n\nWrote analyst result to {self.path}\n" + "\n".join(lines)
+
+    async def list_insights(
+        self,
+        *,
+        workspace: str,
+        page: int,
+        page_size: int,
+        agent: str | None,
+        status: InsightStatus | None,
+    ) -> InsightPage:
+        items = [_record_to_insight(r) for r in self._read_records() if r.get("workspace") == workspace]
+        if agent:
+            items = [i for i in items if i.agent == agent]
+        if status is not None:
+            items = [i for i in items if i.status == status]
+        epoch = datetime.min.replace(tzinfo=timezone.utc)
+        items.sort(key=lambda i: i.created_at or epoch, reverse=True)
+
+        total = len(items)
+        start = (page - 1) * page_size
+        page_items = items[start : start + page_size]
+        pagination = PaginationData(
+            page=page,
+            page_size=page_size,
+            current_page_size=len(page_items),
+            total_pages=max(1, (total + page_size - 1) // page_size) if page_size else 1,
+            total_results=total,
+        )
+        return InsightPage(data=page_items, pagination=pagination)
+
+
+def make_analyst_backend(*, client: AsyncNeMoPlatform, insights_output: str | None) -> AnalystBackend:
+    """Select the analyst backend based on *insights_output*.
+
+    When set, the analyst's result is written to that local YAML file (offline
+    mode); otherwise the Insights plugin API and platform filesets on *client*
+    are used. Reads always go through *client* either way.
+    """
+    if insights_output:
+        return LocalAnalystBackend(client=client, path=Path(insights_output))
+    return RemoteAnalystBackend(client)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
@@ -101,12 +101,30 @@ def _merge_datetime_lower_bound(filter_obj: dict | None, *, key: str, since: dat
     if isinstance(existing, dict):
         existing = dict(existing)
         current = existing.get("gte")
-        if current is None or str(current) < lower_bound:
+        current_datetime = _parse_datetime(current)
+        since_datetime = _parse_datetime(since)
+        if current_datetime is None or since_datetime is None or current_datetime < since_datetime:
             existing["gte"] = lower_bound
         merged[key] = existing
     else:
         merged[key] = {"gte": lower_bound}
     return merged
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    """Parse a datetime-like lower bound and normalize it to UTC."""
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _merge_eval_filter(filter_obj: dict | None, *, evaluation_id: str | None) -> dict | None:
@@ -356,6 +374,8 @@ class RemoteAnalystBackend(AnalystBackend):
                         insight_id=upd.id,
                         trace_refs=upd.trace_refs,
                     )
+                else:
+                    await self._get(workspace=workspace, insight_id=upd.id)
             except InsightNotFoundError:
                 lines.append(f"- skipped (insight not found): {upd.id}")
                 continue
@@ -386,13 +406,21 @@ class RemoteAnalystBackend(AnalystBackend):
         )
 
     async def _add_trace_refs(self, *, workspace: str, insight_id: str, trace_refs: list[str]) -> Insight:
+        current = await self._get(workspace=workspace, insight_id=insight_id)
         try:
-            current = await self._insights.get(workspace=workspace, insight_id=insight_id)
             return await self._insights.update(
                 workspace=workspace,
                 insight_id=insight_id,
                 trace_refs=_union_refs(current.trace_refs, trace_refs),
             )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                raise InsightNotFoundError(insight_id) from exc
+            raise
+
+    async def _get(self, *, workspace: str, insight_id: str) -> Insight:
+        try:
+            return await self._insights.get(workspace=workspace, insight_id=insight_id)
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 404:
                 raise InsightNotFoundError(insight_id) from exc

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/deps.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/deps.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run-time dependencies shared by the analyst agent and its tools.
+
+A single :class:`AnalystDeps` instance is threaded through every tool call via
+Pydantic AI's :class:`~pydantic_ai.RunContext`, replacing the per-function NAT
+config classes. The CLI builds it from its flags; tools read it off
+``ctx.deps``. Keeping it in its own module avoids an import cycle between the
+agent definition and the tool modules it registers.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from nemo_insights_plugin.analyst.analyst_backend import AnalystBackend
+
+
+@dataclass
+class AnalystDeps:
+    """Per-run configuration injected into every analyst tool.
+
+    Every tool talks to the platform through a single :class:`AnalystBackend`
+    built once by the CLI and shared here, rather than constructing an SDK
+    client per call. The CLI owns the backend's client lifecycle (closing it
+    when the run finishes), so tools must not close it.
+
+    Attributes:
+        agent: Agent under test. Used as the default ``agent_name`` filter for
+            span/insight tools.
+        workspace: NMP workspace the analyst operates in.
+        base_url: Base URL of the running NMP instance (run metadata; tools go
+            through ``backend``).
+        insights_output: When set, the backend persists insights to this local
+            YAML file instead of the Insights plugin API (run metadata).
+        backend: Shared data-access backend used by every tool.
+        since: Optional lower bound for scheduled incremental analysis. Backend
+            reads enforce this even if the model omits a time filter.
+        max_results: Hard ceiling on items any single fetch may pull across
+            pages. A fetch's ``limit`` is clamped to this so a wide filter
+            can't flood the model's context; the analyst paginates or narrows
+            its filter to see more.
+    """
+
+    agent: str = ""
+    workspace: str = "default"
+    base_url: str | None = None
+    insights_output: str | None = None
+    backend: AnalystBackend | None = None  # set by the CLI per run
+    since: datetime | None = None
+    evaluation_id: str | None = None  # run scope; AND-pinned onto every span read
+    max_results: int = 200

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/functions/annotations.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/functions/annotations.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Analyst tools over Intake annotations: ``fetch_annotations`` and ``get_annotation``.
+
+Intake is span-based: end-user / developer feedback, labels, notes, and
+metadata are all *annotations* attached to a ``span_id`` (or session-wide, a
+``session_id``), not legacy ``entries``. These tools are thin pass-throughs
+over ``client.intake.annotations``; the analyst supplies the raw Intake filter.
+
+Annotation kinds:
+
+- ``feedback`` — thumbs sentiment; ``value_text`` is "positive" / "negative".
+  This is the strongest signal of a real problem — start here.
+- ``label`` — categorical (``value_text``) or scored (``value_numeric``)
+  labels, e.g. a 1-5 ``helpfulness`` rating.
+- ``note`` / ``metadata`` — free text / structured key-value.
+
+Because annotations hang off spans, each result carries its ``span_id`` /
+``session_id`` — feed those into ``fetch_spans`` / ``get_span`` to inspect the
+interaction the annotation is about.
+
+Schema source of truth (Intake changes often — design against source, not the
+vendored wheel): ``services/intake/src/nmp/intake/spans/api/annotations_schemas.py``
+in ``~/code/nemo-platform`` (``AnnotationFilter``).
+"""
+
+from typing import Any
+
+from nemo_insights_plugin.analyst.deps import AnalystDeps
+from pydantic_ai import RunContext
+
+
+async def fetch_annotations(
+    ctx: RunContext[AnalystDeps],
+    filter: dict[str, Any] | None = None,
+    sort: str = "-created_at",
+    limit: int = 50,
+) -> dict[str, Any]:
+    """List span/session annotations (feedback, labels, notes), newest first.
+
+    Returns ``{"annotations": [...], "count": int, "truncated": bool}``;
+    ``truncated`` means more matched than ``limit``.
+
+    Args:
+        filter: Raw Intake annotation filter pushed to the server. Supported
+            keys: ``kind`` ("feedback"/"label"/"note"/"metadata"),
+            ``value_text`` (e.g. "negative" for feedback, or a label's text
+            value), ``name`` (label name, e.g. "helpfulness"), ``value_numeric``
+            (a range object, e.g. ``{"lte": 2}`` for low scores), ``span_id``,
+            ``session_id``, ``created_by``, and ``created_at`` (a range).
+            To start with negative feedback: ``{"kind": "feedback",
+            "value_text": "negative"}``. Omit to list all annotations.
+        sort: Sort field; "-created_at" (default, newest first) or "created_at".
+        limit: Max annotations to pull across pages (clamped to the ceiling).
+    """
+    deps = ctx.deps
+    assert deps.backend is not None
+    return await deps.backend.list_annotations(
+        workspace=deps.workspace,
+        filter=filter or None,
+        sort=sort,
+        limit=min(limit, deps.max_results),
+        since=deps.since,
+    )
+
+
+async def get_annotation(ctx: RunContext[AnalystDeps], annotation_id: str) -> dict[str, Any]:
+    """Fetch a single annotation by id.
+
+    Args:
+        annotation_id: Intake annotation id.
+    """
+    deps = ctx.deps
+    assert deps.backend is not None
+    return await deps.backend.get_annotation(workspace=deps.workspace, annotation_id=annotation_id)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/functions/insights.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/functions/insights.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Analyst read tool: ``list_insights``.
+
+The analyst no longer mutates Insights through tools — it reports its whole
+change-set at the end via the ``analyst_result`` output tool (see
+:mod:`nemo_insights_plugin.analyst.result`). This module keeps only the
+read-only ``list_insights`` tool, which the analyst uses to see which Insights
+already exist for the agent so it can decide what is new versus an update.
+
+By default it calls the typed ``client.insights.insights`` SDK resource backed
+by the Insights plugin's Insight CRUD API; when ``insights_output`` is
+configured it reads a local YAML file instead. Backend selection lives in
+:mod:`nemo_insights_plugin.analyst.analyst_backend`.
+"""
+
+import json
+
+from nemo_insights_plugin.analyst.deps import AnalystDeps
+from nemo_insights_plugin.entities import InsightStatus
+from pydantic_ai import RunContext
+
+
+async def list_insights(
+    ctx: RunContext[AnalystDeps],
+    agent: str | None = None,
+    status: str | None = None,
+    page: int = 1,
+    page_size: int = 20,
+) -> str:
+    """List existing Insights for the agent under test.
+
+    Use to see which Insights already exist before deciding whether a finding
+    is a new Insight or new evidence for an existing one.
+
+    Args:
+        agent: Filter by agent name. Defaults to the analyst's configured
+            agent; pass an empty string to list across agents.
+        status: Filter by lifecycle status.
+        page: Page number (1-indexed).
+        page_size: Items per page.
+    """
+    deps = ctx.deps
+    assert deps.backend is not None
+    target_agent = agent if agent is not None else deps.agent
+    result = await deps.backend.list_insights(
+        workspace=deps.workspace,
+        page=page,
+        page_size=page_size,
+        agent=target_agent or None,
+        status=InsightStatus(status) if status is not None else None,
+    )
+    return json.dumps(result.model_dump(mode="json"), indent=2)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/functions/spans.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/functions/spans.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Analyst tools over Intake spans: ``fetch_spans``, ``get_span``, ``fetch_scores``.
+
+Spans are the LLM calls, tool invocations, and agent steps inside a trace.
+These tools are thin pass-throughs over ``client.intake.spans`` — the analyst
+supplies the raw Intake filter and composes the results in ``run_code``.
+"""
+
+from typing import Any
+
+from nemo_insights_plugin.analyst.deps import AnalystDeps
+from pydantic_ai import RunContext
+
+# Sentinel the analyst can pass as ``filter["agent_name"]`` to query spans across
+# all agents instead of the run's default agent under test.
+ALL_AGENTS = "__all__"
+
+
+def _effective_span_filter(
+    filter: dict[str, Any] | None,
+    agent: str,
+) -> dict[str, Any] | None:
+    """Default span queries to the run's agent unless the caller opts out."""
+    if filter is None:
+        return {"agent_name": agent} if agent else None
+
+    effective = dict(filter)
+    agent_name = effective.get("agent_name")
+    if agent_name == ALL_AGENTS:
+        effective.pop("agent_name")
+    elif "agent_name" not in effective and agent:
+        effective["agent_name"] = agent
+    return effective or None
+
+
+async def fetch_spans(
+    ctx: RunContext[AnalystDeps],
+    filter: dict[str, Any] | None = None,
+    group_by: str | None = None,
+    sort: str | None = None,
+    mode: str = "detailed",
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """List the AUT's spans from Intake, or roll them up into groups.
+
+    One tool, two modes:
+
+    - **Grouped** (pass ``group_by``, e.g. ``group_by="session_id"``): rolls
+      the matching spans up server-side into one row per group and returns
+      ``{"groups": [...], "grouped_by": str, "count": int, "total": int,
+      "truncated": bool}``, where each group is
+      ``{"group": {<by-field>: value, ...}, "span_count": int}``. ``total`` is
+      the server's full distinct-group count. **Start here** for initial
+      exploration: grouping by ``session_id`` recovers the AUT's sessions (its
+      "traces") so you fan out across **many** of them in one shot — seeing 100
+      sessions is far more informative than 100 spans drawn from 2 sessions.
+    - **Flat** (omit ``group_by``): returns the individual spans as
+      ``{"spans": [...], "count": int, "truncated": bool}``. Use this once you
+      have specific sessions worth opening up — scope it with a ``session_id``
+      or ``trace_id`` filter so it doesn't bunch up in a few heavy sessions.
+
+    In both modes ``truncated`` means more matched than ``limit`` — narrow the
+    filter or raise ``limit``.
+
+    Args:
+        filter: Raw Intake span filter pushed to the server. Supported keys:
+            ``agent_name`` (e.g. "codex"), ``status`` ("ok"/"error"),
+            ``kind`` ("LLM"/"TOOL"/"AGENT"/"CHAIN"/"EVALUATOR"/...),
+            ``session_id``, ``trace_id``, ``parent_span_id`` (direct children
+            of a span), ``model``, ``provider``, ``tool_name``, ``source``,
+            ``evaluation_run_id``, ``dataset_name``, ``test_case_id``, and
+            ``started_at`` (a range, e.g. ``{"gte": "2026-06-01T00:00:00"}``).
+            ``agent_name`` defaults to the run's agent under test when omitted
+            from ``filter``; pass an explicit value to query another agent, or
+            ``"__all__"`` to disable agent scoping. (There is no span-id
+            filter; resolve a known span id with ``get_span``.)
+        group_by: When set, the span field(s) to group by — switches to
+            grouped mode. Only ``session_id`` and ``trace_id`` are groupable;
+            pass one (e.g. "session_id") or both comma-separated
+            ("session_id,trace_id"). Omit for a flat span list.
+        sort: Sort field. Defaults to "-started_at" (newest first) for flat
+            mode and "-span_count" (heaviest groups first) for grouped mode.
+        mode: "summary" omits input/output; "detailed" includes everything.
+            Ignored in grouped mode.
+        limit: Max rows to pull (clamped to the run's ceiling). Defaults to 100
+            in grouped mode and 50 in flat mode.
+    """
+    deps = ctx.deps
+    assert deps.backend is not None
+    effective_filter = _effective_span_filter(filter, deps.agent)
+    if group_by is not None:
+        return await deps.backend.list_span_groups(
+            workspace=deps.workspace,
+            filter=effective_filter or None,
+            group_by=group_by,
+            sort=sort or "-span_count",
+            limit=min(limit or 100, deps.max_results),
+            since=deps.since,
+            evaluation_id=deps.evaluation_id,
+        )
+    return await deps.backend.list_spans(
+        workspace=deps.workspace,
+        filter=effective_filter or None,
+        sort=sort or "-started_at",
+        mode=mode,
+        limit=min(limit or 50, deps.max_results),
+        since=deps.since,
+        evaluation_id=deps.evaluation_id,
+    )
+
+
+async def get_span(ctx: RunContext[AnalystDeps], span_id: str) -> dict[str, Any]:
+    """Fetch a single span by id (e.g. a span id cited by an annotation).
+
+    Args:
+        span_id: Intake span id.
+    """
+    deps = ctx.deps
+    assert deps.backend is not None
+    return await deps.backend.get_span(workspace=deps.workspace, span_id=span_id)
+
+
+async def fetch_scores(ctx: RunContext[AnalystDeps], span_id: str) -> dict[str, Any]:
+    """Fetch evaluator results (scores) attached to a span.
+
+    Evaluator results are the verifier/judge outputs for a span — each has a
+    ``name``, a numeric ``value`` and/or ``string_value``, and an optional
+    ``comment``. For terminal-bench/eval traces the score lives on the
+    EVALUATOR span; pass that span's id (or any span you want scores for).
+    Returns ``{"evaluator_results": [...], "count": int}``.
+
+    Args:
+        span_id: Intake span id to read evaluator results for.
+    """
+    deps = ctx.deps
+    assert deps.backend is not None
+    return await deps.backend.list_scores(workspace=deps.workspace, span_id=span_id)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/observability.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/observability.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenTelemetry setup for analyst self-observability."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+from uuid import uuid4
+
+from nemo_insights_plugin.client import LOOPBACK_HOSTS
+from nemo_platform.config.config import Config
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from pydantic_ai.models.instrumented import InstrumentationSettings
+
+ANALYST_OBSERVABILITY_ENV = "NEMO_INSIGHTS_ANALYST_OBSERVABILITY"
+ANALYST_OBSERVABILITY_AGENT_NAME = "nemo-insights-analyst"
+ANALYST_OBSERVABILITY_SERVICE_NAMESPACE = "nemo-insights"
+OTLP_TRACES_PATH = "/apis/intake/v2/workspaces/{workspace}/ingest/otlp/v1/traces"
+
+
+@dataclass
+class AnalystObservability:
+    """Configured Pydantic AI instrumentation for one analyst run."""
+
+    endpoint: str
+    session_id: str
+    instrumentation_settings: InstrumentationSettings
+    tracer_provider: TracerProvider
+
+    @property
+    def metadata(self) -> dict[str, str]:
+        """Metadata attached to the Pydantic AI agent run span."""
+        return {
+            "session.id": self.session_id,
+            "gen_ai.conversation.id": self.session_id,
+        }
+
+    def shutdown(self) -> None:
+        """Flush pending spans and stop the provider's processors."""
+        self.tracer_provider.force_flush()
+        self.tracer_provider.shutdown()
+
+
+def build_intake_otlp_traces_endpoint(*, base_url: str, workspace: str) -> str:
+    """Return Intake's workspace-scoped OTLP/HTTP traces endpoint."""
+    return f"{base_url.rstrip('/')}{OTLP_TRACES_PATH.format(workspace=workspace)}"
+
+
+def setup_analyst_observability(
+    *,
+    base_url: str,
+    workspace: str,
+    target_agent: str,
+) -> AnalystObservability:
+    """Configure native Pydantic AI OTel instrumentation for Intake export.
+
+    This path is intended for insights dogfooding and is opt-in at the CLI
+    layer, so it always sends the analyst's own spans to the platform Intake
+    endpoint derived from the active ``--base-url`` and ``--workspace``.
+    """
+    endpoint = build_intake_otlp_traces_endpoint(base_url=base_url, workspace=workspace)
+    session_id = f"{ANALYST_OBSERVABILITY_AGENT_NAME}-{uuid4()}"
+    resource_attributes = _resource_attributes(
+        workspace=workspace,
+        target_agent=target_agent,
+        session_id=session_id,
+    )
+
+    tracer_provider = TracerProvider(resource=Resource.create(resource_attributes))
+    otlp_headers = _otlp_auth_headers(base_url)
+    tracer_provider.add_span_processor(
+        BatchSpanProcessor(
+            OTLPSpanExporter(
+                endpoint=endpoint,
+                headers=otlp_headers,
+            )
+        )
+    )
+    instrumentation_settings = InstrumentationSettings(
+        tracer_provider=tracer_provider,
+        include_content=True,
+    )
+    return AnalystObservability(
+        endpoint=endpoint,
+        session_id=session_id,
+        instrumentation_settings=instrumentation_settings,
+        tracer_provider=tracer_provider,
+    )
+
+
+def _otlp_auth_headers(base_url: str) -> dict[str, str] | None:
+    """Return Bearer auth headers for remote Intake OTLP ingest, if available."""
+    host = (urlparse(base_url).hostname or "").lower()
+    config_path = Config.get_default_config_path()
+    if host in LOOPBACK_HOSTS or not config_path.exists():
+        return None
+
+    config = Config.load(config_path, overrides={"base_url": base_url})
+    user = config.resolve().user
+    assert user is not None
+    client_config = user.get_client_config()
+    headers = client_config.get("default_headers")
+    if not isinstance(headers, dict):
+        return None
+    return {str(k): str(v) for k, v in headers.items()}
+
+
+def _resource_attributes(*, workspace: str, target_agent: str, session_id: str) -> dict[str, str]:
+    return {
+        "service.name": ANALYST_OBSERVABILITY_AGENT_NAME,
+        "service.namespace": ANALYST_OBSERVABILITY_SERVICE_NAMESPACE,
+        "gen_ai.agent.name": ANALYST_OBSERVABILITY_AGENT_NAME,
+        "gen_ai.agent.id": ANALYST_OBSERVABILITY_AGENT_NAME,
+        "project.name": ANALYST_OBSERVABILITY_AGENT_NAME,
+        "session.id": session_id,
+        "gen_ai.conversation.id": session_id,
+        "nemo.insights.workspace": workspace,
+        "nemo.insights.target_agent": target_agent,
+    }

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/result.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/result.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The analyst's single terminal result — a pure, storage-agnostic change-set.
+
+Instead of mutating platform state through a series of tool calls
+(``create_insight`` / ``update_insight``) while it
+reasons, the analyst reads observability data only, then emits one
+:class:`AnalystResult` struct that captures *every* change it wants to make.
+That struct is the agent's typed output: Pydantic AI surfaces it as a single
+``analyst_result`` tool, and the model calling that tool both ends the run and
+hands the whole change-set back to the CLI.
+
+These models intentionally know nothing about how the change-set is persisted.
+Each :class:`~nemo_insights_plugin.analyst.analyst_backend.AnalystBackend`
+decides that: the remote backend writes Insight rows to the DB, while the local
+backend writes the result to a YAML file verbatim.
+"""
+
+from nemo_insights_plugin.entities import InsightStatus
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class NewInsight(BaseModel):
+    """A brand-new Insight the analyst wants to file."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = Field(
+        min_length=1,
+        description=(
+            "A short, human-readable sentence naming the insight (e.g. "
+            "'Retrieval drops relevant context near the token limit'). The "
+            "full problem statement goes in 'description', not here."
+        ),
+    )
+    description: str = Field(
+        min_length=1,
+        description=(
+            "Problem statement: the failure mode, the affected tool or model "
+            "call, the conditions that trigger it, and a hypothesis for the "
+            "cause. Specific enough to act on, general enough to recur."
+        ),
+    )
+    status: InsightStatus = Field(
+        default=InsightStatus.OPEN,
+        description="Lifecycle status for the new insight (usually 'open').",
+    )
+    trace_refs: list[str] = Field(
+        default_factory=list,
+        description="Intake trace ids that serve as evidence for this insight.",
+    )
+
+
+class InsightUpdate(BaseModel):
+    """New evidence to add to an existing Insight."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(
+        min_length=1,
+        description=(
+            "Store-assigned id of the existing insight to add evidence to, as "
+            "shown in the ``list_insights`` output (e.g. "
+            "'insight-5Q2LoF8z8M9JZxZsHwJKNn'). Not the human-readable title."
+        ),
+    )
+    trace_refs: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Intake trace ids to append as new evidence (merged with the insight's existing refs, de-duplicated)."
+        ),
+    )
+
+
+class AnalystResult(BaseModel):
+    """The analyst's complete, final change-set for one run.
+
+    The model populates this once, at the end of its analysis, in place of the
+    old mutating tool calls. Calling the ``analyst_result`` tool with this
+    struct ends the run; the CLI then hands it to the backend to persist.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    summary: str = Field(
+        min_length=1,
+        description=(
+            "Brief natural-language summary of the analysis and the "
+            "highest-impact findings, for the developer reading the run."
+        ),
+    )
+    new_insights: list[NewInsight] = Field(
+        default_factory=list,
+        description="Insights to create that do not already exist for the agent.",
+    )
+    updated_insights: list[InsightUpdate] = Field(
+        default_factory=list,
+        description=(
+            "New evidence (trace refs) for insights that already exist for "
+            "the agent. Only evidence can be added to an existing insight — to "
+            "record anything else, file a new insight."
+        ),
+    )

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable insights analyst run orchestration."""
+
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from nemo_insights_plugin.analyst.agent import (
+    KICKOFF,
+    MAX_REQUESTS,
+    build_analyst_agent,
+)
+from nemo_insights_plugin.analyst.analyst_backend import make_analyst_backend
+from nemo_insights_plugin.analyst.deps import AnalystDeps
+from nemo_insights_plugin.analyst.observability import (
+    ANALYST_OBSERVABILITY_ENV,
+    setup_analyst_observability,
+)
+from nemo_insights_plugin.analyst.result import AnalystResult
+from nemo_insights_plugin.client import make_client
+from pydantic_ai import Agent, UsageLimits
+from pydantic_ai.messages import TextPart, ToolCallPart, ToolReturnPart
+
+# Truncate long tool inputs/outputs when echoing the verbose trace so a single
+# span dump doesn't flood the terminal.
+_VERBOSE_TRUNCATE = 2000
+
+
+async def run_analyst(
+    *,
+    agent: str,
+    agent_spec: str | None,
+    workspace: str,
+    base_url: str | None,
+    insights_output: str | Path | None = None,
+    verbose: bool = False,
+    since: datetime | None = None,
+    evaluation_id: str | None = None,
+) -> str:
+    """Build and run the analyst agent against an agent's telemetry.
+
+    The trace-volume floor for scheduled runs lives in the periodic controller,
+    which decides whether a run is worth launching; this entry point just runs.
+
+    Args:
+        agent: Agent under test.
+        agent_spec: Optional markdown spec content for the agent under test.
+        workspace: Platform workspace.
+        base_url: Platform base URL. ``None`` uses the active platform context.
+        insights_output: Optional local YAML output path for Insight writes.
+        verbose: Whether to stream model/tool events to stderr.
+        since: Optional incremental lower bound enforced on trace/span reads.
+        evaluation_id: Optional run scope; AND-pinned onto every span read.
+    """
+    client = make_client(base_url)
+    observability = None
+    insights_output_path = str(insights_output) if insights_output else None
+    backend = make_analyst_backend(
+        client=client,
+        insights_output=insights_output_path,
+    )
+    try:
+        deps = AnalystDeps(
+            agent=agent,
+            workspace=workspace,
+            base_url=base_url,
+            insights_output=insights_output_path,
+            backend=backend,
+            since=since,
+            evaluation_id=evaluation_id,
+        )
+        if base_url and _analyst_observability_enabled():
+            observability = setup_analyst_observability(
+                base_url=base_url,
+                workspace=workspace,
+                target_agent=agent,
+            )
+        analyst = build_analyst_agent(
+            agent=agent,
+            agent_spec=agent_spec,
+            observability=observability,
+        )
+        result = await _run_agent(analyst, deps, verbose=verbose)
+        return await backend.persist_result(workspace=workspace, agent=agent, result=result)
+    finally:
+        if observability is not None:
+            observability.shutdown()
+        await client.close()
+
+
+def _analyst_observability_enabled() -> bool:
+    """True when dogfooding analyst self-observability is explicitly enabled."""
+    value = os.environ.get(ANALYST_OBSERVABILITY_ENV, "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+async def _run_agent(
+    analyst: Agent[AnalystDeps, AnalystResult],
+    deps: AnalystDeps,
+    *,
+    verbose: bool,
+) -> AnalystResult:
+    """Run *analyst*, optionally streaming its tool calls to stderr."""
+    usage_limits = UsageLimits(request_limit=MAX_REQUESTS)
+    if not verbose:
+        result = await analyst.run(KICKOFF, deps=deps, usage_limits=usage_limits)
+        return result.output
+
+    async with analyst.iter(KICKOFF, deps=deps, usage_limits=usage_limits) as run:
+        async for node in run:
+            _echo_node(node)
+    assert run.result is not None
+    return run.result.output
+
+
+def _echo_node(node: Any) -> None:
+    """Print tool calls, model text, and tool returns for one graph node."""
+    if Agent.is_call_tools_node(node):
+        for part in node.model_response.parts:
+            if isinstance(part, ToolCallPart):
+                print(
+                    f"[tool] {part.tool_name}({_truncate(str(part.args))})",
+                    file=sys.stderr,
+                )
+            elif isinstance(part, TextPart) and part.content.strip():
+                print(f"[thought] {part.content.strip()}", file=sys.stderr)
+    elif Agent.is_model_request_node(node):
+        for part in node.request.parts:
+            if isinstance(part, ToolReturnPart):
+                print(
+                    f"[result] {part.tool_name} -> {_truncate(str(part.content))}",
+                    file=sys.stderr,
+                )
+
+
+def _truncate(text: str, limit: int = _VERBOSE_TRUNCATE) -> str:
+    return text if len(text) <= limit else f"{text[:limit]}... ({len(text)} chars)"

--- a/plugins/nemo-insights/src/nemo_insights_plugin/authz.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/authz.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authorization scope shared by Insights routes."""
+
+from nemo_platform_plugin.authz import AuthzScope
+
+scope = AuthzScope("insights")

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Insights CLI and contributed subcommands."""
+
+import asyncio
+import json
+import os
+from importlib.metadata import entry_points
+from pathlib import Path
+from typing import ClassVar
+
+import typer
+from nemo_insights_plugin.analyst.run import run_analyst
+from nemo_insights_plugin.client import make_client
+from nemo_platform_plugin.cli import NemoCLI
+
+DEFAULT_BASE_URL = "http://localhost:8080"
+DEFAULT_WORKSPACE = "default"
+
+# TODO: Add remote train/validation dataset support when remote experiment mode is implemented.
+
+
+class InsightsCLI(NemoCLI):
+    """``nemo insights ...`` subcommands."""
+
+    name: ClassVar[str] = "insights"
+    description: ClassVar[str] = "Analyze agent telemetry and act on insights."
+
+    def get_cli(self) -> typer.Typer:
+        app = typer.Typer(help=self.description, no_args_is_help=True)
+
+        @app.callback()
+        def _root() -> None:
+            """Force subcommand dispatch even when only one verb is registered."""
+
+        analysis_app = typer.Typer(
+            help="Manage periodic agent analysis opt-in state.",
+            no_args_is_help=True,
+        )
+        app.add_typer(analysis_app, name="analysis")
+
+        @app.command("analyze")
+        def analyze(
+            agent: str = typer.Option(
+                ...,
+                "--agent",
+                help="Name of the agent (agent under test) the analyst should focus on.",
+            ),
+            agent_spec: Path | None = typer.Option(
+                None,
+                "--agent-spec",
+                help="Path to a markdown file describing the agent under test (its spec).",
+                exists=True,
+                readable=True,
+            ),
+            workspace: str = typer.Option(
+                DEFAULT_WORKSPACE,
+                "--workspace",
+                help="Workspace the analyst should operate in.",
+            ),
+            base_url: str = typer.Option(
+                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
+                "--base-url",
+                help="Base URL of the running NMP instance the analyst's tools should call.",
+                envvar="NMP_BASE_URL",
+            ),
+            insights_output: Path | None = typer.Option(
+                None,
+                "--insights-file-output",
+                help=(
+                    "Read and write insights from this local YAML file instead "
+                    "of the Insights plugin API. Lets the analyst run against a "
+                    "deployment that hosts observability data but not this "
+                    "plugin; each run merges into the file. Trace/feedback reads "
+                    "still hit --base-url."
+                ),
+            ),
+            verbose: bool = typer.Option(
+                False,
+                "--verbose",
+                "-v",
+                help=(
+                    "Stream the analyst's tool calls and reasoning to stderr "
+                    "while it runs. Off by default so that stdout stays clean "
+                    "for piping the final answer."
+                ),
+            ),
+        ) -> None:
+            """Run the analyst agent against a running NMP instance.
+
+            Builds the analyst agent with ``--agent`` (and optional
+            ``--agent-spec``) formatted into its instructions and tools scoped
+            to ``--agent`` / ``--workspace`` / ``--base-url``, runs it, and
+            prints whatever the agent returns.
+            """
+            output = asyncio.run(
+                run_analyst(
+                    agent=agent,
+                    agent_spec=agent_spec.read_text() if agent_spec else None,
+                    workspace=workspace,
+                    base_url=base_url,
+                    insights_output=insights_output,
+                    verbose=verbose,
+                )
+            )
+            typer.echo(output)
+
+        @analysis_app.command("enable")
+        def enable_analysis(
+            agent: str = typer.Option(
+                ...,
+                "--agent",
+                help="Name of the agent to opt in to periodic analysis.",
+            ),
+            workspace: str = typer.Option(
+                DEFAULT_WORKSPACE,
+                "--workspace",
+                help="Workspace the agent belongs to.",
+            ),
+            base_url: str = typer.Option(
+                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
+                "--base-url",
+                help="Base URL of the running NMP instance.",
+                envvar="NMP_BASE_URL",
+            ),
+        ) -> None:
+            """Enable periodic analysis for an agent."""
+            typer.echo(
+                asyncio.run(
+                    _analysis_config_command(
+                        action="enable",
+                        agent=agent,
+                        workspace=workspace,
+                        base_url=base_url,
+                    )
+                )
+            )
+
+        @analysis_app.command("disable")
+        def disable_analysis(
+            agent: str = typer.Option(
+                ...,
+                "--agent",
+                help="Name of the agent to opt out of periodic analysis.",
+            ),
+            workspace: str = typer.Option(
+                DEFAULT_WORKSPACE,
+                "--workspace",
+                help="Workspace the agent belongs to.",
+            ),
+            base_url: str = typer.Option(
+                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
+                "--base-url",
+                help="Base URL of the running NMP instance.",
+                envvar="NMP_BASE_URL",
+            ),
+        ) -> None:
+            """Disable periodic analysis for an agent."""
+            typer.echo(
+                asyncio.run(
+                    _analysis_config_command(
+                        action="disable",
+                        agent=agent,
+                        workspace=workspace,
+                        base_url=base_url,
+                    )
+                )
+            )
+
+        @analysis_app.command("status")
+        def analysis_status(
+            agent: str | None = typer.Option(
+                None,
+                "--agent",
+                help="Optional agent name. Omit to list all analysis configs.",
+            ),
+            workspace: str = typer.Option(
+                DEFAULT_WORKSPACE,
+                "--workspace",
+                help="Workspace to inspect.",
+            ),
+            base_url: str = typer.Option(
+                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
+                "--base-url",
+                help="Base URL of the running NMP instance.",
+                envvar="NMP_BASE_URL",
+            ),
+        ) -> None:
+            """Show periodic analysis opt-in state."""
+            typer.echo(
+                asyncio.run(
+                    _analysis_config_command(
+                        action="status",
+                        agent=agent,
+                        workspace=workspace,
+                        base_url=base_url,
+                    )
+                )
+            )
+
+        for entry_point in sorted(entry_points(group="nemo.insights.commands"), key=lambda item: item.name):
+            app.add_typer(entry_point.load()(), name=entry_point.name)
+        return app
+
+
+async def _analysis_config_command(
+    *,
+    action: str,
+    agent: str | None,
+    workspace: str,
+    base_url: str,
+) -> str:
+    """Run one analysis-config CLI action and return JSON for stdout."""
+    client = make_client(base_url)
+    try:
+        if action == "enable":
+            if agent is None:
+                raise ValueError("agent is required for enable")
+            result = await client.insights.analysis_configs.enable(workspace=workspace, agent=agent)
+            return _json(result.model_dump(mode="json"))
+        if action == "disable":
+            if agent is None:
+                raise ValueError("agent is required for disable")
+            result = await client.insights.analysis_configs.disable(workspace=workspace, agent=agent)
+            return _json(result.model_dump(mode="json"))
+        if action == "status":
+            if agent:
+                result = await client.insights.analysis_configs.get(workspace=workspace, agent=agent)
+                return _json(result.model_dump(mode="json"))
+            page = await client.insights.analysis_configs.list_configs(workspace=workspace, page_size=100)
+            return _json(page.model_dump(mode="json"))
+        raise ValueError(f"Unknown analysis config action: {action}")
+    finally:
+        await client.close()
+
+
+def _json(payload: object) -> str:
+    """Serialize a CLI payload with stable indentation."""
+    return json.dumps(payload, indent=2)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -18,8 +18,6 @@ from nemo_platform_plugin.cli import NemoCLI
 DEFAULT_BASE_URL = "http://localhost:8080"
 DEFAULT_WORKSPACE = "default"
 
-# TODO: Add remote train/validation dataset support when remote experiment mode is implemented.
-
 
 class InsightsCLI(NemoCLI):
     """``nemo insights ...`` subcommands."""

--- a/plugins/nemo-insights/src/nemo_insights_plugin/client.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/client.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared NeMo Platform SDK client construction for analyst NAT functions.
+
+Auth lives in the active ``nemo auth login`` context in
+``~/.config/nmp/config.yaml``. The SDK only wires up that context (and the
+transparent OIDC token refresh that comes with it) when it runs its config
+bootstrap. Passing ``base_url`` *alone* puts the SDK in "direct mode", which
+skips the bootstrap and injects **no** auth headers — fine for an
+unauthenticated local ``nemo services run``, but it 401s against a remote
+deployment. To authenticate against a remote URL we must trigger the bootstrap
+(by also passing ``config_path``) so the explicit ``base_url`` is combined with
+the context's credentials.
+
+Every analyst function takes ``base_url`` from its workflow context, so this
+helper is the one place that branch lives.
+"""
+
+from urllib.parse import urlparse
+
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform.config.config import Config
+
+# Loopback hosts are served by an unauthenticated local platform; attaching
+# (and refreshing) OAuth tokens there is both unnecessary and a failure mode
+# when the cached token is stale and OIDC discovery against localhost fails.
+LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+
+
+def make_client(base_url: str | None) -> AsyncNeMoPlatform:
+    """Construct an :class:`AsyncNeMoPlatform` honoring an optional ``base_url``.
+
+    - No ``base_url``: use the active nmp context for both URL and auth.
+    - Loopback ``base_url``: direct mode (local platform is unauthenticated).
+    - Remote ``base_url`` with an nmp config present: combine the URL with the
+      context's auth so the SDK injects and refreshes a Bearer token.
+    - Remote ``base_url`` without an nmp config: direct mode (no credentials to
+      use; the request will surface a clear auth error).
+    """
+    if not base_url:
+        return AsyncNeMoPlatform()
+
+    host = (urlparse(base_url).hostname or "").lower()
+    config_path = Config.get_default_config_path()
+    if host in LOOPBACK_HOSTS or not config_path.exists():
+        return AsyncNeMoPlatform(base_url=base_url)
+
+    return AsyncNeMoPlatform(base_url=base_url, config_path=config_path)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/client.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/client.py
@@ -20,6 +20,7 @@ helper is the one place that branch lives.
 from urllib.parse import urlparse
 
 from nemo_platform import AsyncNeMoPlatform
+from nemo_platform.auth.helpers import discover_nmp_config
 from nemo_platform.config.config import Config
 
 # Loopback hosts are served by an unauthenticated local platform; attaching
@@ -33,8 +34,10 @@ def make_client(base_url: str | None) -> AsyncNeMoPlatform:
 
     - No ``base_url``: use the active nmp context for both URL and auth.
     - Loopback ``base_url``: direct mode (local platform is unauthenticated).
-    - Remote ``base_url`` with an nmp config present: combine the URL with the
-      context's auth so the SDK injects and refreshes a Bearer token.
+    - Authenticated remote ``base_url`` with an nmp config present: combine the
+      URL with the context's auth so the SDK injects and refreshes a Bearer token.
+    - Unauthenticated remote ``base_url``: direct mode, even when an unrelated
+      OAuth context exists locally.
     - Remote ``base_url`` without an nmp config: direct mode (no credentials to
       use; the request will surface a clear auth error).
     """
@@ -44,6 +47,9 @@ def make_client(base_url: str | None) -> AsyncNeMoPlatform:
     host = (urlparse(base_url).hostname or "").lower()
     config_path = Config.get_default_config_path()
     if host in LOOPBACK_HOSTS or not config_path.exists():
+        return AsyncNeMoPlatform(base_url=base_url)
+
+    if not discover_nmp_config(base_url).auth_enabled:
         return AsyncNeMoPlatform(base_url=base_url)
 
     return AsyncNeMoPlatform(base_url=base_url, config_path=config_path)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/config.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/config.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration for the NeMo Insights plugin."""
+
+from enum import IntEnum, StrEnum
+from typing import ClassVar
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from nemo_platform_plugin.config import NemoConfig
+from pydantic import BaseModel, Field, field_validator
+
+
+class Frequency(StrEnum):
+    """How often each opted-in agent is analyzed."""
+
+    DAILY = "daily"
+    WEEKLY = "weekly"
+
+
+class Weekday(IntEnum):
+    """Day of week for weekly analysis, with Python's 0=Monday convention."""
+
+    MONDAY = 0
+    TUESDAY = 1
+    WEDNESDAY = 2
+    THURSDAY = 3
+    FRIDAY = 4
+    SATURDAY = 5
+    SUNDAY = 6
+
+    @classmethod
+    def _missing_(cls, value: object) -> "Weekday | None":
+        if isinstance(value, str):
+            try:
+                return cls[value.upper()]
+            except KeyError:
+                return None
+        return None
+
+
+class AnalystSchedulerConfig(BaseModel):
+    """Framework-managed periodic analysis settings."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Whether the insights periodic analysis controller should run.",
+    )
+    frequency: Frequency = Field(
+        default=Frequency.DAILY,
+        description="Global cadence for analyzing each opted-in agent.",
+    )
+    run_at_hour: int = Field(
+        default=0,
+        ge=0,
+        le=23,
+        description="Local hour-of-day (0-23, in `timezone`) scheduled runs fire.",
+    )
+    run_on_weekday: Weekday = Field(
+        default=Weekday.MONDAY,
+        description="Day of week scheduled runs fire. Used only when frequency is weekly.",
+    )
+    timezone: str = Field(
+        default="UTC",
+        description=(
+            "IANA timezone name (e.g. 'America/Denver') the schedule is "
+            "interpreted in. Converted to the server clock at evaluation time "
+            "so runs fire at the intended local hour across DST changes."
+        ),
+    )
+
+    @field_validator("timezone")
+    @classmethod
+    def _validate_timezone(cls, value: str) -> str:
+        try:
+            ZoneInfo(value)
+        except (ZoneInfoNotFoundError, ValueError) as exc:
+            raise ValueError(f"Unknown IANA timezone: {value!r}") from exc
+        return value
+
+    job_profile: str = Field(
+        default="default",
+        description="Jobs execution profile used for scheduled analyst jobs.",
+    )
+    base_url: str | None = Field(
+        default=None,
+        description=(
+            "Optional platform base URL passed to analyst jobs. When unset, jobs use their active platform context."
+        ),
+    )
+    inference_api_key_secret_name: str | None = Field(
+        default=None,
+        description=(
+            "Optional platform secret name whose value is exposed to analyst "
+            "jobs as INFERENCE_API_KEY. Temporary until FP-202 moves analyst "
+            "model execution to platform-registered models."
+        ),
+    )
+
+
+class InsightsConfig(NemoConfig):
+    """Configuration for the NeMo Insights plugin."""
+
+    plugin_name: ClassVar[str] = "insights"
+    plugin_description: ClassVar[str] = "Configuration for NeMo Insights."
+
+    analyst: AnalystSchedulerConfig = Field(
+        default_factory=AnalystSchedulerConfig,
+        description="Periodic insights analyst settings.",
+    )

--- a/plugins/nemo-insights/src/nemo_insights_plugin/controller.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/controller.py
@@ -1,0 +1,288 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Framework-managed periodic controller for insights analysis."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, ClassVar, TypeVar, cast
+from zoneinfo import ZoneInfo
+
+from nemo_insights_plugin.analyst.analyst_backend import make_analyst_backend
+from nemo_insights_plugin.config import InsightsConfig
+from nemo_insights_plugin.entities import AnalysisConfig, AnalysisRunStatus
+from nemo_insights_plugin.jobs.analyze import AnalyzeJob, AnalyzeSpec
+from nemo_insights_plugin.schedule import is_due
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform.resources.entities import AsyncEntitiesResource
+from nemo_platform_plugin.config import get_nemo_config
+from nemo_platform_plugin.controller import NemoController
+from nemo_platform_plugin.entity_client import (
+    NemoEntitiesClient,
+    NemoEntityConflictError,
+    NemoEntityNotFoundError,
+)
+from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
+from nemo_platform_plugin.sdk_provider import get_async_platform_sdk
+
+logger = logging.getLogger(__name__)
+
+_SAFE_JOB_NAME = re.compile(r"[^A-Za-z0-9._-]+")
+_ACTIVE_JOB_STATUSES = [
+    "created",
+    "pending",
+    "active",
+    "cancelling",
+    "paused",
+    "pausing",
+    "resuming",
+]
+
+# Minimum new traces (since the last successful run) before a scheduled job is
+# worth launching. Only enforced once an agent has an incremental cursor, so the
+# first scheduled run still bootstraps.
+_MIN_NEW_TRACES_FOR_ANALYSIS = 10
+
+_T = TypeVar("_T")
+
+
+def _require(value: _T | None, attr: str) -> _T:
+    """Return *value* or raise if the controller was used before startup."""
+    if value is None:
+        raise RuntimeError(f"InsightsAnalysisController.{attr} accessed before startup")
+    return value
+
+
+class InsightsAnalysisController(NemoController):
+    """Submit insights analyzer jobs for enabled agents on a global cadence."""
+
+    name: ClassVar[str] = "insights-analysis"
+    dependencies: ClassVar[list[str]] = ["entities", "jobs"]
+
+    def __init__(self) -> None:
+        self._sdk: AsyncNeMoPlatform | None = None
+        self._entities: NemoEntitiesClient | None = None
+        self._config: InsightsConfig | None = None
+
+    @property
+    def sdk(self) -> AsyncNeMoPlatform:
+        return _require(self._sdk, "sdk")
+
+    @property
+    def entities(self) -> NemoEntitiesClient:
+        return _require(self._entities, "entities")
+
+    @property
+    def insights_config(self) -> InsightsConfig:
+        return _require(self._config, "insights_config")
+
+    @property
+    def interval_seconds(self) -> float:
+        # Override NemoController's 10s default; per-config due/throttle checks
+        # mean a coarser reconcile cadence is enough.
+        return 60.0
+
+    async def on_startup(self) -> None:
+        """Initialise service-principal SDK and entity client."""
+        self._config = get_nemo_config(InsightsConfig)
+        self._sdk = get_async_platform_sdk(as_service="insights", internal=True)
+        self._entities = NemoEntitiesClient(AsyncEntitiesResource(self._sdk))
+        logger.info("InsightsAnalysisController started.")
+
+    async def on_shutdown(self) -> None:
+        logger.info("InsightsAnalysisController shut down.")
+
+    async def list_objects(self) -> list:
+        """List enabled analysis configs across all workspaces."""
+        if not self.insights_config.analyst.enabled:
+            return []
+        try:
+            result = await self.entities.list(
+                AnalysisConfig,
+                workspace="-",
+                filter_obj={"enabled": True},
+            )
+            return result.data
+        except Exception:
+            logger.exception("Failed to list enabled insights analysis configs")
+            return []
+
+    async def reconcile_one(self, obj: object) -> None:
+        config = cast(AnalysisConfig, obj)
+        try:
+            await self._reconcile_config(config)
+        except NemoEntityConflictError:
+            logger.debug(
+                "Optimistic lock conflict on analysis config '%s' in workspace '%s'",
+                config.name,
+                config.workspace,
+            )
+
+    async def _reconcile_config(self, config: AnalysisConfig) -> None:
+        if not config.enabled:
+            return
+        if await self._has_active_job(config):
+            return
+        status = await self._get_run_status(config)
+        now = datetime.now(timezone.utc)
+        if not self._is_due(status, now):
+            return
+        if not await self._has_enough_new_traces(config, status):
+            return
+        await self._submit_analysis_job(config, status, now)
+
+    async def _get_run_status(self, config: AnalysisConfig) -> AnalysisRunStatus | None:
+        try:
+            return await self.entities.get(AnalysisRunStatus, name=config.agent, workspace=config.workspace)
+        except NemoEntityNotFoundError:
+            return None
+        except Exception:
+            logger.exception(
+                "Failed to read analysis run status for agent '%s'; deferring",
+                config.agent,
+            )
+            raise
+
+    async def _has_enough_new_traces(self, config: AnalysisConfig, status: AnalysisRunStatus | None) -> bool:
+        """Whether enough new traces exist to justify submitting a job.
+
+        Mirrors ``run_analyst``'s preflight: the floor is only enforced once an
+        incremental cursor exists, so the first scheduled run still bootstraps.
+        Checking here avoids launching a job that would immediately skip; the
+        job keeps the same floor as a backstop. On count failure we defer to the
+        next reconcile rather than launch a job we can't justify.
+        """
+        since = status.last_successful_run_at if status is not None else None
+        if since is None:
+            return True
+        try:
+            backend = make_analyst_backend(client=self.sdk, insights_output=None)
+            trace_count = await backend.count_agent_sessions(
+                agent=config.agent, workspace=config.workspace, since=since
+            )
+        except Exception:
+            logger.exception(
+                "Failed to count new traces for agent '%s'; deferring submission",
+                config.agent,
+            )
+            return False
+        if trace_count < _MIN_NEW_TRACES_FOR_ANALYSIS:
+            logger.debug(
+                "Agent '%s' has %d new trace(s) since %s; below threshold %d, deferring",
+                config.agent,
+                trace_count,
+                since.isoformat(),
+                _MIN_NEW_TRACES_FOR_ANALYSIS,
+            )
+            return False
+        return True
+
+    async def _has_active_job(self, config: AnalysisConfig) -> bool:
+        try:
+            jobs = self.sdk.jobs.list(
+                workspace=config.workspace,
+                filter=cast(Any, {"source": "insights", "status": _ACTIVE_JOB_STATUSES}),
+                page_size=100,
+                sort="-created_at",
+            )
+        except Exception:
+            logger.debug(
+                "Could not list insights analysis jobs for agent '%s'",
+                config.agent,
+                exc_info=True,
+            )
+            return True
+
+        try:
+            async for job in jobs:
+                if _job_targets_agent(job, config.agent):
+                    return True
+        except Exception:
+            logger.debug(
+                "Could not inspect insights analysis jobs for agent '%s'",
+                config.agent,
+                exc_info=True,
+            )
+            return True
+        return False
+
+    def _is_due(self, status: AnalysisRunStatus | None, now: datetime) -> bool:
+        analyst = self.insights_config.analyst
+        anchor = status.last_successful_run_at if status is not None else None
+        return is_due(
+            now,
+            anchor,
+            frequency=analyst.frequency,
+            run_at_hour=analyst.run_at_hour,
+            run_on_weekday=int(analyst.run_on_weekday),
+            tz=ZoneInfo(analyst.timezone),
+        )
+
+    async def _submit_analysis_job(
+        self,
+        config: AnalysisConfig,
+        status: AnalysisRunStatus | None,
+        submitted_at: datetime,
+    ) -> None:
+        spec = AnalyzeSpec(
+            agent=config.agent,
+            base_url=self.insights_config.analyst.base_url,
+            since=status.last_successful_run_at if status is not None else None,
+            inference_api_key_secret_name=(self.insights_config.analyst.inference_api_key_secret_name),
+        )
+        job_name = _job_name(config, submitted_at)
+        platform_spec = await self._compile_job_spec(
+            workspace=config.workspace,
+            spec=spec,
+            job_name=job_name,
+        )
+        await self.sdk.jobs.create(
+            workspace=config.workspace,
+            source="insights",
+            name=job_name,
+            spec=spec.model_dump(mode="json"),
+            platform_spec=platform_spec,
+            custom_fields={"insights_analysis_agent": config.agent},
+        )
+        logger.info(
+            "Submitted insights analysis job '%s' for agent '%s' in workspace '%s'",
+            job_name,
+            config.agent,
+            config.workspace,
+        )
+
+    async def _compile_job_spec(self, *, workspace: str, spec: AnalyzeSpec, job_name: str) -> PlatformJobSpec:
+        return await AnalyzeJob.compile(
+            workspace=workspace,
+            spec=spec,
+            entity_client=self.entities,
+            job_name=job_name,
+            async_sdk=self.sdk,
+            profile=self.insights_config.analyst.job_profile,
+        )
+
+
+def _job_targets_agent(job: object, agent: str) -> bool:
+    custom_fields = getattr(job, "custom_fields", None)
+    if isinstance(custom_fields, dict):
+        return custom_fields.get("insights_analysis_agent") == agent
+    return False
+
+
+def _job_name(config: AnalysisConfig, submitted_at: datetime) -> str:
+    workspace = _SAFE_JOB_NAME.sub("-", config.workspace).strip("-") or "workspace"
+    agent = _SAFE_JOB_NAME.sub("-", config.agent).strip("-") or "agent"
+    stamp = submitted_at.strftime("%Y%m%d%H%M%S")
+    # The Jobs service also creates a fileset named ``job-fileset-{job_name}``,
+    # and entity names cap at 63 characters. Keep our generated name short
+    # enough for that derived fileset while preserving agent/workspace context.
+    prefix = "opt-analyze"
+    max_name = 63 - len("job-fileset-")
+    suffix = f"-{stamp}"
+    available = max_name - len(prefix) - len(suffix) - 2
+    workspace_part = workspace[: max(1, available // 3)]
+    agent_part = agent[: max(1, available - len(workspace_part))]
+    return f"{prefix}-{workspace_part}-{agent_part}{suffix}"

--- a/plugins/nemo-insights/src/nemo_insights_plugin/entities.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/entities.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Insights plugin entity definitions — stored in the NeMo Platform entity store."""
+
+from datetime import datetime
+from enum import StrEnum
+
+from nemo_platform_plugin.entity import NemoEntity
+from pydantic import Field
+
+
+class InsightStatus(StrEnum):
+    OPEN = "open"
+    RESOLVED = "resolved"
+    DELETED = "deleted"
+
+
+class AnalysisConfigStatus(StrEnum):
+    """Lifecycle state for periodic insights analysis of one agent."""
+
+    IDLE = "idle"
+    RUNNING = "running"
+    ERROR = "error"
+
+
+class Insight(NemoEntity, entity_type="insights_insight"):
+    """A persistent problem, theme, or category of issues in the agent under test."""
+
+    title: str = Field(
+        description=(
+            "A short, human-readable sentence naming the core issue common to "
+            "the linked traces. Editable by the developer."
+        ),
+    )
+    description: str = Field(
+        description=(
+            "The problem statement: specific enough to act on. Editable by the "
+            "developer. A paragraph or two with detail on what exactly is going "
+            "wrong, general enough to apply to many traces rather than to a "
+            "single problematic instance."
+        ),
+    )
+    agent: str = Field(
+        description=(
+            "Name of the registered agent this insight is about, or a local "
+            "filesystem path (as a string) to the agent directory when running "
+            "offline."
+        ),
+    )
+    status: InsightStatus = Field(
+        default=InsightStatus.OPEN,
+        description=(
+            "An insight starts as open. It can be resolved if the developer "
+            "thinks the issue has been fixed. It can be deleted if the "
+            "developer thinks the issue is not actually a problem or if it is "
+            "not a good insight for their domain."
+        ),
+    )
+    trace_refs: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Intake trace ids the analyst identified as evidence for this "
+            "insight. This is used as evidence for the insight UI to "
+            "communicate to the developer what traces triggered the issue, and "
+            "can also be used to identify other similar traces that might "
+            "experience the same issue."
+        ),
+    )
+
+
+class AnalysisConfig(NemoEntity, entity_type="insights_analysis_config"):
+    """Per-agent opt-in state for framework-managed periodic analysis.
+
+    The cadence is intentionally global insights configuration. This entity is
+    only the per-agent switch. Machine-written run state lives on
+    :class:`AnalysisRunStatus` so the controller never races the running job.
+    """
+
+    agent: str = Field(description="Name of the agent this analysis config targets.")
+    enabled: bool = Field(
+        default=True,
+        description="Whether the periodic insights controller should analyze this agent.",
+    )
+
+
+class AnalysisRunStatus(NemoEntity, entity_type="insights_analysis_run_status"):
+    """Machine-written run state for periodic analysis of one agent."""
+
+    agent: str = Field(description="Name of the agent this run status targets.")
+    status: AnalysisConfigStatus = Field(
+        default=AnalysisConfigStatus.IDLE,
+        description="Last known periodic analysis state for this agent.",
+    )
+    last_successful_run_at: datetime | None = Field(
+        default=None,
+        description=(
+            "Cursor for incremental analysis. Scheduled runs only consider telemetry at or after this timestamp."
+        ),
+    )
+    last_attempted_at: datetime | None = Field(
+        default=None,
+        description="When the controller or job last attempted analysis.",
+    )
+    last_completed_at: datetime | None = Field(
+        default=None,
+        description="When the last analysis attempt reached a terminal state.",
+    )
+    last_submitted_job: str = Field(
+        default="",
+        description="Most recent platform job name submitted for this agent.",
+    )
+    last_error: str = Field(
+        default="",
+        description="Most recent error or skip reason from scheduled analysis.",
+    )

--- a/plugins/nemo-insights/src/nemo_insights_plugin/jobs/analyze.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/jobs/analyze.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NemoJob wrapper for one insights analyst run."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+from typing import ClassVar
+
+from nemo_insights_plugin.analyst.run import run_analyst
+from nemo_insights_plugin.entities import AnalysisConfigStatus
+from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.job import NemoJob
+from nemo_platform_plugin.job_context import JobContext
+from nemo_platform_plugin.jobs.api_factory import (
+    ContainerSpec,
+    CPUExecutionProviderSpec,
+    EnvironmentVariable,
+    EnvironmentVariableFromSecret,
+    PlatformJobSpec,
+    PlatformJobStep,
+)
+from nemo_platform_plugin.jobs.constants import (
+    DEFAULT_JOB_STORAGE_PATH,
+    PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+)
+from nemo_platform_plugin.jobs.image import get_qualified_image
+from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
+
+REPORT_RESULT_NAME = "analysis-report"
+REPORT_FILE_NAME = "analysis-report.txt"
+
+
+class AnalyzeSpec(BaseModel):
+    """Canonical input for one insights analyst run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent: str = Field(description="Agent under test.")
+    agent_spec: str | None = Field(
+        default=None,
+        description="Optional markdown spec content for the agent under test.",
+    )
+    base_url: str | None = Field(
+        default=None,
+        description="Optional platform base URL. Unset uses the active platform context.",
+    )
+    insights_output: str | None = Field(
+        default=None,
+        description="Optional local JSON output path for Insight writes.",
+    )
+    since: datetime | None = Field(
+        default=None,
+        description="Optional lower bound for incremental trace/span analysis.",
+    )
+    update_analysis_config: bool = Field(
+        default=True,
+        description="Update the matching AnalysisRunStatus with run metadata.",
+    )
+    inference_api_key_secret_name: str | None = Field(
+        default=None,
+        description=("Optional platform secret exposed as INFERENCE_API_KEY for the current analyst model path."),
+    )
+
+
+class AnalyzeJob(NemoJob):
+    """Run the insights analyst once for a single agent."""
+
+    name: ClassVar[str] = "analyze-job"
+    description: ClassVar[str] = "Run the insights analyst once for a single agent."
+    container: ClassVar[str] = "cpu-tasks"
+    spec_schema: ClassVar[type[BaseModel] | None] = AnalyzeSpec
+
+    @classmethod
+    async def compile(
+        cls,
+        *,
+        workspace: str,
+        spec: BaseModel,
+        entity_client: object,
+        job_name: str | None,
+        async_sdk: object,
+        profile: str | None = None,
+        options: dict | None = None,
+    ) -> PlatformJobSpec:
+        """Compile the analyzer run into one CPU task step."""
+        del workspace, entity_client, job_name, async_sdk, options
+        canonical = _as_analyze_spec(spec)
+        environment = [
+            EnvironmentVariable(
+                name=PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+                value=DEFAULT_JOB_STORAGE_PATH,
+            )
+        ]
+        if canonical.inference_api_key_secret_name:
+            environment.append(
+                EnvironmentVariable(
+                    name="INFERENCE_API_KEY",
+                    from_secret=EnvironmentVariableFromSecret(name=canonical.inference_api_key_secret_name),
+                )
+            )
+        elif inference_api_key := os.environ.get("INFERENCE_API_KEY"):
+            # Local smoke-test fallback until FP-202 moves analyst model
+            # execution onto platform-registered models/secrets.
+            environment.append(EnvironmentVariable(name="INFERENCE_API_KEY", value=inference_api_key))
+
+        return PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="insights-analyze",
+                    executor=CPUExecutionProviderSpec(
+                        profile=profile or "default",
+                        provider="cpu",
+                        container=ContainerSpec(
+                            image=get_qualified_image("nmp-cpu-tasks"),
+                            entrypoint=["python", "-m"],
+                            command=["nemo_insights_plugin.jobs.bridge"],
+                        ),
+                    ),
+                    config=canonical.model_dump(mode="json"),
+                    environment=environment,
+                )
+            ],
+        )
+
+    def run(
+        self,
+        config: dict,
+        *,
+        ctx: JobContext,
+        sdk: NeMoPlatform | None = None,
+    ) -> dict:
+        """Run analysis and persist a small report artifact."""
+        spec = AnalyzeSpec.model_validate(config)
+        started_at = datetime.now(timezone.utc)
+        self._record_analysis_run_status(
+            sdk=sdk,
+            ctx=ctx,
+            spec=spec,
+            status=AnalysisConfigStatus.RUNNING,
+            last_attempted_at=started_at,
+            last_error="",
+        )
+
+        try:
+            report = asyncio.run(
+                run_analyst(
+                    agent=spec.agent,
+                    agent_spec=spec.agent_spec,
+                    workspace=ctx.workspace,
+                    base_url=spec.base_url,
+                    insights_output=spec.insights_output,
+                    since=spec.since,
+                )
+            )
+        except Exception as exc:  # pragma: no cover - exercised by integration paths
+            completed_at = datetime.now(timezone.utc)
+            self._record_analysis_run_status(
+                sdk=sdk,
+                ctx=ctx,
+                spec=spec,
+                status=AnalysisConfigStatus.ERROR,
+                last_completed_at=completed_at,
+                last_error=str(exc),
+            )
+            logger.exception("Insights analyst job failed for agent '%s'", spec.agent)
+            return {
+                "status": "failed",
+                "agent": spec.agent,
+                "workspace": ctx.workspace,
+                "error": str(exc),
+            }
+
+        completed_at = datetime.now(timezone.utc)
+        artifact = self._save_report(ctx, report)
+        self._record_analysis_run_status(
+            sdk=sdk,
+            ctx=ctx,
+            spec=spec,
+            status=AnalysisConfigStatus.IDLE,
+            last_successful_run_at=started_at,
+            last_completed_at=completed_at,
+            last_error="",
+        )
+        return {
+            "status": "completed",
+            "agent": spec.agent,
+            "workspace": ctx.workspace,
+            "since": spec.since.isoformat() if spec.since else None,
+            "last_successful_run_at": started_at.isoformat(),
+            "artifact": artifact.model_dump() if artifact is not None else None,
+        }
+
+    def _save_report(self, ctx: JobContext, report: str):
+        report_path = ctx.storage.persistent / REPORT_FILE_NAME
+        report_path.write_text(report, encoding="utf-8")
+        return ctx.results.save(REPORT_RESULT_NAME, report_path)
+
+    def _record_analysis_run_status(
+        self,
+        *,
+        sdk: NeMoPlatform | None,
+        ctx: JobContext,
+        spec: AnalyzeSpec,
+        status: AnalysisConfigStatus,
+        last_successful_run_at: datetime | None = None,
+        last_attempted_at: datetime | None = None,
+        last_completed_at: datetime | None = None,
+        last_error: str | None = None,
+    ) -> None:
+        """Best-effort update of the per-agent run status entity."""
+        if sdk is None or not spec.update_analysis_config:
+            return
+        try:
+            sdk.insights.analysis_run_statuses.update(
+                workspace=ctx.workspace,
+                agent=spec.agent,
+                status=status,
+                last_successful_run_at=last_successful_run_at,
+                last_attempted_at=last_attempted_at,
+                last_completed_at=last_completed_at,
+                last_submitted_job=ctx.job_id,
+                last_error=last_error,
+            )
+        except Exception:
+            logger.exception("Failed to update analysis run status for agent '%s'", spec.agent)
+
+
+def _as_analyze_spec(spec: BaseModel) -> AnalyzeSpec:
+    """Narrow a generic BaseModel to a validated :class:`AnalyzeSpec`."""
+    if isinstance(spec, AnalyzeSpec):
+        return spec
+    return AnalyzeSpec.model_validate(spec.model_dump())

--- a/plugins/nemo-insights/src/nemo_insights_plugin/jobs/bridge.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/jobs/bridge.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task-process entry point for insights analyzer jobs."""
+
+import signal
+import sys
+from types import FrameType
+
+from nemo_insights_plugin.jobs.analyze import AnalyzeJob
+from nemo_platform_plugin.sdk_provider import get_task_sdk
+from nemo_platform_plugin.tasks.dispatcher import run_task
+
+
+def _shutdown(signum: int, _frame: FrameType | None) -> None:
+    raise SystemExit(128 + signum)
+
+
+def main() -> int:
+    """Run the platform-injected analyzer task config."""
+    signal.signal(signal.SIGTERM, _shutdown)
+    return run_task(AnalyzeJob, sdk=get_task_sdk("insights"))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/nemo-insights/src/nemo_insights_plugin/schedule.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/schedule.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure wall-clock schedule math for periodic insights analysis.
+
+This module is intentionally dependency-free (stdlib only) so the scheduling
+logic is unit-testable in isolation. The operator configures an intended local
+hour plus an IANA timezone; conversion to UTC happens here at evaluation time so
+runs fire at the intended local hour even across DST transitions.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from nemo_insights_plugin.config import Frequency
+
+
+def previous_scheduled(
+    now_utc: datetime,
+    *,
+    frequency: Frequency,
+    run_at_hour: int,
+    run_on_weekday: int,
+    tz: ZoneInfo,
+) -> datetime:
+    """Return the most recent scheduled instant (UTC) at or before ``now_utc``.
+
+    ``run_on_weekday`` follows Python's ``0=Monday`` convention and is only
+    consulted for weekly schedules.
+    """
+    now_local = now_utc.astimezone(tz)
+    candidate = now_local.replace(hour=run_at_hour, minute=0, second=0, microsecond=0)
+    if frequency == Frequency.WEEKLY:
+        candidate -= timedelta(days=(now_local.weekday() - run_on_weekday) % 7)
+        if candidate > now_local:
+            candidate -= timedelta(days=7)
+    else:
+        if candidate > now_local:
+            candidate -= timedelta(days=1)
+    return candidate.astimezone(timezone.utc)
+
+
+def is_due(
+    now_utc: datetime,
+    anchor: datetime | None,
+    *,
+    frequency: Frequency,
+    run_at_hour: int,
+    run_on_weekday: int,
+    tz: ZoneInfo,
+) -> bool:
+    """Whether a run is due given the last run time ``anchor`` (UTC or naive-UTC).
+
+    A run is due when no prior run exists, or when the last run happened before
+    the most recent scheduled instant.
+    """
+    if anchor is None:
+        return True
+    if anchor.tzinfo is None:
+        anchor = anchor.replace(tzinfo=timezone.utc)
+    return anchor < previous_scheduled(
+        now_utc,
+        frequency=frequency,
+        run_at_hour=run_at_hour,
+        run_on_weekday=run_on_weekday,
+        tz=tz,
+    )

--- a/plugins/nemo-insights/src/nemo_insights_plugin/schema.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/schema.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Request/response schemas for the insights plugin HTTP API."""
+
+from datetime import datetime
+
+from nemo_insights_plugin.entities import (
+    AnalysisConfig,
+    AnalysisConfigStatus,
+    AnalysisRunStatus,
+    Insight,
+    InsightStatus,
+)
+from nemo_platform_plugin.schema import NemoListResponse
+from pydantic import BaseModel, Field
+
+
+class CreateInsightRequest(BaseModel):
+    """Body for ``POST /insights``.
+
+    ``status`` defaults to :attr:`InsightStatus.OPEN`; callers that want to
+    mint an insight already in another lifecycle state set it explicitly.
+    """
+
+    title: str = Field(
+        description=(
+            "A short, human-readable sentence naming the core issue. The full "
+            "problem statement goes in 'description'. The store's slug name is "
+            "auto-generated, so no name is supplied here."
+        ),
+    )
+    agent: str = Field(
+        description="Name of the registered agent this insight is about.",
+    )
+    description: str = Field(
+        description=("The problem statement: specific enough to act on. This is editable by the developer."),
+    )
+    status: InsightStatus = Field(default=InsightStatus.OPEN)
+    trace_refs: list[str] = Field(default_factory=list)
+
+
+class UpdateInsightRequest(BaseModel):
+    """Body for ``PATCH /insights/{insight_id}``. Omitted fields are unchanged."""
+
+    title: str | None = None
+    agent: str | None = None
+    description: str | None = None
+    status: InsightStatus | None = None
+    trace_refs: list[str] | None = None
+
+
+InsightPage = NemoListResponse[Insight]
+
+
+class UpdateAnalysisConfigRequest(BaseModel):
+    """Body for ``PATCH /analysis-configs/{agent}``."""
+
+    enabled: bool | None = None
+
+
+class UpdateAnalysisRunStatusRequest(BaseModel):
+    """Body for ``PATCH /analysis-run-statuses/{agent}``."""
+
+    status: AnalysisConfigStatus | None = None
+    last_successful_run_at: datetime | None = None
+    last_attempted_at: datetime | None = None
+    last_completed_at: datetime | None = None
+    last_submitted_job: str | None = None
+    last_error: str | None = None
+
+
+AnalysisConfigPage = NemoListResponse[AnalysisConfig]
+AnalysisRunStatusPage = NemoListResponse[AnalysisRunStatus]

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDK resources for the insights plugin.
+
+Mounted on :class:`~nemo_platform.NeMoPlatform` as ``client.insights`` via
+the ``nemo.sdk`` entry-point in :file:`pyproject.toml`. Exposes:
+
+- ``client.insights.analysis_configs.{enable,disable,list_configs,get,update}``
+  — :class:`~nemo_insights_plugin.entities.AnalysisConfig` CRUD/control for
+  periodic analysis opt-in state.
+- ``client.insights.analysis_run_statuses.{list_statuses,get,update}``
+  — :class:`~nemo_insights_plugin.entities.AnalysisRunStatus` state written by
+  analyzer jobs.
+- ``client.insights.insights.{create,list_insights,get,update,delete}`` —
+  :class:`~nemo_insights_plugin.entities.Insight` CRUD against the FastAPI
+  routes mounted under ``/apis/insights/v2/workspaces/{workspace}/``.
+
+Modeled on ``nemo_auditor.sdk`` — same shape, same hand-written CRUD-only
+resource pattern. No Stainless codegen.
+"""
+
+from nemo_insights_plugin.sdk_resources.analysis_configs import (
+    _AnalysisConfigResource,
+    _AnalysisRunStatusResource,
+    _AsyncAnalysisConfigResource,
+    _AsyncAnalysisRunStatusResource,
+)
+from nemo_insights_plugin.sdk_resources.insights import (
+    _AsyncInsightResource,
+    _InsightResource,
+)
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.sdk import NemoPluginSDKResources
+
+
+class InsightsPluginResource:
+    """Sync SDK namespace mounted as ``client.insights``."""
+
+    def __init__(self, platform: NeMoPlatform) -> None:
+        self._platform = platform
+        self._http_client = platform._client
+        self._insights: _InsightResource | None = None
+        self._analysis_configs: _AnalysisConfigResource | None = None
+        self._analysis_run_statuses: _AnalysisRunStatusResource | None = None
+
+    @property
+    def insights(self) -> _InsightResource:
+        if self._insights is None:
+            self._insights = _InsightResource(self)
+        return self._insights
+
+    @property
+    def analysis_configs(self) -> _AnalysisConfigResource:
+        if self._analysis_configs is None:
+            self._analysis_configs = _AnalysisConfigResource(self)
+        return self._analysis_configs
+
+    @property
+    def analysis_run_statuses(self) -> _AnalysisRunStatusResource:
+        if self._analysis_run_statuses is None:
+            self._analysis_run_statuses = _AnalysisRunStatusResource(self)
+        return self._analysis_run_statuses
+
+    def _url(self, path: str) -> str:
+        return str(self._platform.base_url).rstrip("/") + "/apis/insights" + path
+
+
+class AsyncInsightsPluginResource:
+    """Async SDK namespace mounted as ``client.insights``."""
+
+    def __init__(self, platform: AsyncNeMoPlatform) -> None:
+        self._platform = platform
+        self._http_client = platform._client
+        self._insights: _AsyncInsightResource | None = None
+        self._analysis_configs: _AsyncAnalysisConfigResource | None = None
+        self._analysis_run_statuses: _AsyncAnalysisRunStatusResource | None = None
+
+    @property
+    def insights(self) -> _AsyncInsightResource:
+        if self._insights is None:
+            self._insights = _AsyncInsightResource(self)
+        return self._insights
+
+    @property
+    def analysis_configs(self) -> _AsyncAnalysisConfigResource:
+        if self._analysis_configs is None:
+            self._analysis_configs = _AsyncAnalysisConfigResource(self)
+        return self._analysis_configs
+
+    @property
+    def analysis_run_statuses(self) -> _AsyncAnalysisRunStatusResource:
+        if self._analysis_run_statuses is None:
+            self._analysis_run_statuses = _AsyncAnalysisRunStatusResource(self)
+        return self._analysis_run_statuses
+
+    def _url(self, path: str) -> str:
+        return str(self._platform.base_url).rstrip("/") + "/apis/insights" + path
+
+
+insights_sdk_resources = NemoPluginSDKResources(
+    sync_resource=InsightsPluginResource,
+    async_resource=AsyncInsightsPluginResource,
+)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/_entity.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/_entity.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hydrate entity-store metadata omitted from Pydantic private attributes."""
+
+from datetime import datetime
+from typing import TypeVar
+
+from nemo_platform_plugin.entity import NemoEntity
+
+_EntityT = TypeVar("_EntityT", bound=NemoEntity)
+
+
+def entity_from_response(entity_type: type[_EntityT], data: dict[str, object]) -> _EntityT:
+    """Parse an entity response and restore its store-managed metadata."""
+    entity = entity_type.model_validate(data)
+    entity._id = _optional_str(data.get("id"))
+    entity._parent = _optional_str(data.get("parent"))
+    entity._created_by = _optional_str(data.get("created_by"))
+    entity._updated_by = _optional_str(data.get("updated_by"))
+    entity._created_at = _optional_datetime(data.get("created_at"))
+    entity._updated_at = _optional_datetime(data.get("updated_at"))
+    db_version = data.get("db_version")
+    if isinstance(db_version, int):
+        entity._db_version = db_version
+    return entity
+
+
+def hydrate_page(items: list[_EntityT], raw_items: object) -> None:
+    """Restore metadata on validated page items in response order."""
+    if not isinstance(raw_items, list):
+        return
+    for item, raw in zip(items, raw_items, strict=True):
+        if not isinstance(raw, dict):
+            continue
+        hydrated = entity_from_response(type(item), raw)
+        item.__pydantic_private__ = hydrated.__pydantic_private__
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str) and value:
+        return datetime.fromisoformat(value)
+    return None

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_configs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_configs.py
@@ -1,0 +1,315 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDK sub-resources for periodic analysis opt-in configs and run status."""
+
+from datetime import datetime
+from typing import Any, Protocol
+
+from nemo_insights_plugin.entities import (
+    AnalysisConfig,
+    AnalysisConfigStatus,
+    AnalysisRunStatus,
+)
+from nemo_insights_plugin.schema import (
+    AnalysisConfigPage,
+    AnalysisRunStatusPage,
+    UpdateAnalysisConfigRequest,
+    UpdateAnalysisRunStatusRequest,
+)
+from nemo_insights_plugin.sdk_resources._entity import entity_from_response, hydrate_page
+
+
+class _ResourceParent(Protocol):
+    """The slice of the insights SDK namespace this sub-resource needs."""
+
+    _http_client: Any
+
+    def _url(self, path: str) -> str: ...
+
+
+def _list_params(
+    *,
+    page: int,
+    page_size: int,
+    sort: str,
+    enabled: bool | None,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {"page": page, "page_size": page_size, "sort": sort}
+    if enabled is not None:
+        params["enabled"] = enabled
+    return params
+
+
+def _build_update_body(
+    *,
+    enabled: bool | None,
+) -> dict[str, Any]:
+    body = UpdateAnalysisConfigRequest(enabled=enabled)
+    return body.model_dump(mode="json", exclude_none=True, exclude_unset=True)
+
+
+def _build_status_update_body(
+    *,
+    status: AnalysisConfigStatus | str | None,
+    last_successful_run_at: datetime | None,
+    last_attempted_at: datetime | None,
+    last_completed_at: datetime | None,
+    last_submitted_job: str | None,
+    last_error: str | None,
+) -> dict[str, Any]:
+    body = UpdateAnalysisRunStatusRequest(
+        status=AnalysisConfigStatus(status) if isinstance(status, str) else status,
+        last_successful_run_at=last_successful_run_at,
+        last_attempted_at=last_attempted_at,
+        last_completed_at=last_completed_at,
+        last_submitted_job=last_submitted_job,
+        last_error=last_error,
+    )
+    return body.model_dump(mode="json", exclude_none=True, exclude_unset=True)
+
+
+def _analysis_config_page_from_response(data: dict[str, Any]) -> AnalysisConfigPage:
+    page = AnalysisConfigPage.model_validate(data)
+    hydrate_page(page.data, data.get("data"))
+    return page
+
+
+def _analysis_run_status_page_from_response(data: dict[str, Any]) -> AnalysisRunStatusPage:
+    page = AnalysisRunStatusPage.model_validate(data)
+    hydrate_page(page.data, data.get("data"))
+    return page
+
+
+class _AnalysisConfigResource:
+    """Sync ``analysis_configs`` sub-resource."""
+
+    def __init__(self, parent: _ResourceParent) -> None:
+        self._parent = parent
+
+    def enable(self, *, workspace: str, agent: str) -> AnalysisConfig:
+        response = self._parent._http_client.post(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}/enable")
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisConfig, response.json())
+
+    def disable(self, *, workspace: str, agent: str) -> AnalysisConfig:
+        response = self._parent._http_client.post(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}/disable")
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisConfig, response.json())
+
+    def list_configs(
+        self,
+        *,
+        workspace: str,
+        page: int = 1,
+        page_size: int = 20,
+        sort: str = "-created_at",
+        enabled: bool | None = None,
+    ) -> AnalysisConfigPage:
+        response = self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs"),
+            params=_list_params(page=page, page_size=page_size, sort=sort, enabled=enabled),
+        )
+        response.raise_for_status()
+        return _analysis_config_page_from_response(response.json())
+
+    def get(self, *, workspace: str, agent: str) -> AnalysisConfig:
+        response = self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}")
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisConfig, response.json())
+
+    def update(
+        self,
+        *,
+        workspace: str,
+        agent: str,
+        enabled: bool | None = None,
+    ) -> AnalysisConfig:
+        response = self._parent._http_client.patch(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}"),
+            json=_build_update_body(enabled=enabled),
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisConfig, response.json())
+
+
+class _AsyncAnalysisConfigResource:
+    """Async ``analysis_configs`` sub-resource."""
+
+    def __init__(self, parent: _ResourceParent) -> None:
+        self._parent = parent
+
+    async def enable(self, *, workspace: str, agent: str) -> AnalysisConfig:
+        response = await self._parent._http_client.post(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}/enable")
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisConfig, response.json())
+
+    async def disable(self, *, workspace: str, agent: str) -> AnalysisConfig:
+        response = await self._parent._http_client.post(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}/disable")
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisConfig, response.json())
+
+    async def list_configs(
+        self,
+        *,
+        workspace: str,
+        page: int = 1,
+        page_size: int = 20,
+        sort: str = "-created_at",
+        enabled: bool | None = None,
+    ) -> AnalysisConfigPage:
+        response = await self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs"),
+            params=_list_params(page=page, page_size=page_size, sort=sort, enabled=enabled),
+        )
+        response.raise_for_status()
+        return _analysis_config_page_from_response(response.json())
+
+    async def get(self, *, workspace: str, agent: str) -> AnalysisConfig:
+        response = await self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}")
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisConfig, response.json())
+
+    async def update(
+        self,
+        *,
+        workspace: str,
+        agent: str,
+        enabled: bool | None = None,
+    ) -> AnalysisConfig:
+        response = await self._parent._http_client.patch(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-configs/{agent}"),
+            json=_build_update_body(enabled=enabled),
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisConfig, response.json())
+
+
+class _AnalysisRunStatusResource:
+    """Sync ``analysis_run_statuses`` sub-resource."""
+
+    def __init__(self, parent: _ResourceParent) -> None:
+        self._parent = parent
+
+    def list_statuses(
+        self,
+        *,
+        workspace: str,
+        page: int = 1,
+        page_size: int = 20,
+        sort: str = "-updated_at",
+    ) -> AnalysisRunStatusPage:
+        response = self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses"),
+            params={"page": page, "page_size": page_size, "sort": sort},
+        )
+        response.raise_for_status()
+        return _analysis_run_status_page_from_response(response.json())
+
+    def get(self, *, workspace: str, agent: str) -> AnalysisRunStatus:
+        response = self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses/{agent}")
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisRunStatus, response.json())
+
+    def update(
+        self,
+        *,
+        workspace: str,
+        agent: str,
+        status: AnalysisConfigStatus | str | None = None,
+        last_successful_run_at: datetime | None = None,
+        last_attempted_at: datetime | None = None,
+        last_completed_at: datetime | None = None,
+        last_submitted_job: str | None = None,
+        last_error: str | None = None,
+    ) -> AnalysisRunStatus:
+        response = self._parent._http_client.patch(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses/{agent}"),
+            json=_build_status_update_body(
+                status=status,
+                last_successful_run_at=last_successful_run_at,
+                last_attempted_at=last_attempted_at,
+                last_completed_at=last_completed_at,
+                last_submitted_job=last_submitted_job,
+                last_error=last_error,
+            ),
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisRunStatus, response.json())
+
+
+class _AsyncAnalysisRunStatusResource:
+    """Async ``analysis_run_statuses`` sub-resource."""
+
+    def __init__(self, parent: _ResourceParent) -> None:
+        self._parent = parent
+
+    async def list_statuses(
+        self,
+        *,
+        workspace: str,
+        page: int = 1,
+        page_size: int = 20,
+        sort: str = "-updated_at",
+    ) -> AnalysisRunStatusPage:
+        response = await self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses"),
+            params={"page": page, "page_size": page_size, "sort": sort},
+        )
+        response.raise_for_status()
+        return _analysis_run_status_page_from_response(response.json())
+
+    async def get(self, *, workspace: str, agent: str) -> AnalysisRunStatus:
+        response = await self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses/{agent}")
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisRunStatus, response.json())
+
+    async def update(
+        self,
+        *,
+        workspace: str,
+        agent: str,
+        status: AnalysisConfigStatus | str | None = None,
+        last_successful_run_at: datetime | None = None,
+        last_attempted_at: datetime | None = None,
+        last_completed_at: datetime | None = None,
+        last_submitted_job: str | None = None,
+        last_error: str | None = None,
+    ) -> AnalysisRunStatus:
+        response = await self._parent._http_client.patch(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-run-statuses/{agent}"),
+            json=_build_status_update_body(
+                status=status,
+                last_successful_run_at=last_successful_run_at,
+                last_attempted_at=last_attempted_at,
+                last_completed_at=last_completed_at,
+                last_submitted_job=last_submitted_job,
+                last_error=last_error,
+            ),
+        )
+        response.raise_for_status()
+        return entity_from_response(AnalysisRunStatus, response.json())
+
+
+__all__ = [
+    "_AnalysisConfigResource",
+    "_AnalysisRunStatusResource",
+    "_AsyncAnalysisConfigResource",
+    "_AsyncAnalysisRunStatusResource",
+]

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/insights.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/insights.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDK sub-resources for ``Insight`` CRUD.
+
+Mounted as ``client.insights.insights`` (sync) and on the async client.
+Each method maps 1:1 onto the FastAPI routes in
+:mod:`nemo_insights_plugin.service`.
+"""
+
+from typing import Any, Protocol
+
+from nemo_insights_plugin.entities import Insight, InsightStatus
+from nemo_insights_plugin.schema import (
+    CreateInsightRequest,
+    InsightPage,
+    UpdateInsightRequest,
+)
+from nemo_insights_plugin.sdk_resources._entity import entity_from_response, hydrate_page
+
+
+def _insight_from_response(data: dict[str, Any]) -> Insight:
+    """Parse one insight response body, preserving its store-assigned id."""
+    return entity_from_response(Insight, data)
+
+
+def _page_from_response(data: dict[str, Any]) -> InsightPage:
+    """Parse a list response, preserving each item's store-assigned id.
+
+    Validated items lose their ids (computed field), so we re-attach them
+    positionally from the raw payload, which preserves order.
+    """
+    page = InsightPage.model_validate(data)
+    hydrate_page(page.data, data.get("data"))
+    return page
+
+
+class _ResourceParent(Protocol):
+    """The slice of the insights SDK namespace these sub-resources rely on.
+
+    Both the sync and async ``InsightsPluginResource`` satisfy this — typing
+    against it (rather than importing the concrete classes from
+    :mod:`nemo_insights_plugin.sdk`) avoids an import cycle, since ``sdk``
+    imports the resource classes defined here.
+    """
+
+    _http_client: Any
+
+    def _url(self, path: str) -> str: ...
+
+
+def _build_create_body(
+    *,
+    title: str,
+    agent: str,
+    description: str,
+    status: InsightStatus | str,
+    trace_refs: list[str] | None,
+) -> dict[str, Any]:
+    body = CreateInsightRequest(
+        title=title,
+        agent=agent,
+        description=description,
+        status=InsightStatus(status) if isinstance(status, str) else status,
+        trace_refs=list(trace_refs or []),
+    )
+    return body.model_dump(mode="json")
+
+
+def _build_update_body(
+    *,
+    agent: str | None,
+    description: str | None,
+    status: InsightStatus | str | None,
+    trace_refs: list[str] | None,
+) -> dict[str, Any]:
+    body = UpdateInsightRequest(
+        agent=agent,
+        description=description,
+        status=InsightStatus(status) if isinstance(status, str) else status,
+        trace_refs=trace_refs,
+    )
+    return body.model_dump(mode="json", exclude_none=True)
+
+
+def _list_params(
+    *,
+    page: int,
+    page_size: int,
+    sort: str,
+    agent: str | None,
+    status: InsightStatus | str | None,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {"page": page, "page_size": page_size, "sort": sort}
+    if agent is not None:
+        params["agent"] = agent
+    if status is not None:
+        params["status"] = status.value if isinstance(status, InsightStatus) else status
+    return params
+
+
+class _InsightResource:
+    """Sync ``insights`` sub-resource — five CRUD verbs."""
+
+    def __init__(self, parent: _ResourceParent) -> None:
+        self._parent = parent
+
+    def create(
+        self,
+        *,
+        workspace: str,
+        title: str,
+        agent: str,
+        description: str,
+        status: InsightStatus | str = InsightStatus.OPEN,
+        trace_refs: list[str] | None = None,
+    ) -> Insight:
+        body = _build_create_body(
+            title=title,
+            agent=agent,
+            description=description,
+            status=status,
+            trace_refs=trace_refs,
+        )
+        response = self._parent._http_client.post(
+            self._parent._url(f"/v2/workspaces/{workspace}/insights"),
+            json=body,
+        )
+        response.raise_for_status()
+        return _insight_from_response(response.json())
+
+    def list_insights(
+        self,
+        *,
+        workspace: str,
+        page: int = 1,
+        page_size: int = 20,
+        sort: str = "-created_at",
+        agent: str | None = None,
+        status: InsightStatus | str | None = None,
+    ) -> InsightPage:
+        response = self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/insights"),
+            params=_list_params(
+                page=page,
+                page_size=page_size,
+                sort=sort,
+                agent=agent,
+                status=status,
+            ),
+        )
+        response.raise_for_status()
+        return _page_from_response(response.json())
+
+    def get(self, *, workspace: str, insight_id: str) -> Insight:
+        response = self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
+        )
+        response.raise_for_status()
+        return _insight_from_response(response.json())
+
+    def update(
+        self,
+        *,
+        workspace: str,
+        insight_id: str,
+        agent: str | None = None,
+        description: str | None = None,
+        status: InsightStatus | str | None = None,
+        trace_refs: list[str] | None = None,
+    ) -> Insight:
+        body = _build_update_body(
+            agent=agent,
+            description=description,
+            status=status,
+            trace_refs=trace_refs,
+        )
+        response = self._parent._http_client.patch(
+            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
+            json=body,
+        )
+        response.raise_for_status()
+        return _insight_from_response(response.json())
+
+    def delete(self, *, workspace: str, insight_id: str) -> None:
+        response = self._parent._http_client.delete(
+            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
+        )
+        response.raise_for_status()
+
+
+class _AsyncInsightResource:
+    """Async ``insights`` sub-resource — mirrors :class:`_InsightResource`."""
+
+    def __init__(self, parent: _ResourceParent) -> None:
+        self._parent = parent
+
+    async def create(
+        self,
+        *,
+        workspace: str,
+        title: str,
+        agent: str,
+        description: str,
+        status: InsightStatus | str = InsightStatus.OPEN,
+        trace_refs: list[str] | None = None,
+    ) -> Insight:
+        body = _build_create_body(
+            title=title,
+            agent=agent,
+            description=description,
+            status=status,
+            trace_refs=trace_refs,
+        )
+        response = await self._parent._http_client.post(
+            self._parent._url(f"/v2/workspaces/{workspace}/insights"),
+            json=body,
+        )
+        response.raise_for_status()
+        return _insight_from_response(response.json())
+
+    async def list_insights(
+        self,
+        *,
+        workspace: str,
+        page: int = 1,
+        page_size: int = 20,
+        sort: str = "-created_at",
+        agent: str | None = None,
+        status: InsightStatus | str | None = None,
+    ) -> InsightPage:
+        response = await self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/insights"),
+            params=_list_params(
+                page=page,
+                page_size=page_size,
+                sort=sort,
+                agent=agent,
+                status=status,
+            ),
+        )
+        response.raise_for_status()
+        return _page_from_response(response.json())
+
+    async def get(self, *, workspace: str, insight_id: str) -> Insight:
+        response = await self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
+        )
+        response.raise_for_status()
+        return _insight_from_response(response.json())
+
+    async def update(
+        self,
+        *,
+        workspace: str,
+        insight_id: str,
+        agent: str | None = None,
+        description: str | None = None,
+        status: InsightStatus | str | None = None,
+        trace_refs: list[str] | None = None,
+    ) -> Insight:
+        body = _build_update_body(
+            agent=agent,
+            description=description,
+            status=status,
+            trace_refs=trace_refs,
+        )
+        response = await self._parent._http_client.patch(
+            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
+            json=body,
+        )
+        response.raise_for_status()
+        return _insight_from_response(response.json())
+
+    async def delete(self, *, workspace: str, insight_id: str) -> None:
+        response = await self._parent._http_client.delete(
+            self._parent._url(f"/v2/workspaces/{workspace}/insights/{insight_id}"),
+        )
+        response.raise_for_status()
+
+
+__all__ = ["_AsyncInsightResource", "_InsightResource"]

--- a/plugins/nemo-insights/src/nemo_insights_plugin/service.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/service.py
@@ -1,0 +1,574 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Insights plugin HTTP service.
+
+Mounts Insight CRUD routes under ``/apis/insights/v2/workspaces/{workspace}/``.
+Discovered by the platform via the ``nemo.services`` entry-point.
+"""
+
+import logging
+from typing import ClassVar
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from nemo_insights_plugin._perms import AnalysisConfigPerms, AnalysisRunStatusPerms, InsightPerms
+from nemo_insights_plugin.authz import scope
+from nemo_insights_plugin.entities import (
+    AnalysisConfig,
+    AnalysisRunStatus,
+    Insight,
+    InsightStatus,
+)
+from nemo_insights_plugin.jobs.analyze import AnalyzeJob
+from nemo_insights_plugin.schema import (
+    AnalysisConfigPage,
+    AnalysisRunStatusPage,
+    CreateInsightRequest,
+    InsightPage,
+    UpdateAnalysisConfigRequest,
+    UpdateAnalysisRunStatusRequest,
+    UpdateInsightRequest,
+)
+from nemo_platform_plugin.authz import CallerKind, path_rule
+from nemo_platform_plugin.entities import (
+    EntityValidationError as NemoEntityValidationError,
+)
+from nemo_platform_plugin.entity_client import (
+    NemoEntitiesClient,
+    NemoEntityConflictError,
+    NemoEntityNotFoundError,
+    get_entity_client,
+)
+from nemo_platform_plugin.jobs.routes import add_job_routes
+from nemo_platform_plugin.schema import PaginationData
+from nemo_platform_plugin.service import NemoService, RouterSpec
+
+logger = logging.getLogger(__name__)
+
+
+class InsightsService(NemoService):
+    """NeMo Insights plugin service.
+
+    Exposes CRUD routes for :class:`~nemo_insights_plugin.entities.Insight` —
+    the analyst agent's primary output. Routes are mounted under
+    ``/apis/insights/v2/workspaces/{workspace}/``.
+    """
+
+    name: ClassVar[str] = "insights"
+    dependencies: ClassVar[list[str]] = ["entities", "jobs"]
+
+    def get_routers(self) -> list[RouterSpec]:
+        return [
+            RouterSpec(
+                _build_insights_router(),
+                tag="Insights Insights",
+                description="CRUD for analyst-authored Insight entities.",
+                prefix="/v2/workspaces/{workspace}",
+            ),
+            RouterSpec(
+                _build_analysis_configs_router(),
+                tag="Insights Analysis Configs",
+                description="Per-agent opt-in state for periodic insights analysis.",
+                prefix="/v2/workspaces/{workspace}",
+            ),
+            RouterSpec(
+                _build_analysis_run_statuses_router(),
+                tag="Insights Analysis Run Statuses",
+                description="Machine-written state for periodic insights analysis.",
+                prefix="/v2/workspaces/{workspace}",
+            ),
+            RouterSpec(
+                add_job_routes(AnalyzeJob, authz=scope),
+                tag="Insights Analysis Jobs",
+                description="Submit and track one-shot insights analyst jobs.",
+                prefix="/v2/workspaces/{workspace}",
+            ),
+        ]
+
+
+def _build_insights_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.post(
+        "/insights",
+        response_model=Insight,
+        status_code=201,
+        tags=["Insights Insights"],
+    )
+    @scope.write
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[InsightPerms.CREATE])
+    async def create_insight(
+        workspace: str,
+        body: CreateInsightRequest,
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> Insight:
+        """Create a new Insight. The store auto-generates the slug name."""
+        insight = Insight(
+            workspace=workspace,
+            title=body.title,
+            agent=body.agent,
+            description=body.description,
+            status=body.status,
+            trace_refs=list(body.trace_refs),
+        )
+        try:
+            saved = await entity_client.create(insight)
+        except NemoEntityValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        except Exception as exc:
+            logger.exception("Failed to create insight '%s'", body.title)
+            raise HTTPException(status_code=500, detail="Failed to create insight.") from exc
+        return saved
+
+    @router.get(
+        "/insights",
+        response_model=InsightPage,
+        tags=["Insights Insights"],
+    )
+    @scope.read
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[InsightPerms.LIST])
+    async def list_insights(
+        workspace: str,
+        page: int = Query(default=1, ge=1, description="Page number (1-indexed)."),
+        page_size: int = Query(default=20, ge=1, le=100, description="Items per page."),
+        sort: str = Query(
+            default="-created_at",
+            description="Sort field. Prefix with '-' for descending (e.g. '-created_at').",
+        ),
+        agent: str | None = Query(default=None, description="Filter by agent name."),
+        status: InsightStatus | None = Query(default=None, description="Filter by lifecycle status."),
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> InsightPage:
+        """List Insights with pagination, sort, and basic filters."""
+        filter_obj: dict[str, object] = {}
+        if agent is not None:
+            filter_obj["agent"] = agent
+        if status is not None:
+            filter_obj["status"] = status.value
+
+        try:
+            result = await entity_client.list(
+                Insight,
+                workspace=workspace,
+                page=page,
+                page_size=page_size,
+                sort=sort,
+                filter_obj=filter_obj or None,
+            )
+        except Exception as exc:
+            logger.exception("Failed to list insights in workspace '%s'", workspace)
+            raise HTTPException(status_code=500, detail="Failed to list insights.") from exc
+
+        pagination = PaginationData.model_validate(result.pagination.model_dump()) if result.pagination else None
+        return InsightPage(
+            data=result.data,
+            pagination=pagination,
+            sort=sort,
+            filter=filter_obj or None,
+        )
+
+    @router.get(
+        "/insights/{insight_id}",
+        response_model=Insight,
+        tags=["Insights Insights"],
+    )
+    @scope.read
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[InsightPerms.READ])
+    async def get_insight(
+        workspace: str,
+        insight_id: str,
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> Insight:
+        """Get a single Insight by its store-assigned id."""
+        try:
+            insight = await entity_client.get_by_id(Insight, entity_id=insight_id)
+        except NemoEntityNotFoundError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Insight '{insight_id}' not found in workspace '{workspace}'.",
+            ) from exc
+        except Exception as exc:
+            logger.exception("Failed to get insight '%s'", insight_id)
+            raise HTTPException(status_code=500, detail="Failed to get insight.") from exc
+        return insight
+
+    @router.patch(
+        "/insights/{insight_id}",
+        response_model=Insight,
+        tags=["Insights Insights"],
+    )
+    @scope.write
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[InsightPerms.UPDATE])
+    async def update_insight(
+        workspace: str,
+        insight_id: str,
+        body: UpdateInsightRequest,
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> Insight:
+        """Partially update an Insight by id. Omitted fields are unchanged."""
+        try:
+            insight = await entity_client.get_by_id(Insight, entity_id=insight_id)
+        except NemoEntityNotFoundError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Insight '{insight_id}' not found in workspace '{workspace}'.",
+            ) from exc
+        except Exception as exc:
+            logger.exception("Failed to fetch insight '%s' for update", insight_id)
+            raise HTTPException(status_code=500, detail="Failed to fetch insight.") from exc
+
+        if body.title is not None:
+            insight.title = body.title
+        if body.agent is not None:
+            insight.agent = body.agent
+        if body.description is not None:
+            insight.description = body.description
+        if body.status is not None:
+            insight.status = body.status
+        if body.trace_refs is not None:
+            insight.trace_refs = list(body.trace_refs)
+
+        try:
+            saved = await entity_client.update(insight)
+        except NemoEntityNotFoundError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Insight '{insight_id}' not found in workspace '{workspace}'.",
+            ) from exc
+        except NemoEntityValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        except Exception as exc:
+            logger.exception("Failed to update insight '%s'", insight_id)
+            raise HTTPException(status_code=500, detail="Failed to update insight.") from exc
+        return saved
+
+    @router.delete(
+        "/insights/{insight_id}",
+        status_code=204,
+        tags=["Insights Insights"],
+    )
+    @scope.write
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[InsightPerms.DELETE])
+    async def delete_insight(
+        workspace: str,
+        insight_id: str,
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> None:
+        """Delete an Insight by its store-assigned id. Returns 204 on success."""
+        try:
+            await entity_client.delete_by_id(Insight, entity_id=insight_id)
+        except NemoEntityNotFoundError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Insight '{insight_id}' not found in workspace '{workspace}'.",
+            ) from exc
+        except Exception as exc:
+            logger.exception("Failed to delete insight '%s'", insight_id)
+            raise HTTPException(status_code=500, detail="Failed to delete insight.") from exc
+
+    return router
+
+
+def _config_not_found(agent: str, workspace: str) -> str:
+    """Standard 404 detail for a missing analysis config."""
+    return f"Analysis config for agent '{agent}' not found in workspace '{workspace}'."
+
+
+def _run_status_not_found(agent: str, workspace: str) -> str:
+    """Standard 404 detail for a missing analysis run status."""
+    return f"Analysis run status for agent '{agent}' not found in workspace '{workspace}'."
+
+
+async def _get_or_create_analysis_config(
+    entity_client: NemoEntitiesClient,
+    *,
+    workspace: str,
+    agent: str,
+    enabled_if_created: bool,
+) -> tuple[AnalysisConfig, bool]:
+    """Fetch an analysis config, creating a default one if it is absent.
+
+    Returns the config and whether it was freshly created. Raises
+    :class:`HTTPException` (500) on unexpected fetch failures.
+    """
+    try:
+        config = await entity_client.get(AnalysisConfig, name=agent, workspace=workspace)
+        return config, False
+    except NemoEntityNotFoundError:
+        pass
+    except Exception as exc:
+        logger.exception("Failed to fetch analysis config for agent '%s'", agent)
+        raise HTTPException(status_code=500, detail="Failed to fetch analysis config.") from exc
+
+    config = AnalysisConfig(name=agent, workspace=workspace, agent=agent, enabled=enabled_if_created)
+    try:
+        return await entity_client.create(config), True
+    except NemoEntityConflictError:
+        existing = await entity_client.get(AnalysisConfig, name=agent, workspace=workspace)
+        return existing, False
+
+
+async def _get_or_create_analysis_run_status(
+    entity_client: NemoEntitiesClient,
+    *,
+    workspace: str,
+    agent: str,
+) -> AnalysisRunStatus:
+    """Fetch an analysis run status, creating a default one if it is absent."""
+    try:
+        return await entity_client.get(AnalysisRunStatus, name=agent, workspace=workspace)
+    except NemoEntityNotFoundError:
+        pass
+    except Exception as exc:
+        logger.exception("Failed to fetch analysis run status for agent '%s'", agent)
+        raise HTTPException(status_code=500, detail="Failed to fetch analysis run status.") from exc
+
+    status = AnalysisRunStatus(name=agent, workspace=workspace, agent=agent)
+    try:
+        return await entity_client.create(status)
+    except NemoEntityConflictError:
+        return await entity_client.get(AnalysisRunStatus, name=agent, workspace=workspace)
+
+
+def _build_analysis_configs_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.post(
+        "/analysis-configs/{agent}/enable",
+        response_model=AnalysisConfig,
+        tags=["Insights Analysis Configs"],
+    )
+    @scope.write
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[AnalysisConfigPerms.ENABLE])
+    async def enable_analysis_config(
+        workspace: str,
+        agent: str,
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> AnalysisConfig:
+        """Enable periodic insights analysis for one agent."""
+        config, created = await _get_or_create_analysis_config(
+            entity_client, workspace=workspace, agent=agent, enabled_if_created=True
+        )
+        if created:
+            return config
+
+        config.enabled = True
+        try:
+            return await entity_client.update(config)
+        except Exception as exc:
+            logger.exception("Failed to enable analysis for agent '%s'", agent)
+            raise HTTPException(status_code=500, detail="Failed to enable analysis config.") from exc
+
+    @router.post(
+        "/analysis-configs/{agent}/disable",
+        response_model=AnalysisConfig,
+        tags=["Insights Analysis Configs"],
+    )
+    @scope.write
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[AnalysisConfigPerms.DISABLE])
+    async def disable_analysis_config(
+        workspace: str,
+        agent: str,
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> AnalysisConfig:
+        """Disable periodic insights analysis for one agent."""
+        config, created = await _get_or_create_analysis_config(
+            entity_client, workspace=workspace, agent=agent, enabled_if_created=False
+        )
+        if created:
+            return config
+
+        config.enabled = False
+        try:
+            return await entity_client.update(config)
+        except Exception as exc:
+            logger.exception("Failed to disable analysis for agent '%s'", agent)
+            raise HTTPException(status_code=500, detail="Failed to disable analysis config.") from exc
+
+    @router.get(
+        "/analysis-configs",
+        response_model=AnalysisConfigPage,
+        tags=["Insights Analysis Configs"],
+    )
+    @scope.read
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[AnalysisConfigPerms.LIST])
+    async def list_analysis_configs(
+        workspace: str,
+        page: int = Query(default=1, ge=1, description="Page number (1-indexed)."),
+        page_size: int = Query(default=20, ge=1, le=100, description="Items per page."),
+        sort: str = Query(default="-created_at", description="Sort field."),
+        enabled: bool | None = Query(default=None, description="Filter by enabled state."),
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> AnalysisConfigPage:
+        """List periodic analysis opt-in records."""
+        filter_obj: dict[str, object] = {}
+        if enabled is not None:
+            filter_obj["enabled"] = enabled
+
+        try:
+            result = await entity_client.list(
+                AnalysisConfig,
+                workspace=workspace,
+                page=page,
+                page_size=page_size,
+                sort=sort,
+                filter_obj=filter_obj or None,
+            )
+        except Exception as exc:
+            logger.exception("Failed to list analysis configs in workspace '%s'", workspace)
+            raise HTTPException(status_code=500, detail="Failed to list analysis configs.") from exc
+
+        pagination = PaginationData.model_validate(result.pagination.model_dump()) if result.pagination else None
+        return AnalysisConfigPage(
+            data=result.data,
+            pagination=pagination,
+            sort=sort,
+            filter=filter_obj or None,
+        )
+
+    @router.get(
+        "/analysis-configs/{agent}",
+        response_model=AnalysisConfig,
+        tags=["Insights Analysis Configs"],
+    )
+    @scope.read
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[AnalysisConfigPerms.READ])
+    async def get_analysis_config(
+        workspace: str,
+        agent: str,
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> AnalysisConfig:
+        """Get periodic analysis opt-in state for one agent."""
+        try:
+            return await entity_client.get(AnalysisConfig, name=agent, workspace=workspace)
+        except NemoEntityNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=_config_not_found(agent, workspace)) from exc
+        except Exception as exc:
+            logger.exception("Failed to get analysis config for agent '%s'", agent)
+            raise HTTPException(status_code=500, detail="Failed to get analysis config.") from exc
+
+    @router.patch(
+        "/analysis-configs/{agent}",
+        response_model=AnalysisConfig,
+        tags=["Insights Analysis Configs"],
+    )
+    @scope.write
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[AnalysisConfigPerms.UPDATE])
+    async def update_analysis_config(
+        workspace: str,
+        agent: str,
+        body: UpdateAnalysisConfigRequest,
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> AnalysisConfig:
+        """Partially update periodic analysis state for one agent."""
+        try:
+            config = await entity_client.get(AnalysisConfig, name=agent, workspace=workspace)
+        except NemoEntityNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=_config_not_found(agent, workspace)) from exc
+        except Exception as exc:
+            logger.exception("Failed to fetch analysis config for agent '%s'", agent)
+            raise HTTPException(status_code=500, detail="Failed to fetch analysis config.") from exc
+
+        for field, value in body.model_dump(exclude_unset=True).items():
+            setattr(config, field, value)
+
+        try:
+            return await entity_client.update(config)
+        except NemoEntityNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=_config_not_found(agent, workspace)) from exc
+        except Exception as exc:
+            logger.exception("Failed to update analysis config for agent '%s'", agent)
+            raise HTTPException(status_code=500, detail="Failed to update analysis config.") from exc
+
+    return router
+
+
+def _build_analysis_run_statuses_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.get(
+        "/analysis-run-statuses",
+        response_model=AnalysisRunStatusPage,
+        tags=["Insights Analysis Run Statuses"],
+    )
+    @scope.read
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[AnalysisRunStatusPerms.LIST])
+    async def list_analysis_run_statuses(
+        workspace: str,
+        page: int = Query(default=1, ge=1, description="Page number (1-indexed)."),
+        page_size: int = Query(default=20, ge=1, le=100, description="Items per page."),
+        sort: str = Query(default="-updated_at", description="Sort field."),
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> AnalysisRunStatusPage:
+        """List machine-written periodic analysis run status records."""
+        try:
+            result = await entity_client.list(
+                AnalysisRunStatus,
+                workspace=workspace,
+                page=page,
+                page_size=page_size,
+                sort=sort,
+            )
+        except Exception as exc:
+            logger.exception("Failed to list analysis run statuses in workspace '%s'", workspace)
+            raise HTTPException(status_code=500, detail="Failed to list analysis run statuses.") from exc
+
+        pagination = PaginationData.model_validate(result.pagination.model_dump()) if result.pagination else None
+        return AnalysisRunStatusPage(
+            data=result.data,
+            pagination=pagination,
+            sort=sort,
+            filter=None,
+        )
+
+    @router.get(
+        "/analysis-run-statuses/{agent}",
+        response_model=AnalysisRunStatus,
+        tags=["Insights Analysis Run Statuses"],
+    )
+    @scope.read
+    @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[AnalysisRunStatusPerms.READ])
+    async def get_analysis_run_status(
+        workspace: str,
+        agent: str,
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> AnalysisRunStatus:
+        """Get machine-written periodic analysis run status for one agent."""
+        try:
+            return await entity_client.get(AnalysisRunStatus, name=agent, workspace=workspace)
+        except NemoEntityNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=_run_status_not_found(agent, workspace)) from exc
+        except Exception as exc:
+            logger.exception("Failed to get analysis run status for agent '%s'", agent)
+            raise HTTPException(status_code=500, detail="Failed to get analysis run status.") from exc
+
+    @router.patch(
+        "/analysis-run-statuses/{agent}",
+        response_model=AnalysisRunStatus,
+        tags=["Insights Analysis Run Statuses"],
+    )
+    @scope.write
+    @path_rule(
+        callers=[CallerKind.PRINCIPAL, CallerKind.SERVICE_PRINCIPAL],
+        permissions=[AnalysisRunStatusPerms.UPDATE],
+    )
+    async def update_analysis_run_status(
+        workspace: str,
+        agent: str,
+        body: UpdateAnalysisRunStatusRequest,
+        entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    ) -> AnalysisRunStatus:
+        """Create or partially update periodic analysis run status for one agent."""
+        status = await _get_or_create_analysis_run_status(entity_client, workspace=workspace, agent=agent)
+        for field, value in body.model_dump(exclude_unset=True).items():
+            setattr(status, field, value)
+
+        try:
+            return await entity_client.update(status)
+        except NemoEntityNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=_run_status_not_found(agent, workspace)) from exc
+        except Exception as exc:
+            logger.exception("Failed to update analysis run status for agent '%s'", agent)
+            raise HTTPException(status_code=500, detail="Failed to update analysis run status.") from exc
+
+    return router

--- a/plugins/nemo-insights/src/nemo_insights_plugin/service.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/service.py
@@ -116,7 +116,7 @@ def _build_insights_router() -> APIRouter:
         except NemoEntityValidationError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
         except Exception as exc:
-            logger.exception("Failed to create insight '%s'", body.title)
+            logger.exception("Failed to create insight")
             raise HTTPException(status_code=500, detail="Failed to create insight.") from exc
         return saved
 
@@ -156,7 +156,7 @@ def _build_insights_router() -> APIRouter:
                 filter_obj=filter_obj or None,
             )
         except Exception as exc:
-            logger.exception("Failed to list insights in workspace '%s'", workspace)
+            logger.exception("Failed to list insights")
             raise HTTPException(status_code=500, detail="Failed to list insights.") from exc
 
         pagination = PaginationData.model_validate(result.pagination.model_dump()) if result.pagination else None
@@ -188,7 +188,7 @@ def _build_insights_router() -> APIRouter:
                 detail=f"Insight '{insight_id}' not found in workspace '{workspace}'.",
             ) from exc
         except Exception as exc:
-            logger.exception("Failed to get insight '%s'", insight_id)
+            logger.exception("Failed to get insight")
             raise HTTPException(status_code=500, detail="Failed to get insight.") from exc
         return insight
 
@@ -214,7 +214,7 @@ def _build_insights_router() -> APIRouter:
                 detail=f"Insight '{insight_id}' not found in workspace '{workspace}'.",
             ) from exc
         except Exception as exc:
-            logger.exception("Failed to fetch insight '%s' for update", insight_id)
+            logger.exception("Failed to fetch insight for update")
             raise HTTPException(status_code=500, detail="Failed to fetch insight.") from exc
 
         if body.title is not None:
@@ -238,7 +238,7 @@ def _build_insights_router() -> APIRouter:
         except NemoEntityValidationError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
         except Exception as exc:
-            logger.exception("Failed to update insight '%s'", insight_id)
+            logger.exception("Failed to update insight")
             raise HTTPException(status_code=500, detail="Failed to update insight.") from exc
         return saved
 
@@ -263,7 +263,7 @@ def _build_insights_router() -> APIRouter:
                 detail=f"Insight '{insight_id}' not found in workspace '{workspace}'.",
             ) from exc
         except Exception as exc:
-            logger.exception("Failed to delete insight '%s'", insight_id)
+            logger.exception("Failed to delete insight")
             raise HTTPException(status_code=500, detail="Failed to delete insight.") from exc
 
     return router
@@ -297,7 +297,7 @@ async def _get_or_create_analysis_config(
     except NemoEntityNotFoundError:
         pass
     except Exception as exc:
-        logger.exception("Failed to fetch analysis config for agent '%s'", agent)
+        logger.exception("Failed to fetch analysis config")
         raise HTTPException(status_code=500, detail="Failed to fetch analysis config.") from exc
 
     config = AnalysisConfig(name=agent, workspace=workspace, agent=agent, enabled=enabled_if_created)
@@ -320,7 +320,7 @@ async def _get_or_create_analysis_run_status(
     except NemoEntityNotFoundError:
         pass
     except Exception as exc:
-        logger.exception("Failed to fetch analysis run status for agent '%s'", agent)
+        logger.exception("Failed to fetch analysis run status")
         raise HTTPException(status_code=500, detail="Failed to fetch analysis run status.") from exc
 
     status = AnalysisRunStatus(name=agent, workspace=workspace, agent=agent)
@@ -356,7 +356,7 @@ def _build_analysis_configs_router() -> APIRouter:
         try:
             return await entity_client.update(config)
         except Exception as exc:
-            logger.exception("Failed to enable analysis for agent '%s'", agent)
+            logger.exception("Failed to enable analysis")
             raise HTTPException(status_code=500, detail="Failed to enable analysis config.") from exc
 
     @router.post(
@@ -382,7 +382,7 @@ def _build_analysis_configs_router() -> APIRouter:
         try:
             return await entity_client.update(config)
         except Exception as exc:
-            logger.exception("Failed to disable analysis for agent '%s'", agent)
+            logger.exception("Failed to disable analysis")
             raise HTTPException(status_code=500, detail="Failed to disable analysis config.") from exc
 
     @router.get(
@@ -415,7 +415,7 @@ def _build_analysis_configs_router() -> APIRouter:
                 filter_obj=filter_obj or None,
             )
         except Exception as exc:
-            logger.exception("Failed to list analysis configs in workspace '%s'", workspace)
+            logger.exception("Failed to list analysis configs")
             raise HTTPException(status_code=500, detail="Failed to list analysis configs.") from exc
 
         pagination = PaginationData.model_validate(result.pagination.model_dump()) if result.pagination else None
@@ -444,7 +444,7 @@ def _build_analysis_configs_router() -> APIRouter:
         except NemoEntityNotFoundError as exc:
             raise HTTPException(status_code=404, detail=_config_not_found(agent, workspace)) from exc
         except Exception as exc:
-            logger.exception("Failed to get analysis config for agent '%s'", agent)
+            logger.exception("Failed to get analysis config")
             raise HTTPException(status_code=500, detail="Failed to get analysis config.") from exc
 
     @router.patch(
@@ -466,7 +466,7 @@ def _build_analysis_configs_router() -> APIRouter:
         except NemoEntityNotFoundError as exc:
             raise HTTPException(status_code=404, detail=_config_not_found(agent, workspace)) from exc
         except Exception as exc:
-            logger.exception("Failed to fetch analysis config for agent '%s'", agent)
+            logger.exception("Failed to fetch analysis config")
             raise HTTPException(status_code=500, detail="Failed to fetch analysis config.") from exc
 
         for field, value in body.model_dump(exclude_unset=True).items():
@@ -477,7 +477,7 @@ def _build_analysis_configs_router() -> APIRouter:
         except NemoEntityNotFoundError as exc:
             raise HTTPException(status_code=404, detail=_config_not_found(agent, workspace)) from exc
         except Exception as exc:
-            logger.exception("Failed to update analysis config for agent '%s'", agent)
+            logger.exception("Failed to update analysis config")
             raise HTTPException(status_code=500, detail="Failed to update analysis config.") from exc
 
     return router
@@ -510,7 +510,7 @@ def _build_analysis_run_statuses_router() -> APIRouter:
                 sort=sort,
             )
         except Exception as exc:
-            logger.exception("Failed to list analysis run statuses in workspace '%s'", workspace)
+            logger.exception("Failed to list analysis run statuses")
             raise HTTPException(status_code=500, detail="Failed to list analysis run statuses.") from exc
 
         pagination = PaginationData.model_validate(result.pagination.model_dump()) if result.pagination else None
@@ -539,7 +539,7 @@ def _build_analysis_run_statuses_router() -> APIRouter:
         except NemoEntityNotFoundError as exc:
             raise HTTPException(status_code=404, detail=_run_status_not_found(agent, workspace)) from exc
         except Exception as exc:
-            logger.exception("Failed to get analysis run status for agent '%s'", agent)
+            logger.exception("Failed to get analysis run status")
             raise HTTPException(status_code=500, detail="Failed to get analysis run status.") from exc
 
     @router.patch(
@@ -568,7 +568,7 @@ def _build_analysis_run_statuses_router() -> APIRouter:
         except NemoEntityNotFoundError as exc:
             raise HTTPException(status_code=404, detail=_run_status_not_found(agent, workspace)) from exc
         except Exception as exc:
-            logger.exception("Failed to update analysis run status for agent '%s'", agent)
+            logger.exception("Failed to update analysis run status")
             raise HTTPException(status_code=500, detail="Failed to update analysis run status.") from exc
 
     return router

--- a/plugins/nemo-insights/testbed/README.md
+++ b/plugins/nemo-insights/testbed/README.md
@@ -321,7 +321,7 @@ deliberately after a mint you want as its new shared baseline, or override
 per-run with the dispatch `state` input (applies to every subject in the run;
 locally: `analyze <subject> --state state-vN`).
 
-Secrets: one repo secret, `INFERENCE_API_KEY` (the inference-gateway key; the
-workflow also exposes it as `OPENAI_API_KEY` for litellm/tau2). The analyst and
-the tau2 sim LLMs both reach `inference-api.nvidia.com` (public), so `produce`
-and `analyze` need no VPN and work unmodified on public runners.
+Secrets: the workflow uses Actions secrets `NVIDIA_INFERENCE_KEY` and
+`NVIDIA_INFERENCE_URL`, exposing them under the `INFERENCE_API_KEY` and
+OpenAI-compatible environment names expected by the analyst and litellm/tau2.
+The analyst and tau2 sim LLMs need no VPN and work on public runners.

--- a/plugins/nemo-insights/testbed/README.md
+++ b/plugins/nemo-insights/testbed/README.md
@@ -245,10 +245,10 @@ validation trigger):
   diffing the resulting Insights is the reliability signal ("pass^k for
   insights") this pipeline exists to surface, not noise to suppress.
 
-**One PR = one state per subject:** `pull_request` events (paths under `src/`
-or `testbed/`) force `mode=analyze` against `tau2-airline` and additionally
-require the `run-insights` label, so every labeled push analyzes the same
-pinned state and insight diffs are attributable to code, not state drift.
+**One analysis run per PR:** applying the `run-insights` label runs
+`mode=analyze` against `tau2-airline` at the current PR head. Later commits do
+not rerun it on `synchronize`, avoiding repeated inference spend. Remove and
+reapply the label to request an explicit rerun.
 States are per-produce-dispatch compositions, so subjects pin different
 versions — each under `[subjects]` in `testbed/state.lock`; a subject with no
 entry errors (add its line after minting a fixture). Lock-bump PRs edit the

--- a/plugins/nemo-insights/testbed/README.md
+++ b/plugins/nemo-insights/testbed/README.md
@@ -1,0 +1,327 @@
+# testbed — insights analyst test runner (maintainer tooling)
+
+Runs the Insights analyst against registered **subjects** and emits Insights. Think
+"pytest for the analysis loop." This is dev tooling — it *drives* `nemo insights`;
+it is not the product CLI and is not shipped in the wheel.
+
+```bash
+uv run python -m testbed analyze tau2-airline         # reproducible default: restore the pinned state locally, then analyze
+uv run python -m testbed list
+uv run python -m testbed doctor                       # fresh clone? run this first
+uv run python -m testbed run tau2-airline             # produce: tau2 -> ingest -> record the run (expensive, once)
+uv run python -m testbed analyze tau2-airline --live  # analyze the recorded run's live traces (no restore)
+uv run python -m testbed analyze nvq --live           # intake: analyze existing live traces
+uv run python -m testbed snapshot tau2-airline        # export the subject's workspaces (read API) into a portable bundle
+uv run python -m testbed restore --state state-v7     # re-ingest a state bundle into fixture workspaces (additive, idempotent)
+```
+
+Bare `analyze <subject>` is a fully reproducible run: pinned data (the subject's
+`state.lock` entry) restored onto the local platform, analyzed with fresh
+insights (no prior seed). Every deviation is one explicit flag:
+
+- `--state <state-vN|FILE>` — another published state, or a local bundle file
+  (mutually exclusive with `--live`).
+- `--live [--since S]` — skip the restore and read the platform's live traces
+  (`--since` applies to `analyze --live` and to `snapshot`; pinned/`--state`
+  analysis derives its bound from the bundle manifest).
+- `--update-insights` — run against the existing local insights (prod-like update flow:
+  updates them and adds new ones); default is a fresh start with priors moved to backup.
+  Valid in every mode.
+- `--base URL` — the one platform flag, on every platform-touching command.
+  Fixture targets (restore, roundtrip, pinned/`--state` analyze) default to
+  `http://localhost:8080`; live targets (`run`, `analyze --live`, snapshot's
+  source) default to the stanza's `base_url`. publish's guard runs wherever
+  its `--base` points — no default; `--no-verify` skips it out loud.
+- `--set KEY=VALUE` — one-off config override (`run`/`analyze` only,
+  repeatable). Values take the stanza key's type — bool keys accept only
+  `true`/`false`, so `--set include_rewards=false` is really false; keys new
+  to the stanza stay strings. If you keep reaching for it, move the value
+  into `testbeds.toml`. `--set` applies after `--base`, so `--set base_url=…` wins when both are given.
+
+`run` produces traces and records the run to `testbed/tmp/<subject>.run.json`;
+`analyze --live` then analyzes it — for a `benchmark` it re-uses the last recorded
+run (no tau2 re-run), for an `intake` subject it analyzes the configured agent.
+Iterate on insight generation by re-running `analyze` as often as you like; `run`
+again only when you want fresh traces. (A benchmark `analyze --live` follows the
+base_url recorded at `run` time, so set `--base` on `run`.)
+
+## Breaking changes (2026-07-07)
+
+- **Deleted flags:** `--pinned` (it's the default), `--latest` (release-latest
+  is cross-subject and unsafe under per-subject pins), `--ref` and its `""`
+  sentinel, analyze's `--from` (folded into `--state FILE`), `--local`
+  everywhere (localhost is the default wherever a fixture is the target;
+  `--base` overrides).
+- **Fresh by default:** the old seed flag (`none|keep`) is gone — the seed flag became
+  `--update-insights` (the not-fresh flow), and bundles no longer carry insight
+  YAMLs at all (pure data fixtures; restore seeds run records only).
+- **CI:** the state-ref input is renamed `state` (empty = each subject's
+  `state.lock` pin); the seed input is deleted (runners start clean — CI is
+  inherently fresh).
+- **The `insights` command alias is gone** — one name: `analyze`.
+
+## State bundles
+
+Immutable per-subject fixtures on the `testbed-state` GitHub release, pinned in
+`testbed/state.lock` — analyst changes get measured against fixed data.
+
+Which file do I touch?
+
+| Surface              | Owns                                          |
+| -------------------- | --------------------------------------------- |
+| `testbeds.toml`      | what a subject is                             |
+| `testbed/state.lock` | which data version analysis runs against      |
+| flags                | this invocation only                          |
+| `testbed/.env`       | secrets                                       |
+| CI inputs            | 1:1 flag mirror                               |
+
+**Analyze against the pinned fixture (the everyday loop, and the default):**
+
+```bash
+uv run python -m testbed analyze tau2-airline
+```
+
+Downloads the subject's pinned state (its line under `[subjects]` in
+`testbed/state.lock`; a missing line is a hard error — no latest fallback),
+re-ingests it into fixture workspaces (`tau2-airline-state-v6`) on the local
+platform, and runs the Analyst live. Re-runs skip the ingest (idempotent).
+`--state state-vN` / `--state FILE` select another state; `--base URL`
+retargets the restore; `--update-insights` seeds the analyst with your local
+prior insights (default: fresh — the prior file is moved aside first). `since`
+is derived from the bundle's manifest, so old spans can't hide behind the read
+API's 30-day default lookback. (`--live` skips the restore entirely and
+analyzes the platform's live traces, with `since` from `--since`, the stanza,
+or a 30d default — in that order; the effective bound is always printed.)
+
+**Mint a new fixture (laptop or CI):**
+
+```bash
+uv run python -m testbed snapshot nvq -o testbed/tmp/nvq.tar.zst
+uv run python -m testbed publish testbed/tmp/nvq.tar.zst --base http://localhost:8080 --reason "why this exists"
+```
+
+`snapshot` drains the subject's workspaces (benchmark subjects: realistic +
+`-oracle` twin) into JSONL + manifest — no ClickHouse, no Docker. `publish`
+refuses to mint unverified: `--base` runs the round-trip fidelity guard there
+first (re-ingest into scratch workspaces → re-export → doc diff), or pass
+`--no-verify` to skip out loud (CI does; its guard runs as a separate step).
+Then pin it: add `nvq = "state-vN"` under `[subjects]` in `testbed/state.lock`.
+
+**Restore without analyzing:** `uv run python -m testbed restore (FILE | --state state-v7) [--base URL]`.
+
+What restore touches:
+
+- **Platform: additive only.** Ingests into `<ws>-<ref>` (`<ws>-<sha256[:8]>`
+  for local files); never writes into existing workspaces. Per-collection
+  guard: counts match → skip, empty → ingest, anything else → hard error.
+- **Local `testbed/tmp`: run records seeded.** The bundle's run records
+  replace yours — clobbered files are moved to `testbed/tmp/backup-<timestamp>/`
+  first, and only the bundle's own subjects' files are ever touched. Bundles
+  carry no insight YAMLs (fresh vs not-fresh is purely local state; see
+  `--update-insights`).
+- Accepted losses: annotation/evaluator-result `created_at`/`created_by` are
+  server-stamped at restore (the write APIs reject client values); a running
+  platform is required to analyze.
+- Legacy `state-v1..v5` tars were pruned from the release (the v4 corpus lives
+  on as `state-v6`); a stray local copy restores only from a checkout
+  predating the v6 migration.
+- Client-side re-ingest is a stopgap for the platform team's RBAC-scoped
+  server-side export/import endpoint; when that ships, snapshot/restore
+  collapse to two API calls each.
+
+Each benchmark `run` reuses **two stable workspaces** per subject — `<workspace>`
+(the realistic, oracle-free workspace the Analyst evaluates, blind) and
+`<workspace>-oracle` (the answer key + scores, for the UI). The stanza's `workspace`
+is that base name. Runs no longer mint a workspace each. Run isolation comes from
+the per-span `nemo.experiment.id=<run-id>` tag plus the Analyst's `evaluation_id`
+filter (which AND-pins every span read to that run) — that is what scopes the
+analysis. The matching **Experiment** entity registered on the `-oracle` workspace
+is metadata for the UI (run-picker + leaderboard), not the scoping mechanism. So
+workspaces stop accumulating and each run reads only its own traces. (Old runs'
+spans age out by Intake retention; the Experiment entities are cheap and
+soft-deletable.)
+
+Keys come from `testbed/.env` (see below), so the commands need no inline env. **`doctor`**
+prints a per-subject readiness checklist — on a fresh clone, run it first and it tells you
+exactly what to install/set (`✓ ready` or `✗ needs: …`).
+
+Subjects live in `testbeds.toml` — one table per subject, keyed by `type`:
+- `type = "intake"` — analyze an agent's existing Intake traces (config: `agent`, `workspace`, `base_url`, optional `since`).
+- `type = "benchmark"` — run a benchmark to produce traces, ingest them into Intake, then analyze (config: `domain`, `base_url`, `workspace`, `agent_llm`, `user_llm`, `task_split_name`, `num_trials`, `max_concurrency`, `seed`, optional `num_tasks`/`timeout`/`include_rewards`).
+
+`--since` (analyze `--live`, snapshot) accepts `Nd`/`Nh`/`Nm` (days/hours/minutes)
+or an ISO date; `--since ''` means no lower bound (the epoch). Insights are
+written to `testbed/tmp/insights_<name>.yaml`.
+
+## Config split: secrets in `.env`, everything else in `testbeds.toml`
+
+On startup the CLI auto-loads `testbed/.env` (gitignored) as `KEY=VALUE` lines. Keep
+**only secrets/endpoints** there — `INFERENCE_API_KEY` (analyst) and
+`OPENAI_API_KEY`/`OPENAI_API_BASE` (the proxy litellm uses for the benchmark sim LLMs).
+Real shell environment variables override the file. Everything non-secret (paths, models,
+ports, run sizes) lives in the subject's `testbeds.toml` stanza.
+
+## Benchmark prereqs (tau2-airline / tau2-retail)
+
+Clone tau2-bench as a sibling of this repo and install it once:
+
+```bash
+git clone https://github.com/sierra-research/tau2-bench   # sibling of nemo-insights plugin
+cd tau2-bench && uv sync          # Python 3.12+; installs the `tau2` CLI into .venv
+uv run tau2 check-data            # verify the shipped domain data
+```
+
+The `[tau2-airline]` and `[tau2-retail]` stanzas then need (all non-secret, committed):
+- `tau2_repo` — the checkout above; relative to this repo's root (`../tau2-bench`, the
+  sibling default) or absolute. Both the CLI (`<repo>/.venv/bin/tau2`) and the data dir
+  (`<repo>/data`) are derived from it (`tau2_bin`/`tau2_data_dir` override if needed).
+- `agent_llm`/`user_llm` — models your proxy key serves (`GET {OPENAI_API_BASE}/v1/models`);
+  default `openai/nvidia/nvidia/nemotron-3-super-v3`.
+- `base_url` — a reachable NeMo Platform (default `http://localhost:8080`).
+
+With `testbed/.env` holding the three secrets, run:
+
+```bash
+uv run python -m testbed run tau2-airline
+uv run python -m testbed analyze tau2-airline --live
+
+uv run python -m testbed run tau2-retail
+uv run python -m testbed analyze tau2-retail --live
+```
+
+## CI (`.github/workflows/testbed-insights.yml`)
+
+CI runs the testbed against a **self-contained platform inside the job**
+(ClickHouse + `auth,entities,intake` from a `nemo-platform` checkout) — the
+freeplay remote is not reachable from GitHub-hosted runners. The workflow's
+steps are thin wrappers over the same CLI you run locally (`testbed restore`
+/ `analyze` / `snapshot` / `roundtrip` / `publish`); the shared
+helpers live in `testbed/eval/` (stdlib-only `plan.py`/`prep.py`/
+`run_subjects.py` run on the bare runner before `uv sync`). Dispatch inputs
+mirror the CLI flags 1:1 (`mode`, `subjects`, `state`, `num_tasks`,
+`num_trials`, `publish_state`, `reason`). Three modes, all validated **green
+on real GitHub Actions** (branch `testbed-ci-insights`; API-export pipeline:
+stack-check
+[run 28880210091](https://github.com/NVIDIA-dev/nemo-insights plugin/actions/runs/28880210091),
+analyze vs `state-v6`
+[run 28880474684](https://github.com/NVIDIA-dev/nemo-insights plugin/actions/runs/28880474684)
+(966 spans re-ingested into `<ws>-state-v6` fixtures), produce smoke ×2 tasks
+[run 28881101719](https://github.com/NVIDIA-dev/nemo-insights plugin/actions/runs/28881101719)
+— round-trip guard green in CI, candidate uploaded, publish skipped on the
+validation trigger):
+
+- `stack-check` — bring the stack up, verify `/ping` + `/health/ready`, exit.
+  Cheap CI doctor.
+- `produce` — **explicit dispatch only** (hard-gated to `workflow_dispatch`): a
+  human mints a new fixture when there's a reason — tau2-bench update, agent/sim
+  config change, staleness refresh. Never runs from PRs or any automatic
+  trigger. Fixtures mint from the fresh in-job stack (no base restore):
+  `run_subjects.py` runs the subjects (`subjects=tau2-airline,...`,
+  override size with `num_tasks=`/`num_trials=`; analyze retries absorb
+  post-sim rate-limit heat) with `--base http://localhost:8080`, then
+  `testbed snapshot` exports an **unminted candidate bundle** that is always
+  uploaded as workflow artifact `state-candidate-<run_id>-<attempt>` (even on
+  failure — failed runs never mint a version, they just leave their candidate
+  for inspection; there are no `-failed` refs), and `testbed roundtrip` proves
+  the candidate re-ingests with full read-API fidelity. Only on success does
+  `testbed publish` (`--no-verify`: the guard ran as its own step) mint the
+  next `state-v<N>` — it resolves the next free version at publish time,
+  uploads the asset to the `testbed-state` release, and prepends a row to the
+  **fixture catalog** in the release notes (version, contents, the `reason`
+  input, minted-by). The same `testbed publish` runs from a laptop (that is how
+  `state-v6` was minted). Serialized via a `testbed-state-produce` concurrency
+  group so bundles never race.
+- `analyze` — `testbed analyze "$SUBJECT" ${STATE:+--state "$STATE"}
+  --summary-md "$GITHUB_STEP_SUMMARY"`: an empty `state` input means bare
+  analyze — each subject's own pin under `[subjects]` in `testbed/state.lock`
+  (a subject without an entry fails loudly — no latest fallback); a non-empty
+  ref overrides the lock for **all** subjects in the run. The state is
+  re-ingested into its fixture workspaces (`<ws>-<ref>`) on the in-job
+  platform, insights regenerate and upload as artifact
+  `insights-<subject>-<run_id>-<attempt>` (a `### analyze @ <ref> (<subject>)`
+  line is appended to the step summary right after the restore, ahead of the
+  insights themselves). Runners start clean, so CI is inherently fresh — no
+  priors, no knob. Re-running analyze against a byte-identical state and
+  diffing the resulting Insights is the reliability signal ("pass^k for
+  insights") this pipeline exists to surface, not noise to suppress.
+
+**One PR = one state per subject:** `pull_request` events (paths under `src/`
+or `testbed/`) force `mode=analyze` against `tau2-airline` and additionally
+require the `run-insights` label, so every labeled push analyzes the same
+pinned state and insight diffs are attributable to code, not state drift.
+States are per-produce-dispatch compositions, so subjects pin different
+versions — each under `[subjects]` in `testbed/state.lock`; a subject with no
+entry errors (add its line after minting a fixture). Lock-bump PRs edit the
+subject's line; bump on `main` to advance that subject's shared baseline after
+a `produce` run. The dispatch `state` input still overrides the lock for
+**all** subjects in that run.
+
+### Dispatching a run
+
+`workflow_dispatch` (and `gh workflow run`) only becomes available once the
+workflow file has landed on the repository's **default branch** — a GitHub
+registration requirement (dispatching from a feature branch 404s). After the
+merge, verify with `gh workflow run testbed-insights.yml -f mode=stack-check`,
+then:
+
+```bash
+gh workflow run testbed-insights.yml -f mode=stack-check
+gh workflow run testbed-insights.yml -f mode=produce -f subjects=tau2-airline -f num_tasks=2 \
+  -f reason="2-task smoke after tau2-bench bump"   # reason lands in the release's fixture catalog
+gh workflow run testbed-insights.yml -f mode=analyze                    # each subject's state.lock pin
+gh workflow run testbed-insights.yml -f mode=analyze -f state=state-v6  # explicit override, all subjects
+```
+
+### Pre-merge checklist: validating workflow changes from a branch
+
+Because dispatch requires the default branch, workflow changes are validated
+from the feature branch with a **temporary push trigger** before merge:
+
+1. Add `push: {branches: [<your-branch>]}` plus, for each dispatch input a
+   round needs, a temporary event-scoped fallback arm in the workflow env —
+   `inputs.x`, falling back on push events to a repo variable
+   (`gh variable set TESTBED_X --body ...`) — every arm marked `# TEMPORARY`.
+   produce's dispatch-only event gate needs a temporary
+   `|| github.event_name == 'push'` arm; leave the publish step
+   dispatch-gated so a validation run can never mint.
+2. Drive rounds by setting the variables (e.g. `gh variable set TESTBED_MODE
+   --body produce`) plus a trivial trigger commit; watch `gh run list` /
+   `gh run view --log-failed` (runs take 5–20 min).
+3. Cleanup before merge: remove the push trigger and every `TEMPORARY` arm,
+   `gh variable delete` each temporary variable, and confirm the PR's
+   `pull_request` run all-skips without the `run-insights` label.
+
+### Public-runner constraints
+
+GitHub-hosted runners are unauthenticated and this org allowlists Actions by
+pinned SHA, which shaped the composites in `.github/actions/`:
+- `uv` is curl-installed and pinned to `0.9.14` — the org's allowlist pins
+  `astral-sh/setup-uv` to specific commit SHAs (no `@v*` wildcard), and
+  `nemo-platform`'s `pyproject.toml` requires `uv >=0.9.14,<0.10.0` (latest
+  `0.11.x` is rejected).
+
+### State model
+
+Bundles are immutable `state-v<N>` tarballs — `export/<workspace>/*.jsonl`
+(spans, annotations, evaluator results), `tmp/` (run records only — insights
+never travel in bundles), `manifest.json` (per-workspace counts, span time
+bounds, source URL, platform build, CI lineage) — stored both as a workflow
+artifact and as an asset on the `testbed-state` release. Versions are
+**minted at publish time** (candidate → round-trip guard → mint): only a
+successful guard's publish claims the next `state-v<N>` and prepends its
+catalog row, so failed runs can never burn or collide on a version number.
+Restores are additive re-ingests into `<ws>-<ref>` fixture workspaces, so a
+bundle never perturbs anything else on the target platform; ClickHouse's TTL
+merges are stopped on every CI stack start so restored spans don't age out
+mid-run. `testbed/state.lock` pins, per subject (`[subjects]` table), the
+version `analyze` uses by default (currently `tau2-airline = "state-v6"`, the
+first API-export bundle, and `nvq = "state-v7"`) — a subject without an entry
+hard-errors rather than falling back to latest. Bump a subject's line
+deliberately after a mint you want as its new shared baseline, or override
+per-run with the dispatch `state` input (applies to every subject in the run;
+locally: `analyze <subject> --state state-vN`).
+
+Secrets: one repo secret, `INFERENCE_API_KEY` (the inference-gateway key; the
+workflow also exposes it as `OPENAI_API_KEY` for litellm/tau2). The analyst and
+the tau2 sim LLMs both reach `inference-api.nvidia.com` (public), so `produce`
+and `analyze` need no VPN and work unmodified on public runners.

--- a/plugins/nemo-insights/testbed/README.md
+++ b/plugins/nemo-insights/testbed/README.md
@@ -202,11 +202,11 @@ mirror the CLI flags 1:1 (`mode`, `subjects`, `state`, `num_tasks`,
 `num_trials`, `publish_state`, `reason`). Three modes, all validated **green
 on real GitHub Actions** (branch `testbed-ci-insights`; API-export pipeline:
 stack-check
-[run 28880210091](https://github.com/NVIDIA-dev/nemo-insights plugin/actions/runs/28880210091),
+[run 28880210091](https://github.com/NVIDIA-dev/NeMo-Optimizer/actions/runs/28880210091),
 analyze vs `state-v6`
-[run 28880474684](https://github.com/NVIDIA-dev/nemo-insights plugin/actions/runs/28880474684)
+[run 28880474684](https://github.com/NVIDIA-dev/NeMo-Optimizer/actions/runs/28880474684)
 (966 spans re-ingested into `<ws>-state-v6` fixtures), produce smoke ×2 tasks
-[run 28881101719](https://github.com/NVIDIA-dev/nemo-insights plugin/actions/runs/28881101719)
+[run 28881101719](https://github.com/NVIDIA-dev/NeMo-Optimizer/actions/runs/28881101719)
 — round-trip guard green in CI, candidate uploaded, publish skipped on the
 validation trigger):
 

--- a/plugins/nemo-insights/testbed/__main__.py
+++ b/plugins/nemo-insights/testbed/__main__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from testbed.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/plugins/nemo-insights/testbed/adapters.py
+++ b/plugins/nemo-insights/testbed/adapters.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-type testbed adapters that turn a subject into analyst Insights."""
+
+import os
+import shutil
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol
+
+import httpx
+from nemo_insights_plugin.analyst.run import run_analyst
+from testbed.ingest import (
+    create_experiment,
+    ensure_experiment_group,
+    ensure_workspace,
+    mint_agent_id,
+    poll_visible,
+)
+from testbed.otlp_build import session_id_for, sim_to_spans
+from testbed.otlp_ingest import export_spans, post_evaluator_results, trace_id_for
+from testbed.registry import Subject
+from testbed.tau2run import load_tasks, policy_version, read_policy, resolve_paths, run_tau2
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestbedAdapter(Protocol):
+    def check(self) -> list[str]: ...
+
+    async def produce(self) -> dict[str, object]: ...
+
+    async def analyze(
+        self,
+        *,
+        record: dict[str, object] | None,
+        since: datetime | None,
+        verbose: bool,
+        out_path: Path,
+    ) -> str: ...
+
+
+class IntakeAdapter:
+    """Analyze an agent's existing Intake traces (no production step)."""
+
+    def __init__(self, subject: Subject) -> None:
+        self.subject = subject
+
+    def check(self) -> list[str]:
+        """Unmet prerequisites for this subject (empty list = ready to run)."""
+        cfg = self.subject.config
+        return [f"config key '{k}'" for k in ("agent", "workspace", "base_url") if not cfg.get(k)]
+
+    async def produce(self) -> dict[str, object]:
+        raise SystemExit(
+            f"intake subject '{self.subject.name}' has no produce step — run "
+            f"`uv run python -m testbed analyze {self.subject.name} --live`"
+        )
+
+    async def analyze(
+        self,
+        *,
+        record: dict[str, object] | None,
+        since: datetime | None,
+        verbose: bool,
+        out_path: Path,
+    ) -> str:
+        cfg = self.subject.config
+        if missing := self.check():
+            raise SystemExit(f"intake testbed '{self.subject.name}' is missing: {', '.join(missing)}")
+        return await run_analyst(
+            agent=cfg["agent"],
+            agent_spec=None,
+            workspace=cfg["workspace"],
+            base_url=cfg["base_url"],
+            insights_output=str(out_path),
+            verbose=verbose,
+            since=since,
+        )
+
+
+class BenchmarkAdapter:
+    """Run a benchmark to produce traces, ingest them, then analyze."""
+
+    def __init__(self, subject: Subject) -> None:
+        self.subject = subject
+
+    def check(self) -> list[str]:
+        """Unmet prerequisites for this benchmark (empty list = ready to run)."""
+        cfg = self.subject.config
+        missing: list[str] = []
+        for key in ("domain", "base_url", "workspace", "agent_llm", "user_llm"):
+            val = cfg.get(key)
+            if not val:
+                missing.append(f"config key '{key}'")
+            elif key in ("agent_llm", "user_llm") and "<your-model>" in str(val):
+                missing.append(f"a real model for '{key}' in testbeds.toml (a model your proxy key serves)")
+        # The keys build_argv hard-indexes: absent here = a KeyError mid-run, so
+        # doctor must name them up front. Absence only — 0 is a valid seed.
+        for key in ("task_split_name", "num_trials", "seed", "max_concurrency"):
+            if cfg.get(key) is None:
+                missing.append(f"config key '{key}'")
+        tau2_bin, data_dir = resolve_paths(cfg, repo_root=REPO_ROOT)
+        if tau2_bin is None or data_dir is None:
+            missing.append("config key 'tau2_repo' (your tau2-bench checkout; or set tau2_bin/tau2_data_dir)")
+        else:
+            if not data_dir.is_dir():
+                missing.append(f"tau2 data dir ({data_dir}) — clone tau2-bench + `uv sync`")
+            if shutil.which(tau2_bin) is None:
+                missing.append(f"tau2 binary ({tau2_bin}) — run `uv sync` in the tau2 repo")
+        for env_key in ("OPENAI_API_KEY", "OPENAI_API_BASE"):
+            if not os.environ.get(env_key):
+                missing.append(f"env {env_key} (in testbed/.env)")
+        return missing
+
+    async def produce(self) -> dict[str, object]:
+        cfg = self.subject.config
+        if missing := self.check():
+            raise SystemExit(f"benchmark testbed '{self.subject.name}' is missing: " + "; ".join(missing))
+        tau2_bin, data_dir = resolve_paths(cfg, repo_root=REPO_ROOT)
+        assert tau2_bin is not None and data_dir is not None  # guaranteed by check()
+        domain = str(cfg["domain"])
+        base_url = str(cfg["base_url"])
+        base = str(cfg["workspace"])  # stable workspace + agent + experiment-group name
+        run_id = mint_agent_id(base)  # the per-run Experiment name + nemo.experiment.id tag
+        agent = base  # stable agent name across runs
+        created_at = datetime.now(timezone.utc).isoformat()
+        # Stable workspaces: the realistic (oracle-free, blind-eval) target is always
+        # produced; the oracle twin (answer key, for the UI) only when include_rewards.
+        realistic_workspace = base
+        include_rewards = bool(cfg.get("include_rewards", True))
+        oracle_workspace = f"{base}-oracle" if include_rewards else None
+        dataset_name = f"tau2:{domain}"
+        ensure_workspace(base_url, realistic_workspace)  # fail fast before tau2
+        if oracle_workspace is not None:
+            ensure_workspace(base_url, oracle_workspace)
+        sims = run_tau2(cfg, run_id, data_dir=data_dir, tau2_bin=tau2_bin)
+        if not sims:
+            raise SystemExit(f"benchmark testbed '{self.subject.name}': tau2 produced no simulations")
+        policy = read_policy(data_dir, domain)
+        version = policy_version(policy)
+        tasks = load_tasks(data_dir, domain)
+        agent_llm = str(cfg["agent_llm"])
+        # Register this run as an Experiment on the oracle workspace (where the UI
+        # reads it). The realistic side needs only the span tag, not the entity.
+        if oracle_workspace is not None:
+            group_id = ensure_experiment_group(base_url, oracle_workspace, base)
+            create_experiment(
+                base_url,
+                oracle_workspace,
+                name=run_id,
+                experiment_group_id=group_id,
+                dataset_name=dataset_name,
+                dataset_version=version,
+                metadata={
+                    "agent_llm": agent_llm,
+                    "user_llm": str(cfg.get("user_llm", "")),
+                    "num_trials": cfg.get("num_trials"),
+                    "seed": cfg.get("seed"),
+                    "task_split_name": cfg.get("task_split_name"),
+                    "num_tasks": cfg.get("num_tasks"),
+                    "created_at": created_at,
+                },
+            )
+        session_ids: set[str] = set()
+        client = httpx.Client(timeout=30.0)
+        try:
+            for sim in sims:
+                task = tasks.get(str(sim.get("task_id")))
+                session_id = session_id_for(sim, experiment_id=run_id)
+                trace_id = trace_id_for(session_id)
+                # Stamp spans at ingest time (Intake drops spans dated outside its
+                # retention window); one base shared by a sim's realistic + oracle twins.
+                base_ns = time.time_ns()
+                session_ids.add(session_id)
+                realistic_spans = sim_to_spans(
+                    sim,
+                    agent_name=agent,
+                    agent_version=version,
+                    session_id=session_id,
+                    experiment_id=run_id,
+                    task=task,
+                    include_rewards=False,
+                    agent_llm=agent_llm,
+                    base_ns=base_ns,
+                )
+                export_spans(base_url, realistic_workspace, session_id, trace_id, realistic_spans, client=client)
+                if oracle_workspace is not None:
+                    oracle_spans = sim_to_spans(
+                        sim,
+                        agent_name=agent,
+                        agent_version=version,
+                        session_id=session_id,
+                        experiment_id=run_id,
+                        task=task,
+                        include_rewards=True,
+                        agent_llm=agent_llm,
+                        base_ns=base_ns,
+                    )
+                    export_spans(base_url, oracle_workspace, session_id, trace_id, oracle_spans, client=client)
+                    # OTLP doesn't auto-create the reward row the Analyst reads, so POST it
+                    # separately, targeting the EVALUATOR span this oracle build emitted.
+                    evaluator = next((s for s in oracle_spans if s["kind"] == "EVALUATOR"), None)
+                    if evaluator is not None:
+                        post_evaluator_results(
+                            base_url,
+                            oracle_workspace,
+                            span_id=evaluator["span_id"],
+                            session_id=session_id,
+                            score=float(evaluator["attributes"]["score"]),
+                            client=client,
+                        )
+            if len(session_ids) < 3:
+                print(
+                    f"warning: only {len(session_ids)} session(s) ingested; the analyst needs 3+ to run.",
+                    file=sys.stderr,
+                )
+            visible = poll_visible(base_url, realistic_workspace, session_ids, client=client)
+            if len(visible) < 3:
+                print(
+                    f"warning: only {len(visible)}/{len(session_ids)} session(s) "
+                    "visible in Intake (ingest may still be catching up).",
+                    file=sys.stderr,
+                )
+            if oracle_workspace is not None:
+                poll_visible(base_url, oracle_workspace, session_ids, client=client)
+        finally:
+            client.close()
+        return {
+            "agent": agent,
+            "realistic_workspace": realistic_workspace,
+            "oracle_workspace": oracle_workspace,
+            "experiment_id": run_id,
+            "experiment_group": base,
+            "dataset_name": dataset_name,
+            "dataset_version": version,
+            "base_url": base_url,
+            "domain": domain,
+            "run_id": run_id,
+            "agent_version": version,
+            "created_at": created_at,
+        }
+
+    async def analyze(
+        self,
+        *,
+        record: dict[str, object] | None,
+        since: datetime | None,
+        verbose: bool,
+        out_path: Path,
+    ) -> str:
+        if record is None:
+            raise SystemExit(
+                f"no recorded run for '{self.subject.name}' — run "
+                f"`uv run python -m testbed run {self.subject.name}` first"
+            )
+        _, data_dir = resolve_paths(self.subject.config, repo_root=REPO_ROOT)
+        policy = read_policy(data_dir, str(record["domain"])) if data_dir else None
+        workspace = str(record["realistic_workspace"])
+        evaluation_id = str(record["experiment_id"])
+        print(
+            f"analyzing realistic workspace '{workspace}' run '{evaluation_id}' (oracle withheld — unaided eval)",
+            file=sys.stderr,
+        )
+        return await run_analyst(
+            agent=str(record["agent"]),
+            agent_spec=policy,
+            workspace=workspace,
+            base_url=str(record["base_url"]),
+            insights_output=str(out_path),
+            verbose=verbose,
+            since=since,
+            evaluation_id=evaluation_id,
+        )
+
+
+_ADAPTERS: dict[str, type[IntakeAdapter] | type[BenchmarkAdapter]] = {
+    "intake": IntakeAdapter,
+    "benchmark": BenchmarkAdapter,
+}
+
+
+def build_adapter(subject: Subject) -> TestbedAdapter:
+    """Construct the adapter for a subject's ``type``."""
+    cls = _ADAPTERS.get(subject.type)
+    if cls is None:
+        raise SystemExit(
+            f"testbed '{subject.name}' has unknown type '{subject.type}'. Known types: {', '.join(sorted(_ADAPTERS))}."
+        )
+    return cls(subject)

--- a/plugins/nemo-insights/testbed/artifact.py
+++ b/plugins/nemo-insights/testbed/artifact.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Snapshot the platform's testbed state as portable export bundles.
+
+Snapshot (capture) is a read-API export: :func:`snapshot_export` drains each
+subject's workspaces through :mod:`testbed.export` into a JSONL bundle
+(``kind: testbed-export``) — it works against any platform URL and never
+touches ClickHouse directly.
+
+Restore lives in :mod:`testbed.reingest`: an additive, idempotent re-ingest
+into fixture-scoped workspaces through the real APIs. Legacy tar bundles
+(state-v1..v5) are restorable only from a pre-migration checkout.
+"""
+
+import datetime
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+
+import httpx
+from testbed import export
+from testbed.registry import Subject
+
+LOCAL_URL = "http://localhost:8080"  # the local NeMo Platform (the default restore/analyze target)
+
+
+def pick_records(tmp_dir: Path, subjects: list[str]) -> list[Path]:
+    """The selected *subjects*' run records present in *tmp_dir* (sorted).
+
+    Scoped by name (``<subject>.run.json``) so a bundle never captures another
+    subject's records that happen to sit in the shared ``testbed/tmp``
+    directory. Insight YAMLs never travel in bundles: insights are per-analyze
+    output, not state (``analyze`` is fresh by default; ``--update-insights``
+    seeds the analyst from the local file).
+    """
+    names = {f"{s}.run.json" for s in subjects}
+    return sorted(p for p in (tmp_dir / n for n in names) if p.is_file())
+
+
+# manifest key -> env var it is sourced from (CI produce job; parity with the old bundle.py)
+_LINEAGE_ENV = {
+    "nemo_platform_sha": "GITHUB_SHA",
+    "tau2_bench_sha": "TAU2_BENCH_REF",
+    "github_run_id": "GITHUB_RUN_ID",
+    "num_tasks": "NUM_TASKS",
+    "num_trials": "NUM_TRIALS",
+    "judge_llm": "TAU2_JUDGE_LLM",
+    "reason": "REASON",
+}
+
+
+def build_export_manifest(
+    subjects: list[str],
+    records: list[Path],
+    stats: dict,
+    *,
+    source_url: str,
+    platform_info: dict | None,
+    env: Mapping[str, str] | None = None,
+) -> dict:
+    """Export-bundle manifest; CI lineage fields are merged in only when their env vars are set.
+
+    *stats* is :func:`testbed.export.export_workspaces`'s return value (per-collection
+    counts + span time bounds). *platform_info* is :func:`fetch_platform_info`'s
+    best-effort answer (None when the platform didn't say). Laptop snapshots (no CI
+    env) keep the lite manifest.
+    """
+    manifest = {
+        "kind": "testbed-export",
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "source_url": source_url,
+        "subjects": sorted(subjects),
+        "workspaces": sorted(stats["workspaces"]),
+        "counts": stats["workspaces"],
+        "min_start_time": stats["min_start_time"],
+        "max_start_time": stats["max_start_time"],
+        "platform_version": (platform_info or {}).get("platform_version"),
+        "platform_revision": (platform_info or {}).get("revision"),
+        "records": [r.name for r in records],
+    }
+    env = env or {}
+    manifest |= {key: env[var] for key, var in _LINEAGE_ENV.items() if env.get(var)}
+    return manifest
+
+
+def fetch_platform_info(base_url: str) -> dict | None:
+    """Best-effort platform identity from ``GET /cluster-info`` (None when it can't say).
+
+    The platform serves ``{"platform_version": ..., "revision": ...}`` on an
+    unauthenticated route; recording it pins which platform build minted the
+    bundle (a later task's attribute-catalog inversion keys off it).
+    """
+    try:
+        resp = httpx.get(f"{base_url.rstrip('/')}/cluster-info", timeout=10.0)
+        resp.raise_for_status()
+        data = resp.json()
+        return {"platform_version": data.get("platform_version"), "revision": data.get("revision")}
+    except Exception:
+        return None
+
+
+def workspaces_for_subject(subject: Subject) -> list[str]:
+    """The intake workspaces a subject's export must capture.
+
+    Benchmark subjects own their realistic workspace plus the ``-oracle`` twin
+    (the answer key) unless ``include_rewards`` is off; intake subjects own just
+    their workspace. Any other type has no owned-workspace scoping rule, so it
+    is a hard error.
+    """
+    workspace = str(subject.config.get("workspace") or "")
+    if not workspace:
+        sys.exit(f"snapshot: subject '{subject.name}' has no workspace configured")
+    if subject.type == "benchmark":
+        if subject.config.get("include_rewards", True):
+            return [workspace, f"{workspace}-oracle"]
+        return [workspace]
+    if subject.type == "intake":
+        return [workspace]
+    sys.exit(
+        f"snapshot: subject '{subject.name}' has type '{subject.type}' — only 'benchmark' and "
+        "'intake' subjects own intake workspaces to export (this type has no workspace-scoping rule)"
+    )
+
+
+def backup_records(testbed_tmp: Path, names: list[str], *, backup_dir: Path | None = None) -> Path:
+    """Move the named local files into *backup_dir* (default ``<testbed_tmp>/backup-<UTC stamp>/``);
+    returns that dir.
+
+    The shared no-silent-destruction mechanism: restores park clobbered local
+    records here, and fresh-by-default analyze parks the prior insights YAML
+    here — nothing in ``testbed/tmp`` is ever deleted, only moved (no prompt —
+    CI-safe). Callers print their own one-liner naming the moved files. A CLI
+    invocation that backs up more than once (analyze: the restore's
+    clobber-backup, then the fresh-insights move) passes one *backup_dir* so a
+    single command yields a single backup dir, not one per stamp.
+    """
+    if backup_dir is None:
+        # Microseconds keep two invocations within the same second from sharing a dir.
+        stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+        backup_dir = testbed_tmp / f"backup-{stamp}"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        shutil.move(testbed_tmp / name, backup_dir / name)
+    return backup_dir
+
+
+def seed_records(state_tmp: Path, testbed_tmp: Path, *, backup_dir: Path | None = None) -> tuple[str, list[str]]:
+    """Copy the bundle's ``tmp/`` run records beside the local ones; ``(message, seeded names)``.
+
+    Only ``*.run.json`` files travel: insights are per-analyze output, not
+    state, so any ``insights_*.yaml`` a pre-cutover bundle still carries is
+    ignored (and local insight YAMLs are never touched — the fresh/keep choice
+    lives in the analyze CLI). Never destroys local state silently: any local
+    record the bundle is about to overwrite is first moved into *backup_dir*
+    (default: a fresh ``<testbed_tmp>/backup-<UTC stamp>/``) with one printed
+    line saying so.
+    """
+    testbed_tmp.mkdir(parents=True, exist_ok=True)
+    bundle_files = sorted(p for p in state_tmp.glob("*.run.json") if p.is_file()) if state_tmp.is_dir() else []
+    clobbered = [p.name for p in bundle_files if (testbed_tmp / p.name).exists()]
+    if clobbered:
+        backup_dir = backup_records(testbed_tmp, clobbered, backup_dir=backup_dir)
+        print(f"backed up {len(clobbered)} local record(s) to {backup_dir}: {', '.join(clobbered)}")
+    for item in bundle_files:
+        shutil.copy2(item, testbed_tmp / item.name)
+    seeded = [p.name for p in bundle_files]
+    if not seeded:
+        return "the bundle carries no run records", seeded
+    return f"seeded {len(seeded)} run record(s) from the bundle: {', '.join(seeded)}", seeded
+
+
+def snapshot_export(
+    subjects: list[Subject],
+    out: Path,
+    tmp_dir: Path,
+    *,
+    since: datetime.datetime | None,
+) -> Path:
+    """Export the subjects' workspaces from the read API into one bundle at *out*.
+
+    Bundle layout matches the legacy tar (root ``state/``) but the payload is
+    ``export/<workspace>/*.jsonl`` from :func:`testbed.export.export_workspaces`
+    plus the ``tmp/`` run records and a ``kind: testbed-export`` manifest.
+    Source URL is each subject's stanza ``base_url`` (they must agree; the
+    CLI's ``--base`` override rewrites every stanza before this is called).
+    """
+    workspaces: list[str] = []
+    for subject in subjects:
+        for workspace in workspaces_for_subject(subject):
+            if workspace not in workspaces:
+                workspaces.append(workspace)
+    # Every selected subject must carry a base_url: a partial miss would silently
+    # let the agreement check pass on the configured subset and export the
+    # unconfigured subject from the others' platform.
+    missing = [s.name for s in subjects if not s.config.get("base_url")]
+    if missing:
+        sys.exit("snapshot: no base_url configured for subject(s) " + ", ".join(missing) + " (pass --base URL?)")
+    urls = {str(s.config["base_url"]) for s in subjects}
+    if not urls:
+        sys.exit("snapshot: no base_url configured for the selected subjects (pass --base URL?)")
+    if len(urls) > 1:
+        sys.exit(
+            "snapshot: subjects disagree on base_url (" + ", ".join(sorted(urls)) + ") — "
+            "snapshot them separately or pass --base URL"
+        )
+    source_url = urls.pop()
+    records = pick_records(tmp_dir, [s.name for s in subjects])
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=tmp_dir) as tmp:
+        state = Path(tmp) / "state"
+        (state / "tmp").mkdir(parents=True)
+        stats = export.export_workspaces(source_url, workspaces, state, since=since)
+        for rec in records:
+            shutil.copy2(rec, state / "tmp" / rec.name)
+        manifest = build_export_manifest(
+            [s.name for s in subjects],
+            records,
+            stats,
+            source_url=source_url,
+            platform_info=fetch_platform_info(source_url),
+            env=os.environ,
+        )
+        (state / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+        subprocess.run(["tar", "--zstd", "-cf", str(out), "-C", tmp, "state"], check=True)
+    print(f"export bundle written to {out}")
+    return out

--- a/plugins/nemo-insights/testbed/cli.py
+++ b/plugins/nemo-insights/testbed/cli.py
@@ -1,0 +1,866 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""`testbed` — a test runner for the optimization loop (maintainer tooling).
+
+    uv run python -m testbed list
+    uv run python -m testbed doctor [<name>]
+    uv run python -m testbed run <name> [--base URL] [--set KEY=VALUE ...]                     # benchmark: produce traces + record the run
+    uv run python -m testbed analyze <name> [--update-insights] [--base URL] [--platform-root PATH]  # reproducible default: restore the subject's pinned state, then analyze
+    uv run python -m testbed analyze <name> --state (state-vN | FILE)                          # same, against another published state or a local bundle file
+    uv run python -m testbed analyze <name> --live [--since S] [-v] [--set KEY=VALUE ...]      # analyze the platform's live traces (no restore)
+    uv run python -m testbed snapshot <subject> [...] [-o FILE] [--base URL] [--since S]       # export subject workspaces (read API) into a state bundle
+    uv run python -m testbed restore (FILE | --state state-vN) [--base URL] [--platform-root PATH]  # re-ingest an export bundle (additive, fixture workspaces)
+    uv run python -m testbed roundtrip FILE [--base URL] [--platform-root PATH]                # mint-time fidelity guard: re-ingest into scratch, re-export, diff
+    uv run python -m testbed publish FILE (--base URL | --no-verify) [--reason TEXT] [--platform-root PATH]  # mint the next state-v<N> from a candidate bundle and catalog it (guard first, or skip out loud)
+
+Bare `analyze <subject>` is a fully reproducible run: the subject's pinned state
+(from `[subjects]` in testbed/state.lock) is restored onto the local platform
+(http://localhost:8080) and analyzed. Every deviation is one explicit flag:
+`--state` picks another state, `--live` skips the restore and reads the live
+platform, and `--base URL` retargets any command's platform (restore/analyze
+target; run/snapshot/`analyze --live` source, replacing the stanza base_url).
+
+Export bundles (`kind: testbed-export`) restore by re-ingesting through the real
+APIs into fixture-scoped workspaces (`<ws>-<ref>` for published refs,
+`<ws>-<sha256[:8]>` for local files) — additive and idempotent, never touching
+existing data. Legacy tar bundles (state-v1..v5) are restorable only from a
+pre-migration checkout; see testbed/README.md.
+
+This drives the analyst (`nemo insights analyze`) against registered subjects; it is not
+the product CLI and is not shipped in the wheel.
+"""
+
+import argparse
+import asyncio
+import datetime
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+from testbed import artifact, publish, reingest, release
+from testbed.adapters import build_adapter
+from testbed.export import EPOCH
+from testbed.registry import Subject, load_registry
+from testbed.runstore import load_run, save_run
+from testbed.summary import render_summary_md
+from testbed.timeparse import parse_since
+
+HERE = Path(__file__).parent
+REGISTRY_PATH = HERE / "testbeds.toml"
+TMP = HERE / "tmp"
+ENV_PATH = HERE / ".env"
+LOCAL_URL = artifact.LOCAL_URL  # the local NeMo Platform (the default restore/analyze target)
+
+
+def _load_dotenv(path: Path = ENV_PATH) -> None:
+    """Load ``KEY=VALUE`` lines from a .env file into ``os.environ``.
+
+    A no-op if the file is absent. Existing environment variables win
+    (``setdefault``), so a real shell value overrides the file per run. Lines
+    that are blank, ``#`` comments, or have no ``=`` are skipped; an optional
+    ``export`` prefix and surrounding quotes are stripped.
+    """
+    if not path.exists():
+        return
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.removeprefix("export ").strip()
+        # naive: trims surrounding quotes, not paired-quote matching (matches python-dotenv's laxity)
+        value = value.strip().strip('"').strip("'")
+        if key:
+            os.environ.setdefault(key, value)
+
+
+def _doctor(subjects: dict[str, Subject], name: str | None) -> None:
+    """Print a readiness checklist for one subject (or all): what's set up, what's not."""
+    names = [name] if name else sorted(subjects)
+    for subject_name in names:
+        subject = subjects.get(subject_name)
+        if subject is None:
+            print(f"✗ {subject_name}: unknown subject")
+            continue
+        unmet: list[str] = []
+        if not os.environ.get("INFERENCE_API_KEY"):
+            unmet.append("env INFERENCE_API_KEY (analyst key, in testbed/.env)")
+        if shutil.which("gh") is None:
+            unmet.append("gh CLI (needed for pinned/--state analyze; https://cli.github.com)")
+        unmet += build_adapter(subject).check()
+        if unmet:
+            print(f"✗ {subject_name} ({subject.type}) — needs:")
+            for item in unmet:
+                print(f"    - {item}")
+        else:
+            print(f"✓ {subject_name} ({subject.type}) — ready: uv run python -m testbed analyze {subject_name} --live")
+
+
+def _with_base(subject: Subject, base: str | None) -> Subject:
+    """Rebuild *subject* pointed at *base* (the uniform ``--base`` override); unchanged when None."""
+    if base is None:
+        return subject
+    return Subject(subject.name, subject.type, {**subject.config, "base_url": base})
+
+
+def _local_source(args: argparse.Namespace) -> str | None:
+    """The local bundle file given on the command line, if any.
+
+    ``restore`` takes it as the positional ``FILE`` (its ``--state`` is
+    refs-only); ``analyze``'s ``--state`` doubles as the file source when its
+    value names an existing FILE (``is_file``, so a directory that happens to
+    carry a ref's name falls through to ref resolution) — checked before the
+    ``state-v<N>`` pattern, so a ref-shaped filename still restores the file.
+    """
+    if file := getattr(args, "file", None):
+        return str(file)
+    state = getattr(args, "state", None)
+    if args.cmd == "analyze" and state and Path(state).is_file():
+        return state
+    return None
+
+
+def _resolve_bundle(args: argparse.Namespace) -> tuple[Path, str, str]:
+    """The state bundle to restore, as ``(bundle_path, label, fixture_suffix)``.
+
+    A local file source is used in place: *label* is its filename plus a
+    ``(local file <digest8>)`` marker — so a provenance line can never pass a
+    local file off as a published ref — and the fixture-workspace *suffix* is
+    that content digest. A file whose name collides with the ref pattern
+    shadows the published ref; the file wins, with a printed note. Otherwise
+    the ref is resolved — an explicit ``--state`` verbatim, else the subject's
+    ``state.lock`` pin (``analyze`` carries a subject in ``args.name``;
+    ``restore`` is subject-agnostic, so its lock path hard-exits in
+    resolve_state) — and downloaded into TMP/downloads, with the ref serving
+    as both *label* and *suffix* (e.g. ``state-v6``). A path-shaped value
+    (contains ``/`` or ends in ``.tar.zst``) that names no file exits as a
+    missing file, not as resolve_state's malformed-ref message. *label* is
+    what callers write into the step-summary provenance line.
+    """
+    if local_file := _local_source(args):
+        path = Path(local_file)
+        if not path.is_file():
+            sys.exit(f"no such bundle file: {path}")
+        if args.cmd == "analyze" and re.fullmatch(r"state-v\d+", path.name):
+            print(f"note: '{path.name}' is a local file shadowing a published ref name — analyzing the file")
+        digest = reingest.bundle_digest(path)
+        return path, f"{path.name} (local file {digest})", digest
+    state = getattr(args, "state", None)
+    if (
+        state
+        and not re.fullmatch(r"state-v\d+", state)
+        and not Path(state).is_file()
+        and ("/" in state or state.endswith(".tar.zst"))
+    ):
+        sys.exit(f"no such bundle file: {state}")
+    ref = release.resolve_state(
+        state,
+        subject=getattr(args, "name", None),
+        lock_path=HERE / "state.lock",
+    )
+    print(f"resolved state ref: {ref}")
+    return release.download_ref(ref, TMP / "downloads"), ref, ref
+
+
+def _read_bundle_manifest(bundle: Path) -> dict:
+    """Peek at a bundle's ``state/manifest.json`` without a full extract.
+
+    Each failure mode is loud and distinct: a missing file or an unreadable
+    archive (corrupt/truncated download) exits carrying tar's own error; a
+    readable tar without a parseable ``state/manifest.json`` exits as "not a
+    testbed bundle". A manifest whose ``kind`` isn't ``testbed-export`` (legacy
+    state-v1..v5 tars carry a manifest with ``state_ref`` but no ``kind``) is
+    the callers' case — this returns the parsed manifest and each call site
+    keeps its own legacy-bundle wording.
+    """
+    if not bundle.is_file():
+        sys.exit(f"no such bundle file: {bundle}")
+
+    def _tar_error(proc: subprocess.CompletedProcess) -> str:
+        reason = (proc.stderr.strip().splitlines() or ["tar failed"])[0]
+        return f"could not read bundle {bundle.name}: {reason} (corrupt or truncated? re-download or re-mint)"
+
+    listing = subprocess.run(["tar", "--zstd", "-tf", str(bundle)], capture_output=True, text=True)
+    if listing.returncode != 0:
+        sys.exit(_tar_error(listing))
+    if "state/manifest.json" not in listing.stdout.splitlines():
+        sys.exit(f"{bundle.name} is not a testbed bundle (no state/manifest.json inside)")
+    proc = subprocess.run(
+        ["tar", "--zstd", "-xOf", str(bundle), "state/manifest.json"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.exit(_tar_error(proc))
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        sys.exit(f"{bundle.name} is not a testbed bundle (state/manifest.json is not valid JSON)")
+
+
+def _restore_export_bundle(
+    bundle: Path,
+    *,
+    base_url: str,
+    suffix: str,
+    platform_root: str | None,
+    tmp_dir: Path,
+    backup_dir: Path | None = None,
+) -> tuple[dict, dict[str, str], list[str]]:
+    """Re-ingest an export bundle into fixture workspaces.
+
+    Returns ``(manifest, workspace_map, seeded)`` where *seeded* names the
+    run-record files the bundle left in ``tmp_dir`` (callers use it to refuse
+    analyzing a subject the bundle carries no run record for).
+
+    Additive + idempotent (``reingest.ingest_bundle`` guards on per-collection counts and
+    warns on stale bundles) — no destructive ceremony. The catalog inversion is
+    loaded up front so a missing nemo-platform checkout fails before any
+    extraction or network I/O. The bundle's ``tmp/`` run records are copied
+    beside the local ones (clobbered locals are backed up into *backup_dir*,
+    the caller's per-invocation destination); insights never travel in
+    bundles, so nothing else lands in ``tmp_dir``.
+    """
+    catalog = reingest.load_catalog(reingest.resolve_platform_root(platform_root))
+    TMP.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=TMP) as tmp:
+        subprocess.run(["tar", "--zstd", "-xf", str(bundle), "-C", tmp], check=True)
+        state = Path(tmp) / "state"
+        manifest = json.loads((state / "manifest.json").read_text(encoding="utf-8"))
+        workspace_map = reingest.fixture_workspace_map(manifest["workspaces"], suffix)
+        outcome = reingest.ingest_bundle(
+            base_url,
+            state / "export",
+            manifest,
+            workspace_map=workspace_map,
+            catalog=catalog,
+        )
+        # seed_records must run inside this `with` block: it copies the bundle's
+        # records out of state/tmp (under the tempdir) before teardown.
+        seed_message, seeded = artifact.seed_records(state / "tmp", tmp_dir, backup_dir=backup_dir)
+        print(seed_message)
+    ingested = sum(c["spans"]["ingested"] for c in outcome.values())
+    skipped = sum(c["spans"]["skipped"] for c in outcome.values())
+    targets = ", ".join(sorted(c["workspace"] for c in outcome.values()))
+    print(f"✓ restored: {ingested} spans ingested, {skipped} skipped — workspaces: {targets}")
+    return manifest, workspace_map, seeded
+
+
+def _remap_record(record: dict, workspace_map: dict[str, str], *, base_url: str) -> dict:
+    """Point a restored run record at the fixture workspaces on the target platform.
+
+    Remaps every benchmark workspace field an adapter's analyze step reads
+    (``realistic_workspace`` and its ``oracle_workspace`` twin)
+    and pins ``base_url`` to the platform the bundle was just restored onto
+    (the record's own value points at wherever produce originally ran).
+    """
+    remapped = dict(record)
+    for key in ("realistic_workspace", "oracle_workspace"):
+        value = remapped.get(key)
+        if value and value in workspace_map:
+            remapped[key] = workspace_map[value]
+    remapped["base_url"] = base_url
+    return remapped
+
+
+def _ensure_fresh_insights(subject_name: str, update: bool, *, backup_dir: Path | None = None) -> None:
+    """Fresh-by-default analyze: move any prior local insights YAML out of the analyst's path.
+
+    The analyst backend picks up ``testbed/tmp/insights_<subject>.yaml`` as its
+    prior-insight seed purely by presence, so a fresh run must take the file off
+    that path — it moves into *backup_dir* (the caller's per-invocation
+    ``tmp/backup-<UTC stamp>/``; never deleted) with one printed line saying so.
+    ``--update-insights`` (*update*) leaves it in place to seed the analyst with
+    priors. Runs for EVERY analyze mode (pinned, ``--state``, ``--live``),
+    before the analyst.
+    """
+    if update:
+        return
+    name = f"insights_{subject_name}.yaml"
+    if not (TMP / name).exists():
+        return
+    backup_dir = artifact.backup_records(TMP, [name], backup_dir=backup_dir)
+    print(
+        f"fresh insights: moved prior {name} to {backup_dir.name}/ "
+        "(use --update-insights to seed the analyst with priors)"
+    )
+
+
+def _analysis_workspace(subject: Subject, record: dict | None) -> str | None:
+    """The one workspace this analysis reads (None when it can't be known yet).
+
+    Intake reads the subject config's ``workspace`` (already remapped onto the
+    subject in pinned/state mode); benchmark reads the record's
+    ``realistic_workspace``. A missing record yields None.
+    """
+    if subject.type == "intake":
+        return str(subject.config.get("workspace") or "") or None
+    if record is None:
+        return None
+    return str(record.get("realistic_workspace") or "") or None
+
+
+def _warn_insights_workspace_mismatch(subject_name: str, workspace: str | None) -> None:
+    """--update-insights sanity check: warn when the kept priors can't be seen.
+
+    The analyst backend scopes the local YAML's prior insights by their
+    ``workspace`` field, so priors kept from another mode (e.g. a live run's,
+    before a pinned analyze that runs under fixture workspaces) silently match
+    nothing — the analyst would skip every update and re-create each insight.
+    When ZERO records match this analysis's workspace, print one prominent
+    warning. Never rewrites the file: the priors stay valid for their own
+    workspace.
+    """
+    path = TMP / f"insights_{subject_name}.yaml"
+    if workspace is None or not path.is_file():
+        return
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        return  # best-effort check: not the backend's shape, so nothing to compare
+    carried = sorted({str(r.get("workspace")) for r in raw.get("insights", []) if r.get("workspace")})
+    if not carried or workspace in carried:
+        return
+    print(
+        f"warning: --update-insights: insights_{subject_name}.yaml carries workspace(s) "
+        f"{', '.join(carried)} but this analysis runs under '{workspace}' — "
+        "priors will be invisible and updates will be skipped"
+    )
+
+
+def _run_roundtrip(bundle: Path, base: str, platform_root: str | None) -> None:
+    """Round-trip fidelity guard: re-ingest *bundle* into scratch workspaces, re-export, diff.
+
+    ``sys.exit``s on any mismatch (or on a non-export/corrupt bundle), so
+    callers only continue past this on a fully faithful round trip. Shared by
+    the ``roundtrip`` subcommand and ``publish --base`` (the mint-time gate).
+    """
+    if _read_bundle_manifest(bundle).get("kind") != "testbed-export":
+        sys.exit(f"roundtrip: {bundle.name} is not a testbed-export bundle — nothing to guard")
+    # Load the inversion catalog up front so a missing nemo-platform checkout
+    # fails before any extraction or network I/O (same discipline as restore).
+    catalog = reingest.load_catalog(reingest.resolve_platform_root(platform_root))
+    TMP.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=TMP) as tmp:
+        subprocess.run(["tar", "--zstd", "-xf", str(bundle), "-C", tmp], check=True)
+        state = Path(tmp) / "state"
+        manifest = json.loads((state / "manifest.json").read_text(encoding="utf-8"))
+        mismatches = reingest.roundtrip_diff(
+            base,
+            state / "export",
+            manifest,
+            scratch_prefix="scratch-rt-",
+            catalog=catalog,
+            content_key=reingest.bundle_digest(bundle),
+        )
+    if mismatches:
+        for line in mismatches:
+            print(line)
+        sys.exit(
+            f"✗ round-trip guard: {len(mismatches)} mismatch(es) — "
+            f"{bundle.name} does not restore with full read-API fidelity"
+        )
+    print(f"✓ round-trip guard: {bundle.name} restores with full read-API fidelity")
+
+
+def _coerce_override(subject: Subject, key: str, raw: str) -> object:
+    """Coerce a ``--set`` value to the type of the stanza's existing value for *key*.
+
+    The stanza-type rule: a key already in the merged config keeps its type —
+    bool takes only ``true``/``false`` (case-insensitive), int/float must parse
+    (hard exit naming the key otherwise), str stays verbatim. A key absent from
+    the stanza is allowed: bare ``true``/``false`` literals (case-insensitive)
+    always become booleans — there is no stanza type to preserve, and a
+    ``"false"`` STRING is truthy — while everything else stays a verbatim
+    string (no guessing). bool is checked before int: it's an int subclass.
+    """
+    if key not in subject.config:
+        lowered = raw.strip().lower()
+        if lowered in ("true", "false"):
+            return lowered == "true"
+        return raw
+    current = subject.config[key]
+    if isinstance(current, bool):
+        lowered = raw.strip().lower()
+        if lowered not in ("true", "false"):
+            sys.exit(f"--set {key} expects true or false, got '{raw}'")
+        return lowered == "true"
+    if isinstance(current, int):
+        try:
+            return int(raw)
+        except ValueError:
+            sys.exit(f"--set {key} expects an integer, got '{raw}'")
+    if isinstance(current, float):
+        try:
+            return float(raw)
+        except ValueError:
+            sys.exit(f"--set {key} expects a number, got '{raw}'")
+    return raw
+
+
+def _apply_overrides(subject: Subject, sets: list[str]) -> Subject:
+    """Apply repeatable ``--set key=value`` overrides onto a subject's config.
+
+    Each value is coerced to the type its key already has in the stanza
+    (:func:`_coerce_override`); keys new to the stanza stay strings.
+    """
+    if not sets:
+        return subject
+    cfg = dict(subject.config)
+    for item in sets:
+        key, sep, value = item.partition("=")
+        key = key.strip()
+        if not sep or not key:
+            sys.exit(f"--set expects key=value, got '{item}'")
+        cfg[key] = _coerce_override(subject, key, value)
+    return Subject(subject.name, subject.type, cfg)
+
+
+def main() -> None:
+    _load_dotenv()
+    parser = argparse.ArgumentParser(
+        prog="testbed",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("list", help="List configured testbed subjects.")
+    p_ins = sub.add_parser(
+        "analyze",
+        help="Generate Insights for a subject (default: restore its pinned state onto the "
+        "local platform, then analyze — fully reproducible).",
+    )
+    p_ins.add_argument("name", help="Subject name from testbeds.toml.")
+    p_ins_mode = p_ins.add_mutually_exclusive_group()
+    p_ins_mode.add_argument(
+        "--live",
+        action="store_true",
+        help="Analyze the platform's live traces instead of a pinned state (no restore; "
+        "target = --base, else the stanza base_url).",
+    )
+    p_ins_mode.add_argument(
+        "--state",
+        default=None,
+        metavar="STATE",
+        help="Analyze a specific state instead of the pinned one: a published ref (state-vN) or a local bundle file.",
+    )
+    p_ins.add_argument(
+        "--since",
+        help="Trace lower bound, --live only: Nd/Nh/Nm (days/hours/minutes) or ISO date "
+        "(default: the stanza's since, else 30d; '' = epoch, no lower bound).",
+    )
+    p_ins.add_argument(
+        "--base",
+        default=None,
+        help=f"Target platform URL (default: {LOCAL_URL}; with --live: replaces the stanza "
+        "base_url and the recorded run's).",
+    )
+    p_ins.add_argument("--verbose", "-v", action="store_true")
+    p_ins.add_argument(
+        "--set",
+        dest="sets",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Override a subject config key (repeatable), e.g. --set num_tasks=2. Values take the "
+        "stanza key's type (int/float/bool true|false); keys new to the stanza stay strings.",
+    )
+    p_ins.add_argument(
+        "--summary-md",
+        help="Append a markdown summary of the insights to this file (e.g. $GITHUB_STEP_SUMMARY).",
+    )
+    p_ins.add_argument(
+        "--update-insights",
+        dest="update_insights",
+        action="store_true",
+        help="run against the existing local insights (prod-like update flow: updates them and adds new ones); "
+        "default is a fresh start with priors moved to backup.",
+    )
+    p_ins.add_argument(
+        "--platform-root",
+        default=None,
+        help="nemo-platform checkout for the span-attribute-catalog inversion "
+        "(default: $NMP_PLATFORM_ROOT, the CI sibling checkout, then ~/workstation/nemo-platform).",
+    )
+    p_snap = sub.add_parser(
+        "snapshot",
+        help="Export subject workspaces from the intake read API into a portable bundle.",
+    )
+    p_snap.add_argument("names", nargs="*", metavar="subject", help="Subject names from testbeds.toml.")
+    p_snap.add_argument(
+        "-o",
+        "--out",
+        default=None,
+        help="Output bundle path (default: testbed/tmp/snapshot-<UTC yyyymmdd-hhmmss>.tar.zst).",
+    )
+    p_snap.add_argument(
+        "--base",
+        default=None,
+        help="Export from this platform URL instead of each subject's stanza base_url "
+        "(overrides every listed subject, so stanzas need not agree).",
+    )
+    p_snap.add_argument(
+        "--since",
+        help="Span lower bound: Nd/Nh/Nm (days/hours/minutes) or ISO date (default: epoch — export everything).",
+    )
+    p_snap.add_argument(
+        "--subjects-json",
+        default=None,
+        help="CI sugar: JSON array of subject names, e.g. '[\"tau2-airline\"]'.",
+    )
+    p_res = sub.add_parser(
+        "restore",
+        help="Restore a state bundle by re-ingesting it additively into fixture workspaces "
+        "(legacy tar bundles, state-v1..v5, need a pre-migration checkout).",
+    )
+    # No pinned default here: state.lock pins are per-subject and restore is
+    # subject-agnostic — use `analyze <subject>` for the pinned loop.
+    p_res.add_argument("file", nargs="?", help="Local state bundle file to restore.")
+    p_res.add_argument(
+        "--state",
+        default=None,
+        metavar="STATE-VN",
+        help="Restore a published state ref (state-vN); local files go through the positional FILE. "
+        "Pins are per-subject: for the pinned state, use `analyze <subject>` instead.",
+    )
+    p_res.add_argument(
+        "--base",
+        default=None,
+        help=f"Target platform URL for the re-ingest (default: {LOCAL_URL}).",
+    )
+    p_res.add_argument(
+        "--platform-root",
+        default=None,
+        help="nemo-platform checkout for the span-attribute-catalog inversion "
+        "(default: $NMP_PLATFORM_ROOT, the CI sibling checkout, then ~/workstation/nemo-platform).",
+    )
+    p_rt = sub.add_parser(
+        "roundtrip",
+        help="Mint-time fidelity guard: re-ingest an export bundle into scratch workspaces, "
+        "re-export, and diff (non-zero exit on any mismatch).",
+    )
+    p_rt.add_argument("file", help="Export bundle (tar.zst) to check.")
+    p_rt.add_argument(
+        "--base",
+        default=None,
+        help=f"Target platform URL for the scratch re-ingest (default: {LOCAL_URL}).",
+    )
+    p_rt.add_argument(
+        "--platform-root",
+        default=None,
+        help="nemo-platform checkout for the span-attribute-catalog inversion "
+        "(default: $NMP_PLATFORM_ROOT, the CI sibling checkout, then ~/workstation/nemo-platform).",
+    )
+    p_pub = sub.add_parser(
+        "publish",
+        help="Mint the next state-v<N> from a candidate export bundle: upload it to the "
+        "testbed-state release and prepend its fixture-catalog row.",
+    )
+    p_pub.add_argument("file", help="Candidate export bundle (tar.zst).")
+    p_pub.add_argument(
+        "--reason",
+        default=None,
+        help="Why this fixture exists (one line for the release catalog; REASON env fallback).",
+    )
+    p_pub_verify = p_pub.add_mutually_exclusive_group()
+    p_pub_verify.add_argument(
+        "--base",
+        default=None,
+        help="Platform URL to run the round-trip fidelity guard against before minting.",
+    )
+    p_pub_verify.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="Mint without running the round-trip guard (only when the guard already ran, e.g. as its own CI step).",
+    )
+    p_pub.add_argument(
+        "--platform-root",
+        default=None,
+        help="nemo-platform checkout for the --base round-trip guard's span-attribute-catalog inversion "
+        "(default: $NMP_PLATFORM_ROOT, the CI sibling checkout, then ~/workstation/nemo-platform).",
+    )
+    p_doc = sub.add_parser("doctor", help="Check prerequisites for a subject (or all).")
+    p_doc.add_argument("name", nargs="?", help="Subject name; omit to check every subject.")
+    p_run = sub.add_parser(
+        "run",
+        help="Produce traces for a subject (benchmark: run tau2 + ingest), then record the run.",
+    )
+    p_run.add_argument("name", help="Subject name from testbeds.toml.")
+    p_run.add_argument(
+        "--base",
+        default=None,
+        help=f"Target platform URL instead of the stanza base_url (e.g. {LOCAL_URL}).",
+    )
+    p_run.add_argument(
+        "--set",
+        dest="sets",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Override a subject config key (repeatable), e.g. --set num_tasks=2. Values take the "
+        "stanza key's type (int/float/bool true|false); keys new to the stanza stay strings.",
+    )
+    args = parser.parse_args()
+
+    if not REGISTRY_PATH.exists():
+        sys.exit(f"No testbed registry found at {REGISTRY_PATH}.")
+    subjects = load_registry(REGISTRY_PATH)
+    if args.cmd == "list":
+        print("Testbeds:", ", ".join(sorted(subjects)) or "(none)")
+        return
+    if args.cmd == "doctor":
+        _doctor(subjects, args.name)
+        return
+
+    if args.cmd == "run":
+        subject = subjects.get(args.name)
+        if subject is None:
+            sys.exit(f"Unknown testbed '{args.name}'. Available: {', '.join(sorted(subjects)) or '(none)'}")
+        subject = _with_base(subject, args.base)
+        subject = _apply_overrides(subject, args.sets)
+        record = asyncio.run(build_adapter(subject).produce())
+        TMP.mkdir(parents=True, exist_ok=True)
+        save_run(TMP / f"{args.name}.run.json", record)
+        ws_line = f"realistic ws '{record['realistic_workspace']}'"
+        if record.get("oracle_workspace"):
+            ws_line += f" + oracle ws '{record['oracle_workspace']}'"
+        print(
+            f"✓ recorded run '{record['agent']}' ({ws_line}) — analyze with: "
+            f"uv run python -m testbed analyze {args.name} --live"
+        )
+        return
+
+    if args.cmd == "snapshot":
+        names = list(args.names)
+        if args.subjects_json:
+            try:
+                extra = json.loads(args.subjects_json)
+            except json.JSONDecodeError as exc:
+                sys.exit(f"--subjects-json is not valid JSON: {exc}")
+            if not isinstance(extra, list):
+                sys.exit("--subjects-json must be a JSON array of subject names")
+            names += [str(n) for n in extra]
+        names = list(dict.fromkeys(names))  # de-dupe, order preserved
+        if not names:
+            sys.exit("snapshot: give at least one subject (positional or --subjects-json)")
+        unknown = [n for n in names if n not in subjects]
+        if unknown:
+            sys.exit(f"Unknown testbed(s): {', '.join(unknown)}. Available: {', '.join(sorted(subjects)) or '(none)'}")
+        # parse_since exits on garbage HERE — before any client construction or network I/O.
+        since = parse_since(args.since)
+        out = (
+            Path(args.out)
+            if args.out
+            else TMP / (f"snapshot-{datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d-%H%M%S')}.tar.zst")
+        )
+        # --base replaces every listed subject's source URL, so snapshot_export's
+        # all-stanzas-must-agree check trivially holds; without it the stanza
+        # agreement (or disagreement) stands as-is.
+        result = artifact.snapshot_export(
+            [_with_base(subjects[n], args.base) for n in names],
+            out,
+            TMP,
+            since=since,
+        )
+        print(f"✓ snapshot: {result}")
+        return
+
+    if args.cmd == "restore":
+        if (args.file is not None) + (args.state is not None) != 1:
+            sys.exit(
+                "restore: give exactly one of FILE or --state <state-vN> "
+                "(state pins are per-subject — use `analyze <subject>` for the pinned loop)"
+            )
+        if args.file is not None and not args.file:
+            # `restore ""` passes the arity check but names nothing; without this
+            # it would fall through to ref resolution's subject-less lock lookup.
+            sys.exit("restore: FILE must be a non-empty path")
+        bundle_path, _label, suffix = _resolve_bundle(args)
+        manifest = _read_bundle_manifest(bundle_path)
+        if manifest.get("kind") != "testbed-export":
+            sys.exit(
+                f"restore: {bundle_path.name} is a legacy tar bundle (state-v1..v5) — "
+                "restorable only from a pre-migration checkout; see testbed/README.md"
+            )
+        _restore_export_bundle(
+            bundle_path,
+            base_url=args.base or LOCAL_URL,
+            suffix=suffix,
+            platform_root=args.platform_root,
+            tmp_dir=TMP,
+        )
+        return
+
+    if args.cmd == "roundtrip":
+        _run_roundtrip(Path(args.file), args.base or LOCAL_URL, args.platform_root)
+        return
+
+    if args.cmd == "publish":
+        bundle_path = Path(args.file)
+        # Minting is immutable, so an unverified mint must be an explicit choice:
+        # --base runs the round-trip guard here (sys.exits on mismatch, so a
+        # failed guard can never mint); --no-verify skips it out loud.
+        if args.base:
+            _run_roundtrip(bundle_path, args.base, args.platform_root)
+        elif args.no_verify:
+            print(f"publish: skipping round-trip guard for {bundle_path.name} (--no-verify)")
+        else:
+            sys.exit(
+                "publish: minting is immutable — verify first. Pass --base <platform> to run "
+                "the round-trip guard against it, or --no-verify to mint unverified."
+            )
+        publish.publish(bundle_path, reason=args.reason)
+        return
+
+    # args.cmd == "analyze" — pinned/--state mode restores a bundle first; --live doesn't.
+    subject = subjects.get(args.name)
+    if subject is None:
+        sys.exit(f"Unknown testbed '{args.name}'. Available: {', '.join(sorted(subjects)) or '(none)'}")
+    if not args.live and args.since is not None:
+        # For pinned/state analysis the lower bound is derived from the bundle's
+        # manifest (min_start_time floored) — a user-supplied --since would be
+        # silently ignored.
+        sys.exit("--since only applies to --live; pinned/state analysis derives since from the bundle manifest")
+    # Target platform: --base wins everywhere; without it, pinned/state mode
+    # restores onto the local platform (reproducible default) and --live reads
+    # the stanza's own base_url.
+    subject = _with_base(subject, args.base if args.live else (args.base or LOCAL_URL))
+    subject = _apply_overrides(subject, args.sets)
+    if not os.environ.get("INFERENCE_API_KEY"):
+        sys.exit("Set INFERENCE_API_KEY (NVIDIA Inference Gateway sk-... key) and re-run.")
+    # One backup destination per invocation: the restore's clobber-backup and the
+    # fresh-insights move both park files here, so a single analyze yields at most
+    # one tmp/backup-<stamp>/ dir (created lazily, only if something moves).
+    # Microseconds keep two invocations within the same second from sharing a dir.
+    backup_stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+    backup_dir = TMP / f"backup-{backup_stamp}"
+
+    workspace_map: dict[str, str] = {}
+    if args.live:
+        label = "live"
+        # `--since ''` explicitly means "no lower bound"; only fall back to the
+        # stanza default (then the client-side 30d default, mirroring the read
+        # API's implicit lookback — but pinned explicitly) when the flag is
+        # absent (None), not when it's empty.
+        if args.since == "":
+            # parse_since('') returns None, and a None bound would let the read
+            # API reapply its implicit 30d lookback — pin the epoch instead
+            # (export.py's `since or EPOCH` discipline).
+            since, origin = EPOCH, "--since (epoch — no lower bound)"
+        elif args.since is not None:
+            since, origin = parse_since(args.since), "--since"
+        elif subject.config.get("since") is not None:
+            since, origin = parse_since(subject.config.get("since")), "stanza"
+        else:
+            since = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30)
+            origin = "default 30d"
+        print(f"since: {since.isoformat() if since else 'none'} ({origin})")
+    else:
+        if subject.type not in ("benchmark", "intake"):
+            # Only benchmark/intake subjects own a workspace a bundle can carry.
+            # This must exit HERE, before the membership check would call into
+            # workspace scoping — artifact.workspaces_for_subject's exit for
+            # these types is worded for snapshot, not analyze.
+            sys.exit(
+                f"analyze: subject '{args.name}' has type '{subject.type}' — bundle-based "
+                f"analysis supports benchmark and intake subjects; use `analyze {args.name} --live`"
+            )
+        bundle_path, label, suffix = _resolve_bundle(args)
+        peek = _read_bundle_manifest(bundle_path)
+        if peek.get("kind") != "testbed-export":
+            sys.exit(
+                f"analyze: {bundle_path.name} is a legacy tar bundle (state-v1..v5) — "
+                "restorable only from a pre-migration checkout; see testbed/README.md"
+            )
+        # Membership check BEFORE restoring: the one workspace the analysis reads
+        # (benchmark: the realistic workspace; intake: the workspace) must be in
+        # the bundle, or the analyst would read an empty fixture. The oracle twin
+        # is never required — analysis doesn't read it — but when the bundle
+        # carries it, the restore below still ingests it (restore takes every
+        # manifest workspace).
+        workspace = str(subject.config.get("workspace") or "")
+        if not workspace:
+            sys.exit(f"analyze: subject '{args.name}' has no workspace configured")
+        bundle_workspaces = [str(ws) for ws in peek.get("workspaces") or []]
+        if workspace not in bundle_workspaces:
+            bundle_subjects = ", ".join(str(s) for s in peek.get("subjects") or []) or "(unknown)"
+            sys.exit(
+                f"analyze: subject '{args.name}' needs workspace '{workspace}', "
+                f"but bundle {label} carries only {', '.join(bundle_workspaces) or '(none)'} "
+                f"(subjects: {bundle_subjects})"
+            )
+        manifest, workspace_map, seeded = _restore_export_bundle(
+            bundle_path,
+            base_url=str(subject.config["base_url"]),
+            suffix=suffix,
+            platform_root=args.platform_root,
+            tmp_dir=TMP,
+            backup_dir=backup_dir,
+        )
+        if subject.type != "intake" and f"{args.name}.run.json" not in seeded:
+            # Falling back to a pre-existing local record would be a silent trap: its
+            # stale experiment_id filters every restored trace out of the analysis.
+            sys.exit(
+                f"analyze: bundle {label} carries no run record for subject '{args.name}' — "
+                "it cannot be analyzed from this bundle"
+            )
+        source_ws = str(subject.config.get("workspace") or "")
+        if source_ws in workspace_map:
+            # Intake subjects analyze the workspace from their config stanza (not the
+            # run record), so the fixture remap must land on the subject too.
+            subject = Subject(subject.name, subject.type, {**subject.config, "workspace": workspace_map[source_ws]})
+        # Explicit lower bound derived from the bundle (min_start_time floored): the
+        # read API injects a 30-day default lookback whenever `since` is absent, which
+        # would silently hide restored spans older than a month.
+        since = reingest.manifest_since(manifest)
+
+    if args.summary_md:
+        # Written before the insights rendering below — right after any restore
+        # completes — so the summary records which state (or `live`) the
+        # analysis that follows actually ran against.
+        with Path(args.summary_md).open("a", encoding="utf-8") as fh:
+            fh.write(f"### analyze @ {label} ({args.name})\n")
+
+    # Fresh by default, in every mode: a prior insights YAML on the analyst's
+    # path would silently seed this run — move it aside unless --update-insights.
+    _ensure_fresh_insights(args.name, args.update_insights, backup_dir=backup_dir)
+    out = TMP / f"insights_{args.name}.yaml"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    record = load_run(TMP / f"{args.name}.run.json")
+    if not args.live and record is not None:
+        # The analyst must read the fixture workspaces on the platform the bundle
+        # was just restored onto, not the workspaces/URL the record was minted with.
+        record = _remap_record(record, workspace_map, base_url=str(subject.config["base_url"]))
+        if subject.type == "benchmark":
+            # The record's analysis workspace must be one the restore just wrote,
+            # or the analyst reads an empty (or wrong) fixture. Intake reads its
+            # workspace from config, not the record.
+            analysis_ws = str(record.get("realistic_workspace") or "")
+            if analysis_ws and analysis_ws not in workspace_map.values():
+                sys.exit(
+                    f"bundle record for '{args.name}' points at workspace '{analysis_ws}' "
+                    f"which is not among the restored workspaces "
+                    f"({', '.join(sorted(workspace_map.values()))}) — "
+                    "the bundle was minted with a mismatched record"
+                )
+    elif args.live and args.base is not None and record is not None:
+        # --live --base must be honest end-to-end: benchmark analysis reads the
+        # record's base_url (minted at run time), not the stanza's.
+        record = {**record, "base_url": args.base}
+    if args.update_insights:
+        # The kept priors are workspace-scoped inside the YAML; runs after the
+        # remap (state mode) / record load (live) so it compares against the
+        # workspace this analysis actually reads.
+        _warn_insights_workspace_mismatch(args.name, _analysis_workspace(subject, record))
+    adapter = build_adapter(subject)
+    report = asyncio.run(adapter.analyze(record=record, since=since, verbose=args.verbose, out_path=out))
+    print(report)
+    print(f"\n✓ Insights written to {out}")
+    if args.summary_md:
+        with Path(args.summary_md).open("a", encoding="utf-8") as fh:
+            fh.write(render_summary_md(out, args.name))

--- a/plugins/nemo-insights/testbed/cli.py
+++ b/plugins/nemo-insights/testbed/cli.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""`testbed` — a test runner for the optimization loop (maintainer tooling).
+"""`testbed` — a test runner for the insights analysis workflow (maintainer tooling).
 
     uv run python -m testbed list
     uv run python -m testbed doctor [<name>]

--- a/plugins/nemo-insights/testbed/eval/plan.py
+++ b/plugins/nemo-insights/testbed/eval/plan.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Resolve workflow mode + subjects (stdlib only; runs on the bare runner).
+
+Precedence per value: pull_request hardcodes it -> workflow_dispatch input -> default.
+Branch validation (Task-6 style) re-adds a temporary push trigger by wiring dispatch-input
+fallbacks in the workflow env — no vars.TESTBED_* mechanism lives here anymore.
+"""
+
+import json
+import os
+
+
+def resolve_mode(event: str, input_mode: str) -> str:
+    if event == "pull_request":
+        return "analyze"
+    return input_mode or "analyze"
+
+
+def resolve_subjects(event: str, input_subjects: str) -> list[str]:
+    raw = "tau2-airline" if event == "pull_request" else (input_subjects or "tau2-airline")
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+def main() -> None:
+    env = os.environ
+    mode = resolve_mode(env.get("GITHUB_EVENT_NAME", ""), env.get("INPUT_MODE", ""))
+    subjects = resolve_subjects(env.get("GITHUB_EVENT_NAME", ""), env.get("INPUT_SUBJECTS", ""))
+    with open(env["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+        fh.write(f"mode={mode}\nsubjects={json.dumps(subjects)}\n")
+    with open(env["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+        fh.write(f"### testbed-insights: mode={mode} subjects={','.join(subjects)}\n")
+    print(f"mode={mode} subjects={subjects}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/nemo-insights/testbed/eval/prep.py
+++ b/plugins/nemo-insights/testbed/eval/prep.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Dependency prep for monorepo CI jobs: uv syncs + tau2 judge repoint.
+
+The tau2 checkout is expected beside the nemo-platform checkout.
+Flags: --sync-insights {true,false}, --install-tau2 {true,false}.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+JUDGE_VARS = ("DEFAULT_LLM_NL_ASSERTIONS", "DEFAULT_LLM_ENV_INTERFACE", "DEFAULT_LLM_EVAL_USER_SIMULATOR")
+PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+PLATFORM_ROOT = PLUGIN_ROOT.parents[1]
+TAU2_ROOT = PLATFORM_ROOT.parent / "tau2-bench"
+
+
+def repoint_judge(config_text: str, judge_model: str) -> tuple[str, int]:
+    total = 0
+    for var in JUDGE_VARS:
+        config_text, n = re.subn(rf"^{var} = .*$", f'{var} = "{judge_model}"', config_text, flags=re.M)
+        total += n
+    return config_text, total
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sync-insights", choices=["true", "false"], default="true")
+    parser.add_argument("--install-tau2", choices=["true", "false"], default="true")
+    args = parser.parse_args()
+
+    if args.sync_insights == "true":
+        subprocess.run(["uv", "sync", "--group", "insights"], check=True, cwd=PLATFORM_ROOT)
+
+    config = TAU2_ROOT / "src/tau2/config.py"
+    text, count = repoint_judge(config.read_text(encoding="utf-8"), os.environ["TAU2_JUDGE_LLM"])
+    if count != 3:
+        sys.exit(f"judge repoint failed: {count}/3 defaults matched")
+    config.write_text(text, encoding="utf-8")
+
+    if args.install_tau2 == "true":
+        subprocess.run(["uv", "sync"], check=True, cwd=TAU2_ROOT)
+        subprocess.run(["uv", "run", "tau2", "check-data"], check=True, cwd=TAU2_ROOT)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/nemo-insights/testbed/eval/prep.py
+++ b/plugins/nemo-insights/testbed/eval/prep.py
@@ -22,7 +22,12 @@ TAU2_ROOT = PLATFORM_ROOT.parent / "tau2-bench"
 def repoint_judge(config_text: str, judge_model: str) -> tuple[str, int]:
     total = 0
     for var in JUDGE_VARS:
-        config_text, n = re.subn(rf"^{var} = .*$", f'{var} = "{judge_model}"', config_text, flags=re.M)
+        config_text, n = re.subn(
+            rf"^{var} = .*$",
+            lambda _match, var=var: f'{var} = "{judge_model}"',
+            config_text,
+            flags=re.M,
+        )
         total += n
     return config_text, total
 

--- a/plugins/nemo-insights/testbed/eval/run_subjects.py
+++ b/plugins/nemo-insights/testbed/eval/run_subjects.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run the testbed for each subject (CI produce loop: tau2 -> ingest -> analyze).
+
+Runs from the nemo-insights plugin directory. SUBJECTS is a JSON array of subject
+names. (The analyze job doesn't use this script — it calls
+`uv run python -m testbed analyze` directly.)
+"""
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+LOCAL_URL = "http://localhost:8080"  # the in-job CI stack
+PLATFORM_ROOT = Path(__file__).resolve().parents[4]
+
+
+def build_overrides(num_tasks: str, num_trials: str) -> list[str]:
+    overrides: list[str] = []
+    if num_tasks:
+        overrides += ["--set", f"num_tasks={num_tasks}"]
+    if num_trials:
+        overrides += ["--set", f"num_trials={num_trials}"]
+    return overrides
+
+
+def subjects_from_env(env: dict) -> list[str]:
+    return json.loads(env["SUBJECTS"])
+
+
+def _testbed(*args: str) -> None:
+    subprocess.run(
+        ["uv", "run", "--project", str(PLATFORM_ROOT), "python", "-m", "testbed", *args],
+        check=True,
+    )
+
+
+def analyze_with_retry(subject: str, summary: str, retries: int = 2, delay: float = 90.0) -> None:
+    """Run `testbed analyze` with a rate-limit cool-down retry.
+
+    The analyst shares its gateway key with the tau2 sims, so right after a
+    large sim burst the key's rate window can still be hot and the analyst's
+    first calls can 429. A cool-down retry absorbs that transient.
+    """
+    for attempt in range(retries + 1):
+        try:
+            # --live: this is the produce loop analyzing the traces it just made
+            # on the in-job stack — there is no minted state to restore yet.
+            _testbed("analyze", subject, "--live", "--base", LOCAL_URL, "--summary-md", summary)
+            return
+        except subprocess.CalledProcessError:
+            if attempt == retries:
+                raise
+            print(f"analyze failed (attempt {attempt + 1}/{retries + 1}); cooling down {int(delay)}s", flush=True)
+            time.sleep(delay)
+
+
+def main() -> None:
+    env = os.environ
+    subjects = subjects_from_env(env)
+    overrides = build_overrides(env.get("NUM_TASKS", ""), env.get("NUM_TRIALS", ""))
+    summary = env["GITHUB_STEP_SUMMARY"]
+    for subject in subjects:
+        print(f"::group::{subject}", flush=True)
+        _testbed("doctor", subject)
+        _testbed("run", subject, "--base", LOCAL_URL, *overrides)
+        analyze_with_retry(subject, summary)
+        print(Path(f"testbed/tmp/insights_{subject}.yaml").read_text(encoding="utf-8"))
+        print("::endgroup::", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/nemo-insights/testbed/eval/stack.py
+++ b/plugins/nemo-insights/testbed/eval/stack.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Self-contained Intake stack (ClickHouse + auth, entities, intake on :8080).
+
+State lives under $RUNNER_TEMP/state.
+`--verify` only re-checks both health endpoints and writes the summary line.
+"""
+
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+PLATFORM_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _wait(url: str, attempts: int, delay: float) -> bool:
+    for _ in range(attempts):
+        try:
+            with urllib.request.urlopen(url, timeout=5):
+                return True
+        except OSError:
+            time.sleep(delay)
+    return False
+
+
+def _fail_with_log(log: Path, message: str) -> None:
+    print(message)
+    if log.exists():
+        print("".join(log.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)[-50:]))
+    sys.exit(1)
+
+
+def verify() -> None:
+    for url in ("http://localhost:8123/ping", "http://localhost:8080/health/ready"):
+        if not _wait(url, attempts=1, delay=0):
+            sys.exit(f"verify failed: {url}")
+    with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+        fh.write("### stack-check ✓ ClickHouse + platform ready\n")
+
+
+def main() -> None:
+    if "--verify" in sys.argv[1:]:
+        verify()
+        return
+    runner_temp = Path(os.environ["RUNNER_TEMP"])
+    state = runner_temp / "state"
+    (state / "clickhouse").mkdir(parents=True, exist_ok=True)
+    (state / "nmp").mkdir(parents=True, exist_ok=True)
+    log = runner_temp / "platform.log"
+
+    subprocess.run(
+        [str(PLATFORM_ROOT / "services/intake/scripts/spans/run_clickhouse.sh")],
+        check=True,
+        env={**os.environ, "CLICKHOUSE_DATA_DIR": str(state / "clickhouse")},
+    )
+    if not _wait("http://localhost:8123/ping", attempts=30, delay=2):
+        sys.exit("ClickHouse never became ready")
+    subprocess.run(
+        ["docker", "exec", "nmp-intake-clickhouse", "clickhouse-client", "--query", "SYSTEM STOP TTL MERGES"],
+        check=True,
+    )
+
+    subprocess.run(["uv", "sync"], check=True, cwd=PLATFORM_ROOT)
+    with open(log, "ab") as fh:
+        subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "nemo",
+                "services",
+                "run",
+                "--services",
+                "auth,entities,intake",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8080",
+            ],
+            cwd=PLATFORM_ROOT,
+            env={**os.environ, "NMP_DATA_DIR": str(state / "nmp")},
+            stdout=fh,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    if not _wait("http://localhost:8080/health/ready", attempts=60, delay=5):
+        _fail_with_log(log, "platform never became ready; last log lines:")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/nemo-insights/testbed/export.py
+++ b/plugins/nemo-insights/testbed/export.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Drain the intake read API into per-workspace JSONL files (bundle capture).
+
+The capture side of testbed export bundles: for each workspace, page ALL spans
+(``mode="detailed"``), annotations, and evaluator results through the platform
+SDK — exactly the surface the analyst's remote backend reads — and write one
+JSON document per line under ``<out_dir>/export/<workspace>/``.
+
+Every query carries an explicit lower bound (``since``, else epoch): the read
+API silently injects a 30-day default lookback when none is given, so an
+"unbounded" drain would quietly lose older spans.
+"""
+
+import asyncio
+import json
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import urlparse
+
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform.config.config import Config
+
+EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+PAGE_SIZE = 200  # generous pages: drain-all in few round-trips
+
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+
+
+def make_client(base_url: str) -> AsyncNeMoPlatform:
+    """Async SDK client; platform auth only for remote URLs (mirrors ingest's client)."""
+    host = (urlparse(base_url).hostname or "").lower()
+    config_path = Config.get_default_config_path()
+    if host in _LOOPBACK_HOSTS or not config_path.exists():
+        return AsyncNeMoPlatform(base_url=base_url, timeout=60.0)
+    return AsyncNeMoPlatform(base_url=base_url, config_path=config_path, timeout=60.0)
+
+
+def _dump(item) -> dict:
+    """One SDK model -> plain JSON-able dict (drop null fields, like the analyst does)."""
+    return item.model_dump(mode="json", exclude_none=True)
+
+
+async def _drain_to_jsonl(paginator, path: Path, *, on_doc: Callable[[dict], None] | None = None) -> int:
+    """Write every paginated doc to *path*, one JSON document per line; return the count."""
+    count = 0
+    with path.open("w", encoding="utf-8") as fh:
+        async for item in paginator:
+            doc = _dump(item)
+            fh.write(json.dumps(doc, ensure_ascii=False) + "\n")
+            if on_doc is not None:
+                on_doc(doc)
+            count += 1
+    return count
+
+
+class _StartBounds:
+    """Min/max span ``started_at`` across everything exported (manifest time bounds)."""
+
+    def __init__(self) -> None:
+        self.min: datetime | None = None
+        self.max: datetime | None = None
+
+    def note(self, doc: dict) -> None:
+        raw = doc.get("started_at")
+        if not raw:
+            return
+        try:
+            ts = datetime.fromisoformat(str(raw))
+        except ValueError:
+            return
+        if self.min is None or ts < self.min:
+            self.min = ts
+        if self.max is None or ts > self.max:
+            self.max = ts
+
+
+def export_workspaces(base_url: str, workspaces: list[str], out_dir: Path, *, since: datetime | None) -> dict:
+    """Drain spans/annotations/evaluator-results per workspace into JSONL files.
+
+    Writes ``out_dir/export/<workspace>/{spans,annotations,evaluator_results}.jsonl``
+    and returns ``{"workspaces": {ws: {collection: count}}, "min_start_time": ...,
+    "max_start_time": ...}`` (time bounds from span ``started_at``; ISO strings or
+    None when no spans matched).
+    """
+    return asyncio.run(_export_workspaces(base_url, workspaces, out_dir, since=since))
+
+
+async def _export_workspaces(base_url: str, workspaces: list[str], out_dir: Path, *, since: datetime | None) -> dict:
+    lower = (since or EPOCH).isoformat()
+    bounds = _StartBounds()
+    counts: dict[str, dict[str, int]] = {}
+    client = make_client(base_url)
+    try:
+        for workspace in workspaces:
+            ws_dir = out_dir / "export" / workspace
+            ws_dir.mkdir(parents=True, exist_ok=True)
+            spans = client.intake.spans.list(
+                workspace=workspace,
+                page_size=PAGE_SIZE,
+                mode="detailed",
+                sort="started_at",
+                filter=cast(Any, {"started_at": {"gte": lower}}),
+            )
+            n_spans = await _drain_to_jsonl(spans, ws_dir / "spans.jsonl", on_doc=bounds.note)
+            annotations = client.intake.annotations.list(
+                workspace=workspace,
+                page_size=PAGE_SIZE,
+                sort="created_at",
+                filter=cast(Any, {"created_at": {"gte": lower}}),
+            )
+            n_annotations = await _drain_to_jsonl(annotations, ws_dir / "annotations.jsonl")
+            results = client.intake.evaluator_results.list(
+                workspace=workspace,
+                page_size=PAGE_SIZE,
+                sort="created_at",
+                filter=cast(Any, {"created_at": {"gte": lower}}),
+            )
+            n_results = await _drain_to_jsonl(results, ws_dir / "evaluator_results.jsonl")
+            counts[workspace] = {
+                "spans": n_spans,
+                "annotations": n_annotations,
+                "evaluator_results": n_results,
+            }
+            print(f"exported {workspace}: {n_spans} spans, {n_annotations} annotations, {n_results} evaluator results")
+    finally:
+        await client.close()
+    return {
+        "workspaces": counts,
+        "min_start_time": bounds.min.isoformat() if bounds.min else None,
+        "max_start_time": bounds.max.isoformat() if bounds.max else None,
+    }

--- a/plugins/nemo-insights/testbed/ingest.py
+++ b/plugins/nemo-insights/testbed/ingest.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Mint a per-run agent id and manage a platform's Intake workspaces."""
+
+import os
+import time
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+import httpx
+from nemo_platform import NeMoPlatform
+from nemo_platform.config.config import Config
+
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+
+
+class _HTTPResponse(Protocol):
+    status_code: int
+    text: str
+
+    def json(self) -> dict[str, Any]: ...
+
+
+class _JSONClient(Protocol):
+    def post(self, url: str, *, json: dict[str, Any]) -> _HTTPResponse: ...
+
+    def close(self) -> None: ...
+
+
+class _PollingClient(Protocol):
+    def get(self, url: str, *, params: dict[str, Any]) -> _HTTPResponse: ...
+
+    def close(self) -> None: ...
+
+
+class _PlatformClient(Protocol):
+    def post(
+        self,
+        path: str,
+        *,
+        cast_to: type[httpx.Response],
+        content: bytes,
+        options: dict[str, Any],
+    ) -> httpx.Response: ...
+
+    def close(self) -> None: ...
+
+
+def _make_platform_client(base_url: str) -> NeMoPlatform:
+    """Build a synchronous SDK client with platform auth for remote URLs."""
+    host = (urlparse(base_url).hostname or "").lower()
+    config_path = Config.get_default_config_path()
+    if host in _LOOPBACK_HOSTS or not config_path.exists():
+        return NeMoPlatform(base_url=base_url, timeout=30.0)
+    return NeMoPlatform(base_url=base_url, config_path=config_path, timeout=30.0)
+
+
+def mint_agent_id(base: str) -> str:
+    """A fresh per-run Intake agent id: ``<base>-<YYYYMMDD-HHMMSS>-<4 hex>``."""
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    return f"{base}-{ts}-{os.urandom(2).hex()}"
+
+
+def ensure_workspace(base_url: str, workspace: str, *, client: httpx.Client | None = None) -> None:
+    """Create the Intake workspace if it does not already exist.
+
+    POSTs to the entities create-workspace route; treats 2xx (created) and 409
+    (already exists) as success, raising ``RuntimeError`` on any other status.
+    ``client`` is injectable for tests; when None a short-timeout client is
+    created and closed here. No auth header (matches the unauthenticated local
+    platform, like the OTLP ingest calls).
+    """
+    url = f"{base_url.rstrip('/')}/apis/entities/v2/workspaces"
+    owns_client = client is None
+    active_client = client or httpx.Client(timeout=30.0)
+    try:
+        resp = active_client.post(url, json={"name": workspace})
+    finally:
+        if owns_client:
+            active_client.close()
+    if resp.status_code != 409 and not (200 <= resp.status_code < 300):
+        raise RuntimeError(f"workspace create failed ({resp.status_code}): {resp.text}")
+
+
+def ensure_experiment_group(base_url: str, workspace: str, name: str, *, client: httpx.Client | None = None) -> str:
+    """Create the Intake ExperimentGroup if absent; return its id.
+
+    POSTs to the experiment-groups route; on 2xx returns the created group's
+    ``id``. A 409 means it already exists, so GET it by name and return that id
+    (the group is the per-subject container every run's Experiment hangs off).
+    Raises ``RuntimeError`` on any other status. No auth header.
+    """
+    root = f"{base_url.rstrip('/')}/apis/intake/v2/workspaces/{workspace}/experiment-groups"
+    owns_client = client is None
+    client = client or httpx.Client(timeout=30.0)
+    try:
+        resp = client.post(root, json={"name": name})
+        if 200 <= resp.status_code < 300:
+            return resp.json()["id"]
+        if resp.status_code == 409:
+            existing = client.get(f"{root}/{name}")
+            if 200 <= existing.status_code < 300:
+                return existing.json()["id"]
+            raise RuntimeError(f"experiment-group lookup failed ({existing.status_code}): {existing.text}")
+        raise RuntimeError(f"experiment-group create failed ({resp.status_code}): {resp.text}")
+    finally:
+        if owns_client:
+            client.close()
+
+
+def create_experiment(
+    base_url: str,
+    workspace: str,
+    *,
+    name: str,
+    experiment_group_id: str,
+    dataset_name: str,
+    dataset_version: str,
+    metadata: dict,
+    client: httpx.Client | None = None,
+) -> None:
+    """Create the per-run Experiment under ``experiment_group_id``.
+
+    ``name`` is the run id (timestamped + hex), so it is workspace-unique — a
+    409 here is a genuine collision and is surfaced as ``RuntimeError`` along
+    with every other non-2xx. No auth header.
+    """
+    url = f"{base_url.rstrip('/')}/apis/intake/v2/workspaces/{workspace}/experiments"
+    body = {
+        "name": name,
+        "experiment_group_id": experiment_group_id,
+        "dataset_name": dataset_name,
+        "dataset_version": dataset_version,
+        "metadata": metadata,
+    }
+    owns_client = client is None
+    client = client or httpx.Client(timeout=30.0)
+    try:
+        resp = client.post(url, json=body)
+    finally:
+        if owns_client:
+            client.close()
+    if not (200 <= resp.status_code < 300):
+        raise RuntimeError(f"experiment create failed ({resp.status_code}): {resp.text}")
+
+
+def poll_visible(
+    base_url: str,
+    workspace: str,
+    session_ids: set[str],
+    *,
+    client: httpx.Client | _PollingClient | None = None,
+    timeout_s: float = 60.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> set[str]:
+    """Poll Intake's spans list until each ``session_id`` is queryable (or timeout).
+
+    ClickHouse ingest is asynchronous, so freshly-POSTed ATIF is not immediately
+    returned by the spans query. Polls until every id is seen or the deadline
+    passes; returns the set confirmed visible. Transient GET errors are ignored
+    (ingest lag), and ``sleep`` is injected so tests need not wait.
+    """
+    url = f"{base_url.rstrip('/')}/apis/intake/v2/workspaces/{workspace}/spans"
+    owns_client = client is None
+    active_client = client or httpx.Client(timeout=30.0)
+    seen: set[str] = set()
+    deadline = time.monotonic() + timeout_s
+    try:
+        while True:
+            try:
+                resp = active_client.get(url, params={"page": 1, "page_size": 1000, "mode": "summary"})
+                if resp.status_code == 200:
+                    for span in resp.json().get("data", []):
+                        sid = span.get("session_id")
+                        if sid in session_ids:
+                            seen.add(sid)
+            except httpx.HTTPError:
+                pass
+            if seen >= session_ids or time.monotonic() >= deadline:
+                return seen
+            sleep(2.0)
+    finally:
+        if owns_client:
+            active_client.close()

--- a/plugins/nemo-insights/testbed/ingest.py
+++ b/plugins/nemo-insights/testbed/ingest.py
@@ -5,7 +5,7 @@
 import os
 import time
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Protocol
 from urllib.parse import urlparse
 
@@ -59,7 +59,7 @@ def _make_platform_client(base_url: str) -> NeMoPlatform:
 
 def mint_agent_id(base: str) -> str:
     """A fresh per-run Intake agent id: ``<base>-<YYYYMMDD-HHMMSS>-<4 hex>``."""
-    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
     return f"{base}-{ts}-{os.urandom(2).hex()}"
 
 

--- a/plugins/nemo-insights/testbed/otlp_build.py
+++ b/plugins/nemo-insights/testbed/otlp_build.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Pure transform: one tau2 SimulationRun → a list of OTLP span dicts.
+
+This is the intermediate representation — plain dicts, no protobuf and no
+network — so the transform stays trivially unit-testable. :mod:`testbed.otlp_ingest`
+turns these dicts into an OTLP ``ExportTraceServiceRequest`` and POSTs them.
+
+The span tree mirrors what Intake's ATIF importer produced (so the Analyst reads
+it unchanged), but emitted over the permissive OTLP route so multi-actor traces
+(telecom user-driven device tools) ingest without ATIF-v1.7's agent-only 422::
+
+    AGENT       name=<agent_name>        one per sim (the trajectory root)
+     ├─ CHAIN   name=user-<step_id>      one per user utterance (tau2.actor="user")
+     ├─ LLM     name=agent-<step_id>     one per assistant turn
+     │   └─ TOOL name=<function_name>    agent tool call (child of its LLM turn)
+     ├─ TOOL    name=<function_name>     user-driven device tool  ← multi-actor
+     └─ EVALUATOR name=tau2.verifier     one per sim, oracle (include_rewards) only
+"""
+
+import hashlib
+import json
+import re
+import time
+from typing import Any
+
+_SLUG = re.compile(r"[^A-Za-z0-9_.-]+")
+
+# tau2 sims carry only ISO timestamps / latencies, not the contiguous nanos OTLP
+# wants, so spans get a synthesized monotonic clock seeded from ``base_ns`` (one
+# tick per span). The base must be near ingest time: Intake drops spans dated
+# outside its retention window, so a fixed past base makes them silently
+# un-queryable. Callers pass ``base_ns`` (the adapter passes wall-clock ``now``);
+# tests pin it for determinism. Span ids derive from the session id, not the
+# clock, so the transform stays deterministic regardless of the base.
+_STEP_NS = 1_000_000  # 1ms per span
+
+
+def _slug(value: object) -> str:
+    """Make an id path-safe: collapse any run of disallowed chars to a single '-'."""
+    return _SLUG.sub("-", str(value))
+
+
+def session_id_for(sim: dict[str, Any], *, experiment_id: str) -> str:
+    """The per-run, per-sim session id: ``<experiment_id>-task<task_id>-t<trial>``.
+
+    Scoped by ``experiment_id`` (the run id) so every id derived from it — the span
+    id, trace id, and the evaluator-results id — is unique per run. Runs that
+    re-cover the same task in a shared workspace no longer collide (which would
+    cross-link spans and overwrite one run's scores with another's). ``experiment_id``
+    already carries the agent/base name as its prefix, so the agent stays visible,
+    and the realistic + oracle twins of one sim in one run still share this id.
+    """
+    trial = sim.get("trial") or 0
+    return f"{_slug(experiment_id)}-task{_slug(sim.get('task_id', ''))}-t{trial}"
+
+
+def _span_id(session_id: str, index: int) -> str:
+    """A per-sim-unique, deterministic 8-byte span id (hex).
+
+    Derived from the session id so ids are stable across realistic/oracle builds
+    of the same sim and unique across sims **and runs** in a workspace (the EVALUATOR span id is
+    later the loose target of an evaluator_results row, so cross-sim collisions
+    would cross-link rewards)."""
+    return hashlib.sha256(f"{session_id}:span:{index}".encode()).digest()[:8].hex()
+
+
+def _text(content: object) -> str:
+    """Normalize a message's content to a string (JSON-encode non-strings)."""
+    if content is None:
+        return ""
+    return content if isinstance(content, str) else json.dumps(content)
+
+
+def sim_to_spans(
+    sim: dict[str, Any],
+    *,
+    agent_name: str,
+    agent_version: str,
+    session_id: str,
+    experiment_id: str,
+    task: dict[str, Any] | None = None,
+    include_rewards: bool,
+    agent_llm: str | None = None,
+    base_ns: int | None = None,
+) -> list[dict[str, Any]]:
+    """Transform one tau2 SimulationRun into a list of OTLP span dicts.
+
+    Each span dict is ``{span_id, parent_span_id, name, kind, start_ns, end_ns,
+    attributes, status, status_message}`` where ``kind`` is one of
+    ``AGENT|LLM|TOOL|EVALUATOR``, ``parent_span_id`` is ``None`` for the root, and
+    ids/timestamps are hex/int (no protobuf here). Pure: no network, no wall-clock.
+
+    ``include_rewards`` gates the oracle answer key — the EVALUATOR span and the
+    task's ``evaluation_criteria`` only appear when it is set (the realistic twin
+    withholds them so the eval is unaided).
+
+    ``experiment_id`` is stamped on every span as ``nemo.experiment.id`` (with
+    the sim's task id as ``nemo.test_case.id``) so a run's spans are queryable
+    back via the spans filter ``{"evaluation_id": experiment_id}`` — the per-run
+    scope that lets many runs share one workspace.
+
+    ``base_ns`` seeds the per-span monotonic clock; it must be near ingest time
+    (Intake drops spans dated outside its retention window). Defaults to
+    wall-clock ``now`` when omitted.
+    """
+    messages = sim.get("messages", [])
+    base = base_ns if base_ns is not None else time.time_ns()
+    spans: list[dict[str, Any]] = []
+    test_case_id = str(sim.get("task_id", ""))
+
+    def _common() -> dict[str, Any]:
+        return {
+            "gen_ai.conversation.id": session_id,
+            "session.id": session_id,
+            "nemo.experiment.id": experiment_id,
+            "nemo.test_case.id": test_case_id,
+        }
+
+    def _add(*, name: str, kind: str, parent: str | None, attributes: dict[str, Any]) -> dict[str, Any]:
+        index = len(spans)
+        start = base + index * _STEP_NS
+        span = {
+            "span_id": _span_id(session_id, index),
+            "parent_span_id": parent,
+            "name": name,
+            "kind": kind,
+            "start_ns": start,
+            "end_ns": start + _STEP_NS,
+            "attributes": {"openinference.span.kind": kind, **_common(), **attributes},
+            "status": "OK",
+            "status_message": None,
+        }
+        spans.append(span)
+        return span
+
+    first_user = next((_text(m.get("content")) for m in messages if m.get("role") == "user"), "")
+    last_agent = next((_text(m.get("content")) for m in reversed(messages) if m.get("role") == "assistant"), "")
+    root_attrs: dict[str, Any] = {
+        "gen_ai.agent.name": agent_name,
+        "gen_ai.agent.version": agent_version,
+        "input.value": first_user,
+        "output.value": last_agent,
+    }
+    if task is not None:
+        root_attrs["tau2.task"] = json.dumps(_trim_task(task, include_rewards=include_rewards))
+    root = _add(name=agent_name, kind="AGENT", parent=None, attributes=root_attrs)
+
+    # Match tool results back to their TOOL span: by id, else positional FIFO within
+    # the same actor (agent results never claim a user tool span, and vice versa).
+    tool_span_by_id: dict[str, dict[str, Any]] = {}
+    pending: dict[str, list[dict[str, Any]]] = {"assistant": [], "user": []}
+    step_id = 0
+
+    def _tool_span(call: dict[str, Any], *, parent: str, actor: str) -> dict[str, Any]:
+        name = call.get("name") or ""
+        attrs = {"gen_ai.tool.name": name, "input.value": json.dumps(call.get("arguments") or {})}
+        if actor == "user":
+            attrs["tau2.actor"] = "user"  # not the agent's action; no gen_ai.agent.name
+        else:
+            attrs["gen_ai.agent.name"] = agent_name
+        span = _add(name=name, kind="TOOL", parent=parent, attributes=attrs)
+        call_id = call.get("id")
+        if call_id:
+            tool_span_by_id[call_id] = span
+        pending[actor].append(span)
+        return span
+
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant":
+            step_id += 1
+            content = _text(msg.get("content"))
+            calls = msg.get("tool_calls") or []
+            output = {
+                "content": content,
+                "tool_calls": [
+                    {"id": c.get("id") or "", "name": c.get("name") or "", "arguments": c.get("arguments") or {}}
+                    for c in calls
+                ],
+            }
+            llm_attrs = {
+                "output.value": json.dumps(output),
+                "output.mime_type": "application/json",
+            }
+            if agent_llm:
+                llm_attrs["gen_ai.request.model"] = agent_llm
+            llm = _add(name=f"agent-{step_id}", kind="LLM", parent=root["span_id"], attributes=llm_attrs)
+            for call in calls:
+                actor = call.get("requestor") or "assistant"
+                parent = root["span_id"] if actor == "user" else llm["span_id"]
+                _tool_span(call, parent=parent, actor=actor)
+        elif role == "user":
+            step_id += 1
+            content = _text(msg.get("content"))
+            if content:
+                # The user's utterance as a timeline turn (no LLM span; mark the actor).
+                _add(
+                    name=f"user-{step_id}",
+                    kind="CHAIN",
+                    parent=root["span_id"],
+                    attributes={"tau2.actor": "user", "output.value": content, "output.mime_type": "text/plain"},
+                )
+            # A user turn's device tools also hang off the AGENT root.
+            for call in msg.get("tool_calls") or []:
+                _tool_span(call, parent=root["span_id"], actor=call.get("requestor") or "user")
+        elif role == "system":
+            step_id += 1
+        elif role == "tool":
+            _record_tool_result(msg, tool_span_by_id=tool_span_by_id, pending=pending)
+
+    reward = (sim.get("reward_info") or {}).get("reward")
+    if include_rewards and reward is not None:
+        verifier_result = sim.get("reward_info") or {"score": reward}
+        ev_out = {"score": reward, "verifier_result": verifier_result}
+        _add(
+            name="tau2.verifier",
+            kind="EVALUATOR",
+            parent=root["span_id"],
+            attributes={
+                "score": reward,
+                "output.value": json.dumps(ev_out),
+                "output.mime_type": "application/json",
+            },
+        )
+    root["end_ns"] = max((s["end_ns"] for s in spans), default=root["end_ns"])
+    return spans
+
+
+def _record_tool_result(
+    msg: dict[str, Any], *, tool_span_by_id: dict[str, dict[str, Any]], pending: dict[str, list[dict[str, Any]]]
+) -> None:
+    """Fold a ``role="tool"`` result into its TOOL span's output + error status."""
+    actor = msg.get("requestor") or "assistant"
+    call_id = msg.get("tool_call_id") or msg.get("id")
+    span = tool_span_by_id.pop(call_id, None) if call_id else None
+    if span is not None:
+        for queue in pending.values():
+            if span in queue:
+                queue.remove(span)
+                break
+    elif pending[actor]:
+        span = pending[actor].pop(0)
+    if span is None:
+        return  # orphan tool result with no matching call — nothing to attach to
+    content = _text(msg.get("content"))
+    span["attributes"]["output.value"] = content
+    if msg.get("error"):
+        span["status"] = "ERROR"
+        span["status_message"] = content or "tool call failed"
+        span["attributes"]["exception.message"] = content or "tool call failed"
+
+
+def _trim_task(task: dict[str, Any], *, include_rewards: bool) -> dict[str, Any]:
+    """Keep the task's setup (description, scenario); withhold the gold answer key
+    (``evaluation_criteria``) unless ``include_rewards`` — the oracle-gating invariant."""
+    trimmed: dict[str, Any] = {"description": task.get("description"), "user_scenario": task.get("user_scenario")}
+    if include_rewards:
+        trimmed["evaluation_criteria"] = task.get("evaluation_criteria")
+    return trimmed

--- a/plugins/nemo-insights/testbed/otlp_ingest.py
+++ b/plugins/nemo-insights/testbed/otlp_ingest.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Build and export OTLP protobuf requests, and post reward rows.
+
+:mod:`testbed.otlp_build` produces plain span dicts; this module turns them into an
+``opentelemetry.proto`` ``ExportTraceServiceRequest`` and POSTs it to Intake's
+permissive OTLP route. OTLP ingest does **not** auto-create the queryable
+``evaluator_results`` rows the Analyst reads, so :func:`post_evaluator_results`
+separately POSTs the reward (mirroring exactly the row the ATIF importer used to
+create: ``name="reward"``, ``NUMERIC``, targeting the EVALUATOR span).
+
+The protobuf build mirrors nemo-platform's own
+``services/intake/tests/integration/spans/conftest.py::make_otlp_request`` helper,
+which is the canonical reference for what the OTLP ingest route accepts.
+"""
+
+import hashlib
+
+import httpx
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+_SERVICE_NAME = "nemo-insights-testbed"
+_SCOPE_NAME = "testbed"
+_SCOPE_VERSION = "1.0.0"
+_STATUS_CODE_ERROR = 2  # opentelemetry.proto.trace.v1.Status.STATUS_CODE_ERROR
+
+
+def trace_id_for(session_id: str) -> bytes:
+    """A deterministic, non-zero 16-byte OTLP trace id for a sim's session id."""
+    return hashlib.sha256(f"{session_id}:trace".encode()).digest()[:16]
+
+
+def export_spans(
+    base_url: str,
+    workspace: str,
+    session_id: str,
+    trace_id: bytes,
+    spans: list[dict],
+    *,
+    client: httpx.Client | None = None,
+) -> None:
+    """Build an OTLP ``ExportTraceServiceRequest`` from span dicts and POST it.
+
+    Raises ``RuntimeError`` on a non-2xx response **or** a non-empty ``errors``
+    array (the route ingests good spans and reports per-span failures in the
+    body, so a 2xx with errors is still a failure). ``client`` is injectable for
+    tests; when None a short-timeout client is created and closed here.
+    """
+    export_trace_request(base_url, workspace, _build_request(trace_id, spans), client=client)
+
+
+def export_trace_request(
+    base_url: str,
+    workspace: str,
+    request: ExportTraceServiceRequest,
+    *,
+    client: httpx.Client | None = None,
+    headers: dict[str, str] | None = None,
+) -> None:
+    """POST one OTLP request, raising for HTTP or per-span ingest errors."""
+    url = f"{base_url.rstrip('/')}/apis/intake/v2/workspaces/{workspace}/ingest/otlp/v1/traces"
+    request_headers = {"Content-Type": "application/x-protobuf", **(headers or {})}
+    owns_client = client is None
+    client = client or httpx.Client(timeout=30.0)
+    try:
+        resp = client.post(url, content=request.SerializeToString(), headers=request_headers)
+    finally:
+        if owns_client:
+            client.close()
+    if not (200 <= resp.status_code < 300):
+        raise RuntimeError(f"OTLP ingest failed ({resp.status_code}): {resp.text}")
+    try:
+        response_body = resp.json()
+    except (AttributeError, ValueError):
+        response_body = {}
+    errors = response_body.get("errors") or []
+    if errors:
+        raise RuntimeError(f"OTLP ingest reported {len(errors)} span error(s): {errors}")
+
+
+def post_evaluator_results(
+    base_url: str,
+    workspace: str,
+    *,
+    span_id: str,
+    session_id: str,
+    score: float,
+    client: httpx.Client | None = None,
+) -> None:
+    """POST the reward row the OTLP path doesn't auto-create.
+
+    Reproduces the ATIF importer's row exactly: ``name="reward"``, ``NUMERIC``,
+    targeting the EVALUATOR span — so the Analyst reads the reward unchanged.
+    Raises ``RuntimeError`` on any non-2xx.
+    """
+    url = f"{base_url.rstrip('/')}/apis/intake/v2/workspaces/{workspace}/evaluator-results"
+    body = {
+        "span_id": span_id,
+        "session_id": session_id,
+        "name": "reward",
+        "value": score,
+        "data_type": "NUMERIC",
+    }
+    owns_client = client is None
+    client = client or httpx.Client(timeout=30.0)
+    try:
+        resp = client.post(url, json=body)
+    finally:
+        if owns_client:
+            client.close()
+    if not (200 <= resp.status_code < 300):
+        raise RuntimeError(f"evaluator-results post failed ({resp.status_code}): {resp.text}")
+
+
+def _build_request(trace_id: bytes, spans: list[dict]) -> ExportTraceServiceRequest:
+    request = ExportTraceServiceRequest()
+    resource_spans = request.resource_spans.add()
+    _add_attributes(resource_spans.resource.attributes, {"service.name": _SERVICE_NAME})
+    scope_spans = resource_spans.scope_spans.add()
+    scope_spans.scope.name = _SCOPE_NAME
+    scope_spans.scope.version = _SCOPE_VERSION
+    for spec in spans:
+        span = scope_spans.spans.add()
+        span.trace_id = trace_id
+        span.span_id = bytes.fromhex(spec["span_id"])
+        parent = spec.get("parent_span_id")
+        if parent:  # leave unset for a root — an all-zero parent_span_id is rejected
+            span.parent_span_id = bytes.fromhex(parent)
+        span.name = spec["name"]
+        span.start_time_unix_nano = int(spec["start_ns"])
+        span.end_time_unix_nano = int(spec["end_ns"])
+        if spec.get("status") == "ERROR":
+            span.status.code = _STATUS_CODE_ERROR
+            if spec.get("status_message"):
+                span.status.message = spec["status_message"]
+        _add_attributes(span.attributes, spec.get("attributes", {}))
+    return request
+
+
+def _add_attributes(attributes, values: dict) -> None:
+    for key, value in values.items():
+        item = attributes.add()
+        item.key = key
+        _set_any_value(item.value, value)
+
+
+def _set_any_value(any_value, value) -> None:
+    # bool first: bool is a subclass of int.
+    if isinstance(value, bool):
+        any_value.bool_value = value
+    elif isinstance(value, int):
+        any_value.int_value = value
+    elif isinstance(value, float):
+        any_value.double_value = value
+    elif isinstance(value, list):
+        for item in value:
+            _set_any_value(any_value.array_value.values.add(), item)
+    elif isinstance(value, dict):
+        _add_attributes(any_value.kvlist_value.values, value)
+    else:
+        any_value.string_value = str(value)

--- a/plugins/nemo-insights/testbed/publish.py
+++ b/plugins/nemo-insights/testbed/publish.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Mint the next state ref, upload a candidate bundle, and update the fixture catalog.
+
+Laptop-first: ``uv run python -m testbed publish FILE --reason "why"`` works
+from any machine with ``gh`` auth'd against the repo; the CI produce job runs
+the same command. The catalog's "Minted by" column records the GitHub Actions
+run when ``GITHUB_RUN_ID``/``GITHUB_REPOSITORY`` are set, else
+``laptop (<user>)``; the "Contents" column comes from the bundle's own
+manifest (subjects + per-collection doc counts), so the catalog can never
+disagree with what the asset actually holds.
+"""
+
+import getpass
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+from testbed import release
+
+RELEASE_TAG = release.RELEASE_TAG
+CATALOG_MARKER = "<!-- fixture-catalog: newest rows are auto-inserted below by the publish step -->"
+
+
+def read_manifest(bundle: Path) -> dict:
+    """The bundle's ``state/manifest.json`` (tar peek, no full extract).
+
+    Only ``kind: testbed-export`` bundles are publishable — the catalog row is
+    built from the manifest, so a bundle without one has nothing honest to say
+    in the Contents column. Hard exit otherwise.
+    """
+    if not bundle.is_file():
+        sys.exit(f"no such bundle file: {bundle}")
+    proc = subprocess.run(
+        ["tar", "--zstd", "-xOf", str(bundle), "state/manifest.json"],
+        capture_output=True,
+        text=True,
+    )
+    try:
+        manifest = json.loads(proc.stdout) if proc.returncode == 0 else None
+    except json.JSONDecodeError:
+        manifest = None
+    if not isinstance(manifest, dict) or manifest.get("kind") != "testbed-export":
+        sys.exit(f"publish: {bundle.name} is not a testbed-export bundle — only export bundles are published")
+    return manifest
+
+
+def contents_column(manifest: dict) -> str:
+    """Catalog "Contents": the bundle's subjects and its per-collection doc totals."""
+    subjects = ", ".join(manifest.get("subjects") or []) or "?"
+    totals = {"spans": 0, "annotations": 0, "evaluator_results": 0}
+    for ws_counts in (manifest.get("counts") or {}).values():
+        for key in totals:
+            totals[key] += int(ws_counts.get(key) or 0)
+    return (
+        f"{subjects} — {totals['spans']} spans, {totals['annotations']} annotations, "
+        f"{totals['evaluator_results']} evaluator results"
+    )
+
+
+def minted_by(env: Mapping[str, str]) -> str:
+    """A run link when publishing from CI, else the laptop user."""
+    run_id, repo = env.get("GITHUB_RUN_ID"), env.get("GITHUB_REPOSITORY")
+    if run_id and repo:
+        return f"[run {run_id}](https://github.com/{repo}/actions/runs/{run_id})"
+    return f"laptop ({getpass.getuser()})"
+
+
+def _sanitize_reason(reason: str) -> str:
+    """Force *reason* to stay one Markdown table cell.
+
+    A raw ``|`` adds phantom columns and a newline terminates the row — GitHub
+    stops rendering the release table there, hiding every older catalog row.
+    Whitespace runs (newlines included) collapse to single spaces; pipes are
+    escaped as ``\\|``.
+    """
+    return re.sub(r"\s+", " ", reason).strip().replace("|", "\\|")
+
+
+def catalog_row(ref: str, manifest: dict, *, reason: str, env: Mapping[str, str]) -> str:
+    """One fixture-catalog table row for the release notes (reason sanitized to one cell)."""
+    return f"| {ref} | {contents_column(manifest)} | {_sanitize_reason(reason) or '—'} | {minted_by(env)} |"
+
+
+def insert_catalog_row(body: str, row: str) -> str:
+    """Insert *row* at the top of the catalog table (newest first).
+
+    The marker sits ABOVE the table (a comment inside a markdown table would
+    terminate it), so the row goes after the first header-separator line
+    (`|---`) following the marker. If the marker or separator is missing
+    (hand-edited notes), append a fresh catalog section instead.
+    """
+    if CATALOG_MARKER in body:
+        lines = body.splitlines()
+        start = next(i for i, line in enumerate(lines) if CATALOG_MARKER in line)
+        for i in range(start + 1, len(lines)):
+            if lines[i].startswith("|---"):
+                return "\n".join(lines[: i + 1] + [row] + lines[i + 1 :])
+    return f"{body}\n\n{CATALOG_MARKER}\n| Version | Contents | Why it exists | Minted by |\n|---|---|---|---|\n{row}\n"
+
+
+def _ensure_release() -> None:
+    try:
+        release._gh("release", "view", RELEASE_TAG)
+    except subprocess.CalledProcessError:
+        release._gh(
+            "release",
+            "create",
+            RELEASE_TAG,
+            "--title",
+            "Testbed state fixtures",
+            "--notes",
+            "Immutable testbed state fixtures. Do not delete assets.",
+            "--latest=false",
+        )
+
+
+def publish(candidate: Path, *, reason: str | None, env: Mapping[str, str] | None = None) -> str:
+    """Mint the next ref, upload the bundle, then edit the release notes with its catalog row.
+
+    ``reason=None`` falls back to the ``REASON`` env var. Returns the minted
+    ref; when ``GITHUB_OUTPUT`` is set (CI), also writes ``state_ref=<ref>``.
+
+    A failure between the upload and the notes edit leaves an orphaned asset
+    with no catalog row; recover by deleting the asset or hand-adding the
+    row — a retry mints the next ref, not the orphaned one.
+    """
+    env = os.environ if env is None else env
+    if reason is None:
+        reason = env.get("REASON", "")
+    manifest = read_manifest(candidate)
+    ref = release.next_ref(release.latest_ref(release._release_asset_names()))
+    tarball = candidate.parent / f"{ref}.tar.zst"
+    shutil.copy2(candidate, tarball)
+    _ensure_release()
+    # --clobber: a retry after a partial upload overwrites the broken asset
+    # instead of erroring (next_ref never collides with a *completed* publish —
+    # its ref would already be in the asset list).
+    release._gh("release", "upload", RELEASE_TAG, str(tarball), "--clobber")
+    body = json.loads(release._gh("release", "view", RELEASE_TAG, "--json", "body"))["body"]
+    row = catalog_row(ref, manifest, reason=reason, env=env)
+    release._gh("release", "edit", RELEASE_TAG, "--notes", insert_catalog_row(body, row))
+    if env.get("GITHUB_OUTPUT"):
+        with open(env["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+            fh.write(f"state_ref={ref}\n")
+    print(f"published {ref}")
+    return ref

--- a/plugins/nemo-insights/testbed/registry.py
+++ b/plugins/nemo-insights/testbed/registry.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Load the testbed subject registry (testbeds.toml)."""
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Subject:
+    """One testbed subject: a name, a type, and its merged config."""
+
+    name: str
+    type: str
+    config: dict[str, Any]
+
+
+def load_registry(path: Path) -> dict[str, Subject]:
+    """Parse the registry. Top-level scalars are shared defaults merged into every
+    subject (e.g. ``base_url``); each table is a subject; a per-subject key overrides."""
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    defaults = {k: v for k, v in data.items() if not isinstance(v, dict)}
+    subjects: dict[str, Subject] = {}
+    for name, cfg in data.items():
+        if not isinstance(cfg, dict):
+            continue
+        merged = {**defaults, **cfg}
+        subjects[name] = Subject(name=name, type=str(merged.get("type", "")), config=merged)
+    return subjects

--- a/plugins/nemo-insights/testbed/reingest.py
+++ b/plugins/nemo-insights/testbed/reingest.py
@@ -1,0 +1,851 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Re-ingest export bundles through the platform's real APIs (restore = additive re-ingest).
+
+The consumption side of testbed export bundles: convert exported span docs back
+to OTLP protobuf and POST them to Intake's ingest route, then re-post
+annotations and evaluator results — additive and idempotent, into
+caller-specified workspaces, never touching existing data.
+
+Doc -> OTLP inversion (validated against the live platform, 2026-07-06 spike):
+
+* Protocol fields are taken directly from the doc: ``trace_id``/``span_id``/
+  ``parent_span_id`` are the original OTLP ids (Intake stores and serves the
+  *external* ids), ``started_at``/``ended_at`` become nanosecond timestamps
+  (DateTime64(6) — microseconds are exact), ``status == "error"`` becomes OTLP
+  status code 2.
+* ``raw_attributes`` (a JSON string in detailed docs) carries every attribute
+  the catalog did NOT consume — it passes through verbatim. ``otel.scope`` is
+  re-hoisted onto the protobuf scope (ingest unconditionally re-stamps
+  ``otel.scope`` from the scope, so it must not ride along as an attribute).
+* Catalog-consumed attributes (``model``, ``agent_name``, token counts, ...)
+  are NOT in ``raw_attributes`` — they surface as typed doc columns. The
+  inversion is derived mechanically from ``span_attribute_catalog`` (imported
+  from the nemo-platform checkout): each doc value is re-emitted under the
+  spec's highest-precedence source key, so ingest re-derives the identical
+  semantic column. ``agent_version`` is the one catalog field the read API
+  does not expose — it cannot be restored (invisible to doc-level diffs, which
+  compare read-API output on both sides).
+* Source-only keys (``session.id``, ``input.value``, ``output.value``,
+  ``openinference.span.kind``) are synthesized from the doc's ``session_id``/
+  ``input``/``output``/``kind`` fields.
+
+Idempotency (spike-verified): spans dedup on re-ingest (deterministic
+ClickHouse ORDER BY key + FINAL reads — identical payloads keep counts flat),
+evaluator-result POSTs upsert (identity-derived id), but annotation POSTs
+DUPLICATE (server-side uuid ids). The per-collection count guard in
+:func:`ingest_bundle` is therefore the only protection against double-posting
+annotations, and what lets an interrupted restore heal its missing
+annotations/evaluator-results — its semantics are exact (see the function
+docstring).
+
+Provenance (spike-verified): annotation and evaluator-result POSTs reject
+client ``created_at``/``created_by`` (422, ``extra="forbid"``) — both are
+server-stamped at restore time, as are ``annotation_id``, ``ingested_at``,
+and the workspace-scoped ``evaluator_result_id``. See ``NORMALIZED_FIELDS``.
+"""
+
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from collections import Counter
+from collections.abc import Callable, Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+from testbed import export
+from testbed.ingest import ensure_workspace
+from testbed.otlp_ingest import _add_attributes, export_trace_request
+
+TEMP_ROOT = Path(__file__).resolve().parent / "tmp"
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+_EPOCH_ISO = "1970-01-01T00:00:00Z"
+_STATUS_CODE_ERROR = 2  # opentelemetry.proto.trace.v1.Status.STATUS_CODE_ERROR
+SPAN_BATCH = 100  # spans per OTLP request (ingest caps bodies at 5 MiB; tau2 spans are a few KB)
+
+# Where the attribute catalog lives inside a nemo-platform checkout.
+CATALOG_RELPATH = Path("services/intake/src/nmp/intake/spans/span_attribute_catalog.py")
+
+# The dev platform's ClickHouse container: nemo-platform's
+# services/intake/scripts/spans/run_clickhouse.sh always docker-runs it under this name.
+CLICKHOUSE_CONTAINER = "nmp-intake-clickhouse"
+
+# Fields normalized away in round-trip diffs — every one spike-proven unavoidable:
+# - workspace: the whole point of re-ingest is restoring into a different (fixture/scratch) workspace.
+# - ingested_at: stamped `utc_now()` by ingest for all three collections.
+# - created_at / created_by: the annotation and evaluator-result POSTs reject client values
+#   (pydantic extra="forbid" -> 422); the server stamps now()/auth-principal (None when auth is off).
+# - annotation_id: server-generated uuid per POST.
+# - evaluator_result_id: server-derived stable_id(workspace, session, span, name) — workspace-scoped,
+#   so it necessarily changes when the workspace is remapped.
+NORMALIZED_FIELDS = {
+    "spans": ("workspace", "ingested_at"),
+    "annotations": ("workspace", "ingested_at", "created_at", "created_by", "annotation_id"),
+    "evaluator_results": ("workspace", "ingested_at", "created_at", "created_by", "evaluator_result_id"),
+}
+
+# Server-stamped fields to drop when turning an exported doc back into a POST body.
+_POST_DROP = {
+    "annotations": ("annotation_id", "workspace", "created_by", "created_at", "ingested_at"),
+    "evaluator_results": ("evaluator_result_id", "workspace", "created_by", "created_at", "ingested_at"),
+}
+
+# The platform's entity-name rule (nmp.common NAME_PATTERN) — target workspaces must satisfy it.
+_WS_OK = re.compile(r"^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$")
+
+# Catalog fields that are not flat doc columns: nested under evaluation_context / usage_details.
+_EVAL_CONTEXT_FIELDS = frozenset({"evaluation_id", "evaluation_sha", "evaluation_run_id", "test_case_id"})
+_USAGE_DETAIL_FIELDS = {
+    "prompt_cache_write_tokens": "prompt_details.cache_write",
+    "prompt_audio_tokens": "prompt_details.audio",
+    "completion_reasoning_tokens": "completion_details.reasoning",
+    "completion_audio_tokens": "completion_details.audio",
+}
+
+STALE_AFTER_DAYS = 60  # spans TTL out of ClickHouse 90 days after start_time; warn well before
+
+# Margin subtracted from a bundle's min_start_time when deriving the analyst's `since`:
+# comfortably below the oldest span, so the read API's 30-day default lookback (injected
+# whenever `since` is absent) can never hide restored spans.
+SINCE_MARGIN = timedelta(days=1)
+
+
+def default_platform_roots() -> list[Path]:
+    """Auto-detect candidates for a nemo-platform checkout, in resolution order.
+
+    First the containing monorepo, then the legacy workstation layout.
+    """
+    plugin_root = Path(__file__).resolve().parent.parent
+    return [
+        plugin_root.parents[1],
+        Path.home() / "workstation" / "nemo-platform",
+    ]
+
+
+def resolve_platform_root(
+    explicit: str | Path | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    candidates: list[Path] | None = None,
+) -> Path:
+    """Locate the nemo-platform checkout whose ``span_attribute_catalog`` drives re-ingest.
+
+    Resolution order: explicit ``--platform-root`` > ``NMP_PLATFORM_ROOT`` env >
+    the first :func:`default_platform_roots` candidate that actually contains the
+    catalog. Explicit/env paths are taken at face value (:func:`load_catalog`
+    raises the precise error if the catalog is missing there); with nothing
+    found, exit with the fix.
+    """
+    if explicit:
+        return Path(explicit)
+    env = os.environ if env is None else env
+    if env.get("NMP_PLATFORM_ROOT"):
+        return Path(env["NMP_PLATFORM_ROOT"])
+    for candidate in default_platform_roots() if candidates is None else candidates:
+        if (candidate / CATALOG_RELPATH).is_file():
+            return candidate
+    sys.exit(
+        "no nemo-platform checkout found (its span_attribute_catalog drives the re-ingest "
+        "attribute inversion) — pass --platform-root PATH or set NMP_PLATFORM_ROOT"
+    )
+
+
+def bundle_digest(bundle: Path) -> str:
+    """Fixture-workspace suffix for a local bundle file: sha256 of its bytes, first 8 hex chars."""
+    return hashlib.sha256(Path(bundle).read_bytes()).hexdigest()[:8]
+
+
+def fixture_workspace_map(workspaces: list[str], suffix: str) -> dict[str, str]:
+    """Map bundle workspaces onto fixture-scoped restore targets: ``<ws>-<suffix>``.
+
+    Restores never write into a source-named workspace: published refs land in
+    ``<ws>-<ref>`` (e.g. ``tau2-airline-state-v6``), local bundle files in
+    ``<ws>-<sha256(bundle)[:8]>``. Every target must satisfy the platform's
+    entity-name rule — checked here so the CLI fails before any network I/O
+    (:func:`ingest_bundle` re-checks per workspace as a backstop).
+    """
+    mapping = {ws: f"{ws}-{suffix}" for ws in workspaces}
+    for target in mapping.values():
+        if not _WS_OK.fullmatch(target):
+            sys.exit(f"fixture workspace '{target}' violates the platform naming rule ({_WS_OK.pattern})")
+    return mapping
+
+
+def manifest_since(manifest: dict) -> datetime:
+    """The analyst's explicit lower bound for a restored bundle: ``min_start_time`` floored.
+
+    The intake read API injects a 30-day default lookback whenever ``since`` is
+    absent — analyzing a restored bundle without an explicit bound at or below
+    its oldest span silently reads nothing. Returns ``min_start_time`` minus
+    :data:`SINCE_MARGIN`; epoch when the manifest has no span time bounds.
+    """
+    raw = manifest.get("min_start_time")
+    if not raw:
+        return _EPOCH
+    oldest = datetime.fromisoformat(str(raw))
+    if oldest.tzinfo is None:
+        oldest = oldest.replace(tzinfo=timezone.utc)
+    return oldest - SINCE_MARGIN
+
+
+def load_catalog(platform_root: Path) -> ModuleType:
+    """Import ``span_attribute_catalog`` straight from a nemo-platform checkout.
+
+    The catalog module is pure stdlib (dataclasses/enum/decimal), so it loads
+    by file path without installing the platform's packages. The module must be
+    registered in ``sys.modules`` before exec: its dataclasses use
+    ``from __future__ import annotations`` and field-type resolution looks the
+    module up by name.
+    """
+    path = Path(platform_root) / CATALOG_RELPATH
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"span_attribute_catalog not found at {path} — pass the root of a nemo-platform checkout"
+        )
+    spec = importlib.util.spec_from_file_location("testbed_span_attribute_catalog", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _doc_value(doc: dict, field: str) -> Any:
+    """The doc's value for a catalog semantic field (most are flat columns; a few are nested)."""
+    if field in _EVAL_CONTEXT_FIELDS:
+        return (doc.get("evaluation_context") or {}).get(field)
+    if field in _USAGE_DETAIL_FIELDS:
+        return (doc.get("usage_details") or {}).get(_USAGE_DETAIL_FIELDS[field])
+    if field == "agent_version":
+        return None  # consumed at ingest but never exposed by the read API — unrecoverable
+    return doc.get(field)
+
+
+def _iso_to_ns(value: str) -> int:
+    """Doc timestamp (ISO, naive = UTC) -> OTLP nanoseconds, exact to the stored microsecond."""
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return ((dt - _EPOCH) // timedelta(microseconds=1)) * 1000
+
+
+def doc_to_otlp(doc: dict, catalog) -> dict:
+    """One detailed span doc -> a plain OTLP span dict (no protobuf, no network).
+
+    Returns ``{trace_id, span_id, parent_span_id, name, start_ns, end_ns,
+    status_error, scope, attributes}`` — :func:`build_trace_request` turns a
+    batch of these into one protobuf request. ``catalog`` is the platform's
+    ``span_attribute_catalog`` module (see :func:`load_catalog`); the semantic
+    doc columns are inverted through it mechanically, so a catalog change on
+    the platform side changes the inversion with it.
+    """
+    attrs: dict[str, Any] = json.loads(doc.get("raw_attributes") or "{}")
+    # Ingest re-stamps otel.scope from the protobuf scope on every span, so the exported value
+    # must travel as the scope itself (build_trace_request groups spans by it), not as an attribute.
+    scope = json.loads(attrs.pop("otel.scope", "null") or "null")
+    attrs["session.id"] = doc["session_id"]  # source-only keys never appear in raw_attributes
+    if doc.get("input") is not None:
+        attrs["input.value"] = doc["input"]
+    if doc.get("output") is not None:
+        attrs["output.value"] = doc["output"]
+    if doc.get("status") == "cancelled":
+        attrs["status"] = "cancelled"  # source-only; the only OTLP route to a cancelled row
+    if "openinference.span.kind" not in attrs and doc.get("kind") not in (None, "UNKNOWN"):
+        attrs["openinference.span.kind"] = doc["kind"]
+    for spec in catalog.ATTRIBUTE_SPECS:
+        if any(key in attrs for key in spec.source_keys):
+            continue  # raw passthrough already carries a source alias — let it win, as it did originally
+        value = _doc_value(doc, spec.field.value)
+        if value is not None:
+            attrs[spec.source_keys[0]] = value
+    metadata = (doc.get("evaluation_context") or {}).get("metadata")
+    if metadata and "nemo.experiment.metadata" not in attrs:
+        # Stored in the string bag but excluded from raw_attributes; resurfaces as evaluation_context.metadata.
+        attrs["nemo.experiment.metadata"] = json.dumps(metadata, separators=(",", ":"), ensure_ascii=False)
+    if not doc.get("trace_id"):
+        raise ValueError(f"span {doc.get('span_id')}: no trace_id — cannot rebuild an OTLP span")
+    return {
+        "trace_id": doc["trace_id"],
+        "span_id": doc["span_id"],
+        "parent_span_id": doc.get("parent_span_id"),
+        "name": doc.get("name") or "",
+        "start_ns": _iso_to_ns(doc["started_at"]),
+        "end_ns": _iso_to_ns(doc["ended_at"]) if doc.get("ended_at") else 0,
+        "status_error": doc.get("status") == "error",
+        "scope": scope,
+        "attributes": attrs,
+    }
+
+
+def build_trace_request(otlp_spans: list[dict]) -> ExportTraceServiceRequest:
+    """Batch OTLP span dicts into one ``ExportTraceServiceRequest``.
+
+    Spans are grouped into one ScopeSpans per distinct ``scope`` value so the
+    original ``otel.scope`` round-trips. No resource attributes are set: the
+    original resource layer (e.g. ``service.name``) was merged into the span
+    attributes at first ingest and now rides in the raw-attributes passthrough.
+    """
+    request = ExportTraceServiceRequest()
+    resource_spans = request.resource_spans.add()
+    by_scope: dict[str, Any] = {}
+    for spec in otlp_spans:
+        scope_key = json.dumps(spec["scope"], sort_keys=True)
+        scope_spans = by_scope.get(scope_key)
+        if scope_spans is None:
+            scope_spans = resource_spans.scope_spans.add()
+            if spec["scope"]:
+                scope_spans.scope.name = spec["scope"].get("name") or ""
+                scope_spans.scope.version = spec["scope"].get("version") or ""
+            by_scope[scope_key] = scope_spans
+        span = scope_spans.spans.add()
+        span.trace_id = bytes.fromhex(spec["trace_id"])
+        span.span_id = bytes.fromhex(spec["span_id"])
+        if spec.get("parent_span_id"):
+            span.parent_span_id = bytes.fromhex(spec["parent_span_id"])
+        span.name = spec["name"]
+        span.start_time_unix_nano = spec["start_ns"]
+        span.end_time_unix_nano = spec["end_ns"]
+        if spec["status_error"]:
+            span.status.code = _STATUS_CODE_ERROR
+        _add_attributes(span.attributes, spec["attributes"])
+    return request
+
+
+def _collection_count(
+    base_url: str, workspace: str, collection: str, time_field: str, *, client: httpx.Client | None = None
+) -> int:
+    """Total docs in one workspace collection, read off the list endpoint's pagination total.
+
+    ``page_size=1`` — only ``pagination.total_results`` is consumed. The time
+    filter carries an explicit epoch bound because the read API injects a
+    30-day default lookback whenever none is given (older docs would silently
+    vanish from the count).
+    """
+    url = f"{base_url.rstrip('/')}/apis/intake/v2/workspaces/{workspace}/{collection}"
+    params = {"page": 1, "page_size": 1, f"filter[{time_field}][gte]": _EPOCH_ISO}
+    owns_client = client is None
+    client = client or httpx.Client(timeout=30.0)
+    try:
+        resp = client.get(url, params=params)
+    finally:
+        if owns_client:
+            client.close()
+    if resp.status_code != 200:
+        raise RuntimeError(f"{collection} count failed for {workspace} ({resp.status_code}): {resp.text}")
+    return int(resp.json()["pagination"]["total_results"])
+
+
+def span_count(base_url: str, workspace: str, *, client: httpx.Client | None = None) -> int:
+    """Total spans in a workspace (``started_at`` >= epoch)."""
+    return _collection_count(base_url, workspace, "spans", "started_at", client=client)
+
+
+def annotation_count(base_url: str, workspace: str, *, client: httpx.Client | None = None) -> int:
+    """Total annotations in a workspace (``created_at`` >= epoch)."""
+    return _collection_count(base_url, workspace, "annotations", "created_at", client=client)
+
+
+def evaluator_result_count(base_url: str, workspace: str, *, client: httpx.Client | None = None) -> int:
+    """Total evaluator results in a workspace (``created_at`` >= epoch)."""
+    return _collection_count(base_url, workspace, "evaluator-results", "created_at", client=client)
+
+
+def _post_created(client: httpx.Client, url: str, body: dict) -> None:
+    resp = client.post(url, json=body)
+    if not (200 <= resp.status_code < 300):
+        raise RuntimeError(f"POST {url} failed ({resp.status_code}): {resp.text}")
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _wait_for_spans(
+    base_url: str,
+    workspace: str,
+    expected: int,
+    *,
+    client: httpx.Client,
+    timeout_s: float = 60.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """Block until the workspace serves ``expected`` spans (ingest -> queryable lag).
+
+    Transient poll failures — transport errors and non-200 count responses
+    (``span_count`` raises RuntimeError on those) — are treated as
+    not-yet-visible and retried until the deadline, same spirit as
+    ``ingest.poll_visible``; the last one is quoted in the timeout error.
+    """
+    deadline = time.monotonic() + timeout_s
+    count = 0
+    last_error: Exception | None = None
+    while True:
+        try:
+            count = span_count(base_url, workspace, client=client)
+            last_error = None
+            if count >= expected:
+                return
+        except (httpx.HTTPError, RuntimeError) as exc:
+            last_error = exc
+        if time.monotonic() >= deadline:
+            detail = f" (last poll error: {last_error})" if last_error is not None else ""
+            raise RuntimeError(f"{workspace}: only {count}/{expected} spans queryable after {timeout_s:.0f}s{detail}")
+        sleep(1.0)
+
+
+def _is_loopback(base_url: str) -> bool:
+    """True when the target is the local dev platform — the docker ClickHouse is *its* backing store."""
+    return urlsplit(base_url).hostname in {"localhost", "127.0.0.1", "::1"}
+
+
+def _stop_local_ttl_merges(*, container: str = CLICKHOUSE_CONTAINER) -> None:
+    """Best-effort ``SYSTEM STOP TTL MERGES`` on the local ClickHouse; never raises.
+
+    Intake TTL-drops spans 90 days after ``start_time`` — restoring a stale
+    bundle without freezing TTL merges silently loses the rows on the next
+    merge. CI's stack does this unconditionally; this is the laptop-restore
+    equivalent. On failure, prints the manual command instead.
+    """
+    command = ["docker", "exec", container, "clickhouse-client", "-q", "SYSTEM STOP TTL MERGES"]
+    try:
+        proc = subprocess.run(command, capture_output=True, text=True)
+        failure = (proc.stderr.strip() or f"exit {proc.returncode}") if proc.returncode != 0 else None
+    except Exception as exc:  # docker missing entirely, exec error — protection stays best-effort
+        failure = str(exc)
+    if failure:
+        print(
+            f"could not stop TTL merges ({failure}) — run this manually or restored spans may vanish:\n"
+            f'  docker exec {container} clickhouse-client -q "SYSTEM STOP TTL MERGES"',
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"TTL merges stopped on {container} (stale bundle: restored spans are past the 90-day TTL)", file=sys.stderr
+        )
+
+
+def _first_span_id(base_url: str, workspace: str, *, client: httpx.Client | None = None) -> str | None:
+    """The workspace's earliest span id (``started_at`` ascending), or None when the probe can't answer.
+
+    Fingerprint for the count-guard skip path: ``page_size=1`` + ``sort=started_at``
+    with an explicit epoch bound (the read API injects a 30-day default lookback).
+    Any failure — transport error, non-200, empty page — returns None: the probe
+    is hardening, never a blocker.
+    """
+    url = f"{base_url.rstrip('/')}/apis/intake/v2/workspaces/{workspace}/spans"
+    params = {"page": 1, "page_size": 1, "sort": "started_at", "filter[started_at][gte]": _EPOCH_ISO}
+    owns_client = client is None
+    client = client or httpx.Client(timeout=30.0)
+    try:
+        resp = client.get(url, params=params)
+        if resp.status_code != 200:
+            return None
+        data = resp.json().get("data") or []
+        return (data[0] or {}).get("span_id") if data else None
+    except (httpx.HTTPError, ValueError):
+        return None
+    finally:
+        if owns_client:
+            client.close()
+
+
+def _assert_same_first_span(base_url: str, workspace: str, span_docs: list[dict], *, client: httpx.Client) -> None:
+    """Harden the count-only skip guard: matching counts can still be a different corpus.
+
+    A re-minted ref (same workspaces, same counts, fresh ids — e.g. re-published
+    via ``--clobber``) would silently pass the count guard and every later read
+    would run against the WRONG corpus. Compare the live workspace's first span
+    (``started_at`` asc) against the bundle's; any bundle doc tied at the minimum
+    ``started_at`` qualifies. A probe failure falls back to the count-only guard
+    (see :func:`_first_span_id`) — hardening must never block a restore.
+    """
+    live_first = _first_span_id(base_url, workspace, client=client)
+    if live_first is None:
+        return
+    earliest = min(str(doc.get("started_at") or "") for doc in span_docs)
+    expected = {doc.get("span_id") for doc in span_docs if str(doc.get("started_at") or "") == earliest}
+    if live_first not in expected:
+        raise RuntimeError(
+            f"{workspace}: span count matches the bundle but its first span is {live_first!r} "
+            f"(bundle expects one of {sorted(expected)!r}) — the workspace holds a DIFFERENT corpus "
+            "with matching counts (re-minted ref?). Delete the fixture workspace and restore again."
+        )
+
+
+def warn_if_stale(manifest: dict, *, now: datetime | None = None) -> str | None:
+    """Warn (stderr) when the bundle's spans are old enough to be at TTL risk; return the message.
+
+    Intake's spans table TTLs rows 90 days after ``start_time`` — restoring an
+    old bundle plants spans that the next TTL merge silently deletes — and the
+    read API injects a 30-day default lookback when no explicit ``since`` is
+    passed. Warn at ``STALE_AFTER_DAYS`` so both traps are visible early.
+    """
+    raw = manifest.get("min_start_time")
+    if not raw:
+        return None
+    oldest = datetime.fromisoformat(str(raw))
+    if oldest.tzinfo is None:
+        oldest = oldest.replace(tzinfo=timezone.utc)
+    now = now or datetime.now(timezone.utc)
+    age_days = (now - oldest).days
+    if age_days <= STALE_AFTER_DAYS:
+        return None
+    message = (
+        f"WARNING: bundle spans start {age_days} days ago (min_start_time={raw}).\n"
+        "  Intake TTL-drops spans 90 days after start_time — restored rows can vanish on the next\n"
+        "  TTL merge. Freeze TTL merges on the target ClickHouse first:\n"
+        '    docker exec nmp-intake-clickhouse clickhouse-client --query "SYSTEM STOP TTL MERGES"\n'
+        "  Reads also default to a 30-day lookback: always pass an explicit `since` at or before\n"
+        f"  min_start_time ({raw}) when querying restored spans."
+    )
+    print(message, file=sys.stderr)
+    return message
+
+
+def ingest_bundle(
+    base_url: str,
+    export_dir: Path,
+    manifest: dict,
+    *,
+    workspace_map: dict[str, str],
+    catalog,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict:
+    """Re-ingest a bundle's export into the mapped workspaces through the real APIs.
+
+    ``export_dir`` is the bundle's ``export/`` directory (one subdir per source
+    workspace); ``workspace_map`` maps every manifest workspace to its target.
+    Per workspace, the idempotency guard runs FIRST and is PER COLLECTION — an
+    interrupted restore (transient POST failure, span-visibility timeout) can
+    leave spans landed with annotations/evaluator-results missing, and a
+    span-only guard would skip the workspace forever without healing it:
+
+    * spans: live count equal to the manifest -> skip span ingest; zero -> ingest
+      (OTLP batches, then wait until queryable); any other mismatch -> hard error
+      (partially restored spans, or foreign data).
+    * evaluator results: equal -> skip; fewer than the manifest -> post ALL of
+      them (POSTs upsert on a server-derived stable id, so re-posting is safe —
+      announced as healing); more -> hard error (foreign data).
+    * annotations: equal -> skip; zero existing -> post; anything else -> hard
+      error — annotation POSTs mint fresh server-side uuids, so re-posting a
+      partial set would duplicate; there is no safe heal (delete + re-restore).
+
+    "already restored — skipping" is printed only when EVERY collection is
+    satisfied. Returns
+    ``{source_ws: {"workspace": target, <collection>: {"ingested": n, "skipped": n}}}``.
+
+    Only otel-sourced corpora are restorable: ATIF/chat-completions span docs
+    carry non-hex ids (``span-<digest>``, ``chatcmpl-<hash>``) that the OTLP
+    inversion cannot encode, and re-ingest would re-stamp their ``source`` as
+    otel. Every workspace's docs are scanned up front so a bad bundle errors
+    before ANYTHING is ingested (all-or-nothing).
+    """
+    spans_by_ws: dict[str, list[dict]] = {}
+    foreign_sources: dict[str, Counter] = {}
+    for source_ws in manifest["workspaces"]:
+        docs = _read_jsonl(Path(export_dir) / source_ws / "spans.jsonl")
+        spans_by_ws[source_ws] = docs
+        bad = Counter(doc.get("source") for doc in docs if doc.get("source") != "otel")
+        if bad:
+            foreign_sources[source_ws] = bad
+    if foreign_sources:
+        detail = "; ".join(
+            f"workspace '{ws}': "
+            + ", ".join(f"{src or '<missing>'}={n}" for src, n in sorted(bad.items(), key=lambda kv: str(kv[0])))
+            for ws, bad in foreign_sources.items()
+        )
+        raise RuntimeError(
+            f"bundle contains non-otel span docs ({detail}) — their ids are not OTLP hex, so re-ingest "
+            "would crash mid-batch (partial restore) and any doc that survived would be silently "
+            "re-stamped as otel. Only otel-sourced corpora are restorable today; nothing was ingested."
+        )
+    if warn_if_stale(manifest) and _is_loopback(base_url):
+        # CI's stack freezes TTL merges unconditionally; a laptop restore of a >90d bundle
+        # would otherwise lose its spans on the next TTL merge with only an ignorable warning.
+        _stop_local_ttl_merges()
+    outcome: dict[str, dict] = {}
+    counts = manifest.get("counts") or {}
+    with httpx.Client(timeout=60.0) as client:
+        for source_ws in manifest["workspaces"]:
+            try:
+                target = workspace_map[source_ws]
+            except KeyError:
+                raise RuntimeError(f"workspace_map has no target for bundle workspace '{source_ws}'") from None
+            if not _WS_OK.fullmatch(target):
+                raise RuntimeError(f"target workspace '{target}' violates the platform naming rule ({_WS_OK.pattern})")
+            ws_dir = Path(export_dir) / source_ws
+            spans = spans_by_ws[source_ws]
+            annotations = _read_jsonl(ws_dir / "annotations.jsonl")
+            results = _read_jsonl(ws_dir / "evaluator_results.jsonl")
+            ws_counts = counts.get(source_ws) or {}
+            expected_spans = int(ws_counts.get("spans", len(spans)))
+            expected_ann = int(ws_counts.get("annotations", len(annotations)))
+            expected_res = int(ws_counts.get("evaluator_results", len(results)))
+            ensure_workspace(base_url, target, client=client)
+
+            have_spans = span_count(base_url, target, client=client)
+            if have_spans == expected_spans:
+                ingest_spans = False
+                if expected_spans and spans:
+                    # Counts alone can't tell a restored corpus from a re-minted one — fingerprint it.
+                    _assert_same_first_span(base_url, target, spans, client=client)
+            elif have_spans == 0:
+                ingest_spans = True
+            else:
+                raise RuntimeError(
+                    f"{target}: has {have_spans} spans but the bundle expects {expected_spans} — the workspace "
+                    "is partially restored (or holds foreign data). Delete the workspace (or map to a fresh "
+                    "one) and restore again."
+                )
+            have_ann = annotation_count(base_url, target, client=client)
+            if have_ann == expected_ann:
+                post_annotations = False
+            elif have_ann == 0:
+                post_annotations = True
+            else:
+                raise RuntimeError(
+                    f"{target}: has {have_ann} annotations but the bundle expects {expected_ann} — annotation "
+                    "POSTs mint fresh server-side ids, so re-posting would duplicate what is already there "
+                    "(there is no safe partial re-post). Delete the fixture workspace (or map to a fresh one) "
+                    "and restore again."
+                )
+            have_res = evaluator_result_count(base_url, target, client=client)
+            if have_res == expected_res:
+                post_results = False
+            elif have_res < expected_res:
+                post_results = True  # upsert-safe: re-post the FULL set
+            else:
+                raise RuntimeError(
+                    f"{target}: has {have_res} evaluator results but the bundle expects {expected_res} — the "
+                    "workspace holds foreign evaluator results. Delete the fixture workspace (or map to a "
+                    "fresh one) and restore again."
+                )
+
+            if not (ingest_spans or post_annotations or post_results):
+                print(f"{target}: already restored ({have_spans} spans) — skipping")
+                outcome[source_ws] = {
+                    "workspace": target,
+                    "spans": {"ingested": 0, "skipped": len(spans)},
+                    "annotations": {"ingested": 0, "skipped": len(annotations)},
+                    "evaluator_results": {"ingested": 0, "skipped": len(results)},
+                }
+                continue
+            # Healing = posting into a workspace whose spans already landed (interrupted restore).
+            healing = expected_spans > 0 and not ingest_spans
+            if ingest_spans:
+                print(f"ingesting {len(spans)} spans into {target}")
+                for start in range(0, len(spans), SPAN_BATCH):
+                    batch = [doc_to_otlp(doc, catalog) for doc in spans[start : start + SPAN_BATCH]]
+                    export_trace_request(base_url, target, build_trace_request(batch), client=client)
+                if spans:
+                    _wait_for_spans(base_url, target, expected_spans or len(spans), client=client, sleep=sleep)
+            root = f"{base_url.rstrip('/')}/apis/intake/v2/workspaces/{target}"
+            if post_annotations:
+                if healing:
+                    print(f"{target}: healing annotations: posting {len(annotations)}")
+                for doc in annotations:
+                    body = {k: v for k, v in doc.items() if k not in _POST_DROP["annotations"]}
+                    _post_created(client, f"{root}/annotations", body)
+            if post_results:
+                if healing:
+                    print(f"{target}: healing evaluator results: posting {len(results)}")
+                for doc in results:
+                    body = {k: v for k, v in doc.items() if k not in _POST_DROP["evaluator_results"]}
+                    _post_created(client, f"{root}/evaluator-results", body)
+            outcome[source_ws] = {
+                "workspace": target,
+                "spans": (
+                    {"ingested": len(spans), "skipped": 0} if ingest_spans else {"ingested": 0, "skipped": len(spans)}
+                ),
+                "annotations": (
+                    {"ingested": len(annotations), "skipped": 0}
+                    if post_annotations
+                    else {"ingested": 0, "skipped": len(annotations)}
+                ),
+                "evaluator_results": (
+                    {"ingested": len(results), "skipped": 0}
+                    if post_results
+                    else {"ingested": 0, "skipped": len(results)}
+                ),
+            }
+    return outcome
+
+
+def _normalize(doc: dict, collection: str) -> dict:
+    """Strip the spike-proven server-stamped fields; parse raw_attributes so ordering can't matter."""
+    normalized = {k: v for k, v in doc.items() if k not in NORMALIZED_FIELDS[collection]}
+    if collection == "spans":
+        normalized["raw_attributes"] = json.loads(normalized.get("raw_attributes") or "{}")
+    return normalized
+
+
+def _canonical(doc: dict) -> str:
+    return json.dumps(doc, sort_keys=True, ensure_ascii=False)
+
+
+def _diff_collection(original: list[dict], restored: list[dict], *, workspace: str, collection: str) -> list[str]:
+    """Doc-level diff of one collection, normalized per ``NORMALIZED_FIELDS``; [] = identical."""
+    left = sorted((_normalize(doc, collection) for doc in original), key=_canonical)
+    right = sorted((_normalize(doc, collection) for doc in restored), key=_canonical)
+    mismatches: list[str] = []
+    if len(left) != len(right):
+        mismatches.append(f"{workspace}/{collection}: {len(left)} exported vs {len(right)} restored")
+    for doc_a, doc_b in zip(left, right):
+        if doc_a == doc_b:
+            continue
+        label = doc_a.get("span_id") or doc_a.get("session_id") or "?"
+        for key in sorted(set(doc_a) | set(doc_b)):
+            if doc_a.get(key) != doc_b.get(key):
+                mismatches.append(f"{workspace}/{collection} {label}.{key}: {doc_a.get(key)!r} != {doc_b.get(key)!r}")
+    return mismatches
+
+
+def cleanup_scratch(base_url: str, workspaces: list[str], *, container: str = CLICKHOUSE_CONTAINER) -> None:
+    """Best-effort scratch-workspace cleanup after a round-trip check.
+
+    There is NO delete API for spans/annotations/evaluator-results rows — row
+    cleanup only works where the docker ClickHouse container IS the target's
+    backing store, i.e. loopback targets (the local dev platform); the DELETE
+    mutations are scoped to an exact IN-list of the scratch names. On remote
+    targets NOTHING is deleted — docker-execing the local container would purge
+    the wrong ClickHouse, and deleting just the workspace *record* would orphan
+    the remote rows behind it (a later same-name restore would silently diff
+    against them). Leaving the record intact means a later collision hits the
+    loud foreign-data guard instead; the leftovers are printed for manual
+    cleanup. Failures are reported, never raised: on CI the whole platform is
+    ephemeral, so residue is moot.
+    """
+    if not workspaces:
+        return
+    if not _is_loopback(base_url):
+        print(
+            f"cleanup: remote target {base_url} — no row-delete API exists and the local docker "
+            "ClickHouse is not this target's store. Left behind for manual cleanup (rows AND "
+            f"workspace records): {', '.join(workspaces)}\n"
+            "  (records kept on purpose: a later same-name restore then trips the loud "
+            "foreign-data guard instead of silently diffing against orphaned rows)",
+            file=sys.stderr,
+        )
+        return
+    names = ",".join(f"'{ws}'" for ws in workspaces)
+    if any("'" in ws or not _WS_OK.fullmatch(ws) for ws in workspaces):
+        print(f"cleanup: refusing to build a DELETE for suspicious names: {workspaces}", file=sys.stderr)
+        return
+    if shutil.which("docker"):
+        for table in ("spans", "annotations", "evaluator_results", "trace_index"):
+            proc = subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    container,
+                    "clickhouse-client",
+                    "--query",
+                    f"DELETE FROM intake.{table} WHERE workspace IN ({names})",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            if proc.returncode != 0:
+                print(f"cleanup: rows in {table} not deleted ({proc.stderr.strip()})", file=sys.stderr)
+    else:
+        print("cleanup: docker unavailable — scratch rows left in ClickHouse (no delete API exists)", file=sys.stderr)
+    with httpx.Client(timeout=30.0) as client:
+        for ws in workspaces:
+            resp = client.delete(f"{base_url.rstrip('/')}/apis/entities/v2/workspaces/{ws}")
+            if resp.status_code not in (200, 204, 404):
+                print(f"cleanup: workspace record {ws} not deleted ({resp.status_code})", file=sys.stderr)
+
+
+def _scratch_digest(manifest: dict, content_key: str | None) -> str:
+    """8-char content scope for scratch names: the bundle digest when given (used verbatim when it
+    is name-safe, hashed otherwise), else a hash of the manifest's counts + span time bounds."""
+    if content_key:
+        cleaned = re.sub(r"[^a-z0-9]", "", content_key.lower())
+        if len(cleaned) >= 8:
+            return cleaned[:8]
+    basis = content_key or json.dumps(
+        {
+            "counts": manifest.get("counts") or {},
+            "min_start_time": manifest.get("min_start_time"),
+            "max_start_time": manifest.get("max_start_time"),
+        },
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(basis.encode("utf-8")).hexdigest()[:8]
+
+
+def _scratch_workspace_map(manifest: dict, scratch_prefix: str, content_key: str | None) -> dict[str, str]:
+    """Scratch targets scoped by bundle content: ``<scratch_prefix><digest8>-<ws>``.
+
+    Content scoping keeps one run's residue (remote targets have no row delete —
+    see :func:`cleanup_scratch`) from colliding with the NEXT roundtrip of
+    *different* content: a name collision can then only mean same-content
+    residue, which the ingest guard resolves as already-restored or a loud
+    foreign-data error — never a silent wrong diff. Names are truncated to the
+    platform's 63-char workspace rule (``_WS_OK``) when the source name is long.
+    """
+    digest8 = _scratch_digest(manifest, content_key)
+    mapping: dict[str, str] = {}
+    for ws in manifest["workspaces"]:
+        name = f"{scratch_prefix}{digest8}-{ws}"
+        if len(name) > 63:
+            name = name[:63].rstrip("-")
+        mapping[ws] = name
+    return mapping
+
+
+def roundtrip_diff(
+    base_url: str,
+    export_dir: Path,
+    manifest: dict,
+    *,
+    scratch_prefix: str,
+    catalog,
+    sleep: Callable[[float], None] = time.sleep,
+    content_key: str | None = None,
+) -> list[str]:
+    """The mint-time fidelity guard: ingest into scratch workspaces, re-export, doc-diff.
+
+    Every bundle workspace is re-ingested into a content-scoped scratch
+    workspace (``<scratch_prefix><digest8>-<workspace>`` — pass the bundle
+    digest as ``content_key``; without one the digest is derived from the
+    manifest's counts and time bounds), drained back through the same read API
+    the export used, and compared doc-by-doc. The comparison normalizes ONLY
+    the workspace rename, the server-stamped fields in ``NORMALIZED_FIELDS``,
+    and doc/field ordering. Returns mismatch descriptions — empty list = the
+    bundle restores with full read-API fidelity. Scratch state is cleaned up
+    best-effort (see :func:`cleanup_scratch`).
+    """
+    if not scratch_prefix.startswith("scratch-"):
+        raise ValueError("scratch_prefix must start with 'scratch-' (cleanup deletes rows under these names)")
+    workspace_map = _scratch_workspace_map(manifest, scratch_prefix, content_key)
+    mismatches: list[str] = []
+    try:
+        ingest_bundle(base_url, export_dir, manifest, workspace_map=workspace_map, catalog=catalog, sleep=sleep)
+        TEMP_ROOT.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=TEMP_ROOT) as tmp:
+            re_dir = Path(tmp)
+            export.export_workspaces(base_url, list(workspace_map.values()), re_dir, since=None)
+            for source_ws, scratch_ws in workspace_map.items():
+                for collection in ("spans", "annotations", "evaluator_results"):
+                    original = _read_jsonl(Path(export_dir) / source_ws / f"{collection}.jsonl")
+                    restored = _read_jsonl(re_dir / "export" / scratch_ws / f"{collection}.jsonl")
+                    mismatches.extend(_diff_collection(original, restored, workspace=source_ws, collection=collection))
+    finally:
+        cleanup_scratch(base_url, list(workspace_map.values()))
+    return mismatches

--- a/plugins/nemo-insights/testbed/release.py
+++ b/plugins/nemo-insights/testbed/release.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""State-version release ops shared by the CLI and the CI publish step.
+
+Reference resolution + download operations for the testbed-insights workflow.
+Bundles live as assets named state-v<N>.tar.zst on the `testbed-state` release.
+"""
+
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+RELEASE_TAG = "testbed-state"
+_ASSET = re.compile(r"^state-v(\d+)\.tar\.zst$")
+
+
+def latest_ref(names: list[str]) -> str | None:
+    """Find the latest state version from a list of asset names."""
+    versions = [int(m.group(1)) for n in names if (m := _ASSET.match(n))]
+    return f"state-v{max(versions)}" if versions else None
+
+
+def next_ref(latest: str | None) -> str:
+    """Generate the next state version ref after the given latest."""
+    return f"state-v{int(latest.removeprefix('state-v')) + 1}" if latest else "state-v1"
+
+
+def lock_ref(lock_path: Path, subject: str) -> str | None:
+    """The subject's pinned state ref from the lock file's ``[subjects]`` table.
+
+    Returns None when the file is missing or the subject has no entry. A lock
+    file without a ``[subjects]`` table (e.g. the retired single-pin
+    ``state_ref = "..."`` format) exits with a migration message — states are
+    per-produce-dispatch compositions now, so one global pin cannot be right
+    for every subject.
+    """
+    if not lock_path.exists():
+        return None
+    subjects = tomllib.loads(lock_path.read_text(encoding="utf-8")).get("subjects")
+    if not isinstance(subjects, dict):
+        sys.exit(
+            f"{lock_path} has no [subjects] table — migrate the old single-pin format "
+            "to per-subject pins:\n\n"
+            "[subjects]\n"
+            'tau2-airline = "state-v6"'
+        )
+    value = subjects.get(subject)
+    return None if value is None else str(value)
+
+
+def _gh(*args: str) -> str:
+    """Run a gh CLI command and return stdout; surface stderr on failure.
+
+    A missing gh binary is a clean SystemExit with an install pointer (doctor
+    flags it too), not a raw FileNotFoundError traceback.
+    """
+    try:
+        return subprocess.run(["gh", *args], check=True, capture_output=True, text=True).stdout
+    except FileNotFoundError:
+        sys.exit("gh CLI not found — install GitHub CLI (https://cli.github.com) and run `gh auth login`")
+    except subprocess.CalledProcessError as e:
+        print(e.stderr, file=sys.stderr, end="")
+        raise
+
+
+def _release_asset_names() -> list[str]:
+    """Fetch the list of asset names from the testbed-state release.
+
+    Returns an empty list if the release does not exist (404).
+    Raises on other failures (outages, auth errors, etc.).
+    """
+    try:
+        out = _gh("release", "view", RELEASE_TAG, "--json", "assets")
+    except subprocess.CalledProcessError as e:
+        if "not found" in (e.stderr or "").lower():
+            return []
+        raise
+    return [a["name"] for a in json.loads(out).get("assets", [])]
+
+
+def resolve_state(state: str | None, *, subject: str | None, lock_path: Path) -> str:
+    """Resolve the state ref to restore: an explicit ref verbatim, else the subject's lock pin.
+
+    An explicit *state* must be a published ref (``state-v<N>``) — local bundle
+    files are the caller's business (the CLI detects existing paths before this
+    is reached), so anything else here is a typo and exits naming the pattern.
+    ``state=None`` reads the subject's pin from *lock_path*'s ``[subjects]``
+    table; a missing entry/file (or a subject-less caller, e.g. restore) is a
+    hard SystemExit, so nothing silently analyzes a state nobody pinned.
+    """
+    if state is not None:
+        if not re.fullmatch(r"state-v\d+", state):
+            sys.exit(
+                f"invalid state ref '{state}' — expected state-v<N> (e.g. state-v6); a local bundle "
+                "file goes through --state FILE on analyze, or the positional FILE on restore"
+            )
+        return state
+    if subject is not None and (pinned := lock_ref(lock_path, subject)):
+        if not re.fullmatch(r"state-v\d+", pinned):
+            # A typo'd pin must die naming the entry, not flow into a doomed gh download.
+            sys.exit(f"state.lock entry for '{subject}' is '{pinned}' — expected state-v<N> (e.g. state-v6)")
+        return pinned
+    # This serves both analyze and restore, so the guidance names each command's
+    # real surface instead of recommending flags one of them lacks.
+    sys.exit(
+        f"no state.lock entry for subject '{subject}' — add it under [subjects] "
+        "after minting a fixture, or pass an explicit state "
+        "(analyze: --live / --state <state-vN|FILE>; restore: FILE / --state state-vN)"
+    )
+
+
+def download_ref(ref: str, dest_dir: Path) -> Path:
+    """Download a state version tarball from the testbed-state release.
+
+    Returns the path to the tarball. Published refs are immutable, so an
+    already-downloaded ``<ref>.tar.zst`` in *dest_dir* is reused without
+    invoking gh (one printed line says so). On a fresh download, ``--clobber``
+    overwrites any leftover file from a prior run (gh refuses to overwrite by
+    default, which would make re-downloading the same ref crash). Failures
+    surface gh stderr and propagate the exception.
+    """
+    dest = dest_dir / f"{ref}.tar.zst"
+    if dest.is_file():
+        print(f"using cached {ref}.tar.zst")
+        return dest
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    _gh("release", "download", RELEASE_TAG, "--pattern", f"{ref}.tar.zst", "--dir", str(dest_dir), "--clobber")
+    return dest

--- a/plugins/nemo-insights/testbed/runstore.py
+++ b/plugins/nemo-insights/testbed/runstore.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Persist and load a benchmark's last produced run (the bridge from `run` to `analyze`)."""
+
+import json
+from pathlib import Path
+
+
+def save_run(path: Path, record: dict[str, object]) -> None:
+    """Write a run record as JSON, creating the parent directory if needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+
+
+def load_run(path: Path) -> dict[str, object] | None:
+    """Return the run record at ``path``, or ``None`` if it does not exist."""
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/plugins/nemo-insights/testbed/state.lock
+++ b/plugins/nemo-insights/testbed/state.lock
@@ -1,0 +1,6 @@
+# Analyze-mode CI reads each subject's pinned state from here (one PR = one
+# state per subject). A missing entry fails loudly — add the subject after
+# minting its fixture, or pass --state <state-vN> explicitly.
+[subjects]
+tau2-airline = "state-v6"
+nvq = "state-v7"

--- a/plugins/nemo-insights/testbed/summary.py
+++ b/plugins/nemo-insights/testbed/summary.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Render the local insights YAML as compact markdown (for $GITHUB_STEP_SUMMARY)."""
+
+from pathlib import Path
+
+import yaml
+
+
+def render_summary_md(insights_path: Path, subject: str) -> str:
+    """Markdown summary of ``{"insights": [...]}`` at *insights_path*.
+
+    One bullet per insight: bold title, status, trace-ref count, first
+    description line. Missing/empty file renders an explicit zero section so a
+    CI summary never silently omits a subject.
+    """
+    records: list[dict] = []
+    if insights_path.exists():
+        raw = yaml.safe_load(insights_path.read_text(encoding="utf-8")) or {}
+        records = list(raw.get("insights", []))
+    lines = [f"## Insights — {subject} ({len(records)})", ""]
+    if not records:
+        lines.append("_No insights._")
+    for rec in records:
+        refs = rec.get("trace_refs") or []
+        first_desc = str(rec.get("description", "")).splitlines()[0] if rec.get("description") else ""
+        lines.append(f"- **{rec.get('title', '(untitled)')}** — {rec.get('status', '?')}, {len(refs)} trace refs")
+        if first_desc:
+            lines.append(f"  {first_desc}")
+    return "\n".join(lines) + "\n"

--- a/plugins/nemo-insights/testbed/tau2run.py
+++ b/plugins/nemo-insights/testbed/tau2run.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run the tau2 benchmark as a subprocess and load its simulation output."""
+
+import hashlib
+import json
+import os
+import subprocess
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+
+def resolve_paths(cfg: Mapping[str, object], *, repo_root: Path) -> tuple[str | None, Path | None]:
+    """Resolve the tau2 binary and data dir from the stanza config.
+
+    ``tau2_repo`` (absolute, or relative to the nemo-insights plugin repo root — the
+    sibling-clone convention, e.g. ``../tau2-bench``) yields both the CLI
+    (``<repo>/.venv/bin/tau2``, where ``uv sync`` installs it) and the data dir
+    (``<repo>/data``). The explicit ``tau2_bin``/``tau2_data_dir`` keys override
+    the derived values for non-standard installs (``tau2_data_dir`` is anchored
+    to the repo root when relative; ``tau2_bin`` is taken verbatim so a bare
+    name still resolves on ``PATH``). Either return value is ``None`` when not
+    configured.
+    """
+
+    def _anchor(value: str) -> Path:
+        p = Path(value)
+        return p if p.is_absolute() else repo_root / p
+
+    repo_path = _anchor(str(cfg["tau2_repo"])) if cfg.get("tau2_repo") else None
+
+    bin_override = cfg.get("tau2_bin")
+    if bin_override:
+        tau2_bin: str | None = str(bin_override)
+    elif repo_path:
+        tau2_bin = str(repo_path / ".venv" / "bin" / "tau2")
+    else:
+        tau2_bin = None
+
+    data_override = cfg.get("tau2_data_dir")
+    if data_override:
+        data_dir: Path | None = _anchor(str(data_override))
+    elif repo_path:
+        data_dir = repo_path / "data"
+    else:
+        data_dir = None
+
+    return tau2_bin, data_dir
+
+
+def build_argv(cfg: dict[str, object], run_id: str, *, tau2_bin: str = "tau2") -> list[str]:
+    """Assemble the ``tau2 run`` command line from a benchmark stanza."""
+    argv = [
+        tau2_bin,
+        "run",
+        "--domain",
+        str(cfg["domain"]),
+        "--agent-llm",
+        str(cfg["agent_llm"]),
+        "--user-llm",
+        str(cfg["user_llm"]),
+        "--task-split-name",
+        str(cfg["task_split_name"]),
+        "--num-trials",
+        str(cfg["num_trials"]),
+        "--seed",
+        str(cfg["seed"]),
+        "--max-concurrency",
+        str(cfg["max_concurrency"]),
+        "--save-to",
+        run_id,
+    ]
+    if cfg.get("num_tasks") is not None:
+        argv += ["--num-tasks", str(cfg["num_tasks"])]
+    if cfg.get("timeout") is not None:
+        argv += ["--timeout", str(cfg["timeout"])]
+    return argv
+
+
+def load_simulations(data_dir: Path, run_id: str) -> list[dict]:
+    """Load the SimulationRun list from a tau2 run's ``results.json``.
+
+    Probes the known output layouts (a tau2 checkout may nest under ``tau2/``)
+    and uses the first that exists, so the runner is robust to where the clone
+    actually writes results.
+    """
+    candidates = [
+        data_dir / "simulations" / run_id / "results.json",
+        data_dir / "tau2" / "simulations" / run_id / "results.json",
+        data_dir / "tau2" / "results" / run_id / "results.json",
+    ]
+    path = next((p for p in candidates if p.exists()), None)
+    if path is None:
+        looked = ", ".join(str(p) for p in candidates)
+        raise RuntimeError(f"no tau2 results for run '{run_id}'; looked in: {looked}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, dict):
+        if "simulations" in data:
+            return data["simulations"]
+        if "results" in data:
+            return data["results"]
+        return []
+    if isinstance(data, list):
+        return data
+    raise RuntimeError(f"unexpected tau2 results shape in {path}: {type(data).__name__}")
+
+
+def run_tau2(
+    cfg: dict[str, object],
+    run_id: str,
+    *,
+    data_dir: Path,
+    tau2_bin: str,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> list[dict]:
+    """Run tau2 as a subprocess (with ``TAU2_DATA_DIR`` set) and return its sims."""
+    argv = build_argv(cfg, run_id, tau2_bin=tau2_bin)
+    env = {**os.environ, "TAU2_DATA_DIR": str(data_dir)}
+    result = runner(argv, env=env, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"tau2 run failed (exit {result.returncode}): {' '.join(argv)}")
+    return load_simulations(data_dir, run_id)
+
+
+def load_tasks(data_dir: Path, domain: str) -> dict[str, dict]:
+    """Map ``task_id -> task definition`` from tau2's ``tasks.json`` (``{}`` if absent)."""
+    for base in (data_dir / "tau2" / "domains", data_dir / "domains"):
+        path = base / domain / "tasks.json"
+        if path.exists():
+            tasks = json.loads(path.read_text(encoding="utf-8"))
+            return {str(t.get("id")): t for t in tasks if isinstance(t, dict)}
+    return {}
+
+
+def read_policy(data_dir: Path, domain: str) -> str | None:
+    """Return the domain policy markdown (the analyst's agent_spec), or None.
+
+    A tau2 checkout nests domains under ``tau2/domains/<domain>/``; some data
+    dirs are flat (``domains/<domain>/``). Tries both and returns the first
+    ``policy.md`` found, else ``None`` (the analyst then runs without the spec).
+    """
+    for base in (data_dir / "tau2" / "domains", data_dir / "domains"):
+        path = base / domain / "policy.md"
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+    return None
+
+
+def policy_version(policy_text: str | None) -> str:
+    """A short, stable version string for ATIF agent.version from the policy."""
+    if not policy_text:
+        return "unknown"
+    return hashlib.sha256(policy_text.encode("utf-8")).hexdigest()[:12]

--- a/plugins/nemo-insights/testbed/testbeds.toml
+++ b/plugins/nemo-insights/testbed/testbeds.toml
@@ -1,0 +1,45 @@
+# Testbed subjects for the analyst harness — one table per subject.
+# Top-level keys are shared defaults merged into every subject.
+base_url = "https://nemo-platform-freeplay.dev.aire.nvidia.com"
+
+[nvq]
+type = "intake"
+agent = "content-dedup"
+workspace = "nvq"
+# since = "7d"   # optional default lookback (Nd/Nh/Nm or an ISO date)
+
+[tau2-airline]
+type = "benchmark"
+domain = "airline"
+base_url = "https://nemo-platform-freeplay.dev.aire.nvidia.com"  # remote (freeplay) default
+workspace = "tau2-airline"
+tau2_repo = "../tau2-bench"   # tau2-bench checkout: relative to the repo root (sibling clone), or absolute
+agent_llm = "openai/nvidia/nvidia/nemotron-3-super-v3"   # a model your proxy key serves (GET {OPENAI_API_BASE}/v1/models)
+user_llm  = "openai/nvidia/nvidia/nemotron-3-super-v3"   # the user simulator
+task_split_name = "train"   # dev/iteration split (30 tasks); keep `test` (20) held-out for final eval
+num_tasks = 30       # full train split; narrow (e.g. 5) for faster iteration loops
+num_trials = 1
+max_concurrency = 8
+seed = 300
+include_rewards = true            # also ingest a "-oracle" workspace (answer key) beside the realistic one (default true; false = realistic only)
+# tau2_bin = "/custom/tau2"       # optional: override the derived <tau2_repo>/.venv/bin/tau2
+# tau2_data_dir = "/custom/data"  # optional: override the derived <tau2_repo>/data
+# timeout = 600                   # optional per-task timeout (seconds)
+
+[tau2-retail]
+type = "benchmark"
+domain = "retail"
+base_url = "http://localhost:8080"
+workspace = "tau2-retail"
+tau2_repo = "../tau2-bench"   # tau2-bench checkout: relative to the repo root (sibling clone), or absolute
+agent_llm = "openai/nvidia/nvidia/nemotron-3-super-v3"   # a model your proxy key serves (GET {OPENAI_API_BASE}/v1/models)
+user_llm  = "openai/nvidia/nvidia/nemotron-3-super-v3"   # the user simulator
+task_split_name = "test"
+num_tasks = 40       # full retail test split
+num_trials = 1
+max_concurrency = 8
+seed = 300
+include_rewards = true            # also ingest a "-oracle" workspace (answer key) beside the realistic one (default true; false = realistic only)
+# tau2_bin = "/custom/tau2"       # optional: override the derived <tau2_repo>/.venv/bin/tau2
+# tau2_data_dir = "/custom/data"  # optional: override the derived <tau2_repo>/data
+# timeout = 600                   # optional per-task timeout (seconds)

--- a/plugins/nemo-insights/testbed/timeparse.py
+++ b/plugins/nemo-insights/testbed/timeparse.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Parse a lookback or ISO date into a UTC-aware datetime."""
+
+import re
+import sys
+from datetime import date, datetime, timedelta, timezone
+
+_LOOKBACK = re.compile(r"(\d+)([dhm])")
+
+
+def parse_since(value: str | datetime | date | None) -> datetime | None:
+    """Lower bound for trace reads → UTC datetime (or ``None`` for no bound).
+
+    Accepts ``Nd``/``Nh``/``Nm`` (days/hours/minutes ago) or an ISO string, plus
+    the ``datetime``/``date`` objects ``tomllib`` yields for unquoted date/datetime
+    literals in testbeds.toml (those are honored, not crashed on). Any other type
+    (e.g. a bare integer) exits cleanly rather than raising ``AttributeError``.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+    if not isinstance(value, str):
+        sys.exit(f"Invalid since value {value!r}: use Nd/Nh/Nm (days/hours/minutes) or an ISO date.")
+    text = value.strip()
+    match = _LOOKBACK.fullmatch(text)
+    if match:
+        n, unit = int(match.group(1)), match.group(2)
+        delta = {
+            "d": timedelta(days=n),
+            "h": timedelta(hours=n),
+            "m": timedelta(minutes=n),
+        }[unit]
+        return datetime.now(timezone.utc) - delta
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        sys.exit(f"Invalid --since '{value}': use Nd/Nh/Nm (days/hours/minutes) or an ISO date.")
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/plugins/nemo-insights/tests/test_client.py
+++ b/plugins/nemo-insights/tests/test_client.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, patch
+
+from nemo_insights_plugin.client import make_client
+from nemo_platform.auth.helpers import NMPOIDCConfig
+
+REMOTE_URL = "https://nemo-platform.example.com"
+
+
+def test_remote_no_auth_ignores_unrelated_local_oauth_context() -> None:
+    config_path = MagicMock()
+    config_path.exists.return_value = True
+
+    with (
+        patch("nemo_insights_plugin.client.Config.get_default_config_path", return_value=config_path),
+        patch(
+            "nemo_insights_plugin.client.discover_nmp_config",
+            return_value=NMPOIDCConfig(auth_enabled=False),
+        ),
+        patch("nemo_insights_plugin.client.AsyncNeMoPlatform") as client_cls,
+    ):
+        client = make_client(REMOTE_URL)
+
+    client_cls.assert_called_once_with(base_url=REMOTE_URL)
+    assert client is client_cls.return_value
+
+
+def test_remote_auth_uses_local_oauth_context() -> None:
+    config_path = MagicMock()
+    config_path.exists.return_value = True
+
+    with (
+        patch("nemo_insights_plugin.client.Config.get_default_config_path", return_value=config_path),
+        patch(
+            "nemo_insights_plugin.client.discover_nmp_config",
+            return_value=NMPOIDCConfig(
+                auth_enabled=True,
+                client_id="nemo-cli",
+                token_endpoint="https://auth.example.com/token",
+            ),
+        ),
+        patch("nemo_insights_plugin.client.AsyncNeMoPlatform") as client_cls,
+    ):
+        client = make_client(REMOTE_URL)
+
+    client_cls.assert_called_once_with(base_url=REMOTE_URL, config_path=config_path)
+    assert client is client_cls.return_value

--- a/plugins/nemo-insights/tests/test_periodic_analysis.py
+++ b/plugins/nemo-insights/tests/test_periodic_analysis.py
@@ -8,12 +8,14 @@ from pathlib import Path
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 
+import httpx
 import pytest
 from nemo_insights_plugin.analyst.analyst_backend import (
     RemoteAnalystBackend,
     _merge_eval_filter,
     _merge_since_filter,
 )
+from nemo_insights_plugin.analyst.result import AnalystResult, InsightUpdate
 from nemo_insights_plugin.config import (
     AnalystSchedulerConfig,
     Frequency,
@@ -58,6 +60,38 @@ def test_merge_since_filter_keeps_later_existing_lower_bound() -> None:
     )
 
     assert result == {"started_at": {"gte": "2026-06-04T13:00:00+00:00"}}
+
+
+def test_merge_since_filter_compares_equivalent_iso_representations() -> None:
+    since = datetime(2026, 6, 4, 12, tzinfo=timezone.utc)
+    current = "2026-06-04T07:00:00-05:00"
+
+    result = _merge_since_filter({"started_at": {"gte": current}}, since=since)
+
+    assert result == {"started_at": {"gte": current}}
+
+
+class _MissingInsights:
+    async def get(self, **kwargs: object) -> None:
+        del kwargs
+        request = httpx.Request("GET", "https://example.com/insights/missing")
+        response = httpx.Response(404, request=request)
+        raise httpx.HTTPStatusError("not found", request=request, response=response)
+
+
+@pytest.mark.asyncio
+async def test_remote_persist_validates_updates_without_trace_refs() -> None:
+    client = SimpleNamespace(insights=SimpleNamespace(insights=_MissingInsights()))
+    backend = RemoteAnalystBackend(client)  # type: ignore[arg-type]
+    result = AnalystResult(
+        summary="Nothing new.",
+        updated_insights=[InsightUpdate(id="missing-insight")],
+    )
+
+    report = await backend.persist_result(workspace="default", agent="research-agent", result=result)
+
+    assert "- skipped (insight not found): missing-insight" in report
+    assert "- updated: missing-insight" not in report
 
 
 def test_merge_eval_filter_pins_evaluation_id() -> None:
@@ -450,7 +484,7 @@ async def test_analyze_job_compile_requests_persistent_storage(
         {
             "name": PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
             "value": DEFAULT_JOB_STORAGE_PATH,
-        }
+        },
     ]
 
 

--- a/plugins/nemo-insights/tests/test_periodic_analysis.py
+++ b/plugins/nemo-insights/tests/test_periodic_analysis.py
@@ -1,0 +1,626 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for periodic insights analysis plumbing."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+import pytest
+from nemo_insights_plugin.analyst.analyst_backend import (
+    RemoteAnalystBackend,
+    _merge_eval_filter,
+    _merge_since_filter,
+)
+from nemo_insights_plugin.config import (
+    AnalystSchedulerConfig,
+    Frequency,
+    InsightsConfig,
+    Weekday,
+)
+from nemo_insights_plugin.controller import InsightsAnalysisController, _job_name
+from nemo_insights_plugin.entities import (
+    AnalysisConfig,
+    AnalysisConfigStatus,
+    AnalysisRunStatus,
+)
+from nemo_insights_plugin.jobs.analyze import AnalyzeJob, AnalyzeSpec
+from nemo_insights_plugin.schedule import is_due, previous_scheduled
+from nemo_platform.types.intake.spans.span_group import SpanGroup
+from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
+from nemo_platform_plugin.job_context import JobContext, StoragePaths
+from nemo_platform_plugin.jobs.constants import (
+    DEFAULT_JOB_STORAGE_PATH,
+    PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+)
+from pydantic import ValidationError
+
+
+def test_merge_since_filter_adds_lower_bound() -> None:
+    since = datetime(2026, 6, 4, 12, tzinfo=timezone.utc)
+
+    result = _merge_since_filter({"agent_name": "research-agent"}, since=since)
+
+    assert result == {
+        "agent_name": "research-agent",
+        "started_at": {"gte": "2026-06-04T12:00:00+00:00"},
+    }
+
+
+def test_merge_since_filter_keeps_later_existing_lower_bound() -> None:
+    since = datetime(2026, 6, 4, 12, tzinfo=timezone.utc)
+
+    result = _merge_since_filter(
+        {"started_at": {"gte": "2026-06-04T13:00:00+00:00"}},
+        since=since,
+    )
+
+    assert result == {"started_at": {"gte": "2026-06-04T13:00:00+00:00"}}
+
+
+def test_merge_eval_filter_pins_evaluation_id() -> None:
+    assert _merge_eval_filter({"agent_name": "a"}, evaluation_id="run-1") == {
+        "agent_name": "a",
+        "evaluation_id": "run-1",
+    }
+
+
+def test_merge_eval_filter_none_is_noop() -> None:
+    assert _merge_eval_filter({"agent_name": "a"}, evaluation_id=None) == {"agent_name": "a"}
+    assert _merge_eval_filter(None, evaluation_id=None) is None
+
+
+def test_merge_eval_filter_overwrites_model_supplied_scope() -> None:
+    assert _merge_eval_filter({"evaluation_id": "sneaky"}, evaluation_id="run-1") == {
+        "evaluation_id": "run-1",
+    }
+
+
+class _SpanGroups:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def list(self, **kwargs: object) -> SimpleNamespace:
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            data=[SpanGroup(group={"session_id": "session-1"}, span_count=3)],
+            pagination=SimpleNamespace(total_results=7),
+        )
+
+
+class _SpanGroupClient:
+    def __init__(self) -> None:
+        self.intake = SimpleNamespace(
+            spans=SimpleNamespace(groups=_SpanGroups()),
+        )
+
+
+@pytest.mark.asyncio
+async def test_count_agent_sessions_uses_server_side_session_groups() -> None:
+    since = datetime(2026, 6, 4, 12, tzinfo=timezone.utc)
+    backend = RemoteAnalystBackend(_SpanGroupClient())  # type: ignore[arg-type]
+
+    count = await backend.count_agent_sessions(
+        agent="research-agent",
+        workspace="default",
+        since=since,
+    )
+
+    assert count == 7
+    assert backend.client.intake.spans.groups.calls == [
+        {
+            "workspace": "default",
+            "by": "session_id",
+            "page": 1,
+            "page_size": 1,
+            "filter": {
+                "agent_name": "research-agent",
+                "started_at": {"gte": "2026-06-04T12:00:00+00:00"},
+            },
+            "sort": "-span_count",
+        }
+    ]
+
+
+class _SpanGroupsPaged:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def list(self, **kwargs: object) -> SimpleNamespace:
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            data=[
+                SpanGroup(group={"session_id": "session-1"}, span_count=12),
+                SpanGroup(group={"session_id": "session-2"}, span_count=5),
+            ],
+            pagination=SimpleNamespace(total_results=37),
+        )
+
+
+class _GroupsBackendClient:
+    def __init__(self, groups: _SpanGroupsPaged) -> None:
+        self.intake = SimpleNamespace(spans=SimpleNamespace(groups=groups))
+
+
+@pytest.mark.asyncio
+async def test_list_span_groups_fans_out_over_sessions() -> None:
+    since = datetime(2026, 6, 4, 12, tzinfo=timezone.utc)
+    groups = _SpanGroupsPaged()
+    backend = RemoteAnalystBackend(_GroupsBackendClient(groups))  # type: ignore[arg-type]
+
+    result = await backend.list_span_groups(
+        workspace="default",
+        filter={"agent_name": "research-agent"},
+        group_by="session_id",
+        limit=100,
+        since=since,
+    )
+
+    assert result == {
+        "groups": [
+            {"group": {"session_id": "session-1"}, "span_count": 12},
+            {"group": {"session_id": "session-2"}, "span_count": 5},
+        ],
+        "grouped_by": "session_id",
+        "count": 2,
+        "total": 37,
+        "truncated": True,
+    }
+    assert groups.calls == [
+        {
+            "workspace": "default",
+            "by": "session_id",
+            "page": 1,
+            "page_size": 100,
+            "filter": {
+                "agent_name": "research-agent",
+                "started_at": {"gte": "2026-06-04T12:00:00+00:00"},
+            },
+            "sort": "-span_count",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_count_agent_sessions_pins_evaluation_id() -> None:
+    backend = RemoteAnalystBackend(_SpanGroupClient())  # type: ignore[arg-type]
+
+    await backend.count_agent_sessions(
+        agent="research-agent",
+        workspace="default",
+        evaluation_id="run-1",
+    )
+
+    assert backend.client.intake.spans.groups.calls == [
+        {
+            "workspace": "default",
+            "by": "session_id",
+            "page": 1,
+            "page_size": 1,
+            "filter": {"agent_name": "research-agent", "evaluation_id": "run-1"},
+            "sort": "-span_count",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_span_groups_pins_evaluation_id() -> None:
+    groups = _SpanGroupsPaged()
+    backend = RemoteAnalystBackend(_GroupsBackendClient(groups))  # type: ignore[arg-type]
+
+    await backend.list_span_groups(
+        workspace="default",
+        filter={"agent_name": "research-agent"},
+        group_by="session_id",
+        limit=100,
+        evaluation_id="run-1",
+    )
+
+    assert groups.calls[0]["filter"] == {
+        "agent_name": "research-agent",
+        "evaluation_id": "run-1",
+    }
+
+
+_DENVER = ZoneInfo("America/Denver")
+
+
+def test_previous_scheduled_daily_converts_local_hour_to_utc() -> None:
+    # During MDT (UTC-6), 02:00 Denver local is 08:00 UTC.
+    now = datetime(2026, 6, 10, 12, tzinfo=timezone.utc)
+
+    scheduled = previous_scheduled(
+        now,
+        frequency=Frequency.DAILY,
+        run_at_hour=2,
+        run_on_weekday=int(Weekday.MONDAY),
+        tz=_DENVER,
+    )
+
+    assert scheduled == datetime(2026, 6, 10, 8, tzinfo=timezone.utc)
+
+
+def test_previous_scheduled_daily_rolls_back_when_hour_not_reached() -> None:
+    # 03:00 UTC on 2026-06-10 is 21:00 Denver on 2026-06-09, before 02:00 local,
+    # so the most recent 02:00-local run was the prior day.
+    now = datetime(2026, 6, 10, 3, tzinfo=timezone.utc)
+
+    scheduled = previous_scheduled(
+        now,
+        frequency=Frequency.DAILY,
+        run_at_hour=2,
+        run_on_weekday=int(Weekday.MONDAY),
+        tz=_DENVER,
+    )
+
+    assert scheduled == datetime(2026, 6, 9, 8, tzinfo=timezone.utc)
+
+
+def test_previous_scheduled_weekly_lands_on_configured_weekday() -> None:
+    # 2026-06-10 is a Wednesday; the prior Monday 02:00 Denver is 2026-06-08.
+    now = datetime(2026, 6, 10, 12, tzinfo=timezone.utc)
+
+    scheduled = previous_scheduled(
+        now,
+        frequency=Frequency.WEEKLY,
+        run_at_hour=2,
+        run_on_weekday=int(Weekday.MONDAY),
+        tz=_DENVER,
+    )
+
+    assert scheduled == datetime(2026, 6, 8, 8, tzinfo=timezone.utc)
+    assert scheduled.astimezone(_DENVER).weekday() == int(Weekday.MONDAY)
+
+
+def test_is_due_true_when_no_prior_run() -> None:
+    now = datetime(2026, 6, 10, 12, tzinfo=timezone.utc)
+
+    assert is_due(
+        now,
+        None,
+        frequency=Frequency.DAILY,
+        run_at_hour=2,
+        run_on_weekday=int(Weekday.MONDAY),
+        tz=_DENVER,
+    )
+
+
+def test_is_due_false_when_run_after_last_scheduled() -> None:
+    now = datetime(2026, 6, 10, 12, tzinfo=timezone.utc)
+    anchor = datetime(2026, 6, 10, 9, tzinfo=timezone.utc)  # after 08:00 UTC slot
+
+    assert not is_due(
+        now,
+        anchor,
+        frequency=Frequency.DAILY,
+        run_at_hour=2,
+        run_on_weekday=int(Weekday.MONDAY),
+        tz=_DENVER,
+    )
+
+
+def test_is_due_true_when_run_before_last_scheduled() -> None:
+    now = datetime(2026, 6, 10, 12, tzinfo=timezone.utc)
+    anchor = datetime(2026, 6, 9, 9, tzinfo=timezone.utc)  # prior day's run
+
+    assert is_due(
+        now,
+        anchor,
+        frequency=Frequency.DAILY,
+        run_at_hour=2,
+        run_on_weekday=int(Weekday.MONDAY),
+        tz=_DENVER,
+    )
+
+
+def test_is_due_treats_naive_anchor_as_utc() -> None:
+    now = datetime(2026, 6, 10, 12, tzinfo=timezone.utc)
+    anchor = datetime(2026, 6, 10, 9)  # naive, after the 08:00 UTC slot
+
+    assert not is_due(
+        now,
+        anchor,
+        frequency=Frequency.DAILY,
+        run_at_hour=2,
+        run_on_weekday=int(Weekday.MONDAY),
+        tz=_DENVER,
+    )
+
+
+def test_weekly_not_due_until_configured_weekday() -> None:
+    # Sunday 2026-06-07 12:00 UTC; the upcoming Monday slot has not passed, so
+    # the most recent scheduled run is the previous Monday (2026-06-01).
+    now = datetime(2026, 6, 7, 12, tzinfo=timezone.utc)
+    anchor = datetime(2026, 6, 2, tzinfo=timezone.utc)  # after 2026-06-01 slot
+
+    assert not is_due(
+        now,
+        anchor,
+        frequency=Frequency.WEEKLY,
+        run_at_hour=2,
+        run_on_weekday=int(Weekday.MONDAY),
+        tz=_DENVER,
+    )
+
+
+def test_config_accepts_weekday_name() -> None:
+    config = AnalystSchedulerConfig(run_on_weekday="friday")
+
+    assert config.run_on_weekday is Weekday.FRIDAY
+
+
+def test_config_rejects_unknown_timezone() -> None:
+    with pytest.raises(ValidationError):
+        AnalystSchedulerConfig(timezone="Mars/Olympus_Mons")
+
+
+class _Artifact:
+    def __init__(self, name: str, path: Path) -> None:
+        self.name = name
+        self.path = path
+
+    def model_dump(self) -> dict[str, str]:
+        return {"name": self.name, "path": str(self.path)}
+
+
+class _Results:
+    def __init__(self) -> None:
+        self.saved: list[tuple[str, Path]] = []
+
+    def save(self, name: str, path: Path, **_: object) -> _Artifact:
+        self.saved.append((name, path))
+        return _Artifact(name, path)
+
+
+class _SyncAnalysisRunStatuses:
+    def __init__(self) -> None:
+        self.updates: list[dict[str, object]] = []
+
+    def update(self, **kwargs: object) -> AnalysisRunStatus:
+        self.updates.append(kwargs)
+        return AnalysisRunStatus(
+            name=str(kwargs["agent"]),
+            workspace=str(kwargs["workspace"]),
+            agent=str(kwargs["agent"]),
+        )
+
+
+class _SyncSdk:
+    def __init__(self) -> None:
+        self.insights = SimpleNamespace(analysis_run_statuses=_SyncAnalysisRunStatuses())
+
+
+def _ctx(tmp_path: Path) -> JobContext:
+    persistent = tmp_path / "persistent"
+    ephemeral = tmp_path / "ephemeral"
+    persistent.mkdir()
+    ephemeral.mkdir()
+    return JobContext(
+        workspace="default",
+        storage=StoragePaths(ephemeral=ephemeral, persistent=persistent),
+        results=_Results(),
+        job_id="insights-job-1",
+    )
+
+
+def test_analyze_job_records_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    async def fake_run_analyst(**_: object) -> str:
+        return "analysis report"
+
+    monkeypatch.setattr("nemo_insights_plugin.jobs.analyze.run_analyst", fake_run_analyst)
+    sdk = _SyncSdk()
+
+    result = AnalyzeJob().run(
+        AnalyzeSpec(agent="research-agent").model_dump(mode="json"),
+        ctx=_ctx(tmp_path),
+        sdk=sdk,
+    )
+
+    assert result["status"] == "completed"
+    assert result["artifact"] == {
+        "name": "analysis-report",
+        "path": str(tmp_path / "persistent" / "analysis-report.txt"),
+    }
+    updates = sdk.insights.analysis_run_statuses.updates
+    assert [u["status"] for u in updates] == [
+        AnalysisConfigStatus.RUNNING,
+        AnalysisConfigStatus.IDLE,
+    ]
+    assert updates[-1]["last_submitted_job"] == "insights-job-1"
+    assert (tmp_path / "persistent" / "analysis-report.txt").read_text() == "analysis report"
+
+
+@pytest.mark.asyncio
+async def test_analyze_job_compile_requests_persistent_storage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("INFERENCE_API_KEY", raising=False)
+    platform_spec = await AnalyzeJob.compile(
+        workspace="default",
+        spec=AnalyzeSpec(agent="research-agent"),
+        entity_client=object(),
+        job_name="opt-analyze-default-research-agent-20260608204901",
+        async_sdk=object(),
+    )
+
+    step = platform_spec["steps"][0]
+    assert step["environment"] == [
+        {
+            "name": PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+            "value": DEFAULT_JOB_STORAGE_PATH,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_analyze_job_compile_can_reference_inference_secret() -> None:
+    platform_spec = await AnalyzeJob.compile(
+        workspace="default",
+        spec=AnalyzeSpec(
+            agent="calculator-agent",
+            inference_api_key_secret_name="insights-inference-api-key",
+        ),
+        entity_client=object(),
+        job_name="opt-analyze-default-calculator-agent-20260608210807",
+        async_sdk=object(),
+    )
+
+    step = platform_spec["steps"][0]
+    assert step["environment"] == [
+        {
+            "name": PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+            "value": DEFAULT_JOB_STORAGE_PATH,
+        },
+        {
+            "name": "INFERENCE_API_KEY",
+            "from_secret": {"name": "insights-inference-api-key"},
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_analyze_job_compile_can_forward_local_inference_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INFERENCE_API_KEY", "test-key")
+
+    platform_spec = await AnalyzeJob.compile(
+        workspace="default",
+        spec=AnalyzeSpec(agent="calculator-agent"),
+        entity_client=object(),
+        job_name="opt-analyze-default-calculator-agent-20260608210807",
+        async_sdk=object(),
+    )
+
+    step = platform_spec["steps"][0]
+    assert step["environment"] == [
+        {
+            "name": PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
+            "value": DEFAULT_JOB_STORAGE_PATH,
+        },
+        {"name": "INFERENCE_API_KEY", "value": "test-key"},
+    ]
+
+
+class _AsyncJobList:
+    def __init__(self, jobs: list[SimpleNamespace]) -> None:
+        self.jobs = jobs
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for job in self.jobs:
+            yield job
+
+
+class _AsyncJobs:
+    def __init__(self, jobs: list[SimpleNamespace] | None = None) -> None:
+        self.created: list[dict[str, object]] = []
+        self.jobs = list(jobs or [])
+
+    async def create(self, **kwargs: object) -> SimpleNamespace:
+        self.created.append(kwargs)
+        return SimpleNamespace(name=kwargs.get("name"))
+
+    def list(self, **_: object) -> _AsyncJobList:
+        return _AsyncJobList(self.jobs)
+
+
+class _AsyncSdk:
+    def __init__(self, jobs: list[SimpleNamespace] | None = None) -> None:
+        self.jobs = _AsyncJobs(jobs=jobs)
+
+
+class _Entities:
+    def __init__(self, run_status: AnalysisRunStatus | None = None) -> None:
+        self.updated: list[AnalysisConfig] = []
+        self.run_status = run_status
+
+    async def get(self, entity_type: type, *, name: str, workspace: str) -> AnalysisRunStatus:
+        del name, workspace
+        if entity_type is AnalysisRunStatus and self.run_status is not None:
+            return self.run_status
+        raise NemoEntityNotFoundError("missing")
+
+    async def update(self, config: AnalysisConfig) -> AnalysisConfig:
+        self.updated.append(config)
+        return config
+
+
+def _controller(
+    *,
+    jobs: list[SimpleNamespace] | None = None,
+    run_status: AnalysisRunStatus | None = None,
+) -> InsightsAnalysisController:
+    controller = InsightsAnalysisController()
+    controller._config = InsightsConfig(
+        analyst=AnalystSchedulerConfig(
+            frequency=Frequency.DAILY,
+            run_at_hour=0,
+            job_profile="test-profile",
+        )
+    )
+    controller._sdk = _AsyncSdk(jobs=jobs)
+    controller._entities = _Entities(run_status=run_status)
+    return controller
+
+
+def test_generated_job_name_fits_derived_fileset_name_limit() -> None:
+    config = AnalysisConfig(
+        name="research-agent-with-a-very-long-name",
+        workspace="default",
+        agent="research-agent-with-a-very-long-name",
+    )
+
+    name = _job_name(config, datetime(2026, 6, 8, 20, 31, 22, tzinfo=timezone.utc))
+
+    assert name.startswith("opt-analyze-default-")
+    assert len(name) <= 63 - len("job-fileset-")
+    assert len(f"job-fileset-{name}") <= 63
+
+
+@pytest.mark.asyncio
+async def test_controller_submits_due_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    controller = _controller()
+    config = AnalysisConfig(name="research-agent", workspace="default", agent="research-agent")
+
+    async def fake_compile_job_spec(**_: object) -> dict[str, list[object]]:
+        return {"steps": []}
+
+    monkeypatch.setattr(controller, "_compile_job_spec", fake_compile_job_spec)
+    await controller._reconcile_config(config)
+
+    assert len(controller.sdk.jobs.created) == 1
+    created = controller.sdk.jobs.created[0]
+    assert created["source"] == "insights"
+    assert created["spec"]["agent"] == "research-agent"
+    assert created["spec"]["since"] is None
+    assert controller.entities.updated == []
+
+
+@pytest.mark.asyncio
+async def test_controller_skips_active_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    controller = _controller(
+        jobs=[
+            SimpleNamespace(
+                status="active",
+                custom_fields={"insights_analysis_agent": "research-agent"},
+            )
+        ]
+    )
+    config = AnalysisConfig(
+        name="research-agent",
+        workspace="default",
+        agent="research-agent",
+    )
+
+    async def fake_compile_job_spec(**_: object) -> dict[str, list[object]]:
+        return {"steps": []}
+
+    monkeypatch.setattr(controller, "_compile_job_spec", fake_compile_job_spec)
+    await controller._reconcile_config(config)
+
+    assert controller.sdk.jobs.created == []

--- a/plugins/nemo-insights/tests/test_sdk_entity_hydration.py
+++ b/plugins/nemo-insights/tests/test_sdk_entity_hydration.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for entity metadata returned by plugin SDK resources."""
+
+from nemo_insights_plugin.entities import AnalysisConfig, Insight
+from nemo_insights_plugin.sdk_resources._entity import entity_from_response
+from nemo_insights_plugin.sdk_resources.analysis_configs import _analysis_config_page_from_response
+from nemo_insights_plugin.sdk_resources.insights import _insight_from_response
+
+_METADATA = {
+    "id": "entity-123",
+    "created_at": "2026-07-13T12:00:00+00:00",
+    "created_by": "service:platform",
+    "updated_at": "2026-07-13T12:01:00+00:00",
+    "updated_by": "user:tester",
+    "parent": "entity-parent",
+    "db_version": 3,
+}
+
+
+def test_entity_from_response_restores_store_metadata() -> None:
+    config = entity_from_response(
+        AnalysisConfig,
+        {
+            **_METADATA,
+            "name": "agent-a",
+            "workspace": "default",
+            "agent": "agent-a",
+            "enabled": True,
+        },
+    )
+
+    assert config.id == "entity-123"
+    assert config.created_at.isoformat() == "2026-07-13T12:00:00+00:00"
+    assert config.created_by == "service:platform"
+    assert config.updated_at.isoformat() == "2026-07-13T12:01:00+00:00"
+    assert config.updated_by == "user:tester"
+    assert config.parent == "entity-parent"
+    assert config._db_version == 3
+
+
+def test_analysis_config_page_restores_item_metadata() -> None:
+    page = _analysis_config_page_from_response(
+        {
+            "data": [
+                {
+                    **_METADATA,
+                    "name": "agent-a",
+                    "workspace": "default",
+                    "agent": "agent-a",
+                    "enabled": True,
+                }
+            ],
+            "pagination": {
+                "page": 1,
+                "page_size": 20,
+                "current_page_size": 1,
+                "total_pages": 1,
+                "total_results": 1,
+            },
+            "sort": "-created_at",
+            "filter": None,
+        }
+    )
+
+    assert page.data[0].id == "entity-123"
+    assert page.data[0].created_by == "service:platform"
+
+
+def test_insight_response_restores_all_store_metadata() -> None:
+    insight = _insight_from_response(
+        {
+            **_METADATA,
+            "name": "insight-a",
+            "workspace": "default",
+            "title": "Validation insight",
+            "agent": "agent-a",
+            "description": "description",
+            "status": "open",
+            "trace_refs": [],
+        }
+    )
+
+    assert isinstance(insight, Insight)
+    assert insight.id == "entity-123"
+    assert insight.created_by == "service:platform"
+    assert insight.parent == "entity-parent"

--- a/plugins/nemo-insights/tests/testbed/conftest.py
+++ b/plugins/nemo-insights/tests/testbed/conftest.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Make the `testbed` package importable for its tests.
+
+`testbed/` is maintainer tooling at the repo root (not shipped under `src/`), so its
+tests import `testbed.*` and need the repo root on `sys.path`. Scoped here — to the
+testbed tests only — rather than widening the global `pythonpath` in pyproject.toml.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/plugins/nemo-insights/tests/testbed/test_adapters.py
+++ b/plugins/nemo-insights/tests/testbed/test_adapters.py
@@ -1,0 +1,400 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from testbed.adapters import BenchmarkAdapter, IntakeAdapter, build_adapter
+from testbed.registry import Subject
+
+_CFG = {
+    "domain": "airline",
+    "base_url": "http://localhost:8080",
+    "workspace": "tau2-airline",
+    "agent_llm": "openai/m",
+    "user_llm": "openai/m",
+    "task_split_name": "test",
+    "num_trials": 1,
+    "seed": 300,
+    "max_concurrency": 4,
+}
+
+_SIMS = [
+    {
+        "task_id": "0",
+        "trial": 0,
+        "messages": [{"role": "user", "content": "hi"}],
+        "reward_info": {"reward": 1.0},
+        "termination_reason": "done",
+    },
+    {
+        "task_id": "1",
+        "trial": 0,
+        "messages": [{"role": "user", "content": "yo"}],
+        "reward_info": {"reward": 0.0},
+        "termination_reason": "done",
+    },
+]
+
+
+def _intake_subject(**overrides) -> Subject:
+    config = {"agent": "a", "workspace": "w", "base_url": "u", **overrides}
+    return Subject(name="nvq", type="intake", config=config)
+
+
+def test_build_adapter_returns_intake():
+    assert isinstance(build_adapter(_intake_subject()), IntakeAdapter)
+
+
+def test_build_adapter_unknown_type_exits():
+    with pytest.raises(SystemExit):
+        build_adapter(Subject(name="x", type="bogus", config={}))
+
+
+async def test_intake_analyze_calls_run_analyst(monkeypatch, tmp_path: Path):
+    calls: dict[str, object] = {}
+
+    async def fake_run_analyst(**kwargs):
+        calls.update(kwargs)
+        return "REPORT"
+
+    monkeypatch.setattr("testbed.adapters.run_analyst", fake_run_analyst)
+    out = tmp_path / "insights.json"
+    report = await build_adapter(_intake_subject()).analyze(record=None, since=None, verbose=True, out_path=out)
+    assert report == "REPORT"
+    assert calls["agent"] == "a"
+    assert calls["workspace"] == "w"
+    assert calls["base_url"] == "u"
+    assert calls["agent_spec"] is None
+
+
+async def test_intake_analyze_missing_keys_exits(tmp_path: Path):
+    bad = Subject(name="nvq", type="intake", config={"agent": "a"})
+    with pytest.raises(SystemExit):
+        await IntakeAdapter(bad).analyze(record=None, since=None, verbose=False, out_path=tmp_path / "x.json")
+
+
+async def test_intake_produce_message_says_analyze():
+    """The `insights` alias is gone; the no-produce-step pointer must name `analyze --live`
+    (bare analyze restores a pinned state — not what a produce-less intake subject wants)."""
+    with pytest.raises(SystemExit) as exc:
+        await IntakeAdapter(_intake_subject()).produce()
+    message = str(exc.value)
+    assert "testbed analyze nvq --live" in message
+    assert "testbed insights" not in message
+
+
+def test_build_adapter_dispatches_benchmark():
+    adapter = build_adapter(Subject("tau2-airline", "benchmark", _CFG))
+    assert isinstance(adapter, BenchmarkAdapter)
+
+
+async def test_benchmark_preflight_lists_missing(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    # stanza with no tau2_repo and no model -> tau2_repo + models + creds all flagged
+    adapter = BenchmarkAdapter(Subject("tau2-airline", "benchmark", {"domain": "airline"}))
+    with pytest.raises(SystemExit) as exc:
+        await adapter.produce()
+    msg = str(exc.value)
+    assert "tau2_repo" in msg and "OPENAI_API_KEY" in msg
+
+
+async def test_benchmark_preflight_rejects_placeholder_model(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_BASE", "http://gw")
+    monkeypatch.setattr("testbed.adapters.shutil.which", lambda _name: "/usr/bin/tau2")
+    # valid tau2 paths (via overrides) so ONLY the placeholder model is flagged
+    cfg = {
+        **_CFG,
+        "tau2_data_dir": str(tmp_path),
+        "tau2_bin": "tau2",
+        "agent_llm": "openai/<your-model>",
+    }
+    adapter = BenchmarkAdapter(Subject("tau2-airline", "benchmark", cfg))
+    with pytest.raises(SystemExit) as exc:
+        await adapter.produce()
+    assert "agent_llm" in str(exc.value)
+
+
+async def test_benchmark_preflight_flags_missing_binary(monkeypatch, tmp_path):
+    # tau2 paths resolve (data dir exists) but the binary isn't found -> flagged.
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_BASE", "http://gw")
+    monkeypatch.setattr("testbed.adapters.shutil.which", lambda _name: None)
+    cfg = {**_CFG, "tau2_data_dir": str(tmp_path), "tau2_bin": "tau2"}
+    adapter = BenchmarkAdapter(Subject("tau2-airline", "benchmark", cfg))
+    with pytest.raises(SystemExit) as exc:
+        await adapter.produce()
+    assert "tau2 binary" in str(exc.value)
+
+
+def test_benchmark_check_reports_missing_argv_keys(monkeypatch, tmp_path):
+    """check() covers every key build_argv hard-indexes, so `run` can't KeyError past doctor.
+
+    seed=0 is a valid RNG seed and num_trials/max_concurrency are ints too — only an
+    ABSENT key is missing, never a falsy-but-present value.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_BASE", "http://gw")
+    monkeypatch.setattr("testbed.adapters.shutil.which", lambda _name: "/usr/bin/tau2")
+    base = {
+        "domain": "airline",
+        "base_url": "http://localhost:8080",
+        "workspace": "w",
+        "agent_llm": "openai/m",
+        "user_llm": "openai/m",
+        "tau2_data_dir": str(tmp_path),
+        "tau2_bin": "tau2",
+    }
+    argv_keys = ("task_split_name", "num_trials", "seed", "max_concurrency")
+    missing = BenchmarkAdapter(Subject("t", "benchmark", base)).check()
+    assert {f"config key '{k}'" for k in argv_keys} <= set(missing)
+    ready = {**base, "task_split_name": "train", "num_trials": 1, "seed": 0, "max_concurrency": 1}
+    assert BenchmarkAdapter(Subject("t", "benchmark", ready)).check() == []
+
+
+async def test_benchmark_preflight_flags_repo_when_only_bin_set(monkeypatch, tmp_path):
+    # tau2_bin set but no tau2_repo/tau2_data_dir -> data dir unresolved -> tau2_repo flagged.
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_BASE", "http://gw")
+    monkeypatch.setattr("testbed.adapters.shutil.which", lambda _name: "/usr/bin/tau2")
+    cfg = {**_CFG, "tau2_bin": "tau2"}  # no tau2_repo, no tau2_data_dir
+    adapter = BenchmarkAdapter(Subject("tau2-airline", "benchmark", cfg))
+    with pytest.raises(SystemExit) as exc:
+        await adapter.produce()
+    assert "tau2_repo" in str(exc.value)
+
+
+def _kinds(spans: list[dict[str, Any]]) -> set[str]:
+    return {s["kind"] for s in spans}
+
+
+def _patch_otlp(
+    monkeypatch,
+    *,
+    exported: list[tuple[str, str, list[dict[str, Any]]]],
+    evals: list[tuple[str, str, str, float]],
+    created: list[str] | None = None,
+    experiments: list[tuple[str, str, str, str]] | None = None,
+    poll: bool = True,
+) -> None:
+    """Patch the OTLP ingest seam: capture export_spans / post_evaluator_results."""
+    monkeypatch.setattr("testbed.adapters.shutil.which", lambda _name: "/usr/bin/tau2")
+    monkeypatch.setattr("testbed.adapters.read_policy", lambda data_dir, domain: "POLICY")
+    monkeypatch.setattr(
+        "testbed.adapters.ensure_workspace",
+        lambda base_url, workspace, *, client=None: created.append(workspace) if created is not None else None,
+    )
+    monkeypatch.setattr(
+        "testbed.adapters.ensure_experiment_group",
+        lambda base_url, workspace, name, *, client=None: "grp-1",
+    )
+    monkeypatch.setattr(
+        "testbed.adapters.create_experiment",
+        lambda base_url, workspace, *, name, experiment_group_id, dataset_name, dataset_version, metadata, client=None: (
+            experiments.append((workspace, name, dataset_name, dataset_version)) if experiments is not None else None
+        ),
+    )
+    monkeypatch.setattr(
+        "testbed.adapters.export_spans",
+        lambda base_url, workspace, session_id, trace_id, spans, *, client=None: exported.append(
+            (workspace, session_id, spans)
+        ),
+    )
+    monkeypatch.setattr(
+        "testbed.adapters.post_evaluator_results",
+        lambda base_url, workspace, *, span_id, session_id, score, client=None: evals.append(
+            (workspace, span_id, session_id, score)
+        ),
+    )
+    if poll:
+        monkeypatch.setattr(
+            "testbed.adapters.poll_visible",
+            lambda base_url, workspace, session_ids, *, client=None, **kw: set(session_ids),
+        )
+
+
+async def test_benchmark_produce_records_run_without_analyzing(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_BASE", "http://gw")
+    monkeypatch.setattr(
+        "testbed.adapters.run_tau2",
+        lambda cfg, run_id, *, data_dir, tau2_bin: _SIMS,
+    )
+    created: list[str] = []
+    exported: list[tuple[str, str, list[dict[str, Any]]]] = []
+    evals: list[tuple[str, str, str, float]] = []
+    experiments: list[tuple[str, str, str, str]] = []
+    _patch_otlp(monkeypatch, exported=exported, evals=evals, created=created, experiments=experiments)
+    analyst_called = {"v": False}
+
+    async def fake_run_analyst(**kwargs):
+        analyst_called["v"] = True
+        return "SHOULD-NOT-RUN"
+
+    monkeypatch.setattr("testbed.adapters.run_analyst", fake_run_analyst)
+
+    cfg = {**_CFG, "tau2_data_dir": str(tmp_path), "tau2_bin": "tau2"}
+    record = await BenchmarkAdapter(Subject("tau2-airline", "benchmark", cfg)).produce()
+
+    assert analyst_called["v"] is False  # produce does NOT analyze
+    assert record["realistic_workspace"] == "tau2-airline"  # stable, not per-run
+    assert record["oracle_workspace"] == "tau2-airline-oracle"
+    assert record["experiment_id"].startswith("tau2-airline-")  # run id = experiment name
+    assert record["experiment_id"] != record["realistic_workspace"]
+    assert record["experiment_group"] == "tau2-airline"
+    assert record["dataset_name"] == "tau2:airline"
+    assert created == ["tau2-airline", "tau2-airline-oracle"]  # both stable workspaces ensured
+    # Experiment entity created on the ORACLE workspace only.
+    assert experiments == [("tau2-airline-oracle", record["experiment_id"], "tau2:airline", record["dataset_version"])]
+    assert len(exported) == 4  # 2 sims x 2 workspaces
+    # Every exported span is tagged with the run id.
+    for _ws, _sid, spans in exported:
+        assert all(s["attributes"]["nemo.experiment.id"] == record["experiment_id"] for s in spans)
+    assert all("EVALUATOR" not in _kinds(spans) for ws, _, spans in exported if ws == "tau2-airline")
+    assert all("EVALUATOR" in _kinds(spans) for ws, _, spans in exported if ws == "tau2-airline-oracle")
+    assert len(evals) == 2
+    assert {ws for ws, *_ in evals} == {"tau2-airline-oracle"}
+    assert record["agent"] == "tau2-airline"
+    assert record["base_url"] == "http://localhost:8080"
+    assert record["domain"] == "airline"
+
+
+async def test_benchmark_analyze_uses_record(monkeypatch, tmp_path):
+    monkeypatch.setattr("testbed.adapters.read_policy", lambda data_dir, domain: "POLICY")
+    ran_tau2 = {"v": False}
+    monkeypatch.setattr(
+        "testbed.adapters.run_tau2",
+        lambda *a, **k: ran_tau2.__setitem__("v", True) or [],
+    )
+    seen: dict[str, object] = {}
+
+    async def fake_run_analyst(
+        *, agent, agent_spec, workspace, base_url, insights_output, verbose, since, evaluation_id
+    ):
+        seen.update(
+            agent=agent,
+            agent_spec=agent_spec,
+            workspace=workspace,
+            base_url=base_url,
+            evaluation_id=evaluation_id,
+        )
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.run_analyst", fake_run_analyst)
+
+    cfg = {**_CFG, "tau2_data_dir": str(tmp_path), "tau2_bin": "tau2"}
+    record = {
+        "agent": "tau2-airline",
+        "realistic_workspace": "tau2-airline",
+        "oracle_workspace": "tau2-airline-oracle",
+        "experiment_id": "tau2-airline-20260626-000000-abcd",
+        "base_url": "http://localhost:8080",
+        "domain": "airline",
+    }
+    out = await BenchmarkAdapter(Subject("tau2-airline", "benchmark", cfg)).analyze(
+        record=record, since=None, verbose=True, out_path=tmp_path / "o.json"
+    )
+    assert out == "REPORT-OK"
+    assert ran_tau2["v"] is False  # analyze never runs tau2
+    assert seen["agent"] == "tau2-airline"
+    assert seen["agent_spec"] == "POLICY"
+    assert seen["workspace"] == "tau2-airline"  # the stable REALISTIC workspace, never the oracle one
+    assert seen["evaluation_id"] == "tau2-airline-20260626-000000-abcd"  # run-scoped
+    assert seen["base_url"] == "http://localhost:8080"
+
+
+async def test_benchmark_analyze_without_record_raises(tmp_path):
+    adapter = BenchmarkAdapter(Subject("tau2-airline", "benchmark", _CFG))
+    with pytest.raises(SystemExit):
+        await adapter.analyze(record=None, since=None, verbose=False, out_path=tmp_path / "x.json")
+
+
+async def test_benchmark_produce_splits_oracle_between_workspaces(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_BASE", "http://gw")
+    monkeypatch.setattr(
+        "testbed.adapters.run_tau2",
+        lambda cfg, run_id, *, data_dir, tau2_bin: [
+            {
+                "task_id": "8",
+                "trial": 0,
+                "messages": [{"role": "user", "content": "hi"}],
+                "reward_info": {"reward": 1.0, "reward_breakdown": {"DB": 1.0}},
+                "termination_reason": "done",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "testbed.adapters.load_tasks",
+        lambda data_dir, domain: {
+            "8": {
+                "id": "8",
+                "user_scenario": {"instructions": "do X"},
+                "evaluation_criteria": {"actions": ["book"]},
+            }
+        },
+    )
+    exported: list[tuple[str, str, list[dict[str, Any]]]] = []
+    evals: list[tuple[str, str, str, float]] = []
+    _patch_otlp(monkeypatch, exported=exported, evals=evals)
+
+    async def fake_run_analyst(**kwargs):
+        return "R"
+
+    monkeypatch.setattr("testbed.adapters.run_analyst", fake_run_analyst)
+    cfg = {**_CFG, "tau2_data_dir": str(tmp_path), "tau2_bin": "tau2"}
+    record = await BenchmarkAdapter(Subject("tau2-airline", "benchmark", cfg)).produce()
+
+    by_ws = {ws: spans for ws, _sid, spans in exported}
+    realistic = by_ws[record["realistic_workspace"]]
+    oracle = by_ws[record["oracle_workspace"]]
+
+    def _root_task(spans):
+        (root,) = [s for s in spans if s["kind"] == "AGENT"]
+        return json.loads(root["attributes"]["tau2.task"])
+
+    # Realistic: no EVALUATOR span, task SETUP retained, gold criteria withheld.
+    assert "EVALUATOR" not in {s["kind"] for s in realistic}
+    assert _root_task(realistic)["user_scenario"]["instructions"] == "do X"
+    assert "evaluation_criteria" not in _root_task(realistic)
+
+    # Oracle: EVALUATOR span + full answer key + a reward row targeting that span.
+    (evaluator,) = [s for s in oracle if s["kind"] == "EVALUATOR"]
+    assert _root_task(oracle)["evaluation_criteria"] == {"actions": ["book"]}
+    assert evaluator["attributes"]["score"] == 1.0
+    (eval_ws, eval_span_id, _sid, eval_score) = evals[0]
+    assert eval_ws == record["oracle_workspace"]
+    assert eval_span_id == evaluator["span_id"]  # reward row targets the EVALUATOR span
+    assert eval_score == 1.0
+
+
+async def test_benchmark_produce_realistic_only_when_rewards_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_BASE", "http://gw")
+    monkeypatch.setattr(
+        "testbed.adapters.run_tau2",
+        lambda cfg, run_id, *, data_dir, tau2_bin: _SIMS,
+    )
+    monkeypatch.setattr("testbed.adapters.load_tasks", lambda data_dir, domain: {})
+    created: list[str] = []
+    exported: list[tuple[str, str, list[dict[str, Any]]]] = []
+    evals: list[tuple[str, str, str, float]] = []
+    experiments: list[tuple[str, str, str, str]] = []
+    _patch_otlp(monkeypatch, exported=exported, evals=evals, created=created, experiments=experiments)
+
+    async def fake_run_analyst(**kwargs):
+        return "R"
+
+    monkeypatch.setattr("testbed.adapters.run_analyst", fake_run_analyst)
+    cfg = {**_CFG, "tau2_data_dir": str(tmp_path), "tau2_bin": "tau2", "include_rewards": False}
+    record = await BenchmarkAdapter(Subject("tau2-airline", "benchmark", cfg)).produce()
+
+    assert record["oracle_workspace"] is None  # no oracle workspace
+    assert created == [record["realistic_workspace"]]  # only the realistic one created
+    assert len(exported) == 2  # 2 sims x 1 workspace
+    assert all(ws == record["realistic_workspace"] for ws, _, _ in exported)
+    assert evals == []  # no oracle → no reward rows
+    assert experiments == []  # no oracle workspace → no Experiment entity

--- a/plugins/nemo-insights/tests/testbed/test_artifact.py
+++ b/plugins/nemo-insights/tests/testbed/test_artifact.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+
+from testbed import artifact
+
+
+def test_pick_records_scoped_to_subjects(tmp_path):
+    """Only the selected subjects' run records go into a bundle, not everything in tmp/."""
+    for name in ("a.run.json", "b.run.json"):
+        (tmp_path / name).write_text("{}")
+    (tmp_path / "noise.txt").write_text("x")
+    assert [p.name for p in artifact.pick_records(tmp_path, ["a"])] == ["a.run.json"]
+
+
+def test_pick_records_excludes_insights_yaml(tmp_path):
+    """Insights never travel in bundles: a subject's insights YAML is not a bundle record."""
+    (tmp_path / "a.run.json").write_text("{}")
+    (tmp_path / "insights_a.yaml").write_text("insights: []")
+    assert [p.name for p in artifact.pick_records(tmp_path, ["a"])] == ["a.run.json"]
+
+
+def test_pick_records_tolerates_missing_files(tmp_path):
+    (tmp_path / "a.run.json").write_text("{}")
+    assert [p.name for p in artifact.pick_records(tmp_path, ["a", "ghost"])] == ["a.run.json"]
+
+
+def test_backup_records_moves_named_files(tmp_path):
+    (tmp_path / "a.run.json").write_text("local")
+    backup = artifact.backup_records(tmp_path, ["a.run.json"])
+    assert backup.parent == tmp_path and backup.name.startswith("backup-")
+    # microsecond-stamped: two invocations within the same second must not collide
+    assert re.fullmatch(r"backup-\d{8}-\d{6}-\d{6}", backup.name)
+    assert not (tmp_path / "a.run.json").exists()
+    assert (backup / "a.run.json").read_text() == "local"
+
+
+def test_seed_records_copies_run_records(tmp_path):
+    src = tmp_path / "state" / "tmp"
+    src.mkdir(parents=True)
+    (src / "a.run.json").write_text("{}")
+    dest = tmp_path / "dest"
+    msg, seeded = artifact.seed_records(src, dest)
+    assert (dest / "a.run.json").read_text() == "{}"
+    assert seeded == ["a.run.json"]
+    assert "a.run.json" in msg
+
+
+def test_seed_records_ignores_bundled_insights(tmp_path):
+    """A stray insights YAML inside an old bundle's tmp/ is never copied out."""
+    src = tmp_path / "state" / "tmp"
+    src.mkdir(parents=True)
+    (src / "a.run.json").write_text("{}")
+    (src / "insights_a.yaml").write_text("insights: []")
+    dest = tmp_path / "dest"
+    msg, seeded = artifact.seed_records(src, dest)
+    assert (dest / "a.run.json").exists() and not (dest / "insights_a.yaml").exists()
+    assert seeded == ["a.run.json"]  # the ignored insight YAML is not "seeded"
+
+
+def test_seed_records_leaves_local_insights_alone(tmp_path):
+    """Local insight YAMLs are the analyst's business (cli fresh/keep), never the restore's."""
+    src = tmp_path / "state" / "tmp"
+    src.mkdir(parents=True)
+    (src / "a.run.json").write_text("{}")
+    (src / "insights_a.yaml").write_text("insights: [bundle]")
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    (dest / "insights_a.yaml").write_text("insights: [local]")
+    (dest / "insights_b.yaml").write_text("insights: [other]")
+    artifact.seed_records(src, dest)
+    assert (dest / "insights_a.yaml").read_text() == "insights: [local]"
+    assert (dest / "insights_b.yaml").read_text() == "insights: [other]"
+    assert list(dest.glob("backup-*")) == []  # no run record clobbered -> nothing moved
+
+
+def test_seed_records_missing_state_tmp_ok(tmp_path):
+    msg, seeded = artifact.seed_records(tmp_path / "absent", tmp_path / "dest")
+    assert "no run record" in msg
+    assert seeded == []
+
+
+def test_seed_records_backs_up_clobbered_local_records(tmp_path, capsys):
+    """A restore never silently destroys local records — originals move to backup-<stamp>/."""
+    src = tmp_path / "state" / "tmp"
+    src.mkdir(parents=True)
+    (src / "a.run.json").write_text('{"from": "bundle"}')
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    (dest / "a.run.json").write_text('{"from": "local"}')
+    artifact.seed_records(src, dest)
+    assert (dest / "a.run.json").read_text() == '{"from": "bundle"}'
+    (backup,) = dest.glob("backup-*")
+    assert (backup / "a.run.json").read_text() == '{"from": "local"}'
+    out = capsys.readouterr().out
+    assert "backed up" in out and "a.run.json" in out
+
+
+def test_seed_records_no_backup_when_nothing_clobbered(tmp_path, capsys):
+    src = tmp_path / "state" / "tmp"
+    src.mkdir(parents=True)
+    (src / "a.run.json").write_text("{}")
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    (dest / "other.run.json").write_text("{}")  # name not in the bundle: untouched
+    artifact.seed_records(src, dest)
+    assert list(dest.glob("backup-*")) == []
+    assert "backed up" not in capsys.readouterr().out
+
+
+# Manifest building lives on the export path — see tests/testbed/test_export.py
+# (build_export_manifest, snapshot_export).

--- a/plugins/nemo-insights/tests/testbed/test_cli.py
+++ b/plugins/nemo-insights/tests/testbed/test_cli.py
@@ -1,0 +1,1746 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+from testbed import cli
+
+# --------------------------------------------------------------------------- #
+# bundle fixtures: real tar.zst files, kind-switched exactly like production
+# --------------------------------------------------------------------------- #
+
+
+def _make_export_bundle(
+    path: Path,
+    *,
+    workspaces=("tau2-airline", "tau2-airline-oracle"),
+    min_start_time="2026-06-01T12:00:00+00:00",
+    records: dict[str, str] | None = None,
+) -> Path:
+    """A minimal but structurally faithful `kind: testbed-export` bundle."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=path.parent) as tmp:
+        state = Path(tmp) / "state"
+        (state / "tmp").mkdir(parents=True)
+        counts = {}
+        for ws in workspaces:
+            ws_dir = state / "export" / ws
+            ws_dir.mkdir(parents=True)
+            (ws_dir / "spans.jsonl").write_text('{"span_id": "s1"}\n', encoding="utf-8")
+            (ws_dir / "annotations.jsonl").write_text("", encoding="utf-8")
+            (ws_dir / "evaluator_results.jsonl").write_text("", encoding="utf-8")
+            counts[ws] = {"spans": 1, "annotations": 0, "evaluator_results": 0}
+        for name, text in (records or {}).items():
+            (state / "tmp" / name).write_text(text, encoding="utf-8")
+        manifest = {
+            "kind": "testbed-export",
+            "subjects": sorted({ws.removesuffix("-oracle") for ws in workspaces}),
+            "workspaces": sorted(workspaces),
+            "counts": counts,
+            "min_start_time": min_start_time,
+            "max_start_time": min_start_time,
+            "source_url": "http://origin:8080",
+        }
+        (state / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+        subprocess.run(["tar", "--zstd", "-cf", str(path), "-C", tmp, "state"], check=True)
+    return path
+
+
+def _make_legacy_bundle(path: Path) -> Path:
+    """A legacy tar bundle: state/manifest.json without the testbed-export kind."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=path.parent) as tmp:
+        state = Path(tmp) / "state"
+        (state / "clickhouse").mkdir(parents=True)
+        (state / "manifest.json").write_text('{"created_at": "2026-01-01"}', encoding="utf-8")
+        subprocess.run(["tar", "--zstd", "-cf", str(path), "-C", tmp, "state"], check=True)
+    return path
+
+
+def _make_tar_with_manifest_text(path: Path, manifest_text: str | None) -> Path:
+    """A readable tar.zst whose state/manifest.json is *manifest_text* (or absent when None)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=path.parent) as tmp:
+        state = Path(tmp) / "state"
+        state.mkdir(parents=True)
+        (state / "other.txt").write_text("x", encoding="utf-8")
+        if manifest_text is not None:
+            (state / "manifest.json").write_text(manifest_text, encoding="utf-8")
+        subprocess.run(["tar", "--zstd", "-cf", str(path), "-C", tmp, "state"], check=True)
+    return path
+
+
+_RUN_RECORD = {
+    "agent": "tau2-airline",
+    "realistic_workspace": "tau2-airline",
+    "oracle_workspace": "tau2-airline-oracle",
+    "experiment_id": "run-1",
+    "base_url": "http://origin:8080",
+    "domain": "airline",
+}
+
+
+@pytest.fixture
+def stub_reingest(monkeypatch):
+    """Stub the reingest touchpoints (no catalog import, no network); record every call."""
+    calls = {"ingest": [], "platform_root": [], "catalog_root": []}
+
+    def fake_resolve(explicit=None, **kw):
+        calls["platform_root"].append(explicit)
+        return Path(explicit) if explicit else Path("/stub/nemo-platform")
+
+    def fake_load(root):
+        calls["catalog_root"].append(Path(root))
+        return "stub-catalog"
+
+    def fake_ingest(base_url, export_dir, manifest, *, workspace_map, catalog, **kw):
+        calls["ingest"].append(
+            {
+                "base_url": base_url,
+                "export_dir": Path(export_dir),
+                "manifest": manifest,
+                "workspace_map": dict(workspace_map),
+                "catalog": catalog,
+            }
+        )
+        return {
+            ws: {
+                "workspace": target,
+                "spans": {"ingested": manifest["counts"][ws]["spans"], "skipped": 0},
+                "annotations": {"ingested": 0, "skipped": 0},
+                "evaluator_results": {"ingested": 0, "skipped": 0},
+            }
+            for ws, target in workspace_map.items()
+        }
+
+    monkeypatch.setattr("testbed.reingest.resolve_platform_root", fake_resolve)
+    monkeypatch.setattr("testbed.reingest.load_catalog", fake_load)
+    monkeypatch.setattr("testbed.reingest.ingest_bundle", fake_ingest)
+    return calls
+
+
+def test_list_prints_configured_subjects(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["testbed", "list"])
+    cli.main()
+    out = capsys.readouterr().out
+    assert "nvq" in out
+    assert "tau2-airline" in out
+    assert "tau2-retail" in out
+
+
+def test_analyze_unknown_subject_exits(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nope"])
+    with pytest.raises(SystemExit):
+        cli.main()
+
+
+def test_analyze_without_key_exits(monkeypatch):
+    # Neutralize .env loading so a developer's local testbed/.env can't supply the key.
+    # The key guard must fire before any state resolution/download (bare analyze = pinned mode).
+    monkeypatch.setattr(cli, "_load_dotenv", lambda *a, **k: None)
+    monkeypatch.delenv("INFERENCE_API_KEY", raising=False)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    # Must exit for the key guard, not (e.g.) an "Unknown testbed" reason.
+    assert "INFERENCE_API_KEY" in str(exc.value)
+
+
+def test_analyze_live_happy_path(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)  # keep the suite out of the real testbed/tmp
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--live", "-v"])
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    cli.main()
+    out = capsys.readouterr().out
+    assert "REPORT-OK" in out
+    assert "Insights written" in out
+
+
+def test_missing_registry_exits(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "REGISTRY_PATH", tmp_path / "nope.toml")
+    monkeypatch.setattr(sys, "argv", ["testbed", "list"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "registry" in str(exc.value).lower()
+
+
+def test_empty_since_is_epoch_no_lower_bound(monkeypatch, tmp_path, capsys):
+    # `--live --since ''` means "no lower bound" and must NOT fall back to the stanza
+    # default. The analyst must receive the EPOCH, not None — a None bound lets the
+    # read API reapply its implicit 30d lookback (export.py's `since or EPOCH`
+    # discipline, mirrored).
+    from testbed.registry import Subject
+
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    subject = Subject(
+        "demo",
+        "intake",
+        {"agent": "a", "workspace": "w", "base_url": "u", "since": "7d"},
+    )
+    monkeypatch.setattr(cli, "load_registry", lambda _path: {"demo": subject})
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "demo", "--live", "--since", ""])
+    seen: dict = {}
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        seen["since"] = since
+        return "ok"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    cli.main()
+    assert seen["since"] == datetime(1970, 1, 1, tzinfo=timezone.utc)
+    assert "since: 1970-01-01T00:00:00+00:00 (--since (epoch — no lower bound))" in capsys.readouterr().out
+
+
+def test_load_dotenv_sets_missing_and_preserves_existing(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        '# a comment\nFOO=from_file\nBAR=baz\nexport QUX="q v"\n\nNOEQ_LINE\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FOO", "from_shell")  # already set -> file must NOT override
+    monkeypatch.delenv("BAR", raising=False)
+    monkeypatch.delenv("QUX", raising=False)
+    cli._load_dotenv(env_file)
+    assert os.environ["FOO"] == "from_shell"  # setdefault: real env wins
+    assert os.environ["BAR"] == "baz"
+    assert os.environ["QUX"] == "q v"  # quotes stripped, export prefix dropped
+
+
+def test_load_dotenv_missing_file_is_noop(tmp_path, monkeypatch):
+    monkeypatch.delenv("NOPE_SENTINEL", raising=False)
+    cli._load_dotenv(tmp_path / "nope.env")  # must not raise
+    assert os.environ.get("NOPE_SENTINEL") is None  # and sets nothing
+
+
+def test_doctor_ready(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_load_dotenv", lambda *a, **k: None)
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk")
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.check", lambda self: [])
+    monkeypatch.setattr(cli.shutil, "which", lambda _name: "/usr/bin/gh")  # deterministic: gh "installed"
+    monkeypatch.setattr(sys, "argv", ["testbed", "doctor", "nvq"])
+    cli.main()
+    out = capsys.readouterr().out
+    assert "✓" in out and "ready" in out
+    # doctor checks the adapter's (live-analysis) prerequisites, so the ready
+    # hint must name the live flow, not the pinned restore
+    assert "analyze nvq --live" in out
+
+
+def test_doctor_flags_missing_gh(monkeypatch, capsys):
+    """Pinned/--state analyze shells out to gh; doctor must flag its absence up front."""
+    monkeypatch.setattr(cli, "_load_dotenv", lambda *a, **k: None)
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk")
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.check", lambda self: [])
+    monkeypatch.setattr(cli.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(sys, "argv", ["testbed", "doctor", "nvq"])
+    cli.main()
+    out = capsys.readouterr().out
+    assert "✗" in out
+    assert "gh CLI (needed for pinned/--state analyze; https://cli.github.com)" in out
+
+
+def test_doctor_lists_unmet(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_load_dotenv", lambda *a, **k: None)  # don't let .env supply the key
+    monkeypatch.delenv("INFERENCE_API_KEY", raising=False)
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.check", lambda self: ["config key 'agent'"])
+    monkeypatch.setattr(sys, "argv", ["testbed", "doctor", "nvq"])
+    cli.main()
+    out = capsys.readouterr().out
+    assert "✗" in out and "INFERENCE_API_KEY" in out and "config key 'agent'" in out
+
+
+def test_run_records_and_prints(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+
+    async def fake_produce(self):
+        return {
+            "agent": "tau2-airline-xyz",
+            "realistic_workspace": "tau2-airline-ts-realistic",
+            "oracle_workspace": "tau2-airline-ts-realistic-oracle",
+            "base_url": "u",
+            "domain": "airline",
+        }
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.produce", fake_produce)
+    monkeypatch.setattr(sys, "argv", ["testbed", "run", "tau2-airline"])
+    cli.main()
+    out = capsys.readouterr().out
+    assert "recorded" in out and "tau2-airline-xyz" in out
+    # the hint must name the live flow: bare analyze restores a pinned state,
+    # which would ignore the run that was just recorded
+    assert "analyze tau2-airline --live" in out
+    from testbed.runstore import load_run
+
+    assert load_run(tmp_path / "tau2-airline.run.json")["agent"] == "tau2-airline-xyz"
+
+
+def test_analyze_live_passes_record_to_analyze(monkeypatch, tmp_path):
+    from testbed.runstore import save_run
+
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk")
+    save_run(
+        tmp_path / "tau2-airline.run.json",
+        {
+            "agent": "tau2-airline-xyz",
+            "realistic_workspace": "tau2-airline-ts-realistic",
+            "oracle_workspace": "tau2-airline-ts-realistic-oracle",
+            "base_url": "u",
+            "domain": "airline",
+        },
+    )
+    seen: dict = {}
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        seen["record"] = record
+        return "REPORT"
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "tau2-airline", "--live"])
+    cli.main()
+    assert seen["record"]["agent"] == "tau2-airline-xyz"
+    assert seen["record"]["realistic_workspace"] == "tau2-airline-ts-realistic"  # live mode: no remap
+
+
+def test_run_intake_exits(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["testbed", "run", "nvq"])
+    with pytest.raises(SystemExit):
+        cli.main()
+
+
+def test_run_base_replaces_local(monkeypatch, tmp_path):
+    """`run --base URL` points the subject at URL (the old --local, generalized)."""
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    seen: dict = {}
+
+    async def fake_produce(self):
+        seen["base_url"] = self.subject.config["base_url"]
+        return {
+            "agent": "a",
+            "realistic_workspace": "a",
+            "oracle_workspace": None,
+            "base_url": self.subject.config["base_url"],
+            "domain": "airline",
+        }
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.produce", fake_produce)
+    monkeypatch.setattr(sys, "argv", ["testbed", "run", "tau2-airline", "--base", "http://localhost:8080"])
+    cli.main()
+    assert seen["base_url"] == "http://localhost:8080"
+
+
+def test_analyze_live_base_overrides_stanza(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk")
+    seen: dict = {}
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        seen["base_url"] = self.subject.config["base_url"]
+        return "ok"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--live", "--base", "http://localhost:8080"])
+    cli.main()
+    assert seen["base_url"] == "http://localhost:8080"
+
+
+def test_analyze_live_base_retargets_record(monkeypatch, tmp_path):
+    """--live --base must also retarget the benchmark run record."""
+    from testbed.runstore import save_run
+
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk")
+    save_run(tmp_path / "tau2-airline.run.json", dict(_RUN_RECORD))  # recorded at http://origin:8080
+    seen: dict = {}
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        seen["record"] = record
+        return "REPORT"
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "analyze", "tau2-airline", "--live", "--base", "http://localhost:8080"],
+    )
+    cli.main()
+    assert seen["record"]["base_url"] == "http://localhost:8080"  # not the recorded origin URL
+    assert seen["record"]["realistic_workspace"] == "tau2-airline"  # workspaces still un-remapped (live)
+
+
+def test_run_set_overrides_reach_adapter(monkeypatch, tmp_path):
+    captured = {}
+
+    async def fake_produce(self):
+        captured.update(self.subject.config)
+        return {"agent": "a", "realistic_workspace": "w", "oracle_workspace": None}
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.produce", fake_produce)
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "run", "tau2-airline", "--set", "num_tasks=2", "--set", "user_llm=other/model"],
+    )
+    cli.main()
+    assert captured["num_tasks"] == 2  # int-coerced, not "2"
+    assert captured["user_llm"] == "other/model"
+
+
+def test_set_rejects_malformed_pair(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["testbed", "run", "tau2-airline", "--set", "num_tasks"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "--set" in str(exc.value)
+
+
+def test_set_rejects_non_int_for_int_key(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["testbed", "run", "tau2-airline", "--set", "num_tasks=lots"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "integer" in str(exc.value)
+
+
+def test_analyze_live_set_overrides_reach_adapter(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    captured = {}
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        captured.update(self.subject.config)
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--live", "--set", "agent=other-agent"])
+    cli.main()
+    assert captured["agent"] == "other-agent"
+
+
+def _bool_subject():
+    """A benchmark stanza carrying include_rewards=true (the toml keeps it as a commented default)."""
+    from testbed.registry import Subject
+
+    return Subject(
+        "demo",
+        "benchmark",
+        {
+            "domain": "airline",
+            "base_url": "u",
+            "workspace": "w",
+            "agent_llm": "m",
+            "user_llm": "m",
+            "include_rewards": True,
+        },
+    )
+
+
+def _capture_produce(monkeypatch, captured):
+    async def fake_produce(self):
+        captured.update(self.subject.config)
+        return {"agent": "a", "realistic_workspace": "w", "oracle_workspace": None, "base_url": "u"}
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.produce", fake_produce)
+
+
+def test_set_bool_false_is_false(monkeypatch, tmp_path):
+    """--set include_rewards=false must land as bool False (a "false" STRING is truthy —
+    the adapter would mint the oracle twin and snapshot scoping would export it)."""
+    from testbed import artifact
+    from testbed.registry import Subject
+
+    monkeypatch.setattr(cli, "load_registry", lambda _p: {"demo": _bool_subject()})
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    captured: dict = {}
+    _capture_produce(monkeypatch, captured)
+    monkeypatch.setattr(sys, "argv", ["testbed", "run", "demo", "--set", "include_rewards=false"])
+    cli.main()
+    assert captured["include_rewards"] is False
+    # snapshot scoping drops the oracle twin for the overridden subject
+    assert artifact.workspaces_for_subject(Subject("demo", "benchmark", captured)) == ["w"]
+    # case-insensitive: TRUE/False parse too
+    assert cli._apply_overrides(_bool_subject(), ["include_rewards=FALSE"]).config["include_rewards"] is False
+    assert cli._apply_overrides(_bool_subject(), ["include_rewards=True"]).config["include_rewards"] is True
+
+
+def test_set_bool_garbage_exits(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "load_registry", lambda _p: {"demo": _bool_subject()})
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["testbed", "run", "demo", "--set", "include_rewards=maybe"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "include_rewards" in message  # the exit names the key
+    assert "true" in message.lower() and "false" in message.lower()
+    assert "maybe" in message
+
+
+def test_benchmark_stanzas_carry_include_rewards():
+    """The tau2 benchmark stanzas must carry include_rewards=true so that --set include_rewards=false
+    engages typed coercion (a missing key stays as a truthy "false" STRING)."""
+    from testbed.registry import load_registry
+
+    registry = load_registry(cli.HERE / "testbeds.toml")
+    assert registry["tau2-airline"].config["include_rewards"] is True
+    assert registry["tau2-retail"].config["include_rewards"] is True
+
+
+def test_set_int_coerced(monkeypatch, tmp_path):
+    """Stanza-typed coercion: `seed` (the tau2 RNG, an int in the stanza) still parses to int."""
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    captured: dict = {}
+    _capture_produce(monkeypatch, captured)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "run", "tau2-airline", "--set", "seed=42", "--set", "num_tasks=2"],
+    )
+    cli.main()
+    assert captured["seed"] == 42 and isinstance(captured["seed"], int)
+    assert captured["num_tasks"] == 2 and isinstance(captured["num_tasks"], int)
+
+
+def test_set_float_coerced_by_stanza_type():
+    from testbed.registry import Subject
+
+    subject = Subject("demo", "benchmark", {"user_temperature": 0.0})
+    assert cli._apply_overrides(subject, ["user_temperature=0.7"]).config["user_temperature"] == 0.7
+    with pytest.raises(SystemExit) as exc:
+        cli._apply_overrides(subject, ["user_temperature=warm"])
+    assert "user_temperature" in str(exc.value)
+
+
+def test_set_unknown_key_stays_string(monkeypatch, tmp_path):
+    """Keys absent from the stanza are allowed and stay verbatim strings (no guessing)."""
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    captured: dict = {}
+    _capture_produce(monkeypatch, captured)
+    monkeypatch.setattr(sys, "argv", ["testbed", "run", "tau2-airline", "--set", "brand_new_key=7"])
+    cli.main()
+    assert captured["brand_new_key"] == "7"
+
+
+def test_set_bool_literal_coerces_even_when_key_absent(monkeypatch, tmp_path):
+    """--set include_rewards=false on a stanza WITHOUT the key must land as bool False —
+    a 'false' STRING is truthy, so the adapter would silently mint the oracle twin."""
+    from testbed.registry import Subject
+
+    subject = Subject(
+        "demo",
+        "benchmark",
+        {"domain": "airline", "base_url": "u", "workspace": "w", "agent_llm": "m", "user_llm": "m"},
+    )
+    monkeypatch.setattr(cli, "load_registry", lambda _p: {"demo": subject})
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    captured: dict = {}
+    _capture_produce(monkeypatch, captured)
+    monkeypatch.setattr(sys, "argv", ["testbed", "run", "demo", "--set", "include_rewards=false"])
+    cli.main()
+    assert captured["include_rewards"] is False
+    # bare true/false literals coerce case-insensitively; other unknown-key values stay strings
+    assert cli._apply_overrides(subject, ["new_flag=TRUE"]).config["new_flag"] is True
+    assert cli._apply_overrides(subject, ["new_flag=False"]).config["new_flag"] is False
+    assert cli._apply_overrides(subject, ["new_flag=0"]).config["new_flag"] == "0"
+
+
+def test_doctor_flags_missing_benchmark_argv_keys(monkeypatch, capsys):
+    """A stanza missing a key `tau2 run` hard-indexes gets a doctor line, not a KeyError at run time."""
+    from testbed.registry import Subject
+
+    monkeypatch.setattr(cli, "_load_dotenv", lambda *a, **k: None)
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk")
+    subject = Subject(
+        "demo",
+        "benchmark",
+        {"domain": "airline", "base_url": "u", "workspace": "w", "agent_llm": "m", "user_llm": "m"},
+    )
+    monkeypatch.setattr(cli, "load_registry", lambda _p: {"demo": subject})
+    monkeypatch.setattr(sys, "argv", ["testbed", "doctor", "demo"])
+    cli.main()
+    out = capsys.readouterr().out
+    for key in ("task_split_name", "num_trials", "seed", "max_concurrency"):
+        assert f"config key '{key}'" in out
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["analyze", "nvq", "--pinned"],
+        ["analyze", "nvq", "--latest"],
+        ["analyze", "nvq", "--ref", "state-v4"],
+        ["analyze", "nvq", "--from", "b.tar.zst"],
+        ["analyze", "nvq", "--local"],
+        ["insights", "nvq"],  # the backward-compatible alias is gone
+        ["restore", "--from", "b.tar.zst"],
+        ["restore", "--latest"],
+        ["restore", "--ref", "state-v4"],
+        ["restore", "--pinned"],
+        ["run", "tau2-airline", "--local"],
+        ["snapshot", "nvq", "--local"],
+    ],
+)
+def test_removed_flags_error(monkeypatch, argv):
+    """Every retired source/target flag (and the insights alias) is an argparse usage error."""
+    monkeypatch.setattr(sys, "argv", ["testbed", *argv])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2  # argparse usage error, not a testbed message
+
+
+def test_analyze_defaults_to_pinned_lock_entry(monkeypatch, tmp_path, stub_reingest):
+    """Bare `analyze <subject>` = the subject's state.lock pin restored onto the local platform."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_export_bundle(
+        tmp_path / "dl" / "state-v6.tar.zst",
+        records={"tau2-airline.run.json": json.dumps(_RUN_RECORD)},
+    )
+    seen: dict = {}
+    monkeypatch.setattr(
+        "testbed.release.resolve_state",
+        lambda state, *, subject, lock_path: (
+            seen.update(state=state, subject=subject, lock_path=lock_path) or "state-v6"
+        ),
+    )
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "tau2-airline"])
+    cli.main()
+    assert seen["state"] is None, "no flag -> the lock decides"
+    assert seen["subject"] == "tau2-airline", "analyze must thread its subject into the per-subject lock lookup"
+    assert seen["lock_path"] == cli.HERE / "state.lock"
+    assert seen["lock_path"].is_absolute(), "resolve_state must get an anchored lock path, not a cwd-relative one"
+    assert stub_reingest["ingest"][0]["base_url"] == "http://localhost:8080"  # default restore target: local platform
+
+
+def test_analyze_live_skips_restore_and_targets_stanza(monkeypatch, tmp_path, stub_reingest):
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setattr(
+        "testbed.release.download_ref",
+        lambda *a, **k: pytest.fail("--live must not download a state"),
+    )
+    seen: dict = {}
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        seen["base_url"] = self.subject.config["base_url"]
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--live"])
+    cli.main()
+    assert seen["base_url"] == "https://nemo-platform-freeplay.dev.aire.nvidia.com"  # the stanza, not localhost
+    assert stub_reingest["ingest"] == []  # no restore in live mode
+
+
+def test_analyze_live_since_precedence_and_print(monkeypatch, tmp_path, capsys):
+    """Live-mode since: --since beats the stanza beats the 30d default; one line names the origin."""
+    from testbed.registry import Subject
+
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    seen: dict = {}
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        seen["since"] = since
+        return "ok"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    stanza = Subject("demo", "intake", {"agent": "a", "workspace": "w", "base_url": "u", "since": "2026-06-15"})
+    monkeypatch.setattr(cli, "load_registry", lambda _p: {"demo": stanza})
+
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "demo", "--live", "--since", "2026-07-01"])
+    cli.main()
+    assert seen["since"] == datetime(2026, 7, 1, tzinfo=timezone.utc)
+    assert "since: 2026-07-01T00:00:00+00:00 (--since)" in capsys.readouterr().out
+
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "demo", "--live"])
+    cli.main()
+    assert seen["since"] == datetime(2026, 6, 15, tzinfo=timezone.utc)
+    assert "since: 2026-06-15T00:00:00+00:00 (stanza)" in capsys.readouterr().out
+
+    bare = Subject("demo", "intake", {"agent": "a", "workspace": "w", "base_url": "u"})
+    monkeypatch.setattr(cli, "load_registry", lambda _p: {"demo": bare})
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "demo", "--live"])
+    cli.main()
+    expected = datetime.now(timezone.utc) - timedelta(days=30)
+    assert abs((seen["since"] - expected).total_seconds()) < 60  # computed client-side, ~now-30d
+    out = capsys.readouterr().out
+    assert "(default 30d)" in out
+    assert out.count("since: ") == 1  # exactly one origin line
+
+
+def test_analyze_live_and_state_mutually_exclusive(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--live", "--state", "state-v6"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2
+    assert "not allowed with" in capsys.readouterr().err
+
+
+def test_analyze_state_accepts_ref_and_file(monkeypatch, tmp_path, capsys, stub_reingest):
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+
+    # ref form: resolved verbatim (no lock), downloaded; fixture suffix = the ref
+    dl = _make_export_bundle(tmp_path / "dl" / "state-v4.tar.zst", workspaces=("nvq",))
+    downloads: list = []
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: downloads.append(ref) or dl)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", "state-v4"])
+    cli.main()
+    assert downloads == ["state-v4"]
+    assert stub_reingest["ingest"][0]["workspace_map"] == {"nvq": "nvq-state-v4"}
+    assert "resolved state ref: state-v4" in capsys.readouterr().out
+
+    # file form: an existing path wins over the ref pattern; fixture suffix = content digest
+    local = _make_export_bundle(tmp_path / "local.tar.zst", workspaces=("nvq",))
+    digest = hashlib.sha256(local.read_bytes()).hexdigest()[:8]
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", str(local)])
+    cli.main()
+    assert stub_reingest["ingest"][1]["workspace_map"] == {"nvq": f"nvq-{digest}"}
+    assert downloads == ["state-v4"]  # the file form never downloads
+
+
+def test_analyze_state_directory_named_like_ref_resolves_ref(monkeypatch, tmp_path, stub_reingest):
+    """A DIRECTORY named state-v6 in cwd must not shadow the published ref (is_file, not exists)."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path / "tmp")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "state-v6").mkdir()
+    bundle = _make_export_bundle(tmp_path / "dl" / "state-v6.tar.zst", workspaces=("nvq",))
+    downloads: list = []
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: downloads.append(ref) or bundle)
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", "state-v6"])
+    cli.main()
+    assert downloads == ["state-v6"]  # the dir fell through to ref resolution
+
+
+def test_analyze_state_missing_path_like_value_exits_no_such_file(monkeypatch, tmp_path):
+    """A path-shaped --state that names nothing on disk must exit 'no such bundle file',
+    not resolve_state's malformed-ref message."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path / "tmp")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "testbed.release.download_ref",
+        lambda *a, **k: pytest.fail("a missing file must not resolve"),
+    )
+    for value in (str(tmp_path / "cand.tar.zst"), "./cand.tar.zst", "cand.tar.zst"):
+        monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", value])
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert str(exc.value) == f"no such bundle file: {value}"
+
+
+def test_analyze_file_state_provenance_names_local_file(monkeypatch, tmp_path, stub_reingest):
+    """File-source provenance is disambiguated from refs: label = '<name> (local file <digest8>)'."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    local = _make_export_bundle(tmp_path / "cand.tar.zst", workspaces=("nvq",))
+    digest = hashlib.sha256(local.read_bytes()).hexdigest()[:8]
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        out_path.write_text("insights: []\n")
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    summary = tmp_path / "summary.md"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "analyze", "nvq", "--state", str(local), "--summary-md", str(summary)],
+    )
+    cli.main()
+    assert f"### analyze @ cand.tar.zst (local file {digest}) (nvq)" in summary.read_text()
+
+
+def test_analyze_file_shadowing_ref_name_prints_note(monkeypatch, tmp_path, capsys, stub_reingest):
+    """A local FILE named exactly like a published ref wins over ref resolution — say so."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path / "tmp")
+    monkeypatch.chdir(tmp_path)
+    _make_export_bundle(tmp_path / "state-v6", workspaces=("nvq",))
+    monkeypatch.setattr(
+        "testbed.release.download_ref",
+        lambda *a, **k: pytest.fail("the local file wins — no download"),
+    )
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", "state-v6"])
+    cli.main()
+    out = capsys.readouterr().out
+    assert "note: 'state-v6' is a local file shadowing a published ref name — analyzing the file" in out
+
+
+def test_analyze_base_overrides_fixture_target(monkeypatch, tmp_path, stub_reingest):
+    """Pinned/state mode restores onto --base (and the analyst reads it) instead of localhost."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_export_bundle(tmp_path / "dl" / "state-v4.tar.zst", workspaces=("nvq",))
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+    seen: dict = {}
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        seen["base_url"] = self.subject.config["base_url"]
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "analyze", "nvq", "--state", "state-v4", "--base", "http://ci-host:8080"],
+    )
+    cli.main()
+    assert stub_reingest["ingest"][0]["base_url"] == "http://ci-host:8080"
+    assert seen["base_url"] == "http://ci-host:8080"
+
+
+def test_analyze_summary_md_records_restore_provenance(monkeypatch, tmp_path, capsys, stub_reingest):
+    """A pinned/state analyze must record what it restored, before the insights section."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_export_bundle(tmp_path / "dl" / "state-v4.tar.zst", workspaces=("nvq",))
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        out_path.write_text("insights: []\n")
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    summary = tmp_path / "summary.md"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "analyze", "nvq", "--state", "state-v4", "--summary-md", str(summary)],
+    )
+    cli.main()
+    text = summary.read_text()
+    assert "analyze @ state-v4" in text
+    # provenance line lands before the insights rendering, not after
+    assert text.index("analyze @ state-v4") < text.index("## Insights")
+
+
+def test_analyze_same_ref_twice_succeeds(monkeypatch, tmp_path, stub_reingest):
+    """Re-running analyze with the same --state ref must not crash on the leftover download.
+
+    The real download_ref runs against a fake `gh` that mimics `gh release
+    download`'s refusal to overwrite an existing file unless --clobber is passed.
+    The second restore is the idempotent path: reingest's span-count guard skips
+    already-restored workspaces (covered in test_reingest), so the CLI just
+    reports the skip and analyzes again.
+    """
+    from testbed import release
+
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+
+    def fake_gh(*args):
+        dest = Path(args[args.index("--dir") + 1]) / "state-v4.tar.zst"
+        if dest.exists() and "--clobber" not in args:
+            raise subprocess.CalledProcessError(1, ["gh", *args], stderr="already exists\n")
+        _make_export_bundle(dest, workspaces=("nvq",))
+        return ""
+
+    monkeypatch.setattr(release, "_gh", fake_gh)
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", "state-v4"])
+    cli.main()
+    cli.main()  # second run with the same ref must not raise
+    assert len(stub_reingest["ingest"]) == 2  # restore ran both times (idempotency lives in reingest)
+
+
+def test_analyze_second_restore_reports_skip(monkeypatch, tmp_path, capsys, stub_reingest):
+    """When reingest's guard skips an already-restored workspace, the status line says so."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_export_bundle(tmp_path / "dl" / "state-v4.tar.zst", workspaces=("nvq",))
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+
+    def skip_ingest(base_url, export_dir, manifest, *, workspace_map, catalog, **kw):
+        return {
+            ws: {
+                "workspace": target,
+                "spans": {"ingested": 0, "skipped": manifest["counts"][ws]["spans"]},
+                "annotations": {"ingested": 0, "skipped": 0},
+                "evaluator_results": {"ingested": 0, "skipped": 0},
+            }
+            for ws, target in workspace_map.items()
+        }
+
+    monkeypatch.setattr("testbed.reingest.ingest_bundle", skip_ingest)
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", "state-v4"])
+    cli.main()
+    out = capsys.readouterr().out
+    assert "0 spans ingested, 1 skipped" in out
+    assert "REPORT-OK" in out  # the analysis still runs against the already-restored fixture
+
+
+# --------------------------------------------------------------------------- #
+# restore: export bundles re-ingest (additive); legacy tars exit with a pointer
+# --------------------------------------------------------------------------- #
+
+
+def test_restore_export_bundle_reingests_with_digest_suffix(monkeypatch, tmp_path, capsys, stub_reingest):
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_export_bundle(tmp_path / "b.tar.zst")
+    digest = hashlib.sha256(bundle.read_bytes()).hexdigest()[:8]
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", str(bundle)])
+    cli.main()
+    ingest = stub_reingest["ingest"][0]
+    assert ingest["base_url"] == "http://localhost:8080"  # default target
+    assert ingest["workspace_map"] == {
+        "tau2-airline": f"tau2-airline-{digest}",
+        "tau2-airline-oracle": f"tau2-airline-oracle-{digest}",
+    }
+    assert ingest["catalog"] == "stub-catalog"
+    out = capsys.readouterr().out
+    assert "2 spans ingested, 0 skipped" in out
+    assert f"tau2-airline-{digest}" in out
+
+
+def test_restore_state_ref_downloads(monkeypatch, tmp_path, stub_reingest):
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_export_bundle(tmp_path / "dl" / "state-v6.tar.zst", workspaces=("nvq",))
+    downloads: list = []
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: downloads.append(ref) or bundle)
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", "--state", "state-v6", "--base", "http://ci-host:8080"])
+    cli.main()
+    assert downloads == ["state-v6"]
+    ingest = stub_reingest["ingest"][0]
+    assert ingest["workspace_map"] == {"nvq": "nvq-state-v6"}
+    assert ingest["base_url"] == "http://ci-host:8080"
+
+
+def test_restore_state_only_takes_refs_not_files(monkeypatch, tmp_path, stub_reingest):
+    """restore --state is refs-only; local bundle files go through the positional FILE."""
+    bundle = _make_export_bundle(tmp_path / "b.tar.zst", workspaces=("nvq",))
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", "--state", str(bundle)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "state-v<N>" in str(exc.value)
+    assert stub_reingest["ingest"] == []
+
+
+def test_restore_platform_root_flag_reaches_catalog(monkeypatch, tmp_path, stub_reingest):
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_export_bundle(tmp_path / "b.tar.zst", workspaces=("nvq",))
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", str(bundle), "--platform-root", "/opt/nemo-platform"])
+    cli.main()
+    assert stub_reingest["platform_root"] == ["/opt/nemo-platform"]
+    assert stub_reingest["catalog_root"] == [Path("/opt/nemo-platform")]
+
+
+def test_restore_seeds_run_records_only(monkeypatch, tmp_path, stub_reingest):
+    """Only the bundle's run records land in TMP: insights no longer travel in bundles, so a
+    stray insights YAML inside an old bundle is ignored and local ones stay untouched."""
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    (tmp_path / "insights_nvq.yaml").write_text("local", encoding="utf-8")  # the restored subject's own prior
+    (tmp_path / "insights_stale.yaml").write_text("stale", encoding="utf-8")  # unrelated local subject
+    bundle = _make_export_bundle(
+        tmp_path / "b.tar.zst",
+        workspaces=("nvq",),
+        records={"nvq.run.json": json.dumps(_RUN_RECORD), "insights_nvq.yaml": "insights: []"},
+    )
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", str(bundle)])
+    cli.main()
+    assert (tmp_path / "nvq.run.json").exists()  # record copied out of the bundle
+    assert (tmp_path / "insights_nvq.yaml").read_text() == "local"  # the bundle's stray YAML is ignored
+    assert (tmp_path / "insights_stale.yaml").read_text() == "stale"  # unrelated local file survives
+    assert list(tmp_path.glob("backup-*")) == []  # nothing clobbered, nothing moved
+
+
+def test_restore_legacy_bundle_exits_with_migration_pointer(monkeypatch, tmp_path, stub_reingest):
+    """The destructive tar path is gone; legacy bundles get a clear rejection, not a swap."""
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_legacy_bundle(tmp_path / "legacy.tar.zst")
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", str(bundle)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "legacy tar bundle (state-v1..v5)" in message
+    assert "pre-migration checkout" in message
+    assert "README" in message
+    assert stub_reingest["ingest"] == []  # never re-ingested
+
+
+def test_restore_missing_bundle_file_exits(monkeypatch, tmp_path, stub_reingest):
+    """A missing file must be a hard exit, not a misleading legacy-bundle rejection."""
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", str(tmp_path / "nope.tar.zst")])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "no such bundle" in str(exc.value)
+
+
+def test_restore_corrupt_bundle_exits_with_read_error(monkeypatch, tmp_path, stub_reingest):
+    """A garbage file must surface tar's own error, not the misleading legacy-bundle message."""
+    bad = tmp_path / "bad.tar.zst"
+    bad.write_bytes(b"garbage, definitely not a zstd tar")
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", str(bad)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "could not read bundle bad.tar.zst" in message
+    assert "corrupt or truncated" in message
+    assert "tar" in message  # carries tar's stderr (the actual reason)
+    assert "legacy" not in message
+    assert stub_reingest["ingest"] == []
+
+
+def test_restore_truncated_bundle_not_misdiagnosed_as_legacy(monkeypatch, tmp_path, stub_reingest):
+    good = _make_export_bundle(tmp_path / "good.tar.zst", workspaces=("nvq",))
+    trunc = tmp_path / "trunc.tar.zst"
+    trunc.write_bytes(good.read_bytes()[:40])
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", str(trunc)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "could not read bundle trunc.tar.zst" in message and "corrupt or truncated" in message
+    assert "legacy" not in message
+
+
+def test_restore_tar_without_manifest_is_not_a_testbed_bundle(monkeypatch, tmp_path, stub_reingest):
+    bundle = _make_tar_with_manifest_text(tmp_path / "plain.tar.zst", None)
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", str(bundle)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "not a testbed bundle" in message
+    assert "legacy" not in message and "corrupt" not in message
+
+
+def test_restore_unparseable_manifest_is_not_a_testbed_bundle(monkeypatch, tmp_path, stub_reingest):
+    bundle = _make_tar_with_manifest_text(tmp_path / "badjson.tar.zst", "{not json")
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", str(bundle)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "not a testbed bundle" in message
+    assert "legacy" not in message
+
+
+def test_restore_requires_exactly_one_source(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "exactly one" in str(exc.value)
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", str(tmp_path / "b.tar.zst"), "--state", "state-v6"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "exactly one" in str(exc.value)
+
+
+def test_restore_empty_file_arg_exits(monkeypatch):
+    """`restore ""` satisfies the arity check but names nothing — it must exit clearly,
+    not fall through to ref resolution's subject-less lock lookup."""
+    monkeypatch.setattr(sys, "argv", ["testbed", "restore", ""])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert str(exc.value) == "restore: FILE must be a non-empty path"
+
+
+def _fake_snapshot_export(seen):
+    def fake(subjects, out, tmp_dir, *, since):
+        seen.update(
+            subjects=[s.name for s in subjects],
+            base_urls=[s.config.get("base_url") for s in subjects],
+            out=out,
+            tmp_dir=tmp_dir,
+            since=since,
+        )
+        return out
+
+    return fake
+
+
+def test_snapshot_command_exports_subject(monkeypatch, tmp_path, capsys):
+    seen: dict = {}
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setattr("testbed.artifact.snapshot_export", _fake_snapshot_export(seen))
+    monkeypatch.setattr(sys, "argv", ["testbed", "snapshot", "tau2-airline", "-o", str(tmp_path / "x.tar.zst")])
+    cli.main()
+    assert "x.tar.zst" in capsys.readouterr().out
+    assert seen["subjects"] == ["tau2-airline"]
+    assert seen["since"] is None
+
+
+def test_snapshot_since_flag(monkeypatch, tmp_path):
+    seen: dict = {}
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setattr("testbed.artifact.snapshot_export", _fake_snapshot_export(seen))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "snapshot", "nvq", "--since", "2026-07-01", "-o", str(tmp_path / "x.tar.zst")],
+    )
+    cli.main()
+    assert seen["since"] == datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def test_snapshot_base_overrides_source_url(monkeypatch, tmp_path):
+    """--base replaces every listed subject's stanza URL, so disagreeing stanzas snapshot together."""
+    seen: dict = {}
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setattr("testbed.artifact.snapshot_export", _fake_snapshot_export(seen))
+    # nvq (freeplay) and tau2-retail (localhost) disagree on base_url in testbeds.toml
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "testbed",
+            "snapshot",
+            "nvq",
+            "tau2-retail",
+            "--base",
+            "http://ci-host:8080",
+            "-o",
+            str(tmp_path / "x.tar.zst"),
+        ],
+    )
+    cli.main()
+    assert seen["base_urls"] == ["http://ci-host:8080", "http://ci-host:8080"]
+
+
+def test_snapshot_subjects_json_for_ci(monkeypatch, tmp_path):
+    seen: dict = {}
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setattr("testbed.artifact.snapshot_export", _fake_snapshot_export(seen))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "snapshot", "--subjects-json", '["tau2-airline", "nvq"]', "-o", str(tmp_path / "x.tar.zst")],
+    )
+    cli.main()
+    assert seen["subjects"] == ["tau2-airline", "nvq"]
+
+
+def test_snapshot_garbage_since_exits_before_any_export(monkeypatch):
+    """Injection-shaped --since garbage must die at parse time, before any network I/O."""
+    called: list = []
+    monkeypatch.setattr("testbed.artifact.snapshot_export", lambda *a, **k: called.append("export"))
+    monkeypatch.setattr("testbed.export.make_client", lambda *a, **k: called.append("client"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "snapshot", "tau2-airline", "--since", "'); DROP TABLE spans;--"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "--since" in str(exc.value)
+    assert called == []
+
+
+def test_snapshot_without_subjects_exits(monkeypatch):
+    monkeypatch.setattr("testbed.artifact.snapshot_export", lambda *a, **k: (_ for _ in ()).throw(AssertionError))
+    monkeypatch.setattr(sys, "argv", ["testbed", "snapshot"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "subject" in str(exc.value)
+
+
+def test_snapshot_unknown_subject_exits(monkeypatch):
+    monkeypatch.setattr("testbed.artifact.snapshot_export", lambda *a, **k: (_ for _ in ()).throw(AssertionError))
+    monkeypatch.setattr(sys, "argv", ["testbed", "snapshot", "nope"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "nope" in str(exc.value)
+
+
+def test_snapshot_bad_subjects_json_exits(monkeypatch):
+    monkeypatch.setattr("testbed.artifact.snapshot_export", lambda *a, **k: (_ for _ in ()).throw(AssertionError))
+    monkeypatch.setattr(sys, "argv", ["testbed", "snapshot", "--subjects-json", "not-json"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "--subjects-json" in str(exc.value)
+
+
+def test_analyze_live_summary_md_appends_markdown_with_provenance(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        out_path.write_text("insights:\n- {id: i1, title: T1, status: proposed, description: D, trace_refs: [r1]}\n")
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    summary = tmp_path / "summary.md"
+    summary.write_text("PREVIOUS\n")
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--live", "--summary-md", str(summary)])
+    cli.main()
+    text = summary.read_text()
+    assert text.startswith("PREVIOUS\n")  # appended, not overwritten
+    assert "### analyze @ live (nvq)" in text  # live provenance, ahead of the insights
+    assert text.index("analyze @ live") < text.index("## Insights")
+    assert "## Insights — nvq (1)" in text
+    assert "**T1**" in text
+
+
+# --------------------------------------------------------------------------- #
+# analyze with a state: restore-then-live-analyze against fixture workspaces
+# --------------------------------------------------------------------------- #
+
+
+def test_analyze_state_remaps_workspaces_and_floors_since(monkeypatch, tmp_path, stub_reingest):
+    """The analyst must read the fixture workspaces with an explicit manifest-derived since."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_export_bundle(
+        tmp_path / "dl" / "state-v6.tar.zst",
+        workspaces=("tau2-airline", "tau2-airline-oracle"),
+        min_start_time="2026-06-01T12:00:00+00:00",
+        records={"tau2-airline.run.json": json.dumps(_RUN_RECORD)},
+    )
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+    seen: dict = {}
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        seen["record"] = record
+        seen["since"] = since
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "tau2-airline", "--state", "state-v6"])
+    cli.main()
+    ingest = stub_reingest["ingest"][0]
+    assert ingest["base_url"] == "http://localhost:8080"  # default target: the local platform
+    assert ingest["workspace_map"] == {
+        "tau2-airline": "tau2-airline-state-v6",
+        "tau2-airline-oracle": "tau2-airline-oracle-state-v6",
+    }
+    # the run record the analyst consumes is remapped onto the fixtures + target platform
+    assert seen["record"]["realistic_workspace"] == "tau2-airline-state-v6"
+    assert seen["record"]["oracle_workspace"] == "tau2-airline-oracle-state-v6"
+    assert seen["record"]["base_url"] == "http://localhost:8080"
+    assert seen["record"]["experiment_id"] == "run-1"  # evaluation_id scoping untouched
+    # explicit since = manifest min_start_time floored by one day (defeats the 30-day read default)
+    assert seen["since"] == datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
+
+
+def test_analyze_intake_subject_workspace_remapped(monkeypatch, tmp_path, stub_reingest):
+    """Intake adapters read the workspace from subject config — the remap must land there."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_export_bundle(tmp_path / "dl" / "state-v6.tar.zst", workspaces=("nvq",))
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+    seen: dict = {}
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        seen["workspace"] = self.subject.config["workspace"]
+        seen["base_url"] = self.subject.config["base_url"]
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", "state-v6"])
+    cli.main()
+    assert seen["workspace"] == "nvq-state-v6"
+    assert seen["base_url"] == "http://localhost:8080"
+
+
+def test_analyze_legacy_bundle_exits_with_migration_pointer(monkeypatch, tmp_path, stub_reingest):
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_legacy_bundle(tmp_path / "state-v4.tar.zst")
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", str(bundle)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "legacy tar bundle (state-v1..v5)" in message
+    assert "pre-migration checkout" in message
+    assert "README" in message
+    assert stub_reingest["ingest"] == []
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["analyze", "nvq", "--seed", "none"],
+        ["analyze", "nvq", "--seed", "keep"],
+        ["analyze", "nvq", "--state", "state-v6", "--seed", "keep"],
+        ["restore", "b.tar.zst", "--seed", "none"],
+        ["restore", "--state", "state-v6", "--seed", "keep"],
+        ["analyze", "nvq", "--keep-insights"],  # old flag name
+    ],
+)
+def test_seed_flag_removed(monkeypatch, argv):
+    """--seed died with in-bundle insights; --update-insights is the only prior-seeding surface."""
+    monkeypatch.setattr(sys, "argv", ["testbed", *argv])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2  # argparse usage error
+
+
+def test_analyze_fresh_default_moves_local_insights_to_backup(monkeypatch, tmp_path, capsys, stub_reingest):
+    """Bare analyze is fresh: a prior local insights YAML moves aside (never deleted) before the analyst."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    (tmp_path / "insights_tau2-airline.yaml").write_text("prior", encoding="utf-8")
+    bundle = _make_export_bundle(
+        tmp_path / "dl" / "state-v6.tar.zst",
+        records={"tau2-airline.run.json": json.dumps(_RUN_RECORD)},
+    )
+    monkeypatch.setattr("testbed.release.resolve_state", lambda state, *, subject, lock_path: "state-v6")
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        assert not (tmp_path / "insights_tau2-airline.yaml").exists(), "prior must move BEFORE the analyst runs"
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "tau2-airline"])
+    cli.main()
+    assert not (tmp_path / "insights_tau2-airline.yaml").exists()
+    (backup,) = tmp_path.glob("backup-*")
+    assert (backup / "insights_tau2-airline.yaml").read_text() == "prior"  # moved, not destroyed
+    out = capsys.readouterr().out
+    assert f"fresh insights: moved prior insights_tau2-airline.yaml to {backup.name}/" in out
+    assert "use --update-insights to seed the analyst with priors" in out
+
+
+def test_analyze_update_insights_leaves_file(monkeypatch, tmp_path, capsys, stub_reingest):
+    """--update-insights leaves the local prior in the analyst's path, in every analyze mode."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    (tmp_path / "insights_nvq.yaml").write_text("prior", encoding="utf-8")
+    bundle = _make_export_bundle(tmp_path / "local.tar.zst", workspaces=("nvq",))
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", str(bundle), "--update-insights"])
+    cli.main()
+    assert (tmp_path / "insights_nvq.yaml").read_text() == "prior"  # not-fresh flow preserved
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--live", "--update-insights"])
+    cli.main()
+    assert (tmp_path / "insights_nvq.yaml").read_text() == "prior"  # valid with --live too
+    assert list(tmp_path.glob("backup-*")) == []
+    assert "fresh insights" not in capsys.readouterr().out
+
+
+def test_analyze_live_fresh_also_applies(monkeypatch, tmp_path, capsys):
+    """--live is no less fresh than pinned/state mode: the local prior moves aside there too."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    (tmp_path / "insights_nvq.yaml").write_text("prior", encoding="utf-8")
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--live"])
+    cli.main()
+    assert not (tmp_path / "insights_nvq.yaml").exists()
+    (backup,) = tmp_path.glob("backup-*")
+    assert (backup / "insights_nvq.yaml").read_text() == "prior"
+    # microsecond-stamped: two invocations in the same second must not share a dir
+    assert re.fullmatch(r"backup-\d{8}-\d{6}-\d{6}", backup.name)
+    assert "fresh insights: moved prior insights_nvq.yaml" in capsys.readouterr().out
+
+
+def test_update_insights_warns_when_priors_live_under_other_workspace(monkeypatch, tmp_path, capsys):
+    """--update-insights priors are scoped by 'workspace' inside the YAML: when none of the
+    records match the workspace this analysis reads, warn loudly — and never rewrite."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    prior = yaml.safe_dump({"insights": [{"id": "i1", "workspace": "nvq-state-v6"}]})
+    (tmp_path / "insights_nvq.yaml").write_text(prior, encoding="utf-8")
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    # live intake analysis reads the stanza workspace 'nvq'; the prior carries only the fixture ws
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--live", "--update-insights"])
+    cli.main()
+    out = capsys.readouterr().out
+    assert (
+        "warning: --update-insights: insights_nvq.yaml carries workspace(s) nvq-state-v6 "
+        "but this analysis runs under 'nvq' — priors will be invisible and updates will be skipped"
+    ) in out
+    assert (tmp_path / "insights_nvq.yaml").read_text(encoding="utf-8") == prior  # never rewritten
+
+
+def test_update_insights_no_warning_when_workspace_matches(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    prior = yaml.safe_dump({"insights": [{"id": "i1", "workspace": "nvq"}]})
+    (tmp_path / "insights_nvq.yaml").write_text(prior, encoding="utf-8")
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--live", "--update-insights"])
+    cli.main()
+    assert "warning: --update-insights" not in capsys.readouterr().out
+
+
+def test_update_insights_state_mode_warns_against_fixture_workspace(monkeypatch, tmp_path, capsys, stub_reingest):
+    """The most likely real trip-up: priors kept from a LIVE run, then a pinned/state
+    analyze — the analysis runs under the remapped fixture workspace, so the check must
+    compare against it (post-remap), not the stanza/record original."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    prior = yaml.safe_dump({"insights": [{"id": "i1", "workspace": "tau2-airline"}]})  # live-run prior
+    (tmp_path / "insights_tau2-airline.yaml").write_text(prior, encoding="utf-8")
+    bundle = _make_export_bundle(
+        tmp_path / "dl" / "state-v6.tar.zst",
+        records={"tau2-airline.run.json": json.dumps(_RUN_RECORD)},
+    )
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "analyze", "tau2-airline", "--state", "state-v6", "--update-insights"],
+    )
+    cli.main()
+    out = capsys.readouterr().out
+    assert "warning: --update-insights: insights_tau2-airline.yaml carries workspace(s) tau2-airline" in out
+    assert "runs under 'tau2-airline-state-v6'" in out
+
+
+def _ticking_clock(monkeypatch, *modules):
+    """Replace each module's `datetime` with one whose now() advances 2 minutes per call.
+
+    Deterministically models a slow restore: any code that stamps backup dirs
+    per-call (instead of once per invocation) produces divergent stamps.
+    """
+    import datetime as real
+
+    calls = {"n": 0}
+
+    class TickingDateTime(real.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            calls["n"] += 1
+            return real.datetime(2026, 7, 6, 12, 0, 0, tzinfo=tz) + real.timedelta(minutes=2 * calls["n"])
+
+    fake = types.SimpleNamespace(datetime=TickingDateTime, timezone=real.timezone, timedelta=real.timedelta)
+    for module in modules:
+        monkeypatch.setattr(module, "datetime", fake)
+
+
+def test_analyze_single_backup_dir_per_invocation(monkeypatch, tmp_path, stub_reingest):
+    """One analyze = at most one tmp/backup-<stamp>/: the restore's clobber-backup and the
+    fresh-insights move share one destination even when the restore takes wall-clock time."""
+    from testbed import artifact
+    from testbed.runstore import load_run, save_run
+
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    _ticking_clock(monkeypatch, cli, artifact)
+    save_run(tmp_path / "tau2-airline.run.json", {**_RUN_RECORD, "experiment_id": "stale"})  # will be clobbered
+    (tmp_path / "insights_tau2-airline.yaml").write_text("prior", encoding="utf-8")  # will move (fresh default)
+    bundle = _make_export_bundle(
+        tmp_path / "dl" / "state-v6.tar.zst",
+        records={"tau2-airline.run.json": json.dumps(_RUN_RECORD)},
+    )
+    monkeypatch.setattr("testbed.release.resolve_state", lambda state, *, subject, lock_path: "state-v6")
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "tau2-airline"])
+    cli.main()
+    (backup,) = tmp_path.glob("backup-*")  # exactly one dir carries both parked files
+    assert json.loads((backup / "tau2-airline.run.json").read_text(encoding="utf-8"))["experiment_id"] == "stale"
+    assert (backup / "insights_tau2-airline.yaml").read_text(encoding="utf-8") == "prior"
+    assert load_run(tmp_path / "tau2-airline.run.json")["experiment_id"] == "run-1"  # bundle record seeded
+
+
+def test_analyze_bundle_without_run_record_exits(monkeypatch, tmp_path, stub_reingest):
+    """A stale local run record must not silently stand in for a bundle that carries none —
+    its experiment_id would filter every restored trace to zero (empty 'analysis')."""
+    from testbed.runstore import save_run
+
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    save_run(tmp_path / "tau2-airline.run.json", {**_RUN_RECORD, "experiment_id": "stale-run"})
+    bundle = _make_export_bundle(tmp_path / "dl" / "state-v6.tar.zst")  # no tmp/ records at all
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+    called: list = []
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        called.append(record)
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "tau2-airline", "--state", "state-v6"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "no run record" in message and "tau2-airline" in message and "state-v6" in message
+    assert called == []  # the analyst never ran against the stale record
+
+
+def test_analyze_intake_bundle_without_run_record_still_works(monkeypatch, tmp_path, stub_reingest):
+    """Intake subjects don't need a run record — a record-less bundle must keep analyzing."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_export_bundle(tmp_path / "local.tar.zst", workspaces=("nvq",))
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", str(bundle)])
+    cli.main()  # must not raise
+
+
+def test_analyze_subject_not_in_bundle_exits(monkeypatch, tmp_path, stub_reingest):
+    """Analyzing tau2-retail from an airline-only bundle must die before restoring anything."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bundle = _make_export_bundle(tmp_path / "airline.tar.zst")  # tau2-airline (+oracle) only
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "tau2-retail", "--state", str(bundle)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "workspace 'tau2-retail'" in message  # the one workspace analysis reads
+    assert "tau2-airline" in message  # what the bundle actually carries
+    assert stub_reingest["ingest"] == []  # membership check fires before any restore
+
+
+def test_analyze_benchmark_oracle_twin_not_required(monkeypatch, tmp_path, stub_reingest):
+    """Membership requires only the workspace analysis reads: a realistic-only bundle
+    (no -oracle twin) still analyzes a benchmark subject."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    record = {**_RUN_RECORD, "oracle_workspace": None}
+    bundle = _make_export_bundle(
+        tmp_path / "dl" / "state-v6.tar.zst",
+        workspaces=("tau2-airline",),  # no oracle twin in the bundle
+        records={"tau2-airline.run.json": json.dumps(record)},
+    )
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+    seen: dict = {}
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        seen["record"] = record
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "tau2-airline", "--state", "state-v6"])
+    cli.main()  # must not raise on the absent oracle twin
+    assert seen["record"]["realistic_workspace"] == "tau2-airline-state-v6"
+
+
+def test_analyze_record_workspace_not_in_restored_set_exits(monkeypatch, tmp_path, stub_reingest):
+    """A bundle record pointing at a workspace the bundle doesn't restore is a minting
+    bug — hard exit, or the analyst would read an empty (or wrong) fixture."""
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    record = {**_RUN_RECORD, "realistic_workspace": "tau2-airline-b", "oracle_workspace": None}
+    bundle = _make_export_bundle(
+        tmp_path / "dl" / "state-v6.tar.zst",
+        workspaces=("tau2-airline", "tau2-airline-oracle"),
+        records={"tau2-airline.run.json": json.dumps(record)},
+    )
+    monkeypatch.setattr("testbed.release.download_ref", lambda ref, dest: bundle)
+    called: list = []
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        called.append(record)
+        return "REPORT-OK"
+
+    monkeypatch.setattr("testbed.adapters.BenchmarkAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "tau2-airline", "--state", "state-v6"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "bundle record for 'tau2-airline'" in message
+    assert "'tau2-airline-b'" in message
+    assert "tau2-airline-state-v6" in message  # names the restored workspaces
+    assert "mismatched record" in message
+    assert called == []  # the analyst never ran against the mismatched record
+
+
+def test_analyze_since_with_pinned_exits(monkeypatch, tmp_path, stub_reingest):
+    """--since is live-only; pinned/state analysis derives its lower bound from the manifest."""
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setattr(
+        "testbed.release.download_ref",
+        lambda *a, **k: pytest.fail("must exit before any resolve/download"),
+    )
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--since", "7d"])  # bare = pinned mode
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "--since only applies to --live" in str(exc.value)
+
+    bundle = _make_export_bundle(tmp_path / "b.tar.zst", workspaces=("nvq",))
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", str(bundle), "--since", "7d"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "--since only applies to --live" in str(exc.value)
+    assert stub_reingest["ingest"] == []  # rejected before any restore
+
+
+def test_analyze_corrupt_bundle_exits_with_read_error(monkeypatch, tmp_path, stub_reingest):
+    monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    bad = tmp_path / "bad.tar.zst"
+    bad.write_bytes(b"garbage, definitely not a zstd tar")
+    monkeypatch.setattr(sys, "argv", ["testbed", "analyze", "nvq", "--state", str(bad)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "could not read bundle bad.tar.zst" in message and "corrupt or truncated" in message
+    assert "legacy" not in message
+    assert stub_reingest["ingest"] == []
+
+
+# --------------------------------------------------------------------------- #
+# roundtrip: the mint-time fidelity guard as a CLI hook
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def stub_roundtrip(monkeypatch):
+    """Record roundtrip_diff calls; each test sets the mismatch list it returns."""
+    calls: list[dict] = []
+    result: dict = {"mismatches": []}
+
+    def fake_diff(base_url, export_dir, manifest, *, scratch_prefix, catalog, **kw):
+        calls.append(
+            {
+                "base_url": base_url,
+                "export_dir": Path(export_dir),
+                "manifest": manifest,
+                "scratch_prefix": scratch_prefix,
+                "catalog": catalog,
+            }
+        )
+        return list(result["mismatches"])
+
+    monkeypatch.setattr("testbed.reingest.roundtrip_diff", fake_diff)
+    return {"calls": calls, "result": result}
+
+
+def test_roundtrip_pass_prints_one_liner(monkeypatch, tmp_path, capsys, stub_reingest, stub_roundtrip):
+    bundle = _make_export_bundle(tmp_path / "candidate.tar.zst")
+    monkeypatch.setattr(sys, "argv", ["testbed", "roundtrip", str(bundle)])
+    cli.main()
+    call = stub_roundtrip["calls"][0]
+    assert call["base_url"] == "http://localhost:8080"  # default target
+    assert call["scratch_prefix"] == "scratch-rt-"
+    assert call["catalog"] == "stub-catalog"
+    assert call["export_dir"].name == "export"  # the extracted bundle's export/ dir
+    assert call["manifest"]["kind"] == "testbed-export"
+    out = capsys.readouterr().out
+    assert "✓" in out and "candidate.tar.zst" in out
+
+
+def test_roundtrip_mismatches_print_and_exit_nonzero(monkeypatch, tmp_path, capsys, stub_reingest, stub_roundtrip):
+    stub_roundtrip["result"]["mismatches"] = ["ws/spans s1.name: 'a' != 'b'", "ws/spans: 2 exported vs 1 restored"]
+    bundle = _make_export_bundle(tmp_path / "candidate.tar.zst")
+    monkeypatch.setattr(sys, "argv", ["testbed", "roundtrip", str(bundle)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code != 0
+    assert "2 mismatch" in str(exc.value)
+    assert "ws/spans s1.name" in capsys.readouterr().out
+
+
+def test_roundtrip_base_and_platform_root_flags(monkeypatch, tmp_path, stub_reingest, stub_roundtrip):
+    bundle = _make_export_bundle(tmp_path / "candidate.tar.zst")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "roundtrip", str(bundle), "--base", "http://ci-host:8080", "--platform-root", "/opt/nemo-platform"],
+    )
+    cli.main()
+    assert stub_roundtrip["calls"][0]["base_url"] == "http://ci-host:8080"
+    assert stub_reingest["platform_root"] == ["/opt/nemo-platform"]
+    assert stub_reingest["catalog_root"] == [Path("/opt/nemo-platform")]
+
+
+def test_roundtrip_legacy_bundle_exits(monkeypatch, tmp_path, stub_reingest, stub_roundtrip):
+    bundle = _make_legacy_bundle(tmp_path / "legacy.tar.zst")
+    monkeypatch.setattr(sys, "argv", ["testbed", "roundtrip", str(bundle)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "testbed-export" in str(exc.value)
+    assert stub_roundtrip["calls"] == []  # guard never ran
+
+
+def test_roundtrip_corrupt_bundle_exits_with_read_error(monkeypatch, tmp_path, stub_roundtrip):
+    bad = tmp_path / "bad.tar.zst"
+    bad.write_bytes(b"garbage, definitely not a zstd tar")
+    monkeypatch.setattr(sys, "argv", ["testbed", "roundtrip", str(bad)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "could not read bundle bad.tar.zst" in message and "corrupt or truncated" in message
+    assert stub_roundtrip["calls"] == []
+
+
+def test_roundtrip_missing_bundle_exits(monkeypatch, tmp_path, stub_roundtrip):
+    monkeypatch.setattr(sys, "argv", ["testbed", "roundtrip", str(tmp_path / "nope.tar.zst")])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "no such bundle" in str(exc.value)
+    assert stub_roundtrip["calls"] == []
+
+
+def test_publish_platform_root_threaded(monkeypatch, tmp_path, stub_reingest, stub_roundtrip):
+    """publish --base runs the round-trip guard with --platform-root, not a hardcoded None."""
+    published: list = []
+    monkeypatch.setattr("testbed.publish.publish", lambda path, *, reason: published.append(path))
+    bundle = _make_export_bundle(tmp_path / "candidate.tar.zst")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "publish", str(bundle), "--base", "http://ci-host:8080", "--platform-root", "/opt/nemo-platform"],
+    )
+    cli.main()
+    assert stub_reingest["platform_root"] == ["/opt/nemo-platform"]
+    assert stub_reingest["catalog_root"] == [Path("/opt/nemo-platform")]
+    assert stub_roundtrip["calls"][0]["base_url"] == "http://ci-host:8080"
+    assert published == [bundle]

--- a/plugins/nemo-insights/tests/testbed/test_eval_scripts.py
+++ b/plugins/nemo-insights/tests/testbed/test_eval_scripts.py
@@ -21,6 +21,12 @@ def test_repoint_judge_counts_misses():
     assert count == 0
 
 
+def test_repoint_judge_preserves_backslashes():
+    text, count = prep.repoint_judge(TAU2_CONFIG, r"openai\1\judge")
+    assert count == 3
+    assert text.count(r'"openai\1\judge"') == 3
+
+
 def test_mode_pr_event_forces_analyze():
     assert plan.resolve_mode("pull_request", "produce") == "analyze"
 

--- a/plugins/nemo-insights/tests/testbed/test_eval_scripts.py
+++ b/plugins/nemo-insights/tests/testbed/test_eval_scripts.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from testbed.eval import plan, prep, run_subjects
+
+TAU2_CONFIG = """DEFAULT_LLM_NL_ASSERTIONS = "gpt-4.1-2025-04-14"
+DEFAULT_LLM_NL_ASSERTIONS_ARGS = {"temperature": 0.0}
+DEFAULT_LLM_ENV_INTERFACE = "gpt-4.1-2025-04-14"
+DEFAULT_LLM_EVAL_USER_SIMULATOR = "claude-opus-4-5"
+"""
+
+
+def test_repoint_judge_rewrites_exactly_three():
+    text, count = prep.repoint_judge(TAU2_CONFIG, "openai/x/judge")
+    assert count == 3
+    assert text.count('"openai/x/judge"') == 3
+    assert 'DEFAULT_LLM_NL_ASSERTIONS_ARGS = {"temperature": 0.0}' in text  # untouched
+
+
+def test_repoint_judge_counts_misses():
+    _, count = prep.repoint_judge("UNRELATED = 1\n", "j")
+    assert count == 0
+
+
+def test_mode_pr_event_forces_analyze():
+    assert plan.resolve_mode("pull_request", "produce") == "analyze"
+
+
+def test_mode_dispatch_input_wins():
+    assert plan.resolve_mode("workflow_dispatch", "produce") == "produce"
+
+
+def test_plan_ignores_push_vars_removed():
+    """The vars.TESTBED_* push fallback is gone: push events resolve to plain defaults."""
+    import inspect
+
+    assert plan.resolve_mode("push", "") == "analyze"
+    assert plan.resolve_subjects("push", "") == ["tau2-airline"]
+    assert list(inspect.signature(plan.resolve_mode).parameters) == ["event", "input_mode"]
+    assert list(inspect.signature(plan.resolve_subjects).parameters) == ["event", "input_subjects"]
+
+
+def test_subjects_split_trim_dropempty():
+    assert plan.resolve_subjects("workflow_dispatch", " tau2-airline , tau2-retail ,,") == [
+        "tau2-airline",
+        "tau2-retail",
+    ]
+
+
+def test_subjects_pr_hardcoded():
+    assert plan.resolve_subjects("pull_request", "tau2-retail") == ["tau2-airline"]
+
+
+def test_build_overrides():
+    assert run_subjects.build_overrides("2", "") == ["--set", "num_tasks=2"]
+    assert run_subjects.build_overrides("", "3") == ["--set", "num_trials=3"]
+    assert run_subjects.build_overrides("", "") == []
+
+
+def test_subjects_from_env_json_array():
+    assert run_subjects.subjects_from_env({"SUBJECTS": '["tau2-airline", "tau2-retail"]'}) == [
+        "tau2-airline",
+        "tau2-retail",
+    ]
+
+
+def test_run_subjects_uses_live_base_for_analyze(monkeypatch):
+    """The produce-loop analyze call targets the in-job stack: --live --base <local>."""
+    calls = []
+    monkeypatch.setattr(run_subjects, "_testbed", lambda *a: calls.append(a))
+    run_subjects.analyze_with_retry("tau2-airline", "testbed/tmp/summary.md")
+    assert calls == [
+        (
+            "analyze",
+            "tau2-airline",
+            "--live",
+            "--base",
+            "http://localhost:8080",
+            "--summary-md",
+            "testbed/tmp/summary.md",
+        )
+    ]
+
+
+def test_run_subjects_run_uses_base(monkeypatch, tmp_path):
+    """The produce-loop run call uses explicit --base <local>; --local is gone."""
+    calls = []
+    monkeypatch.setattr(run_subjects, "_testbed", lambda *a: calls.append(a))
+
+    insights = tmp_path / "insights_tau2-airline.yaml"
+    insights.write_text("insights: []\n", encoding="utf-8")
+    monkeypatch.setattr(run_subjects, "Path", lambda *_a: insights)
+
+    monkeypatch.setenv("SUBJECTS", '["tau2-airline"]')
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary.md"))
+    monkeypatch.delenv("NUM_TASKS", raising=False)
+    monkeypatch.delenv("NUM_TRIALS", raising=False)
+    run_subjects.main()
+
+    run_call = next(c for c in calls if c[0] == "run")
+    assert run_call == ("run", "tau2-airline", "--base", "http://localhost:8080")
+    assert "--local" not in [arg for call in calls for arg in call]
+
+
+def test_analyze_with_retry_recovers_after_transient(monkeypatch):
+    import subprocess as sp
+
+    calls = {"n": 0}
+
+    def flaky(*args):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise sp.CalledProcessError(1, args)
+
+    monkeypatch.setattr(run_subjects, "_testbed", flaky)
+    monkeypatch.setattr(run_subjects.time, "sleep", lambda _s: None)
+    run_subjects.analyze_with_retry("tau2-airline", "testbed/tmp/summary.md")
+    assert calls["n"] == 3
+
+
+def test_analyze_with_retry_exhausts_and_raises(monkeypatch):
+    import subprocess as sp
+
+    import pytest
+
+    def always_fail(*args):
+        raise sp.CalledProcessError(1, args)
+
+    monkeypatch.setattr(run_subjects, "_testbed", always_fail)
+    monkeypatch.setattr(run_subjects.time, "sleep", lambda _s: None)
+    with pytest.raises(sp.CalledProcessError):
+        run_subjects.analyze_with_retry("tau2-airline", "testbed/tmp/summary.md")

--- a/plugins/nemo-insights/tests/testbed/test_export.py
+++ b/plugins/nemo-insights/tests/testbed/test_export.py
@@ -1,0 +1,508 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the read-API export (bundle capture): export.py + artifact.snapshot_export."""
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from testbed import artifact, export
+from testbed.registry import Subject
+
+# --------------------------------------------------------------------------- #
+# fake SDK client
+# --------------------------------------------------------------------------- #
+
+
+class Doc:
+    """Stand-in for an SDK model: dumps like the analyst does (json + exclude_none)."""
+
+    def __init__(self, **payload):
+        self.payload = payload
+
+    def model_dump(self, mode="python", exclude_none=False):
+        assert mode == "json", "export must dump SDK models with mode='json'"
+        assert exclude_none, "export must dump SDK models with exclude_none=True"
+        return {k: v for k, v in self.payload.items() if v is not None}
+
+
+def _paginator(items):
+    async def gen():
+        for item in items:
+            yield item
+
+    return gen()
+
+
+class FakeClient:
+    """Captures every list call's kwargs; serves canned docs per (collection, workspace)."""
+
+    def __init__(self, docs: dict):
+        self.docs = docs  # {("spans", ws): [Doc, ...], ...}
+        self.calls: list[tuple[str, dict]] = []
+        self.closed = False
+        outer = self
+
+        class _Collection:
+            def __init__(self, name):
+                self.name = name
+
+            def list(self, **kwargs):
+                outer.calls.append((self.name, kwargs))
+                return _paginator(outer.docs.get((self.name, kwargs["workspace"]), []))
+
+        class _Intake:
+            spans = _Collection("spans")
+            annotations = _Collection("annotations")
+            evaluator_results = _Collection("evaluator_results")
+
+        self.intake = _Intake()
+
+    async def close(self):
+        self.closed = True
+
+    def calls_for(self, collection: str) -> list[dict]:
+        return [kwargs for name, kwargs in self.calls if name == collection]
+
+
+def _install_fake_client(monkeypatch, docs) -> FakeClient:
+    client = FakeClient(docs)
+    monkeypatch.setattr(export, "make_client", lambda base_url: client)
+    return client
+
+
+# --------------------------------------------------------------------------- #
+# export_workspaces
+# --------------------------------------------------------------------------- #
+
+
+def test_export_writes_jsonl_per_workspace_round_trip(tmp_path, monkeypatch):
+    docs = {
+        ("spans", "ws-a"): [
+            Doc(span_id="s1", started_at="2026-07-01T10:00:00Z", raw_attributes={"k": "v"}, model=None),
+            Doc(span_id="s2", started_at="2026-07-01T11:00:00Z"),
+        ],
+        ("annotations", "ws-a"): [Doc(id="a1", kind="feedback", value_text="positive")],
+        ("evaluator_results", "ws-a"): [Doc(id="e1", name="reward", value=1.0)],
+    }
+    _install_fake_client(monkeypatch, docs)
+    export.export_workspaces("http://localhost:8080", ["ws-a"], tmp_path, since=None)
+
+    spans = [json.loads(line) for line in (tmp_path / "export" / "ws-a" / "spans.jsonl").read_text().splitlines()]
+    assert spans == [
+        {"span_id": "s1", "started_at": "2026-07-01T10:00:00Z", "raw_attributes": {"k": "v"}},  # None dropped
+        {"span_id": "s2", "started_at": "2026-07-01T11:00:00Z"},
+    ]
+    anns = [json.loads(line) for line in (tmp_path / "export" / "ws-a" / "annotations.jsonl").read_text().splitlines()]
+    assert anns == [{"id": "a1", "kind": "feedback", "value_text": "positive"}]
+    results_path = tmp_path / "export" / "ws-a" / "evaluator_results.jsonl"
+    assert [json.loads(line) for line in results_path.read_text().splitlines()] == [
+        {"id": "e1", "name": "reward", "value": 1.0}
+    ]
+
+
+def test_export_epoch_lower_bound_when_since_omitted(tmp_path, monkeypatch):
+    """The read API injects a 30-day default lookback: every query MUST carry an explicit bound."""
+    client = _install_fake_client(monkeypatch, {})
+    export.export_workspaces("http://localhost:8080", ["ws-a"], tmp_path, since=None)
+
+    epoch = "1970-01-01T00:00:00+00:00"
+    (span_call,) = client.calls_for("spans")
+    assert span_call["filter"] == {"started_at": {"gte": epoch}}
+    (ann_call,) = client.calls_for("annotations")
+    assert ann_call["filter"] == {"created_at": {"gte": epoch}}
+    (res_call,) = client.calls_for("evaluator_results")
+    assert res_call["filter"] == {"created_at": {"gte": epoch}}
+
+
+def test_export_since_becomes_lower_bound(tmp_path, monkeypatch):
+    client = _install_fake_client(monkeypatch, {})
+    since = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    export.export_workspaces("http://localhost:8080", ["ws-a"], tmp_path, since=since)
+
+    (span_call,) = client.calls_for("spans")
+    assert span_call["filter"] == {"started_at": {"gte": "2026-07-01T00:00:00+00:00"}}
+    (ann_call,) = client.calls_for("annotations")
+    assert ann_call["filter"] == {"created_at": {"gte": "2026-07-01T00:00:00+00:00"}}
+
+
+def test_export_detailed_mode_and_generous_pages(tmp_path, monkeypatch):
+    client = _install_fake_client(monkeypatch, {})
+    export.export_workspaces("http://localhost:8080", ["ws-a"], tmp_path, since=None)
+
+    (span_call,) = client.calls_for("spans")
+    assert span_call["mode"] == "detailed"
+    assert span_call["page_size"] >= 200
+    for name in ("annotations", "evaluator_results"):
+        (call,) = client.calls_for(name)
+        assert call["page_size"] >= 200
+
+
+def test_export_counts_and_time_bounds_across_workspaces(tmp_path, monkeypatch):
+    docs = {
+        ("spans", "ws-a"): [
+            Doc(span_id="s1", started_at="2026-07-01T10:00:00Z"),
+            Doc(span_id="s2", started_at="2026-07-03T10:00:00Z"),
+        ],
+        ("spans", "ws-b"): [Doc(span_id="s3", started_at="2026-06-30T09:00:00Z")],
+        ("annotations", "ws-a"): [Doc(id="a1"), Doc(id="a2")],
+        ("evaluator_results", "ws-b"): [Doc(id="e1")],
+    }
+    _install_fake_client(monkeypatch, docs)
+    stats = export.export_workspaces("http://localhost:8080", ["ws-a", "ws-b"], tmp_path, since=None)
+
+    assert stats["workspaces"] == {
+        "ws-a": {"spans": 2, "annotations": 2, "evaluator_results": 0},
+        "ws-b": {"spans": 1, "annotations": 0, "evaluator_results": 1},
+    }
+    assert stats["min_start_time"] == datetime(2026, 6, 30, 9, tzinfo=timezone.utc).isoformat()
+    assert stats["max_start_time"] == datetime(2026, 7, 3, 10, tzinfo=timezone.utc).isoformat()
+
+
+def test_export_empty_workspace_time_bounds_none(tmp_path, monkeypatch):
+    _install_fake_client(monkeypatch, {})
+    stats = export.export_workspaces("http://localhost:8080", ["ws-a"], tmp_path, since=None)
+    assert stats["min_start_time"] is None
+    assert stats["max_start_time"] is None
+    assert (tmp_path / "export" / "ws-a" / "spans.jsonl").read_text() == ""
+
+
+def test_export_closes_client(tmp_path, monkeypatch):
+    client = _install_fake_client(monkeypatch, {})
+    export.export_workspaces("http://localhost:8080", ["ws-a"], tmp_path, since=None)
+    assert client.closed
+
+
+# --------------------------------------------------------------------------- #
+# subject scoping
+# --------------------------------------------------------------------------- #
+
+
+def _subject(name, type_, **config):
+    return Subject(name, type_, config)
+
+
+def test_scoping_benchmark_gets_oracle_twin_by_default():
+    subject = _subject("tau2-airline", "benchmark", workspace="tau2-airline")
+    assert artifact.workspaces_for_subject(subject) == ["tau2-airline", "tau2-airline-oracle"]
+
+
+def test_scoping_benchmark_include_rewards_false_is_realistic_only():
+    subject = _subject("tau2-airline", "benchmark", workspace="tau2-airline", include_rewards=False)
+    assert artifact.workspaces_for_subject(subject) == ["tau2-airline"]
+
+
+def test_scoping_intake_is_single_workspace():
+    subject = _subject("nvq", "intake", workspace="nvq")
+    assert artifact.workspaces_for_subject(subject) == ["nvq"]
+
+
+def test_scoping_unknown_type_rejected_with_clear_message():
+    subject = _subject("unsupported-subject", "unsupported", workspace="tau2-airline")
+    with pytest.raises(SystemExit) as exc:
+        artifact.workspaces_for_subject(subject)
+    message = str(exc.value)
+    assert "unsupported-subject" in message
+    assert "unsupported" in message
+
+
+def test_scoping_missing_workspace_rejected():
+    subject = _subject("broken", "benchmark")
+    with pytest.raises(SystemExit) as exc:
+        artifact.workspaces_for_subject(subject)
+    assert "broken" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# manifest
+# --------------------------------------------------------------------------- #
+
+_STATS = {
+    "workspaces": {"tau2-airline": {"spans": 2, "annotations": 1, "evaluator_results": 0}},
+    "min_start_time": "2026-07-01T00:00:00+00:00",
+    "max_start_time": "2026-07-02T00:00:00+00:00",
+}
+
+CI_LINEAGE_KEYS = (
+    "nemo_platform_sha",
+    "tau2_bench_sha",
+    "github_run_id",
+    "num_tasks",
+    "num_trials",
+    "judge_llm",
+    "reason",
+)
+
+
+def test_build_export_manifest_fields(tmp_path):
+    rec = tmp_path / "tau2-airline.run.json"
+    rec.write_text("{}")
+    manifest = artifact.build_export_manifest(
+        ["tau2-airline"],
+        [rec],
+        _STATS,
+        source_url="http://localhost:8080",
+        platform_info={"platform_version": "26.07", "revision": "deadbeef"},
+        env={},
+    )
+    assert manifest["kind"] == "testbed-export"
+    assert manifest["source_url"] == "http://localhost:8080"
+    assert manifest["subjects"] == ["tau2-airline"]
+    assert manifest["workspaces"] == ["tau2-airline"]
+    assert manifest["counts"] == _STATS["workspaces"]
+    assert manifest["min_start_time"] == "2026-07-01T00:00:00+00:00"
+    assert manifest["max_start_time"] == "2026-07-02T00:00:00+00:00"
+    assert manifest["platform_version"] == "26.07"
+    assert manifest["platform_revision"] == "deadbeef"
+    assert manifest["records"] == ["tau2-airline.run.json"]
+    assert not any(k in manifest for k in CI_LINEAGE_KEYS)
+
+
+def test_build_export_manifest_platform_info_none(tmp_path):
+    manifest = artifact.build_export_manifest(
+        ["nvq"],
+        [],
+        _STATS,
+        source_url="u",
+        platform_info=None,
+        env={},
+    )
+    assert manifest["platform_version"] is None
+    assert manifest["platform_revision"] is None
+
+
+def test_build_export_manifest_carries_ci_lineage(tmp_path):
+    env = {
+        "GITHUB_SHA": "abc",
+        "TAU2_BENCH_REF": "t2sha",
+        "GITHUB_RUN_ID": "42",
+        "NUM_TASKS": "2",
+        "NUM_TRIALS": "3",
+        "TAU2_JUDGE_LLM": "judge",
+        "REASON": "tau2 bump",
+    }
+    manifest = artifact.build_export_manifest(
+        ["tau2-airline"],
+        [],
+        _STATS,
+        source_url="u",
+        platform_info=None,
+        env=env,
+    )
+    assert manifest["nemo_platform_sha"] == "abc"
+    assert manifest["tau2_bench_sha"] == "t2sha"
+    assert manifest["github_run_id"] == "42"
+    assert manifest["num_tasks"] == "2"
+    assert manifest["num_trials"] == "3"
+    assert manifest["judge_llm"] == "judge"
+    assert manifest["reason"] == "tau2 bump"
+    assert manifest["kind"] == "testbed-export"  # base fields still present alongside lineage
+
+
+# --------------------------------------------------------------------------- #
+# fetch_platform_info (best-effort /cluster-info probe)
+# --------------------------------------------------------------------------- #
+
+
+def test_fetch_platform_info_reads_cluster_info(monkeypatch):
+    seen = {}
+
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"platform_version": "26.07", "revision": "deadbeef"}
+
+    def fake_get(url, timeout):
+        seen["url"] = url
+        return FakeResp()
+
+    monkeypatch.setattr(artifact.httpx, "get", fake_get)
+    info = artifact.fetch_platform_info("http://localhost:8080/")
+    assert seen["url"] == "http://localhost:8080/cluster-info"
+    assert info == {"platform_version": "26.07", "revision": "deadbeef"}
+
+
+def test_fetch_platform_info_none_when_unreachable(monkeypatch):
+    def boom(url, timeout):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(artifact.httpx, "get", boom)
+    assert artifact.fetch_platform_info("http://localhost:8080") is None
+
+
+# --------------------------------------------------------------------------- #
+# snapshot_export
+# --------------------------------------------------------------------------- #
+
+
+def _fake_export(seen):
+    def fake(base_url, workspaces, out_dir, *, since):
+        seen["base_url"] = base_url
+        seen["workspaces"] = list(workspaces)
+        seen["since"] = since
+        for ws in workspaces:
+            ws_dir = out_dir / "export" / ws
+            ws_dir.mkdir(parents=True, exist_ok=True)
+            (ws_dir / "spans.jsonl").write_text('{"span_id": "s1"}\n', encoding="utf-8")
+            (ws_dir / "annotations.jsonl").write_text("", encoding="utf-8")
+            (ws_dir / "evaluator_results.jsonl").write_text("", encoding="utf-8")
+        return {
+            "workspaces": {ws: {"spans": 1, "annotations": 0, "evaluator_results": 0} for ws in workspaces},
+            "min_start_time": "2026-07-01T00:00:00+00:00",
+            "max_start_time": "2026-07-02T00:00:00+00:00",
+        }
+
+    return fake
+
+
+def test_snapshot_export_bundle_layout_and_manifest(tmp_path, monkeypatch):
+    seen: dict = {}
+    monkeypatch.setattr(artifact.export, "export_workspaces", _fake_export(seen))
+    monkeypatch.setattr(
+        artifact,
+        "fetch_platform_info",
+        lambda url: {"platform_version": "26.07", "revision": "deadbeef"},
+    )
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    (tmp_dir / "tau2-airline.run.json").write_text('{"agent": "a"}', encoding="utf-8")
+    (tmp_dir / "insights_tau2-airline.yaml").write_text("insights: []", encoding="utf-8")
+    subject = _subject("tau2-airline", "benchmark", workspace="tau2-airline", base_url="http://remote:8080")
+    out = tmp_path / "bundle.tar.zst"
+
+    result = artifact.snapshot_export([subject], out, tmp_dir, since=None)
+
+    assert result == out and out.exists()
+    assert seen["base_url"] == "http://remote:8080"
+    assert seen["workspaces"] == ["tau2-airline", "tau2-airline-oracle"]
+    extract = tmp_path / "extract"
+    extract.mkdir()
+    subprocess.run(["tar", "--zstd", "-xf", str(out), "-C", str(extract)], check=True)
+    root = extract / "state"
+    assert (root / "export" / "tau2-airline" / "spans.jsonl").read_text() == '{"span_id": "s1"}\n'
+    assert (root / "export" / "tau2-airline-oracle" / "annotations.jsonl").exists()
+    assert (root / "tmp" / "tau2-airline.run.json").exists()
+    # insights never travel in bundles: the subject's local YAML stays out
+    assert not (root / "tmp" / "insights_tau2-airline.yaml").exists()
+    manifest = json.loads((root / "manifest.json").read_text())
+    assert manifest["kind"] == "testbed-export"
+    assert manifest["source_url"] == "http://remote:8080"
+    assert manifest["subjects"] == ["tau2-airline"]
+    assert manifest["workspaces"] == ["tau2-airline", "tau2-airline-oracle"]
+    assert manifest["counts"]["tau2-airline"] == {"spans": 1, "annotations": 0, "evaluator_results": 0}
+    assert manifest["min_start_time"] == "2026-07-01T00:00:00+00:00"
+    assert manifest["platform_version"] == "26.07"
+    assert manifest["platform_revision"] == "deadbeef"
+    assert manifest["records"] == ["tau2-airline.run.json"]
+
+
+def test_snapshot_export_scopes_records_to_selected_subjects(tmp_path, monkeypatch):
+    """Other subjects' run records and insight YAMLs in tmp/ must NOT leak into the bundle."""
+    seen: dict = {}
+    monkeypatch.setattr(artifact.export, "export_workspaces", _fake_export(seen))
+    monkeypatch.setattr(artifact, "fetch_platform_info", lambda url: None)
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    (tmp_dir / "tau2-airline.run.json").write_text('{"agent": "a"}', encoding="utf-8")
+    (tmp_dir / "tau2-retail.run.json").write_text('{"agent": "r"}', encoding="utf-8")
+    (tmp_dir / "insights_tau2-retail.yaml").write_text("insights: []", encoding="utf-8")
+    subject = _subject("tau2-airline", "benchmark", workspace="tau2-airline", base_url="http://remote:8080")
+    out = tmp_path / "bundle.tar.zst"
+
+    artifact.snapshot_export([subject], out, tmp_dir, since=None)
+
+    extract = tmp_path / "extract"
+    extract.mkdir()
+    subprocess.run(["tar", "--zstd", "-xf", str(out), "-C", str(extract)], check=True)
+    names = sorted(p.name for p in (extract / "state" / "tmp").iterdir())
+    assert names == ["tau2-airline.run.json"]
+    manifest = json.loads((extract / "state" / "manifest.json").read_text())
+    assert manifest["records"] == ["tau2-airline.run.json"]
+
+
+def test_snapshot_export_passes_since_through(tmp_path, monkeypatch):
+    seen: dict = {}
+    monkeypatch.setattr(artifact.export, "export_workspaces", _fake_export(seen))
+    monkeypatch.setattr(artifact, "fetch_platform_info", lambda url: None)
+    subject = _subject("nvq", "intake", workspace="nvq", base_url="u")
+    (tmp_path / "tmp").mkdir()
+    since = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    artifact.snapshot_export([subject], tmp_path / "b.tar.zst", tmp_path / "tmp", since=since)
+    assert seen["since"] == since
+
+
+def test_snapshot_export_dedupes_workspaces_across_subjects(tmp_path, monkeypatch):
+    seen: dict = {}
+    monkeypatch.setattr(artifact.export, "export_workspaces", _fake_export(seen))
+    monkeypatch.setattr(artifact, "fetch_platform_info", lambda url: None)
+    a = _subject("a", "intake", workspace="shared", base_url="u")
+    b = _subject("b", "intake", workspace="shared", base_url="u")
+    (tmp_path / "tmp").mkdir()
+    artifact.snapshot_export([a, b], tmp_path / "b.tar.zst", tmp_path / "tmp", since=None)
+    assert seen["workspaces"] == ["shared"]
+
+
+def test_snapshot_export_conflicting_base_urls_exit(tmp_path, monkeypatch):
+    monkeypatch.setattr(artifact.export, "export_workspaces", _fake_export({}))
+    a = _subject("a", "intake", workspace="wa", base_url="http://one:8080")
+    b = _subject("b", "intake", workspace="wb", base_url="http://two:8080")
+    (tmp_path / "tmp").mkdir()
+    with pytest.raises(SystemExit) as exc:
+        artifact.snapshot_export([a, b], tmp_path / "b.tar.zst", tmp_path / "tmp", since=None)
+    assert "base_url" in str(exc.value)
+
+
+def test_snapshot_export_partial_missing_base_url_exits_naming_subject(tmp_path, monkeypatch):
+    """Every selected subject must carry a base_url: a partial miss names the offender
+    instead of silently letting the agreement check pass on the configured subset."""
+    called: list = []
+    monkeypatch.setattr(artifact.export, "export_workspaces", lambda *a, **k: called.append(1))
+    a = _subject("a", "intake", workspace="wa", base_url="http://one:8080")
+    b = _subject("b", "intake", workspace="wb")  # no base_url at all
+    (tmp_path / "tmp").mkdir()
+    with pytest.raises(SystemExit) as exc:
+        artifact.snapshot_export([a, b], tmp_path / "b.tar.zst", tmp_path / "tmp", since=None)
+    message = str(exc.value)
+    assert "no base_url configured for subject(s) b" in message
+    assert "--base" in message
+    assert called == []  # exits before any export I/O
+
+
+def test_snapshot_export_unknown_subject_type_exits_before_export(tmp_path, monkeypatch):
+    called: list = []
+    monkeypatch.setattr(artifact.export, "export_workspaces", lambda *a, **k: called.append(1))
+    subject = _subject("unsupported-subject", "unsupported", workspace="tau2-airline", base_url="u")
+    (tmp_path / "tmp").mkdir()
+    with pytest.raises(SystemExit):
+        artifact.snapshot_export([subject], tmp_path / "b.tar.zst", tmp_path / "tmp", since=None)
+    assert called == []
+
+
+def _extract_manifest(bundle: Path) -> dict:
+    return json.loads(
+        subprocess.run(
+            ["tar", "--zstd", "-xOf", str(bundle), "state/manifest.json"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    )
+
+
+def test_snapshot_export_lineage_env_lands_in_manifest(tmp_path, monkeypatch):
+    """The CI lineage merge is wired through snapshot_export (os.environ), not just the builder."""
+    monkeypatch.setattr(artifact.export, "export_workspaces", _fake_export({}))
+    monkeypatch.setattr(artifact, "fetch_platform_info", lambda url: None)
+    monkeypatch.setenv("GITHUB_SHA", "abc")
+    monkeypatch.setenv("REASON", "export bundles")
+    subject = _subject("nvq", "intake", workspace="nvq", base_url="u")
+    (tmp_path / "tmp").mkdir()
+    out = tmp_path / "b.tar.zst"
+    artifact.snapshot_export([subject], out, tmp_path / "tmp", since=None)
+    manifest = _extract_manifest(out)
+    assert manifest["nemo_platform_sha"] == "abc"
+    assert manifest["reason"] == "export bundles"

--- a/plugins/nemo-insights/tests/testbed/test_ingest.py
+++ b/plugins/nemo-insights/tests/testbed/test_ingest.py
@@ -1,11 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import re
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from testbed.ingest import mint_agent_id
+from testbed import ingest
+
+mint_agent_id = ingest.mint_agent_id
 
 
 def test_mint_agent_id_format():
@@ -14,6 +17,19 @@ def test_mint_agent_id_format():
 
 def test_mint_agent_id_unique():
     assert mint_agent_id("x") != mint_agent_id("x")
+
+
+def test_mint_agent_id_uses_utc(monkeypatch):
+    class _Clock(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            assert tz is timezone.utc
+            return cls(2026, 7, 14, 20, 42, 1, tzinfo=tz)
+
+    monkeypatch.setattr(ingest, "datetime", _Clock)
+    monkeypatch.setattr(ingest.os, "urandom", lambda _size: b"\xab\xcd")
+
+    assert mint_agent_id("agent") == "agent-20260714-204201-abcd"
 
 
 class _StubResponse:

--- a/plugins/nemo-insights/tests/testbed/test_ingest.py
+++ b/plugins/nemo-insights/tests/testbed/test_ingest.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from testbed.ingest import mint_agent_id
+
+
+def test_mint_agent_id_format():
+    assert re.fullmatch(r"tau2-airline-\d{8}-\d{6}-[0-9a-f]{4}", mint_agent_id("tau2-airline"))
+
+
+def test_mint_agent_id_unique():
+    assert mint_agent_id("x") != mint_agent_id("x")
+
+
+class _StubResponse:
+    def __init__(self, *, status_code: int, text: str) -> None:
+        self.status_code = status_code
+        self.text = text
+
+    def json(self) -> dict[str, Any]:
+        return {}
+
+
+class _StubClient:
+    def __init__(
+        self, status: int = 201, body: dict | None = None, get_status: int = 200, get_body: dict | None = None
+    ) -> None:
+        self.status = status
+        self.body = body or {}
+        self.get_status = get_status
+        self.get_body = get_body or {}
+        self.calls: list[tuple[str, str, dict | None]] = []  # (method, url, json)
+
+    def post(self, url: str, json: dict) -> SimpleNamespace:
+        self.calls.append(("POST", url, json))
+        return SimpleNamespace(status_code=self.status, text="body", json=lambda: self.body)
+
+    def get(self, url: str) -> SimpleNamespace:
+        self.calls.append(("GET", url, None))
+        return SimpleNamespace(status_code=self.get_status, text="body", json=lambda: self.get_body)
+
+
+class _PollResp:
+    status_code = 200
+    text = ""
+
+    def __init__(self, spans: list[dict]) -> None:
+        self._spans = spans
+
+    def json(self) -> dict[str, Any]:
+        return {"data": self._spans}
+
+
+class _PollClient:
+    def __init__(self, spans: list[dict]) -> None:
+        self._spans = spans
+        self.closed = False
+
+    def get(self, url: str, *, params: dict[str, Any]) -> _PollResp:
+        return _PollResp(self._spans)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_poll_visible_returns_when_all_visible():
+    from testbed.ingest import poll_visible
+
+    ids = {"s1", "s2"}
+    client = _PollClient([{"session_id": "s1"}, {"session_id": "s2"}])
+    seen = poll_visible("http://x", "w", ids, client=client, sleep=lambda _s: None)
+    assert seen == ids
+
+
+def test_poll_visible_times_out_partial():
+    from testbed.ingest import poll_visible
+
+    client = _PollClient([])  # nothing ever visible
+    seen = poll_visible("http://x", "w", {"s1"}, client=client, timeout_s=0.0, sleep=lambda _s: None)
+    assert seen == set()
+
+
+def test_poll_visible_closes_client_it_creates(monkeypatch: pytest.MonkeyPatch):
+    """When no client is injected, poll_visible must close the one it owns."""
+    import testbed.ingest as ingest
+
+    created = _PollClient([{"session_id": "s1"}])
+    monkeypatch.setattr(ingest.httpx, "Client", lambda **_kwargs: created)
+    seen = ingest.poll_visible("http://x", "w", {"s1"}, sleep=lambda _s: None)
+    assert seen == {"s1"}
+    assert created.closed is True
+
+
+def test_ensure_workspace_posts_to_entities_route():
+    from testbed.ingest import ensure_workspace
+
+    stub = _StubClient(status=201)
+    ensure_workspace("http://localhost:8080/", "tau2-airline-1", client=stub)
+    assert stub.calls == [("POST", "http://localhost:8080/apis/entities/v2/workspaces", {"name": "tau2-airline-1"})]
+
+
+def test_ensure_workspace_treats_409_as_ok():
+    from testbed.ingest import ensure_workspace
+
+    ensure_workspace("http://x", "w", client=_StubClient(status=409))  # must not raise
+
+
+def test_ensure_workspace_accepts_other_2xx():
+    from testbed.ingest import ensure_workspace
+
+    ensure_workspace("http://x", "w", client=_StubClient(status=200))  # must not raise
+
+
+def test_ensure_workspace_raises_on_other_error():
+    from testbed.ingest import ensure_workspace
+
+    with pytest.raises(RuntimeError):
+        ensure_workspace("http://x", "w", client=_StubClient(status=500))
+
+
+def test_ensure_experiment_group_returns_id_on_create():
+    from testbed.ingest import ensure_experiment_group
+
+    stub = _StubClient(status=201, body={"id": "grp-123", "name": "tau2-airline"})
+    gid = ensure_experiment_group("http://x/", "tau2-airline-oracle", "tau2-airline", client=stub)
+    assert gid == "grp-123"
+    assert stub.calls == [
+        ("POST", "http://x/apis/intake/v2/workspaces/tau2-airline-oracle/experiment-groups", {"name": "tau2-airline"})
+    ]
+
+
+def test_ensure_experiment_group_gets_id_on_409():
+    from testbed.ingest import ensure_experiment_group
+
+    stub = _StubClient(status=409, get_status=200, get_body={"id": "grp-existing"})
+    gid = ensure_experiment_group("http://x", "ws", "tau2-airline", client=stub)
+    assert gid == "grp-existing"
+    assert stub.calls == [
+        ("POST", "http://x/apis/intake/v2/workspaces/ws/experiment-groups", {"name": "tau2-airline"}),
+        ("GET", "http://x/apis/intake/v2/workspaces/ws/experiment-groups/tau2-airline", None),
+    ]
+
+
+def test_ensure_experiment_group_raises_on_error():
+    from testbed.ingest import ensure_experiment_group
+
+    with pytest.raises(RuntimeError):
+        ensure_experiment_group("http://x", "ws", "g", client=_StubClient(status=500))
+
+
+def test_create_experiment_posts_full_body():
+    from testbed.ingest import create_experiment
+
+    stub = _StubClient(status=201)
+    create_experiment(
+        "http://x",
+        "ws",
+        name="tau2-airline-20260626-000000-abcd",
+        experiment_group_id="grp-1",
+        dataset_name="tau2:airline",
+        dataset_version="v1",
+        metadata={"seed": 300},
+        client=stub,
+    )
+    assert stub.calls == [
+        (
+            "POST",
+            "http://x/apis/intake/v2/workspaces/ws/experiments",
+            {
+                "name": "tau2-airline-20260626-000000-abcd",
+                "experiment_group_id": "grp-1",
+                "dataset_name": "tau2:airline",
+                "dataset_version": "v1",
+                "metadata": {"seed": 300},
+            },
+        )
+    ]
+
+
+def test_create_experiment_raises_on_error():
+    from testbed.ingest import create_experiment
+
+    with pytest.raises(RuntimeError):
+        create_experiment(
+            "http://x",
+            "ws",
+            name="n",
+            experiment_group_id="g",
+            dataset_name="d",
+            dataset_version="v",
+            metadata={},
+            client=_StubClient(status=409),
+        )

--- a/plugins/nemo-insights/tests/testbed/test_otlp_build.py
+++ b/plugins/nemo-insights/tests/testbed/test_otlp_build.py
@@ -1,0 +1,463 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the pure tau2-sim → OTLP-span-dict transform."""
+
+import json
+import time
+
+from testbed.otlp_build import session_id_for, sim_to_spans
+
+_SESSION = "tau2-airline-task7-t0"
+
+
+def _spans(sim, *, include_rewards=False, task=None, agent_llm="openai/m"):
+    return sim_to_spans(
+        sim,
+        agent_name="tau2-airline",
+        agent_version="v1",
+        session_id=_SESSION,
+        experiment_id="tau2-airline-20260626-000000-abcd",
+        task=task,
+        include_rewards=include_rewards,
+        agent_llm=agent_llm,
+    )
+
+
+def _by_kind(spans, kind):
+    return [s for s in spans if s["kind"] == kind]
+
+
+def _root(spans):
+    (root,) = _by_kind(spans, "AGENT")
+    return root
+
+
+def _basic_sim(messages, *, task_id="7", trial=0, reward=1.0):
+    return {
+        "task_id": task_id,
+        "trial": trial,
+        "messages": messages,
+        "reward_info": {"reward": reward},
+        "termination_reason": "done",
+    }
+
+
+def _telecom_sim():
+    """A telecom sim with a user-driven device tool — the ATIF 422 regression case.
+
+    The customer (user) runs a device tool: a ``role="user"`` message carrying a
+    ``ToolCall`` with ``requestor="user"``, answered by a ``role="tool"`` result
+    that is also ``requestor="user"``. ATIF-v1.7 (agent-only) rejected this; OTLP
+    must ingest it faithfully.
+    """
+    return _basic_sim(
+        [
+            {"role": "user", "content": "my data isn't working"},
+            {
+                "role": "assistant",
+                "content": "Let me check. Can you run a speed test?",
+                "tool_calls": [{"id": "a1", "name": "get_line_status", "arguments": {"id": 7}}],
+            },
+            {"role": "tool", "tool_call_id": "a1", "content": "line ok", "requestor": "assistant"},
+            {
+                "role": "user",
+                "content": "ok running it",
+                "tool_calls": [{"id": "u1", "name": "run_speed_test", "arguments": {}, "requestor": "user"}],
+            },
+            {"role": "tool", "tool_call_id": "u1", "content": "12 Mbps", "requestor": "user"},
+            {"role": "assistant", "content": "Your speed looks fine."},
+        ],
+        task_id="mobile_data",
+    )
+
+
+# --- timestamps (must land in the platform's retention window) -------------
+
+
+def test_spans_timestamped_near_now_not_a_fixed_past_date():
+    # Regression: a hardcoded past base (2023) was silently dropped by Intake's
+    # span retention/TTL window, so OTLP spans never became queryable. Spans must
+    # be stamped at ~ingest time. Default base = wall-clock now.
+    before = time.time_ns()
+    spans = _spans(_basic_sim([{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]))
+    starts = [s["start_ns"] for s in spans]
+    assert min(starts) >= before
+    assert max(s["end_ns"] for s in spans) <= time.time_ns() + 60 * 1_000_000_000
+
+
+def test_base_ns_is_honored_when_provided():
+    base = 1_900_000_000_000_000_000
+    spans = sim_to_spans(
+        _basic_sim([{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]),
+        agent_name="a",
+        agent_version="v",
+        session_id="s",
+        experiment_id="run-x",
+        task=None,
+        include_rewards=False,
+        agent_llm="m",
+        base_ns=base,
+    )
+    assert min(s["start_ns"] for s in spans) == base  # monotonic clock seeded from the provided base
+    assert all(base <= s["start_ns"] < base + 60 * 1_000_000_000 for s in spans)  # tightly clustered
+
+
+# --- session id (stable identity, reproduces the prior ATIF slug) ----------
+
+
+def test_session_id_basic():
+    sim = {"task_id": "7", "trial": 0}
+    assert session_id_for(sim, experiment_id="tau2-airline-x") == "tau2-airline-x-task7-t0"
+
+
+def test_session_id_slugs_experiment_and_task():
+    sim = {"task_id": "set[1]/odd", "trial": 0}
+    assert session_id_for(sim, experiment_id="tau2/airline") == "tau2-airline-taskset-1-odd-t0"
+
+
+def test_session_id_trial_none_defaults_to_zero():
+    assert session_id_for({"task_id": "0", "trial": None}, experiment_id="a").endswith("-t0")
+
+
+def test_session_id_is_run_unique():
+    sim = {"task_id": "7", "trial": 0}
+    a = session_id_for(sim, experiment_id="run-A")
+    b = session_id_for(sim, experiment_id="run-B")
+    assert a != b  # different runs -> different session ids
+    assert a == session_id_for(sim, experiment_id="run-A")  # same run -> stable (twins correlate)
+
+
+# --- AGENT root ------------------------------------------------------------
+
+
+def test_exactly_one_agent_root_with_no_parent():
+    spans = _spans(
+        _basic_sim(
+            [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ]
+        )
+    )
+    root = _root(spans)
+    assert root["name"] == "tau2-airline"
+    assert root["parent_span_id"] is None
+    assert root["attributes"]["openinference.span.kind"] == "AGENT"
+    assert root["attributes"]["gen_ai.agent.name"] == "tau2-airline"
+    assert root["attributes"]["gen_ai.agent.version"] == "v1"
+
+
+def test_agent_root_input_first_user_output_last_agent():
+    spans = _spans(
+        _basic_sim(
+            [
+                {"role": "user", "content": "first-user"},
+                {"role": "assistant", "content": "mid"},
+                {"role": "user", "content": "second-user"},
+                {"role": "assistant", "content": "last-agent"},
+            ]
+        )
+    )
+    root = _root(spans)
+    assert root["attributes"]["input.value"] == "first-user"
+    assert root["attributes"]["output.value"] == "last-agent"
+
+
+# --- grouping --------------------------------------------------------------
+
+
+def test_every_span_carries_conversation_and_session_id():
+    spans = _spans(_telecom_sim())
+    assert spans  # non-empty
+    for s in spans:
+        assert s["attributes"]["gen_ai.conversation.id"] == _SESSION
+        assert s["attributes"]["session.id"] == _SESSION
+
+
+def test_span_ids_unique_and_deterministic():
+    sim = _telecom_sim()
+    spans = _spans(sim)
+    ids = [s["span_id"] for s in spans]
+    assert len(ids) == len(set(ids))  # unique
+    assert all(len(i) == 16 for i in ids)  # 8 bytes hex
+    again = _spans(sim)
+    assert [s["span_id"] for s in again] == ids  # pure / deterministic
+
+
+# --- LLM turns -------------------------------------------------------------
+
+
+def test_one_llm_turn_per_assistant_message():
+    spans = _spans(
+        _basic_sim(
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "one"},
+                {"role": "user", "content": "more"},
+                {"role": "assistant", "content": "two"},
+            ]
+        )
+    )
+    llms = _by_kind(spans, "LLM")
+    assert len(llms) == 2
+    root = _root(spans)
+    for llm in llms:
+        assert llm["parent_span_id"] == root["span_id"]
+        assert llm["name"].startswith("agent-")
+        assert llm["attributes"]["gen_ai.request.model"] == "openai/m"
+
+
+def test_llm_output_value_carries_content_and_tool_calls():
+    spans = _spans(
+        _basic_sim(
+            [
+                {
+                    "role": "assistant",
+                    "content": "calling",
+                    "tool_calls": [{"id": "c1", "name": "lookup", "arguments": {"x": 1}}],
+                },
+            ]
+        )
+    )
+    (llm,) = _by_kind(spans, "LLM")
+    assert llm["attributes"]["output.mime_type"] == "application/json"
+    out = json.loads(llm["attributes"]["output.value"])
+    assert out["content"] == "calling"
+    assert out["tool_calls"][0]["name"] == "lookup"
+
+
+# --- agent-driven TOOL -----------------------------------------------------
+
+
+def test_agent_tool_is_child_of_its_llm_turn():
+    spans = _spans(
+        _basic_sim(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"id": "c1", "name": "lookup", "arguments": {"x": 1}}],
+                },
+                {"role": "tool", "tool_call_id": "c1", "content": "result-text"},
+            ]
+        )
+    )
+    (llm,) = _by_kind(spans, "LLM")
+    (tool,) = _by_kind(spans, "TOOL")
+    assert tool["parent_span_id"] == llm["span_id"]
+    assert tool["name"] == "lookup"
+    assert tool["attributes"]["gen_ai.tool.name"] == "lookup"
+    assert tool["attributes"]["gen_ai.agent.name"] == "tau2-airline"  # agent-driven keeps agent name
+    assert json.loads(tool["attributes"]["input.value"]) == {"x": 1}
+    assert tool["attributes"]["output.value"] == "result-text"
+
+
+# --- user-driven TOOL (the telecom 422 regression) -------------------------
+
+
+def test_user_driven_tool_is_child_of_root_with_actor_and_no_agent_name():
+    spans = _spans(_telecom_sim())
+    user_tools = [s for s in _by_kind(spans, "TOOL") if s["attributes"].get("tau2.actor") == "user"]
+    assert len(user_tools) == 1
+    ut = user_tools[0]
+    root = _root(spans)
+    assert ut["parent_span_id"] == root["span_id"]  # parented to AGENT root, not an LLM turn
+    assert ut["name"] == "run_speed_test"
+    assert ut["attributes"]["gen_ai.tool.name"] == "run_speed_test"
+    assert "gen_ai.agent.name" not in ut["attributes"]  # NOT the agent's action
+    assert ut["attributes"]["output.value"] == "12 Mbps"
+
+
+def test_agent_and_user_tools_distinguishable():
+    spans = _spans(_telecom_sim())
+    tools = _by_kind(spans, "TOOL")
+    agent_tools = [t for t in tools if "gen_ai.agent.name" in t["attributes"]]
+    user_tools = [t for t in tools if t["attributes"].get("tau2.actor") == "user"]
+    assert {t["name"] for t in agent_tools} == {"get_line_status"}
+    assert {t["name"] for t in user_tools} == {"run_speed_test"}
+    # the agent tool hangs off an LLM turn; the user tool hangs off the root
+    llm_ids = {s["span_id"] for s in _by_kind(spans, "LLM")}
+    assert agent_tools[0]["parent_span_id"] in llm_ids
+    assert user_tools[0]["parent_span_id"] == _root(spans)["span_id"]
+
+
+# --- EVALUATOR / reward gating --------------------------------------------
+
+
+def test_no_evaluator_span_in_realistic_mode():
+    spans = _spans(_basic_sim([{"role": "user", "content": "hi"}]), include_rewards=False)
+    assert _by_kind(spans, "EVALUATOR") == []
+
+
+def test_evaluator_span_in_oracle_mode():
+    spans = _spans(_basic_sim([{"role": "user", "content": "hi"}], reward=1.0), include_rewards=True)
+    (ev,) = _by_kind(spans, "EVALUATOR")
+    root = _root(spans)
+    assert ev["name"] == "tau2.verifier"
+    assert ev["parent_span_id"] == root["span_id"]
+    assert ev["attributes"]["score"] == 1.0
+    out = json.loads(ev["attributes"]["output.value"])
+    assert out["score"] == 1.0
+
+
+def test_no_evaluator_when_reward_absent_even_in_oracle_mode():
+    sim = {"task_id": "0", "messages": [{"role": "user", "content": "hi"}]}  # no reward_info
+    assert _by_kind(_spans(sim, include_rewards=True), "EVALUATOR") == []
+
+
+# --- failed tool -> ERROR status ------------------------------------------
+
+
+def test_failed_tool_call_marks_error_status():
+    spans = _spans(
+        _basic_sim(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"id": "c1", "name": "boom", "arguments": {}}],
+                },
+                {"role": "tool", "tool_call_id": "c1", "content": "kaboom", "error": True},
+            ]
+        )
+    )
+    (tool,) = _by_kind(spans, "TOOL")
+    assert tool["status"] == "ERROR"
+    assert tool["status_message"]
+
+
+# --- task gating (oracle-gating invariant) ---------------------------------
+
+
+def test_task_evaluation_criteria_gated_by_include_rewards():
+    task = {
+        "description": {"purpose": "p"},
+        "user_scenario": {"instructions": "book X"},
+        "evaluation_criteria": {"actions": [{"name": "book_reservation"}]},
+    }
+    realistic = _root(_spans(_basic_sim([{"role": "user", "content": "hi"}]), include_rewards=False, task=task))
+    oracle = _root(_spans(_basic_sim([{"role": "user", "content": "hi"}]), include_rewards=True, task=task))
+    realistic_task = json.loads(realistic["attributes"]["tau2.task"])
+    oracle_task = json.loads(oracle["attributes"]["tau2.task"])
+    assert realistic_task["user_scenario"]["instructions"] == "book X"  # setup kept
+    assert "evaluation_criteria" not in realistic_task  # gold withheld in realistic mode
+    assert oracle_task["evaluation_criteria"]["actions"][0]["name"] == "book_reservation"
+
+
+def test_every_span_carries_experiment_and_test_case_tags():
+    sim = _basic_sim([{"role": "user", "content": "hi"}], task_id="7")
+    spans = sim_to_spans(
+        sim,
+        agent_name="tau2-airline",
+        agent_version="v1",
+        session_id=_SESSION,
+        experiment_id="tau2-airline-20260626-000000-abcd",
+        include_rewards=True,
+    )
+    assert spans  # at least the AGENT root + EVALUATOR
+    for s in spans:
+        assert s["attributes"]["nemo.experiment.id"] == "tau2-airline-20260626-000000-abcd"
+        assert s["attributes"]["nemo.test_case.id"] == "7"
+
+
+def test_tags_identical_across_realistic_and_oracle_twins():
+    sim = _basic_sim([{"role": "user", "content": "hi"}], task_id="7")
+    common = dict(
+        agent_name="tau2-airline",
+        agent_version="v1",
+        session_id=_SESSION,
+        experiment_id="run-1",
+    )
+    realistic = sim_to_spans(sim, include_rewards=False, **common)
+    oracle = sim_to_spans(sim, include_rewards=True, **common)
+
+    def tag(s):
+        return (s["attributes"]["nemo.experiment.id"], s["attributes"]["nemo.test_case.id"])
+
+    assert {tag(s) for s in realistic} == {("run-1", "7")}
+    assert {tag(s) for s in oracle} == {("run-1", "7")}
+
+
+# --- user-text CHAIN spans -------------------------------------------------
+
+
+def test_user_text_spans_emitted_per_utterance():
+    """Multi-turn sim emits CHAIN spans for each non-empty user utterance."""
+    sim = _basic_sim(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "thanks"},
+        ]
+    )
+    spans = _spans(sim, include_rewards=False)
+    chain_spans = _by_kind(spans, "CHAIN")
+    assert len(chain_spans) == 2
+    # Names are user-<step_id>; steps are 1-indexed and increment per message
+    names = {s["name"] for s in chain_spans}
+    assert names == {"user-1", "user-3"}
+
+
+def test_user_text_spans_parented_to_agent_root():
+    sim = _basic_sim(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+    )
+    spans = _spans(sim, include_rewards=False)
+    root = _root(spans)
+    (chain,) = _by_kind(spans, "CHAIN")
+    assert chain["parent_span_id"] == root["span_id"]
+
+
+def test_user_text_span_has_correct_attributes():
+    sim = _basic_sim([{"role": "user", "content": "how are you?"}])
+    spans = _spans(sim, include_rewards=False)
+    (chain,) = _by_kind(spans, "CHAIN")
+    assert chain["attributes"]["tau2.actor"] == "user"
+    assert chain["attributes"]["output.value"] == "how are you?"
+    assert chain["attributes"]["output.mime_type"] == "text/plain"
+    assert chain["attributes"]["openinference.span.kind"] == "CHAIN"
+
+
+def test_empty_content_user_message_yields_no_chain_span():
+    """A user message with empty/None content must NOT produce a CHAIN span."""
+    sim = _basic_sim(
+        [
+            {"role": "user", "content": ""},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": None},
+        ]
+    )
+    spans = _spans(sim, include_rewards=False)
+    assert _by_kind(spans, "CHAIN") == []
+
+
+def test_user_text_spans_precede_llm_spans_in_timeline():
+    """User utterance spans must start before subsequent agent LLM spans (correct interleaving)."""
+    sim = _basic_sim(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "thanks"},
+            {"role": "assistant", "content": "sure"},
+        ]
+    )
+    spans = _spans(sim, include_rewards=False)
+    llms = sorted(_by_kind(spans, "LLM"), key=lambda s: s["start_ns"])
+    chains = sorted(_by_kind(spans, "CHAIN"), key=lambda s: s["start_ns"])
+    # Each user utterance at step N precedes the next assistant at step N+1
+    # chain[0] (user-1) < llm[0] (agent-2); chain[1] (user-3) < llm[1] (agent-4)
+    assert chains[0]["start_ns"] < llms[0]["start_ns"]
+    assert chains[1]["start_ns"] < llms[1]["start_ns"]
+
+
+def test_user_text_spans_visible_in_both_twins():
+    """User text is not gated by include_rewards — appears in realistic and oracle twins."""
+    sim = _basic_sim([{"role": "user", "content": "check my bill"}])
+    realistic = _spans(sim, include_rewards=False)
+    oracle = _spans(sim, include_rewards=True)
+    assert len(_by_kind(realistic, "CHAIN")) == 1
+    assert len(_by_kind(oracle, "CHAIN")) == 1

--- a/plugins/nemo-insights/tests/testbed/test_otlp_ingest.py
+++ b/plugins/nemo-insights/tests/testbed/test_otlp_ingest.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the OTLP protobuf builder/exporter and the evaluator-results POST."""
+
+from types import SimpleNamespace
+
+import pytest
+from testbed.otlp_ingest import (
+    export_spans,
+    post_evaluator_results,
+    trace_id_for,
+)
+
+_TRACE_ID = trace_id_for("sess-1")
+
+
+def _span(span_id, parent, kind, name, *, attributes=None, status="OK", status_message=None):
+    return {
+        "span_id": span_id,
+        "parent_span_id": parent,
+        "name": name,
+        "kind": kind,
+        "start_ns": 1_700_000_000_000_000_000,
+        "end_ns": 1_700_000_000_001_000_000,
+        "attributes": {"openinference.span.kind": kind, **(attributes or {})},
+        "status": status,
+        "status_message": status_message,
+    }
+
+
+class _ExportStub:
+    """Captures a single protobuf POST (url, raw body, headers)."""
+
+    def __init__(self, status=200, payload=None):
+        self.status = status
+        self.payload = {"errors": []} if payload is None else payload
+        self.calls: list[dict] = []
+
+    def post(self, url, *, content=None, headers=None, json=None):
+        self.calls.append({"url": url, "content": content, "headers": headers or {}, "json": json})
+        return SimpleNamespace(
+            status_code=self.status,
+            text="body",
+            json=lambda: self.payload,
+        )
+
+
+def _decode(body: bytes):
+    from opentelemetry.proto.collector.trace.v1 import trace_service_pb2
+
+    req = trace_service_pb2.ExportTraceServiceRequest()
+    req.ParseFromString(body)
+    return req
+
+
+def _attr_value(any_value):
+    field = any_value.WhichOneof("value")
+    return getattr(any_value, field) if field else None
+
+
+def _attrs(span):
+    return {a.key: _attr_value(a.value) for a in span.attributes}
+
+
+# --- trace id --------------------------------------------------------------
+
+
+def test_trace_id_for_is_16_bytes_deterministic_nonzero():
+    tid = trace_id_for("sess-1")
+    assert isinstance(tid, bytes) and len(tid) == 16
+    assert any(tid)  # non-zero (Intake rejects all-zero ids)
+    assert tid == trace_id_for("sess-1")  # deterministic
+    assert tid != trace_id_for("sess-2")
+
+
+# --- export_spans: protobuf build + POST -----------------------------------
+
+
+def test_export_spans_posts_protobuf_to_otlp_route():
+    stub = _ExportStub()
+    spans = [_span("0000000000000001", None, "AGENT", "agent")]
+    export_spans("http://x/", "ws", "sess-1", _TRACE_ID, spans, client=stub)
+    (call,) = stub.calls
+    assert call["url"] == "http://x/apis/intake/v2/workspaces/ws/ingest/otlp/v1/traces"
+    assert call["headers"]["Content-Type"] == "application/x-protobuf"
+    assert call["content"] is not None and call["json"] is None
+
+
+def test_export_spans_serializes_ids_parents_kinds():
+    stub = _ExportStub()
+    spans = [
+        _span("0000000000000001", None, "AGENT", "agent"),
+        _span("0000000000000002", "0000000000000001", "LLM", "agent-1"),
+    ]
+    export_spans("http://x", "ws", "sess-1", _TRACE_ID, spans, client=stub)
+    req = _decode(stub.calls[0]["content"])
+    out = req.resource_spans[0].scope_spans[0].spans
+    assert {s.name for s in out} == {"agent", "agent-1"}
+    by_name = {s.name: s for s in out}
+    assert by_name["agent"].trace_id == _TRACE_ID
+    assert by_name["agent"].span_id.hex() == "0000000000000001"
+    assert _attrs(by_name["agent"])["openinference.span.kind"] == "AGENT"
+    # the LLM turn points at the AGENT root
+    assert by_name["agent-1"].parent_span_id.hex() == "0000000000000001"
+
+
+def test_root_parent_span_id_is_empty_not_zero():
+    # Intake rejects an all-zero parent_span_id; a parentless root must leave it unset.
+    stub = _ExportStub()
+    export_spans("http://x", "ws", "s", _TRACE_ID, [_span("0000000000000001", None, "AGENT", "a")], client=stub)
+    root = _decode(stub.calls[0]["content"]).resource_spans[0].scope_spans[0].spans[0]
+    assert len(root.parent_span_id) == 0
+
+
+def test_resource_has_service_name():
+    stub = _ExportStub()
+    export_spans("http://x", "ws", "s", _TRACE_ID, [_span("0000000000000001", None, "AGENT", "a")], client=stub)
+    res = _decode(stub.calls[0]["content"]).resource_spans[0].resource
+    names = {a.key: _attr_value(a.value) for a in res.attributes}
+    assert names["service.name"] == "nemo-insights-testbed"
+
+
+def test_export_spans_typed_attributes_roundtrip():
+    stub = _ExportStub()
+    attrs = {"input.value": "txt", "score": 1.0, "count": 3, "flag": True}
+    export_spans(
+        "http://x", "ws", "s", _TRACE_ID, [_span("0000000000000001", None, "TOOL", "t", attributes=attrs)], client=stub
+    )
+    span = _decode(stub.calls[0]["content"]).resource_spans[0].scope_spans[0].spans[0]
+    decoded = _attrs(span)
+    assert decoded["input.value"] == "txt"
+    assert decoded["score"] == 1.0
+    assert decoded["count"] == 3
+    assert decoded["flag"] is True
+
+
+def test_export_spans_error_status_sets_code_2():
+    stub = _ExportStub()
+    spans = [_span("0000000000000001", None, "TOOL", "boom", status="ERROR", status_message="kaboom")]
+    export_spans("http://x", "ws", "s", _TRACE_ID, spans, client=stub)
+    span = _decode(stub.calls[0]["content"]).resource_spans[0].scope_spans[0].spans[0]
+    assert span.status.code == 2  # STATUS_CODE_ERROR
+    assert span.status.message == "kaboom"
+
+
+def test_export_spans_raises_on_non_2xx():
+    with pytest.raises(RuntimeError):
+        export_spans(
+            "http://x",
+            "ws",
+            "s",
+            _TRACE_ID,
+            [_span("0000000000000001", None, "AGENT", "a")],
+            client=_ExportStub(status=500),
+        )
+
+
+def test_export_spans_raises_on_errors_array():
+    # 2xx but per-span errors reported -> still a failure.
+    stub = _ExportStub(status=200, payload={"errors": ["span 01: bad"]})
+    with pytest.raises(RuntimeError):
+        export_spans("http://x", "ws", "s", _TRACE_ID, [_span("0000000000000001", None, "AGENT", "a")], client=stub)
+
+
+# --- post_evaluator_results ------------------------------------------------
+
+
+class _JsonStub:
+    def __init__(self, status=201):
+        self.status = status
+        self.calls: list[tuple[str, dict]] = []
+
+    def post(self, url, *, json=None, content=None, headers=None):
+        self.calls.append((url, json))
+        return SimpleNamespace(status_code=self.status, text="body")
+
+
+def test_post_evaluator_results_route_and_body():
+    stub = _JsonStub(status=201)
+    post_evaluator_results("http://x/", "ws", span_id="sp1", session_id="sess-1", score=1.0, client=stub)
+    (url, body) = stub.calls[0]
+    assert url == "http://x/apis/intake/v2/workspaces/ws/evaluator-results"
+    assert body == {
+        "span_id": "sp1",
+        "session_id": "sess-1",
+        "name": "reward",
+        "value": 1.0,
+        "data_type": "NUMERIC",
+    }
+
+
+def test_post_evaluator_results_raises_on_error():
+    with pytest.raises(RuntimeError):
+        post_evaluator_results("http://x", "ws", span_id="s", session_id="z", score=0.0, client=_JsonStub(status=500))

--- a/plugins/nemo-insights/tests/testbed/test_publish.py
+++ b/plugins/nemo-insights/tests/testbed/test_publish.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""`testbed publish` — laptop-first mint/upload/catalog for export bundles."""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+from testbed import cli, publish, release
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+MANIFEST = {
+    "kind": "testbed-export",
+    "subjects": ["tau2-airline"],
+    "workspaces": ["tau2-airline", "tau2-airline-oracle"],
+    "counts": {
+        "tau2-airline": {"spans": 450, "annotations": 3, "evaluator_results": 30},
+        "tau2-airline-oracle": {"spans": 456, "annotations": 1, "evaluator_results": 30},
+    },
+    "min_start_time": "2026-07-01T00:00:00+00:00",
+    "max_start_time": "2026-07-02T00:00:00+00:00",
+    "source_url": "http://localhost:8080",
+}
+
+RUN_ENV = {"GITHUB_RUN_ID": "99", "GITHUB_REPOSITORY": "o/r"}
+
+
+def _make_bundle(path: Path, manifest: dict = MANIFEST) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=path.parent) as tmp:
+        state = Path(tmp) / "state"
+        state.mkdir(parents=True)
+        (state / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+        subprocess.run(["tar", "--zstd", "-cf", str(path), "-C", tmp, "state"], check=True)
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# catalog row: contents from the bundle manifest; minted-by run link | laptop
+# --------------------------------------------------------------------------- #
+
+
+def test_catalog_row_contents_from_manifest_run_variant():
+    row = publish.catalog_row("state-v6", MANIFEST, reason="tau2 bump", env=RUN_ENV)
+    assert row == (
+        "| state-v6 | tau2-airline — 906 spans, 4 annotations, 60 evaluator results "
+        "| tau2 bump | [run 99](https://github.com/o/r/actions/runs/99) |"
+    )
+
+
+def test_catalog_row_laptop_variant(monkeypatch):
+    monkeypatch.setattr("getpass.getuser", lambda: "ada")
+    row = publish.catalog_row("state-v6", MANIFEST, reason="", env={})
+    assert row.endswith("| — | laptop (ada) |")  # empty reason -> em dash; no run env -> laptop
+
+
+def test_minted_by_requires_both_run_env_vars(monkeypatch):
+    monkeypatch.setattr("getpass.getuser", lambda: "ada")
+    assert publish.minted_by(RUN_ENV).startswith("[run 99]")
+    assert publish.minted_by({"GITHUB_RUN_ID": "99"}) == "laptop (ada)"
+    assert publish.minted_by({"GITHUB_REPOSITORY": "o/r"}) == "laptop (ada)"
+
+
+def test_contents_column_empty_manifest_is_honest():
+    assert publish.contents_column({}) == "? — 0 spans, 0 annotations, 0 evaluator results"
+
+
+def test_catalog_row_sanitizes_pipes_in_reason():
+    """A raw `|` in --reason would add phantom columns to the catalog table."""
+    row = publish.catalog_row("state-v6", MANIFEST, reason="tau2 bump | with pipe", env=RUN_ENV)
+    assert "tau2 bump \\| with pipe" in row
+    # the row still parses as exactly 4 cells (escaped pipes don't split)
+    assert len(re.split(r"(?<!\\)\|", row)) == 6
+
+
+def test_catalog_row_sanitizes_newlines_in_reason():
+    """A newline in --reason would terminate the GH release table, hiding all older rows."""
+    row = publish.catalog_row("state-v6", MANIFEST, reason="line one\nline\ttwo\r\n  spaced", env=RUN_ENV)
+    assert "\n" not in row and "\r" not in row and "\t" not in row
+    assert "| line one line two spaced |" in row  # whitespace runs collapse to single spaces
+
+
+def test_catalog_row_whitespace_only_reason_falls_back_to_dash():
+    row = publish.catalog_row("state-v6", MANIFEST, reason=" \n\t ", env=RUN_ENV)
+    assert "| — |" in row
+
+
+# --------------------------------------------------------------------------- #
+# catalog insert: marker sits ABOVE the table; new rows go right after the
+# header separator (a non-| line inside a GH release table breaks rendering)
+# --------------------------------------------------------------------------- #
+
+
+def test_insert_catalog_row_newest_first_inside_table():
+    body = (
+        "intro\n\n" + publish.CATALOG_MARKER + "\n"
+        "| Version | Contents | Why it exists | Minted by |\n|---|---|---|---|\n| state-v1 | old | x | y |\n"
+    )
+    out = publish.insert_catalog_row(body, "| state-v2 | new | x | y |")
+    assert out.index("state-v2") < out.index("state-v1")
+    # the new row must directly follow the separator — no line may split the table
+    lines = out.splitlines()
+    sep = next(i for i, ln in enumerate(lines) if ln.startswith("|---"))
+    assert lines[sep + 1].startswith("| state-v2 ")
+
+
+def test_insert_catalog_row_without_marker_appends_section():
+    out = publish.insert_catalog_row("hand-edited notes", "| state-v2 | new | x | y |")
+    assert publish.CATALOG_MARKER in out
+    assert out.rstrip().endswith("| state-v2 | new | x | y |")
+    # marker precedes the table header so the table itself stays contiguous
+    assert out.index(publish.CATALOG_MARKER) < out.index("| Version |")
+
+
+# --------------------------------------------------------------------------- #
+# publish flow: mint next ref -> copy -> ensure release -> upload -> catalog
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def fake_gh(monkeypatch):
+    """Stub release._gh with a plausible testbed-state release; record every call."""
+    state = {
+        "calls": [],
+        "assets": ["state-v6.tar.zst"],
+        "body": (
+            "notes\n\n" + publish.CATALOG_MARKER + "\n"
+            "| Version | Contents | Why it exists | Minted by |\n|---|---|---|---|\n| state-v6 | old | x | y |\n"
+        ),
+    }
+
+    def gh(*args):
+        state["calls"].append(args)
+        if args[:2] == ("release", "view") and "--json" in args:
+            field = args[args.index("--json") + 1]
+            if field == "assets":
+                return json.dumps({"assets": [{"name": n} for n in state["assets"]]})
+            if field == "body":
+                return json.dumps({"body": state["body"]})
+        if args[:2] == ("release", "edit"):
+            state["body"] = args[args.index("--notes") + 1]
+        return ""
+
+    monkeypatch.setattr(release, "_gh", gh)
+    return state
+
+
+def test_publish_mints_next_ref_uploads_and_prepends_row(fake_gh, tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("getpass.getuser", lambda: "ada")
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    bundle = _make_bundle(tmp_path / "candidate.tar.zst")
+    ref = publish.publish(bundle, reason="fresh corpus", env={})
+    assert ref == "state-v7"
+    assert (tmp_path / "state-v7.tar.zst").is_file()  # candidate copied to the ref name
+    uploads = [c for c in fake_gh["calls"] if c[:2] == ("release", "upload")]
+    assert uploads == [("release", "upload", release.RELEASE_TAG, str(tmp_path / "state-v7.tar.zst"), "--clobber")]
+    # new row lands right under the header separator, above the old row
+    assert fake_gh["body"].index("state-v7") < fake_gh["body"].index("| state-v6 |")
+    assert "laptop (ada)" in fake_gh["body"]
+    assert "fresh corpus" in fake_gh["body"]
+    assert "published state-v7" in capsys.readouterr().out
+
+
+def test_publish_creates_release_when_missing(fake_gh, tmp_path, monkeypatch):
+    def view_fails(*args):
+        if args[:2] == ("release", "view") and "--json" not in args:
+            raise subprocess.CalledProcessError(1, ["gh", *args], stderr="not found")
+        return original_gh(*args)
+
+    original_gh = release._gh
+    monkeypatch.setattr(release, "_gh", view_fails)
+    publish.publish(_make_bundle(tmp_path / "c.tar.zst"), reason="", env={})
+    creates = [c for c in fake_gh["calls"] if c[:2] == ("release", "create")]
+    assert len(creates) == 1 and release.RELEASE_TAG in creates[0]
+
+
+def test_publish_writes_github_output_only_when_env_set(fake_gh, tmp_path):
+    out_file = tmp_path / "gh_output"
+    publish.publish(_make_bundle(tmp_path / "a.tar.zst"), reason="", env={"GITHUB_OUTPUT": str(out_file)})
+    assert out_file.read_text(encoding="utf-8") == "state_ref=state-v7\n"
+    publish.publish(_make_bundle(tmp_path / "b.tar.zst"), reason="", env={})  # no env -> nothing written
+
+
+def test_publish_rejects_non_export_bundles(fake_gh, tmp_path):
+    legacy = _make_bundle(tmp_path / "legacy.tar.zst", manifest={"created_at": "2026-01-01"})
+    with pytest.raises(SystemExit) as exc:
+        publish.publish(legacy, reason="", env={})
+    assert "testbed-export" in str(exc.value)
+    assert all(c[:2] != ("release", "upload") for c in fake_gh["calls"])  # nothing uploaded
+
+
+def test_publish_missing_bundle_exits(fake_gh, tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        publish.publish(tmp_path / "nope.tar.zst", reason="", env={})
+    assert "no such bundle" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# CLI surface: testbed publish FILE [--reason TEXT] (--base URL | --no-verify)
+# minting is immutable, so publish enforces verify-or-explicit-skip
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_publish_reason_flag_wins_over_env(fake_gh, tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setenv("REASON", "from-env")
+    bundle = _make_bundle(tmp_path / "c.tar.zst")
+    monkeypatch.setattr(sys, "argv", ["testbed", "publish", str(bundle), "--no-verify", "--reason", "from-flag"])
+    cli.main()
+    assert "from-flag" in fake_gh["body"]
+    assert "from-env" not in fake_gh["body"]
+
+
+def test_cli_publish_reason_falls_back_to_env(fake_gh, tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setenv("REASON", "from-env")
+    bundle = _make_bundle(tmp_path / "c.tar.zst")
+    monkeypatch.setattr(sys, "argv", ["testbed", "publish", str(bundle), "--no-verify"])
+    cli.main()
+    assert "from-env" in fake_gh["body"]
+
+
+def test_cli_publish_without_verify_flags_exits_with_guidance(fake_gh, tmp_path, monkeypatch):
+    """Bare `publish FILE` must refuse: minting is immutable, verify first."""
+    bundle = _make_bundle(tmp_path / "c.tar.zst")
+    monkeypatch.setattr(sys, "argv", ["testbed", "publish", str(bundle)])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    message = str(exc.value)
+    assert "--base" in message and "--no-verify" in message and "immutable" in message
+    assert all(c[:2] != ("release", "upload") for c in fake_gh["calls"])  # nothing minted
+
+
+def test_cli_publish_no_verify_mints_without_guard(fake_gh, tmp_path, monkeypatch, capsys):
+    guard_calls: list = []
+    monkeypatch.setattr(cli, "_run_roundtrip", lambda *a, **k: guard_calls.append(a))
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    bundle = _make_bundle(tmp_path / "c.tar.zst")
+    monkeypatch.setattr(sys, "argv", ["testbed", "publish", str(bundle), "--no-verify"])
+    cli.main()
+    assert guard_calls == []  # guard skipped entirely
+    assert any(c[:2] == ("release", "upload") for c in fake_gh["calls"])  # minted
+    assert "round-trip guard" in capsys.readouterr().out  # one-line skip notice
+
+
+def test_cli_publish_base_runs_guard_before_mint(fake_gh, tmp_path, monkeypatch):
+    order: list[tuple] = []
+    monkeypatch.setattr(
+        cli,
+        "_run_roundtrip",
+        lambda bundle, base, platform_root: order.append(("guard", bundle, base, platform_root)),
+    )
+    real_publish = publish.publish
+    monkeypatch.setattr(
+        publish,
+        "publish",
+        lambda *a, **k: (order.append(("publish",)), real_publish(*a, **k))[1],
+    )
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    bundle = _make_bundle(tmp_path / "c.tar.zst")
+    monkeypatch.setattr(sys, "argv", ["testbed", "publish", str(bundle), "--base", "http://ci-host:8080"])
+    cli.main()
+    assert [step[0] for step in order] == ["guard", "publish"]  # guard strictly before mint
+    assert order[0][1:] == (bundle, "http://ci-host:8080", None)
+
+
+def test_cli_publish_guard_failure_prevents_mint(fake_gh, tmp_path, monkeypatch):
+    def failing_guard(bundle, base, platform_root):
+        sys.exit("round-trip guard: 1 mismatch(es)")
+
+    monkeypatch.setattr(cli, "_run_roundtrip", failing_guard)
+    bundle = _make_bundle(tmp_path / "c.tar.zst")
+    monkeypatch.setattr(sys, "argv", ["testbed", "publish", str(bundle), "--base", "http://ci-host:8080"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "mismatch" in str(exc.value)
+    assert all(c[:2] != ("release", "upload") for c in fake_gh["calls"])  # never minted
+
+
+def test_publish_module_has_no_main(tmp_path):
+    """`python -m testbed.publish` is not a mint path: the CLI's verify-or-explicit-skip
+    gate (`testbed publish --base|--no-verify`) cannot be bypassed by running the module."""
+    assert not hasattr(publish, "main")
+    assert "__main__" not in Path(publish.__file__).read_text(encoding="utf-8")
+    # Running the module does nothing: exit 0, no output, and no gh invocation
+    # (a marker-dropping fake gh shadows the real one for the subprocess).
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "gh-called"
+    (fake_bin / "gh").write_text(f"#!/bin/sh\ntouch {marker}\n", encoding="utf-8")
+    (fake_bin / "gh").chmod(0o755)
+    bundle = _make_bundle(tmp_path / "candidate.tar.zst")
+    proc = subprocess.run(
+        [sys.executable, "-m", "testbed.publish", str(bundle), "--reason", "bypass attempt"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"},
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+    assert not marker.exists()  # gh never ran — nothing was minted
+
+
+def test_cli_publish_base_and_no_verify_conflict(fake_gh, tmp_path, monkeypatch, capsys):
+    """--base (verify) and --no-verify (skip) contradict each other — argparse rejects."""
+    bundle = _make_bundle(tmp_path / "c.tar.zst")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["testbed", "publish", str(bundle), "--base", "http://x:8080", "--no-verify"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2  # argparse mutual-exclusion error
+    assert all(c[:2] != ("release", "upload") for c in fake_gh["calls"])

--- a/plugins/nemo-insights/tests/testbed/test_registry.py
+++ b/plugins/nemo-insights/tests/testbed/test_registry.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+from testbed.registry import load_registry
+
+
+def test_loads_subject_with_shared_default(tmp_path: Path):
+    toml = tmp_path / "t.toml"
+    toml.write_text(
+        'base_url = "https://shared"\n\n[nvq]\ntype = "intake"\nagent = "content-dedup"\nworkspace = "nvq"\n'
+    )
+    subjects = load_registry(toml)
+    assert set(subjects) == {"nvq"}
+    nvq = subjects["nvq"]
+    assert nvq.type == "intake"
+    assert nvq.config["agent"] == "content-dedup"
+    assert nvq.config["base_url"] == "https://shared"  # shared default merged in
+
+
+def test_per_subject_override_wins(tmp_path: Path):
+    toml = tmp_path / "t.toml"
+    toml.write_text('base_url = "https://shared"\n\n[local]\ntype = "intake"\nbase_url = "http://localhost:8000"\n')
+    assert load_registry(toml)["local"].config["base_url"] == "http://localhost:8000"

--- a/plugins/nemo-insights/tests/testbed/test_reingest.py
+++ b/plugins/nemo-insights/tests/testbed/test_reingest.py
@@ -1,0 +1,1250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Offline tests for testbed.reingest (doc->OTLP inversion, idempotency guard, round-trip diff).
+
+Golden docs are real detailed span docs captured from the live dev platform
+during the 2026-07-06 spike (workspace smoke-20260626-121437-5559-oracle),
+verbatim except where a test says it tweaked a field. No network anywhere.
+"""
+
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+import pytest
+from testbed import reingest
+
+# --- stub catalog: mirrors the real span_attribute_catalog surface the inversion reads ---
+
+
+@dataclass(frozen=True)
+class _Field:
+    value: str
+
+
+@dataclass(frozen=True)
+class _Spec:
+    field: _Field
+    source_keys: tuple[str, ...]
+
+
+class _StubCatalog:
+    ATTRIBUTE_SPECS = (
+        _Spec(_Field("model"), ("gen_ai.request.model", "gen_ai.response.model", "llm.model_name")),
+        _Spec(_Field("agent_name"), ("gen_ai.agent.name", "llm.agent.name", "agent.name")),
+        _Spec(_Field("agent_version"), ("gen_ai.agent.version", "agent.version")),
+        _Spec(_Field("evaluation_id"), ("nemo.experiment.id",)),
+        _Spec(_Field("test_case_id"), ("nemo.test_case.id",)),
+        _Spec(_Field("input_tokens"), ("gen_ai.usage.input_tokens", "llm.token_count.prompt")),
+        _Spec(_Field("prompt_cache_write_tokens"), ("llm.token_count.prompt_details.cache_write",)),
+        _Spec(_Field("cost_total_usd"), ("gen_ai.usage.cost", "llm.cost.total")),
+    )
+
+
+CATALOG = _StubCatalog()
+
+# --- golden docs (live spike capture) ---
+
+AGENT_DOC = {
+    "ingested_at": "2026-06-26T18:14:41.412889",
+    "kind": "AGENT",
+    "session_id": "smoke-20260626-121437-5559-task1-t0",
+    "source": "otel",
+    "span_id": "72f937bfcb667a9e",
+    "started_at": "2026-06-26T18:14:41.406179",
+    "status": "success",
+    "workspace": "smoke-20260626-121437-5559-oracle",
+    "agent_name": "smoke-20260626-121437-5559",
+    "cost_details": {},
+    "ended_at": "2026-06-26T18:14:41.408179",
+    "evaluation_context": {
+        "evaluation_id": "smoke-20260626-121437-5559-20260626-121438-a833",
+        "metadata": {},
+        "test_case_id": "1",
+    },
+    "input": "do 1",
+    "name": "smoke-20260626-121437-5559",
+    "output": "ok",
+    "raw_attributes": json.dumps(
+        {
+            "service.name": "nemo-insights-testbed",
+            "openinference.span.kind": "AGENT",
+            "tau2.task": '{"description": {"purpose": "p"}}',
+            "otel.scope": '{"name":"testbed","version":"1.0.0"}',
+        }
+    ),
+    "trace_id": "c9f0d45dfb4defbf92958b76fa367354",
+    "usage_details": {},
+}
+
+LLM_DOC = {
+    "ingested_at": "2026-06-26T18:14:41.412889",
+    "kind": "LLM",
+    "session_id": "smoke-20260626-121437-5559-task1-t0",
+    "source": "otel",
+    "span_id": "76cc9cc7b048160a",
+    "started_at": "2026-06-26T18:14:41.407179",
+    "status": "success",
+    "workspace": "smoke-20260626-121437-5559-oracle",
+    "cost_details": {},
+    "ended_at": "2026-06-26T18:14:41.408179",
+    "evaluation_context": {
+        "evaluation_id": "smoke-20260626-121437-5559-20260626-121438-a833",
+        "metadata": {},
+        "test_case_id": "1",
+    },
+    "model": "m",
+    "name": "agent-2",
+    "output": '{"content": "ok", "tool_calls": []}',
+    "parent_span_id": "72f937bfcb667a9e",
+    "raw_attributes": json.dumps(
+        {
+            "service.name": "nemo-insights-testbed",
+            "openinference.span.kind": "LLM",
+            "output.mime_type": "application/json",
+            "otel.scope": '{"name":"testbed","version":"1.0.0"}',
+        }
+    ),
+    "trace_id": "c9f0d45dfb4defbf92958b76fa367354",
+    "usage_details": {},
+}
+
+
+# --- doc_to_otlp ---
+
+
+def test_agent_doc_golden():
+    otlp = reingest.doc_to_otlp(AGENT_DOC, CATALOG)
+    assert otlp["trace_id"] == "c9f0d45dfb4defbf92958b76fa367354"
+    assert otlp["span_id"] == "72f937bfcb667a9e"
+    assert otlp["parent_span_id"] is None
+    assert otlp["name"] == "smoke-20260626-121437-5559"
+    assert otlp["start_ns"] == 1782497681406179000
+    assert otlp["end_ns"] == 1782497681408179000
+    assert otlp["status_error"] is False
+    assert otlp["scope"] == {"name": "testbed", "version": "1.0.0"}
+    assert otlp["attributes"] == {
+        # raw passthrough (otel.scope hoisted out — ingest re-stamps it from the protobuf scope)
+        "service.name": "nemo-insights-testbed",
+        "openinference.span.kind": "AGENT",
+        "tau2.task": '{"description": {"purpose": "p"}}',
+        # source-only protocol fields, synthesized from doc columns
+        "session.id": "smoke-20260626-121437-5559-task1-t0",
+        "input.value": "do 1",
+        "output.value": "ok",
+        # catalog inversion: semantic columns re-emitted under their top-precedence source key
+        "gen_ai.agent.name": "smoke-20260626-121437-5559",
+        "nemo.experiment.id": "smoke-20260626-121437-5559-20260626-121438-a833",
+        "nemo.test_case.id": "1",
+    }
+
+
+def test_llm_doc_inverts_model_and_sets_parent():
+    otlp = reingest.doc_to_otlp(LLM_DOC, CATALOG)
+    assert otlp["parent_span_id"] == "72f937bfcb667a9e"
+    assert otlp["attributes"]["gen_ai.request.model"] == "m"
+    assert otlp["attributes"]["output.value"] == '{"content": "ok", "tool_calls": []}'
+    assert "input.value" not in otlp["attributes"]  # doc had no input
+
+
+def test_raw_alias_wins_over_inversion():
+    doc = dict(LLM_DOC)
+    doc["raw_attributes"] = json.dumps({"llm.model_name": "other"})
+    otlp = reingest.doc_to_otlp(doc, CATALOG)
+    # the passthrough alias already derives `model` at ingest — the inversion must not double-write
+    assert "gen_ai.request.model" not in otlp["attributes"]
+    assert otlp["attributes"]["llm.model_name"] == "other"
+
+
+def test_error_and_cancelled_status():
+    error_doc = {**AGENT_DOC, "status": "error"}
+    assert reingest.doc_to_otlp(error_doc, CATALOG)["status_error"] is True
+    cancelled_doc = {**AGENT_DOC, "status": "cancelled"}
+    otlp = reingest.doc_to_otlp(cancelled_doc, CATALOG)
+    assert otlp["status_error"] is False
+    assert otlp["attributes"]["status"] == "cancelled"  # source-only key; the OTLP route to a cancelled row
+
+
+def test_kind_synthesized_only_when_missing():
+    doc = {**AGENT_DOC, "raw_attributes": json.dumps({})}
+    assert reingest.doc_to_otlp(doc, CATALOG)["attributes"]["openinference.span.kind"] == "AGENT"
+    unknown = {**doc, "kind": "UNKNOWN"}
+    assert "openinference.span.kind" not in reingest.doc_to_otlp(unknown, CATALOG)["attributes"]
+
+
+def test_evaluation_metadata_and_usage_details_invert():
+    doc = {
+        **LLM_DOC,
+        "evaluation_context": {"evaluation_id": "e1", "metadata": {"num_trials": 2}},
+        "usage_details": {"prompt_details.cache_write": 7},
+        "input_tokens": 11,
+    }
+    attrs = reingest.doc_to_otlp(doc, CATALOG)["attributes"]
+    assert attrs["nemo.experiment.metadata"] == '{"num_trials":2}'
+    assert attrs["llm.token_count.prompt_details.cache_write"] == 7
+    assert attrs["gen_ai.usage.input_tokens"] == 11
+
+
+def test_missing_trace_id_is_an_error():
+    doc = {k: v for k, v in AGENT_DOC.items() if k != "trace_id"}
+    with pytest.raises(ValueError, match="no trace_id"):
+        reingest.doc_to_otlp(doc, CATALOG)
+
+
+def test_iso_to_ns_treats_naive_as_utc():
+    assert reingest._iso_to_ns("2026-06-26T18:14:41.406179") == 1782497681406179000
+    assert reingest._iso_to_ns("2026-06-26T18:14:41.406179+00:00") == 1782497681406179000
+
+
+# --- build_trace_request ---
+
+
+def test_build_request_groups_by_scope_and_encodes_protocol_fields():
+    spans = [reingest.doc_to_otlp(AGENT_DOC, CATALOG), reingest.doc_to_otlp(LLM_DOC, CATALOG)]
+    spans.append({**spans[1], "span_id": "aabbccdd11223344", "scope": None, "status_error": True})
+    request = reingest.build_trace_request(spans)
+    assert len(request.resource_spans) == 1
+    assert not request.resource_spans[0].resource.attributes  # resource layer rides in the raw passthrough
+    scopes = request.resource_spans[0].scope_spans
+    assert len(scopes) == 2  # testbed scope + scope-less
+    named = next(s for s in scopes if s.scope.name == "testbed")
+    assert named.scope.version == "1.0.0"
+    assert len(named.spans) == 2
+    root, child = named.spans
+    assert root.trace_id == bytes.fromhex("c9f0d45dfb4defbf92958b76fa367354")
+    assert root.parent_span_id == b""  # unset for roots — all-zero parents are rejected
+    assert child.parent_span_id == bytes.fromhex("72f937bfcb667a9e")
+    assert root.start_time_unix_nano == 1782497681406179000
+    assert root.status.code == 0
+    scopeless = next(s for s in scopes if s is not named)
+    assert scopeless.spans[0].status.code == 2
+
+
+# --- catalog loading ---
+
+
+def test_load_catalog_from_checkout_layout(tmp_path):
+    path = tmp_path / reingest.CATALOG_RELPATH
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "from __future__ import annotations\n"
+        "from dataclasses import dataclass\n"
+        "@dataclass(frozen=True)\n"
+        "class AttributeSpec:\n"
+        "    field: str\n"
+        "    source_keys: tuple[str, ...]\n"
+        "ATTRIBUTE_SPECS = (AttributeSpec('model', ('gen_ai.request.model',)),)\n",
+        encoding="utf-8",
+    )
+    catalog = reingest.load_catalog(tmp_path)
+    # dataclass field resolution requires the module in sys.modules — this is the regression test
+    assert catalog.ATTRIBUTE_SPECS[0].source_keys == ("gen_ai.request.model",)
+
+
+def test_load_catalog_missing_checkout(tmp_path):
+    with pytest.raises(FileNotFoundError, match="nemo-platform checkout"):
+        reingest.load_catalog(tmp_path / "nowhere")
+
+
+# --- workspace collection counts (the per-collection idempotency guard reads these) ---
+
+
+def _counting_client(seen: list, total: int = 7) -> httpx.Client:
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"pagination": {"total_results": total}})
+
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_annotation_count_reads_workspace_total_with_epoch_bound():
+    seen: list[httpx.Request] = []
+    with _counting_client(seen) as client:
+        assert reingest.annotation_count("http://x/", "ws-a", client=client) == 7
+    assert seen[0].url.path == "/apis/intake/v2/workspaces/ws-a/annotations"
+    # explicit epoch bound: the read API injects a 30-day default lookback without one
+    assert seen[0].url.params["filter[created_at][gte]"] == "1970-01-01T00:00:00Z"
+    assert seen[0].url.params["page_size"] == "1"  # the total rides on pagination, not the page
+
+
+def test_evaluator_result_count_reads_workspace_total_with_epoch_bound():
+    seen: list[httpx.Request] = []
+    with _counting_client(seen) as client:
+        assert reingest.evaluator_result_count("http://x", "ws-a", client=client) == 7
+    assert seen[0].url.path == "/apis/intake/v2/workspaces/ws-a/evaluator-results"
+    assert seen[0].url.params["filter[created_at][gte]"] == "1970-01-01T00:00:00Z"
+
+
+def test_collection_count_non_200_raises():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="nope")
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(RuntimeError, match="count failed for ws-a"):
+            reingest.annotation_count("http://x", "ws-a", client=client)
+
+
+# --- ingest_bundle ---
+
+
+def _write_export(tmp_path: Path, workspace: str, spans: list[dict], annotations=(), results=()) -> Path:
+    ws_dir = tmp_path / "export" / workspace
+    ws_dir.mkdir(parents=True)
+    for name, docs in (("spans", spans), ("annotations", annotations), ("evaluator_results", results)):
+        (ws_dir / f"{name}.jsonl").write_text("".join(json.dumps(d) + "\n" for d in docs), encoding="utf-8")
+    return tmp_path / "export"
+
+
+def _manifest(workspace: str, spans: int, annotations: int = 0, results: int = 0) -> dict:
+    return {
+        "workspaces": [workspace],
+        "counts": {workspace: {"spans": spans, "annotations": annotations, "evaluator_results": results}},
+        "min_start_time": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+ANNOTATION_DOC = {
+    "annotation_id": "ann-997a55ec332c4e9c9af8a78ea38e0437",
+    "created_at": "2026-07-06T22:04:47.443000",
+    "ingested_at": "2026-07-06T22:04:47.443000",
+    "kind": "note",
+    "session_id": "smoke-20260626-121437-5559-task1-t0",
+    "text": "spike note",
+    "workspace": "smoke-20260626-121437-5559-oracle",
+}
+
+RESULT_DOC = {
+    "created_at": "2026-06-26T18:14:41.660000",
+    "data_type": "NUMERIC",
+    "evaluator_result_id": "eval-2b40eb397ed3ea04abc9c942d2eb42a5",
+    "ingested_at": "2026-06-26T18:14:41.660000",
+    "name": "reward",
+    "session_id": "smoke-20260626-121437-5559-task2-t0",
+    "span_id": "671629150455e141",
+    "workspace": "smoke-20260626-121437-5559-oracle",
+    "value": 0.0,
+}
+
+
+@pytest.fixture
+def quiet_platform(monkeypatch):
+    """Stub every network touchpoint; record what ingest_bundle would send.
+
+    Tests preload one count sequence per collection (``span_counts`` /
+    ``annotation_counts`` / ``result_counts``); each stubbed count helper pops
+    its next value, so an unexpected count call fails loudly (IndexError).
+    """
+    calls = {
+        "requests": [],
+        "posts": [],
+        "ensured": [],
+        "counts": [],
+        "span_counts": [],
+        "annotation_counts": [],
+        "result_counts": [],
+        "first_ids": [],
+    }
+
+    def _counter(name):
+        def fake(base_url, workspace, *, client=None):
+            calls["counts"].append((name, workspace))
+            return calls[f"{name}_counts"].pop(0)
+
+        return fake
+
+    def fake_first(base_url, workspace, *, client=None):
+        calls["counts"].append(("first_span", workspace))
+        # default (no preloaded id): probe unavailable -> count-only fallback
+        return calls["first_ids"].pop(0) if calls["first_ids"] else None
+
+    monkeypatch.setattr(reingest, "span_count", _counter("span"))
+    monkeypatch.setattr(reingest, "annotation_count", _counter("annotation"))
+    monkeypatch.setattr(reingest, "evaluator_result_count", _counter("result"))
+    monkeypatch.setattr(reingest, "_first_span_id", fake_first, raising=False)
+    monkeypatch.setattr(reingest, "ensure_workspace", lambda url, ws, client=None: calls["ensured"].append(ws))
+    monkeypatch.setattr(
+        reingest, "export_trace_request", lambda url, ws, req, client=None: calls["requests"].append((ws, req))
+    )
+    monkeypatch.setattr(reingest, "_post_created", lambda client, url, body: calls["posts"].append((url, body)))
+    return calls
+
+
+@pytest.fixture
+def fake_docker(monkeypatch):
+    """Record docker invocations instead of running them; rc=0 unless a test overrides."""
+    runs: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        runs.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(reingest.subprocess, "run", fake_run)
+    return runs
+
+
+def test_ingest_bundle_zero_ingests_everything(tmp_path, quiet_platform):
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC], [ANNOTATION_DOC], [RESULT_DOC])
+    quiet_platform["span_counts"] = [0, 2]  # guard sees empty; wait sees all spans
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [0]
+    outcome = reingest.ingest_bundle(
+        "http://x",
+        export_dir,
+        _manifest("ws-a", 2, 1, 1),
+        workspace_map={"ws-a": "ws-a-state-v6"},
+        catalog=CATALOG,
+        sleep=lambda s: None,
+    )
+    assert quiet_platform["ensured"] == ["ws-a-state-v6"]
+    assert [ws for ws, _ in quiet_platform["requests"]] == ["ws-a-state-v6"]
+    ann_url, ann_body = quiet_platform["posts"][0]
+    assert ann_url.endswith("/workspaces/ws-a-state-v6/annotations")
+    assert ann_body == {"kind": "note", "session_id": "smoke-20260626-121437-5559-task1-t0", "text": "spike note"}
+    res_url, res_body = quiet_platform["posts"][1]
+    assert res_url.endswith("/workspaces/ws-a-state-v6/evaluator-results")
+    assert res_body == {
+        "data_type": "NUMERIC",
+        "name": "reward",
+        "session_id": "smoke-20260626-121437-5559-task2-t0",
+        "span_id": "671629150455e141",
+        "value": 0.0,
+    }
+    assert outcome["ws-a"] == {
+        "workspace": "ws-a-state-v6",
+        "spans": {"ingested": 2, "skipped": 0},
+        "annotations": {"ingested": 1, "skipped": 0},
+        "evaluator_results": {"ingested": 1, "skipped": 0},
+    }
+
+
+def test_ingest_bundle_batches_spans(tmp_path, quiet_platform, monkeypatch):
+    monkeypatch.setattr(reingest, "SPAN_BATCH", 2)
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC, {**LLM_DOC, "span_id": "aabbccdd11223344"}])
+    quiet_platform["span_counts"] = [0, 3]
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [0]
+    reingest.ingest_bundle(
+        "http://x",
+        export_dir,
+        _manifest("ws-a", 3),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+        sleep=lambda s: None,
+    )
+    sizes = [len(req.resource_spans[0].scope_spans[0].spans) for _, req in quiet_platform["requests"]]
+    assert sizes == [2, 1]
+
+
+def test_ingest_bundle_equal_count_skips(tmp_path, quiet_platform, capsys):
+    """All three collections at manifest counts -> one 'already restored' skip, zero POSTs."""
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC], [ANNOTATION_DOC], [RESULT_DOC])
+    quiet_platform["span_counts"] = [2]
+    quiet_platform["annotation_counts"] = [1]
+    quiet_platform["result_counts"] = [1]
+    outcome = reingest.ingest_bundle(
+        "http://x",
+        export_dir,
+        _manifest("ws-a", 2, 1, 1),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+    )
+    assert quiet_platform["requests"] == []
+    assert quiet_platform["posts"] == []  # skipping MUST also skip annotation re-posts (they duplicate)
+    out = capsys.readouterr().out
+    assert out.count("already restored") == 1
+    assert "ws-b: already restored (2 spans) — skipping" in out
+    assert outcome["ws-a"] == {
+        "workspace": "ws-b",
+        "spans": {"ingested": 0, "skipped": 2},
+        "annotations": {"ingested": 0, "skipped": 1},
+        "evaluator_results": {"ingested": 0, "skipped": 1},
+    }
+
+
+def test_ingest_bundle_partial_count_hard_errors(tmp_path, quiet_platform):
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC])
+    quiet_platform["span_counts"] = [1]
+    with pytest.raises(RuntimeError, match="partially restored"):
+        reingest.ingest_bundle(
+            "http://x",
+            export_dir,
+            _manifest("ws-a", 2),
+            workspace_map={"ws-a": "ws-b"},
+            catalog=CATALOG,
+        )
+    assert quiet_platform["requests"] == []
+
+
+def test_ingest_bundle_heals_missing_evaluator_results(tmp_path, quiet_platform, capsys):
+    """Interrupted restore (spans landed, evaluator results never posted): self-heals.
+
+    Evaluator-result POSTs upsert on a server-derived stable id, so re-posting
+    the full set is safe — the guard must post them instead of skipping the
+    workspace (the old span-only guard silently left the fixture incomplete
+    forever).
+    """
+    results = [RESULT_DOC, {**RESULT_DOC, "span_id": "aabbccdd11223344"}]
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC], [ANNOTATION_DOC], results)
+    quiet_platform["span_counts"] = [2]  # spans complete
+    quiet_platform["annotation_counts"] = [1]  # annotations complete
+    quiet_platform["result_counts"] = [0]  # evaluator results missing
+    outcome = reingest.ingest_bundle(
+        "http://x",
+        export_dir,
+        _manifest("ws-a", 2, 1, 2),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+    )
+    assert quiet_platform["requests"] == []  # spans are NOT re-ingested
+    urls = [url for url, _ in quiet_platform["posts"]]
+    assert len(urls) == 2 and all(url.endswith("/workspaces/ws-b/evaluator-results") for url in urls)
+    out = capsys.readouterr().out
+    assert "healing evaluator results: posting 2" in out
+    assert "already restored" not in out
+    assert outcome["ws-a"] == {
+        "workspace": "ws-b",
+        "spans": {"ingested": 0, "skipped": 2},
+        "annotations": {"ingested": 0, "skipped": 1},
+        "evaluator_results": {"ingested": 2, "skipped": 0},
+    }
+
+
+def test_ingest_bundle_heals_partial_evaluator_results_by_reposting_all(tmp_path, quiet_platform, capsys):
+    """Fewer evaluator results than the manifest -> re-post ALL of them (upsert-safe)."""
+    results = [RESULT_DOC, {**RESULT_DOC, "span_id": "aabbccdd11223344"}]
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC], [], results)
+    quiet_platform["span_counts"] = [2]
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [1]  # one of two landed before the interrupt
+    outcome = reingest.ingest_bundle(
+        "http://x",
+        export_dir,
+        _manifest("ws-a", 2, 0, 2),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+    )
+    assert len(quiet_platform["posts"]) == 2  # all, not just the missing one
+    assert "healing evaluator results: posting 2" in capsys.readouterr().out
+    assert outcome["ws-a"]["evaluator_results"] == {"ingested": 2, "skipped": 0}
+
+
+def test_ingest_bundle_surplus_evaluator_results_hard_error(tmp_path, quiet_platform):
+    """More evaluator results than the manifest -> foreign data, never post into it."""
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC], [], [RESULT_DOC])
+    quiet_platform["span_counts"] = [2]
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [3]
+    with pytest.raises(RuntimeError, match="foreign"):
+        reingest.ingest_bundle(
+            "http://x",
+            export_dir,
+            _manifest("ws-a", 2, 0, 1),
+            workspace_map={"ws-a": "ws-b"},
+            catalog=CATALOG,
+        )
+    assert quiet_platform["posts"] == []
+
+
+def test_ingest_bundle_heals_missing_annotations(tmp_path, quiet_platform, capsys):
+    """Interrupted before any annotation landed: zero existing -> safe to post them all."""
+    annotations = [ANNOTATION_DOC, {**ANNOTATION_DOC, "text": "second"}]
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC], annotations, [RESULT_DOC])
+    quiet_platform["span_counts"] = [2]
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [1]
+    outcome = reingest.ingest_bundle(
+        "http://x",
+        export_dir,
+        _manifest("ws-a", 2, 2, 1),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+    )
+    urls = [url for url, _ in quiet_platform["posts"]]
+    assert len(urls) == 2 and all(url.endswith("/workspaces/ws-b/annotations") for url in urls)
+    assert "healing annotations: posting 2" in capsys.readouterr().out
+    assert outcome["ws-a"]["annotations"] == {"ingested": 2, "skipped": 0}
+    assert outcome["ws-a"]["evaluator_results"] == {"ingested": 0, "skipped": 1}
+
+
+def test_ingest_bundle_partial_annotations_hard_error(tmp_path, quiet_platform):
+    """0 < existing annotations < expected: re-posting would duplicate (fresh uuids) — hard error."""
+    annotations = [ANNOTATION_DOC, {**ANNOTATION_DOC, "text": "second"}]
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC], annotations)
+    quiet_platform["span_counts"] = [2]
+    quiet_platform["annotation_counts"] = [1]
+    with pytest.raises(RuntimeError, match="mint fresh") as exc:
+        reingest.ingest_bundle(
+            "http://x",
+            export_dir,
+            _manifest("ws-a", 2, 2),
+            workspace_map={"ws-a": "ws-b"},
+            catalog=CATALOG,
+        )
+    message = str(exc.value)
+    assert "ws-b" in message  # names the workspace
+    assert "duplicate" in message
+    assert "delete" in message.lower() and "restore" in message  # recommends delete + re-restore
+    assert quiet_platform["posts"] == []
+
+
+def test_ingest_bundle_zero_span_workspace_annotations_idempotent(tmp_path, quiet_platform, capsys):
+    """Finding 2: a 0-span workspace with annotations must not re-post them on a second restore.
+
+    The old guard (`if expected and existing == expected`) short-circuited on a
+    zero span count and re-posted (duplicated) the annotations every run.
+    """
+    annotations = [ANNOTATION_DOC, {**ANNOTATION_DOC, "text": "second"}]
+    export_dir = _write_export(tmp_path, "ws-a", [], annotations)
+    manifest = _manifest("ws-a", 0, 2)
+    quiet_platform["span_counts"] = [0]
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [0]
+    first = reingest.ingest_bundle(
+        "http://x",
+        export_dir,
+        manifest,
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+    )
+    assert len(quiet_platform["posts"]) == 2  # first restore posts the annotations
+    assert first["ws-a"]["annotations"] == {"ingested": 2, "skipped": 0}
+    quiet_platform["span_counts"] = [0]
+    quiet_platform["annotation_counts"] = [2]
+    quiet_platform["result_counts"] = [0]
+    second = reingest.ingest_bundle(
+        "http://x",
+        export_dir,
+        manifest,
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+    )
+    assert len(quiet_platform["posts"]) == 2  # second restore posts NOTHING new
+    assert "ws-b: already restored (0 spans) — skipping" in capsys.readouterr().out
+    assert second["ws-a"]["annotations"] == {"ingested": 0, "skipped": 2}
+
+
+def test_ingest_bundle_requires_full_workspace_map(tmp_path, quiet_platform):
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC])
+    with pytest.raises(RuntimeError, match="no target for bundle workspace 'ws-a'"):
+        reingest.ingest_bundle("http://x", export_dir, _manifest("ws-a", 1), workspace_map={}, catalog=CATALOG)
+
+
+def test_ingest_bundle_validates_target_names(tmp_path, quiet_platform):
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC])
+    with pytest.raises(RuntimeError, match="naming rule"):
+        reingest.ingest_bundle(
+            "http://x",
+            export_dir,
+            _manifest("ws-a", 1),
+            workspace_map={"ws-a": "Bad--Name-"},
+            catalog=CATALOG,
+        )
+
+
+# --- source guard: only otel-sourced corpora are restorable (B1) ---
+
+
+def test_ingest_bundle_rejects_non_otel_sources(tmp_path, quiet_platform):
+    """ATIF/chat-completions span ids are not OTLP hex — bytes.fromhex would crash mid-batch
+    (partial restore) and any doc that survived would silently mutate (source_format -> otel).
+    The guard must fire BEFORE any network I/O, naming workspace + offending sources."""
+    atif = {**AGENT_DOC, "source": "atif", "span_id": "span-abc123"}
+    chat = {**LLM_DOC, "source": "chat-completions", "span_id": "chatcmpl-xyz"}
+    export_dir = _write_export(tmp_path, "ws-a", [atif, chat, AGENT_DOC], [ANNOTATION_DOC])
+    with pytest.raises(RuntimeError) as exc:
+        reingest.ingest_bundle(
+            "http://x",
+            export_dir,
+            _manifest("ws-a", 3, 1),
+            workspace_map={"ws-a": "ws-b"},
+            catalog=CATALOG,
+        )
+    message = str(exc.value)
+    assert "ws-a" in message  # names the workspace
+    assert "atif" in message and "chat-completions" in message  # offending source values
+    assert "otel" in message  # states only otel-sourced corpora are restorable
+    assert quiet_platform["requests"] == []
+    assert quiet_platform["posts"] == []
+    assert quiet_platform["ensured"] == []  # nothing touched the platform at all
+
+
+def test_ingest_bundle_non_otel_anywhere_blocks_every_workspace(tmp_path, quiet_platform):
+    """The scan covers ALL bundle workspaces before ingesting ANY — all-or-nothing."""
+    _write_export(tmp_path, "ws-a", [AGENT_DOC])
+    ws_dir = tmp_path / "export" / "ws-c"
+    ws_dir.mkdir(parents=True)
+    bad = {**AGENT_DOC, "source": "atif"}
+    (ws_dir / "spans.jsonl").write_text(json.dumps(bad) + "\n", encoding="utf-8")
+    manifest = {
+        "workspaces": ["ws-a", "ws-c"],
+        "counts": {"ws-a": {"spans": 1}, "ws-c": {"spans": 1}},
+        "min_start_time": datetime.now(timezone.utc).isoformat(),
+    }
+    with pytest.raises(RuntimeError, match="ws-c"):
+        reingest.ingest_bundle(
+            "http://x",
+            tmp_path / "export",
+            manifest,
+            workspace_map={"ws-a": "ws-a-fx", "ws-c": "ws-c-fx"},
+            catalog=CATALOG,
+        )
+    assert quiet_platform["requests"] == []  # ws-a (clean) was NOT ingested either
+    assert quiet_platform["ensured"] == []
+
+
+# --- _wait_for_spans transient-error tolerance (B2) ---
+
+
+def test_wait_for_spans_tolerates_transient_connect_error():
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("transient blip")
+        return httpx.Response(200, json={"pagination": {"total_results": 2}})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        reingest._wait_for_spans("http://x", "ws-a", 2, client=client, timeout_s=30.0, sleep=lambda s: None)
+    assert calls["n"] == 2  # errored once, then saw the count and returned
+
+
+def test_wait_for_spans_treats_non_200_as_transient():
+    """span_count raises RuntimeError on non-200 — poll_visible's spirit: not-yet-visible."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(503, text="warming up")
+        return httpx.Response(200, json={"pagination": {"total_results": 1}})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        reingest._wait_for_spans("http://x", "ws-a", 1, client=client, timeout_s=30.0, sleep=lambda s: None)
+    assert calls["n"] == 2
+
+
+def test_wait_for_spans_deadline_reports_last_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("gateway down")
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(RuntimeError, match="gateway down"):
+            reingest._wait_for_spans("http://x", "ws-a", 2, client=client, timeout_s=0.0, sleep=lambda s: None)
+
+
+# --- first-span fingerprint probe on the skip path (B5) ---
+
+
+def test_first_span_id_fetches_earliest_with_epoch_bound():
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"data": [{"span_id": "72f937bfcb667a9e"}], "pagination": {}})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        assert reingest._first_span_id("http://x", "ws-b", client=client) == "72f937bfcb667a9e"
+    params = seen[0].url.params
+    assert seen[0].url.path == "/apis/intake/v2/workspaces/ws-b/spans"
+    assert params["page_size"] == "1"
+    assert params["sort"] == "started_at"  # ascending: the FIRST span
+    assert params["filter[started_at][gte]"] == "1970-01-01T00:00:00Z"  # beat the 30-day default lookback
+
+
+def test_first_span_id_transient_failure_returns_none():
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("blip")
+
+    with httpx.Client(transport=httpx.MockTransport(boom)) as client:
+        assert reingest._first_span_id("http://x", "ws-b", client=client) is None
+
+    def not_ready(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="nope")
+
+    with httpx.Client(transport=httpx.MockTransport(not_ready)) as client:
+        assert reingest._first_span_id("http://x", "ws-b", client=client) is None
+
+    def empty(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [], "pagination": {}})
+
+    with httpx.Client(transport=httpx.MockTransport(empty)) as client:
+        assert reingest._first_span_id("http://x", "ws-b", client=client) is None
+
+
+def test_skip_path_rejects_different_corpus_with_matching_counts(tmp_path, quiet_platform):
+    """Same span count, different first span id -> re-minted ref / foreign corpus: hard error."""
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC], [ANNOTATION_DOC], [RESULT_DOC])
+    quiet_platform["span_counts"] = [2]  # guard matches -> skip path
+    quiet_platform["first_ids"] = ["ffffffffffffffff"]  # but the workspace holds something else
+    with pytest.raises(RuntimeError, match="(?i)different"):
+        reingest.ingest_bundle(
+            "http://x",
+            export_dir,
+            _manifest("ws-a", 2, 1, 1),
+            workspace_map={"ws-a": "ws-b"},
+            catalog=CATALOG,
+        )
+    assert quiet_platform["requests"] == []
+    assert quiet_platform["posts"] == []
+
+
+def test_skip_path_probe_match_skips_as_before(tmp_path, quiet_platform, capsys):
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC], [ANNOTATION_DOC], [RESULT_DOC])
+    quiet_platform["span_counts"] = [2]
+    quiet_platform["first_ids"] = ["72f937bfcb667a9e"]  # AGENT_DOC is earliest by started_at
+    quiet_platform["annotation_counts"] = [1]
+    quiet_platform["result_counts"] = [1]
+    outcome = reingest.ingest_bundle(
+        "http://x",
+        export_dir,
+        _manifest("ws-a", 2, 1, 1),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+    )
+    assert "already restored" in capsys.readouterr().out
+    assert outcome["ws-a"]["spans"] == {"ingested": 0, "skipped": 2}
+
+
+def test_skip_path_probe_tolerates_started_at_ties(tmp_path, quiet_platform, capsys):
+    """Two docs share the min started_at: either id is an acceptable first span."""
+    tied = {**LLM_DOC, "started_at": AGENT_DOC["started_at"]}
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, tied])
+    quiet_platform["span_counts"] = [2]
+    quiet_platform["first_ids"] = [tied["span_id"]]  # the OTHER member of the tie
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [0]
+    reingest.ingest_bundle(
+        "http://x",
+        export_dir,
+        _manifest("ws-a", 2),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+    )
+    assert "already restored" in capsys.readouterr().out
+
+
+def test_skip_path_probe_failure_falls_back_to_count_guard(tmp_path, quiet_platform, capsys):
+    """Transient probe failure (fixture default: None) must NOT block the restore."""
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC])
+    quiet_platform["span_counts"] = [2]
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [0]
+    outcome = reingest.ingest_bundle(
+        "http://x",
+        export_dir,
+        _manifest("ws-a", 2),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+    )
+    assert ("first_span", "ws-b") in quiet_platform["counts"]  # the probe WAS attempted
+    assert "already restored" in capsys.readouterr().out
+    assert outcome["ws-a"]["spans"] == {"ingested": 0, "skipped": 2}
+
+
+# --- TTL / lookback guardrail ---
+
+
+def test_warn_if_stale_old_bundle(capsys):
+    manifest = {"min_start_time": "2026-01-01T00:00:00+00:00"}
+    message = reingest.warn_if_stale(manifest, now=datetime(2026, 7, 6, tzinfo=timezone.utc))
+    assert "SYSTEM STOP TTL MERGES" in message
+    assert "since" in message
+    assert "SYSTEM STOP TTL MERGES" in capsys.readouterr().err
+
+
+def test_warn_if_stale_fresh_or_unknown(capsys):
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    assert reingest.warn_if_stale({"min_start_time": "2026-06-26T18:14:41"}, now=now) is None
+    assert reingest.warn_if_stale({"min_start_time": None}, now=now) is None
+    assert capsys.readouterr().err == ""
+
+
+# --- TTL merges stopped on stale loopback restores (B3) ---
+
+
+def _stale_manifest(workspace: str, spans: int) -> dict:
+    manifest = _manifest(workspace, spans)
+    manifest["min_start_time"] = "2026-01-01T00:00:00+00:00"  # far past STALE_AFTER_DAYS
+    return manifest
+
+
+def test_stale_loopback_restore_stops_ttl_merges(tmp_path, quiet_platform, fake_docker, capsys):
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC])
+    quiet_platform["span_counts"] = [0, 2]
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [0]
+    reingest.ingest_bundle(
+        "http://localhost:8080",
+        export_dir,
+        _stale_manifest("ws-a", 2),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+        sleep=lambda s: None,
+    )
+    assert fake_docker == [
+        ["docker", "exec", reingest.CLICKHOUSE_CONTAINER, "clickhouse-client", "-q", "SYSTEM STOP TTL MERGES"]
+    ]
+    assert reingest.CLICKHOUSE_CONTAINER == "nmp-intake-clickhouse"  # pinned by run_clickhouse.sh
+    err = capsys.readouterr().err
+    assert "TTL merges" in err and "stopped" in err
+
+
+def test_stale_remote_restore_warns_but_never_touches_docker(tmp_path, quiet_platform, fake_docker, capsys):
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC])
+    quiet_platform["span_counts"] = [0, 2]
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [0]
+    reingest.ingest_bundle(
+        "http://intake.example.com:8080",
+        export_dir,
+        _stale_manifest("ws-a", 2),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+        sleep=lambda s: None,
+    )
+    assert fake_docker == []  # the local docker ClickHouse is NOT the remote target
+    assert "SYSTEM STOP TTL MERGES" in capsys.readouterr().err  # existing warning still shown
+
+
+def test_fresh_bundle_never_touches_ttl_merges(tmp_path, quiet_platform, fake_docker):
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC])
+    quiet_platform["span_counts"] = [0, 2]
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [0]
+    reingest.ingest_bundle(
+        "http://localhost:8080",
+        export_dir,
+        _manifest("ws-a", 2),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+        sleep=lambda s: None,
+    )
+    assert fake_docker == []
+
+
+@pytest.mark.parametrize("failure", ["rc1", "oserror"])
+def test_ttl_stop_failure_is_nonfatal_and_tells_user(tmp_path, quiet_platform, monkeypatch, capsys, failure):
+    def failing_run(cmd, **kwargs):
+        if failure == "oserror":
+            raise FileNotFoundError("docker not installed")
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="no such container")
+
+    monkeypatch.setattr(reingest.subprocess, "run", failing_run)
+    export_dir = _write_export(tmp_path, "ws-a", [AGENT_DOC, LLM_DOC])
+    quiet_platform["span_counts"] = [0, 2]
+    quiet_platform["annotation_counts"] = [0]
+    quiet_platform["result_counts"] = [0]
+    outcome = reingest.ingest_bundle(  # must not raise
+        "http://127.0.0.1:8080",
+        export_dir,
+        _stale_manifest("ws-a", 2),
+        workspace_map={"ws-a": "ws-b"},
+        catalog=CATALOG,
+        sleep=lambda s: None,
+    )
+    assert outcome["ws-a"]["spans"] == {"ingested": 2, "skipped": 0}
+    err = capsys.readouterr().err
+    assert "manually" in err and "SYSTEM STOP TTL MERGES" in err
+
+
+# --- normalization / diff rules ---
+
+
+def test_diff_normalizes_workspace_ingested_at_and_ordering():
+    restored = {
+        **AGENT_DOC,
+        "workspace": "scratch-reingest-x",
+        "ingested_at": "2026-07-06T09:00:00.000000",
+        # same raw attributes, different key order + key order inside the doc doesn't matter either
+        "raw_attributes": json.dumps(json.loads(AGENT_DOC["raw_attributes"]), sort_keys=True),
+    }
+    assert reingest._diff_collection([AGENT_DOC], [restored], workspace="ws-a", collection="spans") == []
+
+
+def test_diff_reports_value_changes_and_count_drift():
+    broken = {**AGENT_DOC, "output": "DIFFERENT"}
+    mismatches = reingest._diff_collection([AGENT_DOC], [broken], workspace="ws-a", collection="spans")
+    assert mismatches == ["ws-a/spans 72f937bfcb667a9e.output: 'ok' != 'DIFFERENT'"]
+    mismatches = reingest._diff_collection([AGENT_DOC], [], workspace="ws-a", collection="spans")
+    assert mismatches == ["ws-a/spans: 1 exported vs 0 restored"]
+
+
+def test_diff_normalizes_annotation_server_fields():
+    restored = {
+        **ANNOTATION_DOC,
+        "annotation_id": "ann-fresh",
+        "created_at": "2026-07-06T00:00:00",
+        "ingested_at": "2026-07-06T00:00:00",
+        "created_by": "someone",
+        "workspace": "scratch-reingest-x",
+    }
+    assert reingest._diff_collection([ANNOTATION_DOC], [restored], workspace="ws-a", collection="annotations") == []
+
+
+def test_diff_normalizes_evaluator_result_id():
+    restored = {**RESULT_DOC, "evaluator_result_id": "eval-other", "workspace": "w2"}
+    diff = reingest._diff_collection([RESULT_DOC], [restored], workspace="ws-a", collection="evaluator_results")
+    assert diff == []
+    changed = {**restored, "value": 1.0}
+    diff = reingest._diff_collection([RESULT_DOC], [changed], workspace="ws-a", collection="evaluator_results")
+    assert len(diff) == 1 and "value" in diff[0]
+
+
+# --- roundtrip_diff wiring ---
+
+
+def test_roundtrip_diff_maps_scratch_reexports_and_cleans_up(tmp_path, monkeypatch):
+    export_dir = _write_export(tmp_path / "src", "ws-a", [AGENT_DOC], [ANNOTATION_DOC], [RESULT_DOC])
+    manifest = _manifest("ws-a", 1, 1, 1)
+    seen = {}
+
+    def fake_ingest(base_url, exp_dir, mani, *, workspace_map, catalog, sleep):
+        seen["map"] = workspace_map
+        return {}
+
+    def fake_export(base_url, workspaces, out_dir, *, since):
+        seen["exported"] = (workspaces, since)
+        restored = {**AGENT_DOC, "workspace": workspaces[0], "ingested_at": "2026-07-06T00:00:00"}
+        ann = {**ANNOTATION_DOC, "annotation_id": "ann-new", "workspace": workspaces[0]}
+        res = {**RESULT_DOC, "evaluator_result_id": "eval-new", "workspace": workspaces[0]}
+        _write_export(out_dir, workspaces[0], [restored], [ann], [res])
+        return {"workspaces": {}}
+
+    monkeypatch.setattr(reingest, "ingest_bundle", fake_ingest)
+    monkeypatch.setattr(reingest.export, "export_workspaces", fake_export)
+    monkeypatch.setattr(reingest, "cleanup_scratch", lambda url, ws: seen.setdefault("cleaned", ws))
+
+    mismatches = reingest.roundtrip_diff(
+        "http://x",
+        export_dir,
+        manifest,
+        scratch_prefix="scratch-reingest-",
+        catalog=CATALOG,
+        content_key="cafef00d",
+    )
+    assert mismatches == []
+    assert seen["map"] == {"ws-a": "scratch-reingest-cafef00d-ws-a"}
+    assert seen["exported"] == (["scratch-reingest-cafef00d-ws-a"], None)
+    assert seen["cleaned"] == ["scratch-reingest-cafef00d-ws-a"]
+
+
+def test_roundtrip_diff_cleans_up_even_when_ingest_fails(tmp_path, monkeypatch):
+    export_dir = _write_export(tmp_path / "src", "ws-a", [AGENT_DOC])
+    cleaned = []
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("ingest exploded")
+
+    monkeypatch.setattr(reingest, "ingest_bundle", boom)
+    monkeypatch.setattr(reingest, "cleanup_scratch", lambda url, ws: cleaned.extend(ws))
+    with pytest.raises(RuntimeError, match="ingest exploded"):
+        reingest.roundtrip_diff(
+            "http://x",
+            export_dir,
+            _manifest("ws-a", 1),
+            scratch_prefix="scratch-reingest-",
+            catalog=CATALOG,
+            content_key="cafef00d",
+        )
+    assert cleaned == ["scratch-reingest-cafef00d-ws-a"]
+
+
+# --- scratch naming is content-scoped (B4a) ---
+
+
+def test_scratch_workspace_map_scoped_by_content_key():
+    manifest = _manifest("ws-a", 2)
+    mapping = reingest._scratch_workspace_map(manifest, "scratch-rt-", "a1b2c3d4")
+    assert mapping == {"ws-a": "scratch-rt-a1b2c3d4-ws-a"}
+    assert all(reingest._WS_OK.fullmatch(name) for name in mapping.values())
+
+
+def test_scratch_workspace_map_default_key_deterministic_from_manifest():
+    manifest = _manifest("ws-a", 2)
+    first = reingest._scratch_workspace_map(manifest, "scratch-rt-", None)
+    again = reingest._scratch_workspace_map(dict(manifest), "scratch-rt-", None)
+    assert first == again  # deterministic: same counts+bounds -> same names
+    other = reingest._scratch_workspace_map(_manifest("ws-a", 3), "scratch-rt-", None)
+    assert first != other  # different content -> different scratch names
+    assert all(reingest._WS_OK.fullmatch(name) for name in first.values())
+    assert first["ws-a"].startswith("scratch-rt-") and first["ws-a"].endswith("-ws-a")
+
+
+def test_scratch_workspace_map_truncates_long_names_within_ws_rules():
+    long_ws = "w" + "x" * 58  # a valid 59-char source workspace
+    manifest = {"workspaces": [long_ws], "counts": {long_ws: {"spans": 1}}}
+    mapping = reingest._scratch_workspace_map(manifest, "scratch-rt-", "a1b2c3d4")
+    name = mapping[long_ws]
+    assert len(name) <= 63
+    assert name.startswith("scratch-rt-a1b2c3d4-")
+    assert reingest._WS_OK.fullmatch(name)
+
+
+def test_scratch_workspace_map_unsafe_content_key_is_hashed():
+    manifest = _manifest("ws-a", 1)
+    mapping = reingest._scratch_workspace_map(manifest, "scratch-rt-", "Not*Hex!")
+    assert all(reingest._WS_OK.fullmatch(name) for name in mapping.values())
+    # still content-scoped: a different key yields a different name
+    other = reingest._scratch_workspace_map(manifest, "scratch-rt-", "Other*Key!")
+    assert mapping != other
+
+
+# --- cleanup_scratch respects the target (B4b) ---
+
+
+def test_cleanup_scratch_remote_leaves_rows_and_record_and_reports(monkeypatch, fake_docker, capsys):
+    """Remote target: local docker is NOT the target's ClickHouse — deleting the workspace
+    record would orphan rows behind it. Leave BOTH; tell the user what was left."""
+
+    class _NoHTTP:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("remote cleanup must not touch the entities API")
+
+    monkeypatch.setattr(reingest.httpx, "Client", _NoHTTP)
+    reingest.cleanup_scratch("http://intake.example.com:8080", ["scratch-rt-abc12345-ws-a", "scratch-rt-abc12345-ws-b"])
+    assert fake_docker == []
+    err = capsys.readouterr().err
+    assert "scratch-rt-abc12345-ws-a" in err and "scratch-rt-abc12345-ws-b" in err
+    assert "manual" in err.lower()
+
+
+def test_cleanup_scratch_loopback_deletes_rows_and_records(monkeypatch, fake_docker):
+    deleted: list[str] = []
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def delete(self, url):
+            deleted.append(url)
+            return httpx.Response(204)
+
+    monkeypatch.setattr(reingest.httpx, "Client", _FakeClient)
+    monkeypatch.setattr(reingest.shutil, "which", lambda name: "/usr/bin/docker")
+    reingest.cleanup_scratch("http://127.0.0.1:8080", ["scratch-rt-abc12345-ws-a"])
+    tables = {cmd[-1].split("FROM intake.")[1].split(" ")[0] for cmd in fake_docker}
+    assert tables == {"spans", "annotations", "evaluator_results", "trace_index"}
+    assert len(deleted) == 1 and deleted[0].endswith("/apis/entities/v2/workspaces/scratch-rt-abc12345-ws-a")
+
+
+def test_roundtrip_diff_rejects_non_scratch_prefix(tmp_path):
+    with pytest.raises(ValueError, match="scratch-"):
+        reingest.roundtrip_diff("http://x", tmp_path, _manifest("ws-a", 1), scratch_prefix="prod-", catalog=CATALOG)
+
+
+def test_roundtrip_diff_surfaces_mismatches(tmp_path, monkeypatch):
+    export_dir = _write_export(tmp_path / "src", "ws-a", [AGENT_DOC])
+    manifest = _manifest("ws-a", 1)
+
+    def fake_export(base_url, workspaces, out_dir, *, since):
+        broken = {**AGENT_DOC, "workspace": workspaces[0], "output": "MANGLED"}
+        _write_export(out_dir, workspaces[0], [broken])
+        return {"workspaces": {}}
+
+    monkeypatch.setattr(reingest, "ingest_bundle", lambda *a, **k: {})
+    monkeypatch.setattr(reingest.export, "export_workspaces", fake_export)
+    monkeypatch.setattr(reingest, "cleanup_scratch", lambda url, ws: None)
+    mismatches = reingest.roundtrip_diff(
+        "http://x", export_dir, manifest, scratch_prefix="scratch-reingest-", catalog=CATALOG
+    )
+    assert mismatches == ["ws-a/spans 72f937bfcb667a9e.output: 'ok' != 'MANGLED'"]
+
+
+# --- platform-root resolution / fixture workspace mapping / bundle since (Task 3 helpers) ---
+
+
+def _checkout_with_catalog(root: Path) -> Path:
+    catalog = root / reingest.CATALOG_RELPATH
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text("ATTRIBUTE_SPECS = ()\n", encoding="utf-8")
+    return root
+
+
+def test_resolve_platform_root_explicit_beats_everything(tmp_path):
+    root = reingest.resolve_platform_root(
+        str(tmp_path / "explicit"),
+        env={"NMP_PLATFORM_ROOT": "/env"},
+        candidates=[tmp_path / "cand"],
+    )
+    assert root == tmp_path / "explicit"
+
+
+def test_resolve_platform_root_env_beats_candidates(tmp_path):
+    good = _checkout_with_catalog(tmp_path / "cand")
+    root = reingest.resolve_platform_root(None, env={"NMP_PLATFORM_ROOT": "/env"}, candidates=[good])
+    assert root == Path("/env")
+
+
+def test_resolve_platform_root_first_candidate_with_catalog_wins(tmp_path):
+    ci = _checkout_with_catalog(tmp_path / "ci" / "nemo-platform")
+    home = _checkout_with_catalog(tmp_path / "home" / "nemo-platform")
+    assert reingest.resolve_platform_root(None, env={}, candidates=[ci, home]) == ci
+
+
+def test_resolve_platform_root_skips_catalogless_candidate(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    good = _checkout_with_catalog(tmp_path / "good")
+    assert reingest.resolve_platform_root(None, env={}, candidates=[empty, good]) == good
+
+
+def test_resolve_platform_root_nothing_found_exits_with_fix(tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        reingest.resolve_platform_root(None, env={}, candidates=[tmp_path / "nowhere"])
+    assert "--platform-root" in str(exc.value)
+    assert "NMP_PLATFORM_ROOT" in str(exc.value)
+
+
+def test_default_platform_roots_monorepo_then_legacy_checkout():
+    plugin_root = Path(reingest.__file__).resolve().parent.parent
+    assert reingest.default_platform_roots() == [
+        plugin_root.parents[1],
+        Path.home() / "workstation" / "nemo-platform",
+    ]
+
+
+def test_fixture_workspace_map_ref_suffix():
+    assert reingest.fixture_workspace_map(["tau2-airline", "tau2-airline-oracle"], "state-v6") == {
+        "tau2-airline": "tau2-airline-state-v6",
+        "tau2-airline-oracle": "tau2-airline-oracle-state-v6",
+    }
+
+
+def test_fixture_workspace_map_rejects_invalid_target():
+    # a trailing hyphen in the source yields a forbidden double hyphen in the target
+    with pytest.raises(SystemExit, match="naming rule"):
+        reingest.fixture_workspace_map(["ws-"], "state-v6")
+
+
+def test_bundle_digest_is_sha256_prefix(tmp_path):
+    import hashlib
+
+    bundle = tmp_path / "b.tar.zst"
+    bundle.write_bytes(b"bundle-bytes")
+    assert reingest.bundle_digest(bundle) == hashlib.sha256(b"bundle-bytes").hexdigest()[:8]
+    assert len(reingest.bundle_digest(bundle)) == 8
+
+
+def test_manifest_since_floors_min_start_time():
+    since = reingest.manifest_since({"min_start_time": "2026-06-01T12:00:00+00:00"})
+    assert since == datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
+
+
+def test_manifest_since_naive_timestamp_is_utc():
+    since = reingest.manifest_since({"min_start_time": "2026-06-01T12:00:00"})
+    assert since == datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
+
+
+def test_manifest_since_missing_bound_is_epoch():
+    assert reingest.manifest_since({}) == datetime(1970, 1, 1, tzinfo=timezone.utc)
+    assert reingest.manifest_since({"min_start_time": None}) == datetime(1970, 1, 1, tzinfo=timezone.utc)

--- a/plugins/nemo-insights/tests/testbed/test_release.py
+++ b/plugins/nemo-insights/tests/testbed/test_release.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+from testbed import release
+
+_LOCK = '[subjects]\ntau2-airline = "state-v6"\nnvq = "state-v9"\n'
+
+
+def _write_lock(tmp_path: Path, text: str = _LOCK) -> Path:
+    lock = tmp_path / "state.lock"
+    lock.write_text(text, encoding="utf-8")
+    return lock
+
+
+def test_latest_ref_numeric_sort():
+    names = ["state-v2.tar.zst", "state-v10.tar.zst", "junk.txt", "state-v3-failed.tar.zst"]
+    assert release.latest_ref(names) == "state-v10"
+
+
+def test_latest_ref_empty():
+    assert release.latest_ref([]) is None
+
+
+def test_next_ref():
+    assert release.next_ref("state-v10") == "state-v11"
+    assert release.next_ref(None) == "state-v1"
+
+
+def test_lock_ref_returns_subject_entry(tmp_path):
+    lock = _write_lock(tmp_path)
+    assert release.lock_ref(lock, "tau2-airline") == "state-v6"
+    assert release.lock_ref(lock, "nvq") == "state-v9"
+
+
+def test_lock_ref_subject_without_entry_returns_none(tmp_path):
+    assert release.lock_ref(_write_lock(tmp_path), "tau2-retail") is None
+
+
+def test_lock_ref_missing_file_returns_none(tmp_path):
+    assert release.lock_ref(tmp_path / "absent.lock", "tau2-airline") is None
+
+
+def test_lock_ref_old_single_pin_format_exits_with_migration_message(tmp_path):
+    lock = _write_lock(tmp_path, '# comment\nstate_ref = "state-v6"\n')
+    with pytest.raises(SystemExit) as exc:
+        release.lock_ref(lock, "tau2-airline")
+    message = str(exc.value)
+    assert "[subjects]" in message
+    assert 'tau2-airline = "state-v6"' in message  # quotes the expected format
+
+
+def test_repo_lock_file_is_per_subject_and_pins_tau2_airline():
+    """The checked-in lock must parse under the new format and pin the live subject."""
+    lock = Path(release.__file__).parent / "state.lock"
+    ref = release.lock_ref(lock, "tau2-airline")
+    assert ref is not None and re.fullmatch(r"state-v\d+", ref)
+
+
+def test_release_asset_names_missing_release_returns_empty(monkeypatch):
+    def fake_gh(*args):
+        raise subprocess.CalledProcessError(1, ["gh", *args], stderr="release not found\n")
+
+    monkeypatch.setattr(release, "_gh", fake_gh)
+    assert release._release_asset_names() == []
+
+
+def test_release_asset_names_other_failure_raises(monkeypatch):
+    def fake_gh(*args):
+        raise subprocess.CalledProcessError(1, ["gh", *args], stderr="HTTP 500 (Internal Server Error)\n")
+
+    monkeypatch.setattr(release, "_gh", fake_gh)
+    with pytest.raises(subprocess.CalledProcessError):
+        release._release_asset_names()
+
+
+def test_gh_prints_stderr_on_failure(monkeypatch, capsys):
+    def fake_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0], stderr="gh: some auth error\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(subprocess.CalledProcessError):
+        release._gh("release", "view", "testbed-state", "--json", "assets")
+    assert "gh: some auth error" in capsys.readouterr().err
+
+
+def test_gh_missing_binary_exits_with_install_pointer(monkeypatch):
+    """No gh on PATH must be a clean exit with an install pointer, not a raw traceback."""
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "gh")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(SystemExit) as exc:
+        release._gh("release", "view", "testbed-state")
+    assert str(exc.value) == ("gh CLI not found — install GitHub CLI (https://cli.github.com) and run `gh auth login`")
+
+
+def test_resolve_state_explicit_ref_bypasses_lock(tmp_path):
+    # tau2-retail has no lock entry and the lock pins other subjects to other
+    # versions — an explicit ref must be returned verbatim, no lock consulted.
+    lock = _write_lock(tmp_path)
+    assert release.resolve_state("state-v2", subject="tau2-airline", lock_path=lock) == "state-v2"
+    assert release.resolve_state("state-v2", subject="tau2-retail", lock_path=lock) == "state-v2"
+    assert release.resolve_state("state-v2", subject=None, lock_path=tmp_path / "absent.lock") == "state-v2"
+
+
+@pytest.mark.parametrize("bad", ["state-6", "latest", "v6", "state-v6.tar.zst", ""])
+def test_resolve_state_rejects_malformed_ref(tmp_path, bad):
+    with pytest.raises(SystemExit) as exc:
+        release.resolve_state(bad, subject="tau2-airline", lock_path=_write_lock(tmp_path))
+    message = str(exc.value)
+    assert bad in message  # names the offender
+    assert "state-v<N>" in message  # names the expected pattern
+    # the file hint must match each command's real surface: analyze takes --state FILE,
+    # restore takes the positional FILE (its --state is refs-only)
+    assert "--state FILE" in message and "positional FILE" in message
+
+
+def test_resolve_state_none_uses_subject_lock_entry(tmp_path):
+    lock = _write_lock(tmp_path)
+    assert release.resolve_state(None, subject="tau2-airline", lock_path=lock) == "state-v6"
+    assert release.resolve_state(None, subject="nvq", lock_path=lock) == "state-v9"
+
+
+def test_resolve_state_rejects_malformed_lock_pin(tmp_path):
+    """A typo'd pin must die naming the entry, not flow into a doomed gh download."""
+    lock = _write_lock(tmp_path, '[subjects]\ntau2-airline = "v6"\n')
+    with pytest.raises(SystemExit) as exc:
+        release.resolve_state(None, subject="tau2-airline", lock_path=lock)
+    assert str(exc.value) == "state.lock entry for 'tau2-airline' is 'v6' — expected state-v<N> (e.g. state-v6)"
+
+
+def test_resolve_state_none_missing_entry_exits_with_guidance(tmp_path):
+    # resolve_state serves both analyze and restore, so the guidance names each
+    # command's real surface instead of recommending flags one of them lacks.
+    for lock_path in (_write_lock(tmp_path), tmp_path / "absent.lock"):
+        with pytest.raises(SystemExit) as exc:
+            release.resolve_state(None, subject="tau2-retail", lock_path=lock_path)
+        assert str(exc.value) == (
+            "no state.lock entry for subject 'tau2-retail' — add it under [subjects] "
+            "after minting a fixture, or pass an explicit state "
+            "(analyze: --live / --state <state-vN|FILE>; restore: FILE / --state state-vN)"
+        )
+
+
+def test_resolve_state_none_without_subject_exits(tmp_path):
+    """Subject-agnostic callers (restore) have no lock entry — a None state must be loud."""
+    with pytest.raises(SystemExit) as exc:
+        release.resolve_state(None, subject=None, lock_path=_write_lock(tmp_path))
+    assert "--state" in str(exc.value)
+
+
+def test_download_ref_gh_args_and_return_path(tmp_path, monkeypatch):
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(*args):
+        calls.append(args)
+        return ""
+
+    monkeypatch.setattr(release, "_gh", fake_gh)
+    dest = tmp_path / "dl"
+    result = release.download_ref("state-v4", dest)
+    assert calls == [
+        ("release", "download", "testbed-state", "--pattern", "state-v4.tar.zst", "--dir", str(dest), "--clobber")
+    ]
+    assert dest.is_dir()
+    assert result == tmp_path / "dl" / "state-v4.tar.zst"
+
+
+def test_download_ref_reuses_cached_file_without_gh(tmp_path, monkeypatch, capsys):
+    """Refs are immutable: an already-downloaded tarball is reused, gh never invoked."""
+    dest = tmp_path / "dl"
+    dest.mkdir()
+    (dest / "state-v4.tar.zst").write_bytes(b"cached bytes")
+    monkeypatch.setattr(release, "_gh", lambda *args: pytest.fail("cached ref must not invoke gh"))
+    result = release.download_ref("state-v4", dest)
+    assert result == dest / "state-v4.tar.zst"
+    assert result.read_bytes() == b"cached bytes"
+    assert "using cached state-v4.tar.zst" in capsys.readouterr().out

--- a/plugins/nemo-insights/tests/testbed/test_runstore.py
+++ b/plugins/nemo-insights/tests/testbed/test_runstore.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from testbed.runstore import load_run, save_run
+
+
+def test_save_and_load_roundtrip(tmp_path):
+    path = tmp_path / "tau2-airline.run.json"
+    record = {
+        "agent": "tau2-airline-x",
+        "workspace": "w",
+        "base_url": "u",
+        "domain": "airline",
+    }
+    save_run(path, record)
+    assert load_run(path) == record
+
+
+def test_load_missing_returns_none(tmp_path):
+    assert load_run(tmp_path / "nope.run.json") is None
+
+
+def test_save_creates_parent_dir(tmp_path):
+    path = tmp_path / "deep" / "nested" / "x.run.json"
+    save_run(path, {"k": 1})
+    assert path.exists()

--- a/plugins/nemo-insights/tests/testbed/test_summary.py
+++ b/plugins/nemo-insights/tests/testbed/test_summary.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import yaml
+from testbed.summary import render_summary_md
+
+
+def _write(tmp_path, insights):
+    path = tmp_path / "insights_x.yaml"
+    path.write_text(yaml.safe_dump({"insights": insights}))
+    return path
+
+
+def test_render_lists_each_insight(tmp_path):
+    path = _write(
+        tmp_path,
+        [
+            {
+                "id": "ins-1",
+                "title": "Agent skips policy lookup",
+                "status": "proposed",
+                "description": "First line.\nSecond line.",
+                "trace_refs": ["a", "b", "c"],
+            },
+            {"id": "ins-2", "title": "Refund loop", "status": "accepted", "trace_refs": []},
+        ],
+    )
+    md = render_summary_md(path, "tau2-airline")
+    assert "## Insights — tau2-airline (2)" in md
+    assert "**Agent skips policy lookup**" in md
+    assert "proposed" in md
+    assert "3 trace refs" in md
+    assert "First line." in md
+    assert "Second line." not in md  # only the first description line
+
+
+def test_render_missing_or_empty_file(tmp_path):
+    md = render_summary_md(tmp_path / "absent.yaml", "nvq")
+    assert "## Insights — nvq (0)" in md
+    assert "No insights" in md

--- a/plugins/nemo-insights/tests/testbed/test_tau2run.py
+++ b/plugins/nemo-insights/tests/testbed/test_tau2run.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from testbed.tau2run import (
+    build_argv,
+    load_simulations,
+    policy_version,
+    read_policy,
+    resolve_paths,
+    run_tau2,
+)
+
+CFG = {
+    "domain": "airline",
+    "agent_llm": "openai/m",
+    "user_llm": "openai/m",
+    "task_split_name": "test",
+    "num_trials": 1,
+    "seed": 300,
+    "max_concurrency": 4,
+}
+
+
+def test_build_argv_core_flags():
+    argv = build_argv(CFG, "run1")
+    assert argv == [
+        "tau2",
+        "run",
+        "--domain",
+        "airline",
+        "--agent-llm",
+        "openai/m",
+        "--user-llm",
+        "openai/m",
+        "--task-split-name",
+        "test",
+        "--num-trials",
+        "1",
+        "--seed",
+        "300",
+        "--max-concurrency",
+        "4",
+        "--save-to",
+        "run1",
+    ]
+
+
+def test_build_argv_optional_flags_and_bin():
+    argv = build_argv({**CFG, "num_tasks": 5, "timeout": 600}, "run1", tau2_bin="/x/tau2")
+    assert argv[0] == "/x/tau2"
+    assert argv[-4:] == ["--num-tasks", "5", "--timeout", "600"]
+
+
+def test_run_tau2_sets_data_dir_and_loads(tmp_path):
+    run_dir = tmp_path / "simulations" / "run1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "results.json").write_text(json.dumps({"simulations": [{"task_id": "0"}]}))
+    recorded = {}
+
+    def fake_runner(argv, *, env, check):
+        recorded["argv"] = argv
+        recorded["env"] = env
+        return subprocess.CompletedProcess(argv, 0)
+
+    sims = run_tau2(CFG, "run1", data_dir=tmp_path, tau2_bin="tau2", runner=fake_runner)
+    assert sims == [{"task_id": "0"}]
+    assert recorded["env"]["TAU2_DATA_DIR"] == str(tmp_path)
+    assert recorded["argv"][:2] == ["tau2", "run"]
+
+
+def test_run_tau2_raises_on_nonzero(tmp_path):
+    def fake_runner(argv, *, env, check):
+        return subprocess.CompletedProcess(argv, 1)
+
+    with pytest.raises(RuntimeError, match="exit 1"):
+        run_tau2(CFG, "run1", data_dir=tmp_path, tau2_bin="tau2", runner=fake_runner)
+
+
+def _write_results(tmp_path: Path, payload) -> Path:
+    run_dir = tmp_path / "simulations" / "r"
+    run_dir.mkdir(parents=True)
+    (run_dir / "results.json").write_text(json.dumps(payload))
+    return tmp_path
+
+
+def test_load_simulations_simulations_wrapper(tmp_path):
+    assert load_simulations(_write_results(tmp_path, {"simulations": [{"a": 1}]}), "r") == [{"a": 1}]
+
+
+def test_load_simulations_results_wrapper(tmp_path):
+    assert load_simulations(_write_results(tmp_path, {"results": [{"b": 2}]}), "r") == [{"b": 2}]
+
+
+def test_load_simulations_bare_list(tmp_path):
+    assert load_simulations(_write_results(tmp_path, [{"c": 3}]), "r") == [{"c": 3}]
+
+
+def test_load_simulations_empty_simulations_not_overridden(tmp_path):
+    payload = {"simulations": [], "results": [{"x": 1}]}
+    assert load_simulations(_write_results(tmp_path, payload), "r") == []
+
+
+def test_load_simulations_finds_tau2_nested(tmp_path):
+    # vanilla tau2-bench writes some layouts under data/tau2/...
+    run_dir = tmp_path / "tau2" / "simulations" / "r"
+    run_dir.mkdir(parents=True)
+    (run_dir / "results.json").write_text(json.dumps({"simulations": [{"n": 1}]}))
+    assert load_simulations(tmp_path, "r") == [{"n": 1}]
+
+
+def test_load_simulations_missing_file_raises(tmp_path):
+    with pytest.raises(RuntimeError, match="no tau2 results"):
+        load_simulations(tmp_path, "nope")
+
+
+def test_read_policy_flat_and_nested_and_absent(tmp_path):
+    # flat layout: <data>/domains/<domain>/policy.md
+    flat = tmp_path / "domains" / "airline"
+    flat.mkdir(parents=True)
+    (flat / "policy.md").write_text("FLAT POLICY")
+    # vanilla tau2-bench layout: <data>/tau2/domains/<domain>/policy.md
+    nested = tmp_path / "tau2" / "domains" / "retail"
+    nested.mkdir(parents=True)
+    (nested / "policy.md").write_text("NESTED POLICY")
+    assert read_policy(tmp_path, "airline") == "FLAT POLICY"
+    assert read_policy(tmp_path, "retail") == "NESTED POLICY"
+    assert read_policy(tmp_path, "telecom") is None
+
+
+def test_resolve_paths_from_repo_absolute():
+    tau2_bin, data_dir = resolve_paths({"tau2_repo": "/r"}, repo_root=Path("/root"))
+    assert tau2_bin == str(Path("/r") / ".venv" / "bin" / "tau2")
+    assert data_dir == Path("/r/data")
+
+
+def test_resolve_paths_relative_anchored_to_repo_root():
+    root = Path("/home/x/proj")
+    tau2_bin, data_dir = resolve_paths({"tau2_repo": "../tau2-bench"}, repo_root=root)
+    assert data_dir == root / "../tau2-bench" / "data"
+    assert tau2_bin == str(root / "../tau2-bench" / ".venv" / "bin" / "tau2")
+
+
+def test_resolve_paths_explicit_overrides_win():
+    tau2_bin, data_dir = resolve_paths(
+        {"tau2_repo": "/r", "tau2_bin": "/x/tau2", "tau2_data_dir": "/d"},
+        repo_root=Path("/root"),
+    )
+    assert tau2_bin == "/x/tau2"
+    assert data_dir == Path("/d")
+
+
+def test_resolve_paths_unset_is_none():
+    tau2_bin, data_dir = resolve_paths({}, repo_root=Path("/root"))
+    assert tau2_bin is None
+    assert data_dir is None
+
+
+def test_policy_version():
+    v = policy_version("POLICY TEXT")
+    assert len(v) == 12 and all(c in "0123456789abcdef" for c in v)
+    assert policy_version(None) == "unknown"
+    assert policy_version("") == "unknown"
+
+
+def test_load_tasks_reads_nested_and_missing(tmp_path):
+    from testbed.tau2run import load_tasks
+
+    dom = tmp_path / "tau2" / "domains" / "airline"
+    dom.mkdir(parents=True)
+    (dom / "tasks.json").write_text(json.dumps([{"id": "8", "description": {"purpose": "p"}}, {"id": 9}]))
+    tasks = load_tasks(tmp_path, "airline")
+    assert set(tasks) == {"8", "9"}
+    assert tasks["8"]["description"]["purpose"] == "p"
+    assert load_tasks(tmp_path, "retail") == {}  # absent -> empty

--- a/plugins/nemo-insights/tests/testbed/test_timeparse.py
+++ b/plugins/nemo-insights/tests/testbed/test_timeparse.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from testbed.timeparse import parse_since
+
+
+def test_none_returns_none():
+    assert parse_since(None) is None
+
+
+def test_empty_string_returns_none():
+    assert parse_since("") is None
+
+
+def test_toml_date_becomes_utc_midnight():
+    # tomllib yields a `date` for an unquoted `since = 2026-06-01`.
+    assert parse_since(date(2026, 6, 1)).isoformat() == "2026-06-01T00:00:00+00:00"
+
+
+def test_toml_datetime_normalized_to_utc():
+    # tomllib yields an aware `datetime` for `since = 2026-06-01T00:00:00-07:00`.
+    aware = datetime(2026, 6, 1, tzinfo=timezone(timedelta(hours=-7)))
+    assert parse_since(aware).isoformat() == "2026-06-01T07:00:00+00:00"
+
+
+def test_non_string_non_date_exits():
+    # `since = 7` (TOML int) is ambiguous → clean exit, not AttributeError.
+    with pytest.raises(SystemExit):
+        parse_since(7)
+
+
+def test_lookback_days_is_utc_aware():
+    dt = parse_since("7d")
+    assert dt is not None and dt.utcoffset().total_seconds() == 0
+
+
+def test_naive_iso_assumed_utc():
+    assert parse_since("2026-06-01").isoformat() == "2026-06-01T00:00:00+00:00"
+
+
+def test_offset_iso_normalized_to_utc():
+    assert parse_since("2026-06-01T00:00:00-07:00").isoformat() == "2026-06-01T07:00:00+00:00"
+
+
+def test_bad_value_exits():
+    with pytest.raises(SystemExit):
+        parse_since("7D")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ dependencies = [
 version = "0.0.0"
 
 [dependency-groups]
+# Optional Insights analyst plugin.
+insights = ["nemo-insights-plugin"]
 dev = [
   "pre-commit>=3.8.0",
   "pydantic-settings>=2.6.1",
@@ -368,6 +370,7 @@ nmp-dev-mcp = { workspace = true }
 nmp-testing = { workspace = true }
 nmp-build-tools = { workspace = true }
 nemo-platform-plugin = { workspace = true }
+nemo-insights-plugin = { path = "plugins/nemo-insights", editable = true }
 
 nemo-evaluator-plugin = { workspace = true }
 nemo-guardrails-plugin = { workspace = true }
@@ -443,7 +446,12 @@ members = [
   "services/unsloth",
   "services/rl",
 ]
-
+exclude = [
+  # Keep the analyst out of `uv sync --all-packages`; install it explicitly
+  # through the `insights` dependency group.
+  "plugins/nemo-insights",
+  "plugins/nemo-insights/examples/*",
+]
 
 
 [build-system]
@@ -520,6 +528,7 @@ output = "coverage.xml"
 extraPaths = [
   "plugins/nemo-guardrails/src",
   "plugins/nemo-evaluator/src",
+  "plugins/nemo-insights/src",
   "tests/agentic-use",
   "tests/agentic-use/shared",
 ]
@@ -553,6 +562,8 @@ extra-paths = [
   # nemo-evaluator plugin is not a workspace member; add its src so ty can
   # resolve nemo_evaluator imports when checking plugin test files.
   "plugins/nemo-evaluator/src",
+  # The optional Insights analyst is not part of the default environment.
+  "plugins/nemo-insights/src",
   # Agentic-use tests place both tests/agentic-use and tests/agentic-use/shared
   # on sys.path in tests/conftest.py.
   "tests/agentic-use",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -370,7 +370,7 @@ nmp-dev-mcp = { workspace = true }
 nmp-testing = { workspace = true }
 nmp-build-tools = { workspace = true }
 nemo-platform-plugin = { workspace = true }
-nemo-insights-plugin = { path = "plugins/nemo-insights", editable = true }
+nemo-insights-plugin = { workspace = true }
 
 nemo-evaluator-plugin = { workspace = true }
 nemo-guardrails-plugin = { workspace = true }
@@ -436,6 +436,7 @@ members = [
   "plugins/nemo-switchyard",
   "plugins/nemo-agents",
   "plugins/nemo-deployments",
+  "plugins/nemo-insights",
   "plugins/nemo-agents/examples/calculator-agent",
   "plugins/nemo-agents/examples/email-phishing-analyzer",
   "plugins/nemo-customizer",
@@ -445,12 +446,6 @@ members = [
   "services/automodel",
   "services/unsloth",
   "services/rl",
-]
-exclude = [
-  # Keep the analyst out of `uv sync --all-packages`; install it explicitly
-  # through the `insights` dependency group.
-  "plugins/nemo-insights",
-  "plugins/nemo-insights/examples/*",
 ]
 
 

--- a/tests/discovery_exclusions.py
+++ b/tests/discovery_exclusions.py
@@ -3,8 +3,14 @@
 
 """Centralized temporary exclusions for automatic root test discovery."""
 
+from importlib.util import find_spec
 from pathlib import Path
 
 TEST_DISCOVERY_EXCLUSIONS: dict[Path, str] = {
     Path("plugins/nemo-agents/tests"): "Not installed by the normal root uv environment yet.",
 }
+
+if find_spec("nemo_insights_plugin") is None:
+    TEST_DISCOVERY_EXCLUSIONS[Path("plugins/nemo-insights/tests")] = (
+        "The optional insights dependency group is not installed in the root test environment."
+    )

--- a/tools/lint/lint-python-types.sh
+++ b/tools/lint/lint-python-types.sh
@@ -24,4 +24,4 @@ for rule in "${ci_ignored_rules[@]}"; do
   ignore_args+=(--ignore "$rule")
 done
 
-uv run --frozen ty check --exit-zero-on-warning "${ignore_args[@]}"
+uv run --frozen --group insights ty check --exit-zero-on-warning "${ignore_args[@]}"

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,7 @@ members = [
     "nemo-evaluator-plugin",
     "nemo-evaluator-sdk",
     "nemo-guardrails-plugin",
+    "nemo-insights-plugin",
     "nemo-nb",
     "nemo-platform",
     "nemo-platform-ext",

--- a/uv.lock
+++ b/uv.lock
@@ -379,7 +379,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.101.0"
+version = "0.116.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -391,9 +391,9 @@ dependencies = [
     { name = "sniffio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/cb/9d0123243e749ac3a579972b2c398971bce1dc57bcc4efb08066df610360/anthropic-0.101.0.tar.gz", hash = "sha256:1116a6a87c55757e0fbe3e1ba40804fbd04de7963601a6dd6b539a889f18de3e", size = 758603, upload-time = "2026-05-11T15:46:33.944Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/a2/d31f14e28d49bae983a3634e38dfb4b31c50110b5e403596c5c6a20b23f8/anthropic-0.116.0.tar.gz", hash = "sha256:5fc248fbb9fe03ef686f8a774f81586bca31a043260aab88b387ea3660f4a396", size = 949149, upload-time = "2026-07-02T19:08:10.534Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/b2/74ff06762d005ecf1658929a292df0acb786d025f6a6c54fcb30e2dc7761/anthropic-0.101.0-py3-none-any.whl", hash = "sha256:cc3cc6576989471e2aa9132258034ad0ff0d8fe500b04ac499e4e46ed68c5ed0", size = 753594, upload-time = "2026-05-11T15:46:32.216Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/dd/2a1e81cf1b163acc340afc4ec74ed1d86f5eed1a809fabdeed3e0997b346/anthropic-0.116.0-py3-none-any.whl", hash = "sha256:6c0a7698e8d652455da3499978279bb2588c7264d0a35be3666009a4258c8256", size = 956896, upload-time = "2026-07-02T19:08:08.756Z" },
 ]
 
 [[package]]
@@ -1718,11 +1718,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.25.2"
+version = "3.29.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
 ]
 
 [[package]]
@@ -1880,6 +1880,19 @@ requires-dist = [
     { name = "xdg-base-dirs", specifier = ">=6.0.1" },
 ]
 provides-extras = ["tests", "lint"]
+
+[[package]]
+name = "genai-prices"
+version = "0.0.62"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/8e/ed322d1f22b57fd455749bdbe2f285d310e1c1ebe921cb3d5c0b920de648/genai_prices-0.0.62.tar.gz", hash = "sha256:baf1ffa64be0d15577878216464d6a2d04244db5fbdf78d56bde43809e7aef44", size = 67611, upload-time = "2026-05-25T18:47:16.306Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/35/ce64112dcc6f406b3e290dcf57a97acfa2b7d3d0391979219cb9d4a9db6d/genai_prices-0.0.62-py3-none-any.whl", hash = "sha256:5d9ab0d9e5d81e035f88bf591fb6a8dde527922786acf1ee2737358f7bbe0167", size = 70333, upload-time = "2026-05-25T18:47:17.642Z" },
+]
 
 [[package]]
 name = "genson"
@@ -3213,6 +3226,15 @@ wheels = [
 ]
 
 [[package]]
+name = "logfire-api"
+version = "4.37.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/04/471b916249fe7e22056818ca734af46418cd3ff9b9b920c1829c3627b4d2/logfire_api-4.37.0.tar.gz", hash = "sha256:0f62debd6ed593d51307277bd6d5636b57bda07935b5604b96db10fe64441af4", size = 88906, upload-time = "2026-06-12T20:47:08.163Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/2f/23e5b8fa22f75f73965c72e5c29e6fb8715263457394601e254fe26fbe31/logfire_api-4.37.0-py3-none-any.whl", hash = "sha256:1d756f8ba23aa56d438e0ba2c0f529a00fcac975b8785c561b058267f9465088", size = 138710, upload-time = "2026-06-12T20:47:05.526Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4347,6 +4369,43 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "ruff", specifier = ">=0.11.8" },
+]
+
+[[package]]
+name = "nemo-insights-plugin"
+version = "0.1.0"
+source = { editable = "plugins/nemo-insights" }
+dependencies = [
+    { name = "fastapi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "genai-prices", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-platform", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-exporter-otlp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic-ai-harness", extra = ["code-mode"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic-ai-slim", extra = ["anthropic"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "tzdata", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.115" },
+    { name = "genai-prices", specifier = "==0.0.62" },
+    { name = "httpx" },
+    { name = "nemo-platform", editable = "packages/nemo_platform" },
+    { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.42.1" },
+    { name = "opentelemetry-sdk", specifier = ">=1.42.1" },
+    { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "pydantic-ai-harness", extras = ["code-mode"], specifier = "==0.3.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic"], specifier = "==1.105.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "typer", specifier = ">=0.20.0" },
+    { name = "tzdata", specifier = "==2026.2" },
 ]
 
 [[package]]
@@ -6218,6 +6277,9 @@ gpu-tasks = [
     { name = "nmp-models", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nmp-platform", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
+insights = [
+    { name = "nemo-insights-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
 nmp-base = [
     { name = "nemo-platform", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -6424,6 +6486,7 @@ gpu-tasks = [
     { name = "nmp-models", editable = "services/core/models" },
     { name = "nmp-platform", editable = "packages/nmp_platform" },
 ]
+insights = [{ name = "nemo-insights-plugin", editable = "plugins/nemo-insights" }]
 nmp-base = [
     { name = "nemo-platform", editable = "packages/nemo_platform" },
     { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
@@ -8615,11 +8678,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.4"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -8952,6 +9015,46 @@ email = [
 ]
 
 [[package]]
+name = "pydantic-ai-harness"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic-ai-slim", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/ae/95ada09e80a7cf71a1a87fb2f824450387b324ddcf68a0dc7c54550c8d3e/pydantic_ai_harness-0.3.0.tar.gz", hash = "sha256:3a803c2569a3346830443ee7a646b0c2267659d2265ada560c12430cd16d2ffe", size = 536553, upload-time = "2026-05-13T19:23:08.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/08/6c3872d654ef40b0dde64bd839e857fc08f930386b583c369b7a07df27ef/pydantic_ai_harness-0.3.0-py3-none-any.whl", hash = "sha256:b3d363ce3bdadba89e6e3378c66a44ce77808a8fa959429d5d7bc07bea8c854f", size = 25497, upload-time = "2026-05-13T19:23:07.356Z" },
+]
+
+[package.optional-dependencies]
+code-mode = [
+    { name = "pydantic-monty", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[[package]]
+name = "pydantic-ai-slim"
+version = "1.105.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "genai-prices", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "griffelib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic-graph", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-inspection", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/ae/1b0370f9b9f1ca7ccf2e6b51ec5a8d11da11d9dd621e5eb015c6420c5e9b/pydantic_ai_slim-1.105.0.tar.gz", hash = "sha256:8b4ad8034b40ab3bde8e0c6285082a204ecd203007150a47943f192b474e06e9", size = 772048, upload-time = "2026-06-02T06:20:01.522Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/6e/8afdff693d21c0743ee71d792ce90afc27d4ddbaf7270d969a84452cfd0d/pydantic_ai_slim-1.105.0-py3-none-any.whl", hash = "sha256:1e65561ba9a58a9d8fc3a63b550c3c2b2c4017da275dea78291e526aa06298d8", size = 956108, upload-time = "2026-06-02T06:19:52.821Z" },
+]
+
+[package.optional-dependencies]
+anthropic = [
+    { name = "anthropic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[[package]]
 name = "pydantic-core"
 version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
@@ -8998,6 +9101,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
+]
+
+[[package]]
+name = "pydantic-graph"
+version = "1.105.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "logfire-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-inspection", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/98/0361e1eb28f8d107e4e12dcd2d14eabef55f4a8ca18b1a6f185df74934c0/pydantic_graph-1.105.0.tar.gz", hash = "sha256:3f5cf97d544b900098d3cc2dbd6a8cdd79ea59dac610d7651f86c9228d33c0b9", size = 62570, upload-time = "2026-06-02T06:20:05.158Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/1b/13882fd4d70299dc2995bee20f21599cb8d453b27f44e239f82384d4ea3f/pydantic_graph-1.105.0-py3-none-any.whl", hash = "sha256:ba76d77ad21a13f2961fbda9d988f3d5a3d9ffc1817ee912e0ea59b0b5a9e825", size = 80099, upload-time = "2026-06-02T06:19:57.098Z" },
+]
+
+[[package]]
+name = "pydantic-monty"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/5b/bb6a8bfdf13eb9808c966bdac064a40ce9ac881ec6d64dba3e055888f22b/pydantic_monty-0.0.18.tar.gz", hash = "sha256:c43794c7c4664fa1403d4841459d0e23f01b4f552283db638f5b40ced4dac6a1", size = 1197105, upload-time = "2026-05-29T08:31:41.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/8e/b3946ee663349fb35f9dceddf1aed394b8e5df1d8767b840844db9cee515/pydantic_monty-0.0.18-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421d1b7956e06a22dc13fe6a34bebf3a1bdde8cf78616eded018f7a9ca746295", size = 8718281, upload-time = "2026-05-29T08:31:06.121Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/5e/cb242ba7bd63985eee94f0dff8864002bb5ded2da7190e73786ddcd5b4e8/pydantic_monty-0.0.18-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd2b37890d8a948606be184bd6e3fa4e445d26e3c7329c6a451a271bfc470f24", size = 8170676, upload-time = "2026-05-29T08:29:38.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8d/d144775ea57b813e97aef9edaf5f867fb82960597af517125e1b513c983c/pydantic_monty-0.0.18-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:19b86e4fc4b73c2c925906bbc31488b9e8b99b54101f8ea7bbdccfd60ded38f0", size = 8585337, upload-time = "2026-05-29T08:31:27.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/6291a4871fbdb8dfa66d1b1f2406c11066757caa1c53092320e5d11ea49d/pydantic_monty-0.0.18-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4de83f38b3658152697c524ea87ce307a13701d807801c9be27870e837829a02", size = 9181594, upload-time = "2026-05-29T08:31:36.736Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/00/28879cee77e24f70c756c4603b4a21b013e601b7821bd07e06cf6718b75a/pydantic_monty-0.0.18-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef3aaa4fb7af8fd84f42df5e1e43d7ff3eae7d81314580462c8ca716e7e6e361", size = 9285193, upload-time = "2026-05-29T08:30:58.727Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/07/52dece571ef47085d2f1053df4c1be8d5b42d8735da4797f5f79d650f81f/pydantic_monty-0.0.18-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d3dd72c195eca243b08c5d68b1f513124feaf22acb87b73cd8bfcdc3f6b4bb7", size = 9264997, upload-time = "2026-05-29T08:29:49.51Z" },
+    { url = "https://files.pythonhosted.org/packages/38/12/b010315be2927c5be43d3a4036cd6857d9981d5116efda5e40540f43a014/pydantic_monty-0.0.18-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6b0409a5f314af54f704d73cd97fe2a0cc8ef2635952bf57c5879b9313281614", size = 8350432, upload-time = "2026-05-29T08:30:10.984Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8b/9674a90269dc0f1a080e606cba642b256e138e7fcee1a3a0b55969946f83/pydantic_monty-0.0.18-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:790f169bb5700e3ab24a8d44fd7016d915c701e27bcd2feabe0de917306bbff0", size = 8900736, upload-time = "2026-05-29T08:29:42.508Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8ccf04b2f9642153702c6eb22d0a0abad57014fd85879ab1f6341b5a1946/pydantic_monty-0.0.18-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2988d3e511131680d9de60647bfe5c697b1e4e4cad474fecf1451c53314e8520", size = 8688756, upload-time = "2026-05-29T08:30:24.677Z" },
+    { url = "https://files.pythonhosted.org/packages/de/b8/c7881620a812850772ae0924863d1399cbecb3e4c8c455a9c7a9c20b06f8/pydantic_monty-0.0.18-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c688dc7c7b28a2f389a61217bae1d50658e28f960abe33a254328cadc8a17a", size = 8171342, upload-time = "2026-05-29T08:29:44.773Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ea/6d10ea1657e303295a75a3854f6dd6b378cbd501dcd1782844107b932acd/pydantic_monty-0.0.18-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f469293f5a776231b9617787a5dd6c58048c6568833ee6848338be6391f15449", size = 8591152, upload-time = "2026-05-29T08:31:29.944Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fb/ab85c4676ccffd0f3b7f509a4c8b396b07c7860577def2f58a22b3fe8aef/pydantic_monty-0.0.18-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6e0cd4991947b8a47210985836f94c14139bc3ea06253d2f38d0d752b165517", size = 9183064, upload-time = "2026-05-29T08:31:12.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/11292178b487052f9e0a1ea7b3d17e1e3bfcba598fefce8cb9ed8712021e/pydantic_monty-0.0.18-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:58b4b96863abbc0ffa5baf64779b3fbb6376cc763488b027ecaddb5052d5ff17", size = 9285440, upload-time = "2026-05-29T08:29:35.642Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/7afb8dde4414d84c042f2cc1b0870a7351cae2e4fbf3fef89b3aa683eca9/pydantic_monty-0.0.18-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1208bd5976c1254b2705559836511c86ea3cc51d9c6f688b1e3e22984715dbc", size = 9233438, upload-time = "2026-05-29T08:31:39.177Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/46/89124cf146725e354b44685b477da6b0b5dc07a8a3af2aec309e88c55405/pydantic_monty-0.0.18-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:977168253d8f6b49bb64f128d02c4b62ee8b435fd62876268377e1f2b00cc00f", size = 8351900, upload-time = "2026-05-29T08:31:08.348Z" },
+    { url = "https://files.pythonhosted.org/packages/00/c5/dda512f5a9c68242faea368844aacefb54c2a13f9b40bee5ab48ccdc78c5/pydantic_monty-0.0.18-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c21319a091dc1ff1fccb8647dae5bb543b3f528c556319ed15c7992dfa9b5e87", size = 8901559, upload-time = "2026-05-29T08:29:26.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9c/7628423f955efb669d2cc1d3a8909bf8271b543ce27036e18229ad0e51e8/pydantic_monty-0.0.18-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d47976a18e3e3da0e86f8cf6068fc8a125930422dc10d3d3bf0b5410a9e9282e", size = 8689116, upload-time = "2026-05-29T08:29:30.906Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/9c/51f8ffa4340bc1986eb9240b0756724f5fdf3c463d6d66c8cc8450e1446d/pydantic_monty-0.0.18-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb84fe51e3f6e00a0cc9628e0acf5904d982c8cc85d4db42b7532d071602f703", size = 8178458, upload-time = "2026-05-29T08:30:09.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ec/7eb84aeb86631571f9acffc91552217dc2b524b00db37b8d10517df467d1/pydantic_monty-0.0.18-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a2e86f3ba67b094d498bc8b071d5e3b8b034bb9f3006216a357c5f71d49d6132", size = 8591295, upload-time = "2026-05-29T08:29:23.357Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/d5210208fa116593bd81789e2e5abb6222d38087c9c1879e18f7e7620275/pydantic_monty-0.0.18-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eb8a412aa0336d4e0334a4e05a54b391d91fa334020bd295a280285ba17ab5ca", size = 9184647, upload-time = "2026-05-29T08:29:51.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/74/4d95c8f65072964c4cb798dbe87d2e1c1349607ab5905874bfa8a0b94de1/pydantic_monty-0.0.18-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1056ce3acef60ab880314caf97775c5ea41b30f9306d0dd28cefeffd42dda366", size = 9291637, upload-time = "2026-05-29T08:31:19.966Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/40/5817780313a3e089ca6f860fbdc836d3aa33790eb72c2e8fe2edc877820e/pydantic_monty-0.0.18-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9593caa45b68fd07ac67bea9974effbe2a1c5453d8a106b913596b0dff6d8471", size = 9233863, upload-time = "2026-05-29T08:31:42.838Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/55/f77565c5797502c7ba995dc23a26759cb33023590f9f2926bc4e8ab87afe/pydantic_monty-0.0.18-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:e15e18ed27a17ee607ad3bcbf82f25a9ec4d496ff493ff64cdabb83ca2174cec", size = 8358264, upload-time = "2026-05-29T08:31:32.531Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1f/c700eb800868d1be4078a99cb00e23fb7e5d8760c8e83b729bba27b5bf92/pydantic_monty-0.0.18-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:96d75a418d96640ff0c7f354a78fc4470a2d0f40ba69e886c2f32756d594d9a0", size = 8906664, upload-time = "2026-05-29T08:30:04.055Z" },
 ]
 
 [[package]]
@@ -10888,11 +11041,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2025.3"
+version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Move the analyzer out of https://github.com/NVIDIA-dev/NeMo-Optimizer into the main platform repo. The plugin is not enabled or installed by default.

This move will let us develop the analyzer more consistently with the rest of the platform and platform plugins and make it easier to release as a research preview when we are ready.

It includes the test bed, which is the way we evaluate the quality of the analyzer.

This does not move the rest of the optimization stack yet. In a future PR to the Optimizer plugin, we will change the optimizer to depend on the insights-driven analysis plugin in this repository.

There are no substantive changes here, this is just a move from the other repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the NeMo Insights plugin with HTTP APIs, SDK resources, and authorization for insight CRUD plus periodic analysis configuration and run-status management.
  * Introduced an `nemo insights` CLI to run analysis and manage enablement/status and reporting.
  * Added a full Insights testbed covering run, snapshot/restore, re-ingest, and state publishing, with automated CI orchestration.
* **Documentation**
  * Added plugin, example, and testbed documentation (including usage and workflow guidance).
* **Tests / CI**
  * Expanded unit and end-to-end coverage, plus a dedicated CI workflow for the testbed pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->