### PR TITLE
fix(studio): Disable templates if no provider (w/ hint)

### DIFF
--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.test.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.test.ts
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { datasetFileContentQueryOptions } from '@studio/api/datasets/useDatasetFileContent';
+import {
+  datasetFileContentQueryOptions,
+  EDITOR_MAX_BYTES,
+} from '@studio/api/datasets/useDatasetFileContent';
+import axios from 'axios';
 
 vi.mock('@nemo/sdk/generated/platform/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@nemo/sdk/generated/platform/api')>();
@@ -47,6 +51,24 @@ describe('useDatasetFileContent gate', () => {
     // and fall through to the Range fetch — treat as text.
     const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, path: 'noextension' });
     await expect((queryFn as () => Promise<string>)()).resolves.toBe('# heading');
+  });
+
+  it('returns full text (no preview cap) for fullContent editor loads', async () => {
+    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, fullContent: true });
+    await expect((queryFn as () => Promise<string>)()).resolves.toBe('# heading');
+  });
+
+  it('refuses fullContent loads above the editor ceiling instead of truncating', async () => {
+    // A file reporting a size past EDITOR_MAX_BYTES must throw so the caller shows a
+    // "too large" state — never silently load a prefix that would truncate on save.
+    const headSpy = vi.spyOn(axios, 'head').mockResolvedValueOnce({
+      headers: { 'content-length': String(EDITOR_MAX_BYTES + 1) },
+    } as never);
+
+    const { queryFn } = datasetFileContentQueryOptions({ ...baseParams, fullContent: true });
+    await expect((queryFn as () => Promise<string>)()).rejects.toThrow(/too large to edit/i);
+
+    headSpy.mockRestore();
   });
 
   it('serializes parquet rows with BigInt columns as JSONL text', async () => {

--- a/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
+++ b/web/packages/studio/src/api/datasets/useDatasetFileContent.ts
@@ -26,9 +26,17 @@ function serializeParquetRow(row: unknown): string {
 // overwrite the source (the loaded rows are only a prefix of the file).
 export const FILE_PREVIEW_MAX_BYTES = 512 * 1024;
 
+export const EDITOR_MAX_BYTES = 8 * 1024 * 1024;
+
 interface UseDatasetFileContentParams extends Required<EntityIdentifier> {
   path: string;
   range?: [number, number];
+  /**
+   * Load the entire file (no preview cap) so its content can be safely edited and written
+   * back. Refuses files larger than {@link EDITOR_MAX_BYTES}. Ignored when `range` is set.
+   * @defaultValue false — callers get the size-capped preview.
+   */
+  fullContent?: boolean;
 }
 
 export type UseDatasetFilesOptions = Omit<UseQueryOptions<string, Error>, 'queryFn' | 'queryKey'> &
@@ -39,12 +47,14 @@ export const datasetFileContentQueryOptions = ({
   name,
   path,
   range,
+  fullContent,
 }: UseDatasetFileContentParams) =>
   queryOptions<string, Error>({
     staleTime: Infinity, // We should prevent refetching full files (costly) unless directly invalidated
     queryKey: [
       ...getDatasetFileContentQueryKey(workspace!, name, path),
       ...(range ? range.map((bound) => String(bound)) : []),
+      ...(fullContent ? ['full'] : []),
     ],
     queryFn: async () => {
       if (isBinaryExtension(path)) {
@@ -94,10 +104,18 @@ export const datasetFileContentQueryOptions = ({
           throw new Error('Invalid response while downloading parquet file');
         }
       } else {
+        if (fullContent && range === undefined) {
+          if (fileSize !== null && fileSize > EDITOR_MAX_BYTES) {
+            throw new Error('File is too large to edit in the browser.');
+          }
+        }
         const start = range ? range[0] : 0;
         const end = range ? range[1] : FILE_PREVIEW_MAX_BYTES - 1;
         const isSizeCappedPreview =
-          range === undefined && fileSize !== null && fileSize > FILE_PREVIEW_MAX_BYTES;
+          !fullContent &&
+          range === undefined &&
+          fileSize !== null &&
+          fileSize > FILE_PREVIEW_MAX_BYTES;
         const needsRange = range !== undefined || isSizeCappedPreview;
         const blob = await customFetch<Blob>({
           url: fileUrl,
@@ -120,10 +138,11 @@ export const useDatasetFileContent = ({
   name,
   path,
   range,
+  fullContent,
   ...options
 }: UseDatasetFilesOptions) => {
   return useQuery({
-    ...datasetFileContentQueryOptions({ workspace, name, path, range }),
+    ...datasetFileContentQueryOptions({ workspace, name, path, range, fullContent }),
     enabled: Boolean(workspace && name && path),
     ...options,
   });
@@ -134,10 +153,11 @@ export const useDatasetFileContentSuspense = ({
   name,
   path,
   range,
+  fullContent,
   ...options
 }: UseDatasetFilesOptions) => {
   return useSuspenseQuery({
-    ...datasetFileContentQueryOptions({ workspace, name, path, range }),
+    ...datasetFileContentQueryOptions({ workspace, name, path, range, fullContent }),
     ...options,
   });
 };

--- a/web/packages/studio/src/components/CreateFilesetStart/StartOptionDetail.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/StartOptionDetail.tsx
@@ -66,7 +66,7 @@ export const StartOptionDetail: FC<StartOptionDetailProps> = ({
 }) => {
   const content =
     option.id === 'template' ? (
-      <Grid colMinWidth="260px" gap="density-md">
+      <Grid colMinWidth="300px" gap="density-md">
         {FILESET_TEMPLATES.map((template) => (
           <TemplateCard
             key={template.id}

--- a/web/packages/studio/src/components/CreateFilesetStart/StartOptionDetail.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/StartOptionDetail.tsx
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Divider, Flex, Grid, Stack, Text } from '@nvidia/foundations-react-core';
+import { Banner, Divider, Flex, Grid, Stack, Text } from '@nvidia/foundations-react-core';
 import { TemplateCard } from '@studio/components/CreateFilesetStart/TemplateCard';
-import { FILESET_TEMPLATES } from '@studio/components/CreateFilesetStart/templates';
+import {
+  FILESET_TEMPLATES,
+  templateRequiresLlm,
+} from '@studio/components/CreateFilesetStart/templates';
 import type {
   DetailPoint,
   StartOption,
@@ -11,6 +14,7 @@ import type {
 } from '@studio/components/CreateFilesetStart/types';
 import { Layers, Sparkles, Wand2 } from 'lucide-react';
 import type { FC, ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 
 const SCRATCH_POINTS: DetailPoint[] = [
   {
@@ -63,7 +67,13 @@ export const StartOptionDetail: FC<StartOptionDetailProps> = ({
   option,
   selectedTemplateId,
   onSelectTemplate,
+  llmDisabled,
+  inferenceProvidersHref,
 }) => {
+  // Show the provider error label only when a card is actually disabled by it.
+  const hasDisabledTemplate =
+    option.id === 'template' && llmDisabled && FILESET_TEMPLATES.some(templateRequiresLlm);
+
   const content =
     option.id === 'template' ? (
       <Grid colMinWidth="300px" gap="density-md">
@@ -72,6 +82,7 @@ export const StartOptionDetail: FC<StartOptionDetailProps> = ({
             key={template.id}
             template={template}
             selected={selectedTemplateId === template.id}
+            disabled={llmDisabled && templateRequiresLlm(template)}
             onSelect={() => onSelectTemplate(template.id)}
           />
         ))}
@@ -91,6 +102,16 @@ export const StartOptionDetail: FC<StartOptionDetailProps> = ({
         {option.title}
       </Text>
       {content}
+      {hasDisabledTemplate ? (
+        <Banner status="warning" kind="inline">
+          Templates that generate data with a model are disabled — this workspace has no NVIDIA
+          Build inference provider.{' '}
+          <Link to={inferenceProvidersHref} className="underline">
+            Add the NVIDIA Build provider
+          </Link>{' '}
+          to enable them.
+        </Banner>
+      ) : null}
     </Stack>
   );
 };

--- a/web/packages/studio/src/components/CreateFilesetStart/TemplateCard.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/TemplateCard.tsx
@@ -10,18 +10,27 @@ import type { FC } from 'react';
  * a leading icon badge above a title, description, and a use-case badge, rendered as a
  * selectable `<button>`. Mirrors {@link StartOptionCard} so the two card rows read alike.
  */
-export const TemplateCard: FC<TemplateCardProps> = ({ template, selected, onSelect }) => {
+export const TemplateCard: FC<TemplateCardProps> = ({
+  template,
+  selected,
+  disabled = false,
+  onSelect,
+}) => {
   const Icon = template.icon;
 
-  const stateClasses = selected
-    ? 'cursor-pointer border-[#76b900]'
-    : 'cursor-pointer border-base hover:-translate-y-0.5 hover:border-[#76b900] hover:bg-surface-hover hover:shadow-md';
+  const stateClasses = disabled
+    ? 'cursor-not-allowed border-base opacity-50'
+    : selected
+      ? 'cursor-pointer border-[#76b900]'
+      : 'cursor-pointer border-base hover:-translate-y-0.5 hover:border-[#76b900] hover:bg-surface-hover hover:shadow-md';
 
   return (
     <button
       type="button"
       onClick={onSelect}
+      disabled={disabled}
       aria-pressed={selected}
+      title={disabled ? 'Requires the NVIDIA Build inference provider' : template.description}
       className={`flex h-[200px] min-w-[260px] flex-1 flex-col items-start gap-3 overflow-hidden rounded-md border bg-surface-raised p-5 text-left transition focus-visible:border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#76b900] ${stateClasses}`}
     >
       <Flex

--- a/web/packages/studio/src/components/CreateFilesetStart/index.test.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/index.test.tsx
@@ -1,13 +1,50 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useModelsListProviders } from '@nemo/sdk/generated/platform/api';
 import { CreateFilesetStart } from '@studio/components/CreateFilesetStart';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@studio/hooks/useWorkspaceFromPath', () => ({
+  useWorkspaceFromPath: () => 'default',
+}));
+
+vi.mock('@nemo/sdk/generated/platform/api', () => ({
+  useModelsListProviders: vi.fn(),
+}));
+
+const mockUseModelsListProviders = vi.mocked(useModelsListProviders);
+
+/** A provider list containing the NVIDIA Build (integrate.api.nvidia.com) endpoint. */
+const withBuildProvider = () =>
+  ({
+    data: { data: [{ host_url: 'https://integrate.api.nvidia.com/v1' }] },
+    isLoading: false,
+  }) as unknown as ReturnType<typeof useModelsListProviders>;
+
+/** A provider list with only a non-build provider. */
+const withoutBuildProvider = () =>
+  ({
+    data: { data: [{ host_url: 'https://api.openai.com/v1' }] },
+    isLoading: false,
+  }) as unknown as ReturnType<typeof useModelsListProviders>;
+
+const renderComponent = (onContinue = vi.fn()) =>
+  render(
+    <MemoryRouter>
+      <CreateFilesetStart onContinue={onContinue} />
+    </MemoryRouter>
+  );
 
 describe('CreateFilesetStart', () => {
+  beforeEach(() => {
+    mockUseModelsListProviders.mockReturnValue(withBuildProvider());
+  });
+
   it('renders all four start options', () => {
-    render(<CreateFilesetStart onContinue={vi.fn()} />);
+    renderComponent();
 
     expect(screen.getByText('Describe with AI')).toBeInTheDocument();
     expect(screen.getByText('Start from a template')).toBeInTheDocument();
@@ -15,7 +52,7 @@ describe('CreateFilesetStart', () => {
   });
 
   it('shows no Continue footer until a selectable option is chosen', () => {
-    render(<CreateFilesetStart onContinue={vi.fn()} />);
+    renderComponent();
 
     expect(screen.queryByRole('button', { name: /continue/i })).not.toBeInTheDocument();
   });
@@ -23,7 +60,7 @@ describe('CreateFilesetStart', () => {
   it('does not select disabled options (they are no-ops)', async () => {
     const user = userEvent.setup();
     const onContinue = vi.fn();
-    render(<CreateFilesetStart onContinue={onContinue} />);
+    renderComponent(onContinue);
 
     await user.click(screen.getByText('Describe with AI'));
 
@@ -34,7 +71,7 @@ describe('CreateFilesetStart', () => {
   it('selecting Build from scratch reveals Continue and invokes onContinue with "scratch"', async () => {
     const user = userEvent.setup();
     const onContinue = vi.fn();
-    render(<CreateFilesetStart onContinue={onContinue} />);
+    renderComponent(onContinue);
 
     await user.click(screen.getByText('Build from scratch'));
 
@@ -48,7 +85,7 @@ describe('CreateFilesetStart', () => {
 
   it('reveals template cards but no Continue until a template is chosen', async () => {
     const user = userEvent.setup();
-    render(<CreateFilesetStart onContinue={vi.fn()} />);
+    renderComponent();
 
     await user.click(screen.getByText('Start from a template'));
 
@@ -59,7 +96,7 @@ describe('CreateFilesetStart', () => {
   it('choosing a template reveals Continue and invokes onContinue with the template id', async () => {
     const user = userEvent.setup();
     const onContinue = vi.fn();
-    render(<CreateFilesetStart onContinue={onContinue} />);
+    renderComponent(onContinue);
 
     await user.click(screen.getByText('Start from a template'));
     await user.click(screen.getByText('Instruction fine-tuning (SFT)'));
@@ -73,7 +110,7 @@ describe('CreateFilesetStart', () => {
 
   it('switching options clears a prior template selection', async () => {
     const user = userEvent.setup();
-    render(<CreateFilesetStart onContinue={vi.fn()} />);
+    renderComponent();
 
     await user.click(screen.getByText('Start from a template'));
     await user.click(screen.getByText('Instruction fine-tuning (SFT)'));
@@ -84,5 +121,48 @@ describe('CreateFilesetStart', () => {
 
     // Template selection was reset when the option changed, so Continue is gone again.
     expect(screen.queryByRole('button', { name: /continue/i })).not.toBeInTheDocument();
+  });
+
+  describe('when no NVIDIA Build inference provider is configured', () => {
+    beforeEach(() => {
+      mockUseModelsListProviders.mockReturnValue(withoutBuildProvider());
+    });
+
+    it('disables LLM-backed templates and shows a link to add the provider', async () => {
+      const user = userEvent.setup();
+      const onContinue = vi.fn();
+      renderComponent(onContinue);
+
+      await user.click(screen.getByText('Start from a template'));
+
+      // LLM template (SFT references a model) is disabled and cannot be selected.
+      const sftCard = screen.getByRole('button', { name: /Instruction fine-tuning/i });
+      expect(sftCard).toBeDisabled();
+      await user.click(sftCard);
+      expect(screen.queryByRole('button', { name: /continue/i })).not.toBeInTheDocument();
+
+      // Error label links to the inference-providers create view (build preset).
+      const link = screen.getByRole('link', { name: /Add the NVIDIA Build provider/i });
+      expect(link).toHaveAttribute(
+        'href',
+        expect.stringContaining('/inference-providers?create=true&preset=build')
+      );
+    });
+
+    it('keeps non-LLM templates enabled and selectable', async () => {
+      const user = userEvent.setup();
+      const onContinue = vi.fn();
+      renderComponent(onContinue);
+
+      await user.click(screen.getByText('Start from a template'));
+
+      const noLlmCard = screen.getByRole('button', { name: /Expression transforms/i });
+      expect(noLlmCard).toBeEnabled();
+
+      await user.click(noLlmCard);
+      const continueButton = screen.getByRole('button', { name: /continue/i });
+      await user.click(continueButton);
+      expect(onContinue).toHaveBeenCalledWith('template', 'expression-transforms');
+    });
   });
 });

--- a/web/packages/studio/src/components/CreateFilesetStart/index.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useModelsListProviders } from '@nemo/sdk/generated/platform/api';
 import {
   Block,
   Button,
@@ -18,13 +19,44 @@ import type {
   CreateFilesetStartProps,
   StartOptionId,
 } from '@studio/components/CreateFilesetStart/types';
+import { DEFAULT_LARGE_PAGE_SIZE } from '@studio/constants/constants';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { PRESET_CREDENTIALS } from '@studio/routes/InferenceProvidersListRoute/CreateInferenceProviderSidePanel/inferenceProviderPresets';
+import { getWorkspaceInferenceProvidersRoute } from '@studio/routes/utils';
 import { ArrowRight } from 'lucide-react';
-import { useState, type FC } from 'react';
+import { useMemo, useState, type FC } from 'react';
+
+/** Hostname of the NVIDIA Build (build.nvidia.com) inference endpoint, e.g. integrate.api.nvidia.com. */
+const BUILD_PROVIDER_HOSTNAME = new URL(PRESET_CREDENTIALS.build.host_url).hostname;
+
+const isBuildProvider = (hostUrl: string | undefined): boolean => {
+  if (!hostUrl) return false;
+  try {
+    return new URL(hostUrl).hostname === BUILD_PROVIDER_HOSTNAME;
+  } catch {
+    return false;
+  }
+};
 
 export const CreateFilesetStart: FC<CreateFilesetStartProps> = ({ onContinue }) => {
+  const workspace = useWorkspaceFromPath();
   const [selectedId, setSelectedId] = useState<StartOptionId | null>(null);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
   const selectedOption = START_OPTIONS.find((option) => option.id === selectedId) ?? null;
+
+  const { data: providersPage, isLoading: isLoadingProviders } = useModelsListProviders(
+    workspace,
+    { page_size: DEFAULT_LARGE_PAGE_SIZE },
+    { query: {} }
+  );
+  const hasBuildProvider = useMemo(
+    () => (providersPage?.data ?? []).some((provider) => isBuildProvider(provider.host_url)),
+    [providersPage?.data]
+  );
+  const llmDisabled = !isLoadingProviders && !hasBuildProvider;
+  const inferenceProvidersHref = getWorkspaceInferenceProvidersRoute(workspace, {
+    preset: 'build',
+  });
 
   const selectOption = (optionId: StartOptionId) => {
     setSelectedId(optionId);
@@ -75,6 +107,8 @@ export const CreateFilesetStart: FC<CreateFilesetStartProps> = ({ onContinue }) 
               option={selectedOption}
               selectedTemplateId={selectedTemplateId}
               onSelectTemplate={setSelectedTemplateId}
+              llmDisabled={llmDisabled}
+              inferenceProvidersHref={inferenceProvidersHref}
             />
           ) : null}
         </Stack>

--- a/web/packages/studio/src/components/CreateFilesetStart/templates.ts
+++ b/web/packages/studio/src/components/CreateFilesetStart/templates.ts
@@ -394,3 +394,12 @@ export const FILESET_TEMPLATES: FilesetTemplate[] = [
 
 export const findTemplate = (id: string): FilesetTemplate | undefined =>
   FILESET_TEMPLATES.find((template) => template.id === id);
+
+/**
+ * Whether a template calls an inference provider. Templates that reference one or more
+ * models (LLM generations, embeddings, judges, …) need the NVIDIA Build provider to run;
+ * pure sampler/expression templates do not. Used to gate cards when no build provider is
+ * configured in the workspace.
+ */
+export const templateRequiresLlm = (template: FilesetTemplate): boolean =>
+  (template.models?.length ?? 0) > 0;

--- a/web/packages/studio/src/components/CreateFilesetStart/types.ts
+++ b/web/packages/studio/src/components/CreateFilesetStart/types.ts
@@ -66,6 +66,7 @@ export interface FilesetTemplate {
 export interface TemplateCardProps {
   template: FilesetTemplate;
   selected: boolean;
+  disabled?: boolean;
   onSelect: () => void;
 }
 
@@ -87,6 +88,8 @@ export interface StartOptionDetailProps {
   /** Id of the currently-chosen template, when {@link option} is "template". */
   selectedTemplateId: string | null;
   onSelectTemplate: (templateId: string) => void;
+  llmDisabled: boolean;
+  inferenceProvidersHref: string;
 }
 
 export interface CreateFilesetStartProps {

--- a/web/packages/studio/src/components/FileRowEditor/index.test.tsx
+++ b/web/packages/studio/src/components/FileRowEditor/index.test.tsx
@@ -77,6 +77,31 @@ describe('FileRowEditor', () => {
     expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument();
   });
 
+  it('re-enables Save File for a second edit after a successful save', async () => {
+    const user = userEvent.setup();
+    const onSaveFile = vi.fn().mockResolvedValue(undefined);
+    render(<FileRowEditor initialRows={SAMPLE_ROWS} onSaveFile={onSaveFile} />);
+
+    const saveFileButton = screen.getByRole('button', { name: 'Save File' });
+
+    // Cycle 1: edit → stage → save.
+    await user.click(screen.getByText('cuDNN'));
+    await user.type(screen.getByLabelText('topic'), ' one');
+    await user.click(screen.getByRole('button', { name: 'Stage Changes' }));
+    expect(saveFileButton).toBeEnabled();
+    await user.click(saveFileButton);
+    await waitFor(() => expect(saveFileButton).toBeDisabled());
+    expect(onSaveFile).toHaveBeenCalledTimes(1);
+
+    // Cycle 2: edit a row again → stage → the button must re-enable and save again.
+    await user.click(screen.getByText('TensorRT'));
+    await user.type(screen.getByLabelText('topic'), ' two');
+    await user.click(screen.getByRole('button', { name: 'Stage Changes' }));
+    await waitFor(() => expect(saveFileButton).toBeEnabled());
+    await user.click(saveFileButton);
+    await waitFor(() => expect(onSaveFile).toHaveBeenCalledTimes(2));
+  });
+
   it('keeps the dirty state when a save fails so the user can retry', async () => {
     const user = userEvent.setup();
     const onSaveFile = vi.fn().mockRejectedValue(new Error('upload failed'));

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
@@ -160,7 +160,7 @@ export const DataDesignerJobBuildRoute: FC = () => {
 
   return (
     <AccessibleTitle title={heading}>
-      <Stack className=" h-full">
+      <Stack className="h-full min-h-0">
         <BuilderToolbar
           name={name}
           onNameChange={setName}
@@ -182,7 +182,7 @@ export const DataDesignerJobBuildRoute: FC = () => {
           onToggle={() => setIsDetailsOpen((open) => !open)}
         />
 
-        <Flex className="min-h-0 border-t border-base h-full">
+        <Flex className="min-h-0 flex-1 border-t border-base">
           <BuilderPalette
             tab={builder.paletteTab}
             onTabChange={builder.setPaletteTab}

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection.tsx
@@ -1,8 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { LogViewer } from '@nemo/common/src/components/LogViewer';
 import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
-import { Flex, Grid, ProgressBar, Skeleton, Stack, Text } from '@nvidia/foundations-react-core';
+import { useJobLogs } from '@nemo/common/src/hooks/useJobLogs';
+import {
+  Card,
+  Flex,
+  Grid,
+  ProgressBar,
+  Skeleton,
+  Stack,
+  Text,
+} from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/Empty';
 import { ColumnProfileCard } from '@studio/routes/DataDesignerJobDetailsRoute/ColumnProfileCard';
 import {
@@ -30,17 +40,24 @@ export const DatasetProfilerSection: FC = () => {
     { enabled: isTerminal }
   );
 
-  // Job still running: the profiler hasn't produced an analysis result yet.
-  if (!isTerminal) {
-    return <Empty title="The dataset profile will appear here once the job completes." />;
-  }
+  const { data: logs, isLoading: isLogsLoading } = useJobLogs({
+    workspace,
+    name: jobName,
+    jobStatus: job?.status,
+    enabled: isTerminal,
+  });
 
-  if (isError) {
+  const CardWrapper: FC<{ children: React.ReactNode }> = ({ children }) => (
+    <Card className="w-full h-full">{children}</Card>
+  );
+
+  if (!isTerminal) {
     return (
-      <Empty
-        title="Failed to load dataset profile"
-        description="The profiler analysis could not be loaded for this job."
-      />
+      <CardWrapper>
+        <Flex className="self-center justify-self-center" gap="2">
+          <Empty title="The dataset profile will appear here once the job completes." />
+        </Flex>
+      </CardWrapper>
     );
   }
 
@@ -54,8 +71,30 @@ export const DatasetProfilerSection: FC = () => {
     );
   }
 
-  if (!hasAnalysis) {
-    return <Empty title="No dataset profile was generated for this job." />;
+  if (isError || !hasAnalysis) {
+    return (
+      <CardWrapper>
+        <Stack gap="density-2xl" className="overflow-hidden">
+          <Empty
+            title={
+              isError
+                ? 'Failed to load dataset profile'
+                : 'No dataset profile was generated for this job.'
+            }
+            description={
+              isError
+                ? 'The profiler analysis could not be loaded for this job. Review the job logs below for details.'
+                : 'Review the job logs below for details.'
+            }
+          />
+          <LogViewer
+            logs={logs}
+            isLoading={isLogsLoading}
+            downloadFilename={`data-designer-${jobName}-logs.txt`}
+          />
+        </Stack>
+      </CardWrapper>
+    );
   }
 
   const columns = analysis?.column_statistics ?? [];

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
@@ -15,7 +15,7 @@ import {
   Text,
 } from '@nvidia/foundations-react-core';
 import {
-  FILE_PREVIEW_MAX_BYTES,
+  EDITOR_MAX_BYTES,
   useDatasetFileContent,
 } from '@studio/api/datasets/useDatasetFileContent';
 import { useDatasetFilesUpload } from '@studio/api/datasets/useDatasetFilesUpload';
@@ -123,6 +123,10 @@ export const JobDatasetEditorSection: FC = () => {
   // The hook returns Parquet content already decoded to JSONL, so parse it as JSONL.
   const parseFormat: DataFileFormat = sourceFormat === 'parquet' ? 'jsonl' : sourceFormat;
 
+  const isTooLargeToEdit = Boolean(
+    selectedFile && sourceFormat !== 'parquet' && selectedFile.size > EDITOR_MAX_BYTES
+  );
+
   const {
     data: rawContent,
     isLoading: isContentLoading,
@@ -131,7 +135,8 @@ export const JobDatasetEditorSection: FC = () => {
     workspace: filesetWorkspace,
     name: filesetName,
     path: selectedPath ?? '',
-    enabled: Boolean(filesetWorkspace && filesetName && selectedPath),
+    fullContent: true,
+    enabled: Boolean(filesetWorkspace && filesetName && selectedPath && !isTooLargeToEdit),
   });
 
   const parsed = useMemo(() => {
@@ -147,13 +152,6 @@ export const JobDatasetEditorSection: FC = () => {
       };
     }
   }, [rawContent, parseFormat]);
-
-  const isContentTruncated = Boolean(
-    selectedFile && sourceFormat !== 'parquet' && selectedFile.size > FILE_PREVIEW_MAX_BYTES
-  );
-  const saveDisabledReason = isContentTruncated
-    ? 'This file is too large to load in full — saving is disabled to avoid truncating it.'
-    : undefined;
 
   const toast = useToast();
   const { mutateAsync: uploadFiles, isPending: isSaving } = useDatasetFilesUpload();
@@ -239,6 +237,15 @@ export const JobDatasetEditorSection: FC = () => {
       );
     }
 
+    if (isTooLargeToEdit) {
+      return centered(
+        <Empty
+          title="File too large to edit"
+          description="This file exceeds the 8 MB limit for in-browser editing. Download it to edit locally."
+        />
+      );
+    }
+
     if (isContentLoading || parsed == null) {
       return centered(<Spinner aria-label="Loading file" description="Loading file..." />);
     }
@@ -265,7 +272,6 @@ export const JobDatasetEditorSection: FC = () => {
         showOpenFile={false}
         onSaveFile={handleSaveFile}
         isSaving={isSaving}
-        saveDisabledReason={saveDisabledReason}
       />
     );
   };

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
@@ -24,6 +24,7 @@ import { JobDatasetEditorSection } from '@studio/routes/DataDesignerJobDetailsRo
 import { JobOutputFilesetSection } from '@studio/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection';
 import { useDataDesignerJobFromRoute } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerJobFromRoute';
 import { getDataDesignerJobListRoute } from '@studio/routes/utils';
+import { formatDateTime } from '@studio/util/date';
 import { ArrowLeft, FileJson } from 'lucide-react';
 import { useState, type FC } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
@@ -114,12 +115,12 @@ export const DataDesignerJobDetailsRoute: FC = () => {
           <Flex gap="density-lg" className="flex-wrap">
             {job.created_at && (
               <Text kind="body/regular/sm" className="text-muted">
-                Created: {new Date(job.created_at).toLocaleString()}
+                Created: {formatDateTime(job.created_at)}
               </Text>
             )}
             {job.updated_at && (
               <Text kind="body/regular/sm" className="text-muted">
-                Updated: {new Date(job.updated_at).toLocaleString()}
+                Updated: {formatDateTime(job.updated_at)}
               </Text>
             )}
           </Flex>

--- a/web/packages/studio/src/util/date.ts
+++ b/web/packages/studio/src/util/date.ts
@@ -3,14 +3,17 @@
 
 /**
  * Turns a dateString like "2024-02-29T02:27:13.509827", or a timestamp in milliseconds like 1721151036524,
- * into a formatted date string.
+ * into a formatted date string. Expects a UTC date string or normalizes input to UTC if a date string is provided without a timezone.
  *
  * If `includeDate` is true, it will include the date like "02/29/24 02:27:13 PM"
  * Otherwise, it will only include the time like "02:27:12 PM"
  */
 export function formatDateTime(dateValue: string | number, includeDate: boolean = true) {
-  const date = new Date(dateValue);
-  const userLocale = navigator.language; // Gets the browser's language setting
+  const tzRegex = /Z|[+-]\d{2}:\d{2}$/;
+  const normalized =
+    typeof dateValue === 'string' && !tzRegex.test(dateValue) ? dateValue + 'Z' : dateValue;
+  const date = new Date(normalized);
+  const userLocale = navigator.language;
 
   const options: Intl.DateTimeFormatOptions = {
     ...(includeDate && {


### PR DESCRIPTION
Disable templates when missing inference provider for build.nvidia.com since it won't be able to make inference requests for the LLM columns. 

<img width="1487" height="516" alt="Screenshot 2026-07-16 at 12 23 53 PM" src="https://github.com/user-attachments/assets/611fb28c-d5d6-4309-948f-b81d0b53e84b" />

Signed-off-by: Sean Teramae <steramae@nvidia.com>