### PR TITLE
fix(guardrails): Wrap ChatNIM as LLMModel; surface status code nested in upstream error messages

### DIFF
--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
@@ -50,7 +50,7 @@ from nemo_guardrails_plugin.responses import (
     build_immediate_response,
     build_inference_response,
     build_output_response_body,
-    extract_upstream_client_error,
+    extract_upstream_error,
     is_blocked_generation_response,
 )
 from nemo_guardrails_plugin.schemas import GuardrailsRequest
@@ -673,11 +673,12 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
             raise
         except Exception as exc:
             # Rail-task LLM calls (e.g. a vision-safety judge) can fail with
-            # an upstream 4xx that is a genuine client error (bad request
-            # shape, unsupported parameter) rather than a transient failure.
-            # Recover it where possible so callers don't retry a
-            # deterministic error as if it were a 503.
-            if upstream_error := extract_upstream_client_error(exc):
+            # a real upstream status code (bad request shape, unsupported
+            # parameter, provider outage, etc.) that nemoguardrails otherwise
+            # buries inside a generic exception. Recover and propagate it
+            # verbatim so callers see the actual upstream status instead of
+            # our own middleware's fallback.
+            if upstream_error := extract_upstream_error(exc):
                 raise upstream_error from exc
             # ``ValueError`` from below the lease boundary is a library bug,
             # not caller-shape (caller-shape ValueErrors are caught and

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
@@ -50,6 +50,7 @@ from nemo_guardrails_plugin.responses import (
     build_immediate_response,
     build_inference_response,
     build_output_response_body,
+    extract_upstream_client_error,
     is_blocked_generation_response,
 )
 from nemo_guardrails_plugin.schemas import GuardrailsRequest
@@ -671,6 +672,13 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
             # 503 here would clobber it.
             raise
         except Exception as exc:
+            # Rail-task LLM calls (e.g. a vision-safety judge) can fail with
+            # an upstream 4xx that is a genuine client error (bad request
+            # shape, unsupported parameter) rather than a transient failure.
+            # Recover it where possible so callers don't retry a
+            # deterministic error as if it were a 503.
+            if upstream_error := extract_upstream_client_error(exc):
+                raise upstream_error from exc
             # ``ValueError`` from below the lease boundary is a library bug,
             # not caller-shape (caller-shape ValueErrors are caught and
             # converted to 400 in ``_prepare_lease_with_503`` before we

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
@@ -27,17 +27,18 @@ GUARDRAILS_DATA_FIELD = "guardrails_data"
 # Matches the "[<status>] <detail>" prefix langchain_nvidia_ai_endpoints prefixes
 # on every error it raises. The status represents the underlying status code
 # that we'd like to preserve when returning the error to the caller.
-_BRACKETED_STATUS_PREFIX_RE = re.compile(r"^\s*\[(\d{3})\]\s*(.*)", re.DOTALL)
-_CLIENT_ERROR_STATUS_RANGE = range(400, 500)
+_LANGCHAIN_ERROR_MESSAGE_PREFIX = re.compile(r"^\s*\[(\d{3})\]\s*(.*)", re.DOTALL)
+_HTTP_STATUS_RANGE = range(100, 600)
 
 
-def extract_upstream_client_error(exc: BaseException) -> InferenceMiddlewareError | None:
-    """Recover a genuine upstream 4xx hidden inside a rail-task LLM call failure.
+def extract_upstream_error(exc: BaseException) -> InferenceMiddlewareError | None:
+    """Recover a genuine upstream status code hidden inside a rail-task LLM call failure.
 
     nemoguardrails wraps every rail-task LLM failure in the same generic
     ``LLMCallException``, so our middleware's catch-all exception handler
     would otherwise map all of them to a 503. This function unwraps the
-    exception and checks for a real underlying 4xx error. If not found,
+    exception and, if the provider library recorded a real upstream status,
+    propagates it as-is (4xx or 5xx) instead of masking it. If not found,
     the plugin falls back to a 503.
 
     Example, given this ``exc`` parameter::
@@ -56,11 +57,11 @@ def extract_upstream_client_error(exc: BaseException) -> InferenceMiddlewareErro
             status_code=400,
         )
 
