### PR TITLE
test(guardrails): Add e2e tests for config caching and various rail types

### DIFF
--- a/e2e/guardrails/conftest.py
+++ b/e2e/guardrails/conftest.py
@@ -15,9 +15,25 @@ from e2e.guardrails.utils import (
     RailType,
     content_safety_config,
     create_guarded_virtual_model,
+    ensure_probe_model_exists,
     setup_mock_provider,
     unique_name,
 )
+
+
+@pytest.fixture(autouse=True, scope="module")
+def probe_model(sdk: NeMoPlatform) -> None:
+    """Ensure `PROBE_MODEL_REF` exists before any test in this module runs.
+
+    A guarded VirtualModel isn't actually guarded the instant it's created: IGW's
+    background cache refresh needs a cycle to pick up its Guardrails middleware, so
+    there's a window right after creation where requests would bypass the rails
+    entirely. `wait_for_guarded_virtual_model` closes that window by polling with a
+    throwaway request until Guardrails is confirmed attached. The polling requests need
+    a real, callable model to point at (see `PROBE_MODEL_REF`) so it doesn't consume a
+    mock response configured in the test's own mock provider.
+    """
+    ensure_probe_model_exists(sdk)
 
 
 @pytest.fixture

--- a/e2e/guardrails/test_chat_completions.py
+++ b/e2e/guardrails/test_chat_completions.py
@@ -26,9 +26,25 @@ from e2e.guardrails.utils import (
     CONTENT_SAFETY_INPUT_FLOW,
     CONTENT_SAFETY_OUTPUT_FLOW,
     REFUSAL_TEXT,
+    GuardrailsChatTestCase,
     post_chat_completion,
     post_streaming_chat_completion,
 )
