### PR TITLE
feat(studio): clarify pin and default sort apply to all users

### DIFF
--- a/web/packages/studio/src/components/DefaultSortControl/index.tsx
+++ b/web/packages/studio/src/components/DefaultSortControl/index.tsx
@@ -79,7 +79,7 @@ export const DefaultSortControl: FC<DefaultSortControlProps> = ({
     <FormField slotLabel="Default sort">
       <Stack gap="density-md">
         <Text kind="body/regular/sm" className="text-secondary">
-          The field this group&apos;s experiments are sorted by on load.
+          Sets the default sort order for all users when they open this group.
         </Text>
         <div className="flex items-center gap-2">
           <SelectRoot

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -214,19 +214,29 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({ grou
           const { pinned_at } = row.original;
           const isPinned = pinned_at != null;
           return (
-            <Button
-              kind="tertiary"
-              color="neutral"
-              size="small"
-              aria-label={isPinned ? 'Unpin experiment' : 'Pin experiment'}
-              aria-pressed={isPinned}
-              onClick={() => togglePin(row.original)}
+            <Tooltip
+              slotContent={
+                <Text kind="body/regular/sm">
+                  {isPinned ? 'Unpin for all users' : 'Pin for all users'}
+                </Text>
+              }
+              className={tooltipClassName}
+              side="right"
             >
-              <Pin
-                className={isPinned ? 'text-brand' : 'text-secondary'}
-                {...(isPinned ? { fill: 'currentColor' } : {})}
-              />
-            </Button>
+              <Button
+                kind="tertiary"
+                color="neutral"
+                size="small"
+                aria-label={isPinned ? 'Unpin experiment' : 'Pin experiment'}
+                aria-pressed={isPinned}
+                onClick={() => togglePin(row.original)}
+              >
+                <Pin
+                  className={isPinned ? 'text-brand' : 'text-secondary'}
+                  {...(isPinned ? { fill: 'currentColor' } : {})}
+                />
+              </Button>
+            </Tooltip>
           );
         },
       }),


### PR DESCRIPTION
Closes #ASE-513

| Pin | Sort |
| --- | --- |
| <img width="1780" height="1103" alt="Screenshot 2026-07-14 at 10 58 03" src="https://github.com/user-attachments/assets/022d75cf-642c-42bc-8c06-c21c2523ff8e" /> | <img width="1780" height="1103" alt="Screenshot 2026-07-14 at 10 58 06" src="https://github.com/user-attachments/assets/d1c54187-06fa-4437-8f93-abcce1dcb25b" /> |

# Summary

Users had no indication that the pin toggle and default sort order in experiment groups are shared settings that affect everyone, not personal preferences. Two small clarifications:

- **Pin button**: now shows a tooltip — "Pin for all users" / "Unpin for all users" — so it's clear the action is group-wide.
- **Default sort helper text** (create/edit group modals): replaced the awkward "The field this group's experiments are sorted by on load" with "Sets the default sort order for all users when they open this group."

# Test plan
- [ ] Open an experiment group → hover the pin icon on any row → confirm tooltip reads "Pin for all users" (or "Unpin for all users" when pinned)
- [ ] Open the create group modal or edit group modal → confirm the Default sort field's helper text reads "Sets the default sort order for all users when they open this group."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips to the pin and unpin controls, clarifying that changes apply to all users.
* **Documentation**
  * Updated the “Default sort” description to explain that it sets the sort order shown when users open a group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->