-    Returns ``None`` if no 4xx is found, so the caller's 503 fallback stands.
+    Returns ``None`` if no status is found, so the caller's 503 fallback stands.
     """
     context: str | None = None
     # `exc` is always this outer LLMCallException in practice. It never has a
-    # 4xx of its own (see checks below), but its `.detail` (e.g. "Error
+    # status of its own (see checks below), but its `.detail` (e.g. "Error
     # invoking LLM (model=..., provider=..., endpoint=...)") stores which call
     # failed, so it's kept as context. `candidate` becomes the wrapped
     # exception the provider library actually raised.
@@ -72,15 +73,15 @@ def extract_upstream_client_error(exc: BaseException) -> InferenceMiddlewareErro
 
     # Signal 1: a genuine `status_code` attribute, e.g. set by `openai.APIStatusError`.
     status_code = getattr(candidate, "status_code", None)
-    if isinstance(status_code, int) and status_code in _CLIENT_ERROR_STATUS_RANGE:
+    if isinstance(status_code, int) and status_code in _HTTP_STATUS_RANGE:
         detail = getattr(candidate, "message", None) or str(candidate)
         return InferenceMiddlewareError(f"{context}: {detail}" if context else detail, status_code=status_code)
 
     # Signal 2: no structured status, so fall back to the "[<status>] ..."
     # message prefix that's all `langchain_nvidia_ai_endpoints` leaves behind.
-    if match := _BRACKETED_STATUS_PREFIX_RE.match(str(candidate)):
+    if match := _LANGCHAIN_ERROR_MESSAGE_PREFIX.match(str(candidate)):
         status_code = int(match.group(1))
-        if status_code in _CLIENT_ERROR_STATUS_RANGE:
+        if status_code in _HTTP_STATUS_RANGE:
             detail = _sanitized_client_error_detail(match.group(2).strip()) or str(candidate)
             return InferenceMiddlewareError(f"{context}: {detail}" if context else detail, status_code=status_code)
 

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
@@ -28,7 +28,8 @@ GUARDRAILS_DATA_FIELD = "guardrails_data"
 # on every error it raises. The status represents the underlying status code
 # that we'd like to preserve when returning the error to the caller.
 _LANGCHAIN_ERROR_MESSAGE_PREFIX = re.compile(r"^\s*\[(\d{3})\]\s*(.*)", re.DOTALL)
-_HTTP_STATUS_RANGE = range(100, 600)
+# Error codes embedded in the upstream error message that we surface to the caller.
+_HTTP_ERROR_STATUS_RANGE = range(400, 600)
 
 
 def extract_upstream_error(exc: BaseException) -> InferenceMiddlewareError | None:
@@ -73,7 +74,7 @@ def extract_upstream_error(exc: BaseException) -> InferenceMiddlewareError | Non
 
     # Signal 1: a genuine `status_code` attribute, e.g. set by `openai.APIStatusError`.
     status_code = getattr(candidate, "status_code", None)
-    if isinstance(status_code, int) and status_code in _HTTP_STATUS_RANGE:
+    if isinstance(status_code, int) and status_code in _HTTP_ERROR_STATUS_RANGE:
         detail = getattr(candidate, "message", None) or str(candidate)
         return InferenceMiddlewareError(f"{context}: {detail}" if context else detail, status_code=status_code)
 
@@ -81,7 +82,7 @@ def extract_upstream_error(exc: BaseException) -> InferenceMiddlewareError | Non
     # message prefix that's all `langchain_nvidia_ai_endpoints` leaves behind.
     if match := _LANGCHAIN_ERROR_MESSAGE_PREFIX.match(str(candidate)):
         status_code = int(match.group(1))
-        if status_code in _HTTP_STATUS_RANGE:
+        if status_code in _HTTP_ERROR_STATUS_RANGE:
             detail = _sanitized_client_error_detail(match.group(2).strip()) or str(candidate)
             return InferenceMiddlewareError(f"{context}: {detail}" if context else detail, status_code=status_code)
 

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
+import re
 import uuid
 from collections.abc import AsyncIterator
 from typing import Any
@@ -15,11 +17,108 @@ from nemo_platform_plugin.inference_middleware import (
     InferenceResponse,
     ResponseResult,
 )
+from nemoguardrails.exceptions import LLMCallException
 from nemoguardrails.rails.llm.options import GenerationResponse
 
 logger = logging.getLogger(__name__)
 
 GUARDRAILS_DATA_FIELD = "guardrails_data"
+
+# Matches the "[<status>] <detail>" prefix langchain_nvidia_ai_endpoints prefixes
+# on every error it raises. The status represents the underlying status code
+# that we'd like to preserve when returning the error to the caller.
+_BRACKETED_STATUS_PREFIX_RE = re.compile(r"^\s*\[(\d{3})\]\s*(.*)", re.DOTALL)
+_CLIENT_ERROR_STATUS_RANGE = range(400, 500)
+
+
+def extract_upstream_client_error(exc: BaseException) -> InferenceMiddlewareError | None:
+    """Recover a genuine upstream 4xx hidden inside a rail-task LLM call failure.
+
+    nemoguardrails wraps every rail-task LLM failure in the same generic
+    ``LLMCallException``, so our middleware's catch-all exception handler
+    would otherwise map all of them to a 503. This function unwraps the
+    exception and checks for a real underlying 4xx error. If not found,
+    the plugin falls back to a 503.
+
+    Example, given this ``exc`` parameter::
+
+        exc = LLMCallException(
+            Exception('[400] At most 1 image(s) may be provided in one '
+                       'request.'),
+            detail="Error invoking LLM (model=..., provider=nvidia_ai_endpoints, endpoint=...)",
+        )
+
+    the return value is::
+
+        InferenceMiddlewareError(
+            "Error invoking LLM (model=..., provider=nvidia_ai_endpoints, endpoint=...): "
+            "At most 1 image(s) may be provided in one request.",
+            status_code=400,
+        )
+
+    Returns ``None`` if no 4xx is found, so the caller's 503 fallback stands.
+    """
+    context: str | None = None
+    # `exc` is always this outer LLMCallException in practice. It never has a
+    # 4xx of its own (see checks below), but its `.detail` (e.g. "Error
+    # invoking LLM (model=..., provider=..., endpoint=...)") stores which call
+    # failed, so it's kept as context. `candidate` becomes the wrapped
+    # exception the provider library actually raised.
+    candidate: BaseException = exc
+    if isinstance(exc, LLMCallException):
+        context = exc.detail
+        if isinstance(exc.inner_exception, BaseException):
+            candidate = exc.inner_exception
+
+    # Signal 1: a genuine `status_code` attribute, e.g. set by `openai.APIStatusError`.
+    status_code = getattr(candidate, "status_code", None)
+    if isinstance(status_code, int) and status_code in _CLIENT_ERROR_STATUS_RANGE:
+        detail = getattr(candidate, "message", None) or str(candidate)
+        return InferenceMiddlewareError(f"{context}: {detail}" if context else detail, status_code=status_code)
+
+    # Signal 2: no structured status, so fall back to the "[<status>] ..."
+    # message prefix that's all `langchain_nvidia_ai_endpoints` leaves behind.
+    if match := _BRACKETED_STATUS_PREFIX_RE.match(str(candidate)):
+        status_code = int(match.group(1))
+        if status_code in _CLIENT_ERROR_STATUS_RANGE:
+            detail = _sanitized_client_error_detail(match.group(2).strip()) or str(candidate)
+            return InferenceMiddlewareError(f"{context}: {detail}" if context else detail, status_code=status_code)
+
+    return None
+
+
+def _sanitized_client_error_detail(text: str) -> str:
+    """Strip the "Unknown Error {...}" placeholder langchain_nvidia_ai_endpoints
+    leaves in front of the real upstream JSON body.
+
+    For example, given this ``text`` parameter:
+
+        text = 'Unknown Error\\n{"message": "At most 1 image(s) may be provided in one request.", "code": 400}'
+
+    the return value is:
+
+        "At most 1 image(s) may be provided in one request."
+
+    For the detail, prefer a nested ``message``/``error``/``detail``/``title`` field
+    from that JSON. Falls back to ``text`` unchanged if it isn't valid JSON, or
+    has none of those fields.
+    """
+    brace_index = text.find("{")
+    if brace_index == -1:
+        return text  # no JSON body at all
+
+    try:
+        body = json.loads(text[brace_index:])
+    except json.JSONDecodeError:
+        return text  # looked like JSON, wasn't
+
+    # Attempt to extract the error detail from the JSON body
+    if isinstance(body, dict):
+        for key in ("message", "error", "detail", "title"):
+            if isinstance(value := body.get(key), str) and value:
+                return value
+
+    return text  # valid JSON, but none of the detail fields we look for
 
 
 def build_chat_completion_response_id() -> str:

--- a/plugins/nemo-guardrails/tests/integration/test_upstream_error_surfacing.py
+++ b/plugins/nemo-guardrails/tests/integration/test_upstream_error_surfacing.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests that exercise the real ``langchain_nvidia_ai_endpoints``
+error path (nemoguardrails' bundled ``nim`` engine), not a hand-constructed
+exception. ``responses.extract_upstream_client_error`` assumes that library
+formats every raised error as a ``"[<status>] <detail>"``-prefixed message —
+these tests call the real library against a mocked upstream so a future
+``langchain_nvidia_ai_endpoints`` upgrade that changes that convention fails
+loudly here, instead of only in production.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import Any
+
+import nemo_platform
+import pytest
+from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
+from nemo_platform.types.inference.middleware_call_param import MiddlewareCallParam
+from nmp.core.inference_gateway.testing.harness import IGWLoopbackHarness
+from nmp.testing.mock_chat_completions import ErrorResponse
+
+from .utils import (
+    GUARDRAILS_PLUGIN_NAME,
+    make_guardrails_test_data_names,
+    make_served_model,
+)
+
+pytestmark = [pytest.mark.integration]
+
+# Sample upstream error body vLLM returns for "too many images" error.
+TOO_MANY_IMAGES_BODY = {
+    "object": "error",
+    "message": (
+        "At most 1 image(s) may be provided in one request. "
+        "You can set `--limit-mm-per-prompt` to increase this limit if the model supports it."
+    ),
+    "type": "BadRequestError",
+    "param": None,
+    "code": 400,
+}
+TOO_MANY_IMAGES_MESSAGE = TOO_MANY_IMAGES_BODY["message"]
+
+
+@dataclass(frozen=True)
+class _Fixture:
+    vm_name: str
+    config_name: str
+    vision_model_entity_ref: str
+
+
+class TestUpstreamErrorSurfacing:
+    IMAGE_DATA_URL = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD"
+
+    @classmethod
+    def _config_data(cls, *, vision_model_entity_ref: str, vision_base_url: str) -> dict[str, Any]:
+        return {
+            "models": [
+                {
+                    "type": "vision_rails",
+                    "engine": "nim",
+                    "model": vision_model_entity_ref,
+                    "parameters": {"base_url": vision_base_url},
+                }
+            ],
+            "rails": {
+                "input": {
+                    "flows": ["content safety check input $model=vision_rails"],
+                }
+            },
+            "prompts": [
+                {
+                    "task": "content_safety_check_input $model=vision_rails",
+                    "messages": [
+                        {"type": "system", "content": "Evaluate whether the user message is safe."},
+                        {"type": "user", "content": "{{ user_input }}"},
+                    ],
+                    "output_parser": "is_content_safe",
+                    "max_tokens": 200,
+                }
+            ],
+        }
+
+    @staticmethod
+    def _middleware_call(workspace: str, config_name: str) -> MiddlewareCallParam:
+        return {
+            "name": GUARDRAILS_PLUGIN_NAME,
+            "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
+            "config_id": f"{workspace}/{config_name}",
+        }
+
+    @staticmethod
+    def _delete_config_if_present(harness: IGWLoopbackHarness, config_name: str) -> None:
+        try:
+            harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
+        except nemo_platform.NotFoundError:
+            pass
+
+    def _setup(self, harness: IGWLoopbackHarness) -> _Fixture:
+        """Wire a vision-judge model + guarded VirtualModel."""
+        test_data_names = make_guardrails_test_data_names(workspace=harness.workspace)
+        vision_model = make_served_model(
+            test_id=test_data_names.test_id,
+            prefix="vision-model",
+            workspace=harness.workspace,
+        )
+
+        harness.add_provider(
+            workspace=harness.workspace,
+            name=test_data_names.model_provider_name,
+            served_models={
+                test_data_names.main_model_served_name: test_data_names.main_model_served_name,
+                vision_model.served_name: vision_model.served_name,
+            },
+        )
+        harness.sdk.guardrail.configs.create(
+            workspace=harness.workspace,
+            name=test_data_names.guardrail_config_name,
+            description="Upstream error surfacing test config",
+            data=self._config_data(
+                vision_model_entity_ref=vision_model.entity_ref,
+                vision_base_url=harness.nim_base_url,
+            ),
+        )
+        harness.add_virtual_model(
+            workspace=harness.workspace,
+            name=test_data_names.main_model_served_name,
+            default_model_entity=test_data_names.main_model_entity_ref,
+        )
+        harness.add_virtual_model(
+            workspace=harness.workspace,
+            name=test_data_names.request_virtual_model_name,
+            default_model_entity=test_data_names.main_model_entity_ref,
+            request_middleware=[self._middleware_call(harness.workspace, test_data_names.guardrail_config_name)],
+        )
+        return _Fixture(
+            vm_name=test_data_names.request_virtual_model_name,
+            config_name=test_data_names.guardrail_config_name,
+            vision_model_entity_ref=vision_model.entity_ref,
+        )
+
+    def _send_message(self, harness: IGWLoopbackHarness, vm_name: str) -> dict[str, Any]:
+        return harness.chat_completions(
+            workspace=harness.workspace,
+            body={
+                "model": f"{harness.workspace}/{vm_name}",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Compare these two images."},
+                            {"type": "image_url", "image_url": {"url": self.IMAGE_DATA_URL}},
+                            {"type": "image_url", "image_url": {"url": self.IMAGE_DATA_URL}},
+                        ],
+                    }
+                ],
+            },
+        )
+
+    def test_upstream_400_error_keeps_status_code(
+        self,
+        igw_loopback_harness: Callable[..., IGWLoopbackHarness],
+    ) -> None:
+        """A real 400 from the vision-judge model (via nemoguardrails' bundled
+        ``langchain_nvidia_ai_endpoints``-backed ``nim`` engine) must reach the
+        caller as a 400 with the upstream detail, not the middleware's generic
+        503. Exercises the real library end-to-end — no hand-built exception —
+        so it fails if a library upgrade changes the ``"[<status>] ..."``
+        convention ``extract_upstream_client_error`` depends on.
+        """
+        harness = igw_loopback_harness()
+
+        with harness.load_plugin(GUARDRAILS_PLUGIN_NAME):
+            fixture = self._setup(harness)
+            try:
+                harness.mock_chat_completions(
+                    fixture.vision_model_entity_ref,
+                    responses=[ErrorResponse(status_code=400, body=TOO_MANY_IMAGES_BODY)],
+                )
+
+                with pytest.raises(nemo_platform.APIStatusError) as exc_info:
+                    self._send_message(harness, fixture.vm_name)
+
+                assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
+                body = exc_info.value.body
+                assert isinstance(body, dict)
+                detail = body.get("detail")
+                assert isinstance(detail, str)
+                assert TOO_MANY_IMAGES_MESSAGE in detail
+            finally:
+                self._delete_config_if_present(harness, fixture.config_name)
+
+    def test_upstream_500_from_vision_judge_stays_503(
+        self,
+        igw_loopback_harness: Callable[..., IGWLoopbackHarness],
+    ) -> None:
+        """A genuine upstream 5xx (outage, not a bad request) must NOT be
+        reinterpreted — it should fall through to the plugin's existing
+        generic 503, same as before this fix existed. Pins the boundary:
+        only 4xx from the provider is treated as a non-transient client
+        error worth surfacing verbatim.
+        """
+        harness = igw_loopback_harness()
+
+        with harness.load_plugin(GUARDRAILS_PLUGIN_NAME):
+            fixture = self._setup(harness)
+            try:
+                harness.mock_chat_completions(
+                    fixture.vision_model_entity_ref,
+                    responses=[
+                        ErrorResponse(
+                            status_code=500,
+                            body={"object": "error", "message": "Internal server error", "code": 500},
+                        )
+                    ],
+                )
+
+                with pytest.raises(nemo_platform.APIStatusError) as exc_info:
+                    self._send_message(harness, fixture.vm_name)
+
+                assert exc_info.value.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+            finally:
+                self._delete_config_if_present(harness, fixture.config_name)

--- a/plugins/nemo-guardrails/tests/integration/test_upstream_error_surfacing.py
+++ b/plugins/nemo-guardrails/tests/integration/test_upstream_error_surfacing.py
@@ -3,9 +3,9 @@
 
 """Integration tests that exercise the real ``langchain_nvidia_ai_endpoints``
 error path (nemoguardrails' bundled ``nim`` engine), not a hand-constructed
-exception. ``responses.extract_upstream_client_error`` assumes that library
-formats every raised error as a ``"[<status>] <detail>"``-prefixed message —
-these tests call the real library against a mocked upstream so a future
+exception. ``responses.extract_upstream_error`` assumes that library formats
+every raised error as a ``"[<status>] <detail>"``-prefixed message — these
+tests call the real library against a mocked upstream so a future
 ``langchain_nvidia_ai_endpoints`` upgrade that changes that convention fails
 loudly here, instead of only in production.
 """
@@ -168,7 +168,7 @@ class TestUpstreamErrorSurfacing:
         caller as a 400 with the upstream detail, not the middleware's generic
         503. Exercises the real library end-to-end — no hand-built exception —
         so it fails if a library upgrade changes the ``"[<status>] ..."``
-        convention ``extract_upstream_client_error`` depends on.
+        convention ``extract_upstream_error`` depends on.
         """
         harness = igw_loopback_harness()
 
@@ -192,15 +192,13 @@ class TestUpstreamErrorSurfacing:
             finally:
                 self._delete_config_if_present(harness, fixture.config_name)
 
-    def test_upstream_500_from_vision_judge_stays_503(
+    def test_upstream_500_from_vision_judge_is_also_preserved(
         self,
         igw_loopback_harness: Callable[..., IGWLoopbackHarness],
     ) -> None:
-        """A genuine upstream 5xx (outage, not a bad request) must NOT be
-        reinterpreted — it should fall through to the plugin's existing
-        generic 503, same as before this fix existed. Pins the boundary:
-        only 4xx from the provider is treated as a non-transient client
-        error worth surfacing verbatim.
+        """A genuine upstream 5xx is propagated verbatim too, same as a 4xx —
+        the middleware's generic 503 fallback is reserved for failures with
+        no recoverable upstream status at all (e.g. a connection error).
         """
         harness = igw_loopback_harness()
 
@@ -220,6 +218,6 @@ class TestUpstreamErrorSurfacing:
                 with pytest.raises(nemo_platform.APIStatusError) as exc_info:
                     self._send_message(harness, fixture.vm_name)
 
-                assert exc_info.value.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+                assert exc_info.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
             finally:
                 self._delete_config_if_present(harness, fixture.config_name)

--- a/plugins/nemo-guardrails/tests/integration/test_upstream_error_surfacing.py
+++ b/plugins/nemo-guardrails/tests/integration/test_upstream_error_surfacing.py
@@ -124,17 +124,23 @@ class TestUpstreamErrorSurfacing:
                 vision_base_url=harness.nim_base_url,
             ),
         )
-        harness.add_virtual_model(
-            workspace=harness.workspace,
-            name=test_data_names.main_model_served_name,
-            default_model_entity=test_data_names.main_model_entity_ref,
-        )
-        harness.add_virtual_model(
-            workspace=harness.workspace,
-            name=test_data_names.request_virtual_model_name,
-            default_model_entity=test_data_names.main_model_entity_ref,
-            request_middleware=[self._middleware_call(harness.workspace, test_data_names.guardrail_config_name)],
-        )
+        # Config is created; clean it up if VirtualModel wiring fails before we
+        # hand a _Fixture (and its teardown responsibility) back to the caller.
+        try:
+            harness.add_virtual_model(
+                workspace=harness.workspace,
+                name=test_data_names.main_model_served_name,
+                default_model_entity=test_data_names.main_model_entity_ref,
+            )
+            harness.add_virtual_model(
+                workspace=harness.workspace,
+                name=test_data_names.request_virtual_model_name,
+                default_model_entity=test_data_names.main_model_entity_ref,
+                request_middleware=[self._middleware_call(harness.workspace, test_data_names.guardrail_config_name)],
+            )
+        except Exception:
+            self._delete_config_if_present(harness, test_data_names.guardrail_config_name)
+            raise
         return _Fixture(
             vm_name=test_data_names.request_virtual_model_name,
             config_name=test_data_names.guardrail_config_name,

--- a/plugins/nemo-guardrails/tests/unit/test_middleware.py
+++ b/plugins/nemo-guardrails/tests/unit/test_middleware.py
@@ -20,7 +20,9 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import nemo_platform
+import openai
 import pytest
 import pytest_asyncio
 from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
@@ -51,6 +53,7 @@ from nemo_platform_plugin.inference_middleware import (
     InferenceResponse,
     ResponseResult,
 )
+from nemoguardrails.exceptions import LLMCallException
 from nemoguardrails.rails.llm.options import ActivatedRail, GenerationLog, GenerationResponse, GenerationStats
 
 # ---------------------------------------------------------------------------
@@ -1742,13 +1745,13 @@ class TestStreamingLeaseLifecycle:
             }
         ]
 
-        class _BoomOnCloseStream:
+        class _llm_erorOnCloseStream:
             """Async iterator that yields normally then fails on aclose()."""
 
             def __init__(self) -> None:
                 self._items = iter(chunks_yielded)
 
-            def __aiter__(self) -> "_BoomOnCloseStream":
+            def __aiter__(self) -> "_llm_erorOnCloseStream":
                 return self
 
             async def __anext__(self) -> dict[str, Any]:
@@ -1766,7 +1769,7 @@ class TestStreamingLeaseLifecycle:
         with patch.object(middleware, "_prepare_lease", new=patched_prepare):
             with patch(
                 "nemo_guardrails_plugin.middleware.handle_streaming_output_check",
-                return_value=_BoomOnCloseStream(),
+                return_value=_llm_erorOnCloseStream(),
             ):
                 result = await _process_response(
                     middleware,
@@ -2316,12 +2319,98 @@ class TestProcessRequestErrorSurfacing:
             "model": "ws/llama",
         }
 
-        async def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        async def _llm_eror(*_args: Any, **_kwargs: Any) -> Any:
             raise RuntimeError("cache exploded")
 
-        with patch.object(middleware, "_prepare_lease", new=_boom):
+        with patch.object(middleware, "_prepare_lease", new=_llm_eror):
             with pytest.raises(InferenceMiddlewareUnavailableError) as exc_info:
                 await _process_request(middleware, request_body, {}, _entity_source())
 
         assert isinstance(exc_info.value.__cause__, RuntimeError)
         assert "cache exploded" in str(exc_info.value.__cause__)
+
+    async def test_bracketed_upstream_400_from_rail_task_llm_preserved(self, middleware: GuardrailsMiddleware) -> None:
+        """A rail-task LLM call (e.g. a vision-safety judge, via
+        ``langchain_nvidia_ai_endpoints``) that rejects the request shape
+        with an upstream 400 must surface as a 400, not a 503.
+
+        The outer ``LLMCallException`` nemoguardrails raises never carries
+        the status prefix itself — only its ``inner_exception`` does — so
+        this pins that the middleware unwraps to ``inner_exception`` rather
+        than checking the outer exception alone.
+        """
+        request_body = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "ws/llama",
+        }
+
+        def _llm_eror(*_args: Any, **_kwargs: Any) -> Any:
+            inner = Exception(  # noqa: TRY002 - mirrors langchain_nvidia_ai_endpoints._format_error
+                '[400] Unknown Error {"object":"error","message":'
+                '"At most 1 image(s) may be provided in one request.",'
+                '"type":"BadRequestError","param":null,"code":400}'
+            )
+            raise LLMCallException(inner, detail="Error invoking LLM (model=vision-judge)") from inner
+
+        with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
+            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_eror):
+                with pytest.raises(InferenceMiddlewareError) as exc_info:
+                    await _process_request(middleware, request_body, {}, _entity_source())
+
+        assert not isinstance(exc_info.value, InferenceMiddlewareUnavailableError)
+        assert exc_info.value.status_code == 400
+        # The outer LLMCallException's ``detail`` (which model/provider/endpoint
+        # failed) is preserved alongside the sanitized upstream message, not
+        # discarded in favor of the inner exception's message alone.
+        assert exc_info.value.detail == (
+            "Error invoking LLM (model=vision-judge): At most 1 image(s) may be provided in one request."
+        )
+
+    async def test_openai_status_error_status_code_preserved(self, middleware: GuardrailsMiddleware) -> None:
+        """An ``openai.APIStatusError`` subclass (``BadRequestError`` here) has
+        a genuine ``status_code`` attribute, so it's picked up directly with
+        no message parsing needed."""
+        request_body = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "ws/llama",
+        }
+
+        def _llm_eror(*_args: Any, **_kwargs: Any) -> Any:
+            response = httpx.Response(422, request=httpx.Request("POST", "http://example.test"))
+            inner = openai.BadRequestError("Unsupported parameter: foo", response=response, body=None)
+            raise LLMCallException(inner, detail="Error invoking LLM") from inner
+
+        with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
+            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_eror):
+                with pytest.raises(InferenceMiddlewareError) as exc_info:
+                    await _process_request(middleware, request_body, {}, _entity_source())
+
+        assert not isinstance(exc_info.value, InferenceMiddlewareUnavailableError)
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail == "Error invoking LLM: Unsupported parameter: foo"
+
+    async def test_upstream_5xx_still_wraps_to_503(self, middleware: GuardrailsMiddleware) -> None:
+        """A ``[5xx]``-prefixed or unrecognized failure keeps the existing
+        503 policy — only 4xx is safe to reinterpret as "don't retry this
+        exact request"; a 5xx from the provider is a genuine outage and
+        collapsing it to some other status would misrepresent that."""
+        request_body = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "ws/llama",
+        }
+
+        def _llm_eror(*_args: Any, **_kwargs: Any) -> Any:
+            raise Exception("[503] Service temporarily overloaded")  # noqa: TRY002
+
+        with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
+            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_eror):
+                with pytest.raises(InferenceMiddlewareUnavailableError) as exc_info:
+                    await _process_request(middleware, request_body, {}, _entity_source())
+
+        assert exc_info.value.status_code == 503
+        # Detail is the generic, fixed error_msg — not the raw upstream text.
+        # extract_upstream_client_error() returned None for this 5xx, so
+        # _run_rails's fallback (not the 4xx-preserving branch) ran.
+        assert exc_info.value.detail == "Failed to run input rails"
+        assert isinstance(exc_info.value.__cause__, Exception)
+        assert "Service temporarily overloaded" in str(exc_info.value.__cause__)

--- a/plugins/nemo-guardrails/tests/unit/test_middleware.py
+++ b/plugins/nemo-guardrails/tests/unit/test_middleware.py
@@ -1745,13 +1745,13 @@ class TestStreamingLeaseLifecycle:
             }
         ]
 
-        class _llm_erorOnCloseStream:
+        class _LlmErrorOnCloseStream:
             """Async iterator that yields normally then fails on aclose()."""
 
             def __init__(self) -> None:
                 self._items = iter(chunks_yielded)
 
-            def __aiter__(self) -> "_llm_erorOnCloseStream":
+            def __aiter__(self) -> "_LlmErrorOnCloseStream":
                 return self
 
             async def __anext__(self) -> dict[str, Any]:
@@ -1769,7 +1769,7 @@ class TestStreamingLeaseLifecycle:
         with patch.object(middleware, "_prepare_lease", new=patched_prepare):
             with patch(
                 "nemo_guardrails_plugin.middleware.handle_streaming_output_check",
-                return_value=_llm_erorOnCloseStream(),
+                return_value=_LlmErrorOnCloseStream(),
             ):
                 result = await _process_response(
                     middleware,
@@ -2319,10 +2319,10 @@ class TestProcessRequestErrorSurfacing:
             "model": "ws/llama",
         }
 
-        async def _llm_eror(*_args: Any, **_kwargs: Any) -> Any:
+        async def _llm_error(*_args: Any, **_kwargs: Any) -> Any:
             raise RuntimeError("cache exploded")
 
-        with patch.object(middleware, "_prepare_lease", new=_llm_eror):
+        with patch.object(middleware, "_prepare_lease", new=_llm_error):
             with pytest.raises(InferenceMiddlewareUnavailableError) as exc_info:
                 await _process_request(middleware, request_body, {}, _entity_source())
 
@@ -2344,7 +2344,7 @@ class TestProcessRequestErrorSurfacing:
             "model": "ws/llama",
         }
 
-        def _llm_eror(*_args: Any, **_kwargs: Any) -> Any:
+        def _llm_error(*_args: Any, **_kwargs: Any) -> Any:
             inner = Exception(  # noqa: TRY002 - mirrors langchain_nvidia_ai_endpoints._format_error
                 '[400] Unknown Error {"object":"error","message":'
                 '"At most 1 image(s) may be provided in one request.",'
@@ -2353,7 +2353,7 @@ class TestProcessRequestErrorSurfacing:
             raise LLMCallException(inner, detail="Error invoking LLM (model=vision-judge)") from inner
 
         with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
-            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_eror):
+            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_error):
                 with pytest.raises(InferenceMiddlewareError) as exc_info:
                     await _process_request(middleware, request_body, {}, _entity_source())
 
@@ -2375,13 +2375,13 @@ class TestProcessRequestErrorSurfacing:
             "model": "ws/llama",
         }
 
-        def _llm_eror(*_args: Any, **_kwargs: Any) -> Any:
+        def _llm_error(*_args: Any, **_kwargs: Any) -> Any:
             response = httpx.Response(422, request=httpx.Request("POST", "http://example.test"))
             inner = openai.BadRequestError("Unsupported parameter: foo", response=response, body=None)
             raise LLMCallException(inner, detail="Error invoking LLM") from inner
 
         with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
-            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_eror):
+            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_error):
                 with pytest.raises(InferenceMiddlewareError) as exc_info:
                     await _process_request(middleware, request_body, {}, _entity_source())
 
@@ -2398,11 +2398,11 @@ class TestProcessRequestErrorSurfacing:
             "model": "ws/llama",
         }
 
-        def _llm_eror(*_args: Any, **_kwargs: Any) -> Any:
+        def _llm_error(*_args: Any, **_kwargs: Any) -> Any:
             raise Exception("[503] Service temporarily overloaded")  # noqa: TRY002
 
         with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
-            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_eror):
+            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_error):
                 with pytest.raises(InferenceMiddlewareError) as exc_info:
                     await _process_request(middleware, request_body, {}, _entity_source())
 
@@ -2418,11 +2418,11 @@ class TestProcessRequestErrorSurfacing:
             "model": "ws/llama",
         }
 
-        def _llm_eror(*_args: Any, **_kwargs: Any) -> Any:
+        def _llm_error(*_args: Any, **_kwargs: Any) -> Any:
             raise ValueError("something went wrong")
 
         with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
-            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_eror):
+            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_error):
                 with pytest.raises(InferenceMiddlewareUnavailableError) as exc_info:
                     await _process_request(middleware, request_body, {}, _entity_source())
 

--- a/plugins/nemo-guardrails/tests/unit/test_middleware.py
+++ b/plugins/nemo-guardrails/tests/unit/test_middleware.py
@@ -2389,11 +2389,10 @@ class TestProcessRequestErrorSurfacing:
         assert exc_info.value.status_code == 422
         assert exc_info.value.detail == "Error invoking LLM: Unsupported parameter: foo"
 
-    async def test_upstream_5xx_still_wraps_to_503(self, middleware: GuardrailsMiddleware) -> None:
-        """A ``[5xx]``-prefixed or unrecognized failure keeps the existing
-        503 policy — only 4xx is safe to reinterpret as "don't retry this
-        exact request"; a 5xx from the provider is a genuine outage and
-        collapsing it to some other status would misrepresent that."""
+    async def test_upstream_5xx_also_propagated_verbatim(self, middleware: GuardrailsMiddleware) -> None:
+        """A ``[5xx]``-prefixed upstream failure is propagated as-is, same as
+        a 4xx — the middleware's generic 503 fallback is now reserved for
+        failures with no recoverable upstream status at all."""
         request_body = {
             "messages": [{"role": "user", "content": "Hi"}],
             "model": "ws/llama",
@@ -2404,13 +2403,33 @@ class TestProcessRequestErrorSurfacing:
 
         with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
             with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_eror):
+                with pytest.raises(InferenceMiddlewareError) as exc_info:
+                    await _process_request(middleware, request_body, {}, _entity_source())
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Service temporarily overloaded"
+
+    async def test_no_recoverable_status_still_wraps_to_generic_503(self, middleware: GuardrailsMiddleware) -> None:
+        """When the failure carries no recoverable upstream status at all
+        (e.g. a plain library bug below the lease boundary), the middleware
+        still falls back to its own generic 503 with the fixed ``error_msg``."""
+        request_body = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "ws/llama",
+        }
+
+        def _llm_eror(*_args: Any, **_kwargs: Any) -> Any:
+            raise ValueError("something went wrong")
+
+        with patch.object(middleware, "_prepare_lease", new=_patch_prepare_lease()):
+            with patch("nemo_guardrails_plugin.middleware.run_generate_in_new_loop", side_effect=_llm_eror):
                 with pytest.raises(InferenceMiddlewareUnavailableError) as exc_info:
                     await _process_request(middleware, request_body, {}, _entity_source())
 
         assert exc_info.value.status_code == 503
         # Detail is the generic, fixed error_msg — not the raw upstream text.
-        # extract_upstream_client_error() returned None for this 5xx, so
-        # _run_rails's fallback (not the 4xx-preserving branch) ran.
+        # extract_upstream_error() returned None here, so _run_rails's
+        # fallback (not the status-preserving branch) ran.
         assert exc_info.value.detail == "Failed to run input rails"
-        assert isinstance(exc_info.value.__cause__, Exception)
-        assert "Service temporarily overloaded" in str(exc_info.value.__cause__)
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "something went wrong" in str(exc_info.value.__cause__)

--- a/plugins/nemo-guardrails/tests/unit/test_responses.py
+++ b/plugins/nemo-guardrails/tests/unit/test_responses.py
@@ -458,6 +458,12 @@ class TestExtractUpstreamError:
         assert result.status_code == 503
         assert result.detail == "Service temporarily overloaded"
 
+    def test_non_error_status_returns_none(self) -> None:
+        """A 1xx-3xx status embedded in the error message is ignored."""
+        exc = Exception("[302] Found")  # noqa: TRY002
+
+        assert extract_upstream_error(exc) is None
+
     def test_no_recoverable_status_returns_none(self) -> None:
         """No status anywhere → ``None``, so the caller keeps its 503 fallback."""
         inner = ValueError("something went wrong")

--- a/plugins/nemo-guardrails/tests/unit/test_responses.py
+++ b/plugins/nemo-guardrails/tests/unit/test_responses.py
@@ -372,10 +372,9 @@ class TestBuildInferenceResponse:
 
 
 class TestExtractUpstreamError:
-    def test_openai_status_error_status_code_preserved(self) -> None:
-        """A genuine ``status_code`` attribute (as set by ``openai.APIStatusError``
-        and all its subclasses) is picked up directly via duck typing — no
-        message parsing needed."""
+    def test_status_code_attribute_4xx_preserved(self) -> None:
+        """A genuine ``status_code`` attribute (``openai.APIStatusError``) is
+        read directly, no message parsing."""
         response = httpx.Response(422, request=httpx.Request("POST", "http://example.test"))
         inner = openai.BadRequestError("Unsupported parameter: foo", response=response, body=None)
         try:
@@ -387,13 +386,9 @@ class TestExtractUpstreamError:
         assert result.status_code == 422
         assert result.detail == "Error invoking LLM: Unsupported parameter: foo"
 
-    def test_bracketed_status_prefix_fallback_on_inner_exception(self) -> None:
-        """When ``inner_exception`` has no structured ``status_code``, falls
-        back to parsing the ``[<status>] <detail>`` prefix convention used by
-        ``langchain_nvidia_ai_endpoints`` — checked on ``inner_exception``,
-        not the outer ``LLMCallException``, since the outer exception's
-        message (``"Error invoking LLM (...): ..."``) never itself starts
-        with a bracketed status."""
+    def test_bracketed_prefix_4xx_preserved(self) -> None:
+        """With no structured ``status_code``, the ``[<status>] ...`` prefix is
+        parsed off ``inner_exception`` (the langchain library's convention)."""
         inner = Exception(  # noqa: TRY002 - mirrors langchain_nvidia_ai_endpoints._format_error
             '[400] Unknown Error {"object":"error","message":'
             '"At most 1 image(s) may be provided in one request.",'
@@ -406,17 +401,14 @@ class TestExtractUpstreamError:
 
         assert result is not None
         assert result.status_code == 400
-        # The outer LLMCallException's ``detail`` is preserved alongside the
-        # sanitized upstream message, and the "Unknown Error" placeholder /
-        # raw JSON body is not leaked verbatim.
+        # LLMCallException.detail is prefixed; "Unknown Error"/raw JSON dropped.
         assert result.detail == (
             "Error invoking LLM (model=vision-judge): At most 1 image(s) may be provided in one request."
         )
 
-    def test_bracketed_status_prefix_without_llm_call_exception_wrapping(self) -> None:
-        """The bracketed-prefix fallback also applies to a bare exception with
-        no ``LLMCallException`` wrapping at all, in which case there is no
-        context to prefix."""
+    def test_bracketed_prefix_without_wrapping_preserved(self) -> None:
+        """A bare bracketed exception (no ``LLMCallException``) works too, with
+        no context to prefix."""
         exc = Exception("[404] Model not found")  # noqa: TRY002
 
         result = extract_upstream_error(exc)
@@ -425,10 +417,8 @@ class TestExtractUpstreamError:
         assert result.status_code == 404
         assert result.detail == "Model not found"
 
-    def test_bracketed_status_prefix_with_unparseable_json_body_falls_back_to_raw_text(self) -> None:
-        """If the text after the bracketed status prefix isn't valid JSON,
-        the raw text is used as-is rather than raising or dropping the
-        message."""
+    def test_bracketed_prefix_unparseable_json_uses_raw_text(self) -> None:
+        """Non-JSON text after the status prefix is used as-is."""
         exc = Exception("[400] Bad Request: not-json-at-all")  # noqa: TRY002
 
         result = extract_upstream_error(exc)
@@ -437,37 +427,16 @@ class TestExtractUpstreamError:
         assert result.status_code == 400
         assert result.detail == "Bad Request: not-json-at-all"
 
-    def test_does_not_follow_plain_cause_chain_when_not_llm_call_exception(self) -> None:
-        """Only two objects are ever examined: ``exc`` itself, and
-        ``exc.inner_exception`` if ``exc`` is an ``LLMCallException``. A plain
-        ``__cause__`` link (e.g. from a bare ``raise ... from ...``, with no
-        ``LLMCallException`` involved at all) is deliberately *not* followed
-        — this doesn't happen on either real error path (nemoguardrails has a
-        single call site that constructs ``LLMCallException``, and it's never
-        nested), so a bracketed 4xx one hop further back via plain
-        ``__cause__`` is not recovered."""
-        inner = Exception("[400] Nested bad request")  # noqa: TRY002
-        try:
-            raise RuntimeError("wrapper") from inner
-        except RuntimeError as wrapper:
-            exc = wrapper
-
-        assert extract_upstream_error(exc) is None
-
-    def test_inner_exception_as_string_falls_back_to_checking_exc_itself(self) -> None:
-        """``LLMCallException.inner_exception`` is typed as ``BaseException | str``
-        — when it's a bare string (no attributes, nothing to unwrap), ``exc``
-        itself is checked instead of crashing on a non-exception ``candidate``.
-        ``exc`` never has a recoverable status of its own, so this returns
-        ``None`` rather than raising."""
+    def test_string_inner_exception_returns_none(self) -> None:
+        """A string ``inner_exception`` (its type is ``BaseException | str``)
+        is skipped without crashing, returning ``None``."""
         exc = LLMCallException("no exception object here, just a string", detail="Error invoking LLM")
 
         assert extract_upstream_error(exc) is None
 
-    def test_5xx_status_code_is_propagated_too(self) -> None:
-        """A genuine ``status_code`` attribute is propagated as-is even for a
-        5xx (e.g. a real upstream outage) — we no longer collapse it to the
-        middleware's own generic 503."""
+    def test_status_code_attribute_5xx_preserved(self) -> None:
+        """A ``status_code`` attribute is preserved for a 5xx too, not
+        collapsed to the middleware's generic 503."""
         response = httpx.Response(500, request=httpx.Request("POST", "http://example.test"))
         inner = openai.InternalServerError("Upstream exploded", response=response, body=None)
         try:
@@ -479,8 +448,8 @@ class TestExtractUpstreamError:
         assert result.status_code == 500
         assert result.detail == "Error invoking LLM: Upstream exploded"
 
-    def test_bracketed_5xx_prefix_is_propagated_too(self) -> None:
-        """A ``[5xx]``-prefixed failure is propagated as-is, same as a 4xx."""
+    def test_bracketed_prefix_5xx_preserved(self) -> None:
+        """A ``[5xx]``-prefixed failure is preserved, same as a 4xx."""
         exc = Exception("[503] Service temporarily overloaded")  # noqa: TRY002
 
         result = extract_upstream_error(exc)
@@ -489,10 +458,8 @@ class TestExtractUpstreamError:
         assert result.status_code == 503
         assert result.detail == "Service temporarily overloaded"
 
-    def test_no_recoverable_status_anywhere_returns_none(self) -> None:
-        """When neither ``exc`` nor ``exc.inner_exception`` has a status code
-        or bracketed prefix, returns ``None`` so the caller keeps its
-        existing 503 fallback."""
+    def test_no_recoverable_status_returns_none(self) -> None:
+        """No status anywhere → ``None``, so the caller keeps its 503 fallback."""
         inner = ValueError("something went wrong")
         try:
             raise LLMCallException(inner, detail="Error invoking LLM") from inner

--- a/plugins/nemo-guardrails/tests/unit/test_responses.py
+++ b/plugins/nemo-guardrails/tests/unit/test_responses.py
@@ -4,6 +4,8 @@
 import json
 from typing import Any
 
+import httpx
+import openai
 import pytest
 from nemo_guardrails_plugin.constants import GUARDRAILS_DATA_MESSAGE_ROLE
 from nemo_guardrails_plugin.responses import (
@@ -12,8 +14,10 @@ from nemo_guardrails_plugin.responses import (
     build_immediate_response,
     build_inference_response,
     build_output_response_body,
+    extract_upstream_client_error,
 )
 from nemo_platform_plugin.inference_middleware import InferenceMiddlewareError, InferenceResponse
+from nemoguardrails.exceptions import LLMCallException
 from nemoguardrails.rails.llm.options import ActivatedRail, GenerationLog, GenerationResponse
 
 # ---------------------------------------------------------------------------
@@ -360,3 +364,133 @@ class TestBuildInferenceResponse:
         )
 
         assert result.response_body_annotations == {"other_plugin": {"trace_id": "abc"}}
+
+
+# ---------------------------------------------------------------------------
+# extract_upstream_client_error
+# ---------------------------------------------------------------------------
+
+
+class TestExtractUpstreamClientError:
+    def test_openai_status_error_status_code_preserved(self) -> None:
+        """A genuine ``status_code`` attribute (as set by ``openai.APIStatusError``
+        and all its subclasses) is picked up directly via duck typing — no
+        message parsing needed."""
+        response = httpx.Response(422, request=httpx.Request("POST", "http://example.test"))
+        inner = openai.BadRequestError("Unsupported parameter: foo", response=response, body=None)
+        try:
+            raise LLMCallException(inner, detail="Error invoking LLM") from inner
+        except LLMCallException as exc:
+            result = extract_upstream_client_error(exc)
+
+        assert result is not None
+        assert result.status_code == 422
+        assert result.detail == "Error invoking LLM: Unsupported parameter: foo"
+
+    def test_bracketed_status_prefix_fallback_on_inner_exception(self) -> None:
+        """When ``inner_exception`` has no structured ``status_code``, falls
+        back to parsing the ``[<status>] <detail>`` prefix convention used by
+        ``langchain_nvidia_ai_endpoints`` — checked on ``inner_exception``,
+        not the outer ``LLMCallException``, since the outer exception's
+        message (``"Error invoking LLM (...): ..."``) never itself starts
+        with a bracketed status."""
+        inner = Exception(  # noqa: TRY002 - mirrors langchain_nvidia_ai_endpoints._format_error
+            '[400] Unknown Error {"object":"error","message":'
+            '"At most 1 image(s) may be provided in one request.",'
+            '"type":"BadRequestError","param":null,"code":400}'
+        )
+        try:
+            raise LLMCallException(inner, detail="Error invoking LLM (model=vision-judge)") from inner
+        except LLMCallException as exc:
+            result = extract_upstream_client_error(exc)
+
+        assert result is not None
+        assert result.status_code == 400
+        # The outer LLMCallException's ``detail`` is preserved alongside the
+        # sanitized upstream message, and the "Unknown Error" placeholder /
+        # raw JSON body is not leaked verbatim.
+        assert result.detail == (
+            "Error invoking LLM (model=vision-judge): At most 1 image(s) may be provided in one request."
+        )
+
+    def test_bracketed_status_prefix_without_llm_call_exception_wrapping(self) -> None:
+        """The bracketed-prefix fallback also applies to a bare exception with
+        no ``LLMCallException`` wrapping at all, in which case there is no
+        context to prefix."""
+        exc = Exception("[404] Model not found")  # noqa: TRY002
+
+        result = extract_upstream_client_error(exc)
+
+        assert result is not None
+        assert result.status_code == 404
+        assert result.detail == "Model not found"
+
+    def test_bracketed_status_prefix_with_unparseable_json_body_falls_back_to_raw_text(self) -> None:
+        """If the text after the bracketed status prefix isn't valid JSON,
+        the raw text is used as-is rather than raising or dropping the
+        message."""
+        exc = Exception("[400] Bad Request: not-json-at-all")  # noqa: TRY002
+
+        result = extract_upstream_client_error(exc)
+
+        assert result is not None
+        assert result.status_code == 400
+        assert result.detail == "Bad Request: not-json-at-all"
+
+    def test_does_not_follow_plain_cause_chain_when_not_llm_call_exception(self) -> None:
+        """Only two objects are ever examined: ``exc`` itself, and
+        ``exc.inner_exception`` if ``exc`` is an ``LLMCallException``. A plain
+        ``__cause__`` link (e.g. from a bare ``raise ... from ...``, with no
+        ``LLMCallException`` involved at all) is deliberately *not* followed
+        — this doesn't happen on either real error path (nemoguardrails has a
+        single call site that constructs ``LLMCallException``, and it's never
+        nested), so a bracketed 4xx one hop further back via plain
+        ``__cause__`` is not recovered."""
+        inner = Exception("[400] Nested bad request")  # noqa: TRY002
+        try:
+            raise RuntimeError("wrapper") from inner
+        except RuntimeError as wrapper:
+            exc = wrapper
+
+        assert extract_upstream_client_error(exc) is None
+
+    def test_inner_exception_as_string_falls_back_to_checking_exc_itself(self) -> None:
+        """``LLMCallException.inner_exception`` is typed as ``BaseException | str``
+        — when it's a bare string (no attributes, nothing to unwrap), ``exc``
+        itself is checked instead of crashing on a non-exception ``candidate``.
+        ``exc`` never has a recoverable status of its own, so this returns
+        ``None`` rather than raising."""
+        exc = LLMCallException("no exception object here, just a string", detail="Error invoking LLM")
+
+        assert extract_upstream_client_error(exc) is None
+
+    def test_status_code_outside_client_error_range_is_ignored(self) -> None:
+        """A ``status_code`` attribute present but outside the 4xx range
+        (e.g. a genuine 500) is not treated as a recoverable client error."""
+        response = httpx.Response(500, request=httpx.Request("POST", "http://example.test"))
+        inner = openai.InternalServerError("Upstream exploded", response=response, body=None)
+        try:
+            raise LLMCallException(inner, detail="Error invoking LLM") from inner
+        except LLMCallException as exc:
+            result = extract_upstream_client_error(exc)
+
+        assert result is None
+
+    def test_bracketed_5xx_prefix_returns_none(self) -> None:
+        """A ``[5xx]``-prefixed failure is left alone — only 4xx is safe to
+        reinterpret as a preserved client error; a 5xx is a genuine outage."""
+        exc = Exception("[503] Service temporarily overloaded")  # noqa: TRY002
+
+        assert extract_upstream_client_error(exc) is None
+
+    def test_no_recoverable_status_anywhere_returns_none(self) -> None:
+        """When neither ``exc`` nor ``exc.inner_exception`` has a status code
+        or bracketed prefix, returns ``None`` so the caller keeps its
+        existing 503 fallback."""
+        inner = ValueError("something went wrong")
+        try:
+            raise LLMCallException(inner, detail="Error invoking LLM") from inner
+        except LLMCallException as exc:
+            result = extract_upstream_client_error(exc)
+
+        assert result is None

--- a/plugins/nemo-guardrails/tests/unit/test_responses.py
+++ b/plugins/nemo-guardrails/tests/unit/test_responses.py
@@ -14,7 +14,7 @@ from nemo_guardrails_plugin.responses import (
     build_immediate_response,
     build_inference_response,
     build_output_response_body,
-    extract_upstream_client_error,
+    extract_upstream_error,
 )
 from nemo_platform_plugin.inference_middleware import InferenceMiddlewareError, InferenceResponse
 from nemoguardrails.exceptions import LLMCallException
@@ -367,11 +367,11 @@ class TestBuildInferenceResponse:
 
 
 # ---------------------------------------------------------------------------
-# extract_upstream_client_error
+# extract_upstream_error
 # ---------------------------------------------------------------------------
 
 
-class TestExtractUpstreamClientError:
+class TestExtractUpstreamError:
     def test_openai_status_error_status_code_preserved(self) -> None:
         """A genuine ``status_code`` attribute (as set by ``openai.APIStatusError``
         and all its subclasses) is picked up directly via duck typing — no
@@ -381,7 +381,7 @@ class TestExtractUpstreamClientError:
         try:
             raise LLMCallException(inner, detail="Error invoking LLM") from inner
         except LLMCallException as exc:
-            result = extract_upstream_client_error(exc)
+            result = extract_upstream_error(exc)
 
         assert result is not None
         assert result.status_code == 422
@@ -402,7 +402,7 @@ class TestExtractUpstreamClientError:
         try:
             raise LLMCallException(inner, detail="Error invoking LLM (model=vision-judge)") from inner
         except LLMCallException as exc:
-            result = extract_upstream_client_error(exc)
+            result = extract_upstream_error(exc)
 
         assert result is not None
         assert result.status_code == 400
@@ -419,7 +419,7 @@ class TestExtractUpstreamClientError:
         context to prefix."""
         exc = Exception("[404] Model not found")  # noqa: TRY002
 
-        result = extract_upstream_client_error(exc)
+        result = extract_upstream_error(exc)
 
         assert result is not None
         assert result.status_code == 404
@@ -431,7 +431,7 @@ class TestExtractUpstreamClientError:
         message."""
         exc = Exception("[400] Bad Request: not-json-at-all")  # noqa: TRY002
 
-        result = extract_upstream_client_error(exc)
+        result = extract_upstream_error(exc)
 
         assert result is not None
         assert result.status_code == 400
@@ -452,7 +452,7 @@ class TestExtractUpstreamClientError:
         except RuntimeError as wrapper:
             exc = wrapper
 
-        assert extract_upstream_client_error(exc) is None
+        assert extract_upstream_error(exc) is None
 
     def test_inner_exception_as_string_falls_back_to_checking_exc_itself(self) -> None:
         """``LLMCallException.inner_exception`` is typed as ``BaseException | str``
@@ -462,26 +462,32 @@ class TestExtractUpstreamClientError:
         ``None`` rather than raising."""
         exc = LLMCallException("no exception object here, just a string", detail="Error invoking LLM")
 
-        assert extract_upstream_client_error(exc) is None
+        assert extract_upstream_error(exc) is None
 
-    def test_status_code_outside_client_error_range_is_ignored(self) -> None:
-        """A ``status_code`` attribute present but outside the 4xx range
-        (e.g. a genuine 500) is not treated as a recoverable client error."""
+    def test_5xx_status_code_is_propagated_too(self) -> None:
+        """A genuine ``status_code`` attribute is propagated as-is even for a
+        5xx (e.g. a real upstream outage) — we no longer collapse it to the
+        middleware's own generic 503."""
         response = httpx.Response(500, request=httpx.Request("POST", "http://example.test"))
         inner = openai.InternalServerError("Upstream exploded", response=response, body=None)
         try:
             raise LLMCallException(inner, detail="Error invoking LLM") from inner
         except LLMCallException as exc:
-            result = extract_upstream_client_error(exc)
+            result = extract_upstream_error(exc)
 
-        assert result is None
+        assert result is not None
+        assert result.status_code == 500
+        assert result.detail == "Error invoking LLM: Upstream exploded"
 
-    def test_bracketed_5xx_prefix_returns_none(self) -> None:
-        """A ``[5xx]``-prefixed failure is left alone — only 4xx is safe to
-        reinterpret as a preserved client error; a 5xx is a genuine outage."""
+    def test_bracketed_5xx_prefix_is_propagated_too(self) -> None:
+        """A ``[5xx]``-prefixed failure is propagated as-is, same as a 4xx."""
         exc = Exception("[503] Service temporarily overloaded")  # noqa: TRY002
 
-        assert extract_upstream_client_error(exc) is None
+        result = extract_upstream_error(exc)
+
+        assert result is not None
+        assert result.status_code == 503
+        assert result.detail == "Service temporarily overloaded"
 
     def test_no_recoverable_status_anywhere_returns_none(self) -> None:
         """When neither ``exc`` nor ``exc.inner_exception`` has a status code
@@ -491,6 +497,6 @@ class TestExtractUpstreamClientError:
         try:
             raise LLMCallException(inner, detail="Error invoking LLM") from inner
         except LLMCallException as exc:
-            result = extract_upstream_client_error(exc)
+            result = extract_upstream_error(exc)
 
         assert result is None

--- a/services/guardrails/src/nmp/guardrails/app/services/rails/__init__.py
+++ b/services/guardrails/src/nmp/guardrails/app/services/rails/__init__.py
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import Any
 
-from nemoguardrails.llm.providers import register_chat_provider, register_llm_provider
+from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
+from nemoguardrails.llm.providers import register_llm_provider, register_provider
+from nemoguardrails.types import LLMModel
 from nmp.guardrails.app.constants import NIM_CHAT, NIM_LLM
 from nmp.guardrails.app.llms.chat.nim import ChatNIM
 from nmp.guardrails.app.llms.completion.nim import NIM
@@ -11,10 +14,15 @@ from nmp.guardrails.app.llms.completion.nim import NIM
 log = logging.getLogger(__name__)
 
 
+def _init_nim_chat_model(*, model: str, **kwargs: Any) -> LLMModel:
+    """Create a NeMo Guardrails model backed by the platform's ChatNIM client."""
+    return LangChainLLMAdapter(ChatNIM(model=model, **kwargs))
+
+
 def register_providers():
     """Register Chat/LLM providers to NeMo Guardrails."""
 
-    register_chat_provider(NIM_CHAT, ChatNIM)
+    register_provider(NIM_CHAT, _init_nim_chat_model)
     register_llm_provider(NIM_LLM, NIM)
 
 

--- a/services/guardrails/tests/services/rails/test_llm_provider_registry.py
+++ b/services/guardrails/tests/services/rails/test_llm_provider_registry.py
@@ -1,11 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
+from nemoguardrails.llm.models.initializer import init_llm_model
 from nemoguardrails.llm.providers import get_chat_provider_names, get_llm_provider_names
 from nmp.guardrails.app.constants import NIM_CHAT, NIM_LLM
-from nmp.guardrails.app.services.rails import register_providers
+from nmp.guardrails.app.services import rails
 
-register_providers()
+rails.register_providers()
 
 
 def test_chat_model_registered_in_nemoguardrails():
@@ -14,3 +16,17 @@ def test_chat_model_registered_in_nemoguardrails():
 
 def test_llm_model_registered_in_nemoguardrails():
     assert NIM_LLM in get_llm_provider_names(), "NIM_LLM provider not registered in NeMo Guardrails"
+
+
+def test_chat_model_uses_nemoguardrails_model_interface(monkeypatch):
+    chat_nim = object()
+    monkeypatch.setattr(rails, "ChatNIM", lambda **_kwargs: chat_nim)
+
+    model = init_llm_model(
+        model_name="default/test-model",
+        provider_name=NIM_CHAT,
+        kwargs={},
+    )
+
+    assert isinstance(model, LangChainLLMAdapter)
+    assert model._llm is chat_nim


### PR DESCRIPTION
## Summary

Fixes two blocking issues:

1. `ChatNIM` needs to wrapped as an LLMModel after bumping `nemoguardrails` to 0.23 due to underlying Langchain upgrades.
2. Upstream errors at input/output rail call-time collapse to a generic 503. A rail-task LLM failure (ex. the vision-safety judge rejecting a multi-image request, or erroring on malformed image input) was always caught and reported as a generic `503 {"detail":"Failed to run input rails"}`.

Added `extract_upstream_error()` that is a best-effort attempt to unwrap nemoguardrails' `LLMCallException`, recover the real upstream status code (from either a structured status_code attribute or the "[<status>] ..." prefix that `langchain_nvidia_ai_endpoints` prepends on every error), and propagate it with the sanitized upstream message.

## Testing
Verified live against a local NMP instance:
- A multi-image request now surfaces the real 400 with the model's actionable message instead of a 503
- A malformed image inputs now surface the real 500 instead of the same generic 503
- Added unit coverage in `test_responses.py/test_middleware.py` and an integration test (`test_upstream_error_surfacing.py`) exercising the real `langchain_nvidia_ai_endpoints` error path so a future library upgrade that changes its error format fails loudly here rather than in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Upstream LLM/provider failures now preserve the original HTTP status code and surface more accurate upstream error details instead of falling back to generic 503 responses.
  - Improved error recovery across rail execution paths so upstream status/detail is consistently returned.
  - NIM chat models are now properly integrated and registered through the guardrail model interface for consistent behavior.

- **Tests**
  - Added unit tests covering upstream status/detail extraction and middleware fallback behavior.
  - Added integration tests verifying upstream error surfacing for both 4xx and 5xx scenarios, including vision-judge flows.
  - Updated/extended middleware and provider registry tests to match the new behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->