### PR TITLE
feat(evaluator): Harbor runner target + agent-eval job list & create-serialization fixes

### DIFF
--- a/packages/nemo_evaluator_sdk/pyproject.toml
+++ b/packages/nemo_evaluator_sdk/pyproject.toml
@@ -42,11 +42,15 @@ agent-runtimes = [
   "openai-agents[docker]>=0.17.3,<0.18",
 ]
 engine = []
-# NOTE: The native Harbor runtime (HarborAgentTaskRunner / run_harbor_eval) needs
-# `harbor`, which is intentionally NOT declared here. Harbor requires Python
-# >=3.12 while this workspace supports >=3.11, so pinning it would make the lock
-# unsatisfiable. It is imported lazily (like nemo_fabric) and installed
-# separately: `uv pip install "harbor>=0.16.1"`.
+# The native Harbor runtime (HarborAgentTaskRunner / run_harbor_eval) needs `harbor`, which requires
+# Python >=3.12 while this workspace floor is >=3.11. The `python_version >= '3.12'` marker (matching
+# harbor's own requires-python) scopes the dependency to the 3.12+ fork of the universal lock, so it
+# installs on 3.12+ and is simply omitted on 3.11 — no floor bump for the rest of the workspace.
+# `harbor` is imported lazily (only inside HarborAgentTaskRunner.run_tasks), so importing the SDK and
+# resolving a HarborRunnerTarget stay valid on 3.11; only *executing* a Harbor job needs this extra.
+harbor = [
+  "harbor>=0.16.1; python_version >= '3.12'",
+]
 nemo-platform = [
   "nemo-platform-sdk",
 ]

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py
@@ -873,7 +873,13 @@ def job_route_factory(
             # the request body's ``spec`` is a plain dict on the wire. The
             # Stainless SDK serialized models implicitly — the typed client
             # validates the body first, so coerce to a dict here.
-            # JSON mode so binary fields (e.g. cloudpickle blobs) serialize as base64, not raw bytes.
+            #
+            # Dump ``mode="json"`` (not python): the spec is bound for JSON transport and JSON storage,
+            # and the request body's ``spec`` is an opaque ``dict`` that has lost the nested models'
+            # serializers. A python-mode dump leaves non-JSON-native values (e.g. a cloudpickle metric
+            # bundle's raw ``bytes``, whose ``ser_json_bytes="base64"`` never runs) that then fail to
+            # JSON-encode on the wire (invalid utf-8 on the pickle marker). ``mode="json"`` runs each
+            # nested model's own JSON serializer, so bytes base64-encode and round-trip on read.
             spec_dict = job_spec.model_dump(mode="json") if isinstance(job_spec, BaseModel) else job_spec
 
             # Only include optional fields when they have values — passing None

--- a/packages/nemo_platform_plugin/tests/test_jobs_filter.py
+++ b/packages/nemo_platform_plugin/tests/test_jobs_filter.py
@@ -15,6 +15,7 @@ deep-object dict.
 
 from __future__ import annotations
 
+import base64
 import json
 from datetime import datetime
 from types import SimpleNamespace
@@ -25,7 +26,7 @@ import pytest
 from fastapi import FastAPI
 from nemo_platform_plugin.dependencies import get_entity_client, get_sdk_client
 from nemo_platform_plugin.jobs.api_factory import job_route_factory
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from starlette.testclient import TestClient
 
 
@@ -400,3 +401,100 @@ class TestForwardedFilterSurvivesSdkSerialization:
         resp = client.get("/apis/widgets/v2/workspaces/default/jobs")
         assert resp.status_code == 200, resp.text
         assert self._round_trip(sdk) == {"source": {"$eq": "widgets"}}
+
+
+# ---------------------------------------------------------------------------
+# Create-path spec serialization
+# ---------------------------------------------------------------------------
+
+
+class _BlobPayload(BaseModel):
+    """Mirrors ``MetricCloudpicklePayload``: a bytes field whose model owns the base64 JSON contract."""
+
+    model_config = ConfigDict(ser_json_bytes="base64", val_json_bytes="base64")
+
+    blob: bytes
+
+
+class _BlobSpec(BaseModel):
+    """A job spec that carries raw bytes (e.g. a cloudpickle metric bundle)."""
+
+    blob_payload: _BlobPayload
+
+
+def _blob_compiler(workspace, original_spec, transformed_spec, entity_client, job_name, sdk):
+    # A minimal-but-valid PlatformJobSpec (one step is required).
+    return {"steps": [{"name": "s1", "executor": {"provider": "cpu", "container": {"image": "img"}}}]}
+
+
+class _CreateCapturingSdk:
+    """Fake jobs client whose ``create_job`` mirrors the real typed client's transport.
+
+    The typed client serializes the request body with ``body.model_dump_json(exclude_unset=True)``
+    (see ``client/endpoint.py``). A spec dumped python-mode leaves raw bytes in the opaque ``spec``
+    dict, so that serialization raises ``PydanticSerializationError`` on the non-utf8 pickle marker —
+    exactly the create-path bug. Captures the serialized body for assertion.
+    """
+
+    def __init__(self) -> None:
+        self.body_json: str | None = None
+
+        async def _create_job(*, workspace: str, body: Any) -> Any:
+            self.body_json = body.model_dump_json(exclude_unset=True)
+            stored = json.loads(self.body_json)
+            job_resp = SimpleNamespace(
+                id="job-1",
+                name=body.name or "job-1",
+                description=None,
+                workspace=workspace,
+                created_at=None,
+                updated_at=None,
+                spec=stored["spec"],
+                status=None,
+                status_details=None,
+                error_details=None,
+                ownership=None,
+                custom_fields=None,
+            )
+            return SimpleNamespace(data=lambda: job_resp)
+
+        self.jobs_client = SimpleNamespace(create_job=_create_job)
+
+
+def _build_create_app() -> tuple[FastAPI, _CreateCapturingSdk]:
+    app = FastAPI()
+    router = job_route_factory(
+        service_name="widgets",
+        job_type="Widget",
+        job_input=_BlobSpec,
+        platform_job_config_compiler=_blob_compiler,
+    )
+    app.include_router(router, prefix="/apis/widgets/v2/workspaces/{workspace}")
+
+    sdk = _CreateCapturingSdk()
+    app.dependency_overrides[get_sdk_client] = lambda: sdk
+    app.dependency_overrides[get_entity_client] = lambda: SimpleNamespace()
+    return app, sdk
+
+
+class TestPluginJobsCreateSerialization:
+    """A created job spec carrying raw bytes (cloudpickle metric bundle) must serialize for transport."""
+
+    def test_create_serializes_spec_with_bytes_payload(self):
+        # Regression: the factory coerces the transformed spec to a dict for the request body. A
+        # python-mode dump leaves raw bytes that the typed client can't JSON-encode (invalid utf-8 on
+        # the pickle marker \x80). The spec is bound for JSON transport + storage, so it must be dumped
+        # json-safe — the payload model's ser_json_bytes="base64" then base64-encodes the blob.
+        app, sdk = _build_create_app()
+        client = TestClient(app)
+        raw = b"\x80\x04not-utf8\xff"
+        resp = client.post(
+            "/apis/widgets/v2/workspaces/default/jobs",
+            json={"spec": {"blob_payload": {"blob": base64.b64encode(raw).decode()}}},
+        )
+        assert resp.status_code == 201, resp.text
+        # The body handed to the jobs client serialized cleanly, with the blob base64-encoded (not raw
+        # bytes) inside the opaque ``spec`` dict.
+        assert sdk.body_json is not None
+        stored_blob = json.loads(sdk.body_json)["spec"]["blob_payload"]["blob"]
+        assert stored_blob == base64.b64encode(raw).decode()

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -1634,6 +1634,7 @@ components:
           - $ref: '#/components/schemas/AgentTargetInput'
           - $ref: '#/components/schemas/CodexRunnerTarget'
           - $ref: '#/components/schemas/FabricRunnerTarget'
+          - $ref: '#/components/schemas/HarborRunnerTarget'
           title: Target
           description: 'What generates trials online: a Model or Agent endpoint, or
             an agent runner (e.g. Codex CLI). Endpoint targets carry their own request
@@ -1786,6 +1787,7 @@ components:
           - $ref: '#/components/schemas/AgentTargetOutput'
           - $ref: '#/components/schemas/CodexRunnerTarget'
           - $ref: '#/components/schemas/FabricRunnerTarget'
+          - $ref: '#/components/schemas/HarborRunnerTarget'
           title: Target
           description: 'What generates trials online: a Model or Agent endpoint, or
             an agent runner (e.g. Codex CLI). Endpoint targets carry their own request
@@ -3140,6 +3142,83 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
+    HarborRunnerTarget:
+      properties:
+        kind:
+          type: string
+          const: harbor
+          title: Kind
+          default: harbor
+        agent_name:
+          title: Agent Name
+          description: Built-in Harbor agent to run (e.g. 'oracle'). Ignored when
+            `agent_import_path` is set.
+          default: oracle
+          type: string
+        agent_import_path:
+          title: Agent Import Path
+          description: Custom Harbor agent import path (e.g. 'harbor_wrapper:WrappedAgent');
+            overrides `agent_name`. The module must already be importable in the run
+            environment.
+          type: string
+        agent_model_name:
+          title: Agent Model Name
+          description: Optional model slug passed to the Harbor agent.
+          type: string
+        n_attempts:
+          type: integer
+          minimum: 1.0
+          title: N Attempts
+          description: Number of attempts Harbor runs per task.
+          default: 1
+        n_concurrent_trials:
+          type: integer
+          minimum: 1.0
+          title: N Concurrent Trials
+          description: Maximum concurrent Harbor trials.
+          default: 4
+        max_retries:
+          type: integer
+          minimum: 0.0
+          title: Max Retries
+          description: Harbor per-trial retry attempts on transient failures.
+          default: 0
+        artifacts:
+          items:
+            type: string
+          type: array
+          title: Artifacts
+          description: Harbor artifact sources to collect per trial.
+        trace_dir:
+          title: Trace Dir
+          description: Container path of agent traces to collect as the 'traces' artifact
+            (e.g. '/app/traces').
+          type: string
+        reward_key:
+          type: string
+          title: Reward Key
+          description: Key read from Harbor's per-trial rewards mapping to score against.
+          default: reward
+      additionalProperties: false
+      type: object
+      title: HarborRunnerTarget
+      description: 'Generate trials by driving a Harbor job through the SDK''s :class:`HarborAgentTaskRunner`.
+
+
+        Runs in *native* mode: Harbor builds and runs its own ``JobConfig`` (executing
+        each task in a
+
+        Docker environment, retrying, and writing a per-trial results tree), then
+        the runtime adapts that
+
+        tree into SDK trials. The dataset Harbor runs against is recovered from each
+        task''s
+
+        ``harbor_dataset_path`` metadata, so it is not configured here. The runtime-only
+        jobs directory is
+
+        injected from the job''s storage at run time; only the harness-selection and
+        run knobs live here.'
     HelloResponse:
       properties:
         message:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
@@ -33,6 +33,7 @@ from nemo_evaluator.jobs.agent_spec import (
     AgentTarget,
     CodexRunnerTarget,
     FabricRunnerTarget,
+    HarborRunnerTarget,
     ModelTarget,
     Target,
 )
@@ -44,6 +45,7 @@ from nemo_evaluator_sdk.agent_eval.persistence import persist_run
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.agent_eval.runtimes.codex.runtime import CodexCliAgentRuntime
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric.runtime import FabricAgentRuntime
+from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import HarborAgentTaskRunner, HarborRuntimeConfig
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTarget
 from nemo_evaluator_sdk.metrics.protocol import Metric
@@ -263,6 +265,22 @@ class AgentEvalJob(NemoJob):
                 work_root=ctx.storage.persistent / "fabric",
             )
             return fabric_runtime, None, None
