### PR TITLE
fix: port and rename `nmp` mcp to `nemo`

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
-    "nmp"
+    "nemo"
   ],
   "sandbox": {
     "excludedCommands": [
@@ -13,7 +13,7 @@
     ],
     "filesystem": {
       "allowWrite": [
-        "$HOME/.config/nmp",
+        "$HOME/.config/nemo",
         "$HOME/.local/share/nemo"
       ]
     }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,12 @@
 {
   "mcpServers": {
-    "nmp": {
+    "nemo": {
       "type": "stdio",
       "command": "sh",
-      "args": ["-c", "uv run nemo-mcp --base-url ${NMP_BASE_URL:-http://localhost:8000}"]
+      "args": [
+        "-c",
+        "uv run nemo-mcp --base-url ${NMP_BASE_URL:-http://localhost:8080}"
+      ]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "uv run nemo-mcp --base-url ${NMP_BASE_URL:-http://localhost:8080}"
+        "uv run nemo-mcp --base-url \"${NMP_BASE_URL:-http://localhost:8080}\""
       ]
     }
   }


### PR DESCRIPTION
I noticed the port for the `nmp` MCP was incorrect, so I updated that and renamed it to `nemo` since that's what the platform is now known as.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Nemo service configuration and local file-access path.
  - Renamed the MCP server entry from the previous identifier to Nemo.
  - Changed the default local service endpoint from port **8000** to **8080** when no base URL is provided.
  - Reformatted the Nemo service launch settings for clearer readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->