### PR TITLE
fix(evaluator): normalize Docker Codex evidence permissions

### DIFF
--- a/packages/nemo_evaluator_sdk/examples/codex_docker/example.py
+++ b/packages/nemo_evaluator_sdk/examples/codex_docker/example.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run an agent evaluation through the Docker Codex CLI evidence path.
+
+Prerequisites:
+
+* Docker is installed and the daemon is running.
+* ``codex login`` has created ``~/.codex/auth.json``. Set ``CODEX_AUTH_PATH``
+  when the auth file lives elsewhere.
+
+Run from the repository root with::
+
+    uv run python packages/nemo_evaluator_sdk/examples/codex_docker/example.py
+
+Run bundles are stored under ``temp/codex-docker-eval-output`` by default.
+Set ``CODEX_DOCKER_EVAL_OUTPUT_ROOT`` to use a different location.
+
+The example deliberately reads a nested file through the trial's ``workspace``
+evidence descriptor. A successful score therefore exercises the Docker bind mount,
+post-run ownership/permission normalization, private-tree validation, final-output
+publication, and metric-side filesystem evidence access.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import stat
+from datetime import UTC, datetime
+from pathlib import Path
+
+from nemo_evaluator_sdk import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
+from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
+from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
+from nemo_evaluator_sdk.agent_eval.runtimes.codex.runtime import CodexDockerCliAgentRuntime
+from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+from nemo_evaluator_sdk.agent_eval.trials import AgentTaskRunner
+
+EXPECTED_TEXT = "codex docker evidence works"
+ARTIFACT_PATH = "sanity/result.txt"
+CODEX_AUTH_PATH_ENV_NAME = "CODEX_AUTH_PATH"
+CODEX_MODEL_ENV_NAME = "CODEX_MODEL"
+OUTPUT_ROOT_ENV_NAME = "CODEX_DOCKER_EVAL_OUTPUT_ROOT"
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+class WorkspaceArtifactMetric:
+    """Score the final response and a file read through workspace evidence."""
+
+    @property
+    def type(self) -> str:
+        return "workspace_artifact"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [
+            MetricOutputSpec.boolean("output_matches"),
+            MetricOutputSpec.boolean("artifact_matches"),
+        ]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        reference = input.row.data.get("reference", {})
+        expected = reference.get("expected") if isinstance(reference, dict) else None
+        artifact_path = reference.get("artifact_path") if isinstance(reference, dict) else None
+
+        output_matches = (
+            isinstance(expected, str)
+            and input.candidate.output_text is not None
+            and input.candidate.output_text.strip() == expected
+        )
+
+        artifact_matches = False
+        evidence = input.candidate.evidence
+        if evidence is not None and isinstance(expected, str) and isinstance(artifact_path, str):
+            try:
+                workspace = await evidence.filesystem("workspace")
+                artifact_matches = (await workspace.read_text(artifact_path)).strip() == expected
+            except (KeyError, OSError, ValueError):
+                artifact_matches = False
+
+        return MetricResult(
+            outputs=[
+                MetricOutput(name="output_matches", value=output_matches),
+                MetricOutput(name="artifact_matches", value=artifact_matches),
+            ]
+        )
+
+
+def _new_output_dir() -> Path:
+    default_root = REPO_ROOT / "temp" / "codex-docker-eval-output"
+    output_root = Path(os.getenv(OUTPUT_ROOT_ENV_NAME, str(default_root))).expanduser()
+    timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    return output_root / timestamp
+
+
+def _docker_runtime(output_dir: Path) -> CodexDockerCliAgentRuntime:
+    auth_path = os.getenv(CODEX_AUTH_PATH_ENV_NAME)
+    model = os.getenv(CODEX_MODEL_ENV_NAME)
+    return CodexDockerCliAgentRuntime(
+        model=model or None,
+        work_root=output_dir / "evidence" / "codex-docker",
+        auth_path=auth_path or None,
+    )
+
+
+async def evaluate(
+    *,
+    output_dir: str | Path | None = None,
+    runtime: AgentTaskRunner | None = None,
+    write_dashboard: bool = True,
+) -> AgentEvalResult:
+    """Run one Docker Codex task and score its host-readable workspace evidence."""
+    resolved_output_dir = Path(output_dir).expanduser() if output_dir is not None else _new_output_dir()
+    target = runtime or _docker_runtime(resolved_output_dir)
+
+    task = AgentEvalTask(
+        id="codex-docker-evidence",
+        intent="Create a nested artifact that remains private and host-readable after Docker exits.",
+        inputs={
+            "instruction": (
+                f"Create the directory {Path(ARTIFACT_PATH).parent.as_posix()} in the workspace. "
+                f"Write exactly '{EXPECTED_TEXT}' followed by a newline to {ARTIFACT_PATH}. "
+                f"Then reply with exactly: {EXPECTED_TEXT}"
+            )
+        },
+        reference={"artifact_path": ARTIFACT_PATH, "expected": EXPECTED_TEXT},
+        metrics=[WorkspaceArtifactMetric()],
+    )
+
+    return await AgentEvaluator().run(
+        tasks=[task],
+        target=target,
+        config=AgentEvalRunConfig(
+            output_dir=resolved_output_dir,
+            parallelism=1,
+            write_dashboard=write_dashboard,
+            benchmark={"name": "codex-docker-evidence-sanity"},
+        ),
+    )
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+    result = await evaluate()
+
+    trial = result.trials[0]
+    if trial.output is None or trial.evidence is None:
+        raise RuntimeError(f"Docker Codex trial failed: {trial.metadata}")
+
+    workspace = await trial.evidence.filesystem("workspace")
+    artifact = workspace.path(ARTIFACT_PATH)
+    artifact_stat = artifact.stat()
+    scores = {f"{score.metric_type}.{output.name}": output.value for score in result.scores for output in score.outputs}
+
+    print(f"response: {trial.output.output_text}")
+    print(f"artifact: {artifact}")
+    print(f"artifact contents: {artifact.read_text(encoding='utf-8').strip()}")
+    print(f"artifact uid: {artifact_stat.st_uid} (host uid: {os.getuid()})")
+    print(f"artifact mode: {stat.S_IMODE(artifact_stat.st_mode):04o}")
+    print(f"workspace_artifact.output_matches: {scores['workspace_artifact.output_matches']}")
+    print(f"workspace_artifact.artifact_matches: {scores['workspace_artifact.artifact_matches']}")
+    print(f"run bundle: {result.output_dir}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/nemo_evaluator_sdk/examples/codex_docker/example.py
+++ b/packages/nemo_evaluator_sdk/examples/codex_docker/example.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import stat
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -150,14 +149,11 @@ async def main() -> None:
 
     workspace = await trial.evidence.filesystem("workspace")
     artifact = workspace.path(ARTIFACT_PATH)
-    artifact_stat = artifact.stat()
     scores = {f"{score.metric_type}.{output.name}": output.value for score in result.scores for output in score.outputs}
 
     print(f"response: {trial.output.output_text}")
     print(f"artifact: {artifact}")
     print(f"artifact contents: {artifact.read_text(encoding='utf-8').strip()}")
-    print(f"artifact uid: {artifact_stat.st_uid} (host uid: {os.getuid()})")
-    print(f"artifact mode: {stat.S_IMODE(artifact_stat.st_mode):04o}")
     print(f"workspace_artifact.output_matches: {scores['workspace_artifact.output_matches']}")
     print(f"workspace_artifact.artifact_matches: {scores['workspace_artifact.artifact_matches']}")
     print(f"run bundle: {result.output_dir}")

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/codex/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/codex/runtime.py
@@ -3,6 +3,8 @@
 
 """Codex-backed agent-eval runtimes."""
 
+# ruff: noqa: I001, T201 - the vendored SDK mirror uses different import-order and print settings.
+
 from __future__ import annotations
 
 import asyncio

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/codex/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/codex/runtime.py
@@ -289,11 +289,26 @@ class CodexDockerCliAgentRuntime(CodexCliAgentRuntime):
         if self._model is not None:
             inner_command.extend(["--model", self._model])
         inner_command.append("-")
+        # Codex intentionally runs as root: the container mounts its auth under /root and coding tasks
+        # may need to install tools. Repair the bind-mounted trees before Docker returns so the host can
+        # score and persist every artifact the agent created. Keep the Codex failure authoritative; only
+        # surface the chmod status when Codex itself succeeded.
+        shell_command = (
+            f"{shlex.join(inner_command)}; "
+            "codex_status=$?; "
+            f"chown -R {os.getuid()}:{os.getgid()} /workspace /evidence 2>/dev/null || true; "
+            "chmod -R u+rwX,go+rX /workspace /evidence; "
+            "permissions_status=$?; "
+            'if [ "$codex_status" -ne 0 ]; then exit "$codex_status"; fi; '
+            'exit "$permissions_status"'
+        )
         return [
             self._docker_bin,
             "run",
             "--rm",
             "-i",
+            "-e",
+            "PYTHONDONTWRITEBYTECODE=1",
             "-v",
             f"{self._auth_path.resolve()}:/root/.codex/auth.json:ro",
             "-v",
@@ -303,7 +318,7 @@ class CodexDockerCliAgentRuntime(CodexCliAgentRuntime):
             self._image,
             "sh",
             "-lc",
-            shlex.join(inner_command),
+            shell_command,
         ]
 
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/codex/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/codex/runtime.py
@@ -13,7 +13,9 @@ import json
 import os
 import shlex
 import shutil
+import stat
 import subprocess
+import tempfile
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from enum import StrEnum
 from pathlib import Path
@@ -94,8 +96,16 @@ class CodexCliAgentRuntime:
     async def _run_task(self, index: int, task: AgentEvalTask, config: AgentEvalRunConfig) -> AgentEvalTrial:
         evidence_dir = self._evidence_dir(index, task, config)
         workspace_dir = evidence_dir / "workspace"
-        evidence_dir.mkdir(parents=True, exist_ok=True)
-        workspace_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            # The task directory is mounted into Docker, but its private parent is not. Keeping that
+            # parent host-owned and 0700 preserves the local confidentiality boundary even when a
+            # container is interrupted before its recursive cleanup completes.
+            _ensure_private_directory(evidence_dir.parent)
+            _ensure_private_directory(evidence_dir)
+            _ensure_private_directory(workspace_dir)
+        except Exception as exc:
+            return _failed_codex_trial(task, evidence_dir, exc, runtime_name=self._runtime_name)
 
         prompt_path = evidence_dir / "prompt.txt"
         task_path = evidence_dir / "task.json"
@@ -107,7 +117,10 @@ class CodexCliAgentRuntime:
         # this evidence dir into the sandbox (danger-full-access), so serializing `intent` (desired
         # behavior) or `reference` (held-out ground truth) here would let the agent read them back out
         # of `/evidence/task.json` — the same reward-hacking leak the intent-free prompt closes.
-        task_path.write_text(task.model_dump_json(indent=2, exclude={"intent", "reference"}), encoding="utf-8")
+        try:
+            _write_private_text(task_path, task.model_dump_json(indent=2, exclude={"intent", "reference"}))
+        except Exception as exc:
+            return _failed_codex_trial(task, evidence_dir, exc, runtime_name=self._runtime_name)
 
         command = self._command(workspace_dir=workspace_dir, final_output_path=final_output_path)
         process: Any | None = None
@@ -120,13 +133,15 @@ class CodexCliAgentRuntime:
             # Build the prompt after seeding and inside the guarded block: an instruction-less task
             # raises here, failing just this task instead of aborting the run (and seeding wins if both).
             prompt = self._prompt_builder(task)
-            prompt_path.write_text(prompt, encoding="utf-8")
+            _write_private_text(prompt_path, prompt)
             process = await self._process_factory(
                 *command,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
+            if process is None:
+                raise RuntimeError("process factory failed to create a process")
             stdout, stderr = await asyncio.wait_for(
                 process.communicate(prompt.encode("utf-8")),
                 timeout=self._timeout_s,
@@ -139,8 +154,18 @@ class CodexCliAgentRuntime:
 
         stdout_text = _decode_process_output(stdout)
         stderr_text = _decode_process_output(stderr)
-        stdout_path.write_text(stdout_text, encoding="utf-8")
-        stderr_path.write_text(stderr_text, encoding="utf-8")
+        artifact_persistence_error: str | None = None
+        try:
+            _write_private_text(stdout_path, stdout_text)
+            _write_private_text(stderr_path, stderr_text)
+        except Exception as exc:
+            artifact_persistence_error = f"{exc.__class__.__name__}: {exc}"
+
+        permission_cleanup_error: str | None = None
+        try:
+            self._validate_artifact_permissions(evidence_dir)
+        except Exception as exc:
+            permission_cleanup_error = f"{exc.__class__.__name__}: {exc}"
 
         if process.returncode != 0:
             return _failed_codex_trial(
@@ -148,13 +173,36 @@ class CodexCliAgentRuntime:
                 evidence_dir,
                 RuntimeError(f"codex exec exited with status {process.returncode}: {stderr_text.strip()}"),
                 runtime_name=self._runtime_name,
+                permission_cleanup_error=permission_cleanup_error,
+                artifact_persistence_error=artifact_persistence_error,
             )
 
-        if final_output_path.exists():
-            output_text = final_output_path.read_text(encoding="utf-8")
-        else:
-            output_text = stdout_text
-            final_output_path.write_text(output_text, encoding="utf-8")
+        if artifact_persistence_error is not None:
+            return _failed_codex_trial(
+                task,
+                evidence_dir,
+                RuntimeError(f"failed to persist Codex evidence: {artifact_persistence_error}"),
+                runtime_name=self._runtime_name,
+                permission_cleanup_error=permission_cleanup_error,
+                artifact_persistence_error=artifact_persistence_error,
+            )
+        if permission_cleanup_error is not None:
+            return _failed_codex_trial(
+                task,
+                evidence_dir,
+                PermissionError(f"Codex evidence permission normalization failed: {permission_cleanup_error}"),
+                runtime_name=self._runtime_name,
+                permission_cleanup_error=permission_cleanup_error,
+            )
+
+        try:
+            if final_output_path.exists():
+                output_text = final_output_path.read_text(encoding="utf-8")
+            else:
+                output_text = stdout_text
+                _write_private_text(final_output_path, output_text)
+        except Exception as exc:
+            return _failed_codex_trial(task, evidence_dir, exc, runtime_name=self._runtime_name)
         return AgentEvalTrial(
             id=f"{task.id}:codex",
             task_id=task.id,
@@ -208,6 +256,9 @@ class CodexCliAgentRuntime:
             command.extend(["--model", self._model])
         command.append("-")
         return command
+
+    def _validate_artifact_permissions(self, evidence_dir: Path) -> None:
+        """Validate runtime-specific artifact postconditions after the process exits."""
 
     def _evidence_dir(self, index: int, task: AgentEvalTask, config: AgentEvalRunConfig) -> Path:
         root = self._work_root
@@ -293,13 +344,18 @@ class CodexDockerCliAgentRuntime(CodexCliAgentRuntime):
         inner_command.append("-")
         # Codex intentionally runs as root: the container mounts its auth under /root and coding tasks
         # may need to install tools. Repair the bind-mounted trees before Docker returns so the host can
-        # score and persist every artifact the agent created. Keep the Codex failure authoritative; only
-        # surface the chmod status when Codex itself succeeded.
+        # score and persist every artifact the agent created without widening access to other host users.
+        # Capture the bind mount's owner as seen inside this container before Codex runs: raw host UID/GID
+        # values are not portable across Docker Desktop and rootless user-namespace mappings. Keep Codex
+        # failures authoritative; only surface the required chmod status when Codex itself succeeded.
         shell_command = (
+            "host_owner=\"$(stat -c '%u:%g' /evidence 2>/dev/null)\" || true; "
             f"{shlex.join(inner_command)}; "
             "codex_status=$?; "
-            f"chown -R {os.getuid()}:{os.getgid()} /workspace /evidence 2>/dev/null || true; "
-            "chmod -R u+rwX,go+rX /workspace /evidence; "
+            'if [ -n "$host_owner" ]; then '
+            'chown -R "$host_owner" /workspace /evidence 2>/dev/null || true; '
+            "fi; "
+            "chmod -R u+rwX,go-rwx /workspace /evidence; "
             "permissions_status=$?; "
             'if [ "$codex_status" -ne 0 ]; then exit "$codex_status"; fi; '
             'exit "$permissions_status"'
@@ -322,6 +378,9 @@ class CodexDockerCliAgentRuntime(CodexCliAgentRuntime):
             "-lc",
             shell_command,
         ]
+
+    def _validate_artifact_permissions(self, evidence_dir: Path) -> None:
+        _validate_private_tree(evidence_dir)
 
 
 def resolve_codex_runtime(
@@ -415,28 +474,95 @@ def _failed_codex_trial(
     exc: Exception,
     *,
     runtime_name: str = "codex_cli",
+    permission_cleanup_error: str | None = None,
+    artifact_persistence_error: str | None = None,
 ) -> AgentEvalTrial:
     error_path = evidence_dir / "error.json"
-    error_path.write_text(
-        json.dumps({"error_type": exc.__class__.__name__, "error": str(exc)}) + "\n", encoding="utf-8"
-    )
+    evidence: CandidateEvidence | None = None
+    error_artifact_error: str | None = None
+    try:
+        _write_private_text(error_path, json.dumps({"error_type": exc.__class__.__name__, "error": str(exc)}) + "\n")
+    except Exception as artifact_exc:
+        error_artifact_error = f"{artifact_exc.__class__.__name__}: {artifact_exc}"
+    else:
+        evidence = CandidateEvidence(
+            descriptors={"error": EvidenceDescriptor(kind="error", format="json", ref=str(error_path))},
+            metadata={"runtime": runtime_name, "agent": "codex"},
+        )
+
+    metadata: dict[str, Any] = {
+        "runtime": runtime_name,
+        "agent": "codex",
+        "agent_ok": False,
+        "error_type": exc.__class__.__name__,
+        "error": str(exc),
+    }
+    if permission_cleanup_error is not None:
+        metadata["permission_cleanup_error"] = permission_cleanup_error
+    if artifact_persistence_error is not None:
+        metadata["artifact_persistence_error"] = artifact_persistence_error
+    if error_artifact_error is not None:
+        metadata["error_artifact_error"] = error_artifact_error
     return AgentEvalTrial(
         id=f"{task.id}:codex",
         task_id=task.id,
         status=AgentEvalTrialStatus.FAILED,
         output=None,
-        evidence=CandidateEvidence(
-            descriptors={"error": EvidenceDescriptor(kind="error", format="json", ref=str(error_path))},
-            metadata={"runtime": runtime_name, "agent": "codex"},
-        ),
-        metadata={
-            "runtime": runtime_name,
-            "agent": "codex",
-            "agent_ok": False,
-            "error_type": exc.__class__.__name__,
-            "error": str(exc),
-        },
+        evidence=evidence,
+        metadata=metadata,
     )
+
+
+def _ensure_private_directory(path: Path) -> None:
+    """Create or repair a host-owned directory without following a leaf symlink."""
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        path_stat = os.fstat(descriptor)
+        if path_stat.st_uid != os.getuid():
+            raise PermissionError(f"directory is not owned by the invoking host user: {path}")
+        os.fchmod(descriptor, 0o700)
+    finally:
+        os.close(descriptor)
+
+
+def _write_private_text(path: Path, content: str) -> None:
+    """Atomically publish a host-created evidence artifact with owner-only access."""
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as temporary_file:
+            temporary_file.write(content)
+        os.replace(temporary_path, path)
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(descriptor)
+        temporary_path.unlink(missing_ok=True)
+
+
+def _validate_private_tree(root: Path) -> None:
+    """Require a host-owned, owner-only tree without following agent-created symlinks."""
+    expected_uid = os.getuid()
+    pending = [root]
+    while pending:
+        path = pending.pop()
+        path_stat = path.lstat()
+        if stat.S_ISLNK(path_stat.st_mode):
+            continue
+        if path_stat.st_uid != expected_uid:
+            raise PermissionError(f"artifact is not owned by the invoking host user: {path}")
+
+        mode = stat.S_IMODE(path_stat.st_mode)
+        if mode & 0o077:
+            raise PermissionError(f"artifact grants group or other access: {path} ({mode:o})")
+        if stat.S_ISDIR(path_stat.st_mode):
+            if mode & 0o700 != 0o700:
+                raise PermissionError(f"directory is not owner-readable, writable, and traversable: {path} ({mode:o})")
+            with os.scandir(path) as entries:
+                pending.extend(Path(entry.path) for entry in entries)
+        elif mode & 0o600 != 0o600:
+            raise PermissionError(f"file is not owner-readable and writable: {path} ({mode:o})")
 
 
 async def _terminate_process(process: Any | None) -> None:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/codex/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/codex/runtime.py
@@ -196,11 +196,7 @@ class CodexCliAgentRuntime:
             )
 
         try:
-            if final_output_path.exists():
-                output_text = final_output_path.read_text(encoding="utf-8")
-            else:
-                output_text = stdout_text
-                _write_private_text(final_output_path, output_text)
+            output_text = _read_private_final_output(final_output_path, fallback=stdout_text)
         except Exception as exc:
             return _failed_codex_trial(task, evidence_dir, exc, runtime_name=self._runtime_name)
         return AgentEvalTrial(
@@ -541,6 +537,28 @@ def _write_private_text(path: Path, content: str) -> None:
         temporary_path.unlink(missing_ok=True)
 
 
+def _read_private_final_output(path: Path, *, fallback: str) -> str:
+    """Read a regular agent-created final output without following it, then republish it privately."""
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    except FileNotFoundError:
+        _write_private_text(path, fallback)
+        return fallback
+
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise PermissionError(f"final output is not a regular file: {path}")
+        with os.fdopen(descriptor, "r", encoding="utf-8") as output_file:
+            descriptor = -1
+            output_text = output_file.read()
+    finally:
+        if descriptor != -1:
+            os.close(descriptor)
+
+    _write_private_text(path, output_text)
+    return output_text
+
+
 def _validate_private_tree(root: Path) -> None:
     """Require a host-owned, owner-only tree without following agent-created symlinks."""
     expected_uid = os.getuid()
@@ -561,8 +579,11 @@ def _validate_private_tree(root: Path) -> None:
                 raise PermissionError(f"directory is not owner-readable, writable, and traversable: {path} ({mode:o})")
             with os.scandir(path) as entries:
                 pending.extend(Path(entry.path) for entry in entries)
-        elif mode & 0o600 != 0o600:
-            raise PermissionError(f"file is not owner-readable and writable: {path} ({mode:o})")
+        elif stat.S_ISREG(path_stat.st_mode):
+            if mode & 0o600 != 0o600:
+                raise PermissionError(f"file is not owner-readable and writable: {path} ({mode:o})")
+        else:
+            raise PermissionError(f"artifact is not a regular file or directory: {path}")
 
 
 async def _terminate_process(process: Any | None) -> None:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/codex/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/codex/runtime.py
@@ -105,7 +105,9 @@ class CodexCliAgentRuntime:
             _ensure_private_directory(evidence_dir)
             _ensure_private_directory(workspace_dir)
         except Exception as exc:
-            return _failed_codex_trial(task, evidence_dir, exc, runtime_name=self._runtime_name)
+            # The path that failed setup is not safe to use for artifact persistence. In particular,
+            # writing through a rejected evidence-directory symlink would escape the private tree.
+            return _failed_codex_trial(task, None, exc, runtime_name=self._runtime_name)
 
         prompt_path = evidence_dir / "prompt.txt"
         task_path = evidence_dir / "task.json"
@@ -466,25 +468,28 @@ def print_codex_agent_models(*, codex_bin: str = "codex") -> None:
 
 def _failed_codex_trial(
     task: AgentEvalTask,
-    evidence_dir: Path,
+    evidence_dir: Path | None,
     exc: Exception,
     *,
     runtime_name: str = "codex_cli",
     permission_cleanup_error: str | None = None,
     artifact_persistence_error: str | None = None,
 ) -> AgentEvalTrial:
-    error_path = evidence_dir / "error.json"
     evidence: CandidateEvidence | None = None
     error_artifact_error: str | None = None
-    try:
-        _write_private_text(error_path, json.dumps({"error_type": exc.__class__.__name__, "error": str(exc)}) + "\n")
-    except Exception as artifact_exc:
-        error_artifact_error = f"{artifact_exc.__class__.__name__}: {artifact_exc}"
-    else:
-        evidence = CandidateEvidence(
-            descriptors={"error": EvidenceDescriptor(kind="error", format="json", ref=str(error_path))},
-            metadata={"runtime": runtime_name, "agent": "codex"},
-        )
+    if evidence_dir is not None:
+        error_path = evidence_dir / "error.json"
+        try:
+            _write_private_text(
+                error_path, json.dumps({"error_type": exc.__class__.__name__, "error": str(exc)}) + "\n"
+            )
+        except Exception as artifact_exc:
+            error_artifact_error = f"{artifact_exc.__class__.__name__}: {artifact_exc}"
+        else:
+            evidence = CandidateEvidence(
+                descriptors={"error": EvidenceDescriptor(kind="error", format="json", ref=str(error_path))},
+                metadata={"runtime": runtime_name, "agent": "codex"},
+            )
 
     metadata: dict[str, Any] = {
         "runtime": runtime_name,
@@ -528,12 +533,15 @@ def _write_private_text(path: Path, content: str) -> None:
     temporary_path = Path(temporary_name)
     try:
         os.fchmod(descriptor, 0o600)
-        with os.fdopen(descriptor, "w", encoding="utf-8") as temporary_file:
+        temporary_file = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = -1
+        with temporary_file:
             temporary_file.write(content)
         os.replace(temporary_path, path)
     finally:
-        with contextlib.suppress(OSError):
-            os.close(descriptor)
+        if descriptor != -1:
+            with contextlib.suppress(OSError):
+                os.close(descriptor)
         temporary_path.unlink(missing_ok=True)
 
 

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_docker_example.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_docker_example.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise the customer-facing Docker Codex evidence example."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
+from nemo_evaluator_sdk.execution.samples import build_metric_input
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "examples" / "codex_docker" / "example.py"
+_spec = importlib.util.spec_from_file_location("codex_docker_example", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+codex_docker = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(codex_docker)
+
+
+class _FakeCodexRuntime:
+    def __init__(self, workspace: Path) -> None:
+        self._workspace = workspace
+
+    async def run_tasks(
+        self,
+        tasks: list[AgentEvalTask],
+        config: AgentEvalRunConfig | None = None,
+    ) -> list[AgentEvalTrial]:
+        task = tasks[0]
+        artifact = self._workspace / codex_docker.ARTIFACT_PATH
+        artifact.parent.mkdir(parents=True)
+        artifact.write_text(f"{codex_docker.EXPECTED_TEXT}\n", encoding="utf-8")
+        return [
+            AgentEvalTrial(
+                id=f"{task.id}:fake-codex",
+                task_id=task.id,
+                status=AgentEvalTrialStatus.COMPLETED,
+                output=AgentOutput(
+                    output_text=codex_docker.EXPECTED_TEXT,
+                    metadata={"runtime": "fake_codex_docker"},
+                ),
+                evidence=CandidateEvidence(
+                    descriptors={
+                        "workspace": EvidenceDescriptor(kind="filesystem", ref=str(self._workspace)),
+                    }
+                ),
+                metadata={"runtime": "fake_codex_docker", "agent_ok": True},
+            )
+        ]
+
+
+def test_default_output_dir_is_under_repo_temp(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(codex_docker.OUTPUT_ROOT_ENV_NAME, raising=False)
+
+    output_dir = codex_docker._new_output_dir()
+
+    assert output_dir.parent == codex_docker.REPO_ROOT / "temp" / "codex-docker-eval-output"
+
+
+@pytest.mark.asyncio
+async def test_codex_docker_example_scores_workspace_artifact(tmp_path: Path) -> None:
+    result = await codex_docker.evaluate(
+        output_dir=tmp_path / "run",
+        runtime=_FakeCodexRuntime(tmp_path / "workspace"),
+        write_dashboard=False,
+    )
+
+    assert result.trials[0].status is AgentEvalTrialStatus.COMPLETED
+    assert {
+        f"{score.metric_type}.{output.name}": output.value for score in result.scores for output in score.outputs
+    } == {
+        "workspace_artifact.artifact_matches": True,
+        "workspace_artifact.output_matches": True,
+    }
+    assert (tmp_path / "run" / "run.json").is_file()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("answer", "artifact", "expected_outputs"),
+    [
+        (codex_docker.EXPECTED_TEXT, codex_docker.EXPECTED_TEXT, [True, True]),
+        ("wrong output", codex_docker.EXPECTED_TEXT, [False, True]),
+        (codex_docker.EXPECTED_TEXT, "wrong artifact", [True, False]),
+    ],
+)
+async def test_workspace_artifact_metric(
+    tmp_path: Path,
+    answer: str,
+    artifact: str,
+    expected_outputs: list[bool],
+) -> None:
+    workspace = tmp_path / "workspace"
+    artifact_path = workspace / codex_docker.ARTIFACT_PATH
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text(artifact, encoding="utf-8")
+    evidence = CandidateEvidence(descriptors={"workspace": EvidenceDescriptor(kind="filesystem", ref=str(workspace))})
+
+    metric_result = await codex_docker.WorkspaceArtifactMetric().compute_scores(
+        build_metric_input(
+            {
+                "reference": {
+                    "artifact_path": codex_docker.ARTIFACT_PATH,
+                    "expected": codex_docker.EXPECTED_TEXT,
+                }
+            },
+            {"output_text": answer, "evidence": evidence},
+            index=0,
+        )
+    )
+
+    assert [output.value for output in metric_result.outputs] == expected_outputs

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
 import os
 import stat
@@ -156,6 +157,9 @@ async def test_codex_cli_agent_runtime_uses_local_codex_command_and_writes_evide
     assert trials[0].evidence.require("workspace", kind="filesystem").ref == str(
         tmp_path / "codex" / "000000-task-1" / "workspace"
     )
+    final_output = tmp_path / "codex" / "000000-task-1" / "final_output.txt"
+    assert final_output.read_text(encoding="utf-8") == "codex answer"
+    assert final_output.stat().st_mode & 0o777 == 0o600
     assert (tmp_path / "codex" / "000000-task-1" / "stdout.jsonl").read_text(encoding="utf-8") == '{"type":"event"}\n'
     assert (tmp_path / "codex" / "000000-task-1" / "stdout.jsonl").stat().st_mode & 0o777 == 0o600
     assert (tmp_path / "codex" / "000000-task-1" / "stderr.txt").stat().st_mode & 0o777 == 0o600
@@ -341,6 +345,69 @@ async def test_codex_cli_agent_runtime_falls_back_to_stdout_and_persists_final_o
     assert final_output.stat().st_mode & 0o777 == 0o600
 
 
+@pytest.mark.asyncio
+async def test_codex_cli_agent_runtime_rejects_agent_created_final_output_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    external = tmp_path / "external.txt"
+    external.write_text("secret", encoding="utf-8")
+
+    class FakeProcess:
+        returncode = 0
+
+        def __init__(self, command: tuple[str, ...]) -> None:
+            self.command = command
+
+        async def communicate(self, input: bytes) -> tuple[bytes, bytes]:
+            final_output_path = Path(self.command[self.command.index("--output-last-message") + 1])
+            final_output_path.symlink_to(external)
+            return b"stdout fallback\n", b""
+
+    async def fake_process_factory(*command: str, **kwargs: Any) -> FakeProcess:
+        return FakeProcess(command)
+
+    monkeypatch.setattr(codex_runtime.shutil, "which", lambda value: f"/bin/{value}")
+    runtime = codex_runtime.CodexCliAgentRuntime(work_root=tmp_path / "codex", process_factory=fake_process_factory)
+    task = AgentEvalTask(id="task-symlink", intent="Answer.", inputs={"instruction": "Q?"})
+
+    trials = await runtime.run_tasks([task])
+
+    assert trials[0].status == "failed"
+    assert trials[0].output is None
+    assert trials[0].metadata["error_type"] == "OSError"
+    assert external.read_text(encoding="utf-8") == "secret"
+
+
+@pytest.mark.asyncio
+async def test_codex_cli_agent_runtime_rejects_agent_created_final_output_fifo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FakeProcess:
+        returncode = 0
+
+        def __init__(self, command: tuple[str, ...]) -> None:
+            self.command = command
+
+        async def communicate(self, input: bytes) -> tuple[bytes, bytes]:
+            final_output_path = Path(self.command[self.command.index("--output-last-message") + 1])
+            os.mkfifo(final_output_path, 0o600)
+            final_output_path.chmod(0o600)
+            return b"stdout fallback\n", b""
+
+    async def fake_process_factory(*command: str, **kwargs: Any) -> FakeProcess:
+        return FakeProcess(command)
+
+    monkeypatch.setattr(codex_runtime.shutil, "which", lambda value: f"/bin/{value}")
+    runtime = codex_runtime.CodexCliAgentRuntime(work_root=tmp_path / "codex", process_factory=fake_process_factory)
+    task = AgentEvalTask(id="task-fifo", intent="Answer.", inputs={"instruction": "Q?"})
+
+    trials = await asyncio.wait_for(runtime.run_tasks([task]), timeout=5)
+
+    assert trials[0].status == "failed"
+    assert trials[0].output is None
+    assert trials[0].metadata["error_type"] == "PermissionError"
+
+
 def test_private_directory_creation_repairs_modes_and_rejects_unsafe_paths(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -437,6 +504,17 @@ def test_private_tree_validation_is_root_inclusive_and_does_not_follow_symlinks(
     different_uid = os.getuid() + 1
     monkeypatch.setattr(codex_runtime.os, "getuid", lambda: different_uid)
     with pytest.raises(PermissionError, match="not owned"):
+        codex_runtime._validate_private_tree(root)
+
+
+def test_private_tree_validation_rejects_special_files(tmp_path: Path) -> None:
+    root = tmp_path / "evidence"
+    root.mkdir(mode=0o700)
+    fifo = root / "agent.fifo"
+    os.mkfifo(fifo, 0o600)
+    fifo.chmod(0o600)
+
+    with pytest.raises(PermissionError, match="not a regular file or directory"):
         codex_runtime._validate_private_tree(root)
 
 

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
+import stat
 import threading
 from collections.abc import Mapping
 from pathlib import Path
@@ -120,6 +122,12 @@ async def test_codex_cli_agent_runtime_uses_local_codex_command_and_writes_evide
             return b'{"type":"event"}\n', b""
 
     async def fake_process_factory(*command: str, **kwargs: Any) -> FakeProcess:
+        evidence_dir = Path(command[command.index("--output-last-message") + 1]).parent
+        assert stat.S_IMODE(evidence_dir.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(evidence_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE((evidence_dir / "workspace").stat().st_mode) == 0o700
+        assert stat.S_IMODE((evidence_dir / "task.json").stat().st_mode) == 0o600
+        assert stat.S_IMODE((evidence_dir / "prompt.txt").stat().st_mode) == 0o600
         commands.append((command, kwargs))
         return FakeProcess(command)
 
@@ -149,6 +157,8 @@ async def test_codex_cli_agent_runtime_uses_local_codex_command_and_writes_evide
         tmp_path / "codex" / "000000-task-1" / "workspace"
     )
     assert (tmp_path / "codex" / "000000-task-1" / "stdout.jsonl").read_text(encoding="utf-8") == '{"type":"event"}\n'
+    assert (tmp_path / "codex" / "000000-task-1" / "stdout.jsonl").stat().st_mode & 0o777 == 0o600
+    assert (tmp_path / "codex" / "000000-task-1" / "stderr.txt").stat().st_mode & 0o777 == 0o600
 
 
 @pytest.mark.asyncio
@@ -208,6 +218,10 @@ async def test_codex_docker_cli_agent_runtime_runs_codex_in_container_and_writes
             evidence_mount = self.command[self.command.index(f"{auth_path.resolve()}:/root/.codex/auth.json:ro") + 4]
             evidence_dir = Path(evidence_mount.split(":/evidence", maxsplit=1)[0])
             (evidence_dir / "final_output.txt").write_text("docker codex answer", encoding="utf-8")
+            for directory, _subdirectories, filenames in os.walk(evidence_dir):
+                Path(directory).chmod(0o700)
+                for filename in filenames:
+                    (Path(directory) / filename).chmod(0o600)
             return b'{"type":"event"}\n', b""
 
     async def fake_process_factory(*command: str, **kwargs: Any) -> FakeProcess:
@@ -215,8 +229,6 @@ async def test_codex_docker_cli_agent_runtime_runs_codex_in_container_and_writes
         return FakeProcess(command)
 
     monkeypatch.setattr(codex_runtime.shutil, "which", lambda value: f"/bin/{value}")
-    monkeypatch.setattr(codex_runtime.os, "getuid", lambda: 1234)
-    monkeypatch.setattr(codex_runtime.os, "getgid", lambda: 5678)
     runtime = codex_runtime.CodexDockerCliAgentRuntime(
         model="gpt-5.4",
         work_root=tmp_path / "codex-docker",
@@ -237,11 +249,14 @@ async def test_codex_docker_cli_agent_runtime_runs_codex_in_container_and_writes
     assert f"npx -y {codex_runtime.DEFAULT_CODEX_DOCKER_CLI_PACKAGE} exec" in command[-1]
     assert "--sandbox danger-full-access" in command[-1]
     assert "--model gpt-5.4" in command[-1]
+    assert "host_owner=\"$(stat -c '%u:%g' /evidence 2>/dev/null)\" || true" in command[-1]
+    assert command[-1].index("host_owner=") < command[-1].index("npx -y")
     assert "codex_status=$?" in command[-1]
-    assert "chown -R 1234:5678 /workspace /evidence 2>/dev/null || true" in command[-1]
-    assert "chmod -R u+rwX,go+rX /workspace /evidence" in command[-1]
+    assert 'chown -R "$host_owner" /workspace /evidence 2>/dev/null || true' in command[-1]
+    assert "chmod -R u+rwX,go-rwx /workspace /evidence" in command[-1]
     assert 'if [ "$codex_status" -ne 0 ]; then exit "$codex_status"; fi' in command[-1]
     assert 'exit "$permissions_status"' in command[-1]
+    assert command[-1].index('if [ "$codex_status"') < command[-1].index('exit "$permissions_status"')
     assert kwargs["stdin"] == codex_runtime.subprocess.PIPE
     assert trials[0].status == "completed"
     assert trials[0].output is not None
@@ -293,6 +308,7 @@ async def test_codex_cli_agent_runtime_kills_process_on_timeout(
     assert trials[0].status == "failed"
     assert trials[0].output is None
     assert trials[0].metadata["error_type"] == "TimeoutError"
+    assert (tmp_path / "codex" / "000000-task-timeout" / "error.json").stat().st_mode & 0o777 == 0o600
 
 
 @pytest.mark.asyncio
@@ -322,6 +338,194 @@ async def test_codex_cli_agent_runtime_falls_back_to_stdout_and_persists_final_o
     assert trials[0].output.output_text == "stdout fallback\n"
     final_output = tmp_path / "codex" / "000000-task-2" / "final_output.txt"
     assert final_output.read_text(encoding="utf-8") == "stdout fallback\n"
+    assert final_output.stat().st_mode & 0o777 == 0o600
+
+
+def test_private_directory_creation_repairs_modes_and_rejects_unsafe_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    private_dir = tmp_path / "private"
+    private_dir.mkdir(mode=0o755)
+
+    codex_runtime._ensure_private_directory(private_dir)
+
+    assert stat.S_IMODE(private_dir.stat().st_mode) == 0o700
+
+    symlink = tmp_path / "symlink"
+    symlink.symlink_to(private_dir, target_is_directory=True)
+    with pytest.raises(OSError):
+        codex_runtime._ensure_private_directory(symlink)
+
+    not_a_directory = tmp_path / "file"
+    not_a_directory.touch()
+    with pytest.raises(FileExistsError):
+        codex_runtime._ensure_private_directory(not_a_directory)
+
+    different_uid = os.getuid() + 1
+    monkeypatch.setattr(codex_runtime.os, "getuid", lambda: different_uid)
+    with pytest.raises(PermissionError, match="not owned"):
+        codex_runtime._ensure_private_directory(private_dir)
+
+
+def test_private_text_write_is_owner_only_atomic_and_replaces_symlinks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    external = tmp_path / "external.txt"
+    external.write_text("external", encoding="utf-8")
+    target = tmp_path / "artifact.txt"
+    target.symlink_to(external)
+    original_replace = codex_runtime.os.replace
+
+    def checked_replace(source: str | Path, destination: str | Path) -> None:
+        assert stat.S_IMODE(Path(source).stat().st_mode) == 0o600
+        original_replace(source, destination)
+
+    monkeypatch.setattr(codex_runtime.os, "replace", checked_replace)
+
+    codex_runtime._write_private_text(target, "private")
+
+    assert not target.is_symlink()
+    assert target.read_text(encoding="utf-8") == "private"
+    assert external.read_text(encoding="utf-8") == "external"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_private_text_write_cleans_temporary_file_on_replace_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "artifact.txt"
+
+    def fail_replace(source: str | Path, destination: str | Path) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(codex_runtime.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        codex_runtime._write_private_text(target, "private")
+
+    assert list(tmp_path.glob(".artifact.txt.*.tmp")) == []
+
+
+def test_private_tree_validation_is_root_inclusive_and_does_not_follow_symlinks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "evidence"
+    root.mkdir(mode=0o700)
+    nested = root / "nested"
+    nested.mkdir(mode=0o700)
+    regular = nested / "regular.txt"
+    regular.write_text("ok", encoding="utf-8")
+    regular.chmod(0o600)
+    executable = nested / "script.sh"
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o700)
+    (nested / "host-link").symlink_to("/etc/passwd")
+
+    codex_runtime._validate_private_tree(root)
+
+    regular.chmod(0o640)
+    with pytest.raises(PermissionError, match="group or other"):
+        codex_runtime._validate_private_tree(root)
+    regular.chmod(0o400)
+    with pytest.raises(PermissionError, match="owner-readable and writable"):
+        codex_runtime._validate_private_tree(root)
+    regular.chmod(0o600)
+    root.chmod(0o750)
+    with pytest.raises(PermissionError, match="group or other"):
+        codex_runtime._validate_private_tree(root)
+    root.chmod(0o700)
+    different_uid = os.getuid() + 1
+    monkeypatch.setattr(codex_runtime.os, "getuid", lambda: different_uid)
+    with pytest.raises(PermissionError, match="not owned"):
+        codex_runtime._validate_private_tree(root)
+
+
+@pytest.mark.asyncio
+async def test_codex_success_fails_when_permission_postcondition_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text("{}", encoding="utf-8")
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self, input: bytes) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    async def fake_process_factory(*command: str, **kwargs: Any) -> FakeProcess:
+        return FakeProcess()
+
+    monkeypatch.setattr(codex_runtime.shutil, "which", lambda value: f"/bin/{value}")
+    runtime = codex_runtime.CodexDockerCliAgentRuntime(
+        work_root=tmp_path / "codex-docker",
+        auth_path=auth_path,
+        process_factory=fake_process_factory,
+    )
+
+    def fail_validation(evidence_dir: Path) -> None:
+        raise PermissionError("unsafe evidence")
+
+    monkeypatch.setattr(runtime, "_validate_artifact_permissions", fail_validation)
+    task = AgentEvalTask(id="success", intent="Succeed.", inputs={"instruction": "succeed"})
+
+    (trial,) = await runtime.run_tasks([task])
+
+    assert trial.status == "failed"
+    assert trial.metadata["error_type"] == "PermissionError"
+    assert "unsafe evidence" in trial.metadata["permission_cleanup_error"]
+
+
+@pytest.mark.asyncio
+async def test_codex_failure_preserves_status_and_reports_permission_cleanup_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text("{}", encoding="utf-8")
+
+    class FakeProcess:
+        returncode = 23
+
+        async def communicate(self, input: bytes) -> tuple[bytes, bytes]:
+            return b"", b"codex failed"
+
+    async def fake_process_factory(*command: str, **kwargs: Any) -> FakeProcess:
+        return FakeProcess()
+
+    monkeypatch.setattr(codex_runtime.shutil, "which", lambda value: f"/bin/{value}")
+    runtime = codex_runtime.CodexDockerCliAgentRuntime(
+        work_root=tmp_path / "codex-docker",
+        auth_path=auth_path,
+        process_factory=fake_process_factory,
+    )
+
+    def fail_validation(evidence_dir: Path) -> None:
+        raise PermissionError("unsafe evidence")
+
+    monkeypatch.setattr(runtime, "_validate_artifact_permissions", fail_validation)
+    task = AgentEvalTask(id="failure", intent="Fail.", inputs={"instruction": "fail"})
+
+    (trial,) = await runtime.run_tasks([task])
+
+    assert trial.status == "failed"
+    assert "status 23" in trial.metadata["error"]
+    assert "unsafe evidence" in trial.metadata["permission_cleanup_error"]
+
+
+def test_failed_trial_survives_inaccessible_error_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    task = AgentEvalTask(id="failure", intent="Fail.", inputs={"instruction": "fail"})
+
+    def fail_write(path: Path, content: str) -> None:
+        raise PermissionError("inaccessible")
+
+    monkeypatch.setattr(codex_runtime, "_write_private_text", fail_write)
+
+    trial = codex_runtime._failed_codex_trial(task, tmp_path / "missing", RuntimeError("original"))
+
+    assert trial.status == "failed"
+    assert trial.evidence is None
+    assert trial.metadata["error"] == "original"
+    assert "inaccessible" in trial.metadata["error_artifact_error"]
 
 
 @pytest.mark.asyncio

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime.py
@@ -461,16 +461,70 @@ def test_private_text_write_cleans_temporary_file_on_replace_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     target = tmp_path / "artifact.txt"
+    explicitly_closed: list[int] = []
+    original_close = codex_runtime.os.close
 
     def fail_replace(source: str | Path, destination: str | Path) -> None:
         raise OSError("replace failed")
 
+    def track_close(descriptor: int) -> None:
+        explicitly_closed.append(descriptor)
+        original_close(descriptor)
+
     monkeypatch.setattr(codex_runtime.os, "replace", fail_replace)
+    monkeypatch.setattr(codex_runtime.os, "close", track_close)
 
     with pytest.raises(OSError, match="replace failed"):
         codex_runtime._write_private_text(target, "private")
 
+    assert explicitly_closed == []
     assert list(tmp_path.glob(".artifact.txt.*.tmp")) == []
+
+
+def test_private_text_write_closes_descriptor_when_fdopen_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "artifact.txt"
+    explicitly_closed: list[int] = []
+    original_close = codex_runtime.os.close
+
+    def fail_fdopen(descriptor: int, mode: str, *, encoding: str) -> None:
+        raise OSError("fdopen failed")
+
+    def track_close(descriptor: int) -> None:
+        explicitly_closed.append(descriptor)
+        original_close(descriptor)
+
+    monkeypatch.setattr(codex_runtime.os, "fdopen", fail_fdopen)
+    monkeypatch.setattr(codex_runtime.os, "close", track_close)
+
+    with pytest.raises(OSError, match="fdopen failed"):
+        codex_runtime._write_private_text(target, "private")
+
+    assert len(explicitly_closed) == 1
+    assert list(tmp_path.glob(".artifact.txt.*.tmp")) == []
+
+
+@pytest.mark.asyncio
+async def test_setup_failure_does_not_write_error_through_untrusted_evidence_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work_root = tmp_path / "codex"
+    work_root.mkdir(mode=0o700)
+    external = tmp_path / "external"
+    external.mkdir()
+    evidence_dir = work_root / "000000-task-symlink"
+    evidence_dir.symlink_to(external, target_is_directory=True)
+    monkeypatch.setattr(codex_runtime.shutil, "which", lambda value: f"/bin/{value}")
+    runtime = codex_runtime.CodexCliAgentRuntime(work_root=work_root)
+    task = AgentEvalTask(id="task-symlink", intent="Answer.", inputs={"instruction": "Q?"})
+
+    trial = (await runtime.run_tasks([task]))[0]
+
+    assert trial.status == "failed"
+    assert trial.output is None
+    assert trial.evidence is None
+    assert not (external / "error.json").exists()
 
 
 def test_private_tree_validation_is_root_inclusive_and_does_not_follow_symlinks(

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime.py
@@ -215,6 +215,8 @@ async def test_codex_docker_cli_agent_runtime_runs_codex_in_container_and_writes
         return FakeProcess(command)
 
     monkeypatch.setattr(codex_runtime.shutil, "which", lambda value: f"/bin/{value}")
+    monkeypatch.setattr(codex_runtime.os, "getuid", lambda: 1234)
+    monkeypatch.setattr(codex_runtime.os, "getgid", lambda: 5678)
     runtime = codex_runtime.CodexDockerCliAgentRuntime(
         model="gpt-5.4",
         work_root=tmp_path / "codex-docker",
@@ -227,6 +229,7 @@ async def test_codex_docker_cli_agent_runtime_runs_codex_in_container_and_writes
 
     command, kwargs = commands[0]
     assert command[:4] == ("docker", "run", "--rm", "-i")
+    assert command[command.index("-e") + 1] == "PYTHONDONTWRITEBYTECODE=1"
     assert f"{auth_path.resolve()}:/root/.codex/auth.json:ro" in command
     assert f"{(tmp_path / 'codex-docker' / '000000-task-1' / 'workspace').resolve()}:/workspace" in command
     assert f"{(tmp_path / 'codex-docker' / '000000-task-1').resolve()}:/evidence" in command
@@ -234,6 +237,11 @@ async def test_codex_docker_cli_agent_runtime_runs_codex_in_container_and_writes
     assert f"npx -y {codex_runtime.DEFAULT_CODEX_DOCKER_CLI_PACKAGE} exec" in command[-1]
     assert "--sandbox danger-full-access" in command[-1]
     assert "--model gpt-5.4" in command[-1]
+    assert "codex_status=$?" in command[-1]
+    assert "chown -R 1234:5678 /workspace /evidence 2>/dev/null || true" in command[-1]
+    assert "chmod -R u+rwX,go+rX /workspace /evidence" in command[-1]
+    assert 'if [ "$codex_status" -ne 0 ]; then exit "$codex_status"; fi' in command[-1]
+    assert 'exit "$permissions_status"' in command[-1]
     assert kwargs["stdin"] == codex_runtime.subprocess.PIPE
     assert trials[0].status == "completed"
     assert trials[0].output is not None

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime_live.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime_live.py
@@ -41,6 +41,7 @@ const cacheFile = path.join(cacheDir, "probe.pyc");
 fs.mkdirSync(cacheDir, {recursive: true});
 fs.writeFileSync(cacheFile, "fake bytecode");
 fs.writeFileSync(finalOutput, "fake codex answer");
+fs.symlinkSync("/etc/passwd", path.join(workspace, "host-link"));
 fs.chmodSync(cacheFile, 0o000);
 fs.chmodSync(cacheDir, 0o000);
 fs.chmodSync(finalOutput, 0o000);
@@ -77,18 +78,21 @@ def _fake_codex_task(task_id: str, *, exit_code: int | None = None) -> AgentEval
     )
 
 
-def _assert_tree_host_readable(root: Path) -> None:
+def _assert_tree_host_private(root: Path) -> None:
     assert root.is_dir()
-    for path in root.rglob("*"):
+    for path in (root, *root.rglob("*")):
         if path.is_symlink():
             continue
-        mode = stat.S_IMODE(path.stat().st_mode)
+        path_stat = path.stat()
+        mode = stat.S_IMODE(path_stat.st_mode)
+        assert path_stat.st_uid == os.getuid(), f"artifact is not owned by the host user: {path}"
+        assert mode & 0o077 == 0, f"artifact is accessible to group or other users: {path} ({mode:o})"
         if path.is_dir():
-            assert mode & 0o555 == 0o555, f"directory is not traversable by the host: {path} ({mode:o})"
-            assert os.access(path, os.R_OK | os.X_OK)
+            assert mode & 0o700 == 0o700, f"directory is not accessible to the host user: {path} ({mode:o})"
+            assert os.access(path, os.R_OK | os.W_OK | os.X_OK)
         elif path.is_file():
-            assert mode & 0o444 == 0o444, f"file is not host-readable: {path} ({mode:o})"
-            assert os.access(path, os.R_OK)
+            assert mode & 0o600 == 0o600, f"file is not readable and writable by the host user: {path} ({mode:o})"
+            assert os.access(path, os.R_OK | os.W_OK)
             path.read_bytes()
 
 
@@ -114,13 +118,17 @@ async def test_codex_docker_normalizes_concurrent_workspace_and_evidence_trees(t
         assert trial.output.output_text == "fake codex answer"
         assert trial.evidence is not None
         workspace = await trial.evidence.filesystem("workspace")
-        verifier = await workspace.run_verifier(["true"])
+        verifier = await workspace.run_verifier(["test", "!", "-e", "host-link"])
         assert verifier.ok
 
         evidence_dir = Path(trial.output.metadata["evidence_dir"])
-        _assert_tree_host_readable(evidence_dir / "workspace")
-        _assert_tree_host_readable(evidence_dir)
-        shutil.copytree(evidence_dir, tmp_path / "copies" / trial.task_id)
+        _assert_tree_host_private(evidence_dir / "workspace")
+        _assert_tree_host_private(evidence_dir)
+        copy = tmp_path / "copies" / trial.task_id
+        shutil.copytree(evidence_dir, copy, symlinks=True)
+        assert (copy / "workspace" / "host-link").is_symlink()
+
+    assert stat.S_IMODE(work_root.stat().st_mode) == 0o700
 
 
 async def test_codex_docker_preserves_failure_status_after_permission_normalization(tmp_path: Path) -> None:
@@ -139,7 +147,8 @@ async def test_codex_docker_preserves_failure_status_after_permission_normalizat
     assert trial.status == "failed"
     assert trial.metadata["agent_ok"] is False
     assert "status 23" in trial.metadata["error"]
+    assert "permission_cleanup_error" not in trial.metadata
     evidence_dir = work_root / "000000-failure"
-    _assert_tree_host_readable(evidence_dir / "workspace")
-    _assert_tree_host_readable(evidence_dir)
+    _assert_tree_host_private(evidence_dir / "workspace")
+    _assert_tree_host_private(evidence_dir)
     assert (evidence_dir / "final_output.txt").read_text(encoding="utf-8") == "fake codex answer"

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime_live.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime_live.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live Docker regressions for host-readable Codex CLI evidence."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+from nemo_evaluator_sdk.agent_eval.runtimes.codex.runtime import CodexDockerCliAgentRuntime
+from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
+
+_IMAGE = "node:22-alpine"
+_FAKE_PACKAGE_JSON = """{
+  "name": "fake-codex",
+  "version": "1.0.0",
+  "bin": {"fake-codex": "fake-codex.js"}
+}
+"""
+_FAKE_CODEX_JS = """#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+function argumentValue(name) {
+  const index = process.argv.indexOf(name);
+  if (index < 0 || index + 1 >= process.argv.length) {
+    throw new Error(`missing ${name}`);
+  }
+  return process.argv[index + 1];
+}
+
+const workspace = argumentValue("--cd");
+const finalOutput = argumentValue("--output-last-message");
+const cacheDir = path.join(workspace, "__pycache__");
+const cacheFile = path.join(cacheDir, "probe.pyc");
+fs.mkdirSync(cacheDir, {recursive: true});
+fs.writeFileSync(cacheFile, "fake bytecode");
+fs.writeFileSync(finalOutput, "fake codex answer");
+fs.chmodSync(cacheFile, 0o000);
+fs.chmodSync(cacheDir, 0o000);
+fs.chmodSync(finalOutput, 0o000);
+
+const exitCodePath = path.join(workspace, "exit-code.txt");
+const exitCode = fs.existsSync(exitCodePath) ? Number(fs.readFileSync(exitCodePath, "utf8")) : 0;
+process.exit(exitCode);
+"""
+
+
+def _docker_ready() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=15).returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _docker_ready(), reason="docker daemon not available")
+
+
+def _fake_codex_task(task_id: str, *, exit_code: int | None = None) -> AgentEvalTask:
+    files = {
+        "package.json": _FAKE_PACKAGE_JSON,
+        "fake-codex.js": _FAKE_CODEX_JS,
+    }
+    if exit_code is not None:
+        files["exit-code.txt"] = str(exit_code)
+    return AgentEvalTask(
+        id=task_id,
+        intent="Exercise Docker evidence permissions.",
+        inputs={"instruction": "Create restrictive evidence.", "files": files},
+    )
+
+
+def _assert_tree_host_readable(root: Path) -> None:
+    assert root.is_dir()
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            continue
+        mode = stat.S_IMODE(path.stat().st_mode)
+        if path.is_dir():
+            assert mode & 0o555 == 0o555, f"directory is not traversable by the host: {path} ({mode:o})"
+            assert os.access(path, os.R_OK | os.X_OK)
+        elif path.is_file():
+            assert mode & 0o444 == 0o444, f"file is not host-readable: {path} ({mode:o})"
+            assert os.access(path, os.R_OK)
+            path.read_bytes()
+
+
+async def test_codex_docker_normalizes_concurrent_workspace_and_evidence_trees(tmp_path: Path) -> None:
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text("{}", encoding="utf-8")
+    work_root = tmp_path / "codex-docker"
+    runtime = CodexDockerCliAgentRuntime(
+        work_root=work_root,
+        image=_IMAGE,
+        codex_package="/workspace",
+        auth_path=auth_path,
+    )
+
+    trials = await runtime.run_tasks(
+        [_fake_codex_task("success-a"), _fake_codex_task("success-b")],
+        AgentEvalRunConfig(parallelism=2),
+    )
+
+    assert [trial.status for trial in trials] == ["completed", "completed"]
+    for trial in trials:
+        assert trial.output is not None
+        assert trial.output.output_text == "fake codex answer"
+        assert trial.evidence is not None
+        workspace = await trial.evidence.filesystem("workspace")
+        verifier = await workspace.run_verifier(["true"])
+        assert verifier.ok
+
+        evidence_dir = Path(trial.output.metadata["evidence_dir"])
+        _assert_tree_host_readable(evidence_dir / "workspace")
+        _assert_tree_host_readable(evidence_dir)
+        shutil.copytree(evidence_dir, tmp_path / "copies" / trial.task_id)
+
+
+async def test_codex_docker_preserves_failure_status_after_permission_normalization(tmp_path: Path) -> None:
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text("{}", encoding="utf-8")
+    work_root = tmp_path / "codex-docker"
+    runtime = CodexDockerCliAgentRuntime(
+        work_root=work_root,
+        image=_IMAGE,
+        codex_package="/workspace",
+        auth_path=auth_path,
+    )
+
+    (trial,) = await runtime.run_tasks([_fake_codex_task("failure", exit_code=23)])
+
+    assert trial.status == "failed"
+    assert trial.metadata["agent_ok"] is False
+    assert "status 23" in trial.metadata["error"]
+    evidence_dir = work_root / "000000-failure"
+    _assert_tree_host_readable(evidence_dir / "workspace")
+    _assert_tree_host_readable(evidence_dir)
+    assert (evidence_dir / "final_output.txt").read_text(encoding="utf-8") == "fake codex answer"

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/codex/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/codex/runtime.py
@@ -13,7 +13,9 @@ import json
 import os
 import shlex
 import shutil
+import stat
 import subprocess
+import tempfile
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from enum import StrEnum
 from pathlib import Path
@@ -94,8 +96,16 @@ class CodexCliAgentRuntime:
     async def _run_task(self, index: int, task: AgentEvalTask, config: AgentEvalRunConfig) -> AgentEvalTrial:
         evidence_dir = self._evidence_dir(index, task, config)
         workspace_dir = evidence_dir / "workspace"
-        evidence_dir.mkdir(parents=True, exist_ok=True)
-        workspace_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            # The task directory is mounted into Docker, but its private parent is not. Keeping that
+            # parent host-owned and 0700 preserves the local confidentiality boundary even when a
+            # container is interrupted before its recursive cleanup completes.
+            _ensure_private_directory(evidence_dir.parent)
+            _ensure_private_directory(evidence_dir)
+            _ensure_private_directory(workspace_dir)
+        except Exception as exc:
+            return _failed_codex_trial(task, evidence_dir, exc, runtime_name=self._runtime_name)
 
         prompt_path = evidence_dir / "prompt.txt"
         task_path = evidence_dir / "task.json"
@@ -107,7 +117,10 @@ class CodexCliAgentRuntime:
         # this evidence dir into the sandbox (danger-full-access), so serializing `intent` (desired
         # behavior) or `reference` (held-out ground truth) here would let the agent read them back out
         # of `/evidence/task.json` — the same reward-hacking leak the intent-free prompt closes.
-        task_path.write_text(task.model_dump_json(indent=2, exclude={"intent", "reference"}), encoding="utf-8")
+        try:
+            _write_private_text(task_path, task.model_dump_json(indent=2, exclude={"intent", "reference"}))
+        except Exception as exc:
+            return _failed_codex_trial(task, evidence_dir, exc, runtime_name=self._runtime_name)
 
         command = self._command(workspace_dir=workspace_dir, final_output_path=final_output_path)
         process: Any | None = None
@@ -120,13 +133,15 @@ class CodexCliAgentRuntime:
             # Build the prompt after seeding and inside the guarded block: an instruction-less task
             # raises here, failing just this task instead of aborting the run (and seeding wins if both).
             prompt = self._prompt_builder(task)
-            prompt_path.write_text(prompt, encoding="utf-8")
+            _write_private_text(prompt_path, prompt)
             process = await self._process_factory(
                 *command,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
+            if process is None:
+                raise RuntimeError("process factory failed to create a process")
             stdout, stderr = await asyncio.wait_for(
                 process.communicate(prompt.encode("utf-8")),
                 timeout=self._timeout_s,
@@ -139,8 +154,18 @@ class CodexCliAgentRuntime:
 
         stdout_text = _decode_process_output(stdout)
         stderr_text = _decode_process_output(stderr)
-        stdout_path.write_text(stdout_text, encoding="utf-8")
-        stderr_path.write_text(stderr_text, encoding="utf-8")
+        artifact_persistence_error: str | None = None
+        try:
+            _write_private_text(stdout_path, stdout_text)
+            _write_private_text(stderr_path, stderr_text)
+        except Exception as exc:
+            artifact_persistence_error = f"{exc.__class__.__name__}: {exc}"
+
+        permission_cleanup_error: str | None = None
+        try:
+            self._validate_artifact_permissions(evidence_dir)
+        except Exception as exc:
+            permission_cleanup_error = f"{exc.__class__.__name__}: {exc}"
 
         if process.returncode != 0:
             return _failed_codex_trial(
@@ -148,13 +173,36 @@ class CodexCliAgentRuntime:
                 evidence_dir,
                 RuntimeError(f"codex exec exited with status {process.returncode}: {stderr_text.strip()}"),
                 runtime_name=self._runtime_name,
+                permission_cleanup_error=permission_cleanup_error,
+                artifact_persistence_error=artifact_persistence_error,
             )
 
-        if final_output_path.exists():
-            output_text = final_output_path.read_text(encoding="utf-8")
-        else:
-            output_text = stdout_text
-            final_output_path.write_text(output_text, encoding="utf-8")
+        if artifact_persistence_error is not None:
+            return _failed_codex_trial(
+                task,
+                evidence_dir,
+                RuntimeError(f"failed to persist Codex evidence: {artifact_persistence_error}"),
+                runtime_name=self._runtime_name,
+                permission_cleanup_error=permission_cleanup_error,
+                artifact_persistence_error=artifact_persistence_error,
+            )
+        if permission_cleanup_error is not None:
+            return _failed_codex_trial(
+                task,
+                evidence_dir,
+                PermissionError(f"Codex evidence permission normalization failed: {permission_cleanup_error}"),
+                runtime_name=self._runtime_name,
+                permission_cleanup_error=permission_cleanup_error,
+            )
+
+        try:
+            if final_output_path.exists():
+                output_text = final_output_path.read_text(encoding="utf-8")
+            else:
+                output_text = stdout_text
+                _write_private_text(final_output_path, output_text)
+        except Exception as exc:
+            return _failed_codex_trial(task, evidence_dir, exc, runtime_name=self._runtime_name)
         return AgentEvalTrial(
             id=f"{task.id}:codex",
             task_id=task.id,
@@ -208,6 +256,9 @@ class CodexCliAgentRuntime:
             command.extend(["--model", self._model])
         command.append("-")
         return command
+
+    def _validate_artifact_permissions(self, evidence_dir: Path) -> None:
+        """Validate runtime-specific artifact postconditions after the process exits."""
 
     def _evidence_dir(self, index: int, task: AgentEvalTask, config: AgentEvalRunConfig) -> Path:
         root = self._work_root
@@ -293,13 +344,18 @@ class CodexDockerCliAgentRuntime(CodexCliAgentRuntime):
         inner_command.append("-")
         # Codex intentionally runs as root: the container mounts its auth under /root and coding tasks
         # may need to install tools. Repair the bind-mounted trees before Docker returns so the host can
-        # score and persist every artifact the agent created. Keep the Codex failure authoritative; only
-        # surface the chmod status when Codex itself succeeded.
+        # score and persist every artifact the agent created without widening access to other host users.
+        # Capture the bind mount's owner as seen inside this container before Codex runs: raw host UID/GID
+        # values are not portable across Docker Desktop and rootless user-namespace mappings. Keep Codex
+        # failures authoritative; only surface the required chmod status when Codex itself succeeded.
         shell_command = (
+            "host_owner=\"$(stat -c '%u:%g' /evidence 2>/dev/null)\" || true; "
             f"{shlex.join(inner_command)}; "
             "codex_status=$?; "
-            f"chown -R {os.getuid()}:{os.getgid()} /workspace /evidence 2>/dev/null || true; "
-            "chmod -R u+rwX,go+rX /workspace /evidence; "
+            'if [ -n "$host_owner" ]; then '
+            'chown -R "$host_owner" /workspace /evidence 2>/dev/null || true; '
+            "fi; "
+            "chmod -R u+rwX,go-rwx /workspace /evidence; "
             "permissions_status=$?; "
             'if [ "$codex_status" -ne 0 ]; then exit "$codex_status"; fi; '
             'exit "$permissions_status"'
@@ -322,6 +378,9 @@ class CodexDockerCliAgentRuntime(CodexCliAgentRuntime):
             "-lc",
             shell_command,
         ]
+
+    def _validate_artifact_permissions(self, evidence_dir: Path) -> None:
+        _validate_private_tree(evidence_dir)
 
 
 def resolve_codex_runtime(
@@ -415,28 +474,95 @@ def _failed_codex_trial(
     exc: Exception,
     *,
     runtime_name: str = "codex_cli",
+    permission_cleanup_error: str | None = None,
+    artifact_persistence_error: str | None = None,
 ) -> AgentEvalTrial:
     error_path = evidence_dir / "error.json"
-    error_path.write_text(
-        json.dumps({"error_type": exc.__class__.__name__, "error": str(exc)}) + "\n", encoding="utf-8"
-    )
+    evidence: CandidateEvidence | None = None
+    error_artifact_error: str | None = None
+    try:
+        _write_private_text(error_path, json.dumps({"error_type": exc.__class__.__name__, "error": str(exc)}) + "\n")
+    except Exception as artifact_exc:
+        error_artifact_error = f"{artifact_exc.__class__.__name__}: {artifact_exc}"
+    else:
+        evidence = CandidateEvidence(
+            descriptors={"error": EvidenceDescriptor(kind="error", format="json", ref=str(error_path))},
+            metadata={"runtime": runtime_name, "agent": "codex"},
+        )
+
+    metadata: dict[str, Any] = {
+        "runtime": runtime_name,
+        "agent": "codex",
+        "agent_ok": False,
+        "error_type": exc.__class__.__name__,
+        "error": str(exc),
+    }
+    if permission_cleanup_error is not None:
+        metadata["permission_cleanup_error"] = permission_cleanup_error
+    if artifact_persistence_error is not None:
+        metadata["artifact_persistence_error"] = artifact_persistence_error
+    if error_artifact_error is not None:
+        metadata["error_artifact_error"] = error_artifact_error
     return AgentEvalTrial(
         id=f"{task.id}:codex",
         task_id=task.id,
         status=AgentEvalTrialStatus.FAILED,
         output=None,
-        evidence=CandidateEvidence(
-            descriptors={"error": EvidenceDescriptor(kind="error", format="json", ref=str(error_path))},
-            metadata={"runtime": runtime_name, "agent": "codex"},
-        ),
-        metadata={
-            "runtime": runtime_name,
-            "agent": "codex",
-            "agent_ok": False,
-            "error_type": exc.__class__.__name__,
-            "error": str(exc),
-        },
+        evidence=evidence,
+        metadata=metadata,
     )
+
+
+def _ensure_private_directory(path: Path) -> None:
+    """Create or repair a host-owned directory without following a leaf symlink."""
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        path_stat = os.fstat(descriptor)
+        if path_stat.st_uid != os.getuid():
+            raise PermissionError(f"directory is not owned by the invoking host user: {path}")
+        os.fchmod(descriptor, 0o700)
+    finally:
+        os.close(descriptor)
+
+
+def _write_private_text(path: Path, content: str) -> None:
+    """Atomically publish a host-created evidence artifact with owner-only access."""
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as temporary_file:
+            temporary_file.write(content)
+        os.replace(temporary_path, path)
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(descriptor)
+        temporary_path.unlink(missing_ok=True)
+
+
+def _validate_private_tree(root: Path) -> None:
+    """Require a host-owned, owner-only tree without following agent-created symlinks."""
+    expected_uid = os.getuid()
+    pending = [root]
+    while pending:
+        path = pending.pop()
+        path_stat = path.lstat()
+        if stat.S_ISLNK(path_stat.st_mode):
+            continue
+        if path_stat.st_uid != expected_uid:
+            raise PermissionError(f"artifact is not owned by the invoking host user: {path}")
+
+        mode = stat.S_IMODE(path_stat.st_mode)
+        if mode & 0o077:
+            raise PermissionError(f"artifact grants group or other access: {path} ({mode:o})")
+        if stat.S_ISDIR(path_stat.st_mode):
+            if mode & 0o700 != 0o700:
+                raise PermissionError(f"directory is not owner-readable, writable, and traversable: {path} ({mode:o})")
+            with os.scandir(path) as entries:
+                pending.extend(Path(entry.path) for entry in entries)
+        elif mode & 0o600 != 0o600:
+            raise PermissionError(f"file is not owner-readable and writable: {path} ({mode:o})")
 
 
 async def _terminate_process(process: Any | None) -> None:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/codex/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/codex/runtime.py
@@ -3,6 +3,8 @@
 
 """Codex-backed agent-eval runtimes."""
 
+# ruff: noqa: I001, T201 - the vendored SDK mirror uses different import-order and print settings.
+
 from __future__ import annotations
 
 import asyncio
@@ -289,11 +291,26 @@ class CodexDockerCliAgentRuntime(CodexCliAgentRuntime):
         if self._model is not None:
             inner_command.extend(["--model", self._model])
         inner_command.append("-")
+        # Codex intentionally runs as root: the container mounts its auth under /root and coding tasks
+        # may need to install tools. Repair the bind-mounted trees before Docker returns so the host can
+        # score and persist every artifact the agent created. Keep the Codex failure authoritative; only
+        # surface the chmod status when Codex itself succeeded.
+        shell_command = (
+            f"{shlex.join(inner_command)}; "
+            "codex_status=$?; "
+            f"chown -R {os.getuid()}:{os.getgid()} /workspace /evidence 2>/dev/null || true; "
+            "chmod -R u+rwX,go+rX /workspace /evidence; "
+            "permissions_status=$?; "
+            'if [ "$codex_status" -ne 0 ]; then exit "$codex_status"; fi; '
+            'exit "$permissions_status"'
+        )
         return [
             self._docker_bin,
             "run",
             "--rm",
             "-i",
+            "-e",
+            "PYTHONDONTWRITEBYTECODE=1",
             "-v",
             f"{self._auth_path.resolve()}:/root/.codex/auth.json:ro",
             "-v",
@@ -303,7 +320,7 @@ class CodexDockerCliAgentRuntime(CodexCliAgentRuntime):
             self._image,
             "sh",
             "-lc",
-            shlex.join(inner_command),
+            shell_command,
         ]
 
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/codex/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/codex/runtime.py
@@ -196,11 +196,7 @@ class CodexCliAgentRuntime:
             )
 
         try:
-            if final_output_path.exists():
-                output_text = final_output_path.read_text(encoding="utf-8")
-            else:
-                output_text = stdout_text
-                _write_private_text(final_output_path, output_text)
+            output_text = _read_private_final_output(final_output_path, fallback=stdout_text)
         except Exception as exc:
             return _failed_codex_trial(task, evidence_dir, exc, runtime_name=self._runtime_name)
         return AgentEvalTrial(
@@ -541,6 +537,28 @@ def _write_private_text(path: Path, content: str) -> None:
         temporary_path.unlink(missing_ok=True)
 
 
+def _read_private_final_output(path: Path, *, fallback: str) -> str:
+    """Read a regular agent-created final output without following it, then republish it privately."""
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    except FileNotFoundError:
+        _write_private_text(path, fallback)
+        return fallback
+
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise PermissionError(f"final output is not a regular file: {path}")
+        with os.fdopen(descriptor, "r", encoding="utf-8") as output_file:
+            descriptor = -1
+            output_text = output_file.read()
+    finally:
+        if descriptor != -1:
+            os.close(descriptor)
+
+    _write_private_text(path, output_text)
+    return output_text
+
+
 def _validate_private_tree(root: Path) -> None:
     """Require a host-owned, owner-only tree without following agent-created symlinks."""
     expected_uid = os.getuid()
@@ -561,8 +579,11 @@ def _validate_private_tree(root: Path) -> None:
                 raise PermissionError(f"directory is not owner-readable, writable, and traversable: {path} ({mode:o})")
             with os.scandir(path) as entries:
                 pending.extend(Path(entry.path) for entry in entries)
-        elif mode & 0o600 != 0o600:
-            raise PermissionError(f"file is not owner-readable and writable: {path} ({mode:o})")
+        elif stat.S_ISREG(path_stat.st_mode):
+            if mode & 0o600 != 0o600:
+                raise PermissionError(f"file is not owner-readable and writable: {path} ({mode:o})")
+        else:
+            raise PermissionError(f"artifact is not a regular file or directory: {path}")
 
 
 async def _terminate_process(process: Any | None) -> None:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/codex/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/codex/runtime.py
@@ -105,7 +105,9 @@ class CodexCliAgentRuntime:
             _ensure_private_directory(evidence_dir)
             _ensure_private_directory(workspace_dir)
         except Exception as exc:
-            return _failed_codex_trial(task, evidence_dir, exc, runtime_name=self._runtime_name)
+            # The path that failed setup is not safe to use for artifact persistence. In particular,
+            # writing through a rejected evidence-directory symlink would escape the private tree.
+            return _failed_codex_trial(task, None, exc, runtime_name=self._runtime_name)
 
         prompt_path = evidence_dir / "prompt.txt"
         task_path = evidence_dir / "task.json"
@@ -466,25 +468,28 @@ def print_codex_agent_models(*, codex_bin: str = "codex") -> None:
 
 def _failed_codex_trial(
     task: AgentEvalTask,
-    evidence_dir: Path,
+    evidence_dir: Path | None,
     exc: Exception,
     *,
     runtime_name: str = "codex_cli",
     permission_cleanup_error: str | None = None,
     artifact_persistence_error: str | None = None,
 ) -> AgentEvalTrial:
-    error_path = evidence_dir / "error.json"
     evidence: CandidateEvidence | None = None
     error_artifact_error: str | None = None
-    try:
-        _write_private_text(error_path, json.dumps({"error_type": exc.__class__.__name__, "error": str(exc)}) + "\n")
-    except Exception as artifact_exc:
-        error_artifact_error = f"{artifact_exc.__class__.__name__}: {artifact_exc}"
-    else:
-        evidence = CandidateEvidence(
-            descriptors={"error": EvidenceDescriptor(kind="error", format="json", ref=str(error_path))},
-            metadata={"runtime": runtime_name, "agent": "codex"},
-        )
+    if evidence_dir is not None:
+        error_path = evidence_dir / "error.json"
+        try:
+            _write_private_text(
+                error_path, json.dumps({"error_type": exc.__class__.__name__, "error": str(exc)}) + "\n"
+            )
+        except Exception as artifact_exc:
+            error_artifact_error = f"{artifact_exc.__class__.__name__}: {artifact_exc}"
+        else:
+            evidence = CandidateEvidence(
+                descriptors={"error": EvidenceDescriptor(kind="error", format="json", ref=str(error_path))},
+                metadata={"runtime": runtime_name, "agent": "codex"},
+            )
 
     metadata: dict[str, Any] = {
         "runtime": runtime_name,
@@ -528,12 +533,15 @@ def _write_private_text(path: Path, content: str) -> None:
     temporary_path = Path(temporary_name)
     try:
         os.fchmod(descriptor, 0o600)
-        with os.fdopen(descriptor, "w", encoding="utf-8") as temporary_file:
+        temporary_file = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = -1
+        with temporary_file:
             temporary_file.write(content)
         os.replace(temporary_path, path)
     finally:
-        with contextlib.suppress(OSError):
-            os.close(descriptor)
+        if descriptor != -1:
+            with contextlib.suppress(OSError):
+                os.close(descriptor)
         temporary_path.unlink(missing_ok=True)
 
 


### PR DESCRIPTION
## Summary

- keep the Dockerized Codex CLI running as root so its auth mount and tool-install behavior continue to work
- return every workspace and evidence tree readable and writable by the invoking host user without granting access to unrelated local users
- support rootful Docker, rootless Docker, and Docker Desktop ownership mappings without assuming container UID/GID values equal host values
- preserve the original Codex failure status while treating an unsafe or unreadable artifact tree as a trial-production failure
- synchronize the generated Python SDK mirror
- added a simple demo [example.py](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/packages/nemo_evaluator_sdk/examples/codex_docker/example.py) about how to evaluate codex in docker container mode

## Problem reported in AALGO-346

`CodexDockerCliAgentRuntime` runs `node:22-alpine` as root and bind-mounts the host workspace and evidence directories. Agent processes could create root-owned, mode-restricted files such as `__pycache__` entries. After Docker returned, the host evaluator, filesystem verifiers, CI artifact collection, and Allure result persistence could fail with `Permission denied` even though Codex completed successfully.

## Additional problems found during review

- **The first readability fallback overexposed evidence.** Recursive `chmod -R u+rwX,go+rX` changed restrictive files and directories to group/world-readable and traversable modes. On a shared POSIX host, another UID could read prompts, task inputs, seeded source, logs, generated files, and final output.
- **Raw host UID/GID values are not portable inside containers.** `chown <os.getuid()>:<os.getgid()>` can fail or map to subordinate host IDs under Docker Desktop and rootless user namespaces. Making that `chown` authoritative caused otherwise successful tasks to fail on Docker Desktop.
- **Some host-created evidence bypassed container cleanup.** Task metadata and prompts existed before Docker ran; stdout, stderr, fallback output, and errors were written after it returned. Ordinary write-then-`chmod` behavior left an umask-dependent exposure window and did not cover all failure paths.
- **Permissive or reused output directories weakened the boundary.** A private ancestor was not enforced before task inputs and workspace seeds were written.
- **Cleanup failures could mask or compound Codex failures.** Failed executions still contain sensitive evidence, and an inaccessible `error.json` path could raise while constructing a failed trial and abort sibling tasks.
- **The generated SDK mirror could retain the old permission behavior.** The source and vendored runtime must change together.

## Fix

- Create or repair the unmounted run root, task evidence directory, and workspace as host-owned `0700` directories. Reject a leaf symlink, non-directory, or directory owned by a different host UID before writing sensitive data.
- Publish task, prompt, stdout, stderr, fallback-output, and error files atomically through same-directory `0600` temporary files and `os.replace`.
- Capture the evidence mount's UID:GID as observed inside the container before Codex starts. Use that namespace-correct identity for best-effort recursive ownership repair.
- Require `chmod -R u+rwX,go-rwx /workspace /evidence`. This restores owner access, preserves owner execute where appropriate, and removes all group/other access.
- Validate the complete tree on the host with no-follow traversal after every completed Docker wrapper outcome:
  - every non-symlink artifact must be owned by the invoking host UID
  - directories must provide owner `rwx`
  - files must provide owner `rw`, with owner execute allowed
  - no group or other permission bits may remain
- Keep a Codex nonzero status authoritative. If permission validation also fails, retain the Codex error and add `permission_cleanup_error`; if Codex succeeds but the postcondition fails, fail the trial.
- Make `error.json` persistence best-effort so an inaccessible evidence directory still produces a task-local failed trial instead of aborting concurrent work.
- Set `PYTHONDONTWRITEBYTECODE=1` as defense in depth and regenerate the Python SDK mirror.

## Impact

Successful Docker Codex trials now return private, host-consumable workspace and evidence trees across the tested Docker Desktop ownership model. Failed trials retain their original Codex status while exposing cleanup failures separately. Verifiers and recursive persistence can consume the artifacts without making them readable to unrelated host users.

## Validation

- `uv run --frozen pytest packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime.py packages/nemo_evaluator_sdk/tests/agent_eval/test_codex_runtime_live.py -q -rs` — **22 passed**
  - two successful tasks run concurrently
  - restrictive container-created files are normalized
  - the real filesystem verifier and symlink-preserving recursive copy succeed
  - escaping symlinks are not dereferenced by the verifier
  - fake Codex status `23` remains authoritative
  - unsafe ownership/mode and failed error-artifact paths are covered
- original cross-UID reproduction after the fix — directory `0700`, file `0600`, distinct UID in the same GID denied
- scoped Ruff lint and format checks — passed
- scoped `ty` checks — passed
- `make vendor` — passed twice; only the expected SDK mirror changed
- `git diff --check` — passed

Linear: [AALGO-346](https://linear.app/nvidia/issue/AALGO-346/agent-evalcodex-docker-docker-codex-runtime-creates-unreadable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced host-private, owner-only evidence/workspace handling for Codex-backed runs, with safer persistence of prompt/output artifacts.
  * Improved trial failure reporting by separating Codex execution errors from artifact persistence and permission cleanup issues, while preserving the original failure details.
  * Made final output retrieval more resilient using `final_output.txt` when present, with clearer failure outcomes when reading/republishing fails.
  * Disabled Python bytecode generation during Docker-based Codex runs.

* **Tests**
  * Expanded local and live Docker regression coverage for strict ownership/permission enforcement, including `error.json`, final output, and negative cases (e.g., symlink/special-file attempts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