+        if isinstance(target, HarborRunnerTarget):
+            harbor_runtime = HarborAgentTaskRunner(
+                config=HarborRuntimeConfig(
+                    jobs_dir=ctx.storage.persistent / "harbor",
+                    agent_name=target.agent_name,
+                    agent_import_path=target.agent_import_path,
+                    agent_model_name=target.agent_model_name,
+                    n_attempts=target.n_attempts,
+                    n_concurrent_trials=target.n_concurrent_trials,
+                    max_retries=target.max_retries,
+                    artifacts=target.artifacts,
+                    trace_dir=target.trace_dir,
+                    reward_key=target.reward_key,
+                )
+            )
+            return harbor_runtime, None, None
         return None, None, None
 
     @staticmethod

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
@@ -108,9 +108,45 @@ class FabricRunnerTarget(BaseModel):
     )
 
 
+class HarborRunnerTarget(BaseModel):
+    """Generate trials by driving a Harbor job through the SDK's :class:`HarborAgentTaskRunner`.
+
+    Runs in *native* mode: Harbor builds and runs its own ``JobConfig`` (executing each task in a
+    Docker environment, retrying, and writing a per-trial results tree), then the runtime adapts that
+    tree into SDK trials. The dataset Harbor runs against is recovered from each task's
+    ``harbor_dataset_path`` metadata, so it is not configured here. The runtime-only jobs directory is
+    injected from the job's storage at run time; only the harness-selection and run knobs live here.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["harbor"] = "harbor"
+    agent_name: str | None = Field(
+        default="oracle",
+        description="Built-in Harbor agent to run (e.g. 'oracle'). Ignored when `agent_import_path` is set.",
+    )
+    agent_import_path: str | None = Field(
+        default=None,
+        description="Custom Harbor agent import path (e.g. 'harbor_wrapper:WrappedAgent'); overrides `agent_name`. "
+        "The module must already be importable in the run environment.",
+    )
+    agent_model_name: str | None = Field(default=None, description="Optional model slug passed to the Harbor agent.")
+    n_attempts: int = Field(default=1, ge=1, description="Number of attempts Harbor runs per task.")
+    n_concurrent_trials: int = Field(default=4, ge=1, description="Maximum concurrent Harbor trials.")
+    max_retries: int = Field(default=0, ge=0, description="Harbor per-trial retry attempts on transient failures.")
+    artifacts: list[str] = Field(default_factory=list, description="Harbor artifact sources to collect per trial.")
+    trace_dir: str | None = Field(
+        default=None,
+        description="Container path of agent traces to collect as the 'traces' artifact (e.g. '/app/traces').",
+    )
+    reward_key: str = Field(
+        default="reward", description="Key read from Harbor's per-trial rewards mapping to score against."
+    )
+
+
 #: The agent-runner slot of the target union — the spec-side mirror of ``AgentTaskRunner``, resolved
 #: to a runtime at run time. ``kind``-discriminated; widen with more members as runners land.
-AgentRunnerTarget: TypeAlias = CodexRunnerTarget | FabricRunnerTarget
+AgentRunnerTarget: TypeAlias = CodexRunnerTarget | FabricRunnerTarget | HarborRunnerTarget
 
 #: What generates trials: a Model or Agent endpoint, or an agent runner. ``kind``-discriminated, and
 #: the spec-level analog of the SDK's runtime ``AgentEvalTarget`` (Model | Agent | AgentTaskRunner).

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/result_persistence.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/result_persistence.py
@@ -20,7 +20,14 @@ import re
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from nemo_evaluator.entities import AgentEvalResultEntity, EvaluateResultEntity
-from nemo_evaluator.jobs.agent_spec import AgentTarget, CodexRunnerTarget, ModelTarget, Target
+from nemo_evaluator.jobs.agent_spec import (
+    AgentTarget,
+    CodexRunnerTarget,
+    FabricRunnerTarget,
+    HarborRunnerTarget,
+    ModelTarget,
+    Target,
+)
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.execution.metric_execution import run_sync
 from nemo_evaluator_sdk.values import Agent, AgentBase, Model
@@ -82,6 +89,10 @@ def _agent_target_fields(target: Target | None) -> tuple[str | None, str | None,
         return "agent", getattr(target.agent, "name", None), _safe_target_url(target.agent.url)
     if isinstance(target, CodexRunnerTarget):
         return "codex", target.model, None
+    if isinstance(target, FabricRunnerTarget):
+        return "fabric", target.model, None
+    if isinstance(target, HarborRunnerTarget):
+        return "harbor", target.agent_import_path or target.agent_name, None
     return None, None, None
 
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/service.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/service.py
@@ -21,6 +21,13 @@ from nemo_platform_plugin.authz import CallerKind, PermissionSet, path_rule, per
 from nemo_platform_plugin.jobs.routes import add_job_routes
 from nemo_platform_plugin.service import NemoService, RouterSpec
 
+#: The ``source`` tag for agent-evaluate job records, passed as ``add_job_routes(..., service_name=)``.
+#: Distinct from ``EvaluateJob``'s derived ``nemo-evaluator`` source: the evaluator plugin owns two job
+#: types (row ``evaluate`` + ``agent-evaluate``), and a shared source makes each collection's list
+#: endpoint 500 when it renders the other type's spec. ``EvaluateJob`` keeps the derived default so its
+#: existing records still match its list.
+AGENT_EVAL_JOB_SOURCE = "nemo-evaluator.agent-evaluate"
+
 
 class EvaluatorPerms(PermissionSet, namespace="evaluator"):
     """Permissions owned by the evaluator plugin's hand-written routes.
