### PR TITLE
fix(studio): Fix empty UI in DD details

### DIFF
--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.test.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.test.ts
@@ -53,20 +53,60 @@ describe('useDatasetFileContent gate', () => {
     await expect((queryFn as () => Promise<string>)()).resolves.toBe('# heading');
   });
 
-  it('returns full text (no preview cap) for fullContent editor loads', async () => {
+  it('returns full text (no preview cap) for fullContent editor loads within the ceiling', async () => {
+    const headSpy = vi.spyOn(axios, 'head').mockResolvedValueOnce({
+      headers: { 'content-length': String(EDITOR_MAX_BYTES - 1) },
+    } as never);
+
     const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, fullContent: true });
     await expect((queryFn as () => Promise<string>)()).resolves.toBe('# heading');
+
+    headSpy.mockRestore();
   });
 
   it('refuses fullContent loads above the editor ceiling instead of truncating', async () => {
-    // A file reporting a size past EDITOR_MAX_BYTES must throw so the caller shows a
-    // "too large" state — never silently load a prefix that would truncate on save.
     const headSpy = vi.spyOn(axios, 'head').mockResolvedValueOnce({
       headers: { 'content-length': String(EDITOR_MAX_BYTES + 1) },
     } as never);
 
     const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, fullContent: true });
     await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/too large to edit/i);
+
+    headSpy.mockRestore();
+  });
+
+  it('fails closed on fullContent loads when Content-Length is missing', async () => {
+    const headSpy = vi.spyOn(axios, 'head').mockResolvedValueOnce({ headers: {} } as never);
+
+    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, fullContent: true });
+    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/too large to edit/i);
+
+    headSpy.mockRestore();
+  });
+
+  it('fails closed on fullContent loads when Content-Length is non-numeric', async () => {
+    const headSpy = vi.spyOn(axios, 'head').mockResolvedValueOnce({
+      headers: { 'content-length': 'not-a-number' },
+    } as never);
+
+    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, fullContent: true });
+    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/too large to edit/i);
+
+    headSpy.mockRestore();
+  });
+
+  it('enforces the cap before downloading a parquet blob on fullContent loads', async () => {
+    const { filesDownloadFile } = await import('@nemo/sdk/generated/platform/api');
+    vi.mocked(filesDownloadFile).mockClear();
+    const headSpy = vi.spyOn(axios, 'head').mockResolvedValueOnce({ headers: {} } as never);
+
+    const { queryFn } = datasetFileContentQueryOptions({
+      ...baseParams,
+      path: 'data/sample.parquet',
+      fullContent: true,
+    });
+    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/too large to edit/i);
+    expect(filesDownloadFile).not.toHaveBeenCalled();
 
     headSpy.mockRestore();
   });

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.test.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.test.ts
@@ -95,6 +95,29 @@ describe('useDatasetFileContent gate', () => {
     headSpy.mockRestore();
   });
 
