### PR TITLE
fix(evaluator): emit evaluation_context in publish-to-intake

### DIFF
--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
@@ -37,7 +37,7 @@ from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEval
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
 from nemo_platform.types.intake.evaluator_result_create_params import EvaluatorResultCreateParams
 from nemo_platform.types.intake.evaluator_result_data_type import EvaluatorResultDataType
-from nemo_platform.types.intake.experiment_context_param import ExperimentContextParam
+from nemo_platform.types.intake.evaluation_context_param import EvaluationContextParam
 from nemo_platform.types.intake.ingest.atif_agent_param import AtifAgentParam
 from nemo_platform.types.intake.ingest.atif_create_params import AtifCreateParams
 from nemo_platform.types.intake.ingest.atif_final_metrics_param import AtifFinalMetricsParam
@@ -69,14 +69,14 @@ def session_id_for(run_id: str, trial_id: str) -> str:
     return f"{run_id}:{trial_id}"
 
 
-def run_task_to_experiment_context(trial: AgentEvalTrial, *, experiment_id: str) -> ExperimentContextParam:
-    """Build the lean ingest ``experiment_context`` for a trial.
+def run_task_to_evaluation_context(trial: AgentEvalTrial, *, experiment_id: str) -> EvaluationContextParam:
+    """Build the lean ingest ``evaluation_context`` for a trial.
 