@@ -42,7 +49,10 @@ class EvaluatorPluginService(NemoService):
     def get_routers(self) -> list[RouterSpec]:
         router = APIRouter()
         jobs_router = add_job_routes(EvaluateJob, authz=scope)
-        agent_jobs_router = add_job_routes(AgentEvalJob, authz=scope)
+        # A distinct ``service_name`` gives agent-evaluate jobs their own ``source`` tag so this
+        # collection's list endpoint doesn't return (and 500 rendering) row EvaluateJob specs, and
+        # vice versa. EvaluateJob keeps its derived ``nemo-evaluator`` source. See AGENT_EVAL_JOB_SOURCE.
+        agent_jobs_router = add_job_routes(AgentEvalJob, service_name=AGENT_EVAL_JOB_SOURCE, authz=scope)
 
         @router.get("/healthz")
         @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])

--- a/plugins/nemo-evaluator/tests/integration/test_agent_evaluate_job.py
+++ b/plugins/nemo-evaluator/tests/integration/test_agent_evaluate_job.py
@@ -45,11 +45,14 @@ from nemo_evaluator.jobs.agent_spec import (
     CodexRunnerTarget,
     ModelTarget,
 )
+from nemo_evaluator.jobs.evaluate import EvaluateInputSpec, EvaluateJob
 from nemo_evaluator.metric_refs import MetricRef
 from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
 from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator.shared.metric_bundles.inline import InlineMetricBundlePackager
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
 from nemo_evaluator_sdk.enums import AgentFormat, ModelFormat
+from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
 from nemo_evaluator_sdk.values import GenericAgent, Model, RunConfigOnline, RunConfigOnlineModel
 from nemo_platform import NeMoPlatform
@@ -288,6 +291,104 @@ def _offline_trials_input_spec() -> dict:
             )
         ],
     ).model_dump(mode="json")
