### PR TITLE
docs(evaluator): mark agent-eval platform-plugin support as in progress

### DIFF
--- a/docs/evaluator/agent-eval/index.mdx
+++ b/docs/evaluator/agent-eval/index.mdx
@@ -11,6 +11,15 @@ for how it compares to metrics). You define **tasks**, an **agent** performs eac
 and you score the resulting **trial** — not just whether the final answer is right, but *how the agent
 got there*. Each task carries its own metrics, so a single suite can grade heterogeneous work.
 
+<Note>
+
+**Platform-plugin support is in progress.** The pages in this section run agent evaluations through
+the **local SDK** (`AgentEvaluator().run()`). Running them through the **NeMo Platform plugin** as
+durable platform jobs — the way [dataset-driven metrics](/documentation/evaluate-models/metrics)
+already can — is under active development; for now, use the local SDK path shown here.
+
+</Note>
+
 ## The model
 
 One run flows through five pieces:
@@ -76,7 +85,8 @@ print(result.summary)
   - **views** — named roll-ups you define on a task that combine two or more of its metric outputs into one reported score (for example, averaging an accuracy metric and a tool-use metric into a single `quality` score);
   - the **run-level aggregate** — results also roll up across the whole run.
 - **Runs locally.** A full run — including the `report.html` dashboard — is produced on your machine
-  with no platform services required; the same run can also be submitted as a platform job.
+  with no platform services required. (Running the same suite as a durable platform job through the
+  evaluator plugin is in progress — see the note above.)
 - **Measurement, not decisions.** The evaluator produces scores, aggregates, and provenance — it
   doesn't decide pass/fail, gate a release, or compare runs. Those decisions belong to whatever
   consumes the results.


### PR DESCRIPTION
## What

Marks agent-eval **platform-plugin execution as in progress**, so the docs don't imply a capability that isn't shipped.

- Adds a `<Note>` on the Agent Evaluation landing page: the section runs through the **local SDK** (`AgentEvaluator().run()`); running agent evals through the **NeMo Platform plugin** as durable platform jobs — the way dataset-driven evaluation already can — is under active development.
- Softens the "Runs locally" key-property bullet, which asserted "the same run can also be submitted as a platform job" — a forward reference to a path the plugin doesn't expose for agent evals yet.

## Why

Follow-up to the agent-eval docs ([#710](https://github.com/NVIDIA-NeMo/nemo-platform/pull/710)). Reviewer feedback flagged that the pages are SDK-only while forward-referencing a submit/job path that doesn't exist for agent evals. This keeps the docs honest until plugin support lands.

## Notes

- Docs-only; one file (`docs/evaluator/agent-eval/index.mdx`).
- Release-notes coverage for agent evaluation is deferred to the **0.3** release notes, to be added when that page is started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that platform-plugin support for agent evaluations is still in progress.
  * Updated examples to use the local SDK for running evaluations.
  * Revised key-property guidance to note that evaluations run locally without requiring platform services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->