### PR TITLE
fix(studio): Support line wraps in LogViewer

### DIFF
--- a/web/packages/common/src/components/DataView/FilterPanelToggle.test.tsx
+++ b/web/packages/common/src/components/DataView/FilterPanelToggle.test.tsx
@@ -21,9 +21,9 @@ vi.mock('@nvidia/foundations-react-core', () => ({
   ),
 }));
 
-vi.mock('lucide-react', () => ({
-  Filter: () => <span data-testid="filter-icon" />,
-}));
+vi.mock('lucide-react', async () => {
+  return (await import('@nemo/testing/mocks/lucide')).mockLucideReact(await import('react'));
+});
 
 describe('FilterPanelToggle', () => {
   it('returns null when no columns have getCanFilter', () => {

--- a/web/packages/common/src/components/DataView/StudioAppliedFilters.test.tsx
+++ b/web/packages/common/src/components/DataView/StudioAppliedFilters.test.tsx
@@ -36,9 +36,9 @@ vi.mock('@nvidia/foundations-react-core', () => ({
   ),
 }));
 
-vi.mock('lucide-react', () => ({
-  X: () => <span data-testid="x-icon" />,
-}));
+vi.mock('lucide-react', async () => {
+  return (await import('@nemo/testing/mocks/lucide')).mockLucideReact(await import('react'));
+});
 
 function makeColumn(
   id: string,

--- a/web/packages/common/src/components/LogViewer/index.tsx
+++ b/web/packages/common/src/components/LogViewer/index.tsx
@@ -15,7 +15,7 @@ import {
   Text,
 } from '@nvidia/foundations-react-core';
 import classNames from 'classnames';
-import { ArrowUp, Download } from 'lucide-react';
+import { ArrowUp, Download, WrapText } from 'lucide-react';
 import { FC, useMemo, useState } from 'react';
 
 const DEFAULT_ROW_COUNT = 30;
@@ -36,6 +36,7 @@ export const LogViewer: FC<LogViewerProps> = ({
   emptyMessage = 'No logs available yet',
 }) => {
   const [showAllLogs, setShowAllLogs] = useState(false);
+  const [wrapLines, setWrapLines] = useState(false);
   const tailLogs = logs?.slice(-rows) || [];
   const displayedLogs = showAllLogs ? logs : tailLogs;
   const logText = formatLogs(displayedLogs);
@@ -68,7 +69,7 @@ export const LogViewer: FC<LogViewerProps> = ({
   }
 
   return (
-    <Block className="relative overflow-hidden">
+    <Block className="relative w-full min-w-0 max-w-full overflow-hidden">
       {!showAllLogs && hasMoreLogs && (
         <Block className="absolute top-6 mt-[2px] left-px right-px z-10 py-5 text-center bg-[linear-gradient(to_bottom,var(--background-color-surface-sunken),transparent)]">
           <Tag color="gray" kind="solid" onClick={handleLoadMore}>
@@ -86,7 +87,14 @@ export const LogViewer: FC<LogViewerProps> = ({
         attributes={{
           CodeSnippetCode: {
             ref: codeScrollRef,
-            className: classNames({ '!overflow-y-hidden': !showAllLogs }),
+            className: classNames(
+              'min-w-0 max-w-full',
+              { '!overflow-y-hidden': !showAllLogs },
+              {
+                'whitespace-pre-wrap [overflow-wrap:anywhere] [&_code]:whitespace-pre-wrap [&_pre]:whitespace-pre-wrap [&_pre]:[overflow-wrap:anywhere]':
+                  wrapLines,
+              }
+            ),
           },
         }}
         slotActions={
@@ -94,13 +102,21 @@ export const LogViewer: FC<LogViewerProps> = ({
             <Text kind="mono/md">
               {displayedLogs.length} {!showAllLogs && hasMoreLogs && `of ${logs.length}`} lines
             </Text>
-            {downloadFilename && (
-              <Flex gap="density-sm">
+            <Flex gap="0.25">
+              <Button
+                size="tiny"
+                kind={wrapLines ? 'secondary' : 'tertiary'}
+                aria-pressed={wrapLines}
+                onClick={() => setWrapLines((prev) => !prev)}
+              >
+                <WrapText />
+              </Button>
+              {downloadFilename && (
                 <Button size="tiny" kind="tertiary" onClick={handleDownload}>
                   <Download />
                 </Button>
-              </Flex>
-            )}
+              )}
+            </Flex>
           </Flex>
         }
       />

--- a/web/packages/common/src/components/LogViewer/index.tsx
+++ b/web/packages/common/src/components/LogViewer/index.tsx
@@ -89,7 +89,8 @@ export const LogViewer: FC<LogViewerProps> = ({
             ref: codeScrollRef,
             className: classNames(
               'min-w-0 max-w-full',
-              { '!overflow-y-hidden': !showAllLogs },
+              // Keep scroll on when wrapping: wrapped rows exceed the fixed height.
+              { '!overflow-y-hidden': !showAllLogs && !wrapLines },
               {
                 'whitespace-pre-wrap [overflow-wrap:anywhere] [&_code]:whitespace-pre-wrap [&_pre]:whitespace-pre-wrap [&_pre]:[overflow-wrap:anywhere]':
                   wrapLines,
@@ -106,6 +107,7 @@ export const LogViewer: FC<LogViewerProps> = ({
               <Button
                 size="tiny"
                 kind={wrapLines ? 'secondary' : 'tertiary'}
+                aria-label="Wrap lines"
                 aria-pressed={wrapLines}
                 onClick={() => setWrapLines((prev) => !prev)}
               >

--- a/web/packages/studio/src/routes/SafeSynthesizerJobDetailsRoute/components/JobConfigDrawer.test.tsx
+++ b/web/packages/studio/src/routes/SafeSynthesizerJobDetailsRoute/components/JobConfigDrawer.test.tsx
@@ -25,10 +25,9 @@ vi.mock('@nemo/common/src/components/CodeEditor', () => ({
 }));
 
 // Mock brand assets icons
-vi.mock('lucide-react', () => ({
-  Cog: () => <svg data-testid="cog-icon" />,
-  Copy: () => <svg data-testid="copy-doc-icon" />,
-}));
+vi.mock('lucide-react', async () => {
+  return (await import('@nemo/testing/mocks/lucide')).mockLucideReact(await import('react'));
+});
 
 // Create a test wrapper with theme provider and toast provider
 const createWrapper = (theme: 'light' | 'dark' = 'light') => {

--- a/web/packages/studio/src/routes/SafeSynthesizerJobDetailsRoute/components/JobDetailsPanel.test.tsx
+++ b/web/packages/studio/src/routes/SafeSynthesizerJobDetailsRoute/components/JobDetailsPanel.test.tsx
@@ -123,13 +123,9 @@ vi.mock('@studio/providers/toast/useToast', () => ({
 }));
 
 // Mock brand assets icons
-vi.mock('lucide-react', () => ({
-  Play: () => <svg data-testid="running-icon" />,
-  File: () => <svg data-testid="document-icon" />,
-  Cog: () => <svg data-testid="cog-icon" />,
-  Copy: () => <svg data-testid="copy-doc-icon" />,
-  Palette: () => <svg data-testid="palette-icon" />,
-}));
+vi.mock('lucide-react', async () => {
+  return (await import('@nemo/testing/mocks/lucide')).mockLucideReact(await import('react'));
+});
 
 // Test wrapper
 const createWrapper = () => {
@@ -216,7 +212,7 @@ describe('JobDetailsPanel', () => {
       render(<JobDetailsPanel job={job} />, { wrapper: createWrapper() });
 
       expect(screen.getByText('Job Details')).toBeInTheDocument();
-      expect(screen.getByTestId('running-icon')).toBeInTheDocument();
+      expect(screen.getByTestId('play-icon')).toBeInTheDocument();
     });
 
     it('should display job status with badge', () => {

--- a/web/packages/studio/src/routes/SafeSynthesizerJobDetailsRoute/components/ProgressSection.test.tsx
+++ b/web/packages/studio/src/routes/SafeSynthesizerJobDetailsRoute/components/ProgressSection.test.tsx
@@ -19,11 +19,9 @@ vi.mock('@nemo/common/src/providers/toast/useToast', () => ({
   }),
 }));
 
-// Mock brand assets icons
-vi.mock('lucide-react', () => ({
-  Download: () => <svg data-testid="download-icon" />,
-  ArrowUp: () => <svg data-testid="arrow-up-icon" />,
-}));
+vi.mock('lucide-react', async () => {
+  return (await import('@nemo/testing/mocks/lucide')).mockLucideReact(await import('react'));
+});
 
 // Mock CodeSnippet to avoid act() warnings from async Shiki highlighting.
 vi.mock('@nvidia/foundations-react-core', async (importOriginal) => {

--- a/web/packages/studio/src/routes/SafeSynthesizerJobDetailsRoute/components/ReportSummaryPanel.test.tsx
+++ b/web/packages/studio/src/routes/SafeSynthesizerJobDetailsRoute/components/ReportSummaryPanel.test.tsx
@@ -45,9 +45,9 @@ vi.mock('@nemo/common/src/components/Dial', () => ({
 }));
 
 // Mock brand assets icons
-vi.mock('lucide-react', () => ({
-  File: () => <svg data-testid="document-icon" />,
-}));
+vi.mock('lucide-react', async () => {
+  return (await import('@nemo/testing/mocks/lucide')).mockLucideReact(await import('react'));
+});
 
 // Mock the util constants
 vi.mock('@studio/routes/SafeSynthesizerJobRoute/util', () => ({
@@ -96,7 +96,7 @@ describe('ReportSummaryPanel', () => {
       });
 
       expect(screen.getByText('Report Summary')).toBeInTheDocument();
-      expect(screen.getByTestId('document-icon')).toBeInTheDocument();
+      expect(screen.getByTestId('file-icon')).toBeInTheDocument();
     });
 
     it('should render Quality (SQS) and Privacy (DPS) labels', () => {

--- a/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/components/OverviewPanel.test.tsx
+++ b/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/components/OverviewPanel.test.tsx
@@ -12,9 +12,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // Mock brand assets icons
-vi.mock('lucide-react', () => ({
-  Download: () => <svg data-testid="download-icon" />,
-}));
+vi.mock('lucide-react', async () => {
+  return (await import('@nemo/testing/mocks/lucide')).mockLucideReact(await import('react'));
+});
 
 // Mock SafeSynthesizerFilesetPreview component
 vi.mock('@studio/components/SafeSynthesizerFilesetPreview', () => ({

--- a/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/components/ScorePanels/DataPrivacyPanel.test.tsx
+++ b/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/components/ScorePanels/DataPrivacyPanel.test.tsx
@@ -31,19 +31,9 @@ vi.mock('@nemo/common/src/components/Dial', () => ({
   ),
 }));
 
-// Mock lucide-react icons (React 19: ref is a plain prop, no forwardRef needed).
-// Spread the real module so other icons used by rendered children (e.g. the
-// DataView SearchBar's `Search`) keep working, and only stub the asserted ones.
-vi.mock('lucide-react', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('lucide-react')>()),
-  CircleCheck: ({ className, ref }: { className?: string; ref?: React.Ref<SVGSVGElement> }) => (
-    <svg ref={ref} data-testid="check-circle-icon" className={className} />
-  ),
-  Ban: ({ ref }: { ref?: React.Ref<SVGSVGElement> }) => <svg ref={ref} data-testid="cancel-icon" />,
-  Info: ({ className, ref }: { className?: string; ref?: React.Ref<SVGSVGElement> }) => (
-    <svg ref={ref} data-testid="info-circle-icon" className={className} />
-  ),
-}));
+vi.mock('lucide-react', async () => {
+  return (await import('@nemo/testing/mocks/lucide')).mockLucideReact(await import('react'));
+});
 
 // Mock the ScrollTable component
 /* eslint-disable testing-library/no-node-access */
@@ -354,8 +344,8 @@ describe('DataPrivacyPanel', () => {
         { wrapper: createWrapper() }
       );
 
-      const checkIcons = screen.getAllByTestId('check-circle-icon');
-      const cancelIcons = screen.getAllByTestId('cancel-icon');
+      const checkIcons = screen.getAllByTestId('circle-check-icon');
+      const cancelIcons = screen.getAllByTestId('ban-icon');
 
       expect(checkIcons).toHaveLength(2);
       expect(cancelIcons).toHaveLength(2);

--- a/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/components/ScorePanels/ScoreItem.test.tsx
+++ b/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/components/ScorePanels/ScoreItem.test.tsx
@@ -5,13 +5,9 @@ import { ThemeProvider } from '@nvidia/foundations-react-core';
 import { ScoreItem } from '@studio/routes/SafeSynthesizerJobReportRoute/components/ScorePanels/ScoreItem';
 import { render, screen } from '@testing-library/react';
 
-// Mock brand assets icons
-vi.mock('lucide-react', () => ({
-  CircleCheck: ({ className }: { className?: string }) => (
-    <svg data-testid="check-circle-icon" className={className} />
-  ),
-  Ban: () => <svg data-testid="cancel-icon" />,
-}));
+vi.mock('lucide-react', async () => {
+  return (await import('@nemo/testing/mocks/lucide')).mockLucideReact(await import('react'));
+});
 
 const renderScoreItem = (success: boolean, value: string) => {
   return render(
@@ -25,15 +21,15 @@ describe('ScoreItem', () => {
   it('renders CheckCircle icon when success is true', () => {
     renderScoreItem(true, 'Test passed');
 
-    expect(screen.getByTestId('check-circle-icon')).toBeInTheDocument();
-    expect(screen.queryByTestId('cancel-icon')).not.toBeInTheDocument();
+    expect(screen.getByTestId('circle-check-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('ban-icon')).not.toBeInTheDocument();
   });
 
   it('renders Cancel icon when success is false', () => {
     renderScoreItem(false, 'Test failed');
 
-    expect(screen.getByTestId('cancel-icon')).toBeInTheDocument();
-    expect(screen.queryByTestId('check-circle-icon')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ban-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('circle-check-icon')).not.toBeInTheDocument();
   });
 
   it('displays the correct value text', () => {
@@ -46,7 +42,7 @@ describe('ScoreItem', () => {
   it('applies text-brand className to CheckCircle when success is true', () => {
     renderScoreItem(true, 'Success message');
 
-    const icon = screen.getByTestId('check-circle-icon');
+    const icon = screen.getByTestId('circle-check-icon');
     expect(icon).toHaveClass('text-brand');
   });
 });

--- a/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/components/ScorePanels/SyntheticQualityPanel.test.tsx
+++ b/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/components/ScorePanels/SyntheticQualityPanel.test.tsx
@@ -29,18 +29,8 @@ vi.mock('@nemo/common/src/components/Dial', () => ({
   ),
 }));
 
-// Mock brand assets icons - use forwardRef for icons used inside Tooltip triggers
 vi.mock('lucide-react', async () => {
-  const React = await import('react');
-  return {
-    CircleCheck: ({ className }: { className?: string }) => (
-      <svg data-testid="check-circle-icon" className={className} />
-    ),
-    Ban: () => <svg data-testid="cancel-icon" />,
-    Info: React.forwardRef<SVGSVGElement, { className?: string }>(({ className }, ref) => (
-      <svg ref={ref} data-testid="info-circle-icon" className={className} />
-    )),
-  };
+  return (await import('@nemo/testing/mocks/lucide')).mockLucideReact(await import('react'));
 });
 
 // Mock the ScrollTable component
@@ -344,8 +334,8 @@ describe('SyntheticQualityPanel', () => {
       );
 
       // Verify that both check and cancel icons are rendered
-      const checkIcons = screen.getAllByTestId('check-circle-icon');
-      const cancelIcons = screen.getAllByTestId('cancel-icon');
+      const checkIcons = screen.getAllByTestId('circle-check-icon');
+      const cancelIcons = screen.getAllByTestId('ban-icon');
 
       expect(checkIcons.length).toBeGreaterThan(0);
       expect(cancelIcons.length).toBeGreaterThan(0);

--- a/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/SafeSynthesizerJobReportRoute/index.test.tsx
@@ -118,14 +118,8 @@ vi.mock('@studio/routes/SafeSynthesizerJobReportRoute/components/ReportMenu', ()
 }));
 
 // Mock icons - use importOriginal to preserve other exports
-vi.mock('lucide-react', async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown>;
-  return {
-    ...actual,
-    File: () => <svg data-testid="document-icon" />,
-    BadgeCheck: () => <svg data-testid="checkmark-badge-icon" />,
-    Lock: () => <svg data-testid="lock-closed-icon" />,
-  };
+vi.mock('lucide-react', async () => {
+  return (await import('@nemo/testing/mocks/lucide')).mockLucideReact(await import('react'));
 });
 
 const mockuseWorkspaceFromPath = vi.mocked(useWorkspaceFromPath);
@@ -308,9 +302,9 @@ describe('SafeSynthesizerJobReportRoute - Rendering', () => {
     expect(panelTitles[2]).toHaveTextContent('Data Privacy');
 
     // Verify icons are rendered
-    expect(screen.getByTestId('document-icon')).toBeInTheDocument();
-    expect(screen.getByTestId('checkmark-badge-icon')).toBeInTheDocument();
-    expect(screen.getByTestId('lock-closed-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('file-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('badge-check-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('lock-icon')).toBeInTheDocument();
   });
 
   it('should pass correct props to OverviewPanel', () => {

--- a/web/packages/testing/src/mocks/lucide.ts
+++ b/web/packages/testing/src/mocks/lucide.ts
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * lucide-react mock factory.
+ *
+ *   vi.mock('lucide-react', async () =>
+ *     (await import('@nemo/testing/mocks/lucide')).mockLucideReact(import('react'))
+ *   );
+ *
+ *   // query in a test:
+ *   screen.getByTestId('download-icon');
+ *   // or, to avoid guessing the kebab-case spelling:
+ *   screen.getByTestId(iconTestId('Download'));
+ */
+
+/*
+ * Minimal slice of the React API this mock needs, supplied by the consumer.
+ *
+ * The signatures are deliberately the "top function type" (`(...args: never[]) =>
+ * unknown`) so the real, heavily-overloaded react module is structurally
+ * assignable to this. A precise signature (e.g. `createElement(type: string, ...)`)
+ * would NOT accept `typeof import('react')` under strictFunctionTypes, and this
+ * package has no @types/react of its own to borrow the real types from. The
+ * functions are narrowed to their usable shapes inside `mockLucideReact`.
+ */
+interface ReactLike {
+  createElement: (...args: never[]) => unknown;
+  forwardRef: (...args: never[]) => unknown;
+}
+
+/** The usable slice of React we narrow to internally, once handed in. */
+type CreateElement = (type: string, props?: Record<string, unknown> | null) => unknown;
+type ForwardRef = (render: (props: Record<string, unknown>, ref: unknown) => unknown) => {
+  (props: Record<string, unknown>): unknown;
+  displayName?: string;
+};
+
+/** Convert a lucide icon name (PascalCase) to its mock `data-testid`. */
+export const iconTestId = (iconName: string): string =>
+  `${iconName
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase()}-icon`;
+
+const DOM_SAFE_PROPS = new Set([
+  'className',
+  'style',
+  'id',
+  'role',
+  'tabIndex',
+  'onClick',
+  'onMouseEnter',
+  'onMouseLeave',
+  'onFocus',
+  'onBlur',
+]);
+
+const pickDomProps = (props: Record<string, unknown>): Record<string, unknown> => {
+  const forwarded: Record<string, unknown> = {};
+  for (const key of Object.keys(props)) {
+    if (DOM_SAFE_PROPS.has(key) || key.startsWith('aria-') || key.startsWith('data-')) {
+      forwarded[key] = props[key];
+    }
+  }
+  return forwarded;
+};
+
+/**
+ * Build a lucide-react module namespace whose every export is a mock icon.
+ */
+export const mockLucideReact = async (react: ReactLike | Promise<ReactLike>): Promise<unknown> => {
+  const resolved = await react;
+  // Narrow from the top-function-type accepted at the boundary to the shapes we
+  // actually call. Safe: the real react module supplies exactly these functions.
+  const createElement = resolved.createElement as CreateElement;
+  const forwardRef = resolved.forwardRef as ForwardRef;
+  const iconCache = new Map<string, unknown>();
+
+  const makeIcon = (name: string): unknown => {
+    const testId = iconTestId(name);
+    const Icon = forwardRef((props, ref) =>
+      createElement('svg', {
+        ref,
+        'data-testid': testId,
+        ...pickDomProps(props),
+      })
+    );
+    Icon.displayName = name;
+    return Icon;
+  };
+
+  const namespace: unknown = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === '__esModule') return true;
+        if (prop === 'default') return namespace;
+        if (prop === 'then' || typeof prop === 'symbol') return undefined;
+
+        const name = prop;
+        if (!iconCache.has(name)) iconCache.set(name, makeIcon(name));
+        return iconCache.get(name);
+      },
+      has() {
+        return true;
+      },
+    }
+  );
+  return namespace;
+};


### PR DESCRIPTION

<img width="1110" height="368" alt="Screenshot 2026-07-15 at 3 52 26 PM" src="https://github.com/user-attachments/assets/85a2878a-f1aa-458f-8c68-7786298b3856" />

Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a wrap-lines toggle to the log viewer for easier reading of long log output.
  * Improved wrapped log display to better use available space, and updated the log viewer action bar with a new wrap control.

* **Tests**
  * Standardized icon mocking across test suites using a shared lucide mock helper.
  * Updated UI assertions to match the new icon test identifiers produced by the shared mock.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->