### PR TITLE
fix(studio): disable delete button for default workspace

### DIFF
--- a/web/packages/studio/src/routes/WorkspaceSettingsRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/WorkspaceSettingsRoute/index.test.tsx
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { DEFAULT_WORKSPACE } from '@nemo/common/src/models/constants';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { WorkspaceSettingsRoute } from '@studio/routes/WorkspaceSettingsRoute';
+import { render, screen } from '@studio/tests/util/render';
+
+vi.mock('@studio/hooks/useWorkspaceFromPath');
+vi.mock('@studio/routes/WorkspaceSettingsRoute/DeleteWorkspaceModal', () => ({
+  DeleteWorkspaceModal: () => null,
+}));
+vi.mock('@studio/routes/WorkspaceSettingsRoute/EditDescriptionModal', () => ({
+  EditDescriptionModal: () => null,
+}));
+
+const mockUseWorkspaceFromPath = vi.mocked(useWorkspaceFromPath);
+
+const getDeleteButton = () => screen.getByRole('button', { name: 'Delete Workspace' });
+
+describe('WorkspaceSettingsRoute', () => {
+  it('disables the Delete Workspace button for the default workspace', () => {
+    mockUseWorkspaceFromPath.mockReturnValue(DEFAULT_WORKSPACE);
+    render(<WorkspaceSettingsRoute />);
+
+    expect(getDeleteButton()).toBeDisabled();
+    expect(screen.getByText('The default workspace cannot be deleted.')).toBeInTheDocument();
+  });
+
+  it('enables the Delete Workspace button for non-default workspaces', () => {
+    mockUseWorkspaceFromPath.mockReturnValue('my-workspace');
+    render(<WorkspaceSettingsRoute />);
+
+    expect(getDeleteButton()).toBeEnabled();
+  });
+});

--- a/web/packages/studio/src/routes/WorkspaceSettingsRoute/index.tsx
+++ b/web/packages/studio/src/routes/WorkspaceSettingsRoute/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { DEFAULT_WORKSPACE } from '@nemo/common/src/models/constants';
 import {
   Button,
   Divider,
@@ -51,6 +52,7 @@ const SettingsSection: FC<SettingsSectionProps> = ({ label, body, action }) => (
 
 export const WorkspaceSettingsRoute: FC = () => {
   const workspace = useWorkspaceFromPath();
+  const isDefaultWorkspace = workspace === DEFAULT_WORKSPACE;
   const navigate = useNavigate();
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
@@ -152,10 +154,15 @@ export const WorkspaceSettingsRoute: FC = () => {
             <Divider />
             <SettingsSection
               label="Delete Workspace"
-              body="Permanently delete your Workspace and all of its contents from NeMo Studio. Once deleted, it cannot be recovered."
+              body={
+                isDefaultWorkspace
+                  ? 'The default workspace cannot be deleted.'
+                  : 'Permanently delete your Workspace and all of its contents from NeMo Studio. Once deleted, it cannot be recovered.'
+              }
               action={
                 <Button
                   color="danger"
+                  disabled={isDefaultWorkspace}
                   onClick={() => setDeleteModalOpen(true)}
                   className="shrink-0"
                 >


### PR DESCRIPTION
## Summary

Disables the **Delete Workspace** button on the workspace settings page (`/studio/workspaces/default/settings`) when viewing the `default` workspace, which cannot be deleted. Body copy swaps to explain why.

Closes ASTD-290.

## Changes

- `WorkspaceSettingsRoute/index.tsx` — `disabled={isDefaultWorkspace}` on the delete button (`workspace === DEFAULT_WORKSPACE`); contextual body text.
- `WorkspaceSettingsRoute/index.test.tsx` — new tests: disabled for `default`, enabled otherwise.

## Testing

`pnpm --filter nemo-studio-ui test src/routes/WorkspaceSettingsRoute/index.test.tsx` — 2 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deletion of the default workspace.
  * Added a clear message explaining that the default workspace cannot be deleted.
  * Kept deletion available for other workspaces with the existing permanent-deletion warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->