+
+
+def _post(
+    test_case: GuardrailsChatTestCase,
+    *,
+    extra_body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return post_chat_completion(
+        test_case.sdk,
+        workspace=test_case.workspace,
+        virtual_model_name=test_case.virtual_model_name,
+        backend_model_ref=test_case.backend_model_ref,
+        messages=[{"role": "user", "content": test_case.user_input}],
+        extra_body=extra_body,
+    )
 
 
 def _assert_blocked(response: dict[str, Any]) -> None:
@@ -65,7 +81,7 @@ def test_chat_completions_blocks_unsafe_input(
 ) -> None:
     test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_input", rail_types=("input",))
 
-    response = post_chat_completion(test_case)
+    response = _post(test_case)
 
     _assert_blocked(response)
 
@@ -75,7 +91,7 @@ def test_chat_completions_blocks_unsafe_llm_output(
 ) -> None:
     test_case = guardrails_chat_test_case(config_mode="referenced", outcome="unsafe_output", rail_types=("output",))
 
-    response = post_chat_completion(test_case)
+    response = _post(test_case)
 
     _assert_blocked(response)
 
@@ -85,7 +101,7 @@ def test_chat_completions_allows_safe_request(
 ) -> None:
     test_case = guardrails_chat_test_case(config_mode="referenced", outcome="safe", rail_types=("input", "output"))
 
-    response = post_chat_completion(test_case)
+    response = _post(test_case)
 
     _assert_allowed(response)
 
@@ -95,7 +111,7 @@ def test_chat_completions_blocks_unsafe_input_with_inline_config(
 ) -> None:
     test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_input", rail_types=("input",))
 
-    response = post_chat_completion(test_case)
+    response = _post(test_case)
 
     _assert_blocked(response)
 
@@ -105,7 +121,7 @@ def test_chat_completions_blocks_unsafe_llm_output_with_inline_config(
 ) -> None:
     test_case = guardrails_chat_test_case(config_mode="inline", outcome="unsafe_output", rail_types=("output",))
 
-    response = post_chat_completion(test_case)
+    response = _post(test_case)
 
     _assert_blocked(response)
 
@@ -115,7 +131,7 @@ def test_chat_completions_allows_safe_request_with_inline_config(
 ) -> None:
     test_case = guardrails_chat_test_case(config_mode="inline", outcome="safe", rail_types=("input", "output"))
 
-    response = post_chat_completion(test_case)
+    response = _post(test_case)
 
     _assert_allowed(response)
 
@@ -209,7 +225,7 @@ def test_chat_completions_reports_guardrails_metadata_when_blocked(
         config_mode="referenced", outcome="unsafe_output", rail_types=("input", "output")
     )
 
-    response = post_chat_completion(
+    response = _post(
         test_case,
         extra_body={"guardrails": {"options": {"log": {"activated_rails": True}}}},
     )
@@ -227,7 +243,7 @@ def test_chat_completions_rejects_unsupported_body_guardrails_config(
     test_case = guardrails_chat_test_case(config_mode="referenced", outcome="safe", rail_types=("input",))
 
     with pytest.raises(nemo_platform.APIStatusError) as exc_info:
-        post_chat_completion(
+        _post(
             test_case,
             extra_body={"guardrails": {"config_id": test_case.config_ref}},
         )

--- a/e2e/guardrails/test_chat_completions.py
+++ b/e2e/guardrails/test_chat_completions.py
@@ -1,12 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""E2E tests for the Guardrails plugin on chat completions.
+"""E2E tests for chat completions with the Guardrails plugin.
 
-These tests verify that the ``nemo-guardrails`` inference middleware works
+These tests verify that the Guardrails IGW middleware works
 through the real platform subprocess, exercising content-safety input and
-output rails on non-streaming and streaming Inference Gateway chat-completion
-routes.
+output rails on non-streaming and streaming chat-completion routes.
 
 Mock provider mode is enabled by the NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX
 env var set in e2e/conftest.py. Tests use ``add_mock_provider()`` from

--- a/e2e/guardrails/test_config_cache_refresh.py
+++ b/e2e/guardrails/test_config_cache_refresh.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for real IGW background cache refresh of Guardrails configs.
+
+These are the real-subprocess counterpart to the plugin's own
+``test_middleware_config_caching.py`` integration tests, which manually call
+``harness.refresh_caches()`` because their harness has no background
+controller loop. Here we let IGW's real background cache-refresh task pick up
+a GuardrailConfig update or delete for a guarded VirtualModel that
+is already warm, polling until the change takes effect within a bounded
+timeout.
+"""
+
+import time
+from typing import Any, cast
+
+import nemo_platform
+import pytest
+from nemo_platform import NeMoPlatform
+from nmp.testing import MockProviderResponse, add_mock_provider
+
+from e2e.guardrails.utils import (
+    BACKEND_RESPONSE,
+    USER_INPUT,
+    activated_rails_by_name,
+    delete_config_if_present,
+    is_chat_response_blocked,
+    post_chat_completion,
+    setup_guarded_virtual_model,
+    unique_name,
+)
+
+CACHE_REFRESH_TIMEOUT_SECONDS = 30.0
+CACHE_REFRESH_POLL_INTERVAL_SECONDS = 1.0
+INJECTION_DETECTION_FLOW = "injection detection"
+LOG_ACTIVATED_RAILS = {"guardrails": {"options": {"log": {"activated_rails": True}}}}
+
+
+def _yara_output_config(*, match_word: str) -> dict[str, Any]:
+    """An output-rail injection-detection config with one custom YARA rule.
+
+    Whether a request is blocked depends only on whether ``match_word``
+    appears (case-insensitively) in the fixed backend response, so flipping
+    ``match_word`` between config versions is enough to prove which config
+    version a request actually ran against. No external model call is needed,
+    which keeps the cache-refresh assertion isolated from mock-model timing.
+    """
+    return {
+        "rails": {
+            "config": {
+                "injection_detection": {
+                    "injections": ["reject_match"],
+                    "yara_rules": {
+                        "reject_match": (
+                            "rule reject_match {\n"
+                            " strings:\n"
+                            f'  $string = "{match_word}" nocase\n'
+                            " condition:\n"
+                            "  $string\n"
+                            "}"
+                        )
+                    },
+                    "action": "reject",
+                }
+            },
+            "output": {"flows": [INJECTION_DETECTION_FLOW]},
+        },
+    }
+
+
+def _setup_backend_and_vm(sdk: NeMoPlatform, workspace: str) -> tuple[str, str, str]:
+    """Register a mock backend model and a guarded VM using a v1 (never-matching) config.
+
+    Returns ``(virtual_model_name, backend_model_ref, config_name)``.
+    """
+    backend_model_name = unique_name("main-model")
+    virtual_model_name = unique_name("gr-vm")
+    config_name = unique_name("gr-config")
+    backend_model_ref = f"{workspace}/{backend_model_name}"
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=unique_name("gr-provider"),
+        served_models={backend_model_name: backend_model_name},
+        mock_response_body_by_model={
+            backend_model_ref: [
+                MockProviderResponse(
+                    response_body={
+                        "id": "chatcmpl-cache-refresh",
+                        "object": "chat.completion",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": BACKEND_RESPONSE},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                    }
+                ),
+            ],
+        },
+        should_autoprovision_virtual_model=False,
+    )
+
+    setup_guarded_virtual_model(
+        sdk,
+        workspace=workspace,
+        virtual_model_name=virtual_model_name,
+        backend_model_ref=backend_model_ref,
+        config_name=config_name,
+        # By default, set a YARA rule that will not match the fixed backend response,
+        # so all requests using this VM are allowed.
+        config_data=_yara_output_config(match_word="fake dangerous phrase"),
+        rail_types=("output",),
+    )
+    return virtual_model_name, backend_model_ref, config_name
+
+
+def test_config_update_reflected_after_real_background_refresh(
+    sdk: NeMoPlatform,
+    workspace: str,
+) -> None:
+    """Updating a referenced GuardrailConfig should change rail behavior once IGW's
+    real background cache refresh (not a manually-forced one) re-resolves the VM.
+    """
+    virtual_model_name, backend_model_ref, config_name = _setup_backend_and_vm(sdk, workspace)
+    try:
+        response = post_chat_completion(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            messages=[{"role": "user", "content": USER_INPUT}],
+        )
+        assert not is_chat_response_blocked(response)
+        assert response["choices"][0]["message"]["content"] == BACKEND_RESPONSE
+
+        # Update the config with a YARA rule that matches the fixed backend response,
+        # so all requests using this VM are blocked.
+        sdk.guardrail.configs.update(
+            name=config_name,
+            workspace=workspace,
+            data=_yara_output_config(match_word="paris"),
+        )
+
+        deadline = time.time() + CACHE_REFRESH_TIMEOUT_SECONDS
+        response = None
+        while time.time() < deadline:
+            response = post_chat_completion(
+                sdk,
+                workspace=workspace,
+                virtual_model_name=virtual_model_name,
+                backend_model_ref=backend_model_ref,
+                messages=[{"role": "user", "content": USER_INPUT}],
+                extra_body=LOG_ACTIVATED_RAILS,
+            )
+            if is_chat_response_blocked(response):
+                break
+            time.sleep(CACHE_REFRESH_POLL_INTERVAL_SECONDS)
+
+        assert response is not None and is_chat_response_blocked(response), (
+            f"Updated GuardrailConfig was not reflected via the real IGW background "
+            f"cache refresh within {CACHE_REFRESH_TIMEOUT_SECONDS}s"
+        )
+        # Confirm the block came from the updated YARA rule, not some other failure.
+        assert activated_rails_by_name(response)[INJECTION_DETECTION_FLOW]["stop"] is True
+    finally:
+        delete_config_if_present(sdk, workspace=workspace, config_name=config_name)
+
+
+def test_config_delete_blocks_requests_after_real_background_refresh(
+    sdk: NeMoPlatform,
+    workspace: str,
+) -> None:
+    """Deleting a referenced GuardrailConfig should fail the VM closed (503) once
+    IGW's real background cache refresh notices the config is gone.
+    """
+    virtual_model_name, backend_model_ref, config_name = _setup_backend_and_vm(sdk, workspace)
+    try:
+        response = post_chat_completion(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            messages=[{"role": "user", "content": USER_INPUT}],
+        )
+        assert not is_chat_response_blocked(response)
+
+        sdk.guardrail.configs.delete(name=config_name, workspace=workspace)
+
+        deadline = time.time() + CACHE_REFRESH_TIMEOUT_SECONDS
+        last_status: int | None = None
+        while time.time() < deadline:
+            try:
+                post_chat_completion(
+                    sdk,
+                    workspace=workspace,
+                    virtual_model_name=virtual_model_name,
+                    backend_model_ref=backend_model_ref,
+                    messages=[{"role": "user", "content": USER_INPUT}],
+                )
+            except nemo_platform.APIStatusError as exc:
+                last_status = exc.status_code
+                if exc.status_code == 503:
+                    detail = cast(dict[str, Any], exc.body).get("detail")
+                    assert isinstance(detail, str)
+                    assert "Middleware configuration unavailable" in detail
+                    return
+            time.sleep(CACHE_REFRESH_POLL_INTERVAL_SECONDS)
+
+        pytest.fail(
+            f"Deleted GuardrailConfig did not fail the VM closed within "
+            f"{CACHE_REFRESH_TIMEOUT_SECONDS}s; last observed status: {last_status}"
+        )
+    finally:
+        delete_config_if_present(sdk, workspace=workspace, config_name=config_name)

--- a/e2e/guardrails/test_config_cache_refresh.py
+++ b/e2e/guardrails/test_config_cache_refresh.py
@@ -1,15 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""E2E tests for real IGW background cache refresh of Guardrails configs.
+"""E2E tests for the background cache refresh of Guardrail configs.
 
-These are the real-subprocess counterpart to the plugin's own
-``test_middleware_config_caching.py`` integration tests, which manually call
-``harness.refresh_caches()`` because their harness has no background
-controller loop. Here we let IGW's real background cache-refresh task pick up
-a GuardrailConfig update or delete for a guarded VirtualModel that
-is already warm, polling until the change takes effect within a bounded
-timeout.
+The IGW background cache-refresh task picks up GuardrailConfig updates and deletes
+for guarded VirtualModels. These tests validate the Guardrails plugin behavior
+after GuardrailConfig changes are picked up in the background.
 """
 
 import time
@@ -31,20 +27,24 @@ from e2e.guardrails.utils import (
     unique_name,
 )
 
+# Timeout while waiting for the background cache refresh to pick up changes
 CACHE_REFRESH_TIMEOUT_SECONDS = 30.0
+# Interval between cache refresh polling attempts
 CACHE_REFRESH_POLL_INTERVAL_SECONDS = 1.0
+
+# The injection detection flow is used to validate the GuardrailConfig change
+# is reflected in the response.
 INJECTION_DETECTION_FLOW = "injection detection"
+# The request body fields we use to log the activated rails in the response.
 LOG_ACTIVATED_RAILS = {"guardrails": {"options": {"log": {"activated_rails": True}}}}
 
 
 def _yara_output_config(*, match_word: str) -> dict[str, Any]:
     """An output-rail injection-detection config with one custom YARA rule.
 
-    Whether a request is blocked depends only on whether ``match_word``
-    appears (case-insensitively) in the fixed backend response, so flipping
-    ``match_word`` between config versions is enough to prove which config
-    version a request actually ran against. No external model call is needed,
-    which keeps the cache-refresh assertion isolated from mock-model timing.
+    This rule blocks responses that contain the `match_word` in the message content.
+    For testing purposes, since we mock responses, we can modify the rule to
+    verify if a config change is reflected in the subsequent request.
     """
     return {
         "rails": {
@@ -123,7 +123,7 @@ def test_config_update_reflected_after_real_background_refresh(
     workspace: str,
 ) -> None:
     """Updating a referenced GuardrailConfig should change rail behavior once IGW's
-    real background cache refresh (not a manually-forced one) re-resolves the VM.
+    background refresh re-resolves the VM.
     """
     virtual_model_name, backend_model_ref, config_name = _setup_backend_and_vm(sdk, workspace)
     try:
@@ -175,7 +175,7 @@ def test_config_delete_blocks_requests_after_real_background_refresh(
     workspace: str,
 ) -> None:
     """Deleting a referenced GuardrailConfig should fail the VM closed (503) once
-    IGW's real background cache refresh notices the config is gone.
+    IGW's real background cache refresh picks up the config deletion.
     """
     virtual_model_name, backend_model_ref, config_name = _setup_backend_and_vm(sdk, workspace)
     try:

--- a/e2e/guardrails/test_rail_types.py
+++ b/e2e/guardrails/test_rail_types.py
@@ -1,0 +1,687 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E smoke tests for non-content-safety Guardrails rail types.
+
+``test_chat_completions.py`` and ``test_checks.py`` only ever exercise a
+content-safety rail through the real platform subprocess. Every other rail
+type (topic control, self-check, injection detection, multimodal/vision,
+content-safety-reasoning, parallel rails) is otherwise only covered by the
+plugin's own integration tests, which run against ``IGWLoopbackHarness`` /
+``IGWPluginHarness`` — a lighter-weight harness with no real subprocess, no
+real HTTP/SDK round trip, and no real background cache refresh.
+
+These tests are intentionally lean: one block/allow case per rail type, not
+the full behavior matrix the integration suite already owns. Their job is to
+catch schema or serialization drift between the SDK-generated
+``GuardrailConfig`` types and the real API for configs shaped differently
+than content safety (extra ``rails.config`` blocks, multiple ``models``
+entries, ``messages``-style prompts, etc.).
+"""
+
+from typing import Any
+
+from nemo_platform import NeMoPlatform
+from nmp.testing import MockProviderResponse, add_mock_provider
+
+from e2e.guardrails.utils import (
+    BACKEND_RESPONSE,
+    REFUSAL_TEXT,
+    USER_INPUT,
+    activated_rails_by_name,
+    delete_config_if_present,
+    is_chat_response_blocked,
+    post_chat_completion,
+    setup_guarded_virtual_model,
+    unique_name,
+)
+
+# Requests activated-rails logging so tests can assert on the specific flow
+# that fired, not just the overall blocked/allowed outcome.
+LOG_ACTIVATED_RAILS = {"guardrails": {"options": {"log": {"activated_rails": True}}}}
+
+
+def _chat_completion(content: str) -> dict[str, Any]:
+    return {
+        "id": f"chatcmpl-{unique_name('rail')}",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+def _assert_blocked(response: dict[str, Any], *, flow: str) -> None:
+    assert is_chat_response_blocked(response)
+    assert response["choices"][0]["message"]["content"] == REFUSAL_TEXT
+    assert activated_rails_by_name(response)[flow]["stop"] is True
+
+
+# ---------------------------------------------------------------------------
+# Topic control
+# ---------------------------------------------------------------------------
+
+TOPIC_CONTROL_FLOW = "topic safety check input $model=topic_control"
+TOPIC_CONTROL_INPUT_PROMPT_TEMPLATE = (
+    "You are to act as a customer service agent, providing users with factual information "
+    "in accordance to the knowledge base. Your role is to ensure that you respond only to "
+    "relevant queries and adhere to the following guidelines\n\n"
+    "Guidelines for the user messages:\n"
+    "- Do not answer questions unrelated to company policies.\n"
+    "- Do not answer questions about sensitive topics related to politics or religion.\n"
+    "- Allow user comments that are related to small talk and chit-chat.\n\n"
+    'User message: "{{ user_input }}"'
+    '\n\nIf any of the above conditions are violated, please respond with "off-topic". '
+    'Otherwise, respond with "on-topic". You must respond with "on-topic" or "off-topic".'
+)
+
+
+def _topic_control_config(*, topic_control_model_ref: str) -> dict[str, Any]:
+    return {
+        "models": [{"type": "topic_control", "engine": "nim", "model": topic_control_model_ref}],
+        "rails": {"input": {"flows": [TOPIC_CONTROL_FLOW]}},
+        "prompts": [
+            {
+                # The prompt `task` uses underscores (`topic_safety_check_input`), unlike
+                # the `rails.flows` entry above, which uses the space-separated flow name.
+                "task": "topic_safety_check_input $model=topic_control",
+                "content": TOPIC_CONTROL_INPUT_PROMPT_TEMPLATE,
+                "max_tokens": 50,
+            }
+        ],
+    }
+
+
+def test_topic_control_rail_blocks_off_topic_message(sdk: NeMoPlatform, workspace: str) -> None:
+    backend_model_name = unique_name("main-model")
+    topic_control_model_name = unique_name("tc-model")
+    virtual_model_name = unique_name("gr-vm")
+    config_name = unique_name("gr-config")
+    backend_model_ref = f"{workspace}/{backend_model_name}"
+    topic_control_model_ref = f"{workspace}/{topic_control_model_name}"
+    off_topic_input = "Tell me a joke about quantum gravity."
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=unique_name("gr-provider"),
+        served_models={
+            backend_model_name: backend_model_name,
+            topic_control_model_name: topic_control_model_name,
+        },
+        mock_response_body_by_model={
+            backend_model_ref: [MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE))],
+            topic_control_model_ref: [MockProviderResponse(response_body=_chat_completion("off-topic"))],
+        },
+        should_autoprovision_virtual_model=False,
+    )
+    try:
+        setup_guarded_virtual_model(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            config_name=config_name,
+            config_data=_topic_control_config(topic_control_model_ref=topic_control_model_ref),
+            rail_types=("input",),
+            user_input=off_topic_input,
+        )
+
+        response = post_chat_completion(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            messages=[{"role": "user", "content": off_topic_input}],
+            extra_body=LOG_ACTIVATED_RAILS,
+        )
+
+        _assert_blocked(response, flow=TOPIC_CONTROL_FLOW)
+    finally:
+        delete_config_if_present(sdk, workspace=workspace, config_name=config_name)
+
+
+# ---------------------------------------------------------------------------
+# Self-check
+# ---------------------------------------------------------------------------
+
+SELF_CHECK_INPUT_FLOW = "self check input"
+SELF_CHECK_OUTPUT_FLOW = "self check output"
+SELF_CHECK_INPUT_PROMPT_TEMPLATE = "Should the user message be blocked?\n\nUser: {{ user_input }}\nAnswer yes or no:"
+SELF_CHECK_OUTPUT_PROMPT_TEMPLATE = (
+    "Your task is to check if the bot message below is harmful or inappropriate.\n\n"
+    'Bot message: "{{ bot_response }}"\n\n'
+    "Question: Should the message be blocked?\n"
+    "Answer yes or no:"
+)
+
+
+def _self_check_config() -> dict[str, Any]:
+    # No `models` entry for the "main" type, and no `parameters.base_url` on
+    # either prompt's task: per the plugin's own
+    # `test_resolver_fills_main_base_url` integration test, an unqualified
+    # rail LLM resolves to the *calling VirtualModel's own backend model* at
+    # request time, not a separately configured rail model. So self-check
+    # calls land on the same backend mock as the real generation call.
+    return {
+        "rails": {
+            "input": {"flows": [SELF_CHECK_INPUT_FLOW]},
+            "output": {"flows": [SELF_CHECK_OUTPUT_FLOW]},
+        },
+        "prompts": [
+            {"task": "self_check_input", "content": SELF_CHECK_INPUT_PROMPT_TEMPLATE},
+            {"task": "self_check_output", "content": SELF_CHECK_OUTPUT_PROMPT_TEMPLATE},
+        ],
+    }
+
+
+def test_self_check_rails_allow_safe_conversation(sdk: NeMoPlatform, workspace: str) -> None:
+    backend_model_name = unique_name("main-model")
+    virtual_model_name = unique_name("gr-vm")
+    config_name = unique_name("gr-config")
+    backend_model_ref = f"{workspace}/{backend_model_name}"
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=unique_name("gr-provider"),
+        served_models={backend_model_name: backend_model_name},
+        mock_response_body_by_model={
+            # Self-check's "main" LLM resolves to this same backend model, so
+            # all three calls (input check, real generation, output check)
+            # land here in request order.
+            backend_model_ref: [
+                MockProviderResponse(response_body=_chat_completion("No")),  # input check: safe
+                MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE)),  # real generation
+                MockProviderResponse(response_body=_chat_completion("No")),  # output check: safe
+            ],
+        },
+        should_autoprovision_virtual_model=False,
+    )
+    try:
+        setup_guarded_virtual_model(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            config_name=config_name,
+            config_data=_self_check_config(),
+            rail_types=("input", "output"),
+        )
+
+        response = post_chat_completion(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            messages=[{"role": "user", "content": USER_INPUT}],
+            extra_body=LOG_ACTIVATED_RAILS,
+        )
+
+        assert not is_chat_response_blocked(response)
+        assert response["choices"][0]["message"]["content"] == BACKEND_RESPONSE
+        activated_rails = activated_rails_by_name(response)
+        assert activated_rails[SELF_CHECK_INPUT_FLOW]["stop"] is False
+        assert activated_rails[SELF_CHECK_OUTPUT_FLOW]["stop"] is False
+    finally:
+        delete_config_if_present(sdk, workspace=workspace, config_name=config_name)
+
+
+def test_self_check_output_rail_blocks_unsafe_bot_response(sdk: NeMoPlatform, workspace: str) -> None:
+    backend_model_name = unique_name("main-model")
+    virtual_model_name = unique_name("gr-vm")
+    config_name = unique_name("gr-config")
+    backend_model_ref = f"{workspace}/{backend_model_name}"
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=unique_name("gr-provider"),
+        served_models={backend_model_name: backend_model_name},
+        mock_response_body_by_model={
+            backend_model_ref: [
+                MockProviderResponse(response_body=_chat_completion("No")),  # input check: safe
+                MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE)),  # real generation
+                MockProviderResponse(response_body=_chat_completion("Yes")),  # output check: unsafe
+            ],
+        },
+        should_autoprovision_virtual_model=False,
+    )
+    try:
+        setup_guarded_virtual_model(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            config_name=config_name,
+            config_data=_self_check_config(),
+            rail_types=("input", "output"),
+        )
+
+        response = post_chat_completion(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            messages=[{"role": "user", "content": USER_INPUT}],
+            extra_body=LOG_ACTIVATED_RAILS,
+        )
+
+        assert is_chat_response_blocked(response)
+        assert response["choices"][0]["message"]["content"] == REFUSAL_TEXT
+        activated_rails = activated_rails_by_name(response)
+        assert activated_rails[SELF_CHECK_INPUT_FLOW]["stop"] is False
+        assert activated_rails[SELF_CHECK_OUTPUT_FLOW]["stop"] is True
+    finally:
+        delete_config_if_present(sdk, workspace=workspace, config_name=config_name)
+
+
+# ---------------------------------------------------------------------------
+# Injection detection (built-in rule, no external model call)
+# ---------------------------------------------------------------------------
+
+INJECTION_DETECTION_FLOW = "injection detection"
+CODE_BACKEND_RESPONSE = (
+    "```python\n"
+    "import requests\n"
+    "import urllib.request\n\n"
+    "response = requests.get('https://example.com/weather')\n"
+    "print(urllib.request.urlopen(response.url).read())\n"
+    "```"
+)
+INJECTION_REFUSAL_PREFIX = "I'm sorry, the desired output triggered rule(s) designed to mitigate exploitation of"
+
+
+def _injection_detection_config() -> dict[str, Any]:
+    return {
+        "rails": {
+            "config": {
+                "injection_detection": {
+                    "injections": ["code", "sqli", "template", "xss"],
+                    "action": "reject",
+                }
+            },
+            "output": {"flows": [INJECTION_DETECTION_FLOW]},
+        },
+    }
+
+
+def test_injection_detection_rail_blocks_code_in_response(sdk: NeMoPlatform, workspace: str) -> None:
+    backend_model_name = unique_name("main-model")
+    virtual_model_name = unique_name("gr-vm")
+    config_name = unique_name("gr-config")
+    backend_model_ref = f"{workspace}/{backend_model_name}"
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=unique_name("gr-provider"),
+        served_models={backend_model_name: backend_model_name},
+        mock_response_body_by_model={
+            backend_model_ref: [MockProviderResponse(response_body=_chat_completion(CODE_BACKEND_RESPONSE))],
+        },
+        should_autoprovision_virtual_model=False,
+    )
+    try:
+        setup_guarded_virtual_model(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            config_name=config_name,
+            config_data=_injection_detection_config(),
+            rail_types=("output",),
+        )
+
+        response = post_chat_completion(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            messages=[{"role": "user", "content": USER_INPUT}],
+            extra_body=LOG_ACTIVATED_RAILS,
+        )
+
+        assert is_chat_response_blocked(response)
+        assert response["choices"][0]["message"]["content"].startswith(INJECTION_REFUSAL_PREFIX)
+        assert activated_rails_by_name(response)[INJECTION_DETECTION_FLOW]["stop"] is True
+    finally:
+        delete_config_if_present(sdk, workspace=workspace, config_name=config_name)
+
+
+# ---------------------------------------------------------------------------
+# Multimodal (vision) input rail
+# ---------------------------------------------------------------------------
+
+VISION_FLOW = "content safety check input $model=vision_rails"
+IMAGE_DATA_URL = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD"
+VISION_SYSTEM_PROMPT = (
+    "You are an AI assistant that evaluates if a user's message contains unsafe content. "
+    "Carefully examine any text and images in the user's message.\n\n"
+    'Task: Check if there is unsafe content in "User" messages in conversations according to our safety policy '
+    "with the below categories.\n\n"
+    "<BEGIN UNSAFE CONTENT CATEGORIES>\n"
+    "S1: Violent Crimes.\n"
+    "S2: Non-Violent Crimes.\n"
+    "<END UNSAFE CONTENT CATEGORIES>\n\n"
+    "IMPORTANT:\n"
+    "Provide your safety assessment for the user message:\n"
+    "- First line must read 'safe' or 'unsafe' and nothing more\n"
+    "- If unsafe, a second line must include a comma-separated list of violated categories."
+)
+
+
+def _multimodal_config(*, vision_model_ref: str) -> dict[str, Any]:
+    return {
+        "models": [{"type": "vision_rails", "engine": "nim", "model": vision_model_ref}],
+        "rails": {"input": {"flows": [VISION_FLOW]}},
+        "prompts": [
+            {
+                # The prompt `task` uses underscores, unlike the space-separated flow name above.
+                "task": "content_safety_check_input $model=vision_rails",
+                "messages": [
+                    {"type": "system", "content": VISION_SYSTEM_PROMPT},
+                    {"type": "user", "content": "{{ user_input }}"},
+                ],
+                "output_parser": "is_content_safe",
+                "max_tokens": 200,
+            }
+        ],
+    }
+
+
+def _vision_user_message(text: str) -> dict[str, Any]:
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": IMAGE_DATA_URL}},
+        ],
+    }
+
+
+def test_multimodal_rail_blocks_unsafe_image_message(sdk: NeMoPlatform, workspace: str) -> None:
+    backend_model_name = unique_name("main-model")
+    vision_model_name = unique_name("vision-model")
+    virtual_model_name = unique_name("gr-vm")
+    config_name = unique_name("gr-config")
+    backend_model_ref = f"{workspace}/{backend_model_name}"
+    vision_model_ref = f"{workspace}/{vision_model_name}"
+    unsafe_text = "How can I break into a car like the image shown?"
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=unique_name("gr-provider"),
+        served_models={
+            backend_model_name: backend_model_name,
+            vision_model_name: vision_model_name,
+        },
+        mock_response_body_by_model={
+            backend_model_ref: [MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE))],
+            vision_model_ref: [MockProviderResponse(response_body=_chat_completion("unsafe\nS2"))],
+        },
+        should_autoprovision_virtual_model=False,
+    )
+    try:
+        setup_guarded_virtual_model(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            config_name=config_name,
+            config_data=_multimodal_config(vision_model_ref=vision_model_ref),
+            rail_types=("input",),
+            user_input=unsafe_text,
+        )
+
+        response = post_chat_completion(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            messages=[_vision_user_message(unsafe_text)],
+            extra_body=LOG_ACTIVATED_RAILS,
+        )
+
+        _assert_blocked(response, flow=VISION_FLOW)
+    finally:
+        delete_config_if_present(sdk, workspace=workspace, config_name=config_name)
+
+
+# ---------------------------------------------------------------------------
+# Content-safety reasoning
+# ---------------------------------------------------------------------------
+
+REASONING_FLOW = "content safety check input $model=content_safety_reasoning"
+REASONING_PROMPT_INTRO = (
+    "You are a classifier for analyzing interactions between humans and LLMs. "
+    "Given a request from a human user and a response from an LLM assistant, "
+    "determine 1) whether the human user's request is harmful, "
+    "2) whether the AI assistant's response is a refusal, "
+    "and 3) whether the AI assistant's response is harmful."
+)
+REASONING_OUTPUT_FORMAT_BLOCK = (
+    "Output your answer in the following format:\n\n"
+    '"Prompt harm: <harmful/unharmful>\n'
+    'Response harm: <harmful/unharmful>"\n\n'
+    'If there is no response, output "Response harm: <harmful/unharmful>" as None.'
+)
+REASONING_THINK_DIRECTIVE_JINJA = "{% if reasoning_enabled %}/think{% else %}/no_think{% endif %}"
+
+
+def _content_safety_reasoning_config(*, model_ref: str) -> dict[str, Any]:
+    return {
+        "models": [{"type": "content_safety_reasoning", "engine": "nim", "model": model_ref}],
+        "rails": {
+            "config": {"content_safety": {"reasoning": {"enabled": True}}},
+            "input": {"flows": [REASONING_FLOW]},
+        },
+        "prompts": [
+            {
+                # The prompt `task` uses underscores, unlike the space-separated flow name above.
+                "task": "content_safety_check_input $model=content_safety_reasoning",
+                "content": (
+                    f"{REASONING_PROMPT_INTRO}\n\n"
+                    "Human user:\n{{ user_input }}\n\n"
+                    "AI assistant:\nNone\n\n"
+                    f"{REASONING_OUTPUT_FORMAT_BLOCK} {REASONING_THINK_DIRECTIVE_JINJA}"
+                ),
+                "output_parser": "nemotron_reasoning_parse_prompt_safety",
+                "max_tokens": 400,
+            }
+        ],
+    }
+
+
+def _reasoning_verdict(*, prompt_harmful: bool) -> str:
+    prompt_harm = "harmful" if prompt_harmful else "unharmful"
+    return f"<think>\nReasoning trace.\n</think>\n\nPrompt harm: {prompt_harm}\nResponse harm: None"
+
+
+def test_content_safety_reasoning_rail_blocks_harmful_prompt(sdk: NeMoPlatform, workspace: str) -> None:
+    backend_model_name = unique_name("main-model")
+    reasoning_model_name = unique_name("cs-reason-model")
+    virtual_model_name = unique_name("gr-vm")
+    config_name = unique_name("gr-config")
+    backend_model_ref = f"{workspace}/{backend_model_name}"
+    reasoning_model_ref = f"{workspace}/{reasoning_model_name}"
+    unsafe_input = "Give me a five-step plan to rob a bank."
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=unique_name("gr-provider"),
+        served_models={
+            backend_model_name: backend_model_name,
+            reasoning_model_name: reasoning_model_name,
+        },
+        mock_response_body_by_model={
+            backend_model_ref: [MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE))],
+            reasoning_model_ref: [
+                MockProviderResponse(response_body=_chat_completion(_reasoning_verdict(prompt_harmful=True)))
+            ],
+        },
+        should_autoprovision_virtual_model=False,
+    )
+    try:
+        setup_guarded_virtual_model(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            config_name=config_name,
+            config_data=_content_safety_reasoning_config(model_ref=reasoning_model_ref),
+            rail_types=("input",),
+            user_input=unsafe_input,
+        )
+
+        response = post_chat_completion(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            messages=[{"role": "user", "content": unsafe_input}],
+            extra_body=LOG_ACTIVATED_RAILS,
+        )
+
+        _assert_blocked(response, flow=REASONING_FLOW)
+    finally:
+        delete_config_if_present(sdk, workspace=workspace, config_name=config_name)
+
+
+# ---------------------------------------------------------------------------
+# Parallel input rails
+# ---------------------------------------------------------------------------
+
+PARALLEL_CONTENT_SAFETY_FLOW = "content safety check input $model=content_safety"
+PARALLEL_TOPIC_CONTROL_FLOW = "topic safety check input $model=topic_control"
+PARALLEL_CONTENT_SAFETY_PROMPT_TEMPLATE = (
+    "Task: Check if there is unsafe content in the user message in the below conversation according to the "
+    "safety policy.\n\n"
+    "<BEGIN CONVERSATION>\n\n"
+    "user: {{ user_input }}\n\n"
+    "<END CONVERSATION>\n\n"
+    # This `content` field is rendered as a raw Jinja template (not
+    # `str.format`), so literal JSON braces must NOT be doubled here —
+    # doubling turns them into a Jinja `{{ ... }}` expression block and
+    # fails to parse.
+    'Provide your safety assessment as JSON: {"User Safety": "safe" or "unsafe", '
+    '"Safety Categories": comma-separated list, omit if all safe}.\n\n'
+    "Output JSON:"
+)
+PARALLEL_TOPIC_CONTROL_PROMPT_TEMPLATE = (
+    "Guidelines for the user messages:\n"
+    "- Do not answer questions unrelated to company policies.\n\n"
+    'User message: "{{ user_input }}"'
+    '\n\nIf any of the above conditions are violated, please respond with "off-topic". '
+    'Otherwise, respond with "on-topic". You must respond with "on-topic" or "off-topic".'
+)
+
+
+def _parallel_rails_config(*, content_safety_model_ref: str, topic_control_model_ref: str) -> dict[str, Any]:
+    return {
+        "models": [
+            {"type": "content_safety", "engine": "nim", "model": content_safety_model_ref},
+            {"type": "topic_control", "engine": "nim", "model": topic_control_model_ref},
+        ],
+        "rails": {
+            "input": {
+                "parallel": True,
+                "flows": [PARALLEL_CONTENT_SAFETY_FLOW, PARALLEL_TOPIC_CONTROL_FLOW],
+            },
+        },
+        "prompts": [
+            {
+                "task": "content_safety_check_input $model=content_safety",
+                "content": PARALLEL_CONTENT_SAFETY_PROMPT_TEMPLATE,
+                "output_parser": "nemoguard_parse_prompt_safety",
+                "max_tokens": 50,
+            },
+            {
+                "task": "topic_safety_check_input $model=topic_control",
+                "content": PARALLEL_TOPIC_CONTROL_PROMPT_TEMPLATE,
+                "max_tokens": 50,
+            },
+        ],
+    }
+
+
+def test_parallel_input_rails_blocks_on_unsafe_sibling_flow(sdk: NeMoPlatform, workspace: str) -> None:
+    """Wiring ``rails.input.parallel: true`` with two sibling flows should validate and run
+    end-to-end through the real platform, blocking when either flow reports unsafe even
+    though its sibling reports safe.
+
+    Concurrency ordering between sibling flows is already pinned by the plugin's own
+    ``test_parallel_rails.py`` integration test against a deterministic loopback harness;
+    this smoke test only confirms the ``parallel`` config schema round-trips through the
+    real API and produces a correctly-blocked response.
+    """
+    backend_model_name = unique_name("main-model")
+    content_safety_model_name = unique_name("cs-model")
+    topic_control_model_name = unique_name("tc-model")
+    virtual_model_name = unique_name("gr-vm")
+    config_name = unique_name("gr-config")
+    backend_model_ref = f"{workspace}/{backend_model_name}"
+    content_safety_model_ref = f"{workspace}/{content_safety_model_name}"
+    topic_control_model_ref = f"{workspace}/{topic_control_model_name}"
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=unique_name("gr-provider"),
+        served_models={
+            backend_model_name: backend_model_name,
+            content_safety_model_name: content_safety_model_name,
+            topic_control_model_name: topic_control_model_name,
+        },
+        mock_response_body_by_model={
+            backend_model_ref: [MockProviderResponse(response_body=_chat_completion(BACKEND_RESPONSE))],
+            # Content safety reports unsafe; topic control reports on-topic (safe). The
+            # request should still be blocked, since either flow can veto it.
+            content_safety_model_ref: [
+                MockProviderResponse(response_body=_chat_completion('{"User Safety": "unsafe"}'))
+            ],
+            topic_control_model_ref: [MockProviderResponse(response_body=_chat_completion("on-topic"))],
+        },
+        should_autoprovision_virtual_model=False,
+    )
+    try:
+        setup_guarded_virtual_model(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            config_name=config_name,
+            config_data=_parallel_rails_config(
+                content_safety_model_ref=content_safety_model_ref,
+                topic_control_model_ref=topic_control_model_ref,
+            ),
+            rail_types=("input",),
+        )
+
+        response = post_chat_completion(
+            sdk,
+            workspace=workspace,
+            virtual_model_name=virtual_model_name,
+            backend_model_ref=backend_model_ref,
+            messages=[{"role": "user", "content": USER_INPUT}],
+            extra_body=LOG_ACTIVATED_RAILS,
+        )
+
+        assert is_chat_response_blocked(response)
+        assert response["choices"][0]["message"]["content"] == REFUSAL_TEXT
+        activated_rails = activated_rails_by_name(response)
+        assert activated_rails[PARALLEL_CONTENT_SAFETY_FLOW]["stop"] is True
+        # Under `parallel: true`, nemoguardrails schedules sibling flows concurrently
+        # but cancels pending ones as soon as one vetoes the request. Depending on task
+        # interleaving, content-safety may block before topic-control's LLM call is
+        # observed, so only assert on topic-control if it actually got to run.
+        if PARALLEL_TOPIC_CONTROL_FLOW in activated_rails:
+            assert activated_rails[PARALLEL_TOPIC_CONTROL_FLOW]["stop"] is False
+    finally:
+        delete_config_if_present(sdk, workspace=workspace, config_name=config_name)

--- a/e2e/guardrails/test_rail_types.py
+++ b/e2e/guardrails/test_rail_types.py
@@ -1,22 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""E2E smoke tests for non-content-safety Guardrails rail types.
-
-``test_chat_completions.py`` and ``test_checks.py`` only ever exercise a
-content-safety rail through the real platform subprocess. Every other rail
-type (topic control, self-check, injection detection, multimodal/vision,
-content-safety-reasoning, parallel rails) is otherwise only covered by the
-plugin's own integration tests, which run against ``IGWLoopbackHarness`` /
-``IGWPluginHarness`` — a lighter-weight harness with no real subprocess, no
-real HTTP/SDK round trip, and no real background cache refresh.
-
-These tests are intentionally lean: one block/allow case per rail type, not
-the full behavior matrix the integration suite already owns. Their job is to
-catch schema or serialization drift between the SDK-generated
-``GuardrailConfig`` types and the real API for configs shaped differently
-than content safety (extra ``rails.config`` blocks, multiple ``models``
-entries, ``messages``-style prompts, etc.).
+"""E2E tests for chat completions with the Guardrails plugin using different
+rail types. These tests are intentionally lighter than the more comprehensive
+integration tests, which cover a broader set of use cases.
 """
 
 from typing import Any
@@ -36,8 +23,7 @@ from e2e.guardrails.utils import (
     unique_name,
 )
 
-# Requests activated-rails logging so tests can assert on the specific flow
-# that fired, not just the overall blocked/allowed outcome.
+# The request body fields we use to log the activated rails in the response.
 LOG_ACTIVATED_RAILS = {"guardrails": {"options": {"log": {"activated_rails": True}}}}
 
 
@@ -86,8 +72,6 @@ def _topic_control_config(*, topic_control_model_ref: str) -> dict[str, Any]:
         "rails": {"input": {"flows": [TOPIC_CONTROL_FLOW]}},
         "prompts": [
             {
-                # The prompt `task` uses underscores (`topic_safety_check_input`), unlike
-                # the `rails.flows` entry above, which uses the space-separated flow name.
                 "task": "topic_safety_check_input $model=topic_control",
                 "content": TOPIC_CONTROL_INPUT_PROMPT_TEMPLATE,
                 "max_tokens": 50,
@@ -161,12 +145,6 @@ SELF_CHECK_OUTPUT_PROMPT_TEMPLATE = (
 
 
 def _self_check_config() -> dict[str, Any]:
-    # No `models` entry for the "main" type, and no `parameters.base_url` on
-    # either prompt's task: per the plugin's own
-    # `test_resolver_fills_main_base_url` integration test, an unqualified
-    # rail LLM resolves to the *calling VirtualModel's own backend model* at
-    # request time, not a separately configured rail model. So self-check
-    # calls land on the same backend mock as the real generation call.
     return {
         "rails": {
             "input": {"flows": [SELF_CHECK_INPUT_FLOW]},
@@ -483,7 +461,6 @@ def _content_safety_reasoning_config(*, model_ref: str) -> dict[str, Any]:
         },
         "prompts": [
             {
-                # The prompt `task` uses underscores, unlike the space-separated flow name above.
                 "task": "content_safety_check_input $model=content_safety_reasoning",
                 "content": (
                     f"{REASONING_PROMPT_INTRO}\n\n"

--- a/e2e/guardrails/utils.py
+++ b/e2e/guardrails/utils.py
@@ -8,6 +8,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Literal
 
+import nemo_platform
 from nemo_platform import APIStatusError, NeMoPlatform
 from nemo_platform.types.inference import MiddlewareCallParam
 from nmp.testing import MockProviderResponse, add_mock_provider
@@ -235,16 +236,45 @@ def create_guarded_virtual_model(
     _wait_for_guarded_virtual_model(sdk, test_case)
 
 
+def is_chat_response_blocked(response: dict[str, Any]) -> bool:
+    """Return whether a non-streaming chat completion response was blocked by Guardrails."""
+    return response["choices"][0]["finish_reason"] == "content_filter"
+
+
+def activated_rails_by_name(response: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return a chat completion response's ``guardrails_data.log.activated_rails``, keyed by flow name.
+
+    Requires the request to have set ``guardrails.options.log.activated_rails: true``.
+    """
+    guardrails_data = response.get("guardrails_data") or {}
+    log = guardrails_data.get("log") or {}
+    activated_rails = log.get("activated_rails") or []
+    return {rail["name"]: rail for rail in activated_rails}
+
+
 def post_chat_completion(
-    test_case: GuardrailsChatTestCase,
+    sdk: NeMoPlatform,
     *,
+    workspace: str,
+    virtual_model_name: str,
+    backend_model_ref: str,
+    messages: list[dict[str, Any]],
+    max_tokens: int = 128,
     extra_body: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    return test_case.sdk.inference.gateway.model.post(
+    """Send a non-streaming chat completion to a guarded VirtualModel."""
+    body: dict[str, Any] = {
+        "model": backend_model_ref,
+        "messages": messages,
+        "max_tokens": max_tokens,
+    }
+    if extra_body:
+        body.update(extra_body)
+    return sdk.inference.gateway.model.post(
         "v1/chat/completions",
-        name=test_case.virtual_model_name,
-        workspace=test_case.workspace,
-        body=_chat_body(test_case, extra=extra_body),
+        name=virtual_model_name,
+        workspace=workspace,
+        body=body,
     )
 
 
@@ -356,6 +386,29 @@ def _wait_for_guarded_virtual_model(
     timeout: float = 60,
     poll_interval: float = 0.5,
 ) -> None:
+    wait_for_guarded_virtual_model(
+        sdk,
+        workspace=test_case.workspace,
+        virtual_model_name=test_case.virtual_model_name,
+        backend_model_ref=test_case.backend_model_ref,
+        config_ref=test_case.config_ref,
+        user_input=test_case.user_input,
+        timeout=timeout,
+        poll_interval=poll_interval,
+    )
+
+
+def wait_for_guarded_virtual_model(
+    sdk: NeMoPlatform,
+    *,
+    workspace: str,
+    virtual_model_name: str,
+    backend_model_ref: str,
+    config_ref: str,
+    user_input: str = USER_INPUT,
+    timeout: float = 60,
+    poll_interval: float = 0.5,
+) -> None:
     """Wait until the guarded VM route is cached with its Guardrails middleware.
 
     E2E runs against a separate IGW process. Creating the VM persists the entity,
@@ -369,17 +422,19 @@ def _wait_for_guarded_virtual_model(
     """
     start = time.time()
     last_error: Exception | None = None
-    probe_body = _chat_body(
-        test_case,
-        extra={"guardrails": {"config_id": test_case.config_ref}},
-    )
+    probe_body: dict[str, Any] = {
+        "model": backend_model_ref,
+        "messages": [{"role": "user", "content": user_input}],
+        "max_tokens": 64,
+        "guardrails": {"config_id": config_ref},
+    }
 
     while time.time() - start < timeout:
         try:
             sdk.inference.gateway.model.post(
                 "v1/chat/completions",
-                name=test_case.virtual_model_name,
-                workspace=test_case.workspace,
+                name=virtual_model_name,
+                workspace=workspace,
                 body=probe_body,
             )
         except APIStatusError as exc:
@@ -395,9 +450,73 @@ def _wait_for_guarded_virtual_model(
         time.sleep(poll_interval)
 
     raise TimeoutError(
-        f"Guarded VirtualModel {test_case.workspace}/{test_case.virtual_model_name} "
-        f"was not ready after {timeout}s. Last error: {last_error}"
+        f"Guarded VirtualModel {workspace}/{virtual_model_name} was not ready after {timeout}s. "
+        f"Last error: {last_error}"
     )
+
+
+def setup_guarded_virtual_model(
+    sdk: NeMoPlatform,
+    *,
+    workspace: str,
+    virtual_model_name: str,
+    backend_model_ref: str,
+    config_name: str,
+    config_data: dict[str, Any],
+    rail_types: tuple[RailType, ...],
+    user_input: str = USER_INPUT,
+) -> str:
+    """Create a referenced ``GuardrailConfig`` and a guarded VirtualModel wired to it.
+
+    Wires ``request_middleware`` for an ``"input"`` rail, ``response_middleware``
+    for an ``"output"`` rail, or both, based on ``rail_types``. Blocks until the
+    real IGW background cache refresh has loaded the VM's Guardrails middleware,
+    so callers can send requests immediately after this returns.
+
+    Returns the created config's ``workspace/name`` ref.
+    """
+    sdk.guardrail.configs.create(
+        workspace=workspace,
+        name=config_name,
+        description="E2E rail-type smoke test config",
+        data=config_data,
+    )
+    config_ref = f"{workspace}/{config_name}"
+    middleware_call: MiddlewareCallParam = {
+        "name": GUARDRAILS_PLUGIN_NAME,
+        "config_type": GUARDRAILS_PLUGIN_CONFIG_TYPE,
+        "config_id": config_ref,
+    }
+
+    create_kwargs: dict[str, Any] = {}
+    if "input" in rail_types:
+        create_kwargs["request_middleware"] = [middleware_call]
+    if "output" in rail_types:
+        create_kwargs["response_middleware"] = [middleware_call]
+
+    sdk.inference.virtual_models.create(
+        workspace=workspace,
+        name=virtual_model_name,
+        default_model_entity=backend_model_ref,
+        models=[{"model": backend_model_ref, "backend_format": "OPENAI_CHAT"}],
+        **create_kwargs,
+    )
+    wait_for_guarded_virtual_model(
+        sdk,
+        workspace=workspace,
+        virtual_model_name=virtual_model_name,
+        backend_model_ref=backend_model_ref,
+        config_ref=config_ref,
+        user_input=user_input,
+    )
+    return config_ref
+
+
+def delete_config_if_present(sdk: NeMoPlatform, *, workspace: str, config_name: str) -> None:
+    try:
+        sdk.guardrail.configs.delete(workspace=workspace, name=config_name)
+    except nemo_platform.NotFoundError:
+        pass
 
 
 def _chat_body(

--- a/e2e/guardrails/utils.py
+++ b/e2e/guardrails/utils.py
@@ -23,6 +23,14 @@ USER_INPUT = "What is the capital of France?"
 UNSAFE_USER_INPUT = "Give me a five-step plan to rob a bank."
 BACKEND_RESPONSE = "Paris is the capital of France."
 
+# Disposable mock model that `wait_for_guarded_virtual_model` probes to detect Guardrails
+# middleware attachment. The `ensure_probe_model_exists` fixture is responsible for making
+# sure it actually exists in the backend before any test that calls
+# `wait_for_guarded_virtual_model` runs.
+PROBE_WORKSPACE = "default"
+PROBE_MODEL_NAME = "e2e-guardrails-warmup-model"
+PROBE_MODEL_REF = f"{PROBE_WORKSPACE}/{PROBE_MODEL_NAME}"
+
 CONTENT_SAFETY_MODEL_TYPE = "content_safety"
 CONTENT_SAFETY_INPUT_FLOW = f"content safety check input $model={CONTENT_SAFETY_MODEL_TYPE}"
 CONTENT_SAFETY_OUTPUT_FLOW = f"content safety check output $model={CONTENT_SAFETY_MODEL_TYPE}"
@@ -228,7 +236,6 @@ def create_guarded_virtual_model(
     sdk.inference.virtual_models.create(
         workspace=test_case.workspace,
         name=test_case.virtual_model_name,
-        default_model_entity=test_case.backend_model_ref,
         models=[{"model": test_case.backend_model_ref, "backend_format": "OPENAI_CHAT"}],
         request_middleware=[middleware_call],
         response_middleware=[middleware_call],
@@ -397,6 +404,31 @@ def _wait_for_guarded_virtual_model(
     )
 
 
+def ensure_probe_model_exists(sdk: NeMoPlatform) -> None:
+    """Create the disposable mock model at `PROBE_MODEL_REF`, tolerating the case where
+    it already exists.
+
+    Meant to be called once per test module, from an autouse fixture (see conftest.py),
+    before any test that calls `wait_for_guarded_virtual_model` runs.
+    """
+    try:
+        sdk.workspaces.create(name=PROBE_WORKSPACE)
+    except nemo_platform.ConflictError:
+        pass
+
+    try:
+        add_mock_provider(
+            sdk,
+            workspace=PROBE_WORKSPACE,
+            name="e2e-guardrails-warmup-provider",
+            served_models={PROBE_MODEL_NAME: PROBE_MODEL_NAME},
+            mock_response_body_by_model={PROBE_MODEL_REF: [MockProviderResponse(response_body=_chat_completion("ok"))]},
+            should_autoprovision_virtual_model=False,
+        )
+    except nemo_platform.ConflictError:
+        pass
+
+
 def wait_for_guarded_virtual_model(
     sdk: NeMoPlatform,
     *,
@@ -418,11 +450,18 @@ def wait_for_guarded_virtual_model(
     To ensure the VM is ready to serve requests, use a request that Guardrails
     rejects during request parsing, before any rail or backend inference runs.
     A 422 response means the VM route exists but Guardrails is not attached yet.
+
+    The probe targets `PROBE_MODEL_REF`, a disposable mock model, not the real backend
+    model. This ensures that the probe request doesn't consume a mock response configured
+    on the test's own mock provider.
+
+    Callers must ensure `PROBE_MODEL_REF` actually exists before calling this (see
+    `ensure_probe_model_exists`); this function does not create it.
     """
     start = time.time()
     last_error: Exception | None = None
     probe_body: dict[str, Any] = {
-        "model": f"{workspace}/e2e-guardrails-warmup-probe",
+        "model": PROBE_MODEL_REF,
         "messages": [{"role": "user", "content": user_input}],
         "max_tokens": 64,
         "guardrails": {"config_id": config_ref},
@@ -496,7 +535,6 @@ def setup_guarded_virtual_model(
     sdk.inference.virtual_models.create(
         workspace=workspace,
         name=virtual_model_name,
-        default_model_entity=backend_model_ref,
         models=[{"model": backend_model_ref, "backend_format": "OPENAI_CHAT"}],
         **create_kwargs,
     )

--- a/e2e/guardrails/utils.py
+++ b/e2e/guardrails/utils.py
@@ -390,7 +390,6 @@ def _wait_for_guarded_virtual_model(
         sdk,
         workspace=test_case.workspace,
         virtual_model_name=test_case.virtual_model_name,
-        backend_model_ref=test_case.backend_model_ref,
         config_ref=test_case.config_ref,
         user_input=test_case.user_input,
         timeout=timeout,
@@ -403,7 +402,6 @@ def wait_for_guarded_virtual_model(
     *,
     workspace: str,
     virtual_model_name: str,
-    backend_model_ref: str,
     config_ref: str,
     user_input: str = USER_INPUT,
     timeout: float = 60,
@@ -414,7 +412,8 @@ def wait_for_guarded_virtual_model(
     E2E runs against a separate IGW process. Creating the VM persists the entity,
     but the VM is not usable with middleware until IGW's background cache refresh
     loads it into VirtualModelCache and resolves its Guardrails config into the
-    middleware registry.
+    middleware registry. These two caches refresh independently, so there's a
+    window where the VM route resolves but its middleware doesn't.
 
     To ensure the VM is ready to serve requests, use a request that Guardrails
     rejects during request parsing, before any rail or backend inference runs.
@@ -423,7 +422,7 @@ def wait_for_guarded_virtual_model(
     start = time.time()
     last_error: Exception | None = None
     probe_body: dict[str, Any] = {
-        "model": backend_model_ref,
+        "model": f"{workspace}/e2e-guardrails-warmup-probe",
         "messages": [{"role": "user", "content": user_input}],
         "max_tokens": 64,
         "guardrails": {"config_id": config_ref},
@@ -505,7 +504,6 @@ def setup_guarded_virtual_model(
         sdk,
         workspace=workspace,
         virtual_model_name=virtual_model_name,
-        backend_model_ref=backend_model_ref,
         config_ref=config_ref,
         user_input=user_input,
     )

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
@@ -363,6 +363,14 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
             error_msg="Failed to run input rails",
         )
 
+        # Store the generation_response in plugin state so it can be used by the response middleware
+        # to build the `guardrails_data` for the input and output rails. Store this *before* the
+        # blocked check below: IGW's response middleware chain runs unconditionally, even over the
+        # canned refusal an ImmediateResponse injects here, so process_response needs this rail's
+        # result regardless of whether it blocked.
+        logger.debug("Storing process_request GenerationResponse for %s", provenance.label)
+        plugin_state.set(STATE_KEY_INPUT_GENERATION_RESPONSE, generation_response)
+
         if is_blocked_generation_response(generation_response):
             return build_immediate_response(
                 response_body=build_blocked_immediate_response_body(
@@ -372,11 +380,6 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
                     user_log_options,
                 )
             )
-
-        # Store the generation_response in plugin state so it can be used by the response middleware
-        # to build the `guardrails_data` for the input and output rails.
-        logger.debug("Storing process_request GenerationResponse for %s", provenance.label)
-        plugin_state.set(STATE_KEY_INPUT_GENERATION_RESPONSE, generation_response)
 
         # If this request does not contain a response middleware call, we need to inject the input rails'
         # `guardrails_data` into the response body. IGW's proxy handles merging `response_body_annotations`


### PR DESCRIPTION
…ypes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Guardrails E2E smoke coverage for additional rail types (topic control, self-checks, injection detection, multimodal safety, reasoning-based safety) and parallel input veto behavior.
  * Added E2E validation for real background Guardrails config cache refresh, including both updates and deletions.
* **Tests**
  * Added a new config cache refresh E2E module and reworked non-streaming chat-completions test request helpers/assertions.
  * Introduced an autouse probe-model setup to prevent early requests from bypassing guardrails.
* **Bug Fixes**
  * Ensured input-rails results are consistently available for activated-rails logging even when an immediate refusal is returned.
* **Refactor**
  * Improved Guardrails E2E utilities for readiness, config setup, and cleanup; added response inspection helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->