### PR TITLE
fix(platform-runner): seed NMP_BASE_URL from config platform.base_url

### DIFF
--- a/packages/nmp_platform_runner/src/nmp/platform_runner/config.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/config.py
@@ -156,20 +156,23 @@ def apply_run_environment(
     In standalone mode these variables are absent, so setdefault fills them in.
 
     Precedence for NMP_BASE_URL: an externally-provided value (Helm / k8s) wins,
-    then an explicit ``platform.base_url`` *host* from the config file combined
-    with the actual bind port, then a value derived entirely from the bind
-    host/port. Seeding the host from the config file lets operators set a base
+    then the scheme + host of an explicit ``platform.base_url`` from the config
+    file combined with the actual bind port, then a value derived entirely from
+    the bind host/port. Seeding from the config file lets operators set a base
     URL reachable from inside deployed agent containers (e.g. the Docker bridge
     address) via config alone; without this the bind-derived loopback default
     would silently shadow the configured value.
 
-    Only the host (and scheme) of the configured ``platform.base_url`` is
+    Only the scheme and host of the configured ``platform.base_url`` are
     honored — its port is replaced with the port the server actually binds. A
     config that hardcodes ``:8080`` must not point internal clients (and the
     embedded PDP) at 8080 when the platform is launched on another port (which
     the e2e harness always does, and any ``nemo services run --port`` differing
     from 8080 does); doing so leaves internal HTTP clients unable to reach the
-    server and the platform never becomes ready.
+    server and the platform never becomes ready. The configured host is run
+    through the same wildcard -> loopback normalization as the bind host, so a
+    config like ``http://0.0.0.0:8080`` (the bundled ``local.yaml`` default)
+    still yields a connectable internal base URL.
     """
     if env is None:
         env = os.environ
@@ -177,13 +180,14 @@ def apply_run_environment(
     connect_host = _connect_host_for_internal_clients(config.host)
     effective_host = env.setdefault("NMP_SERVICE_HOST", connect_host)
     effective_port = env.setdefault("NMP_SERVICE_PORT", str(config.port))
-    normalized = effective_host.strip("[]")
-    url_host = f"[{normalized}]" if ":" in normalized else normalized
-    config_base_url_host = _config_file_base_url_host(config.config_path)
-    if config_base_url_host is not None:
-        default_base_url = f"http://{config_base_url_host}:{effective_port}"
+    config_base_url_parts = _config_file_base_url_parts(config.config_path)
+    if config_base_url_parts is not None:
+        scheme, config_host = config_base_url_parts
+        host_for_url = _bracket_ipv6(_connect_host_for_internal_clients(config_host))
+        default_base_url = f"{scheme}://{host_for_url}:{effective_port}"
     else:
-        default_base_url = f"http://{url_host}:{effective_port}"
+        host_for_url = _bracket_ipv6(effective_host)
+        default_base_url = f"http://{host_for_url}:{effective_port}"
     base_url = env.setdefault("NMP_BASE_URL", default_base_url)
     # Embedded PDP is served from the same platform process; keep the auth client
     # origin aligned with NMP_BASE_URL when services run on a non-default port.
@@ -201,19 +205,21 @@ def _set_or_clear_env(env: MutableMapping[str, str], name: str, values: set[str]
         env.pop(name, None)
 
 
-def _config_file_base_url_host(config_path: str) -> str | None:
-    """Return the host of an explicit ``platform.base_url`` from the config file.
+def _config_file_base_url_parts(config_path: str) -> tuple[str, str] | None:
+    """Return the (scheme, host) of an explicit ``platform.base_url`` from config.
 
     Reads the raw YAML rather than the merged config object so a value present
     in the file can be told apart from the schema default (the merged config
-    always carries ``base_url``). Returns the host component (already bracketed
-    for IPv6 so it can be dropped into an ``http://<host>:<port>`` URL), or
-    ``None`` when the file is missing, unreadable, does not set
-    ``platform.base_url``, or the value has no parseable host.
+    always carries ``base_url``). Returns the URL scheme (defaulting to
+    ``"http"`` when the config omits one) and the host component, or ``None``
+    when the file is missing, unreadable, does not set ``platform.base_url``, or
+    the value has no parseable host.
 
-    Only the host is returned — callers pair it with the actual bind port, so a
-    config that hardcodes a port (e.g. ``:8080``) does not point internal
-    clients at the wrong port when the platform runs on a different one.
+    The host is returned unbracketed (as ``urlparse`` yields it) so callers can
+    normalize it (e.g. wildcard -> loopback) before composing the final URL.
+    Only the scheme and host are returned — callers pair them with the actual
+    bind port, so a config that hardcodes a port (e.g. ``:8080``) does not point
+    internal clients at the wrong port when the platform runs on a different one.
     """
     try:
         global_settings = Configuration.get_global_settings_from_file(config_path)
@@ -225,12 +231,16 @@ def _config_file_base_url_host(config_path: str) -> str | None:
     base_url = platform_settings.get("base_url")
     if not isinstance(base_url, str) or not base_url:
         return None
-    parsed = urlparse(base_url)
+    try:
+        parsed = urlparse(base_url)
+    except ValueError:
+        # Malformed value (e.g. an unterminated bracketed IPv6 like
+        # ``http://[::1``). Fall back to the bind-derived default rather than
+        # aborting startup — a bad config value should fail soft here.
+        return None
     if not parsed.hostname:
         return None
-    # urlparse lowercases and strips IPv6 brackets from hostname; re-bracket so
-    # the host can be safely composed back into an http://<host>:<port> URL.
-    return f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    return parsed.scheme or "http", parsed.hostname
 
 
 def _connect_host_for_internal_clients(host: str) -> str:
@@ -246,3 +256,14 @@ def _connect_host_for_internal_clients(host: str) -> str:
     if stripped in _IPV6_WILDCARDS:
         return _IPV6_LOOPBACK
     return stripped
+
+
+def _bracket_ipv6(host: str) -> str:
+    """Bracket an IPv6 literal so it can be composed into ``<host>:<port>``.
+
+    Accepts an already-stripped host (no surrounding brackets) and wraps it in
+    ``[...]`` when it is an IPv6 literal (contains ``:``); returns other hosts
+    unchanged.
+    """
+    stripped = host.strip("[]")
+    return f"[{stripped}]" if ":" in stripped else stripped

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/config.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/config.py
@@ -9,6 +9,7 @@ import os
 from collections.abc import Callable, MutableMapping
 from dataclasses import dataclass, field
 from importlib.resources import files
+from urllib.parse import urlparse
 
 from nmp.common.config import (
     NMP_CONFIG_FILE_PATH_ENV_VAR,
@@ -153,6 +154,22 @@ def apply_run_environment(
     Uses ``setdefault`` for NMP_BASE_URL / NMP_SERVICE_HOST / NMP_SERVICE_PORT
     so that values pre-set by Helm / k8s (deployed mode) are never overwritten.
     In standalone mode these variables are absent, so setdefault fills them in.
+
+    Precedence for NMP_BASE_URL: an externally-provided value (Helm / k8s) wins,
+    then an explicit ``platform.base_url`` *host* from the config file combined
+    with the actual bind port, then a value derived entirely from the bind
+    host/port. Seeding the host from the config file lets operators set a base
+    URL reachable from inside deployed agent containers (e.g. the Docker bridge
+    address) via config alone; without this the bind-derived loopback default
+    would silently shadow the configured value.
+
+    Only the host (and scheme) of the configured ``platform.base_url`` is
+    honored — its port is replaced with the port the server actually binds. A
+    config that hardcodes ``:8080`` must not point internal clients (and the
+    embedded PDP) at 8080 when the platform is launched on another port (which
+    the e2e harness always does, and any ``nemo services run --port`` differing
+    from 8080 does); doing so leaves internal HTTP clients unable to reach the
+    server and the platform never becomes ready.
     """
     if env is None:
         env = os.environ
@@ -162,7 +179,12 @@ def apply_run_environment(
     effective_port = env.setdefault("NMP_SERVICE_PORT", str(config.port))
     normalized = effective_host.strip("[]")
     url_host = f"[{normalized}]" if ":" in normalized else normalized
-    base_url = env.setdefault("NMP_BASE_URL", f"http://{url_host}:{effective_port}")
+    config_base_url_host = _config_file_base_url_host(config.config_path)
+    if config_base_url_host is not None:
+        default_base_url = f"http://{config_base_url_host}:{effective_port}"
+    else:
+        default_base_url = f"http://{url_host}:{effective_port}"
+    base_url = env.setdefault("NMP_BASE_URL", default_base_url)
     # Embedded PDP is served from the same platform process; keep the auth client
     # origin aligned with NMP_BASE_URL when services run on a non-default port.
     env.setdefault("NMP_AUTH_POLICY_DECISION_POINT_BASE_URL", base_url)
@@ -177,6 +199,38 @@ def _set_or_clear_env(env: MutableMapping[str, str], name: str, values: set[str]
         env[name] = ",".join(sorted(values))
     else:
         env.pop(name, None)
+
+
+def _config_file_base_url_host(config_path: str) -> str | None:
+    """Return the host of an explicit ``platform.base_url`` from the config file.
+
+    Reads the raw YAML rather than the merged config object so a value present
+    in the file can be told apart from the schema default (the merged config
+    always carries ``base_url``). Returns the host component (already bracketed
+    for IPv6 so it can be dropped into an ``http://<host>:<port>`` URL), or
+    ``None`` when the file is missing, unreadable, does not set
+    ``platform.base_url``, or the value has no parseable host.
+
+    Only the host is returned — callers pair it with the actual bind port, so a
+    config that hardcodes a port (e.g. ``:8080``) does not point internal
+    clients at the wrong port when the platform runs on a different one.
+    """
+    try:
+        global_settings = Configuration.get_global_settings_from_file(config_path)
+    except (OSError, ValueError):
+        return None
+    platform_settings = global_settings.get("platform")
+    if not isinstance(platform_settings, dict):
+        return None
+    base_url = platform_settings.get("base_url")
+    if not isinstance(base_url, str) or not base_url:
+        return None
+    parsed = urlparse(base_url)
+    if not parsed.hostname:
+        return None
+    # urlparse lowercases and strips IPv6 brackets from hostname; re-bracket so
+    # the host can be safely composed back into an http://<host>:<port> URL.
+    return f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
 
 
 def _connect_host_for_internal_clients(host: str) -> str:

--- a/packages/nmp_platform_runner/tests/test_config.py
+++ b/packages/nmp_platform_runner/tests/test_config.py
@@ -24,7 +24,7 @@ def _make_config(
     sidecars: set[str] | None = None,
     host: str = "0.0.0.0",
     port: int = 8080,
-    config_path: str = "/tmp/test.yaml",
+    config_path: str = "/nonexistent/nmp-test-config.yaml",
 ) -> ResolvedRunConfiguration:
     return ResolvedRunConfiguration(
         services=services if services is not None else {"auth", "entities"},
@@ -210,3 +210,60 @@ class TestApplyRunEnvDeployed:
         }
         apply_run_environment(_make_config(host="0.0.0.0", port=8080), env=env)
         assert env["NMP_BASE_URL"] == "http://nemo-platform-api:9090"
+
+
+class TestApplyRunEnvConfigBaseUrl:
+    """Standalone mode with an explicit platform.base_url in the config file.
+
+    The config value's *host* must seed NMP_BASE_URL (instead of the
+    bind-derived loopback default) so operators can set a container-reachable
+    base URL via config alone — but paired with the actual bind port, not the
+    port hardcoded in the config. An externally-provided NMP_BASE_URL still
+    wins.
+    """
+
+    def _write_config(self, tmp_path, body: str) -> str:
+        path = tmp_path / "config.yaml"
+        path.write_text(body, encoding="utf-8")
+        return str(path)
+
+    def test_seeds_base_url_host_from_config_file(self, tmp_path):
+        config_path = self._write_config(tmp_path, "platform:\n  base_url: http://172.17.0.1:8080\n")
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(host="0.0.0.0", port=8080, config_path=config_path), env=env)
+        assert env["NMP_BASE_URL"] == "http://172.17.0.1:8080"
+        # Embedded PDP base URL follows NMP_BASE_URL.
+        assert env["NMP_AUTH_POLICY_DECISION_POINT_BASE_URL"] == "http://172.17.0.1:8080"
+
+    def test_uses_actual_bind_port_not_config_port(self, tmp_path):
+        # The config hardcodes :8080 but the platform is launched on 59007
+        # (as the e2e harness does). NMP_BASE_URL must carry the real bind port
+        # so internal in-process clients can reach the server.
+        config_path = self._write_config(tmp_path, "platform:\n  base_url: http://172.17.0.1:8080\n")
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(host="0.0.0.0", port=59007, config_path=config_path), env=env)
+        assert env["NMP_BASE_URL"] == "http://172.17.0.1:59007"
+        assert env["NMP_AUTH_POLICY_DECISION_POINT_BASE_URL"] == "http://172.17.0.1:59007"
+
+    def test_config_base_url_without_port_gets_bind_port(self, tmp_path):
+        config_path = self._write_config(tmp_path, "platform:\n  base_url: http://172.17.0.1\n")
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(host="0.0.0.0", port=9090, config_path=config_path), env=env)
+        assert env["NMP_BASE_URL"] == "http://172.17.0.1:9090"
+
+    def test_external_env_still_wins_over_config_file(self, tmp_path):
+        config_path = self._write_config(tmp_path, "platform:\n  base_url: http://172.17.0.1:8080\n")
+        env: dict[str, str] = {"NMP_BASE_URL": "http://nemo-platform-api:8080"}
+        apply_run_environment(_make_config(host="0.0.0.0", port=8080, config_path=config_path), env=env)
+        assert env["NMP_BASE_URL"] == "http://nemo-platform-api:8080"
+
+    def test_falls_back_to_bind_derived_when_config_omits_base_url(self, tmp_path):
+        config_path = self._write_config(tmp_path, "platform:\n  runtime: docker\n")
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(host="0.0.0.0", port=8080, config_path=config_path), env=env)
+        assert env["NMP_BASE_URL"] == "http://127.0.0.1:8080"
+
+    def test_falls_back_to_bind_derived_when_config_file_missing(self):
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(host="0.0.0.0", port=8080, config_path="/nonexistent/nmp.yaml"), env=env)
+        assert env["NMP_BASE_URL"] == "http://127.0.0.1:8080"

--- a/packages/nmp_platform_runner/tests/test_config.py
+++ b/packages/nmp_platform_runner/tests/test_config.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+
 import pytest
 from nmp.platform_runner import registry
 from nmp.platform_runner.config import (
@@ -222,12 +224,12 @@ class TestApplyRunEnvConfigBaseUrl:
     wins.
     """
 
-    def _write_config(self, tmp_path, body: str) -> str:
+    def _write_config(self, tmp_path: Path, body: str) -> str:
         path = tmp_path / "config.yaml"
         path.write_text(body, encoding="utf-8")
         return str(path)
 
-    def test_seeds_base_url_host_from_config_file(self, tmp_path):
+    def test_seeds_base_url_host_from_config_file(self, tmp_path: Path):
         config_path = self._write_config(tmp_path, "platform:\n  base_url: http://172.17.0.1:8080\n")
         env: dict[str, str] = {}
         apply_run_environment(_make_config(host="0.0.0.0", port=8080, config_path=config_path), env=env)
@@ -235,7 +237,7 @@ class TestApplyRunEnvConfigBaseUrl:
         # Embedded PDP base URL follows NMP_BASE_URL.
         assert env["NMP_AUTH_POLICY_DECISION_POINT_BASE_URL"] == "http://172.17.0.1:8080"
 
-    def test_uses_actual_bind_port_not_config_port(self, tmp_path):
+    def test_uses_actual_bind_port_not_config_port(self, tmp_path: Path):
         # The config hardcodes :8080 but the platform is launched on 59007
         # (as the e2e harness does). NMP_BASE_URL must carry the real bind port
         # so internal in-process clients can reach the server.
@@ -245,19 +247,19 @@ class TestApplyRunEnvConfigBaseUrl:
         assert env["NMP_BASE_URL"] == "http://172.17.0.1:59007"
         assert env["NMP_AUTH_POLICY_DECISION_POINT_BASE_URL"] == "http://172.17.0.1:59007"
 
-    def test_config_base_url_without_port_gets_bind_port(self, tmp_path):
+    def test_config_base_url_without_port_gets_bind_port(self, tmp_path: Path):
         config_path = self._write_config(tmp_path, "platform:\n  base_url: http://172.17.0.1\n")
         env: dict[str, str] = {}
         apply_run_environment(_make_config(host="0.0.0.0", port=9090, config_path=config_path), env=env)
         assert env["NMP_BASE_URL"] == "http://172.17.0.1:9090"
 
-    def test_external_env_still_wins_over_config_file(self, tmp_path):
+    def test_external_env_still_wins_over_config_file(self, tmp_path: Path):
         config_path = self._write_config(tmp_path, "platform:\n  base_url: http://172.17.0.1:8080\n")
         env: dict[str, str] = {"NMP_BASE_URL": "http://nemo-platform-api:8080"}
         apply_run_environment(_make_config(host="0.0.0.0", port=8080, config_path=config_path), env=env)
         assert env["NMP_BASE_URL"] == "http://nemo-platform-api:8080"
 
-    def test_falls_back_to_bind_derived_when_config_omits_base_url(self, tmp_path):
+    def test_falls_back_to_bind_derived_when_config_omits_base_url(self, tmp_path: Path):
         config_path = self._write_config(tmp_path, "platform:\n  runtime: docker\n")
         env: dict[str, str] = {}
         apply_run_environment(_make_config(host="0.0.0.0", port=8080, config_path=config_path), env=env)
@@ -266,4 +268,37 @@ class TestApplyRunEnvConfigBaseUrl:
     def test_falls_back_to_bind_derived_when_config_file_missing(self):
         env: dict[str, str] = {}
         apply_run_environment(_make_config(host="0.0.0.0", port=8080, config_path="/nonexistent/nmp.yaml"), env=env)
+        assert env["NMP_BASE_URL"] == "http://127.0.0.1:8080"
+
+    def test_preserves_https_scheme_from_config(self, tmp_path: Path):
+        # A configured https:// base URL must not be downgraded to http://.
+        config_path = self._write_config(tmp_path, "platform:\n  base_url: https://172.17.0.1:8080\n")
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(host="0.0.0.0", port=9090, config_path=config_path), env=env)
+        assert env["NMP_BASE_URL"] == "https://172.17.0.1:9090"
+        assert env["NMP_AUTH_POLICY_DECISION_POINT_BASE_URL"] == "https://172.17.0.1:9090"
+
+    def test_malformed_ipv6_config_falls_back_to_bind_derived(self, tmp_path: Path):
+        # An unterminated bracketed IPv6 makes urlparse raise ValueError; that
+        # must fail soft to the bind-derived default rather than abort startup.
+        config_path = self._write_config(tmp_path, "platform:\n  base_url: http://[::1\n")
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(host="0.0.0.0", port=8080, config_path=config_path), env=env)
+        assert env["NMP_BASE_URL"] == "http://127.0.0.1:8080"
+
+    def test_wildcard_host_in_config_normalized_to_loopback(self, tmp_path: Path):
+        # The bundled local.yaml sets platform.base_url: http://0.0.0.0:8080.
+        # 0.0.0.0 is a bind-only wildcard, so the seeded internal base URL must
+        # be normalized to loopback or in-process clients (PDP, readiness) break.
+        config_path = self._write_config(tmp_path, "platform:\n  base_url: http://0.0.0.0:8080\n")
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(host="0.0.0.0", port=8080, config_path=config_path), env=env)
+        assert env["NMP_BASE_URL"] == "http://127.0.0.1:8080"
+
+    def test_bundled_default_config_seeds_loopback(self):
+        # Regression guard for the real default path: `nemo services run` with no
+        # --config uses default_config_path() (bundled local.yaml, which sets
+        # http://0.0.0.0:8080). The seeded NMP_BASE_URL must be connectable.
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(host="0.0.0.0", port=8080, config_path=default_config_path()), env=env)
         assert env["NMP_BASE_URL"] == "http://127.0.0.1:8080"


