### PR TITLE
ci: add nuance to the cleanup around multi-arch images plus ghcr

### DIFF
--- a/.github/scripts/cleanup-ghcr-ci-images.sh
+++ b/.github/scripts/cleanup-ghcr-ci-images.sh
@@ -66,25 +66,99 @@ echo "Scanning ${CLEANUP_SCOPE:-ci} package versions last updated before ${cutof
 echo "dry_run=${DRY_RUN}"
 
 total_deleted=0
-total_candidates=0
+total_primary_candidates=0
+total_child_candidates=0
 
 url_encode() {
   jq -nr --arg value "$1" '$value|@uri'
 }
 
-find_stale_versions() {
+find_package_versions() {
   local endpoint="$1"
+
+  gh api --paginate "${endpoint}/versions?per_page=100" --jq '.[]'
+}
+
+find_stale_versions() {
+  local package_versions="$1"
   local jq_filter
   jq_filter="
-    .[] |
     select(.updated_at != null and .updated_at < \"${cutoff}\") |
+    select((.metadata.container.tags // []) | length > 0) |
     select(((.metadata.container.tags // []) | index(\"latest\")) | not) |
     ${tag_filter} |
     [.id, .name, .updated_at, ((.metadata.container.tags // []) | join(\",\"))] |
     @tsv
   "
 
-  gh api --paginate "${endpoint}/versions?per_page=100" --jq "${jq_filter}"
+  jq -r "${jq_filter}" <<< "${package_versions}"
+}
+
+find_tagged_versions() {
+  local package_versions="$1"
+
+  jq -r '
+    select((.metadata.container.tags // []) | length > 0) |
+    [.id, .name] |
+    @tsv
+  ' <<< "${package_versions}"
+}
+
+find_manifest_children() {
+  local package_ref="$1"
+  local parent_versions="$2"
+  local parent_id
+  local parent_digest
+
+  while IFS=$'\t' read -r parent_id parent_digest; do
+    if [ -z "${parent_id}" ]; then
+      continue
+    fi
+
+    if ! docker manifest inspect "${package_ref}@${parent_digest}" |
+      jq -r --arg parent_id "${parent_id}" '
+        .manifests[]? |
+        [$parent_id, .digest] |
+        @tsv
+      '; then
+      return 1
+    fi
+  done <<< "${parent_versions}"
+}
+
+find_child_versions() {
+  local package_versions="$1"
+  local child_digests="$2"
+  local child_digest
+  local child_version
+  local child_id
+  local child_tag_count
+
+  while IFS= read -r child_digest; do
+    if [ -z "${child_digest}" ]; then
+      continue
+    fi
+
+    child_version="$(
+      jq -r --arg digest "${child_digest}" '
+        select(.name == $digest) |
+        [.id, ((.metadata.container.tags // []) | length)] |
+        @tsv
+      ' <<< "${package_versions}"
+    )"
+    if [ -z "${child_version}" ]; then
+      echo "Could not find package version for child manifest ${child_digest}." >&2
+      return 1
+    fi
+
+    IFS=$'\t' read -r child_id child_tag_count <<< "${child_version}"
+    if [ "${child_tag_count}" -ne 0 ]; then
+      echo "Keeping child manifest ${child_digest}; it has tags." >&2
+      continue
+    fi
+
+    printf '%s\t%s\n' "${child_id}" "${child_digest}"
+  done <<< "${child_digests}"
 }
 
 for package_id in "${package_ids[@]}"; do
@@ -95,7 +169,7 @@ for package_id in "${package_ids[@]}"; do
   echo "::group::${package_name}"
 
   api_error="$(mktemp)"
-  if ! stale_versions="$(find_stale_versions "${endpoint}" 2>"${api_error}")"; then
+  if ! package_versions="$(find_package_versions "${endpoint}" 2>"${api_error}")"; then
     if grep -q "HTTP 404" "${api_error}"; then
       echo "Package ${package_name} was not found; skipping."
       echo "::endgroup::"
@@ -106,8 +180,69 @@ for package_id in "${package_ids[@]}"; do
     exit 1
   fi
 
+  stale_versions="$(find_stale_versions "${package_versions}")"
   if [ -z "${stale_versions}" ]; then
     echo "No stale package versions found."
+    echo "::endgroup::"
+    continue
+  fi
+
+  tagged_versions="$(find_tagged_versions "${package_versions}")"
+  candidate_ids="$(cut -f1 <<< "${stale_versions}")"
+  candidate_parents="$(cut -f1,2 <<< "${stale_versions}")"
+  retained_parents="$(
+    awk -F $'\t' '
+      NR == FNR { candidate[$1] = 1; next }
+      !candidate[$1]
+    ' <(printf '%s\n' "${candidate_ids}") <<< "${tagged_versions}"
+  )"
+  package_ref="ghcr.io/${GITHUB_REPOSITORY,,}/${package_id}"
+
+  if ! candidate_children="$(find_manifest_children "${package_ref}" "${candidate_parents}")"; then
+    echo "Could not inspect candidate manifests; no package versions were deleted." >&2
+    exit 1
+  fi
+
+  candidate_child_digests="$(cut -f2 <<< "${candidate_children}" | sort -u)"
+  retained_children=""
+  if [ -n "${candidate_child_digests}" ] && [ -n "${retained_parents}" ]; then
+    if ! retained_children="$(find_manifest_children "${package_ref}" "${retained_parents}")"; then
+      echo "Could not inspect retained manifests; no package versions were deleted." >&2
+      exit 1
+    fi
+  fi
+
+  child_digests_to_delete="$(
+    awk -F $'\t' '
+      NR == FNR { retained[$2] = 1; next }
+      !retained[$1] { print $1 }
+    ' <(printf '%s\n' "${retained_children}") <(printf '%s\n' "${candidate_child_digests}")
+  )"
+  if ! child_versions="$(find_child_versions "${package_versions}" "${child_digests_to_delete}")"; then
+    echo "Could not resolve child manifest versions; no package versions were deleted." >&2
+    exit 1
+  fi
+
+  while IFS=$'\t' read -r version_id digest updated_at tags; do
+    if [ -z "${version_id}" ]; then
+      continue
+    fi
+
+    total_primary_candidates=$((total_primary_candidates + 1))
+    tag_summary="${tags:-<untagged>}"
+    echo "Candidate ${package_name}@${digest} updated_at=${updated_at} tags=${tag_summary}"
+  done <<< "${stale_versions}"
+
+  while IFS=$'\t' read -r child_id child_digest; do
+    if [ -z "${child_id}" ]; then
+      continue
+    fi
+
+    total_child_candidates=$((total_child_candidates + 1))
+    echo "Child candidate ${package_name}@${child_digest}"
+  done <<< "${child_versions}"
+
+  if [ "${DRY_RUN}" = "true" ]; then
     echo "::endgroup::"
     continue
   fi
@@ -117,21 +252,24 @@ for package_id in "${package_ids[@]}"; do
       continue
     fi
 
-    total_candidates=$((total_candidates + 1))
-    tag_summary="${tags:-<untagged>}"
-    echo "Candidate ${package_name}@${digest} updated_at=${updated_at} tags=${tag_summary}"
-
-    if [ "${DRY_RUN}" = "true" ]; then
-      continue
-    fi
-
     gh api -X DELETE "${endpoint}/versions/${version_id}" >/dev/null
     total_deleted=$((total_deleted + 1))
     echo "Deleted package version ${version_id}"
   done <<< "${stale_versions}"
 
+  while IFS=$'\t' read -r child_id child_digest; do
+    if [ -z "${child_id}" ]; then
+      continue
+    fi
+
+    gh api -X DELETE "${endpoint}/versions/${child_id}" >/dev/null
+    total_deleted=$((total_deleted + 1))
+    echo "Deleted child package version ${child_id}"
+  done <<< "${child_versions}"
+
   echo "::endgroup::"
 done
 
-echo "Stale candidates: ${total_candidates}"
+echo "Stale primary candidates: ${total_primary_candidates}"
+echo "Child manifest candidates: ${total_child_candidates}"
 echo "Deleted versions: ${total_deleted}"

--- a/.github/workflows/ghcr-cleanup.yaml
+++ b/.github/workflows/ghcr-cleanup.yaml
@@ -39,6 +39,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Delete stale package versions
         shell: bash
         env:
@@ -60,6 +67,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Delete stale nightly release versions
         shell: bash


### PR DESCRIPTION
So we discovered that GCHR doesn't preserve easy logical links between manfests sometimes and cleaning up containers using the GH API can corrupt manifests if anything is quirky with that. 

This repo doesn't have the same issue around this as some, but nuance doesn't hurt. This should

1. skip enumerating the untagged manifests
2. gather child manifests from the primary one
3. delete all of them for a flagged version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated container image cleanup to safely identify and remove stale image versions and related manifests.
  * Added authenticated registry access to scheduled cleanup workflows, improving reliability when managing stored images.
  * Updated cleanup reporting to separately summarize primary and related image versions processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->