### PR TITLE
fix(evaluator): remove stale standalone retriever-evaluation references

### DIFF
--- a/docs/customizer/tutorials/embedding-customization-job.mdx
+++ b/docs/customizer/tutorials/embedding-customization-job.mdx
@@ -758,7 +758,7 @@ print("\nThe fine-tuned model pushes 'Random Forest' down and ranks CRF papers h
 
 **Benchmark Evaluation**
 
-For systematic evaluation, use the NeMo Evaluator service with retrieval benchmarks like SciDocs, BEIR, or MTEB. Refer to the [Evaluator documentation](/documentation/evaluate-models) for details.
+For systematic evaluation of end-to-end retrieval quality in a RAG pipeline, use the NeMo Evaluator [RAG metrics](/documentation/evaluate-models/metrics/rag-metrics) (RAGAS `context_recall`, `context_precision`, and `context_relevance`).
 
 ---
 
@@ -799,6 +799,6 @@ For detailed information on all available hyperparameters, recommended values, a
 ## Next Steps
 
 - [Monitor training metrics](/documentation/customizer-reference/manage-customization-jobs/get-job-status) in detail
-- [Evaluate your model](/documentation/evaluate-models) with retrieval benchmarks
+- [Evaluate your model](/documentation/evaluate-models/metrics/rag-metrics) with RAG metrics
 - Integrate the fine-tuned embedding model into your RAG pipeline
 - Scale up training with the full SPECTER dataset (~684K triplets) for better results

--- a/docs/evaluator/index.mdx
+++ b/docs/evaluator/index.mdx
@@ -145,10 +145,10 @@ Most teams get the best results by starting metric-first:
 
 1. **Develop and validate your metrics first**
  - Start with [Metrics](/documentation/evaluate-models/metrics) to define how quality should be scored for your use case.
- - Use live evaluation (`POST /v2/workspaces/{workspace}/evaluation/metric-evaluate`) with small `DatasetRows` payloads to iterate quickly.
+ - Iterate quickly with the SDK's local evaluation (`Evaluator.run()`) on small inline datasets—it runs in-process and returns a completed result without creating a platform job. See [SDK Resources](/documentation/evaluate-models/sdk-resources).
 
 1. **Scale metric evaluation to jobs**
- - When metrics are validated, run async metric jobs (`/evaluation/metric-jobs`) on larger datasets.
+ - When metrics are validated, run durable evaluate jobs (`POST /v2/workspaces/{workspace}/evaluate/jobs`, or `Evaluator.submit()`) on larger datasets.
  - Use filesets for production-scale inputs. See [Manage Files](/documentation/get-started/core-concepts/manage-files).
 
 1. **Monitor and analyze results**
@@ -168,8 +168,7 @@ Most teams get the best results by starting metric-first:
 
 Review configurations, data formats, and result examples for each evaluation.
 
--   **Retrieval** — Evaluate document retrieval pipelines on standard or custom datasets.
--   **RAG** — Evaluate Retrieval Augmented Generation pipelines (retrieval plus generation).
+-   **RAG** — Evaluate Retrieval Augmented Generation pipelines (retrieval plus generation), including retrieval quality via RAGAS metrics.
 -   **Agentic** — Assess agent-based and multi-step reasoning models, including topic adherence and tool use.
 -   **LLM-as-a-Judge** — Use another LLM to evaluate outputs with flexible scoring criteria. Define custom rubrics or numerical ranges.
 -   **Similarity Metrics** — Create metrics for text similarity, exact matching, and standard NLP evaluations using Jinja2 templating.

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/enums.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/enums.py
@@ -36,7 +36,6 @@ class MetricType(str, Enum):
     NOISE_SENSITIVITY = "noise_sensitivity"
 
     SYSTEM = "system"
-    SYSTEM_RETRIEVER = "system-retriever"
 
 
 class TaskStatus(str, Enum):

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/common.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/common.py
@@ -11,7 +11,6 @@ from pydantic import Field, RootModel
 class SupportedJobTypes(str, Enum):
     ONLINE = "online"
     OFFLINE = "offline"
-    RETRIEVER = "retriever"
 
 
 class SecretRef(RootModel):

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/enums.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/enums.py
@@ -36,7 +36,6 @@ class MetricType(str, Enum):
     NOISE_SENSITIVITY = "noise_sensitivity"
 
     SYSTEM = "system"
-    SYSTEM_RETRIEVER = "system-retriever"
 
 
 class TaskStatus(str, Enum):

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/common.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/common.py
@@ -11,7 +11,6 @@ from pydantic import Field, RootModel
 class SupportedJobTypes(str, Enum):
     ONLINE = "online"
     OFFLINE = "offline"
-    RETRIEVER = "retriever"
 
 
 class SecretRef(RootModel):


### PR DESCRIPTION
## What

Removes stale references to standalone **Retrieval / retriever evaluation** from published docs, and deletes the corresponding dead enum members. The 0.3 product no longer exposes a standalone retriever eval surface (no API, SDK resource, job type, or metric implementation), so the docs and leftover enums were misleading users and release QA.

## Changes

**Docs**
- `docs/evaluator/index.mdx` — drop the standalone **Retrieval** item from "Available Evaluations" (retrieval quality is covered under RAG); replace the dead `/evaluation/metric-evaluate` and `/evaluation/metric-jobs` paths in the Recommended Evaluation Journey with the real surfaces — local `Evaluator.run()` for fast iteration and durable `POST /evaluate/jobs` / `Evaluator.submit()` for scale.
- `docs/customizer/tutorials/embedding-customization-job.mdx` — the two pointers at "NeMo Evaluator with SciDocs/BEIR/MTEB retrieval benchmarks" now direct users to RAG/RAGAS metrics (`context_recall`, `context_precision`, `context_relevance`).

**Dead code**
- Remove `MetricType.SYSTEM_RETRIEVER` (`packages/nemo_evaluator_sdk/.../enums.py`) and `SupportedJobTypes.RETRIEVER` (`.../values/common.py`) — no live references anywhere in the repo.
- Re-vendored into `sdk/python/.../beta/evaluator/` via `make vendor` (not hand-edited).

## Out of scope

- Benchmark category-table docs (`discover-industry-benchmarks.mdx`) left untouched — non-navigable, deliberately descoped.
- `MetricType.SYSTEM` left in place (separate member, not requested).

## Validation

- `make docs-check` and `make docs-broken-links` — clean.
- `test_cli_metric_types_reports_sdk_metric_union_types` passes (the listing never included the dead types).
- `ruff check` clean; `ty` clean for changed files; verified zero remaining references before removal.

Fixes NVBugs 6466390 / AALGO-345


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated evaluation guidance to recommend RAGAS metrics, including context recall, context precision, and context relevance.
  * Clarified the recommended workflow: validate metrics locally with the SDK, then submit durable evaluation jobs at scale.
  * Expanded RAG evaluation guidance to include retrieval quality.
  * Updated tutorial links and next steps to direct readers to RAG metrics documentation.

* **SDK Updates**
  * Simplified system metric and supported job type terminology for clearer evaluation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->