+
+
+def _offline_row_eval_spec() -> dict:
+    """An offline row (``EvaluateJob``) spec built with a JSON-native (inline-bundled) built-in metric.
+
+    ExactMatch is in ``MetricsUnion``, so ``InlineMetricBundlePackager`` serializes it as declarative
+    JSON — no cloudpickle bytes to survive on the create request body. No target — the dataset's
+    ``model_output`` is scored directly. Seeds a *row* job alongside an agent-eval job so the mixed
+    collection list endpoints can be exercised.
+    """
+    bundle = bundle_metric(
+        ExactMatchMetric(reference="{{item.expected}}", candidate="{{item.model_output}}"),
+        InlineMetricBundlePackager(),
+    )
+    return EvaluateInputSpec.model_validate(
+        {
+            "metrics": [bundle.model_dump(mode="json")],
+            "dataset": [{"expected": "blue", "model_output": "blue"}],
+        }
+    ).model_dump(mode="json")
+
+
+def _offline_agent_eval_spec_no_metrics() -> dict:
+    """An offline agent-eval spec: one task (no metrics) scored against one precomputed trial.
+
+    Metrics are optional on an agent task, so omitting them keeps the spec fully JSON-native (no
+    cloudpickle) — enough to *create* a persisted AgentEvalJob record, which is all the list-endpoint
+    regression needs.
+    """
+    return AgentEvalInputSpec(
+        tasks=[
+            AgentEvalTaskInput(
+                id="say-done",
+                intent="Agent follows a trivial instruction and exits cleanly.",
+                inputs={"instruction": "Reply with the single word DONE and nothing else."},
+            )
+        ],
+        trials=[
+            AgentEvalTrial(
+                id="t-1",
+                task_id="say-done",
+                status=AgentEvalTrialStatus.COMPLETED,
+                output=AgentOutput(output_text="DONE"),
+            )
+        ],
+    ).model_dump(mode="json")
+
+
+@pytest.mark.timeout(300)
+def test_mixed_job_types_list_endpoints_do_not_cross_render(subprocess_platform: str) -> None:
+    """Regression (reported by Studio): a workspace holding BOTH a row ``EvaluateJob`` and an
+    ``AgentEvalJob`` must not 500 either collection's list endpoint.
+
+    Both job types are owned by the evaluator plugin. Before the fix they shared one ``source`` tag,
+    so ``GET .../agent-evaluate/jobs`` returned every evaluator job and then rendered each against
+    ``AgentEvalSpec`` — a row spec failed validation and the list 500'd (and vice versa). The fix
+    gives agent-evaluate jobs a distinct ``source`` (``service.AGENT_EVAL_JOB_SOURCE``), so each list
+    is scoped to its own collection. The list bug fires on *persisted* records, so this only creates
+    one job of each type (no run/wait) and asserts the list endpoints; JSON-native specs keep create
+    off the cloudpickle path.
+
+    Runs in a fresh workspace so the assertions see only these two jobs — the shared subprocess DB may
+    hold legacy agent-eval records written under the old shared source (the documented pre-fix caveat),
+    which would otherwise still cross-render into the row list.
+    """
+    workspace = _unique("mixed-list")
+    client = NeMoPlatform(base_url=subprocess_platform, max_retries=2)
+    client.workspaces.create(name=workspace, exist_ok=True)
+
+    row_resp = NemoJobScheduler().submit_remote(
+        EvaluateJob, _offline_row_eval_spec(), base_url=subprocess_platform, workspace=workspace, profile="default"
+    )
+    row_name = row_resp.get("name") or row_resp.get("id")
+    agent_resp = NemoJobScheduler().submit_remote(
+        AgentEvalJob,
+        _offline_agent_eval_spec_no_metrics(),
+        base_url=subprocess_platform,
+        workspace=workspace,
+        profile="default",
+    )
+    agent_name = agent_resp.get("name") or agent_resp.get("id")
+    assert row_name and agent_name, f"submit responses carried no name/id: {row_resp}, {agent_resp}"
+
+    base = f"{subprocess_platform}/apis/evaluator/v2/workspaces/{workspace}"
+    # The core regression: the agent-evaluate list must 200 (not 500) in a mixed workspace, and it
+    # must contain only the agent job — the row job is filtered out by the distinct source.
+    agent_list = httpx.get(f"{base}/agent-evaluate/jobs", params={"page_size": 100}, timeout=30)
+    assert agent_list.status_code == 200, agent_list.text
+    agent_names = {item["name"] for item in agent_list.json()["data"]}
+    assert agent_name in agent_names
+    assert row_name not in agent_names
+
+    # And symmetrically: the row list must 200 and exclude the agent job.
+    row_list = httpx.get(f"{base}/evaluate/jobs", params={"page_size": 100}, timeout=30)
+    assert row_list.status_code == 200, row_list.text
+    row_names = {item["name"] for item in row_list.json()["data"]}
+    assert row_name in row_names
+    assert agent_name not in row_names
 
 
 def _codex_eval_input_spec() -> dict:

--- a/plugins/nemo-evaluator/tests/integration/test_harbor_plugin_run.py
+++ b/plugins/nemo-evaluator/tests/integration/test_harbor_plugin_run.py
@@ -43,7 +43,12 @@ _DATASET_DIR = Path(__file__).resolve().parents[4] / "packages/nemo_evaluator_sd
 def _docker_available() -> bool:
     if shutil.which("docker") is None:
         return False
-    return subprocess.run(["docker", "info"], capture_output=True).returncode == 0
+    try:
+        # Bound the probe: a wedged daemon can make ``docker info`` hang until the
+        # test-level timeout. Treat a stalled daemon as unavailable and skip.
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=10).returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
 
 
 def _reward_metric() -> MetricInline:

--- a/plugins/nemo-evaluator/tests/integration/test_harbor_plugin_run.py
+++ b/plugins/nemo-evaluator/tests/integration/test_harbor_plugin_run.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plugin-level end-to-end Harbor run through the real local execution machinery.
+
+Unlike the unit tests (which fake the evaluator so the Harbor runner is built but never executed),
+this drives ``NemoJobScheduler().run_local(AgentEvalJob, ...)`` against a *real* HarborRunnerTarget:
+the scheduler validates the submitter ``AgentEvalInputSpec``, runs ``to_spec`` to the canonical spec,
+builds/uses the job context, then runs — the same in-process lifecycle a local job goes through. The
+Harbor runner resolves to a native ``HarborAgentTaskRunner``, Harbor runs the bundled hello-world task
+in Docker, and the verifier reward is scored (by a cloudpickle-bundled ``HarborRewardMetric``) and
+persisted into the run bundle. It is the plugin analog of the SDK's ``test_harbor_runtime_e2e.py``.
+
+Needs the ``harbor`` extra (Python >=3.12; ``pip install nemo-evaluator-sdk[harbor]``) and a working
+Docker daemon; ``importorskip('harbor')`` + a Docker check skip it otherwise (so it's inert on the
+3.11 workspace and in CI). Marked ``integration`` — a heavy, external-dependency run — but unlike the
+sibling tests it stands up no platform and isn't gated on ``RUN_AGENT_EVAL_INTEGRATION``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.jobs.agent_evaluate import AGENT_BUNDLE_DIR, DEFAULT_RESULT_NAME, AgentEvalJob
+from nemo_evaluator.jobs.agent_spec import AgentEvalInputSpec, AgentEvalTaskInput, HarborRunnerTarget
+from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import HarborRewardMetric, discover_harbor_tasks
+from nemo_platform_plugin.job_context import JobContext, StoragePaths
+from nemo_platform_plugin.job_results import LocalJobResults
+from nemo_platform_plugin.scheduler import NemoJobScheduler
+
+pytestmark = [pytest.mark.integration]
+
+#: The bundled Harbor hello-world dataset (repo root → SDK examples).
+_DATASET_DIR = Path(__file__).resolve().parents[4] / "packages/nemo_evaluator_sdk/examples/harbor/hello_world_dataset"
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    return subprocess.run(["docker", "info"], capture_output=True).returncode == 0
+
+
+def _reward_metric() -> MetricInline:
+    # HarborRewardMetric is a custom metric (not in MetricsUnion), so it rides as a cloudpickle bundle.
+    bundle = bundle_metric(HarborRewardMetric(), CloudpickleMetricBundlePackager())
+    return MetricInline.model_validate(bundle.model_dump(mode="json"))
+
+
+def _job_context(tmp_path: Path) -> JobContext:
+    storage = StoragePaths(ephemeral=tmp_path / "ephemeral", persistent=tmp_path / "persistent")
+    storage.ephemeral.mkdir()
+    storage.persistent.mkdir()
+    return JobContext(
+        workspace="dev",
+        storage=storage,
+        results=LocalJobResults(root=storage.persistent / "results"),
+        job_id="harbor-plugin-run",
+    )
+
+
+@pytest.mark.timeout(600)
+def test_run_local_runs_a_real_harbor_target(tmp_path: Path) -> None:
+    pytest.importorskip("harbor")
+    if not _docker_available():
+        pytest.skip("Docker daemon is required to run a Harbor job")
+
+    # Reuse the SDK's dataset discovery so the task id matches the name Harbor writes into result.json,
+    # and the tasks carry the `harbor_dataset_path` metadata the native runner reads. Each task is
+    # scored by a HarborRewardMetric, re-bundled here into the plugin's inline-metric wire shape.
+    runtime_tasks = discover_harbor_tasks(_DATASET_DIR)
+    assert runtime_tasks, "no Harbor tasks discovered in the hello-world dataset"
+    input_spec = AgentEvalInputSpec(
+        tasks=[
+            AgentEvalTaskInput(
+                id=rt.id,
+                intent=rt.intent,
+                inputs=rt.inputs,
+                metrics=[_reward_metric()],
+                metadata=[{"key": key, "value": str(value)} for key, value in rt.metadata.items()],
+            )
+            for rt in runtime_tasks
+        ],
+        target=HarborRunnerTarget(agent_name="oracle"),
+    )
+    ctx = _job_context(tmp_path)
+
+    # The real local execution path: the scheduler validates the submitter spec, runs to_spec, and
+    # invokes run() with the real evaluator (no fake) → resolve the Harbor target → native
+    # HarborAgentTaskRunner → Harbor runs the task in Docker → adapt to trials → score → persist. The
+    # explicit ctx keeps storage hermetic under tmp_path so the persisted bundle is readable here.
+    result = NemoJobScheduler().run_local(AgentEvalJob, input_spec.model_dump(mode="json"), workspace="dev", ctx=ctx)
+
+    assert result["status"] == "completed", result
+    assert result["artifact"]["name"] == DEFAULT_RESULT_NAME
+
+    # The persisted bundle records the Harbor verifier reward: the oracle agent solves hello-world, so
+    # the reward metric scores 1.0.
+    scores_path = ctx.storage.persistent / AGENT_BUNDLE_DIR / "scores.jsonl"
+    assert scores_path.exists(), "run bundle is missing scores.jsonl"
+    scores_text = scores_path.read_text(encoding="utf-8")
+    assert '"reward"' in scores_text
+    assert "1.0" in scores_text

--- a/plugins/nemo-evaluator/tests/test_agent_evaluate.py
+++ b/plugins/nemo-evaluator/tests/test_agent_evaluate.py
@@ -26,6 +26,7 @@ from nemo_evaluator.jobs.agent_spec import (
     AgentTarget,
     CodexRunnerTarget,
     FabricRunnerTarget,
+    HarborRunnerTarget,
     ModelTarget,
     Target,
 )