-    Only ``experiment_id`` and ``test_case_id`` live here. Dataset, group, and
-    free-form metadata belong on the Experiment entity (created separately via
-    the platform Experiments SDK), not on the per-ingest context.
+    Only ``evaluation_id`` (the Evaluation's name — ``experiment_id`` holds it) and
+    ``test_case_id`` live here. Dataset, group, and free-form metadata belong on the
+    Evaluation entity (created separately via the platform SDK), not on the per-ingest context.
     """
-    return {"experiment_id": experiment_id, "test_case_id": trial.task_id}
+    return {"evaluation_id": experiment_id, "test_case_id": trial.task_id}
 
 
 def trial_to_atif_ingest(
@@ -107,7 +107,7 @@ def trial_to_atif_ingest(
         "session_id": session_id_for(run_id, trial.id),
         "agent": agent,
         "steps": [step],
-        "experiment_context": run_task_to_experiment_context(trial, experiment_id=experiment_id),
+        "evaluation_context": run_task_to_evaluation_context(trial, experiment_id=experiment_id),
     }
     if final_metrics is not None:
         body["final_metrics"] = final_metrics

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
@@ -35,9 +35,9 @@ from typing import Literal
 
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
+from nemo_platform.types.intake.evaluation_context_param import EvaluationContextParam
 from nemo_platform.types.intake.evaluator_result_create_params import EvaluatorResultCreateParams
 from nemo_platform.types.intake.evaluator_result_data_type import EvaluatorResultDataType
-from nemo_platform.types.intake.evaluation_context_param import EvaluationContextParam
 from nemo_platform.types.intake.ingest.atif_agent_param import AtifAgentParam
 from nemo_platform.types.intake.ingest.atif_create_params import AtifCreateParams
 from nemo_platform.types.intake.ingest.atif_final_metrics_param import AtifFinalMetricsParam

--- a/plugins/nemo-evaluator/tests/intake/test_mapping.py
+++ b/plugins/nemo-evaluator/tests/intake/test_mapping.py
@@ -11,7 +11,7 @@ import pytest
 from nemo_evaluator.intake.mapping import (
     ATIF_SCHEMA_VERSION,
     DEFAULT_AGENT_VERSION,
-    run_task_to_experiment_context,
+    run_task_to_evaluation_context,
     score_to_evaluator_results,
     session_id_for,
     trial_to_atif_ingest,
@@ -72,12 +72,12 @@ def test_session_id_is_stable_per_trial() -> None:
     assert session_id_for("run-1", "trial-1") == "run-1:trial-1"
 
 
-# --- run_task_to_experiment_context -----------------------------------------
+# --- run_task_to_evaluation_context -----------------------------------------
 
 
-def test_experiment_context_is_lean() -> None:
-    context = run_task_to_experiment_context(_trial(task_id="task-42"), experiment_id="bench-x-variant")
-    assert context == {"experiment_id": "bench-x-variant", "test_case_id": "task-42"}
+def test_evaluation_context_is_lean() -> None:
+    context = run_task_to_evaluation_context(_trial(task_id="task-42"), experiment_id="bench-x-variant")
+    assert context == {"evaluation_id": "bench-x-variant", "test_case_id": "task-42"}
 
 
 # --- trial_to_atif_ingest ---------------------------------------------------
@@ -95,7 +95,7 @@ def test_trial_to_atif_ingest_shape() -> None:
     assert body["session_id"] == "run-1:t-1"
     assert body["agent"] == {"name": "my-agent", "version": DEFAULT_AGENT_VERSION, "model_name": "gpt-4o"}
     assert body["steps"] == [{"source": "agent", "step_id": 1, "message": "final answer"}]
-    assert body["experiment_context"] == {"experiment_id": "exp-1", "test_case_id": "task-1"}
+    assert body["evaluation_context"] == {"evaluation_id": "exp-1", "test_case_id": "task-1"}
     assert "final_metrics" not in body
 
 

--- a/plugins/nemo-evaluator/tests/intake/test_publish.py
+++ b/plugins/nemo-evaluator/tests/intake/test_publish.py
@@ -139,7 +139,7 @@ async def test_publishes_trajectory_and_scores() -> None:
 
     assert len(client.atif_calls) == 1
     assert client.atif_calls[0]["session_id"] == "run-1:t-1"
-    assert client.atif_calls[0]["experiment_context"] == {"experiment_id": "exp-1", "test_case_id": "task-1"}
+    assert client.atif_calls[0]["evaluation_context"] == {"evaluation_id": "exp-1", "test_case_id": "task-1"}
     # 3 metric outputs across the two score records -> 3 evaluator-result rows.
     assert len(client.eval_calls) == 3
     assert {call["name"] for call in client.eval_calls} == {"accuracy.score", "accuracy.passed", "latency.p50"}

--- a/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
+++ b/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
@@ -208,9 +208,9 @@ async def test_publish_to_intake_round_trip(platform_base_url: str) -> None:
         trace = traces[0]
         assert trace.session_id == t1.session_id
         assert trace.root_span_id == t1.span_id
-        assert trace.experiment_context is not None
-        assert trace.experiment_context.experiment_id == EXPERIMENT_NAME
-        assert trace.experiment_context.test_case_id == "task-1"
+        assert trace.evaluation_context is not None
+        assert trace.evaluation_context.evaluation_id == EXPERIMENT_NAME
+        assert trace.evaluation_context.test_case_id == "task-1"
 
         # --- trial-1 scores: every field, every data_type coercion.
         rows = await client.intake.spans.evaluator_results.list(t1.span_id, workspace=WORKSPACE)


### PR DESCRIPTION
## Summary

The evaluator's publish-to-intake path (added in #456) still emits the deprecated `experiment_context` on ATIF ingest. As part of the **Experiment → Evaluation** rename, intake deprecated `experiment_context` in favor of `evaluation_context`. This migrates the boundary mapping to the canonical shape.

Per `mapping.py`'s own design note ("a later rename is a one-file change"), the wire migration lives entirely in that module:

- `ExperimentContextParam` → `EvaluationContextParam`
- `run_task_to_experiment_context` → `run_task_to_evaluation_context`, now emitting `{"evaluation_id": …, "test_case_id": …}` under the `"evaluation_context"` ATIF body key
- tests updated to match (unit `test_mapping.py`/`test_publish.py` + the integration trace read)

### Left for the evaluator team
The public `publish_to_intake(experiment_id=…)` parameter and `PublishReport.experiment_id` field are **intentionally unchanged** — renaming that external surface to `evaluation_id` is your call. The value already flows through to `evaluation_context.evaluation_id`, so functionally this is complete.

### Not urgent / non-breaking
`experiment_context` still works as a deprecated alias in intake (`evaluation_context` takes precedence when both are sent), so publish isn't broken today — this is a forward migration before the alias is removed. No SDK version bump needed: the plugin uses the in-repo workspace SDK, which already exposes `EvaluationContextParam`.

## Validation
- In-repo SDK confirmed to export `EvaluationContextParam` (TypedDict: `evaluation_id`, `test_case_id`).
- `mapping.py` compiles; no stale `experiment_context`/`ExperimentContextParam` references remain in the changed files.
- Unit + integration test assertions updated in lockstep. (Full suite runs in CI — the plugin needs the whole workspace built.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the evaluation data sent to Intake to use evaluation context.
  - Evaluation records now include the evaluation ID and test case ID for clearer traceability.
  - Updated published trajectory and score metadata to consistently reflect the new evaluation context.
  - Improved integration coverage to verify evaluation context is preserved end-to-end through the publishing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->