### PR TITLE
fix: add service-principal-only agent routes

### DIFF
--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -125,6 +125,8 @@ auth:
   embedded_pdp_memory_limit_mb: 32
   # Fail-mode for a plugin that contributes invalid HTTP authz. | default: 'hard_fail' | values: 'deny_route' | 'quarantine' | 'hard_fail'
   on_invalid_plugin: hard_fail
+  # Allow human PlatformAdmin principals to use plugin routes that declare callers=[SERVICE_PRINCIPAL]. Disabled by default so service-only routes stay machine-only unless an operator explicitly opts into the admin exemption. | default: False
+  platform_admin_exempt_from_service_only: false
 ```
 
 ### `entities`

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -296,6 +296,7 @@ basePlatformConfig: |
     policy_decision_point_base_url: "{{ printf "http://%s:%s" (include "nmp-api.api-servicename" . ) (toString .Values.api.service.port) }}"
     policy_data_refresh_interval: 5
     bundle_cache_seconds: 5
+    platform_admin_exempt_from_service_only: false
     admin_email: "admin@example.com"
 
   # -- service is the common configuration for service settings on the platform

--- a/packages/nmp_platform/config/local.yaml
+++ b/packages/nmp_platform/config/local.yaml
@@ -27,6 +27,7 @@ auth:
   # Low timeouts for fast test feedback (same as integration tests)
   policy_data_refresh_interval: 2
   bundle_cache_seconds: 15  # 0 = refresh on every authz call for instant permission changes
+  platform_admin_exempt_from_service_only: false
   admin_email: "admin@example.com"
 
   # --- Azure AD OIDC (NeMo Platform dev deployment) ---

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml
@@ -13,6 +13,7 @@ auth:
   policy_decision_point_base_url: "http://127.0.0.1:8080"
   policy_data_refresh_interval: 2
   bundle_cache_seconds: 15
+  platform_admin_exempt_from_service_only: false
   admin_email: "admin@example.com"
 
 entities: {}

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -10,9 +10,17 @@ Two proxy routes:
     forwards the request.  This is the primary user-facing path, analogous to
     how IGW routes by model name.
 
+``/v2/workspaces/{workspace}/agents/{name}/-/internal/{trailing_uri}``
+    Internal-only proxy by **agent name** — same runtime target as the user-facing
+    path, but reserved for service principals.
+
 ``/v2/workspaces/{workspace}/deployments/{name}/-/{trailing_uri}``
     Proxy by **deployment name** — for direct targeting of a specific
     deployment (e.g. A/B testing).
+
+``/v2/workspaces/{workspace}/deployments/{name}/-/internal/{trailing_uri}``
+    Internal-only proxy by **deployment name** — same runtime target as the
+    user-facing deployment path, but reserved for service principals.
 
 The ``/-/`` separator prevents URL conflicts with the CRUD routes
 (``/agents/{name}`` and ``/deployments/{name}``).  This mirrors the pattern
@@ -135,6 +143,50 @@ async def _serve_agent_proxy(
 
 
 @router.api_route(
+    "/agents/{name}/-/internal/{trailing_uri:path}",
+    methods=_PROXY_READ_METHODS,
+    tags=["Agent Gateway"],
+    include_in_schema=False,
+)
+@scope.read
+@path_rule(
+    callers=[CallerKind.SERVICE_PRINCIPAL],
+    permissions=[GatewayPerms.INVOKE],
+)
+async def proxy_by_agent_name_internal_read(
+    workspace: str,
+    name: str,
+    trailing_uri: str,
+    request: Request,
+    entity_client: NemoEntitiesClient = Depends(get_entity_client),
+) -> StreamingResponse:
+    """Service-principal read proxy to the active deployment for *agent name*."""
+    return await _serve_agent_proxy(workspace, name, trailing_uri, request, entity_client)
+
+
+@router.api_route(
+    "/agents/{name}/-/internal/{trailing_uri:path}",
+    methods=_PROXY_WRITE_METHODS,
+    tags=["Agent Gateway"],
+    include_in_schema=False,
+)
+@scope.write
+@path_rule(
+    callers=[CallerKind.SERVICE_PRINCIPAL],
+    permissions=[GatewayPerms.INVOKE],
+)
+async def proxy_by_agent_name_internal_write(
+    workspace: str,
+    name: str,
+    trailing_uri: str,
+    request: Request,
+    entity_client: NemoEntitiesClient = Depends(get_entity_client),
+) -> StreamingResponse:
+    """Service-principal write proxy to the active deployment for *agent name*."""
+    return await _serve_agent_proxy(workspace, name, trailing_uri, request, entity_client)
+
+
+@router.api_route(
     "/agents/{name}/-/{trailing_uri:path}",
     methods=_PROXY_READ_METHODS,
     tags=["Agent Gateway"],
@@ -214,6 +266,50 @@ async def _serve_deployment_proxy(
         )
 
     return await _proxy(request, endpoint, trailing_uri, model_name=name)
+
+
+@router.api_route(
+    "/deployments/{name}/-/internal/{trailing_uri:path}",
+    methods=_PROXY_READ_METHODS,
+    tags=["Agent Gateway"],
+    include_in_schema=False,
+)
+@scope.read
+@path_rule(
+    callers=[CallerKind.SERVICE_PRINCIPAL],
+    permissions=[GatewayPerms.INVOKE],
+)
+async def proxy_by_deployment_name_internal_read(
+    workspace: str,
+    name: str,
+    trailing_uri: str,
+    request: Request,
+    entity_client: NemoEntitiesClient = Depends(get_entity_client),
+) -> StreamingResponse:
+    """Service-principal read proxy directly to the named deployment."""
+    return await _serve_deployment_proxy(workspace, name, trailing_uri, request, entity_client)
+
+
+@router.api_route(
+    "/deployments/{name}/-/internal/{trailing_uri:path}",
+    methods=_PROXY_WRITE_METHODS,
+    tags=["Agent Gateway"],
+    include_in_schema=False,
+)
+@scope.write
+@path_rule(
+    callers=[CallerKind.SERVICE_PRINCIPAL],
+    permissions=[GatewayPerms.INVOKE],
+)
+async def proxy_by_deployment_name_internal_write(
+    workspace: str,
+    name: str,
+    trailing_uri: str,
+    request: Request,
+    entity_client: NemoEntitiesClient = Depends(get_entity_client),
+) -> StreamingResponse:
+    """Service-principal write proxy directly to the named deployment."""
+    return await _serve_deployment_proxy(workspace, name, trailing_uri, request, entity_client)
 
 
 @router.api_route(

--- a/plugins/nemo-agents/tests/test_authz.py
+++ b/plugins/nemo-agents/tests/test_authz.py
@@ -18,6 +18,7 @@ from nemo_platform_plugin.authz_discovery import _derive_service_contribution
 
 _BASE = "/apis/agents/v2/workspaces/{workspace}"
 _GATEWAY_AGENT = f"{_BASE}/agents/{{name}}/-/{{trailing_uri:path}}"
+_GATEWAY_AGENT_INTERNAL = f"{_BASE}/agents/{{name}}/-/internal/{{trailing_uri:path}}"
 # Methods the gateway forwards, split by scope (see gateway._PROXY_READ_METHODS /
 # _PROXY_WRITE_METHODS), lower-cased for the wire format.
 _PROXY_READ_METHODS = {"get", "head", "options"}
@@ -87,6 +88,25 @@ def test_gateway_proxy_binding() -> None:
     assert contrib.endpoints[deployment_gw]["post"].permissions == ["agents.gateway.invoke"]
     # The coarse permission is declared.
     assert "agents.gateway.invoke" in contrib.permissions
+
+
+def test_gateway_internal_proxy_binding() -> None:
+    contrib = _contribution()
+    methods = contrib.endpoints[_GATEWAY_AGENT_INTERNAL]
+    assert set(methods) == _PROXY_METHODS
+    for method, binding in methods.items():
+        assert binding.permissions == ["agents.gateway.invoke"], method
+        assert binding.callers == ["service_principal"], method
+        assert not binding.deny, method
+        expected_scopes = (
+            ["agents:write", "platform:write"] if method in _PROXY_WRITE_METHODS else ["agents:read", "platform:read"]
+        )
+        assert binding.scopes == expected_scopes, method
+
+    deployment_internal_gw = f"{_BASE}/deployments/{{name}}/-/internal/{{trailing_uri:path}}"
+    assert set(contrib.endpoints[deployment_internal_gw]) == _PROXY_METHODS
+    assert contrib.endpoints[deployment_internal_gw]["post"].callers == ["service_principal"]
+    assert contrib.endpoints[deployment_internal_gw]["post"].permissions == ["agents.gateway.invoke"]
 
 
 def test_gateway_invoke_granted_to_viewer() -> None:

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -176,6 +176,22 @@ class TestProxyByDeploymentName:
         assert resp.status_code == 200
         assert resp.content == upstream_body
 
+    def test_internal_route_strips_internal_prefix(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        dep = _make_deployment(status="running", endpoint="http://localhost:9001")
+        mock_entity_client.get = AsyncMock(return_value=dep)
+
+        httpx_mock = _make_httpx_mock(200, b'{"ok": true}')
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock) as mock_cls:
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/internal/v1/chat/completions",
+                json={"messages": []},
+            )
+
+        assert resp.status_code == 200
+        stream_call = mock_cls.return_value.__aenter__.return_value.stream
+        assert stream_call.call_args.kwargs["url"] == "http://localhost:9001/v1/chat/completions"
+
     def test_5xx_from_agent_becomes_502(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         """Agent 5xx responses must be translated to 502 Bad Gateway."""
         dep = _make_deployment(status="running", endpoint="http://localhost:9001")
@@ -335,6 +351,25 @@ class TestProxyByAgentName:
             )
 
         assert resp.status_code == 200
+
+    def test_internal_route_resolves_running_deployment(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        mock_entity_client.get = AsyncMock(return_value=_make_agent("calc"))
+        dep = _make_deployment(agent="calc", status="running", endpoint="http://localhost:9001")
+        mock_entity_client.list = AsyncMock(return_value=_list_response([dep]))
+
+        httpx_mock = _make_httpx_mock(200, b'{"ok": true}')
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock) as mock_cls:
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/internal/v1/chat/completions",
+                json={"messages": []},
+            )
+
+        assert resp.status_code == 200
+        stream_call = mock_cls.return_value.__aenter__.return_value.stream
+        assert stream_call.call_args.kwargs["url"] == "http://localhost:9001/v1/chat/completions"
 
     def test_agent_not_found_returns_404(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         mock_entity_client.get = AsyncMock(side_effect=NemoEntityNotFoundError("not found"))

--- a/services/core/auth/src/nmp/core/auth/app/bundle.py
+++ b/services/core/auth/src/nmp/core/auth/app/bundle.py
@@ -29,7 +29,7 @@ _bundle_cache: Optional[Tuple[bytes, str, float]] = None  # (bundle_bytes, etag,
 _bundle_lock = asyncio.Lock()
 
 
-def get_bundle_cache_seconds() -> int:
+def get_bundle_cache_seconds() -> float:
     """Get bundle cache seconds from config."""
     return get_service_config(AuthServiceConfig).bundle_cache_seconds
 
@@ -192,6 +192,16 @@ def merge_plugin_authz_contributions(static_data: dict) -> dict:
     return merged
 
 
+def _inject_runtime_authz_config(static_data: dict) -> dict:
+    """Attach auth-service runtime knobs consumed by the Rego policy."""
+    config = get_service_config(AuthServiceConfig)
+    authz_config = static_data.setdefault("authz", {}).setdefault("config", {})
+    authz_config["platform_admin_exempt_from_service_only"] = bool(
+        getattr(config, "platform_admin_exempt_from_service_only", False)
+    )
+    return static_data
+
+
 async def _build_authorization_data_internal(entities_client: Optional[EntityClient] = None) -> dict:
     """Build authorization data for NeMo Platform.
 
@@ -215,6 +225,7 @@ async def _build_authorization_data_internal(entities_client: Optional[EntityCli
         static_data = yaml.safe_load(f)
 
     static_data = merge_plugin_authz_contributions(static_data)
+    static_data = _inject_runtime_authz_config(static_data)
     validate_static_authz_data(static_data)
 
     # Initialize workspaces and principals if not present

--- a/services/core/auth/src/nmp/core/auth/app/policies/authz.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/authz.rego
@@ -331,15 +331,16 @@ service_only_route if {
 }
 
 # Deny a human (non-service) caller on a service-only route. This is a deny_request so it
-# overrides the allow rules — including the ServiceSystem "*" wildcard — otherwise humans
-# would leak onto service-only routes. Service principals (id starts with "service:") are
-# unaffected and stay allowed. A human PlatformAdmin keeps its global bypass here: an admin
-# retains access to every route, service-only routes included.
+# overrides the allow rules — including the ServiceSystem "*" wildcard and the PlatformAdmin
+# global allow — otherwise humans would leak onto service-only routes. Service principals
+# (id starts with "service:") are unaffected and stay allowed. Operators may opt a human
+# PlatformAdmin back into service-only routes with
+# authz.config.platform_admin_exempt_from_service_only=true.
 deny_request if {
 	service_only_route
 	principal_id := extract_principal_id
 	not startswith(principal_id, "service:")
-	not platform_admin_in_system
+	not platform_admin_service_only_exempt
 }
 
 # Caller-kind enforcement for principal-only routes — the symmetric counterpart of the
@@ -374,6 +375,13 @@ platform_admin_in_system if {
 	count(applicable_principals) > 0
 	some principal in applicable_principals
 	"PlatformAdmin" in data.authz.principals[principal].workspaces.system
+}
+
+default platform_admin_service_only_exempt := false
+
+platform_admin_service_only_exempt if {
+	platform_admin_in_system
+	object.get(data.authz.config, "platform_admin_exempt_from_service_only", false) == true
 }
 
 entities_workspace_object_path(base_path, method) if {

--- a/services/core/auth/src/nmp/core/auth/app/policies/common.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/common.rego
@@ -212,8 +212,11 @@ get_applicable_principals := principals if {
 #
 # For patterns containing /-/:
 #   - Wildcard suffix (single placeholder like {trailing_uri}): matches any trailing segments.
-#   - Structured suffix (e.g., v1/models or v1/models/{name}): each suffix segment must match
-#     the corresponding trailing path segment exactly (or be a placeholder).
+#   - Structured suffix ending in a FastAPI path converter (e.g., internal/{trailing_uri:path}):
+#     static leading suffix segments match exactly, and the final path converter matches one or
+#     more remaining trailing segments.
+#   - Other structured suffixes (e.g., v1/models or v1/models/{name}): each suffix segment must
+#     match the corresponding trailing path segment exactly (or be a placeholder).
 #
 # This distinction prevents /openai/-/v1/models from incorrectly matching
 # /openai/-/v1/chat/completions — only the catch-all /-/{trailing_uri} pattern matches.
@@ -253,6 +256,44 @@ path_matches_pattern(path, pattern) if {
 
 	# At least one trailing segment must exist after the separator
 	count(path_parts) > count(prefix_pattern_parts) + 1
+} else if {
+	# /-/ pattern with a structured suffix whose final segment is a FastAPI path
+	# converter. For example, .../-/internal/{trailing_uri:path} matches
+	# .../-/internal/v1/chat/completions, while still requiring the "internal" segment.
+	contains(pattern, "/-/")
+	startswith(pattern, "/-/") == false
+
+	# Split pattern at first /-/ into prefix and suffix (same as wildcard branch above).
+	pattern_prefix_with_sep := split(pattern, "/-/")[0]
+	suffix_raw := concat("/", array.slice(split(pattern, "/-/"), 1, count(split(pattern, "/-/"))))
+	suffix_parts := split(suffix_raw, "/")
+	count(suffix_parts) > 1
+
+	path_wildcard_suffix := suffix_parts[count(suffix_parts) - 1]
+	startswith(path_wildcard_suffix, "{")
+	endswith(path_wildcard_suffix, ":path}")
+
+	path_parts := split(path, "/")
+	prefix_pattern_parts := split(pattern_prefix_with_sep, "/")
+
+	# Index where trailing segments begin (right after the "-" separator)
+	trailing_start := count(prefix_pattern_parts) + 1
+
+	# Path must include every fixed suffix segment plus at least one segment for the path converter.
+	count(path_parts) - trailing_start >= count(suffix_parts)
+
+	# Match prefix segments
+	every i in numbers.range(0, count(prefix_pattern_parts) - 1) {
+		segment_matches(path_parts[i], prefix_pattern_parts[i])
+	}
+
+	# Next segment must be the separator "-"
+	path_parts[count(prefix_pattern_parts)] == "-"
+
+	# Match each non-wildcard suffix segment.
+	every j in numbers.range(0, count(suffix_parts) - 2) {
+		segment_matches(path_parts[trailing_start + j], suffix_parts[j])
+	}
 } else if {
 	# /-/ pattern with a structured suffix (specific segments after the separator).
 	# For example, the pattern .../openai/-/v1/models must NOT match the path
@@ -327,8 +368,9 @@ normalize_endpoint(path) := pattern if {
 		path_matches_pattern(base_path, p)
 	}
 
-	# Find the pattern with the fewest placeholders (most specific)
-	# Count placeholders by counting segments that start with {
+	# Find the pattern with the fewest placeholders (most specific), then prefer the
+	# longer pattern among ties so a route such as /-/internal/{trailing_uri:path}
+	# wins over a public /-/{trailing_uri:path} catch-all for internal paths.
 	pattern_scores := {p: count([seg |
 		some seg in split(p, "/")
 		startswith(seg, "{")
@@ -338,10 +380,15 @@ normalize_endpoint(path) := pattern if {
 
 	# Get the minimum score (fewest placeholders)
 	min_score := min([score | some score in [pattern_scores[p] | some p in matching_patterns]])
+	most_specific_patterns := {p |
+		some p in matching_patterns
+		pattern_scores[p] == min_score
+	}
+	max_segments := max([count(split(p, "/")) | some p in most_specific_patterns])
 
-	# Return a pattern with the minimum score
-	some pattern in matching_patterns
-	pattern_scores[pattern] == min_score
+	# Return a pattern with the minimum score and greatest segment count.
+	some pattern in most_specific_patterns
+	count(split(pattern, "/")) == max_segments
 }
 
 # --- Request-scoped memoization -------------------------------------------------

--- a/services/core/auth/src/nmp/core/auth/app/policy_tests/caller_kind_test.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policy_tests/caller_kind_test.rego
@@ -7,8 +7,9 @@ import data.authz
 # Data contract: an endpoint method may declare an optional `callers` list of
 # caller-kind strings ("principal", "service_principal"). A route is "service-only"
 # when it lists "service_principal" but NOT "principal". On such routes, human
-# (non-service) callers are denied — overriding the permission allows — except a
-# PlatformAdmin, who keeps its global bypass and stays allowed. Absence of `callers`
+# (non-service) callers are denied — overriding the permission allows and the
+# PlatformAdmin global allow by default. Operators may opt PlatformAdmin back in with
+# authz.config.platform_admin_exempt_from_service_only=true. Absence of `callers`
 # preserves today's PRINCIPAL-default behavior (no new restriction).
 
 caller_kind_test_data := {
@@ -96,10 +97,9 @@ test_service_only_route_allows_service_principal if {
 	result.allowed == true
 }
 
-# A human PlatformAdmin is ALLOWED on a service-only route — its global admin bypass is not
-# clawed back here (only non-admin humans are denied, per
-# test_service_only_route_denies_human_principal above).
-test_service_only_route_allows_platform_admin if {
+# A human PlatformAdmin is DENIED on a service-only route by default — the caller-kind
+# deny overrides the global admin allow unless the runtime exemption knob is enabled.
+test_service_only_route_denies_platform_admin_by_default if {
 	result := authz.allow
 		with input as {
 			"principal_id": "platform-admin@example.com",
@@ -110,6 +110,23 @@ test_service_only_route_allows_platform_admin if {
 		with data.authz.endpoints as caller_kind_test_data.endpoints
 		with data.authz.workspaces as caller_kind_test_data.workspaces
 		with data.authz.principals as caller_kind_test_data.principals
+
+	result.allowed == false
+}
+
+# The runtime knob can restore PlatformAdmin access to service-only routes.
+test_service_only_route_allows_platform_admin_when_exempted if {
+	result := authz.allow
+		with input as {
+			"principal_id": "platform-admin@example.com",
+			"method": "GET",
+			"path": "/apis/jobs/v2/workspaces/ws1/internal-jobs/job-1",
+		}
+		with data.authz.roles as caller_kind_test_data.roles
+		with data.authz.endpoints as caller_kind_test_data.endpoints
+		with data.authz.workspaces as caller_kind_test_data.workspaces
+		with data.authz.principals as caller_kind_test_data.principals
+		with data.authz.config as {"platform_admin_exempt_from_service_only": true}
 
 	result.allowed == true
 }

--- a/services/core/auth/src/nmp/core/auth/app/policy_tests/path_matching_test.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policy_tests/path_matching_test.rego
@@ -63,6 +63,25 @@ test_path_matches_provider_gateway_trailing_uri if {
 	)
 }
 
+test_path_matches_structured_path_suffix if {
+	common.path_matches_pattern(
+		"/apis/agents/v2/workspaces/my-ns/agents/my-agent/-/internal/v1/chat/completions",
+		"/apis/agents/v2/workspaces/{workspace}/agents/{name}/-/internal/{trailing_uri:path}",
+	)
+}
+
+test_normalize_endpoint_prefers_structured_path_suffix_over_catch_all if {
+	mock_endpoints := {
+		"/apis/agents/v2/workspaces/{workspace}/agents/{name}/-/{trailing_uri:path}": {"post": {}},
+		"/apis/agents/v2/workspaces/{workspace}/agents/{name}/-/internal/{trailing_uri:path}": {"post": {}},
+	}
+
+	common.normalize_endpoint(
+		"/apis/agents/v2/workspaces/my-ns/agents/my-agent/-/internal/v1/chat/completions",
+	) == "/apis/agents/v2/workspaces/{workspace}/agents/{name}/-/internal/{trailing_uri:path}"
+		with data.authz.endpoints as mock_endpoints
+}
+
 # TEST: Negative cases for trailing URI
 test_path_matches_trailing_uri_wrong_prefix if {
 	not common.path_matches_pattern(

--- a/services/core/auth/src/nmp/core/auth/app/policy_tests/platform_admin_test.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policy_tests/platform_admin_test.rego
@@ -261,9 +261,9 @@ service_only_endpoints := {
     }
 }
 
-# Test platform admin is ALLOWED on a service-only route — the admin global bypass holds
-# here (only non-admin humans are denied on service-only routes).
-test_platform_admin_allowed_on_service_only_route if {
+# Test platform admin is DENIED on a service-only route by default — the caller-kind deny
+# overrides the admin global allow unless the runtime exemption knob is enabled.
+test_platform_admin_denied_on_service_only_route_by_default if {
     result := authz.allow with input as {
         "principal_id": "platform-admin@example.com",
         "method": "DELETE",
@@ -273,6 +273,22 @@ test_platform_admin_allowed_on_service_only_route if {
     with data.authz.endpoints as service_only_endpoints
     with data.authz.workspaces as platform_admin_test_data.workspaces
     with data.authz.principals as platform_admin_test_data.principals
+
+    result.allowed == false
+}
+
+# Test platform admin can be explicitly exempted for service-only routes.
+test_platform_admin_allowed_on_service_only_route_when_exempted if {
+    result := authz.allow with input as {
+        "principal_id": "platform-admin@example.com",
+        "method": "DELETE",
+        "path": "/apis/models/v2/workspaces/workspace1/models/model1"
+    }
+    with data.authz.roles as platform_admin_test_data.roles
+    with data.authz.endpoints as service_only_endpoints
+    with data.authz.workspaces as platform_admin_test_data.workspaces
+    with data.authz.principals as platform_admin_test_data.principals
+    with data.authz.config as {"platform_admin_exempt_from_service_only": true}
 
     result.allowed == true
 }

--- a/services/core/auth/src/nmp/core/auth/config.py
+++ b/services/core/auth/src/nmp/core/auth/config.py
@@ -71,6 +71,15 @@ class AuthServiceConfig(SharedAuthConfig):
         description="Fail-mode for a plugin that contributes invalid HTTP authz.",
     )
 
+    platform_admin_exempt_from_service_only: bool = Field(
+        default=False,
+        description=(
+            "Allow human PlatformAdmin principals to use plugin routes that declare "
+            "callers=[SERVICE_PRINCIPAL]. Disabled by default so service-only routes stay "
+            "machine-only unless an operator explicitly opts into the admin exemption."
+        ),
+    )
+
 
 # Backward compatibility alias
 AuthConfig = AuthServiceConfig

--- a/services/core/auth/tests/test_bundle.py
+++ b/services/core/auth/tests/test_bundle.py
@@ -7,6 +7,7 @@ import gzip
 import io
 import json
 import tarfile
+from types import SimpleNamespace
 
 import pytest
 
@@ -50,6 +51,25 @@ async def test_authorization_data_merges_plugin_authz_contributions(monkeypatch)
 
     assert data["authz"]["endpoints"][plugin_path]["get"]["permissions"] == ["example-plugin.jobs.read"]
     assert "example-plugin.jobs.read" in data["authz"]["roles"]["Viewer"]["permissions"]
+
+
+@pytest.mark.asyncio
+async def test_authorization_data_includes_runtime_authz_config(monkeypatch):
+    from nmp.core.auth.app import bundle
+
+    monkeypatch.setattr("nemo_platform_plugin.authz_discovery.discover_plugin_authz", lambda: [])
+    monkeypatch.setattr(
+        bundle,
+        "get_service_config",
+        lambda _cls: SimpleNamespace(
+            on_invalid_plugin="hard_fail",
+            platform_admin_exempt_from_service_only=True,
+        ),
+    )
+
+    data = await bundle._build_authorization_data_internal(entities_client=None)
+
+    assert data["authz"]["config"]["platform_admin_exempt_from_service_only"] is True
 
 
 @pytest.mark.asyncio

--- a/services/core/auth/tests/test_config.py
+++ b/services/core/auth/tests/test_config.py
@@ -21,6 +21,7 @@ def test_auth_config_defaults():
     assert cfg.bundle_cache_seconds == 5
     assert cfg.admin_email is None
     assert cfg.default_workspace == "default"
+    assert cfg.platform_admin_exempt_from_service_only is False
 
 
 def test_default_workspace_custom():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added internal agent and deployment proxy routes for service-to-service requests.
  - Added an optional setting allowing Platform Administrators to access service-only routes.
- **Bug Fixes**
  - Improved route matching so internal paths resolve to the correct upstream services.
  - Platform Administrator access to service-only routes is now denied by default unless explicitly enabled.
- **Documentation**
  - Documented the new authentication configuration setting and its default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->