@@ -37,6 +38,7 @@ from nemo_evaluator.tasks.runner import SDK_INITIALIZATION_EXIT_CODE
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSummary
 from nemo_evaluator_sdk.agent_eval.runtimes.codex.runtime import CodexCliAgentRuntime
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric.runtime import FabricAgentRuntime
+from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import HarborAgentTaskRunner
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import (
     AgentEvalTarget,
@@ -232,6 +234,30 @@ def test_resolve_target_builds_fabric_runtime_from_runner_target(tmp_path: Path)
     assert params is None
 
 
+def test_resolve_target_builds_harbor_runtime_from_runner_target(tmp_path: Path) -> None:
+    ctx = _job_context(tmp_path)
+    harbor_target = HarborRunnerTarget(
+        agent_name="oracle",
+        agent_model_name="openai/gpt-5.4",
+        n_attempts=2,
+        n_concurrent_trials=8,
+        max_retries=1,
+        reward_key="score",
+    )
+    target, prompt_template, params = AgentEvalJob._resolve_target(harbor_target, ctx)
+    assert isinstance(target, HarborAgentTaskRunner)
+    # The runtime-only jobs directory is injected from the job's persistent storage.
+    assert target._config is not None
+    assert target._config.jobs_dir == ctx.storage.persistent / "harbor"
+    # Spec knobs are forwarded onto the Harbor runtime config.
+    assert target._config.agent_model_name == "openai/gpt-5.4"
+    assert target._config.n_attempts == 2
+    assert target._config.reward_key == "score"
+    # A runner shapes its own request, so it contributes no prompt template or inference params.
+    assert prompt_template is None
+    assert params is None
+
+
 def test_resolve_target_unpacks_model_target_request_config(tmp_path: Path) -> None:
     ctx = _job_context(tmp_path)
     model = Model(url="http://model.test/v1/chat/completions", name="m")
@@ -261,6 +287,25 @@ def test_resolve_target_resolves_none_to_no_target(tmp_path: Path) -> None:
 def test_runner_target_is_accepted(tmp_path: Path) -> None:
     spec = AgentEvalSpec(tasks=[_task_spec()], target=CodexRunnerTarget(model="gpt-5.5"))
     assert isinstance(spec.target, CodexRunnerTarget)
+
+
+def test_harbor_runner_target_is_accepted() -> None:
+    spec = AgentEvalSpec(tasks=[_task_spec()], target=HarborRunnerTarget(agent_name="oracle"))
+    assert isinstance(spec.target, HarborRunnerTarget)
+
+
+def test_agent_eval_job_source_is_distinct_from_evaluate_job() -> None:
+    """The two evaluator job types must not share a ``source`` (mixed-list-crash regression).
+
+    A shared source makes the agent-evaluate and evaluate list endpoints return each other's jobs and
+    500 rendering the foreign spec. ``service.py`` passes ``AGENT_EVAL_JOB_SOURCE`` as the agent-eval
+    routes' ``service_name`` so it lands a distinct ``source`` from EvaluateJob's derived default.
+    """
+    from nemo_evaluator.jobs.evaluate import EvaluateJob
+    from nemo_evaluator.service import AGENT_EVAL_JOB_SOURCE
+    from nemo_platform_plugin.jobs.routes import _derive_service_name
+
+    assert AGENT_EVAL_JOB_SOURCE != _derive_service_name(EvaluateJob)
 
 
 def _sdk_with_identity(sdk_cls: type[NeMoPlatform | AsyncNeMoPlatform]) -> NeMoPlatform | AsyncNeMoPlatform:
@@ -398,6 +443,7 @@ def _assert_agent_eval_step_entrypoint(job_spec: PlatformJobSpec) -> None:
             "test-model",
         ),
         (AgentTarget(agent=_agent(), params=RunConfigOnline()), "agent", "test-agent"),
+        (HarborRunnerTarget(agent_name="oracle"), "harbor", None),
     ],
 )
 async def test_compile_produces_cpu_task_step_carrying_each_target(
@@ -476,6 +522,7 @@ async def test_compile_rejects_reserved_secret_env_name() -> None:
         ),
         AgentTarget(agent=_agent(), params=RunConfigOnline()),
         CodexRunnerTarget(model="gpt-5.5"),
+        HarborRunnerTarget(agent_name="oracle"),
     ],
 )
 def test_run_local_executes_each_target_type(target: Target, mocker: MockerFixture) -> None:
@@ -500,6 +547,8 @@ def test_run_local_executes_each_target_type(target: Target, mocker: MockerFixtu
     assert fake.received_trials is None  # online generation, not precomputed
     if isinstance(target, CodexRunnerTarget):
         assert isinstance(fake.received_target, CodexCliAgentRuntime)
+    elif isinstance(target, HarborRunnerTarget):
+        assert isinstance(fake.received_target, HarborAgentTaskRunner)
     elif isinstance(target, ModelTarget):
         assert getattr(fake.received_target, "name", None) == target.model.name
     else:

--- a/plugins/nemo-evaluator/tests/test_result_persistence.py
+++ b/plugins/nemo-evaluator/tests/test_result_persistence.py
@@ -15,7 +15,13 @@ from typing import cast
 import pytest
 from nemo_evaluator.entities import AgentEvalResultEntity, EvaluateResultEntity
 from nemo_evaluator.jobs import result_persistence
-from nemo_evaluator.jobs.agent_spec import AgentTarget, CodexRunnerTarget, ModelTarget
+from nemo_evaluator.jobs.agent_spec import (
+    AgentTarget,
+    CodexRunnerTarget,
+    FabricRunnerTarget,
+    HarborRunnerTarget,
+    ModelTarget,
+)
 from nemo_evaluator.jobs.result_persistence import (
     _agent_target_fields,
     _row_target_fields,
@@ -61,6 +67,12 @@ def _agent() -> Agent:
         (ModelTarget(model=_model()), ("model", "my-model", "https://model.test/v1/chat/completions")),
         (AgentTarget(agent=_agent()), ("agent", "my-agent", "http://agent.test")),
         (CodexRunnerTarget(model="gpt-5.5"), ("codex", "gpt-5.5", None)),
+        (
+            FabricRunnerTarget(config={"metadata": {"name": "a"}}, model="openai/gpt-5.4"),
+            ("fabric", "openai/gpt-5.4", None),
+        ),
+        (HarborRunnerTarget(agent_name="oracle"), ("harbor", "oracle", None)),
+        (HarborRunnerTarget(agent_import_path="wrapper:Agent"), ("harbor", "wrapper:Agent", None)),
         (None, (None, None, None)),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -1310,6 +1310,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "diff-cover"
 version = "10.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1351,6 +1363,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/17/4d/ac7ffa80c69ea1df30a8aa11b3578692a5118e7cd1aa157e3ef73b092d15/dill-0.3.8.tar.gz", hash = "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca", size = 184847, upload-time = "2024-01-27T23:42:16.145Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/7a/cef76fd8438a42f96db64ddaa85280485a9c395e7df3db8158cfec1eee34/dill-0.3.8-py3-none-any.whl", hash = "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7", size = 116252, upload-time = "2024-01-27T23:42:14.239Z" },
+]
+
+[[package]]
+name = "dirhash"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "scantree", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/70/49f93897f3a4f7ab5f20a854ebc91aad47854e9fb2cd169e3a4452fa3f5e/dirhash-0.5.0.tar.gz", hash = "sha256:e60760f0ab2e935d8cb088923ea2c6492398dca42cec785df778985fd4cd5386", size = 21377, upload-time = "2024-08-03T22:14:13.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/1f/c8bf92552b7f0a13b9f12b85e3de8df6d9814240e0f8ce8f37433df028b3/dirhash-0.5.0-py3-none-any.whl", hash = "sha256:523dfd6b058c64f45b31604376926c6e2bd2ea301d0df23095d4055674e38b09", size = 13119, upload-time = "2024-08-03T22:14:11.688Z" },
 ]
 
 [[package]]