+  it('fails closed on fullContent loads when Content-Length is partially numeric', async () => {
+    // parseInt('123garbage') === 123, which would slip a truncated size past the cap.
+    const headSpy = vi.spyOn(axios, 'head').mockResolvedValueOnce({
+      headers: { 'content-length': `${EDITOR_MAX_BYTES - 1}garbage` },
+    } as never);
+
+    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, fullContent: true });
+    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/too large to edit/i);
+
+    headSpy.mockRestore();
+  });
+
+  it('fails closed on fullContent loads when Content-Length is negative', async () => {
+    const headSpy = vi.spyOn(axios, 'head').mockResolvedValueOnce({
+      headers: { 'content-length': '-1' },
+    } as never);
+
+    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, fullContent: true });
+    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/too large to edit/i);
+
+    headSpy.mockRestore();
+  });
+
   it('enforces the cap before downloading a parquet blob on fullContent loads', async () => {
     const { filesDownloadFile } = await import('@nemo/sdk/generated/platform/api');
     vi.mocked(filesDownloadFile).mockClear();

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.test.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.test.ts
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { datasetFileContentQueryOptions } from '@studio/api/datasets/useDatasetFileContent';
+import {
+  datasetFileContentQueryOptions,
+  EDITOR_MAX_BYTES,
+} from '@studio/api/datasets/useDatasetFileContent';
+import axios from 'axios';
 
 vi.mock('@nemo/sdk/generated/platform/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@nemo/sdk/generated/platform/api')>();
@@ -47,6 +51,24 @@ describe('useDatasetFileContent gate', () => {
     // and fall through to the Range fetch — treat as text.
     const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, path: 'noextension' });
     await expect((queryFn as () => Promise<string>)()).resolves.toBe('# heading');
+  });
+
+  it('returns full text (no preview cap) for fullContent editor loads', async () => {
+    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, fullContent: true });
+    await expect((queryFn as () => Promise<string>)()).resolves.toBe('# heading');
+  });
+
+  it('refuses fullContent loads above the editor ceiling instead of truncating', async () => {
+    // A file reporting a size past EDITOR_MAX_BYTES must throw so the caller shows a
+    // "too large" state — never silently load a prefix that would truncate on save.
+    const headSpy = vi.spyOn(axios, 'head').mockResolvedValueOnce({
+      headers: { 'content-length': String(EDITOR_MAX_BYTES + 1) },
+    } as never);
+
+    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, fullContent: true });
+    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/too large to edit/i);
+
+    headSpy.mockRestore();
   });
 
   it('serializes parquet rows with BigInt columns as JSONL text', async () => {

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -80,6 +80,17 @@ export const datasetFileContentQueryOptions = ({
         throw new Error('Unable to find base file.');
       }
 
+      // Enforce the editor cap before either branch pulls the whole file into memory —
+      // the parquet branch downloads the entire blob unconditionally, so a check inside
+      // it would come after the very download it's meant to prevent. Fail closed when the
+      // size is unknown: a missing or non-numeric Content-Length must not slip an
+      // unbounded file through.
+      if (fullContent && range === undefined) {
+        if (fileSize === null || Number.isNaN(fileSize) || fileSize > EDITOR_MAX_BYTES) {
+          throw new Error('File is too large to edit in the browser.');
+        }
+      }
+
       if (path.endsWith('parquet')) {
         try {
           let data: string = '';
@@ -104,11 +115,6 @@ export const datasetFileContentQueryOptions = ({
           throw new Error('Invalid response while downloading parquet file');
         }
       } else {
-        if (fullContent && range === undefined) {
-          if (fileSize !== null && fileSize > EDITOR_MAX_BYTES) {
-            throw new Error('File is too large to edit in the browser.');
-          }
-        }
         const start = range ? range[0] : 0;
         const end = range ? range[1] : FILE_PREVIEW_MAX_BYTES - 1;
         const isSizeCappedPreview =

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -26,9 +26,17 @@ function serializeParquetRow(row: unknown): string {
 // overwrite the source (the loaded rows are only a prefix of the file).
 export const FILE_PREVIEW_MAX_BYTES = 512 * 1024;
 
+export const EDITOR_MAX_BYTES = 8 * 1024 * 1024;
+
 interface UseDatasetFileContentParams extends Required<EntityIdentifier> {
   path: string;
   range?: [number, number];
+  /**
+   * Load the entire file (no preview cap) so its content can be safely edited and written
+   * back. Refuses files larger than {@link EDITOR_MAX_BYTES}. Ignored when `range` is set.
+   * @defaultValue false — callers get the size-capped preview.
+   */
+  fullContent?: boolean;
 }
 
 export type UseDatasetFilesOptions = Omit<UseQueryOptions<string, Error>, 'queryFn' | 'queryKey'> &
@@ -39,12 +47,14 @@ export const datasetFileContentQueryOptions = ({
   name,
   path,
   range,
+  fullContent,
 }: UseDatasetFileContentParams) =>
   queryOptions<string, Error>({
     staleTime: Infinity, // We should prevent refetching full files (costly) unless directly invalidated
     queryKey: [
       ...getDatasetFileContentQueryKey(workspace!, name, path),
       ...(range ? range.map((bound) => String(bound)) : []),
+      ...(fullContent ? ['full'] : []),
     ],
     queryFn: async () => {
       if (isBinaryExtension(path)) {
@@ -94,10 +104,18 @@ export const datasetFileContentQueryOptions = ({
           throw new Error('Invalid response while downloading parquet file');
         }
       } else {
+        if (fullContent && range === undefined) {
+          if (fileSize !== null && fileSize > EDITOR_MAX_BYTES) {
+            throw new Error('File is too large to edit in the browser.');
+          }
+        }
         const start = range ? range[0] : 0;
         const end = range ? range[1] : FILE_PREVIEW_MAX_BYTES - 1;
         const isSizeCappedPreview =
-          range === undefined && fileSize !== null && fileSize > FILE_PREVIEW_MAX_BYTES;
+          !fullContent &&
+          range === undefined &&
+          fileSize !== null &&
+          fileSize > FILE_PREVIEW_MAX_BYTES;
         const needsRange = range !== undefined || isSizeCappedPreview;
         const blob = await customFetch<Blob>({
           url: fileUrl,
@@ -120,10 +138,11 @@ export const useDatasetFileContent = ({
   name,
   path,
   range,
+  fullContent,
   ...options
 }: UseDatasetFilesOptions) => {
   return useQuery({
-    ...datasetFileContentQueryOptions({ workspace, name, path, range }),
+    ...datasetFileContentQueryOptions({ workspace, name, path, range, fullContent }),
     enabled: Boolean(workspace && name && path),
     ...options,
   });
@@ -134,10 +153,11 @@ export const useDatasetFileContentSuspense = ({
   name,
   path,
   range,
+  fullContent,
   ...options
 }: UseDatasetFilesOptions) => {
   return useSuspenseQuery({
-    ...datasetFileContentQueryOptions({ workspace, name, path, range }),
+    ...datasetFileContentQueryOptions({ workspace, name, path, range, fullContent }),
     ...options,
   });
 };

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -20,10 +20,21 @@ function jsonReplacer(_key: string, value: unknown): unknown {
 function serializeParquetRow(row: unknown): string {
   return JSON.stringify(row, jsonReplacer);
 }
-// Cap text-file preview at 512 KB. Enough to show meaningful JSONL content
-// while preventing OOM crashes on multi-GB external dataset shards. Text files larger
-// than this are fetched with a Range request, so callers that write content back must not
-// overwrite the source (the loaded rows are only a prefix of the file).
+
+/**
+ * Parse a Content-Length header into a byte count, accepting only a strict
+ * non-negative integer. Returns null for missing, malformed (`123garbage`),
+ * negative (`-1`), or otherwise non-numeric values so the fail-closed editor
+ * cap treats an untrustworthy size as unknown rather than letting a partially
+ * numeric value (which `parseInt` would happily coerce) slip through.
+ */
+function parseContentLength(contentLength: unknown): number | null {
+  if (typeof contentLength !== 'string' || !/^\d+$/.test(contentLength)) {
+    return null;
+  }
+  const size = Number(contentLength);
+  return Number.isSafeInteger(size) ? size : null;
+}
 export const FILE_PREVIEW_MAX_BYTES = 512 * 1024;
 
 export const EDITOR_MAX_BYTES = 8 * 1024 * 1024;
@@ -67,24 +78,14 @@ export const datasetFileContentQueryOptions = ({
         encodeURIComponent(path)
       );
 
-      // HEAD the file to confirm it exists and read Content-Length for conditional ranging.
-      // Prepend PLATFORM_BASE_URL so axios resolves the correct host (the relative
-      // path alone resolves against window.location, which differs in tests and
-      // may differ in deployed environments with a custom base path).
       let fileSize: number | null = null;
       try {
         const headResponse = await axios.head(`${PLATFORM_BASE_URL}${fileUrl}`);
-        const contentLength = headResponse.headers['content-length'];
-        fileSize = contentLength ? parseInt(String(contentLength), 10) : null;
+        fileSize = parseContentLength(headResponse.headers['content-length']);
       } catch {
         throw new Error('Unable to find base file.');
       }
 
-      // Enforce the editor cap before either branch pulls the whole file into memory —
-      // the parquet branch downloads the entire blob unconditionally, so a check inside
-      // it would come after the very download it's meant to prevent. Fail closed when the
-      // size is unknown: a missing or non-numeric Content-Length must not slip an
-      // unbounded file through.
       if (fullContent && range === undefined) {
         if (fileSize === null || Number.isNaN(fileSize) || fileSize > EDITOR_MAX_BYTES) {
           throw new Error('File is too large to edit in the browser.');
@@ -94,7 +95,6 @@ export const datasetFileContentQueryOptions = ({
       if (path.endsWith('parquet')) {
         try {
           let data: string = '';
-          // Use SDK so the request includes auth (Bearer token). asyncBufferFromUrl does a raw fetch with no credentials → 401.
           const blob = await filesDownloadFile(workspace!, name, path);
           if (!blob) throw new Error('Invalid response while downloading parquet file');
           const buffer = await blob.arrayBuffer();

--- a/web/packages/studio/src/components/CreateFilesetStart/StartOptionDetail.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/StartOptionDetail.tsx
@@ -66,7 +66,7 @@ export const StartOptionDetail: FC<StartOptionDetailProps> = ({
 }) => {
   const content =
     option.id === 'template' ? (
-      <Grid colMinWidth="260px" gap="density-md">
+      <Grid colMinWidth="300px" gap="density-md">
         {FILESET_TEMPLATES.map((template) => (
           <TemplateCard
             key={template.id}

--- a/web/packages/studio/src/components/FileRowEditor/index.test.tsx
+++ b/web/packages/studio/src/components/FileRowEditor/index.test.tsx
@@ -77,6 +77,31 @@ describe('FileRowEditor', () => {
     expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument();
   });
 
+  it('re-enables Save File for a second edit after a successful save', async () => {
+    const user = userEvent.setup();
+    const onSaveFile = vi.fn().mockResolvedValue(undefined);
+    render(<FileRowEditor initialRows={SAMPLE_ROWS} onSaveFile={onSaveFile} />);
+
+    const saveFileButton = screen.getByRole('button', { name: 'Save File' });
+
+    // Cycle 1: edit → stage → save.
+    await user.click(screen.getByText('cuDNN'));
+    await user.type(screen.getByLabelText('topic'), ' one');
+    await user.click(screen.getByRole('button', { name: 'Stage Changes' }));
+    expect(saveFileButton).toBeEnabled();
+    await user.click(saveFileButton);
+    await waitFor(() => expect(saveFileButton).toBeDisabled());
+    expect(onSaveFile).toHaveBeenCalledTimes(1);
+
+    // Cycle 2: edit a row again → stage → the button must re-enable and save again.
+    await user.click(screen.getByText('TensorRT'));
+    await user.type(screen.getByLabelText('topic'), ' two');
+    await user.click(screen.getByRole('button', { name: 'Stage Changes' }));
+    await waitFor(() => expect(saveFileButton).toBeEnabled());
+    await user.click(saveFileButton);
+    await waitFor(() => expect(onSaveFile).toHaveBeenCalledTimes(2));
+  });
+
   it('keeps the dirty state when a save fails so the user can retry', async () => {
     const user = userEvent.setup();
     const onSaveFile = vi.fn().mockRejectedValue(new Error('upload failed'));

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection.tsx
@@ -1,8 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { LogViewer } from '@nemo/common/src/components/LogViewer';
 import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
-import { Flex, Grid, ProgressBar, Skeleton, Stack, Text } from '@nvidia/foundations-react-core';
+import { useJobLogs } from '@nemo/common/src/hooks/useJobLogs';
+import {
+  Card,
+  Flex,
+  Grid,
+  ProgressBar,
+  Skeleton,
+  Stack,
+  Text,
+} from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/Empty';
 import { ColumnProfileCard } from '@studio/routes/DataDesignerJobDetailsRoute/ColumnProfileCard';
 import {
@@ -30,17 +40,24 @@ export const DatasetProfilerSection: FC = () => {
     { enabled: isTerminal }
   );
 
-  // Job still running: the profiler hasn't produced an analysis result yet.
-  if (!isTerminal) {
-    return <Empty title="The dataset profile will appear here once the job completes." />;
-  }
+  const { data: logs, isLoading: isLogsLoading } = useJobLogs({
+    workspace,
+    name: jobName,
+    jobStatus: job?.status,
+    enabled: isTerminal,
+  });
 
-  if (isError) {
+  const CardWrapper: FC<{ children: React.ReactNode }> = ({ children }) => (
+    <Card className="w-full h-full">{children}</Card>
+  );
+
+  if (!isTerminal) {
     return (
-      <Empty
-        title="Failed to load dataset profile"
-        description="The profiler analysis could not be loaded for this job."
-      />
+      <CardWrapper>
+        <Flex className="self-center justify-self-center" gap="2">
+          <Empty title="The dataset profile will appear here once the job completes." />
+        </Flex>
+      </CardWrapper>
     );
   }
 
@@ -54,8 +71,30 @@ export const DatasetProfilerSection: FC = () => {
     );
   }
 
-  if (!hasAnalysis) {
-    return <Empty title="No dataset profile was generated for this job." />;
+  if (isError || !hasAnalysis) {
+    return (
+      <CardWrapper>
+        <Stack gap="density-2xl" className="overflow-hidden">
+          <Empty
+            title={
+              isError
+                ? 'Failed to load dataset profile'
+                : 'No dataset profile was generated for this job.'
+            }
+            description={
+              isError
+                ? 'The profiler analysis could not be loaded for this job. Review the job logs below for details.'
+                : 'Review the job logs below for details.'
+            }
+          />
+          <LogViewer
+            logs={logs}
+            isLoading={isLogsLoading}
+            downloadFilename={`data-designer-${jobName}-logs.txt`}
+          />
+        </Stack>
+      </CardWrapper>
+    );
   }
 
   const columns = analysis?.column_statistics ?? [];

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
@@ -15,7 +15,7 @@ import {
   Text,
 } from '@nvidia/foundations-react-core';
 import {
-  FILE_PREVIEW_MAX_BYTES,
+  EDITOR_MAX_BYTES,
   useDatasetFileContent,
 } from '@studio/api/datasets/useDatasetFileContent';
 import { useDatasetFilesUpload } from '@studio/api/datasets/useDatasetFilesUpload';
@@ -123,6 +123,10 @@ export const JobDatasetEditorSection: FC = () => {
   // The hook returns Parquet content already decoded to JSONL, so parse it as JSONL.
   const parseFormat: DataFileFormat = sourceFormat === 'parquet' ? 'jsonl' : sourceFormat;
 
+  const isTooLargeToEdit = Boolean(
+    selectedFile && sourceFormat !== 'parquet' && selectedFile.size > EDITOR_MAX_BYTES
+  );
+
   const {
     data: rawContent,
     isLoading: isContentLoading,
@@ -131,7 +135,8 @@ export const JobDatasetEditorSection: FC = () => {
     workspace: filesetWorkspace,
     name: filesetName,
     path: selectedPath ?? '',
-    enabled: Boolean(filesetWorkspace && filesetName && selectedPath),
+    fullContent: true,
+    enabled: Boolean(filesetWorkspace && filesetName && selectedPath && !isTooLargeToEdit),
   });
 
   const parsed = useMemo(() => {
@@ -147,13 +152,6 @@ export const JobDatasetEditorSection: FC = () => {
       };
     }
   }, [rawContent, parseFormat]);
-
-  const isContentTruncated = Boolean(
-    selectedFile && sourceFormat !== 'parquet' && selectedFile.size > FILE_PREVIEW_MAX_BYTES
-  );
-  const saveDisabledReason = isContentTruncated
-    ? 'This file is too large to load in full — saving is disabled to avoid truncating it.'
-    : undefined;
 
   const toast = useToast();
   const { mutateAsync: uploadFiles, isPending: isSaving } = useDatasetFilesUpload();
@@ -239,6 +237,15 @@ export const JobDatasetEditorSection: FC = () => {
       );
     }
 
+    if (isTooLargeToEdit) {
+      return centered(
+        <Empty
+          title="File too large to edit"
+          description="This file exceeds the 8 MB limit for in-browser editing. Download it to edit locally."
+        />
+      );
+    }
+
     if (isContentLoading || parsed == null) {
       return centered(<Spinner aria-label="Loading file" description="Loading file..." />);
     }
@@ -265,7 +272,6 @@ export const JobDatasetEditorSection: FC = () => {
         showOpenFile={false}
         onSaveFile={handleSaveFile}
         isSaving={isSaving}
-        saveDisabledReason={saveDisabledReason}
       />
     );
   };

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
@@ -24,6 +24,7 @@ import { JobDatasetEditorSection } from '@studio/routes/DataDesignerJobDetailsRo
 import { JobOutputFilesetSection } from '@studio/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection';
 import { useDataDesignerJobFromRoute } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerJobFromRoute';
 import { getDataDesignerJobListRoute } from '@studio/routes/utils';
+import { formatDateTime } from '@studio/util/date';
 import { ArrowLeft, FileJson } from 'lucide-react';
 import { useState, type FC } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
@@ -114,12 +115,12 @@ export const DataDesignerJobDetailsRoute: FC = () => {
           <Flex gap="density-lg" className="flex-wrap">
             {job.created_at && (
               <Text kind="body/regular/sm" className="text-muted">
-                Created: {new Date(job.created_at).toLocaleString()}
+                Created: {formatDateTime(job.created_at)}
               </Text>
             )}
             {job.updated_at && (
               <Text kind="body/regular/sm" className="text-muted">
-                Updated: {new Date(job.updated_at).toLocaleString()}
+                Updated: {formatDateTime(job.updated_at)}
               </Text>
             )}
           </Flex>

--- a/web/packages/studio/src/util/date.ts
+++ b/web/packages/studio/src/util/date.ts
@@ -3,14 +3,17 @@
 
 /**
  * Turns a dateString like "2024-02-29T02:27:13.509827", or a timestamp in milliseconds like 1721151036524,
- * into a formatted date string.
+ * into a formatted date string. Expects a UTC date string or normalizes input to UTC if a date string is provided without a timezone.
  *
  * If `includeDate` is true, it will include the date like "02/29/24 02:27:13 PM"
  * Otherwise, it will only include the time like "02:27:12 PM"
  */
 export function formatDateTime(dateValue: string | number, includeDate: boolean = true) {
-  const date = new Date(dateValue);
-  const userLocale = navigator.language; // Gets the browser's language setting
+  const tzRegex = /Z|[+-]\d{2}:\d{2}$/;
+  const normalized =
+    typeof dateValue === 'string' && !tzRegex.test(dateValue) ? dateValue + 'Z' : dateValue;
+  const date = new Date(normalized);
+  const userLocale = navigator.language;
 
   const options: Intl.DateTimeFormatOptions = {
     ...(includeDate && {


### PR DESCRIPTION
<img width="1129" height="898" alt="Screenshot 2026-07-14 at 3 19 44 PM" src="https://github.com/user-attachments/assets/1c4b2195-a39e-4af4-8c81-5f78900c4c6b" />

fix(studio): Fix empty UI in DD details

Signed-off-by: Sean Teramae <steramae@nvidia.com>

fix TZ in details

Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit complete text files in-browser up to an 8 MB limit, with clear errors when files are too large.
  * Display dataset profiling job logs when analysis can’t be loaded or no results are generated (including terminal job states).
* **Bug Fixes**
  * Fixed the “Save File” workflow to allow a second edit/save cycle after a prior successful save.
  * Improved job timestamp formatting for timezone-free date strings.
* **UI Improvements**
  * Refined template card sizing for better wrapping.
  * When a file exceeds the editing limit, users are prompted to download it for local editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->