### PR TITLE
fix(evaluator): validate metric refs on persisted task create

### DIFF
--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/service/task_service.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/service/task_service.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 
-from nemo_evaluator.api.schemas import MetricInline, MetricRef, Task, TaskInput
+from nemo_evaluator.api.schemas import MetricInline, MetricRef, Task, TaskInput, parse_entity_ref
 from nemo_evaluator.api.service.metric_service import MetricService
 from nemo_evaluator.entities import TaskEntity
 from nemo_platform_plugin.entities import EntityClient, EntityConflictError, EntityNotFoundError, PaginationInfo
@@ -23,6 +23,10 @@ from nemo_platform_plugin.log_utils import sanitize_for_log
 from nemo_platform_plugin.schema import Page, PaginationData
 
 logger = logging.getLogger(__name__)
+
+
+class MetricRefNotFoundError(ValueError):
+    """A task references a stored metric that does not exist."""
 
 
 def _entity_to_task(entity: TaskEntity) -> Task:
@@ -70,7 +74,14 @@ class TaskService:
         refs: list[MetricRef] = []
         for metric in metrics:
             if isinstance(metric, MetricRef):
-                refs.append(metric)
+                ref_workspace, name = parse_entity_ref(metric.root, workspace)
+                if await self.metric_service.get_metric(ref_workspace, name) is None:
+                    raise MetricRefNotFoundError(
+                        f"Metric reference '{metric.root}' not found. "
+                        f"Ensure a stored metric named '{name}' exists in workspace '{ref_workspace}', "
+                        "or pass an inline metric instead."
+                    )
+                refs.append(MetricRef(f"{ref_workspace}/{name}"))
             else:
                 refs.append(await self.metric_service.store_derived_metric(metric, workspace=workspace))
         return refs

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/tasks.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/tasks.py
@@ -11,7 +11,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from nemo_evaluator.api.dependencies import get_task_service
 from nemo_evaluator.api.schemas import Task, TaskFilter, TaskInput, TaskSort
-from nemo_evaluator.api.service.task_service import TaskService
+from nemo_evaluator.api.service.task_service import MetricRefNotFoundError, TaskService
 from nemo_evaluator.authz import scope
 from nemo_evaluator.entities import MAX_NAME_LENGTH, NAME_PATTERN
 from nemo_platform_plugin.api.parsed_filter import ParsedFilter, make_filter_dep
@@ -101,6 +101,9 @@ async def create_task(
         return await service.create_task(name, task, workspace=workspace, project=project)
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during task creation: {e}")
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+    except MetricRefNotFoundError as e:
+        logger.warning(f"Task has an invalid metric reference: {e}")
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
     except ValueError as e:
         if "already exists" in str(e).lower():

--- a/plugins/nemo-evaluator/tests/api/service/test_task_service.py
+++ b/plugins/nemo-evaluator/tests/api/service/test_task_service.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 
 import pytest
 from nemo_evaluator.api.schemas import MetricInline, MetricRef, Task, TaskInput
-from nemo_evaluator.api.service.task_service import TaskService
+from nemo_evaluator.api.service.task_service import MetricRefNotFoundError, TaskService
 from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
 from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
@@ -23,12 +23,16 @@ from nemo_platform_plugin.entities import (
 class _FakeMetricService:
     """Records inline-metric normalization so we can assert a task stores refs, not bundles."""
 
-    def __init__(self) -> None:
+    def __init__(self, existing: set[tuple[str, str]] | None = None) -> None:
         self.stored: list[MetricInline] = []
+        self.existing = existing if existing is not None else {("default", "stored-metric")}
 
     async def store_derived_metric(self, metric: MetricInline, *, workspace: str) -> MetricRef:
         self.stored.append(metric)
         return MetricRef(f"{workspace}/derived.{metric.payload.digest}")
+
+    async def get_metric(self, workspace: str, name: str) -> object | None:
+        return object() if (workspace, name) in self.existing else None
 
 
 def _inline_metric() -> MetricInline:
@@ -133,6 +137,19 @@ async def test_create_normalizes_inline_metrics_to_refs(
     assert all(isinstance(m, MetricRef) for m in created.metrics)
     assert created.metrics[0].root == "default/stored-metric"
     assert created.metrics[1].root == f"default/derived.{inline.payload.digest}"
+
+
+async def test_create_rejects_missing_metric_ref(service: TaskService) -> None:
+    task_input = TaskInput(intent="x", inputs={"instruction": "?"}, metrics=[MetricRef("default/nope")])
+    with pytest.raises(MetricRefNotFoundError, match="not found"):
+        await service.create_task("task-1", task_input, workspace="default")
+
+
+async def test_create_canonicalizes_bare_metric_ref(service: TaskService) -> None:
+    # A bare "stored-metric" ref resolves against the task workspace and is persisted as "default/stored-metric".
+    task_input = TaskInput(intent="x", inputs={"instruction": "?"}, metrics=[MetricRef("stored-metric")])
+    created = await service.create_task("task-1", task_input, workspace="default")
+    assert created.metrics[0].root == "default/stored-metric"
 
 
 async def test_create_rejects_duplicate(service: TaskService) -> None:

--- a/plugins/nemo-evaluator/tests/api/v2/test_tasks_routes.py
+++ b/plugins/nemo-evaluator/tests/api/v2/test_tasks_routes.py
@@ -67,10 +67,14 @@ class _FakeEntityClient:
 
 
 class _FakeMetricService:
-    """Normalizes inline metrics to derived refs; the route tests submit refs only, so it's unused."""
+    """Normalizes inline metrics to derived refs and resolves the ``default/stored-metric`` ref the
+    route bodies submit, so task-create metric-ref validation passes for the happy-path tests."""
 
     async def store_derived_metric(self, metric, *, workspace: str) -> MetricRef:
         return MetricRef(f"{workspace}/derived.{metric.payload.digest}")
+
+    async def get_metric(self, workspace: str, name: str) -> object | None:
+        return object() if (workspace, name) == ("default", "stored-metric") else None
 
 
 @pytest.fixture
@@ -116,6 +120,12 @@ def test_create_rejects_duplicate_metadata_keys(client: TestClient) -> None:
     # metadata is a key→value map as a list; duplicate keys are a 422, not a silent last-wins collapse.
     body = _body()
     body["metadata"] = [{"key": "suite", "value": "smoke"}, {"key": "suite", "value": "regression"}]
+    assert client.post(f"{_BASE}/task-1", json=body).status_code == 422
+
+
+def test_create_missing_metric_ref_returns_422(client: TestClient) -> None:
+    body = _body()
+    body["metrics"] = ["default/missing-metric"]
     assert client.post(f"{_BASE}/task-1", json=body).status_code == 422
 
 


### PR DESCRIPTION
## Summary
- Validate stored-metric refs when creating persisted agent-eval tasks; reject missing refs with HTTP 422 instead of persisting an unusable task.
- Canonicalize bare metric refs (`metric-name`) to `workspace/metric-name` at create time, mirroring the existing taskset task-ref validation pattern.
- NVBugs: https://nvbugspro.nvidia.com/bug/6466828

## Test plan
- [x] `uv run --frozen pytest plugins/nemo-evaluator/tests/api/service/test_task_service.py`
- [x] `uv run --frozen pytest plugins/nemo-evaluator/tests/api/v2/test_tasks_routes.py`