@@ -2087,6 +2111,51 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "hyperframe", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "harbor"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dirhash", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "fastapi", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "filelock", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jinja2", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "litellm", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "packaging", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pathspec", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "platformdirs", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyjwt", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "python-dotenv", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyyaml", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "requests", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rich", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "shortuuid", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "supabase", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "tenacity", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "toml", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typer", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "uvicorn", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/24/7222433d3b9f665db1759456c281a9c136b921300be5d7af269f183ee59e/harbor-0.18.0.tar.gz", hash = "sha256:9b918b99ec38b4e16db7e0b797dcebf92bfc8be9d9ba22a2d2ed6ebb8feb38df", size = 1535447, upload-time = "2026-07-07T20:29:46.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/81/b5d4f3119b131ee4a41e7036c7c1315e13c27849ffb59c3364875768132a/harbor-0.18.0-py3-none-any.whl", hash = "sha256:e436f04fca35bb3705be603b8c123d0472418d10120cfd7e5ba8dc902e56bc32", size = 1735449, upload-time = "2026-07-07T20:29:45.064Z" },
+]
+
+[[package]]
 name = "hatchling"
 version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2141,6 +2210,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
     { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
     { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]
@@ -2299,6 +2377,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e2/57/b46c397fb3842cfb02a44609aa834c887f38dd75f290c2fc5a34da4b2fee/hvac-2.4.0.tar.gz", hash = "sha256:e0056ad9064e7923e874e6769015b032580b639e29246f5ab1044f7959c1c7e0", size = 332543, upload-time = "2025-10-30T12:57:47.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/33/71e45a6bd6875f44a26f99da31c63b6840123e88bedf2c0b1ce429b8be12/hvac-2.4.0-py3-none-any.whl", hash = "sha256:008db5efd8c2f77bd37d2368ea5f713edceae1c65f11fd608393179478649e0f", size = 155921, upload-time = "2025-10-30T12:57:46.253Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -4245,6 +4332,9 @@ dependencies = [
 agent-runtimes = [
     { name = "openai-agents", extra = ["docker"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
+harbor = [
+    { name = "harbor", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
 nemo-platform = [
     { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
@@ -4257,6 +4347,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "harbor", marker = "python_full_version >= '3.12' and extra == 'harbor'", specifier = ">=0.16.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonpath-ng", specifier = ">=1.7.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },
@@ -4273,7 +4364,7 @@ requires-dist = [
     { name = "rouge-score", specifier = "==0.1.2" },
     { name = "sacrebleu", specifier = ">=2.5.1" },
 ]
-provides-extras = ["agent-runtimes", "engine", "nemo-platform"]
+provides-extras = ["agent-runtimes", "engine", "harbor", "nemo-platform"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -8649,6 +8740,21 @@ wheels = [
 ]
 
 [[package]]
+name = "postgrest"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", extra = ["http2"], marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "yarl", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/22/88c470d8838d2678a44e0172d061630b8837cba3fb7fb492e28f6578c309/postgrest-2.31.0.tar.gz", hash = "sha256:2f395d84b2ee34fc57622ff2f711df603e2ede625f98e5015240741888f7bd0c", size = 14419, upload-time = "2026-06-04T13:37:20.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/3e/41909586cb148db0259e0208310067afda4cc097f4c7a779e829c1e68c46/postgrest-2.31.0-py3-none-any.whl", hash = "sha256:c2fd47c94e13ee8335111c4f03c9a24ea9766ce9d35fc3cd7330057c9e7ea0c3", size = 23098, upload-time = "2026-06-04T13:37:19.452Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -9598,6 +9704,20 @@ wheels = [
 ]
 
 [[package]]
+name = "realtime"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", extra = ["email"], marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "websockets", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/34/54a1eaaefa24db5cb12596fd74792e08efa53ed30dc5bce2c0a68ded6146/realtime-2.31.0.tar.gz", hash = "sha256:9e641cb4d77ca0fe768515f8cf9f83550c79f49ce1550a95afc2dc0e252be8c9", size = 18716, upload-time = "2026-06-04T13:37:22.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/60/164246615e8b059f6d53d34648a0784260421ec98a07eb1e45160f063221/realtime-2.31.0-py3-none-any.whl", hash = "sha256:f6e494b53d6a6e80b6efcee6711c8dd40413a52e766271de1bce8ced6c36cc1d", size = 22374, upload-time = "2026-06-04T13:37:21.162Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
@@ -9962,6 +10082,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
     { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
     { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+]
+
+[[package]]
+name = "scantree"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pathspec", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/e4/40998faefc72ba1ddeb640a44fba92935353525dba110488806da8339c0b/scantree-0.0.4.tar.gz", hash = "sha256:15bd5cb24483b04db2c70653604e8ea3522e98087db7e38ab8482f053984c0ac", size = 24643, upload-time = "2024-08-03T20:08:59.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/ce/828467ddfa0d2fe473673026442d2032d552a168e42cfbf25fd0e5264e0c/scantree-0.0.4-py3-none-any.whl", hash = "sha256:7616ab65aa6b7f16fcf8e6fa1d9afaa99a27ab72bba05c61b691853b96763174", size = 20690, upload-time = "2024-08-03T20:08:58.137Z" },
 ]
 
 [[package]]
@@ -10429,6 +10562,21 @@ wheels = [
 ]
 
 [[package]]
+name = "storage3"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", extra = ["http2"], marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "yarl", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/30/fee43d523d3f680a833a4aae5bf8094de0b9031b0c2bddb3e0bc6e829e1b/storage3-2.31.0.tar.gz", hash = "sha256:d2161e2ea650dc115a1787c30e09b118365589ac772f4dd8643e3a503ecfc667", size = 20348, upload-time = "2026-06-04T13:37:23.703Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/b2/60d86a3a99ae743e8a00a6df912f85269b3bc882ba217b8ce1690881c669/storage3-2.31.0-py3-none-any.whl", hash = "sha256:4bf46e8bea320743179a6beafdc7531c5242495e00e0cc22af7c7a9d69d4ed84", size = 28492, upload-time = "2026-06-04T13:37:22.792Z" },
+]
+
+[[package]]
 name = "streaming-form-data"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -10450,12 +10598,67 @@ wheels = [
 ]
 
 [[package]]
+name = "strenum"
+version = "0.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ad/430fb60d90e1d112a62ff57bdd1f286ec73a2a0331272febfddd21f330e1/StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff", size = 23384, upload-time = "2023-06-29T22:02:58.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659", size = 8851, upload-time = "2023-06-29T22:02:56.947Z" },
+]
+
+[[package]]
 name = "structlog"
 version = "25.5.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "supabase"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "postgrest", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "realtime", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "storage3", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "supabase-auth", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "supabase-functions", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "yarl", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8e/54a2f950629689b1613434a61fc3bff5f92f84ba6b20213f5b2add05c1bb/supabase-2.31.0.tar.gz", hash = "sha256:3467b09d00482b9a0138235bdbde7a350426f93cf2a1342372eaddfc669f1206", size = 9805, upload-time = "2026-06-04T13:37:25.22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/06/5e6f4bf89dedadf81f893832115c1866da1aa093142c9989c2818780dae3/supabase-2.31.0-py3-none-any.whl", hash = "sha256:25f2a99207a75f2d9377e2332783b4389cf56b02cbebdaf0c1743112dcbb704e", size = 16728, upload-time = "2026-06-04T13:37:24.278Z" },
+]
+
+[[package]]
+name = "supabase-auth"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"], marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyjwt", extra = ["crypto"], marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/8a/408689cf39820f0d46d2731d6747ff94dbefc87ae977b4b5c4066da5b070/supabase_auth-2.31.0.tar.gz", hash = "sha256:0945b33fa96239c76dc8eaf96d7d2c94991950d24b4cfe4a5c2da9aa5e909663", size = 39151, upload-time = "2026-06-04T13:37:27.375Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/5e/22f3b0546bb1f0985f06fb1ebf5f6405a3b1bb7a5db01142c26cf148e988/supabase_auth-2.31.0-py3-none-any.whl", hash = "sha256:5e9c8b4ecdee6af04dbcb06455ce78cb15674806fcb6b425170455307d70b0ee", size = 48363, upload-time = "2026-06-04T13:37:26.26Z" },
+]
+
+[[package]]
+name = "supabase-functions"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"], marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "strenum", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "yarl", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/5d/61c2446ed26a57fa5543f9c270a731320911569202340d15341f72cdba7c/supabase_functions-2.31.0.tar.gz", hash = "sha256:4ad027b3ae3bd28b31233339f4db1da6965affd3546f655b421baf40cee2690f", size = 4683, upload-time = "2026-06-04T13:37:28.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/79/1a8162ce7d705381a4f2668c0da68e097b103c1aa701418a31da52905c7b/supabase_functions-2.31.0-py3-none-any.whl", hash = "sha256:3fdc4c4766152bfda63bdd0e286fc8a06f50e1280711fae4a1dfc9b7e9ebabc6", size = 8794, upload-time = "2026-06-04T13:37:28.022Z" },
 ]
 
 [[package]]
