### PR TITLE
fix(studio): QA polish — sessions column label and trace-viewer header [ASE-584]

### DIFF
--- a/web/packages/studio/src/components/IntakeDetail/TraceDetailView.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/TraceDetailView.tsx
@@ -32,6 +32,8 @@ interface IntakeTraceDetailViewProps {
   traceId: string;
   /** Leading breadcrumb items. Defaults to the Intake root when omitted. */
   parentBreadcrumbs?: BreadcrumbsItemProps[];
+  /** When true, shows "Test case: <test_case_id>" as the header instead of "Trace <name>". Falls back to "Trace <name>" when test_case_id is absent. */
+  showTestCaseTitle?: boolean;
 }
 
 /**
@@ -41,6 +43,7 @@ export const IntakeTraceDetailView: FC<IntakeTraceDetailViewProps> = ({
   workspace,
   traceId,
   parentBreadcrumbs,
+  showTestCaseTitle,
 }) => {
   const {
     data: trace,
@@ -98,12 +101,15 @@ export const IntakeTraceDetailView: FC<IntakeTraceDetailViewProps> = ({
     return null;
   }
 
-  const title = getTraceDisplayName(trace);
+  const title =
+    showTestCaseTitle && trace.experiment_context?.test_case_id
+      ? `Test case: ${trace.experiment_context.test_case_id}`
+      : `Trace ${getTraceDisplayName(trace)}`;
 
   return (
-    <AccessibleTitle title={`Trace ${title}`}>
+    <AccessibleTitle title={title}>
       <Stack gap="density-2xl" padding="density-2xl" className="h-full overflow-auto">
-        <PageHeader className="p-0" slotHeading={`Trace ${title}`} />
+        <PageHeader className="p-0" slotHeading={title} />
         <TraceSummaryHeader trace={trace} />
         <TraceSpanAccordions workspace={workspace} trace={trace} />
         <IntakeAccordion

--- a/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
@@ -151,7 +151,7 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
     accessor,
   }) => [
     accessor('test_case_id', {
-      header: 'Case',
+      header: 'Test case',
       enableSorting: false,
       size: 200,
       cell: ({ row }) => {

--- a/web/packages/studio/src/routes/EvaluationTraceDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/EvaluationTraceDetailRoute/index.test.tsx
@@ -25,18 +25,18 @@ const renderTraceDetail = () =>
 describe('EvaluationTraceDetailRoute', () => {
   it('renders the trace detail content', async () => {
     renderTraceDetail();
-    expect(await screen.findByText('Trace Answer customer policy question')).toBeInTheDocument();
+    expect(await screen.findByText('Test case: case-0042')).toBeInTheDocument();
   });
 
   it('renders the evaluation context panel', async () => {
     renderTraceDetail();
-    await screen.findByText('Trace Answer customer policy question');
+    await screen.findByText('Test case: case-0042');
     expect(screen.getByText('Evaluation Context')).toBeInTheDocument();
   });
 
   it('does not render an Intake link in the page content', async () => {
     renderTraceDetail();
-    await screen.findByText('Trace Answer customer policy question');
+    await screen.findByText('Test case: case-0042');
     // "Intake" should not appear anywhere in the rendered page content
     // (breadcrumbs are rendered by WorkspaceLayout, absent from unit tests, but the
     // page body itself should have no Intake references)

--- a/web/packages/studio/src/routes/EvaluationTraceDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/EvaluationTraceDetailRoute/index.tsx
@@ -36,5 +36,11 @@ export const EvaluationTraceDetailRoute: FC = () => {
     [workspace, experimentGroupName, evaluationName]
   );
 
-  return <IntakeTraceDetailContent traceId={traceId} parentBreadcrumbs={parentBreadcrumbs} />;
+  return (
+    <IntakeTraceDetailContent
+      traceId={traceId}
+      parentBreadcrumbs={parentBreadcrumbs}
+      showTestCaseTitle
+    />
+  );
 };

--- a/web/packages/studio/src/routes/IntakeTraceDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/IntakeTraceDetailRoute/index.tsx
@@ -27,6 +27,8 @@ export interface IntakeTraceDetailContentProps {
   traceId: string;
   /** Leading breadcrumb items. Defaults to the Intake root when omitted. */
   parentBreadcrumbs?: BreadcrumbsItemProps[];
+  /** When true, shows "Test case: <test_case_id>" as the header instead of "Trace <name>". */
+  showTestCaseTitle?: boolean;
 }
 
 /**
@@ -36,6 +38,7 @@ export interface IntakeTraceDetailContentProps {
 export const IntakeTraceDetailContent: FC<IntakeTraceDetailContentProps> = ({
   traceId,
   parentBreadcrumbs,
+  showTestCaseTitle,
 }) => {
   const workspace = useWorkspaceFromPath();
 
@@ -44,6 +47,7 @@ export const IntakeTraceDetailContent: FC<IntakeTraceDetailContentProps> = ({
       workspace={workspace}
       traceId={traceId}
       parentBreadcrumbs={parentBreadcrumbs}
+      showTestCaseTitle={showTestCaseTitle}
     />
   );
 };


### PR DESCRIPTION
Closes #ASE-584

# Summary

Two small, independent QA fixes on the Experiments/Evaluations Studio surface.

**Sessions table column label (ASE-589):** The `test_case_id` column in the evaluation sessions table was labeled "Case" — renamed to "Test case" to match the terminology used elsewhere in the product.

**Context-aware trace-viewer header (ASE-588):** `IntakeTraceDetailView` previously rendered `Trace <root-span-name>` on both the regular Intake route and the Experiment/Evaluation test-case route. Added a `showTestCaseTitle` prop that, when set, switches the header to `Test case: <test_case_id>` (read from `experiment_context.test_case_id` on the trace). Falls back to the original `Trace <name>` format when the field is absent. The regular Intake route is untouched.

# Test plan
- [ ] Navigate to an Evaluation's sessions table — confirm the column reads "Test case" (not "Case")
- [ ] Click a session row to open the trace viewer — confirm the page header reads "Test case: \<id\>"
- [ ] Open a trace directly from Intake (not from an Evaluation) — confirm the header still reads "Trace \<root-span-name\>"
- [ ] Open a trace from an Evaluation session where `test_case_id` is absent — confirm header falls back to "Trace \<root-span-name\>"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation trace pages can now show the associated test case ID in the page header (with a fallback to the existing trace name when absent).
  * The updated header text is applied consistently for page heading and accessibility labeling.
* **Improvements**
  * Updated the evaluation sessions table column label from “Case” to “Test case.”
* **Tests**
  * Updated route tests to assert the new “Test case: …” header text where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->