### PR TITLE
ci: harmonize test harness a little with GPU test setup

### DIFF
--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/config.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/config.py
@@ -84,6 +84,20 @@ def get_default_executor_profiles_for_runtime(
                     backend="kubernetes_job",
                     config=defaults.kubernetes_job,
                 ),
+                # Customizer uses the gpu profile for both CPU preparation and
+                # GPU training steps. The provider selects the requested resources.
+                KubernetesJobExecutionProfile(
+                    provider="cpu",
+                    profile="gpu",
+                    backend="kubernetes_job",
+                    config=defaults.kubernetes_job,
+                ),
+                KubernetesJobExecutionProfile(
+                    provider="gpu",
+                    profile="gpu",
+                    backend="kubernetes_job",
+                    config=defaults.kubernetes_job,
+                ),
                 VolcanoJobExecutionProfile(
                     provider="gpu_distributed",
                     profile="default",

--- a/services/core/jobs/tests/test_config.py
+++ b/services/core/jobs/tests/test_config.py
@@ -346,7 +346,11 @@ def test_subprocess_execution_profile_defaults_provider_to_subprocess():
 def test_default_profiles_exclude_subprocess_for_kubernetes_runtime():
     profiles = get_default_executor_profiles_for_runtime(Runtime.KUBERNETES, DefaultExecutionProfileConfig())
 
-    assert ("subprocess", "default", "subprocess") not in [(p.provider, p.profile, p.backend) for p in profiles]
+    profile_keys = [(p.provider, p.profile, p.backend) for p in profiles]
+
+    assert ("cpu", "gpu", "kubernetes_job") in profile_keys
+    assert ("gpu", "gpu", "kubernetes_job") in profile_keys
+    assert ("subprocess", "default", "subprocess") not in profile_keys
 
 
 def test_merged_profiles():
@@ -371,7 +375,7 @@ def test_merged_profiles():
         ],
     ]
 
-    assert len(default_executors) == 4
+    assert len(default_executors) == 6
     # Assert that the storage config is set correctly
     for executor in default_executors:
         if hasattr(executor.config, "storage"):
@@ -398,7 +402,7 @@ def test_merged_profiles():
 
     merged = merge_executor_profiles(custom_executor_profiles, default_executors)
 
-    assert len(merged) == 5
+    assert len(merged) == 7
 
     cpu_default = next((p for p in merged if p.provider == "cpu" and p.profile == "default"), None)
     assert cpu_default is not None

--- a/services/core/models/src/nmp/core/models/api/v2/models.py
+++ b/services/core/models/src/nmp/core/models/api/v2/models.py
@@ -274,9 +274,8 @@ async def start_update_model_spec_job(model_entity: ModelEntity):
                 name="model-spec-analysis",
                 executor=CPUExecutionProviderSpec(
                     provider="cpu",
-                    # Profile ``gpu`` selects the Docker CPU executor (see jobs.executors
-                    # in platform config). Avoid ``default``, which is translated to the
-                    # host subprocess backend when subprocess/default is registered.
+                    # Customizer uses the ``gpu`` profile for both CPU preparation
+                    # and GPU training steps. The provider selects CPU resources here.
                     profile="gpu",
                     container=ContainerSpec(
                         image=get_qualified_image("nmp-customizer-tasks"),


### PR DESCRIPTION
E2E tests running in other repos occasionally have a problem with missing kubernetes resource profiles that aren't surfaced here. Adding them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes-based model job execution by using the appropriate GPU execution profile during CPU preparation.
  * Ensured CPU preparation and GPU training steps use consistent execution settings while selecting the correct CPU resources.

* **Documentation**
  * Clarified execution profile behavior for model update jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->