### PR TITLE
fix(studio): Show model as subtitle in Agent Panel

### DIFF
--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/index.test.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/index.test.tsx
@@ -79,8 +79,8 @@ describe('AgentPanel', () => {
       renderPanel(MOCK_AGENT_WITH_DEPLOYMENTS);
 
       expect(
-        await screen.findByText('meta-llama-3-1-70b-instruct', {}, { timeout: 5000 })
-      ).toBeInTheDocument();
+        await screen.findAllByText('meta-llama-3-1-70b-instruct', {}, { timeout: 5000 })
+      ).toHaveLength(2);
     });
 
     it('renders a non-empty description when present', async () => {

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/index.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/index.tsx
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { AgentDeployment } from '@nemo/sdk/generated/agents/schema/AgentDeployment';
-import { Block, SegmentedControl, SidePanel } from '@nvidia/foundations-react-core';
+import { Block, SegmentedControl, SidePanel, Stack, Text } from '@nvidia/foundations-react-core';
+import type { AgentConfig } from '@studio/components/dataViews/AgentsDataView';
+import { getAgentModelNames } from '@studio/components/dataViews/AgentsDataView/utils';
 import { DeleteConfirmationModal } from '@studio/components/DeleteConfirmationModal';
 import { AgentDetailsContent } from '@studio/components/sidePanels/AgentPanels/AgentPanel/AgentDetailsContent';
 import { ChatPlaygroundContent } from '@studio/components/sidePanels/AgentPanels/AgentPanel/ChatPlaygroundContent';
@@ -72,7 +74,6 @@ export const AgentPanel: FC<AgentPanelProps> = ({
   useEffect(() => {
     setSelectedDeploymentName(undefined);
     setWalkthroughDismissed(false);
-    // Start the walkthrough only for the agent it was queued for (just created).
     setWalkthroughActive(!!agentName && isAgentWalkthroughPending(agentName));
   }, [agentName]);
 
@@ -106,6 +107,8 @@ export const AgentPanel: FC<AgentPanelProps> = ({
     setSelectedTab('chat-playground');
     onTabChange?.('chat-playground');
   };
+
+  const agentModelNames = getAgentModelNames(agent?.config as AgentConfig | undefined);
 
   let content: React.ReactNode;
 
@@ -150,7 +153,16 @@ export const AgentPanel: FC<AgentPanelProps> = ({
       <SidePanel
         open={open}
         onOpenChange={onOpenChange}
-        slotHeading={agentName}
+        slotHeading={
+          <Stack gap="1">
+            <Text kind="inherit">{agentName}</Text>
+            {agentModelNames.length > 0 && (
+              <Text kind="body/regular/sm" className="text-secondary">
+                {agentModelNames.join(', ')}
+              </Text>
+            )}
+          </Stack>
+        }
         bordered
         modal
         className="[&.nv-side-panel-content]:w-full [&.nv-side-panel-content]:max-w-[50vw] [&_.nv-side-panel-main]:gap-4 [&_.nv-side-panel-main]:p-0"


### PR DESCRIPTION

<img width="587" height="300" alt="Screenshot 2026-07-16 at 1 07 18 PM" src="https://github.com/user-attachments/assets/65764e9b-47fc-4078-84a5-84cd953cc20a" />


Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Agent panels now display the agent name along with the configured model names when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->