### PR TITLE
feat(studio): Support seeding DD

### DIFF
--- a/web/packages/studio/src/components/AddColumnPalette/ColumnTypeCard.tsx
+++ b/web/packages/studio/src/components/AddColumnPalette/ColumnTypeCard.tsx
@@ -12,19 +12,22 @@ import type { FC } from 'react';
 interface ColumnTypeCardProps {
   option: ColumnTypeOption;
   onSelect: (selection: AddColumnSelection) => void;
+  disabledReason?: string;
 }
 
 /**
  * A single column-type option, rendered as a {@link SelectableCard} so it is reachable and
  * activatable by keyboard (Tab to focus, Enter/Space to add) with no drag interaction.
  */
-export const ColumnTypeCard: FC<ColumnTypeCardProps> = ({ option, onSelect }) => {
+export const ColumnTypeCard: FC<ColumnTypeCardProps> = ({ option, onSelect, disabledReason }) => {
   const { icon: Icon, label, description, color, columnType, samplerType } = option;
   return (
     <SelectableCard
       className="w-full"
       title={label}
       subtitle={description}
+      disabled={Boolean(disabledReason)}
+      disabledReason={disabledReason}
       onActivate={() => onSelect({ columnType, samplerType })}
       leading={
         <CardIconBadge>

--- a/web/packages/studio/src/components/AddColumnPalette/ColumnTypeGroupSection.tsx
+++ b/web/packages/studio/src/components/AddColumnPalette/ColumnTypeGroupSection.tsx
@@ -14,6 +14,8 @@ interface ColumnTypeGroupSectionProps {
   group: ColumnTypeGroup;
   options: ColumnTypeOption[];
   onSelect: (selection: AddColumnSelection) => void;
+  /** Disabled reasons keyed by column type; a set entry disables that option's card. */
+  disabledReasons?: Partial<Record<string, string>>;
 }
 
 /** A labeled group heading (with a count) above its option cards. */
@@ -21,6 +23,7 @@ export const ColumnTypeGroupSection: FC<ColumnTypeGroupSectionProps> = ({
   group,
   options,
   onSelect,
+  disabledReasons,
 }) => (
   <Stack gap="1" className="w-full">
     <Flex align="center" gap="density-xs">
@@ -30,7 +33,12 @@ export const ColumnTypeGroupSection: FC<ColumnTypeGroupSectionProps> = ({
     </Flex>
     <Stack gap="1.5" className="w-full">
       {options.map((option) => (
-        <ColumnTypeCard key={option.id} option={option} onSelect={onSelect} />
+        <ColumnTypeCard
+          key={option.id}
+          option={option}
+          onSelect={onSelect}
+          disabledReason={option.columnType ? disabledReasons?.[option.columnType] : undefined}
+        />
       ))}
     </Stack>
   </Stack>

--- a/web/packages/studio/src/components/AddColumnPalette/index.tsx
+++ b/web/packages/studio/src/components/AddColumnPalette/index.tsx
@@ -18,6 +18,11 @@ const matchesQuery = (option: ColumnTypeOption, query: string): boolean =>
 export interface AddColumnPaletteProps {
   /** Called with the chosen column type when an option is activated. */
   onAddColumn?: (selection: AddColumnSelection) => void;
+  /**
+   * Disabled reasons keyed by column type. An option whose column type has an entry renders as a
+   * disabled card with the reason as its tooltip — e.g. `{ 'seed-dataset': 'Only one…' }`.
+   */
+  disabledReasons?: Partial<Record<string, string>>;
   className?: string;
 }
 
@@ -30,7 +35,11 @@ export interface AddColumnPaletteProps {
  * presentational: wire {@link AddColumnPaletteProps.onAddColumn} to append a column to
  * the recipe.
  */
-export const AddColumnPalette: FC<AddColumnPaletteProps> = ({ onAddColumn, className }) => {
+export const AddColumnPalette: FC<AddColumnPaletteProps> = ({
+  onAddColumn,
+  disabledReasons,
+  className,
+}) => {
   const [search, setSearch] = useState('');
 
   const handleSelect = (selection: AddColumnSelection) => onAddColumn?.(selection);
@@ -76,6 +85,7 @@ export const AddColumnPalette: FC<AddColumnPaletteProps> = ({ onAddColumn, class
               group={group}
               options={options}
               onSelect={handleSelect}
+              disabledReasons={disabledReasons}
             />
           ))
         )}

--- a/web/packages/studio/src/components/ColumnConfigPanel/SeedDatasetConfig.tsx
+++ b/web/packages/studio/src/components/ColumnConfigPanel/SeedDatasetConfig.tsx
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getPartsFromReference } from '@nemo/common/src/namedEntity';
+import { useFilesListFilesetFiles } from '@nemo/sdk/generated/platform/api';
+import { Flex, FormField, Select, Tag, Text } from '@nvidia/foundations-react-core';
+import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import {
+  SAMPLING_STRATEGY_OPTIONS,
+  SEED_AVAILABLE_COLUMNS_KEY,
+  SEED_FILE_PATH_KEY,
+  SEED_FILESET_REF_KEY,
+  SEED_SAMPLING_STRATEGY_KEY,
+} from '@studio/routes/DataDesignerJobBuildRoute/columns';
+import { FilesetSearchableSelect } from '@studio/routes/DeploymentsListRoute/CreateDeploymentSidePanel/FilesetSearchableSelect';
+import { getContentColumns, getFileExtension } from '@studio/util/files';
+import { type FC, useEffect, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+
+export interface SeedDatasetConfigProps {
+  /** The seed-dataset column's current field values. */
+  values: Record<string, string>;
+  /** Merges the given keys into the column's values (parent spreads onto the rest). */
+  onPatch: (patch: Record<string, string>) => void;
+}
+
+interface SeedFilesetForm {
+  [SEED_FILESET_REF_KEY]: string;
+}
+
+/**
+ * Config controls for a seed-dataset column, sourced from a platform fileset.
+ *
+ * The SDK's `FilesetFileSeedSource` takes a single composite `path`
+ * (`{workspace}/{fileset}#{file}`); rather than have the user hand-type that, this collects the
+ * fileset and the in-fileset file as separate picks (stored under {@link SEED_FILESET_REF_KEY} /
+ * {@link SEED_FILE_PATH_KEY}). `buildSeedConfig` assembles them into the composite path at submit.
+ *
+ * The fileset uses {@link FilesetSearchableSelect} for server-side `$like` search + paging. It is
+ * react-hook-form based, so a local form holds its value and pushes changes up via `onPatch`.
+ * The panel keys this component by column id, so each column mounts a form seeded from its values.
+ */
+export const SeedDatasetConfig: FC<SeedDatasetConfigProps> = ({ values, onPatch }) => {
+  const workspace = useWorkspaceFromPath();
+  const filesetRef = values[SEED_FILESET_REF_KEY] ?? '';
+  const filePath = values[SEED_FILE_PATH_KEY] ?? '';
+  const samplingStrategy = values[SEED_SAMPLING_STRATEGY_KEY] ?? '';
+
+  const { control, watch } = useForm<SeedFilesetForm>({
+    defaultValues: { [SEED_FILESET_REF_KEY]: filesetRef },
+  });
+
+  useEffect(() => {
+    const subscription = watch((formValues, { name }) => {
+      if (name !== SEED_FILESET_REF_KEY) return;
+      onPatch({
+        [SEED_FILESET_REF_KEY]: formValues[SEED_FILESET_REF_KEY] ?? '',
+        [SEED_FILE_PATH_KEY]: '',
+        [SEED_AVAILABLE_COLUMNS_KEY]: '',
+      });
+    });
+    return () => subscription.unsubscribe();
+  }, [watch, onPatch]);
+
+  const { workspace: filesetWorkspace, name: filesetName } = getPartsFromReference(filesetRef);
+  const { data: filesResponse, isLoading: isLoadingFiles } = useFilesListFilesetFiles(
+    filesetWorkspace,
+    filesetName,
+    undefined,
+    { query: { enabled: Boolean(filesetRef) } }
+  );
+  const fileItems = useMemo(
+    () => (filesResponse?.data ?? []).map((file) => ({ children: file.path, value: file.path })),
+    [filesResponse?.data]
+  );
+
+  const isParquet = filePath.endsWith('parquet');
+  const {
+    data: fileContent,
+    isLoading: isLoadingSchema,
+    isError: isSchemaError,
+  } = useDatasetFileContent({
+    workspace: filesetWorkspace,
+    name: filesetName,
+    path: filePath,
+    range: isParquet ? [0, 1] : undefined,
+    enabled: Boolean(filesetRef && filePath),
+  });
+  const availableColumns = useMemo(() => {
+    if (!fileContent) return [];
+    const fileType = isParquet ? 'jsonl' : (getFileExtension(filePath) ?? undefined);
+    return getContentColumns(fileContent, fileType);
+  }, [fileContent, filePath, isParquet]);
+
+  useEffect(() => {
+    const joined = availableColumns.join(',');
+    if ((values[SEED_AVAILABLE_COLUMNS_KEY] ?? '') !== joined) {
+      onPatch({ [SEED_AVAILABLE_COLUMNS_KEY]: joined });
+    }
+  }, [availableColumns, values, onPatch]);
+
+  const samplingItems = SAMPLING_STRATEGY_OPTIONS.map((option) => ({
+    children: option.label,
+    value: option.value,
+  }));
+
+  return (
+    <>
+      <FilesetSearchableSelect
+        workspace={workspace}
+        useControllerProps={{ control, name: SEED_FILESET_REF_KEY }}
+        formFieldProps={{
+          slotLabel: 'Fileset',
+          slotInfo: 'The platform fileset to seed rows from.',
+        }}
+        triggerPlaceholder="Select a fileset"
+      />
+
+      <FormField
+        slotLabel="File"
+        required
+        slotInfo="The file within the fileset to read rows from."
+      >
+        <Select
+          aria-label="Seed file"
+          disabled={!filesetRef}
+          items={fileItems}
+          value={filePath || undefined}
+          onValueChange={(value) => onPatch({ [SEED_FILE_PATH_KEY]: value ?? '' })}
+          placeholder={
+            !filesetRef
+              ? 'Select a fileset first'
+              : isLoadingFiles
+                ? 'Loading files…'
+                : 'Select a file'
+          }
+        />
+      </FormField>
+
+      {filePath && (
+        <FormField
+          slotLabel="Available columns"
+          slotInfo="Columns provided by the seed file. Reference them from other columns with {{ name }}."
+        >
+          {isLoadingSchema ? (
+            <Text kind="body/regular/sm" className="text-secondary">
+              Reading columns…
+            </Text>
+          ) : isSchemaError ? (
+            <Text kind="body/regular/sm" className="text-feedback-danger">
+              Couldn't read columns from this file.
+            </Text>
+          ) : availableColumns.length === 0 ? (
+            <Text kind="body/regular/sm" className="text-secondary">
+              No columns found in this file.
+            </Text>
+          ) : (
+            <Flex gap="density-xs" className="flex-wrap">
+              {availableColumns.map((name) => (
+                <Tag key={name} kind="outline" color="gray" readOnly>
+                  {name}
+                </Tag>
+              ))}
+            </Flex>
+          )}
+        </FormField>
+      )}
+
+      <FormField
+        slotLabel="Sampling strategy"
+        slotInfo="How rows are read from the seed dataset. Defaults to ordered."
+      >
+        <Select
+          aria-label="Sampling strategy"
+          items={samplingItems}
+          value={samplingStrategy || undefined}
+          onValueChange={(value) => onPatch({ [SEED_SAMPLING_STRATEGY_KEY]: value ?? '' })}
+          placeholder="Ordered"
+        />
+      </FormField>
+    </>
+  );
+};

--- a/web/packages/studio/src/components/ColumnConfigPanel/SeedDatasetConfig.tsx
+++ b/web/packages/studio/src/components/ColumnConfigPanel/SeedDatasetConfig.tsx
@@ -127,7 +127,12 @@ export const SeedDatasetConfig: FC<SeedDatasetConfigProps> = ({ values, onPatch 
           disabled={!filesetRef}
           items={fileItems}
           value={filePath || undefined}
-          onValueChange={(value) => onPatch({ [SEED_FILE_PATH_KEY]: value ?? '' })}
+          onValueChange={(value) =>
+            onPatch({
+              [SEED_FILE_PATH_KEY]: value ?? '',
+              [SEED_AVAILABLE_COLUMNS_KEY]: '',
+            })
+          }
           placeholder={
             !filesetRef
               ? 'Select a fileset first'

--- a/web/packages/studio/src/components/ColumnConfigPanel/index.tsx
+++ b/web/packages/studio/src/components/ColumnConfigPanel/index.tsx
@@ -19,6 +19,7 @@ import {
   TextInput,
 } from '@nvidia/foundations-react-core';
 import { ICON_COLOR_CLASS } from '@studio/components/AddColumnPalette/constants';
+import { SeedDatasetConfig } from '@studio/components/ColumnConfigPanel/SeedDatasetConfig';
 import { CardIconBadge } from '@studio/components/common/SelectableCard';
 import {
   type BuilderColumn,
@@ -209,14 +210,22 @@ export const ColumnConfigPanel: FC<ColumnConfigPanelProps> = ({
           />
         </FormField>
 
-        {fields.map((field) => (
-          <FieldControl
-            key={field.key}
-            field={field}
-            value={values[field.key] ?? ''}
-            onChange={(value) => setValue(field.key, value)}
+        {option.columnType === 'seed-dataset' ? (
+          <SeedDatasetConfig
+            key={column.id}
+            values={values}
+            onPatch={(patch) => onChange({ values: { ...values, ...patch } })}
           />
-        ))}
+        ) : (
+          fields.map((field) => (
+            <FieldControl
+              key={field.key}
+              field={field}
+              value={values[field.key] ?? ''}
+              onChange={(value) => setValue(field.key, value)}
+            />
+          ))
+        )}
       </Stack>
 
       <Flex align="center" justify="start" className="shrink-0 border-t border-base p-density-lg">

--- a/web/packages/studio/src/components/SafeSynthesizerFilesetPreview/util.test.ts
+++ b/web/packages/studio/src/components/SafeSynthesizerFilesetPreview/util.test.ts
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { parseFilesetUrl } from '@nemo/common/src/components/DatasetFileSelect/utils';
-import { parseCSV, parseFileContent } from '@studio/components/SafeSynthesizerFilesetPreview/util';
+import {
+  parseCSVTable,
+  parseFileContent,
+} from '@studio/components/SafeSynthesizerFilesetPreview/util';
 
 vi.mock('papaparse', () => ({
   default: {
@@ -39,7 +42,7 @@ describe('SafeSynthesizerDatasetPreview utils', () => {
 
       mockPapaParse.mockImplementation(vi.fn().mockReturnValue(mockParsedData));
 
-      const result = parseCSV(mockCsvContent);
+      const result = parseCSVTable(mockCsvContent);
 
       expect(mockPapaParse).toHaveBeenCalledWith(mockCsvContent, { header: true });
       expect(result.columns).toEqual([
@@ -71,7 +74,7 @@ describe('SafeSynthesizerDatasetPreview utils', () => {
 
       mockPapaParse.mockImplementation(vi.fn().mockReturnValue(mockParsedData));
 
-      const result = parseCSV('id,name\ncustom-id,John');
+      const result = parseCSVTable('id,name\ncustom-id,John');
 
       expect(result.rows[0].id).toBe('custom-id');
     });
@@ -92,7 +95,7 @@ describe('SafeSynthesizerDatasetPreview utils', () => {
 
       mockPapaParse.mockImplementation(vi.fn().mockReturnValue(mockParsedData));
 
-      const result = parseCSV('name\nJohn\nJane');
+      const result = parseCSVTable('name\nJohn\nJane');
 
       expect(result.rows[0].id).toBe('0');
       expect(result.rows[1].id).toBe('1');
@@ -114,7 +117,7 @@ describe('SafeSynthesizerDatasetPreview utils', () => {
 
       mockPapaParse.mockImplementation(vi.fn().mockReturnValue(mockParsedData));
 
-      const result = parseCSV('name,age,city\nJohn,,');
+      const result = parseCSVTable('name,age,city\nJohn,,');
 
       expect(result.rows[0].cells[1].children).toBe('');
       expect(result.rows[0].cells[2].children).toBe('');

--- a/web/packages/studio/src/components/SafeSynthesizerFilesetPreview/util.ts
+++ b/web/packages/studio/src/components/SafeSynthesizerFilesetPreview/util.ts
@@ -4,7 +4,12 @@
 import Papa from 'papaparse';
 import { ReactNode } from 'react';
 
-export const parseCSVTable = (response: string) => {
+export interface ParsedCSVTable {
+  rows: { id: string; cells: { children: ReactNode }[] }[];
+  columns: { children: string }[];
+}
+
+export const parseCSVTable = (response: string): ParsedCSVTable => {
   const csvData = Papa.parse(response, { header: true });
   const rawRows = csvData.data as Record<string, unknown>[];
   const columnNames = csvData.meta.fields || [];
@@ -28,10 +33,7 @@ export const parseCSVTable = (response: string) => {
 export interface ParsedFileContent {
   type: 'json' | 'csv' | 'error';
   jsonData?: string;
-  tabularData?: {
-    rows: { id: string; cells: { children: ReactNode }[] }[];
-    columns: { children: string }[];
-  };
+  tabularData?: ParsedCSVTable;
   error?: string;
 }
 

--- a/web/packages/studio/src/components/SafeSynthesizerFilesetPreview/util.ts
+++ b/web/packages/studio/src/components/SafeSynthesizerFilesetPreview/util.ts
@@ -4,7 +4,7 @@
 import Papa from 'papaparse';
 import { ReactNode } from 'react';
 
-export const parseCSV = (response: string) => {
+export const parseCSVTable = (response: string) => {
   const csvData = Papa.parse(response, { header: true });
   const rawRows = csvData.data as Record<string, unknown>[];
   const columnNames = csvData.meta.fields || [];
@@ -43,7 +43,7 @@ export interface ParsedFileContent {
  */
 export const parseFileContent = (filePath: string, content: string): ParsedFileContent => {
   if (filePath.endsWith('.csv')) {
-    const csvData = parseCSV(content);
+    const csvData = parseCSVTable(content);
     return { type: 'csv', tabularData: csvData };
   }
   if (filePath.endsWith('.json') || filePath.endsWith('.jsonl')) {

--- a/web/packages/studio/src/components/common/SelectableCard/index.tsx
+++ b/web/packages/studio/src/components/common/SelectableCard/index.tsx
@@ -74,7 +74,7 @@ export const SelectableCard: FC<SelectableCardProps> = ({
   <button
     type="button"
     onClick={disabled ? undefined : onActivate}
-    aria-disabled={disabled || undefined}
+    disabled={disabled}
     aria-pressed={selected}
     title={disabled ? disabledReason : undefined}
     className={`flex w-[240px] justify-between flex-col items-start gap-1.5 rounded-md border bg-surface-raised px-2 py-1.5 text-left transition-colors ${

--- a/web/packages/studio/src/components/common/SelectableCard/index.tsx
+++ b/web/packages/studio/src/components/common/SelectableCard/index.tsx
@@ -39,6 +39,10 @@ export interface SelectableCardProps {
   tags?: string[];
   /** Whether the card reads as selected (draws the strong border). */
   selected?: boolean;
+  /** When true, the card is non-interactive and muted; `onActivate` never fires. */
+  disabled?: boolean;
+  /** Tooltip explaining why the card is disabled (shown on hover when `disabled`). */
+  disabledReason?: string;
   /** Activation handler; fired on click and on keyboard Enter/Space. */
   onActivate?: () => void;
   className?: string;
@@ -62,14 +66,22 @@ export const SelectableCard: FC<SelectableCardProps> = ({
   description,
   tags,
   selected = false,
+  disabled = false,
+  disabledReason,
   onActivate,
   className,
 }) => (
   <button
     type="button"
-    onClick={onActivate}
+    onClick={disabled ? undefined : onActivate}
+    aria-disabled={disabled || undefined}
     aria-pressed={selected}
-    className={`flex w-[240px] justify-between cursor-pointer flex-col items-start gap-1.5 rounded-md border bg-surface-raised px-2 py-1.5 text-left transition-colors hover:border-strong hover:bg-surface-hover focus-visible:border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-brand,#76b900) ${selected ? 'border-strong' : 'border-base'} ${className ?? ''}`}
+    title={disabled ? disabledReason : undefined}
+    className={`flex w-[240px] justify-between flex-col items-start gap-1.5 rounded-md border bg-surface-raised px-2 py-1.5 text-left transition-colors ${
+      disabled
+        ? 'cursor-not-allowed opacity-50 border-base'
+        : `cursor-pointer hover:border-strong hover:bg-surface-hover focus-visible:border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-brand,#76b900) ${selected ? 'border-strong' : 'border-base'}`
+    } ${className ?? ''}`}
   >
     <Stack gap="1.5">
       <Flex className="w-full items-center gap-2">

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/BuilderPalette.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/BuilderPalette.tsx
@@ -19,6 +19,7 @@ export interface BuilderPaletteProps {
   modelGroups: ModelWorkspaceGroup[];
   isLoadingModels?: boolean;
   onAddColumn: (selection: AddColumnSelection) => void;
+  disabledColumnReasons?: Partial<Record<string, string>>;
   onAddModel: (selection: ModelSelection, provider: string) => void;
   onSelectModel: (id: string | null) => void;
 }
@@ -32,6 +33,7 @@ export const BuilderPalette: FC<BuilderPaletteProps> = ({
   modelGroups,
   isLoadingModels,
   onAddColumn,
+  disabledColumnReasons,
   onAddModel,
   onSelectModel,
 }) => (
@@ -48,7 +50,7 @@ export const BuilderPalette: FC<BuilderPaletteProps> = ({
     />
     <div className="min-h-0 flex-1">
       {tab === 'columns' ? (
-        <AddColumnPalette onAddColumn={onAddColumn} />
+        <AddColumnPalette onAddColumn={onAddColumn} disabledReasons={disabledColumnReasons} />
       ) : (
         <AddModelPalette
           models={models}

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.test.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.test.ts
@@ -345,6 +345,82 @@ describe('sampler-showcase template', () => {
   });
 });
 
+describe('seed-dataset columns', () => {
+  it('hoists the fileset source to seed_config and does NOT emit a seed column', () => {
+    const columns = [
+      column('a', 'seed', 'seed-dataset', {
+        fileset_ref: 'default/my-fileset',
+        file_path: 'data.parquet',
+        sampling_strategy: 'shuffle',
+        available_columns: 'question,answer',
+      }),
+      column('b', 'graded', 'llm-text', {
+        prompt: 'Grade {{ answer }}',
+        model_alias: 'default',
+      }),
+    ];
+
+    const config = buildDataDesignerConfig(columns);
+    expect(config.columns).toEqual([
+      {
+        name: 'graded',
+        column_type: 'llm-text',
+        prompt: 'Grade {{ answer }}',
+        model_alias: 'default',
+      },
+    ]);
+    expect(config.seed_config).toEqual({
+      source: { seed_type: 'nmp', path: 'default/my-fileset#data.parquet' },
+      sampling_strategy: 'shuffle',
+    });
+  });
+
+  it('omits sampling strategy when unset', () => {
+    const columns = [
+      column('a', 'seed', 'seed-dataset', {
+        fileset_ref: 'default/my-fileset',
+        file_path: 'data.parquet',
+      }),
+    ];
+
+    expect(buildDataDesignerConfig(columns).seed_config).toEqual({
+      source: { seed_type: 'nmp', path: 'default/my-fileset#data.parquet' },
+    });
+  });
+
+  it('omits seed_config until both a fileset and a file are picked', () => {
+    const noFile = [column('a', 'seed', 'seed-dataset', { fileset_ref: 'default/my-fileset' })];
+    expect(buildDataDesignerConfig(noFile).seed_config).toBeUndefined();
+
+    const none = [column('b', 'seed', 'seed-dataset', {})];
+    expect(buildDataDesignerConfig(none).seed_config).toBeUndefined();
+  });
+
+  it('requires a fileset and a file before submit', () => {
+    const errors = validateColumns([column('a', 'seed', 'seed-dataset', {})]);
+    expect(errors).toContainEqual(expect.stringContaining('Fileset is required'));
+    expect(errors).toContainEqual(expect.stringContaining('File is required'));
+  });
+
+  it('exposes the seed file columns as referenceable outputs and draws edges from the seed node', () => {
+    const columns = [
+      column('a', 'seed', 'seed-dataset', {
+        fileset_ref: 'default/my-fileset',
+        file_path: 'data.parquet',
+        available_columns: 'question, answer',
+      }),
+      column('b', 'graded', 'llm-text', {
+        prompt: 'Grade the {{ answer }} to {{ question }}',
+        model_alias: 'default',
+      }),
+    ];
+
+    const { nodes, edges } = buildGraph(columns);
+    expect(nodes.find((n) => n.id === 'a')?.data.tags).toEqual(['{{question}}', '{{answer}}']);
+    expect(edges).toEqual([{ source: 'a', target: 'b' }]);
+  });
+});
+
 describe('llm-judge columns', () => {
   const scores =
     '[{ "name": "Quality", "description": "Overall answer quality.", "options": { "1": "Very poor", "5": "Excellent" } }]';

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.ts
@@ -6,6 +6,8 @@ import {
   DatetimeSamplerParamsUnit,
   PersonSamplerParamsSex,
   SamplerType,
+  type SamplingStrategy,
+  type SeedConfig,
   TimeDeltaSamplerParamsUnit,
 } from '@nemo/sdk/generated/data-designer/schema';
 import { COLUMN_TYPE_GROUPS } from '@studio/components/AddColumnPalette/constants';
@@ -101,6 +103,23 @@ const CODE_LANGS = [
 ] as const;
 
 const asOptions = (values: readonly string[]) => values.map((value) => ({ label: value, value }));
+
+export const SEED_FILESET_REF_KEY = 'fileset_ref';
+export const SEED_FILE_PATH_KEY = 'file_path';
+export const SEED_SAMPLING_STRATEGY_KEY = 'sampling_strategy';
+export const SEED_AVAILABLE_COLUMNS_KEY = 'available_columns';
+
+export const SAMPLING_STRATEGY_OPTIONS = [
+  { label: 'Ordered', value: 'ordered' },
+  { label: 'Shuffle', value: 'shuffle' },
+] as const;
+
+/** The seed file's discovered column names for a seed-dataset column (empty if none/undiscovered). */
+export const getSeedAvailableColumns = (column: BuilderColumn): string[] =>
+  (column.values[SEED_AVAILABLE_COLUMNS_KEY] ?? '')
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean);
 
 const PROMPT_FIELD: ColumnField = {
   key: 'prompt',
@@ -233,7 +252,22 @@ const FIELDS_BY_COLUMN_TYPE: Record<NonNullable<DataDesignerColumnType>, ColumnF
         'Parameters for the chosen validator. For "code": { "code_lang": "python" }. For "remote": { "url": "https://…" }.',
     },
   ],
-  'seed-dataset': [],
+  'seed-dataset': [
+    {
+      key: SEED_FILESET_REF_KEY,
+      label: 'Fileset',
+      kind: 'text',
+      required: true,
+      helperText: 'The platform fileset to seed rows from.',
+    },
+    {
+      key: SEED_FILE_PATH_KEY,
+      label: 'File',
+      kind: 'text',
+      required: true,
+      helperText: 'The file within the fileset to read rows from.',
+    },
+  ],
   custom: [
     {
       key: 'generation_strategy',
@@ -645,12 +679,25 @@ export const buildGraph = (columns: BuilderColumn[]): { nodes: DagNode[]; edges:
   const knownNames = new Set(columns.map((column) => column.name).filter(Boolean));
   const idByName = new Map(columns.filter((c) => c.name).map((c) => [c.name, c.id]));
 
+  for (const column of columns) {
+    if (column.option.columnType !== 'seed-dataset') continue;
+    for (const name of getSeedAvailableColumns(column)) {
+      knownNames.add(name);
+      if (!idByName.has(name)) idByName.set(name, column.id);
+    }
+  }
+
   const nodes: DagNode[] = [];
   const edges: DagEdge[] = [];
+  const edgeKeys = new Set<string>();
 
   for (const column of columns) {
     const { option } = column;
     const deps = columnDependencies(column, knownNames);
+    const tags =
+      option.columnType === 'seed-dataset'
+        ? getSeedAvailableColumns(column).map((name) => `{{${name}}}`)
+        : [...deps].map((name) => `{{${name}}}`);
     nodes.push({
       id: column.id,
       data: {
@@ -659,12 +706,16 @@ export const buildGraph = (columns: BuilderColumn[]): { nodes: DagNode[]; edges:
         description: option.description,
         icon: option.icon,
         colorClassName: ACCENT_VAR_CLASS[option.color],
-        tags: [...deps].map((name) => `{{${name}}}`),
+        tags,
       },
     });
     for (const dep of deps) {
       const source = idByName.get(dep);
-      if (source && source !== column.id) edges.push({ source, target: column.id });
+      if (!source || source === column.id) continue;
+      const key = `${source}->${column.id}`;
+      if (edgeKeys.has(key)) continue;
+      edgeKeys.add(key);
+      edges.push({ source, target: column.id });
     }
   }
 
@@ -818,15 +869,44 @@ const toColumnConfig = (column: BuilderColumn): Record<string, unknown> => {
   return config;
 };
 
+/** Assembles the `FilesetFileSeedSource` composite path: `{workspace}/{fileset}#{file}`. */
+export const buildSeedFilesetPath = (filesetRef: string, filePath: string): string =>
+  `${filesetRef}#${filePath}`;
+
+const buildSeedConfig = (columns: BuilderColumn[]): SeedConfig | undefined => {
+  const seedColumn = columns.find(
+    (column) =>
+      column.option.columnType === 'seed-dataset' &&
+      column.values[SEED_FILESET_REF_KEY]?.trim() &&
+      column.values[SEED_FILE_PATH_KEY]?.trim()
+  );
+  if (!seedColumn) return undefined;
+
+  const path = buildSeedFilesetPath(
+    seedColumn.values[SEED_FILESET_REF_KEY].trim(),
+    seedColumn.values[SEED_FILE_PATH_KEY].trim()
+  );
+  const seedConfig: SeedConfig = {
+    source: { seed_type: 'nmp', path },
+  };
+  const samplingStrategy = seedColumn.values[SEED_SAMPLING_STRATEGY_KEY]?.trim();
+  if (samplingStrategy) seedConfig.sampling_strategy = samplingStrategy as SamplingStrategy;
+  return seedConfig;
+};
+
 export const buildDataDesignerConfig = (
   columns: BuilderColumn[],
   models: BuilderModel[] = [],
   servedModelNames: Map<string, string> = new Map()
 ): DataDesignerConfig => {
   const config: DataDesignerConfig = {
-    columns: columns.map(toColumnConfig) as unknown as DataDesignerConfig['columns'],
+    columns: columns
+      .filter((column) => column.option.columnType !== 'seed-dataset')
+      .map(toColumnConfig) as unknown as DataDesignerConfig['columns'],
   };
   const modelConfigs = buildModelConfigs(models, servedModelNames);
   if (modelConfigs) config.model_configs = modelConfigs;
+  const seedConfig = buildSeedConfig(columns);
+  if (seedConfig) config.seed_config = seedConfig;
   return config;
 };

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
@@ -191,6 +191,7 @@ export const DataDesignerJobBuildRoute: FC = () => {
             modelGroups={modelGroups}
             isLoadingModels={isLoadingModels}
             onAddColumn={builder.handleAddColumn}
+            disabledColumnReasons={builder.disabledColumnReasons}
             onAddModel={builder.handleAddModel}
             onSelectModel={builder.selectModel}
           />

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/useJobBuilder.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/useJobBuilder.ts
@@ -105,7 +105,13 @@ export const useJobBuilder = (
     if (id !== null) setSelectedId(null);
   };
 
+  const hasSeedColumn = columns.some((column) => column.option.columnType === 'seed-dataset');
+  const disabledColumnReasons = hasSeedColumn
+    ? { 'seed-dataset': 'Only one seed dataset is supported per recipe.' }
+    : undefined;
+
   const handleAddColumn = (selection: AddColumnSelection) => {
+    if (selection.columnType === 'seed-dataset' && hasSeedColumn) return;
     const option = findColumnOption(selection);
     if (!option) return;
     const id = `col-${nextId.current++}`;
@@ -162,6 +168,7 @@ export const useJobBuilder = (
     edges,
     takenNames,
     takenAliases,
+    disabledColumnReasons,
     selectColumn,
     selectModel,
     handleAddColumn,

--- a/web/packages/studio/src/util/files.test.ts
+++ b/web/packages/studio/src/util/files.test.ts
@@ -4,6 +4,7 @@
 import { ContentType } from '@nemo/common/src/components/CodeEditor/constants';
 import {
   collectFolderPathsFromDatasetFiles,
+  getContentColumns,
   getContentSchema,
   getDatasetDisplayNameFromFilesUrl,
   getFileNameFromPath,
@@ -250,6 +251,36 @@ describe('resolveDatasetFilePath', () => {
 
   it('returns multi-segment paths unchanged when folder is empty string', () => {
     expect(resolveDatasetFilePath('a/b/c.txt', '')).toBe('a/b/c.txt');
+  });
+});
+
+describe('getContentColumns', () => {
+  it('reads CSV headers', () => {
+    expect(getContentColumns('question,answer,score\na,b,1\n', '.csv')).toEqual([
+      'question',
+      'answer',
+      'score',
+    ]);
+  });
+
+  it('reads CSV headers even when a later row is truncated (Range request)', () => {
+    // A body cut mid-row would make the all-or-nothing CSV parser return no rows; the header
+    // must still resolve since only the first row is parsed.
+    const truncated = 'question,answer\nhello,world\ntrunc';
+    expect(getContentColumns(truncated, '.csv')).toEqual(['question', 'answer']);
+  });
+
+  it('reads JSONL keys from the first row', () => {
+    expect(getContentColumns('{"a":1,"b":2}\n{"a":3,"b":4}\n', 'jsonl')).toEqual(['a', 'b']);
+  });
+
+  it('reads keys from a JSON array', () => {
+    expect(getContentColumns('[{"x":1,"y":2}]', '.json')).toEqual(['x', 'y']);
+  });
+
+  it('returns [] for empty or missing content', () => {
+    expect(getContentColumns(undefined, '.csv')).toEqual([]);
+    expect(getContentColumns('', 'jsonl')).toEqual([]);
   });
 });
 

--- a/web/packages/studio/src/util/files.ts
+++ b/web/packages/studio/src/util/files.ts
@@ -3,6 +3,7 @@
 
 import { ContentType } from '@nemo/common/src/components/CodeEditor/constants';
 import { FileSystemDirectory, FileSystemNode } from '@studio/components/FilesTable/utils';
+import { parseCSVTable } from '@studio/components/SafeSynthesizerFilesetPreview/util';
 import { logger } from '@studio/util/logger';
 import { getTextWithCount, parseCSV } from '@studio/util/strings';
 
@@ -215,6 +216,16 @@ export const getContentSchema = (content?: string, opts?: ContentSchemaOptions) 
   }
 
   return ret;
+};
+
+export const getContentColumns = (content?: string, fileType?: string): string[] => {
+  if (!content) return [];
+  if (fileType?.includes('csv')) {
+    return parseCSVTable(content).columns.map((column) => column.children);
+  }
+  const { rows } = parseFileContent({ content, fileType });
+  const firstRow = rows[0];
+  return firstRow && typeof firstRow === 'object' ? Object.keys(firstRow) : [];
 };
 
 /**


### PR DESCRIPTION

<img width="470" height="396" alt="Screenshot 2026-07-14 at 11 59 00 AM" src="https://github.com/user-attachments/assets/40030e60-5724-4b23-b3f9-f5726edd6ee9" />
<img width="255" height="640" alt="Screenshot 2026-07-14 at 11 58 59 AM" src="https://github.com/user-attachments/assets/703b8185-d6ac-42eb-b501-28837732c069" />

Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added seed-dataset column configuration with fileset/file selection, sampling strategy, and automatic “available columns” discovery.
  * Data Designer job building now incorporates seed configuration and dependency relationships for seed-based outputs.
  * Added automatic column detection for CSV, JSONL, and JSON content.
  * Column-type options in the add-column palette can now be disabled with user-visible explanations.
* **Bug Fixes**
  * Prevented adding more than one seed-dataset column per recipe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->