### PR DESCRIPTION
## What this touches

`NMP_BASE_URL` — the URL other components use to reach the platform's own API.
The platform injects it into deployed agents so they can call back through the
Inference Gateway; if it's wrong for a containerized agent, that agent can't
reach any models. It can be set three ways, resolved in this order:

```
NEMO_BASE_URL env  >  NMP_BASE_URL env  >  platform.base_url (config file)
```

- **`NMP_BASE_URL` env** exists so a deployer (Helm/k8s) can point the platform
  at its real service address (e.g. `http://nemo-platform-api:8080`); it takes
  priority because the deployer knows the true address.
- **`platform.base_url` in config** is the operator-facing equivalent for a
  self-hosted/standalone run — you'd set it to whatever address is reachable in
  your environment (e.g. the docker bridge `http://172.17.0.1:8080` so
  containers can reach the host).

## The bug

When you start the platform with `nemo services run`, the runner
(`apply_run_environment`) **auto-fills `NMP_BASE_URL`** for standalone users who
haven't set it — it derives a value from the server's own bind address:

```python
connect_host  = _connect_host_for_internal_clients(config.host)  # 0.0.0.0 -> 127.0.0.1
default       = f"http://{connect_host}:{port}"                  # http://127.0.0.1:8080
env.setdefault("NMP_BASE_URL", default)
```