@@ -10624,6 +10827,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
     { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
     { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Three related changes to the evaluator plugin's agent-eval path:

### 1. Harbor runner target (feature)
- Adds `HarborRunnerTarget` to the agent-eval runner-target union and wires it through `_resolve_target` (native `HarborAgentTaskRunner`, `jobs_dir` injected from job storage) and result-entity trait extraction (also fills in the previously-missing Fabric trait branch).
- Declares a **marker-gated** `harbor` extra on `nemo-evaluator-sdk`: `harbor = ["harbor>=0.16.1; python_version >= '3.12'"]`. Harbor requires Python ≥3.12; the marker scopes it to the 3.12 slice of the universal lock so `pip install nemo-evaluator-sdk[harbor]` works on 3.12 while the workspace floor stays 3.11 (no floor bump). `harbor` stays lazily imported, so importing the SDK / resolving a Harbor target is valid on 3.11 — only *executing* a run needs the extra.

### 2. Mixed-job list-endpoint 500 (bug fix — reported by Studio)
The evaluator plugin owns two job types (`evaluate` + `agent-evaluate`) that shared one `source` tag. The list endpoints filter by `source`, so in a workspace with both, each collection returned the other type's records and 500'd rendering the foreign spec (dozens of validation errors). Fix: give `AgentEvalJob` a distinct source via `add_job_routes(service_name=AGENT_EVAL_JOB_SOURCE)`. `EvaluateJob` keeps its derived `nemo-evaluator` source so existing records still match.

> **Pre-GA caveat:** agent-evaluate records persisted *before* this change keep the old shared source and will still cross-render into the `evaluate` list until re-sourced. agent-evaluate is pre-GA with negligible persisted data, so no migration ships here (documented in `service.py`).

### 3. Plugin job create serialization for bytes-bearing specs (latent bug fix)
The shared job factory coerced the transformed spec with `model_dump()` (python mode), leaving raw `bytes` (e.g. an inline cloudpickle metric bundle) that the typed jobs client couldn't JSON-encode — `PydanticSerializationError: invalid utf-8` on the `\x80` pickle marker. Fix: dump `mode="json"` so nested payload models' `ser_json_bytes="base64"` runs and the blob round-trips. This is in the shared `api_factory`, so it fixes create for any plugin/job type whose spec carries bytes. (Latent because the opt-in E2E suite that exercises it isn't in CI.)

## Testing

- **Unit:** Harbor resolve/compile/`run_local` (faked evaluator) across target types; harbor/fabric result traits; distinct-source list-filter forwarding; `nemo-evaluator-sdk` source distinctness; create-path bytes-serialization regression driving the real `POST /jobs` route.
- **Integration (opt-in):** mixed-job list partitioning against a live subprocess platform; a real Docker-backed Harbor e2e via `NemoJobScheduler().run_local(...)` (gated on `harbor` + Docker; oracle solves hello-world, reward 1.0 persisted).
- Validated on both Python 3.11 (CI's default) and 3.12.13; `uv lock --check` clean; ruff + ty clean for changed files.

## Follow-up

- **AALGO-343** (related) — Harbor targets under containerized job backends (docker/k8s). Harbor works via the host daemon (in-process `run_local` / subprocess backend) but not inside the `cpu-tasks` container; direction is to route Harbor at a remote/k8s sandbox rather than plugin-side DinD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-evaluation support for Harbor runner targets (agent selection, model overlays, execution/retry/concurrency settings, artifacts/traces, and reward scoring).
  * Updated OpenAPI to expose Harbor runner targets in both the input and canonical spec.
* **Bug Fixes**
  * Improved job-spec JSON transport for create requests containing binary payloads (safe encoding for round-tripping).
  * Isolated agent-evaluation job listing to prevent cross-type validation/rendering.
* **Tests**
  * Added unit and integration coverage for Harbor target resolution, persistence mapping, mixed listing behavior, and local Harbor execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->