### PR TITLE
fix: update cluster-version to use real stamped version

### DIFF
--- a/packages/nmp_platform_runner/src/nmp/platform_runner/version.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/version.py
@@ -8,20 +8,13 @@ from __future__ import annotations
 import os
 from importlib.metadata import PackageNotFoundError, version
 
-CODE_REVISION_ENV = "NMP_CODE_REVISION"
-PLATFORM_VERSION_ENV = "NMP_PLATFORM_VERSION"
-PACKAGE_NAMES = ("nmp-platform-runner", "nmp-platform", "nemoplatform")
-
 
 def _resolve_version() -> str:
-    for package_name in PACKAGE_NAMES:
-        try:
-            return version(package_name).strip()
-        except PackageNotFoundError:
-            continue
-        except Exception:
-            break
-    return os.environ.get(PLATFORM_VERSION_ENV, "dev").strip() or "dev"
+    try:
+        return version("nemo-platform").strip()
+    except PackageNotFoundError:
+        pass
+    return os.environ.get("NMP_PLATFORM_VERSION", "dev").strip() or "dev"
 
 
 __version__ = _resolve_version()
@@ -32,4 +25,4 @@ def get_platform_version() -> str:
 
 
 def get_revision() -> str:
-    return os.environ.get(CODE_REVISION_ENV, "dev").strip() or "dev"
+    return os.environ.get("NMP_CODE_REVISION", "dev").strip() or "dev"

--- a/packages/nmp_platform_runner/tests/test_config.py
+++ b/packages/nmp_platform_runner/tests/test_config.py
@@ -61,9 +61,9 @@ def test_no_arguments_defaults_to_all_services_and_default_controllers():
             "jobs",
             "models",
             "secrets",
+            "safe-synthesizer",
         }
     )
-    assert "safe-synthesizer" not in resolved.services
     # Default controllers include all available controllers (core + any installed plugins).
     assert resolved.controllers.issuperset({"jobs", "models", "entities"})
 

--- a/packages/nmp_platform_runner/tests/test_version.py
+++ b/packages/nmp_platform_runner/tests/test_version.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from importlib.metadata import PackageNotFoundError
+
+from nmp.platform_runner.version import _resolve_version, get_revision
+
+
+def test_resolve_version_uses_nemo_platform(monkeypatch):
+    monkeypatch.setattr("nmp.platform_runner.version.version", lambda _: "1.2.3")
+    assert _resolve_version() == "1.2.3"
+
+
+def test_resolve_version_falls_back_to_env(monkeypatch):
+    def _missing(_name: str) -> str:
+        raise PackageNotFoundError("nemo-platform")
+
+    monkeypatch.setattr("nmp.platform_runner.version.version", _missing)
+    monkeypatch.setenv("NMP_PLATFORM_VERSION", "9.9.9")
+    assert _resolve_version() == "9.9.9"
+
+
+def test_resolve_version_defaults_to_dev(monkeypatch):
+    def _missing(_name: str) -> str:
+        raise PackageNotFoundError("nemo-platform")
+
+    monkeypatch.setattr("nmp.platform_runner.version.version", _missing)
+    monkeypatch.delenv("NMP_PLATFORM_VERSION", raising=False)
+    assert _resolve_version() == "dev"
+
+
+def test_get_revision(monkeypatch):
+    monkeypatch.setenv("NMP_CODE_REVISION", "abc123")
+    assert get_revision() == "abc123"
+    monkeypatch.delenv("NMP_CODE_REVISION", raising=False)
+    assert get_revision() == "dev"

--- a/pytest.ini
+++ b/pytest.ini
@@ -26,6 +26,7 @@ pythonpath =
 testpaths =
     packages/nemo_platform_plugin/tests
     packages/nmp_platform/tests
+    packages/nmp_platform_runner/tests
     plugins/*/tests
     packages/data_designer_nemo/tests
     packages/models/tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved platform version detection by prioritizing the installed platform package, with environment-based fallback and a `"dev"` default.
  * Added code revision reporting from the configured environment variable (defaulting to `"dev"` when unset).
  * Included `safe-synthesizer` in the default available services.

* **Tests**
  * Added/expanded test coverage for version and revision resolution, including fallback behavior.
  * Updated test discovery to include platform runner tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->