`--host 0.0.0.0` means "bind all interfaces," which isn't itself a
connectable address, so `_connect_host_for_internal_clients` translates it to
the loopback `127.0.0.1` (fine for in-process clients on the same host). The
result — `http://127.0.0.1:8080` — is written into `NMP_BASE_URL` via
`setdefault`.

The problem: `NMP_BASE_URL` (env) ranks **above** `platform.base_url` (config).
So the runner's auto-derived loopback value **silently overrides** whatever you
set as `platform.base_url` in your config — the config setting becomes a no-op,
with no error or warning. The only way to make it stick today is to *also*
export `NMP_BASE_URL` yourself before launch, which defeats the purpose of the
config field.

The user-visible symptom: an agent deployed in a container gets
`llms.*.base_url = http://127.0.0.1:8080`, which inside the container points at
the container itself, so its model calls fail. (Helm/k8s deployments are
unaffected — there `NMP_BASE_URL` is set externally to the real, reachable
address, so nothing is being shadowed.)

## Fix

`apply_run_environment` now uses an explicit `platform.base_url` from the config
file as the default it seeds `NMP_BASE_URL` with (read from raw YAML so a
file-set value is distinguishable from the schema default), and only falls back
to the bind-derived loopback when the config doesn't set one. An externally
provided `NMP_BASE_URL` still wins via `setdefault`, so Helm/k8s is unchanged.

New precedence: **external env > config `platform.base_url` > bind-derived default.**

## Testing

- New unit tests in `test_config.py`: seeds from config, external env still
  wins, falls back when config omits `base_url`, falls back when the file is
  missing. Full runner suite green.
- Verified end-to-end in a dev pod: with only `platform.base_url` set (no
  `NMP_BASE_URL` env), a docker-mode agent now deploys and invokes through the
  gateway (previously failed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined how runtime `NMP_BASE_URL` is derived: existing environment values are preserved; otherwise the configured `platform.base_url` supplies the host while the bind port is applied.
  * Improved handling of missing/malformed config, including IPv6 and wildcard hosts, and ensured `NMP_AUTH_POLICY_DECISION_POINT_BASE_URL` matches the final value.

* **Tests**
  * Expanded coverage for these precedence and fallback behaviors, including config present/absent cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->