### PR TITLE
fix(studio): keep workspace side nav settings always visible

### DIFF
--- a/web/packages/studio/src/components/Layouts/NavigationDrawer/index.tsx
+++ b/web/packages/studio/src/components/Layouts/NavigationDrawer/index.tsx
@@ -81,13 +81,13 @@ export const NavigationDrawer: FC<Props> = ({ items, bottomItems, collapsed = fa
 
   return (
     <Stack
-      className={`min-h-full transition-[width] duration-200 overflow-y-auto overflow-x-hidden ${collapsed ? 'w-12' : 'w-60'}`}
+      className={`h-[calc(100vh-var(--nv-app-bar-height))] transition-[width] duration-200 overflow-hidden ${collapsed ? 'w-12' : 'w-60'}`}
     >
-      <VerticalNavRoot className="flex-1 w-full ">
+      <VerticalNavRoot className="flex-1 min-h-0 w-full overflow-y-auto overflow-x-hidden">
         <VerticalNavList className="pt-2 w-max min-w-full">{renderGroups(groups)}</VerticalNavList>
       </VerticalNavRoot>
-      <VerticalNavRoot className="shrink-0 w-full">
-        <VerticalNavList className="w-max min-w-full pb-2">
+      <VerticalNavRoot className="shrink-0 h-auto! w-full">
+        <VerticalNavList className="h-auto! w-max min-w-full pb-2">
           {renderGroups(bottomGroups)}
         </VerticalNavList>
       </VerticalNavRoot>


### PR DESCRIPTION
## Summary
The settings icon in the workspace side nav shared a scroll container with the rest of the nav items, so it scrolled out of view. Separate the bottom-anchored settings section from the main nav scroll area — pin the drawer to a definite height and let only the top nav list scroll, keeping Settings visible independently.

## Root cause
Foundations `.nv-vertical-nav-root` ships `height: 100%`. Once the drawer got a definite height, the bottom section's flex-basis claimed the whole column (squeezing the main nav to zero). Overriding the bottom section to `h-auto` restores the layout.

## Changes
- `NavigationDrawer`: fixed drawer height to `calc(100vh - var(--nv-app-bar-height))`, moved scroll to the top nav (`flex-1 min-h-0 overflow-y-auto`), and content-sized the bottom (settings) section so it stays pinned.

## Testing
- `NavigationDrawer` unit tests pass (3/3)
- Manual: main nav scrolls, Settings stays anchored and visible

Ticket: ASTD-278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation drawer sizing and scrolling behavior.
  * Prevented horizontal overflow while allowing the main navigation area to scroll vertically.
  * Adjusted bottom navigation items to display at their natural height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->