### PR TITLE
feat(experiments): test-case-weighted rollups (aggregate per test case before pooling)

### DIFF
--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -3402,8 +3402,8 @@ paths:
             \ (the first field dominates); prefix any field with '-' for descending\
             \ \u2014 e.g. '-evaluators.reward.mean,cost_usd.mean'. Each field is an\
             \ evaluation attribute (name, created_at, updated_at, pinned_at) or an\
-            \ aggregate metric: run_count, cost_usd.<stat>, latency_ms.<stat>, or\
-            \ evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
+            \ aggregate metric: run_count, test_case_count, cost_usd.<stat>, latency_ms.<stat>,\
+            \ or evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
             \ p95, p99, sum, count. When omitted, defaults to -created_at with pinned\
             \ evaluations first."
           title: Sort
@@ -3412,9 +3412,10 @@ paths:
           \ (the first field dominates); prefix any field with '-' for descending\
           \ \u2014 e.g. '-evaluators.reward.mean,cost_usd.mean'. Each field is an\
           \ evaluation attribute (name, created_at, updated_at, pinned_at) or an aggregate\
-          \ metric: run_count, cost_usd.<stat>, latency_ms.<stat>, or evaluators.<name>.<stat>,\
-          \ where <stat> is one of mean, median, p90, p95, p99, sum, count. When omitted,\
-          \ defaults to -created_at with pinned evaluations first."
+          \ metric: run_count, test_case_count, cost_usd.<stat>, latency_ms.<stat>,\
+          \ or evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
+          \ p95, p99, sum, count. When omitted, defaults to -created_at with pinned\
+          \ evaluations first."
       - in: query
         name: filter
         style: deepObject
@@ -10455,6 +10456,14 @@ components:
           title: Run Count
           description: Number of distinct ingested evaluation sessions; one session
             is treated as one run.
+          default: 0
+        test_case_count:
+          type: integer
+          title: Test Case Count
+          description: Number of distinct test cases in the evaluation, i.e. distinct
+            test_case_id values (sessions with no test_case_id each count as their
+            own). A test case run k times counts once; the rollup metrics are averaged
+            per test case before pooling across test cases.
           default: 0
         cost_usd:
           $ref: '#/components/schemas/EvaluatorAggregate'

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -3402,8 +3402,8 @@ paths:
             \ (the first field dominates); prefix any field with '-' for descending\
             \ \u2014 e.g. '-evaluators.reward.mean,cost_usd.mean'. Each field is an\
             \ evaluation attribute (name, created_at, updated_at, pinned_at) or an\
-            \ aggregate metric: run_count, cost_usd.<stat>, latency_ms.<stat>, or\
-            \ evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
+            \ aggregate metric: run_count, test_case_count, cost_usd.<stat>, latency_ms.<stat>,\
+            \ or evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
             \ p95, p99, sum, count. When omitted, defaults to -created_at with pinned\
             \ evaluations first."
           title: Sort
@@ -3412,9 +3412,10 @@ paths:
           \ (the first field dominates); prefix any field with '-' for descending\
           \ \u2014 e.g. '-evaluators.reward.mean,cost_usd.mean'. Each field is an\
           \ evaluation attribute (name, created_at, updated_at, pinned_at) or an aggregate\
-          \ metric: run_count, cost_usd.<stat>, latency_ms.<stat>, or evaluators.<name>.<stat>,\
-          \ where <stat> is one of mean, median, p90, p95, p99, sum, count. When omitted,\
-          \ defaults to -created_at with pinned evaluations first."
+          \ metric: run_count, test_case_count, cost_usd.<stat>, latency_ms.<stat>,\
+          \ or evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
+          \ p95, p99, sum, count. When omitted, defaults to -created_at with pinned\
+          \ evaluations first."
       - in: query
         name: filter
         style: deepObject
@@ -10455,6 +10456,14 @@ components:
           title: Run Count
           description: Number of distinct ingested evaluation sessions; one session
             is treated as one run.
+          default: 0
+        test_case_count:
+          type: integer
+          title: Test Case Count
+          description: Number of distinct test cases in the evaluation, i.e. distinct
+            test_case_id values (sessions with no test_case_id each count as their
+            own). A test case run k times counts once; the rollup metrics are averaged
+            per test case before pooling across test cases.
           default: 0
         cost_usd:
           $ref: '#/components/schemas/EvaluatorAggregate'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -3402,8 +3402,8 @@ paths:
             \ (the first field dominates); prefix any field with '-' for descending\
             \ \u2014 e.g. '-evaluators.reward.mean,cost_usd.mean'. Each field is an\
             \ evaluation attribute (name, created_at, updated_at, pinned_at) or an\
-            \ aggregate metric: run_count, cost_usd.<stat>, latency_ms.<stat>, or\
-            \ evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
+            \ aggregate metric: run_count, test_case_count, cost_usd.<stat>, latency_ms.<stat>,\
+            \ or evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
             \ p95, p99, sum, count. When omitted, defaults to -created_at with pinned\
             \ evaluations first."
           title: Sort
@@ -3412,9 +3412,10 @@ paths:
           \ (the first field dominates); prefix any field with '-' for descending\
           \ \u2014 e.g. '-evaluators.reward.mean,cost_usd.mean'. Each field is an\
           \ evaluation attribute (name, created_at, updated_at, pinned_at) or an aggregate\
-          \ metric: run_count, cost_usd.<stat>, latency_ms.<stat>, or evaluators.<name>.<stat>,\
-          \ where <stat> is one of mean, median, p90, p95, p99, sum, count. When omitted,\
-          \ defaults to -created_at with pinned evaluations first."
+          \ metric: run_count, test_case_count, cost_usd.<stat>, latency_ms.<stat>,\
+          \ or evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
+          \ p95, p99, sum, count. When omitted, defaults to -created_at with pinned\
+          \ evaluations first."
       - in: query
         name: filter
         style: deepObject
@@ -10455,6 +10456,14 @@ components:
           title: Run Count
           description: Number of distinct ingested evaluation sessions; one session
             is treated as one run.
+          default: 0
+        test_case_count:
+          type: integer
+          title: Test Case Count
+          description: Number of distinct test cases in the evaluation, i.e. distinct
+            test_case_id values (sessions with no test_case_id each count as their
+            own). A test case run k times counts once; the rollup metrics are averaged
+            per test case before pooling across test cases.
           default: 0
         cost_usd:
           $ref: '#/components/schemas/EvaluatorAggregate'

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -3402,8 +3402,8 @@ paths:
             \ (the first field dominates); prefix any field with '-' for descending\
             \ \u2014 e.g. '-evaluators.reward.mean,cost_usd.mean'. Each field is an\
             \ evaluation attribute (name, created_at, updated_at, pinned_at) or an\
-            \ aggregate metric: run_count, cost_usd.<stat>, latency_ms.<stat>, or\
-            \ evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
+            \ aggregate metric: run_count, test_case_count, cost_usd.<stat>, latency_ms.<stat>,\
+            \ or evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
             \ p95, p99, sum, count. When omitted, defaults to -created_at with pinned\
             \ evaluations first."
           title: Sort
@@ -3412,9 +3412,10 @@ paths:
           \ (the first field dominates); prefix any field with '-' for descending\
           \ \u2014 e.g. '-evaluators.reward.mean,cost_usd.mean'. Each field is an\
           \ evaluation attribute (name, created_at, updated_at, pinned_at) or an aggregate\
-          \ metric: run_count, cost_usd.<stat>, latency_ms.<stat>, or evaluators.<name>.<stat>,\
-          \ where <stat> is one of mean, median, p90, p95, p99, sum, count. When omitted,\
-          \ defaults to -created_at with pinned evaluations first."
+          \ metric: run_count, test_case_count, cost_usd.<stat>, latency_ms.<stat>,\
+          \ or evaluators.<name>.<stat>, where <stat> is one of mean, median, p90,\
+          \ p95, p99, sum, count. When omitted, defaults to -created_at with pinned\
+          \ evaluations first."
       - in: query
         name: filter
         style: deepObject
@@ -10456,6 +10457,14 @@ components:
           description: Number of distinct ingested evaluation sessions; one session
             is treated as one run.
           default: 0
+        test_case_count:
+          type: integer
+          title: Test Case Count
+          description: Number of distinct test cases in the evaluation, i.e. distinct
+            test_case_id values (sessions with no test_case_id each count as their
+            own). A test case run k times counts once; the rollup metrics are averaged
+            per test case before pooling across test cases.
+          default: 0
         cost_usd:
           $ref: '#/components/schemas/EvaluatorAggregate'
         latency_ms:
@@ -15004,7 +15013,7 @@ components:
       - source
       - -source
       title: PlatformJobListSortField
-      description: 'Sort fields for the job *list* endpoint.'
+      description: Sort fields for the job *list* endpoint.
     PlatformJobListTaskResponse:
       properties:
         data:

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/evaluations/evaluations.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/evaluations/evaluations.py
@@ -342,9 +342,9 @@ class EvaluationsResource(SyncAPIResource):
               dominates); prefix any field with '-' for descending — e.g.
               '-evaluators.reward.mean,cost_usd.mean'. Each field is an evaluation attribute
               (name, created_at, updated_at, pinned_at) or an aggregate metric: run_count,
-              cost_usd.<stat>, latency_ms.<stat>, or evaluators.<name>.<stat>, where <stat> is
-              one of mean, median, p90, p95, p99, sum, count. When omitted, defaults to
-              -created_at with pinned evaluations first.
+              test_case_count, cost_usd.<stat>, latency_ms.<stat>, or
+              evaluators.<name>.<stat>, where <stat> is one of mean, median, p90, p95, p99,
+              sum, count. When omitted, defaults to -created_at with pinned evaluations first.
 
           extra_headers: Send extra headers
 
@@ -793,9 +793,9 @@ class AsyncEvaluationsResource(AsyncAPIResource):
               dominates); prefix any field with '-' for descending — e.g.
               '-evaluators.reward.mean,cost_usd.mean'. Each field is an evaluation attribute
               (name, created_at, updated_at, pinned_at) or an aggregate metric: run_count,
-              cost_usd.<stat>, latency_ms.<stat>, or evaluators.<name>.<stat>, where <stat> is
-              one of mean, median, p90, p95, p99, sum, count. When omitted, defaults to
-              -created_at with pinned evaluations first.
+              test_case_count, cost_usd.<stat>, latency_ms.<stat>, or
+              evaluators.<name>.<stat>, where <stat> is one of mean, median, p90, p95, p99,
+              sum, count. When omitted, defaults to -created_at with pinned evaluations first.
 
           extra_headers: Send extra headers
 

--- a/sdk/python/nemo-platform/src/nemo_platform/types/evaluations/evaluation_list_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/evaluations/evaluation_list_params.py
@@ -51,7 +51,7 @@ class EvaluationListParams(TypedDict, total=False):
     dominates); prefix any field with '-' for descending — e.g.
     '-evaluators.reward.mean,cost_usd.mean'. Each field is an evaluation attribute
     (name, created_at, updated_at, pinned_at) or an aggregate metric: run_count,
-    cost_usd.<stat>, latency_ms.<stat>, or evaluators.<name>.<stat>, where <stat> is
-    one of mean, median, p90, p95, p99, sum, count. When omitted, defaults to
-    -created_at with pinned evaluations first.
+    test_case_count, cost_usd.<stat>, latency_ms.<stat>, or
+    evaluators.<name>.<stat>, where <stat> is one of mean, median, p90, p95, p99,
+    sum, count. When omitted, defaults to -created_at with pinned evaluations first.
     """

--- a/sdk/python/nemo-platform/src/nemo_platform/types/evaluations/evaluation_response.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/evaluations/evaluation_response.py
@@ -89,6 +89,14 @@ class EvaluationResponse(BaseModel):
 
     status: Optional[str] = None
 
+    test_case_count: Optional[int] = None
+    """Number of distinct test cases in the evaluation, i.e.
+
+    distinct test_case_id values (sessions with no test_case_id each count as their
+    own). A test case run k times counts once; the rollup metrics are averaged per
+    test case before pooling across test cases.
+    """
+
     updated_at: Optional[datetime] = None
 
     if not PYDANTIC_V1:

--- a/services/intake/src/nmp/intake/api/v2/experiments/endpoints.py
+++ b/services/intake/src/nmp/intake/api/v2/experiments/endpoints.py
@@ -394,7 +394,8 @@ async def list_evaluations(
             "Comma-separated list of fields to sort by, applied in order (the first field dominates); "
             "prefix any field with '-' for descending — e.g. '-evaluators.reward.mean,cost_usd.mean'. "
             "Each field is an evaluation attribute (name, created_at, updated_at, pinned_at) or an "
-            "aggregate metric: run_count, cost_usd.<stat>, latency_ms.<stat>, or evaluators.<name>.<stat>, "
+            "aggregate metric: run_count, test_case_count, cost_usd.<stat>, latency_ms.<stat>, or "
+            "evaluators.<name>.<stat>, "
             "where <stat> is one of mean, median, p90, p95, p99, sum, count. When omitted, defaults to "
             "-created_at with pinned evaluations first."
         ),
@@ -977,8 +978,9 @@ class _MetricPredicate(NamedTuple):
 
 
 def _is_valid_metric_path(field: str) -> bool:
-    """True if `field` is a rollup-metric path: run_count, <metric>.<stat>, or evaluators.<name>.<stat>."""
-    if field == "run_count":
+    """True if `field` is a rollup-metric path: run_count, test_case_count, <metric>.<stat>, or
+    evaluators.<name>.<stat>."""
+    if field in ("run_count", "test_case_count"):
         return True
     head, _, rest = field.partition(".")
     if head in ("cost_usd", "latency_ms"):
@@ -1031,7 +1033,7 @@ def _is_metric_field(field: str) -> bool:
     extracted and rejected with a 400 rather than forwarded to the entity store. Entity fields (already
     translated to ``data.*`` by the filter dep) never match.
     """
-    return field == "run_count" or field.split(".", 1)[0] in _METRIC_NAMESPACES
+    return field in ("run_count", "test_case_count") or field.split(".", 1)[0] in _METRIC_NAMESPACES
 
 
 def _operation_references_metric(operation: FilterOperation | None) -> bool:
@@ -1130,6 +1132,8 @@ def _evaluation_sort_value(response: EvaluationResponse, field: str) -> Any:
         return getattr(response, field)
     if field == "run_count":
         return response.run_count
+    if field == "test_case_count":
+        return response.test_case_count
     head, _, rest = field.partition(".")
     if head == "cost_usd":
         return getattr(response.cost_usd, rest, None) if response.cost_usd is not None else None
@@ -1224,6 +1228,7 @@ def _apply_rollup(response: EvaluationResponse, rollup: EvaluationRollup) -> Non
     response.agent_versions = rollup.agent_versions
     response.aggregate_scores = {name: _aggregate(score) for name, score in rollup.evaluator_scores.items()} or None
     response.run_count = rollup.run_count
+    response.test_case_count = rollup.test_case_count
     response.cost_usd = _aggregate(rollup.cost_usd) if rollup.cost_usd is not None else None
     response.latency_ms = _aggregate(rollup.latency_ms) if rollup.latency_ms is not None else None
 

--- a/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
+++ b/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
@@ -192,6 +192,14 @@ class EvaluationResponse(BaseModel):
         default=0,
         description="Number of distinct ingested evaluation sessions; one session is treated as one run.",
     )
+    test_case_count: int = Field(
+        default=0,
+        description=(
+            "Number of distinct test cases in the evaluation, i.e. distinct test_case_id values "
+            "(sessions with no test_case_id each count as their own). A test case run k times counts once; "
+            "the rollup metrics are averaged per test case before pooling across test cases."
+        ),
+    )
     cost_usd: EvaluatorAggregate | None = None
     latency_ms: EvaluatorAggregate | None = None
 

--- a/services/intake/src/nmp/intake/spans/evaluation_rollup_repository.py
+++ b/services/intake/src/nmp/intake/spans/evaluation_rollup_repository.py
@@ -29,6 +29,7 @@ class ScoreRollup:
 class EvaluationRollup:
     evaluation_id: str
     run_count: int = 0
+    test_case_count: int = 0
     model_names: list[str] = field(default_factory=list)
     agent_names: list[str] = field(default_factory=list)
     agent_versions: list[str] = field(default_factory=list)
@@ -62,6 +63,7 @@ class EvaluationRollupRepository:
             )
         ):
             rollups[row["evaluation_id"]].run_count = int(row["run_count"])
+            rollups[row["evaluation_id"]].test_case_count = int(row["test_case_count"])
 
         for row in result_rows(
             await self._client.query(
@@ -116,7 +118,7 @@ def _evaluation_id_parameters(evaluation_ids: list[str]) -> tuple[str, dict[str,
 
 def _scoped_sessions_sql(trace_index_table: str, evaluation_names_sql: str) -> str:
     return f"""
-        SELECT workspace, evaluation_id, session_id, latency_ms
+        SELECT workspace, evaluation_id, session_id, test_case_id, latency_ms
         FROM {trace_index_table} FINAL
         WHERE workspace = %(workspace)s
             AND is_deleted = 0
@@ -126,6 +128,16 @@ def _scoped_sessions_sql(trace_index_table: str, evaluation_names_sql: str) -> s
     """
 
 
+def _test_case_key_sql(sessions_alias: str = "") -> str:
+    """Per-test-case grouping key for the two-level rollup: the test case (``test_case_id``) when set,
+    else the individual attempt (``session_id``) so unlabeled runs pool per-attempt exactly like a flat
+    rollup. Namespaced so a ``test_case_id`` can never collide with a ``session_id``. Counting the
+    distinct values of this key over an evaluation's sessions gives ``test_case_count``.
+    """
+    prefix = f"{sessions_alias}." if sessions_alias else ""
+    return f"if({prefix}test_case_id != '', concat('t:', {prefix}test_case_id), concat('s:', {prefix}session_id))"
+
+
 def _run_counts_sql(trace_index_table: str, evaluation_names_sql: str) -> str:
     return f"""
         WITH scoped_sessions AS (
@@ -133,7 +145,8 @@ def _run_counts_sql(trace_index_table: str, evaluation_names_sql: str) -> str:
         )
         SELECT
             evaluation_id,
-            count() AS run_count
+            count() AS run_count,
+            uniqExact({_test_case_key_sql()}) AS test_case_count
         FROM scoped_sessions
         GROUP BY evaluation_id
         ORDER BY evaluation_id ASC
@@ -179,10 +192,11 @@ def _stat_columns(value_expr: str, *, prefix: str = "", guarded: bool = False) -
 
 
 def _score_rollups_sql(*, trace_index_table: str, evaluator_results_table: str, evaluation_names_sql: str) -> str:
-    # Each run (session) contributes one score per evaluator, so reduce the per-span
-    # evaluator_results rows to a single per-(evaluation, session, evaluator) value before
-    # the distribution rollup. This keeps `count` aligned with run_count and the mean
-    # run-weighted rather than weighted by spans-per-session.
+    # Two-level rollup. Each run (session) contributes one score per evaluator, so first reduce the
+    # per-span evaluator_results rows to one per-(session, evaluator) value; then average those per
+    # test case (pass@1 = mean over a test case's k attempts); then take the distribution across test cases. The mean
+    # is test-case-weighted (each test case counts once regardless of k), and `count` is the number of test cases.
+    test_case_key = _test_case_key_sql("sessions")
     return f"""
         WITH
         scoped_sessions AS (
@@ -191,6 +205,7 @@ def _score_rollups_sql(*, trace_index_table: str, evaluator_results_table: str, 
         session_scores AS (
             SELECT
                 sessions.evaluation_id AS evaluation_id,
+                {test_case_key} AS test_case_key,
                 results.name AS evaluator_name,
                 avg(results.value) AS value
             FROM scoped_sessions AS sessions
@@ -207,19 +222,32 @@ def _score_rollups_sql(*, trace_index_table: str, evaluator_results_table: str, 
             ) AS results
                 ON sessions.workspace = results.workspace
                 AND sessions.session_id = results.session_id
-            GROUP BY sessions.evaluation_id, sessions.session_id, results.name
+            GROUP BY sessions.evaluation_id, sessions.session_id, sessions.test_case_id, results.name
+        ),
+        test_case_scores AS (
+            SELECT
+                evaluation_id,
+                test_case_key,
+                evaluator_name,
+                avg(value) AS value
+            FROM session_scores
+            GROUP BY evaluation_id, test_case_key, evaluator_name
         )
         SELECT
             evaluation_id,
             evaluator_name,
             {_stat_columns("value")}
-        FROM session_scores
+        FROM test_case_scores
         GROUP BY evaluation_id, evaluator_name
         ORDER BY evaluation_id ASC, evaluator_name ASC
     """
 
 
 def _metric_rollups_sql(*, trace_index_table: str, spans_table: str, evaluation_names_sql: str) -> str:
+    # Two-level rollup: per-attempt cost/latency, then averaged per test case (avg per attempt — the number
+    # must not scale with k), then the distribution across test cases (test-case-weighted). Attempts with no
+    # cost/latency are excluded from a test case's average rather than counted as zero.
+    test_case_key = _test_case_key_sql("sessions")
     return f"""
         WITH
         scoped_sessions AS (
@@ -239,7 +267,7 @@ def _metric_rollups_sql(*, trace_index_table: str, spans_table: str, evaluation_
         session_costs AS (
             SELECT
                 sessions.evaluation_id AS evaluation_id,
-                sessions.session_id AS session_id,
+                {test_case_key} AS test_case_key,
                 sessions.latency_ms AS latency_ms,
                 if(
                     countIf(has(mapKeys(spans.attributes_number), %(cost_key)s)) = 0,
@@ -269,7 +297,19 @@ def _metric_rollups_sql(*, trace_index_table: str, spans_table: str, evaluation_
                 ON sessions.workspace = spans.workspace
                 AND sessions.session_id = spans.session_id
                 AND spans.is_deleted = 0
-            GROUP BY sessions.evaluation_id, sessions.session_id, sessions.latency_ms
+            GROUP BY sessions.evaluation_id, sessions.session_id, sessions.test_case_id, sessions.latency_ms
+        ),
+        test_case_metrics AS (
+            SELECT
+                evaluation_id,
+                test_case_key,
+                if(countIf(isNotNull(cost_usd)) = 0, NULL, avgIf(cost_usd, isNotNull(cost_usd))) AS cost_usd,
+                if(countIf(isNotNull(latency_ms)) = 0, NULL, avgIf(latency_ms, isNotNull(latency_ms))) AS latency_ms,
+                arrayDistinct(arrayFlatten(groupArray(model_names))) AS model_names,
+                arrayDistinct(arrayFlatten(groupArray(agent_names))) AS agent_names,
+                arrayDistinct(arrayFlatten(groupArray(agent_versions))) AS agent_versions
+            FROM session_costs
+            GROUP BY evaluation_id, test_case_key
         )
         SELECT
             evaluation_id,
@@ -278,7 +318,7 @@ def _metric_rollups_sql(*, trace_index_table: str, spans_table: str, evaluation_
             arraySort(arrayDistinct(arrayFlatten(groupArray(agent_versions)))) AS agent_versions,
             {_stat_columns("cost_usd", prefix="cost", guarded=True)},
             {_stat_columns("latency_ms", prefix="latency", guarded=True)}
-        FROM session_costs
+        FROM test_case_metrics
         GROUP BY evaluation_id
         ORDER BY evaluation_id ASC
     """

--- a/services/intake/src/nmp/intake/spans/evaluation_rollup_repository.py
+++ b/services/intake/src/nmp/intake/spans/evaluation_rollup_repository.py
@@ -128,17 +128,10 @@ def _scoped_sessions_sql(trace_index_table: str, evaluation_names_sql: str) -> s
     """
 
 
-def _test_case_key_sql(sessions_alias: str = "") -> str:
-    """Per-test-case grouping key for the two-level rollup: the test case (``test_case_id``) when set,
-    else the individual attempt (``session_id``) so unlabeled runs pool per-attempt exactly like a flat
-    rollup. Namespaced so a ``test_case_id`` can never collide with a ``session_id``. Counting the
-    distinct values of this key over an evaluation's sessions gives ``test_case_count``.
-    """
-    prefix = f"{sessions_alias}." if sessions_alias else ""
-    return f"if({prefix}test_case_id != '', concat('t:', {prefix}test_case_id), concat('s:', {prefix}session_id))"
-
-
 def _run_counts_sql(trace_index_table: str, evaluation_names_sql: str) -> str:
+    # run_count is every ingested session; test_case_count is the distinct test cases those sessions
+    # belong to. Sessions with no test_case_id aren't attributable to a test case, so they don't count
+    # toward test_case_count (and are excluded from the test-case-weighted rollups below).
     return f"""
         WITH scoped_sessions AS (
             {_scoped_sessions_sql(trace_index_table, evaluation_names_sql)}
@@ -146,7 +139,7 @@ def _run_counts_sql(trace_index_table: str, evaluation_names_sql: str) -> str:
         SELECT
             evaluation_id,
             count() AS run_count,
-            uniqExact({_test_case_key_sql()}) AS test_case_count
+            uniqExactIf(test_case_id, test_case_id != '') AS test_case_count
         FROM scoped_sessions
         GROUP BY evaluation_id
         ORDER BY evaluation_id ASC
@@ -193,10 +186,11 @@ def _stat_columns(value_expr: str, *, prefix: str = "", guarded: bool = False) -
 
 def _score_rollups_sql(*, trace_index_table: str, evaluator_results_table: str, evaluation_names_sql: str) -> str:
     # Two-level rollup. Each run (session) contributes one score per evaluator, so first reduce the
-    # per-span evaluator_results rows to one per-(session, evaluator) value; then average those per
-    # test case (pass@1 = mean over a test case's k attempts); then take the distribution across test cases. The mean
-    # is test-case-weighted (each test case counts once regardless of k), and `count` is the number of test cases.
-    test_case_key = _test_case_key_sql("sessions")
+    # per-span evaluator_results rows to one per-(session, evaluator) value; then average those per test
+    # case (pass@1 = mean over a test case's k attempts); then take the distribution across test cases.
+    # The mean is test-case-weighted (each test case counts once regardless of k) and `count` is the
+    # number of test cases. Sessions with no test_case_id aren't attributable to a test case, so they're
+    # dropped here.
     return f"""
         WITH
         scoped_sessions AS (
@@ -205,7 +199,7 @@ def _score_rollups_sql(*, trace_index_table: str, evaluator_results_table: str, 
         session_scores AS (
             SELECT
                 sessions.evaluation_id AS evaluation_id,
-                {test_case_key} AS test_case_key,
+                sessions.test_case_id AS test_case_key,
                 results.name AS evaluator_name,
                 avg(results.value) AS value
             FROM scoped_sessions AS sessions
@@ -222,6 +216,7 @@ def _score_rollups_sql(*, trace_index_table: str, evaluator_results_table: str, 
             ) AS results
                 ON sessions.workspace = results.workspace
                 AND sessions.session_id = results.session_id
+            WHERE sessions.test_case_id != ''
             GROUP BY sessions.evaluation_id, sessions.session_id, sessions.test_case_id, results.name
         ),
         test_case_scores AS (
@@ -244,10 +239,10 @@ def _score_rollups_sql(*, trace_index_table: str, evaluator_results_table: str, 
 
 
 def _metric_rollups_sql(*, trace_index_table: str, spans_table: str, evaluation_names_sql: str) -> str:
-    # Two-level rollup: per-attempt cost/latency, then averaged per test case (avg per attempt — the number
-    # must not scale with k), then the distribution across test cases (test-case-weighted). Attempts with no
-    # cost/latency are excluded from a test case's average rather than counted as zero.
-    test_case_key = _test_case_key_sql("sessions")
+    # Two-level rollup: per-attempt cost/latency, then averaged per test case (avg per attempt — the
+    # number must not scale with k), then the distribution across test cases (test-case-weighted).
+    # Attempts with no cost/latency are excluded from a test case's average rather than counted as zero;
+    # sessions with no test_case_id aren't attributable to a test case, so they're dropped.
     return f"""
         WITH
         scoped_sessions AS (
@@ -267,7 +262,7 @@ def _metric_rollups_sql(*, trace_index_table: str, spans_table: str, evaluation_
         session_costs AS (
             SELECT
                 sessions.evaluation_id AS evaluation_id,
-                {test_case_key} AS test_case_key,
+                sessions.test_case_id AS test_case_key,
                 sessions.latency_ms AS latency_ms,
                 if(
                     countIf(has(mapKeys(spans.attributes_number), %(cost_key)s)) = 0,
@@ -297,6 +292,7 @@ def _metric_rollups_sql(*, trace_index_table: str, spans_table: str, evaluation_
                 ON sessions.workspace = spans.workspace
                 AND sessions.session_id = spans.session_id
                 AND spans.is_deleted = 0
+            WHERE sessions.test_case_id != ''
             GROUP BY sessions.evaluation_id, sessions.session_id, sessions.test_case_id, sessions.latency_ms
         ),
         test_case_metrics AS (

--- a/services/intake/src/nmp/intake/spans/evaluation_rollup_repository.py
+++ b/services/intake/src/nmp/intake/spans/evaluation_rollup_repository.py
@@ -187,10 +187,9 @@ def _stat_columns(value_expr: str, *, prefix: str = "", guarded: bool = False) -
 def _score_rollups_sql(*, trace_index_table: str, evaluator_results_table: str, evaluation_names_sql: str) -> str:
     # Two-level rollup. Each run (session) contributes one score per evaluator, so first reduce the
     # per-span evaluator_results rows to one per-(session, evaluator) value; then average those per test
-    # case (pass@1 = mean over a test case's k attempts); then take the distribution across test cases.
-    # The mean is test-case-weighted (each test case counts once regardless of k) and `count` is the
-    # number of test cases. Sessions with no test_case_id aren't attributable to a test case, so they're
-    # dropped here.
+    # case; then take the distribution across test cases. The mean is test-case-weighted (each test case
+    # counts once regardless of k) and `count` is the number of test cases. Sessions with no test_case_id
+    # aren't attributable to a test case, so they're dropped here.
     return f"""
         WITH
         scoped_sessions AS (

--- a/services/intake/tests/integration/spans/test_experiment_rollups.py
+++ b/services/intake/tests/integration/spans/test_experiment_rollups.py
@@ -167,9 +167,10 @@ def test_evaluation_rollups_aggregate_per_test_case_before_pooling(client: TestC
     assert latency["count"] == 2
 
 
-def test_evaluation_rollups_without_test_case_id_pool_per_attempt(client: TestClient) -> None:
-    # No test_case_id -> each attempt is its own test case, so the rollup pools per attempt exactly like a
-    # flat aggregate (count = attempts, not collapsed into a single empty-string bucket).
+def test_evaluation_rollups_exclude_sessions_without_test_case_id(client: TestClient) -> None:
+    # Sessions with no test_case_id aren't attributable to a test case, so they're dropped from the
+    # test-case-weighted rollup: no scores/cost/latency and test_case_count 0, though run_count still
+    # reflects that the runs were ingested.
     evaluation_id = "rollup-no-test-case-exp"
     group_id = _ensure_group(client)
     created = client.post(
@@ -205,10 +206,11 @@ def test_evaluation_rollups_without_test_case_id_pool_per_attempt(client: TestCl
         assert response.status_code == 201, response.text
 
     evaluation = client.get(f"{EVALUATIONS}/{evaluation_id}").json()
-    assert evaluation["test_case_count"] == 2  # 2 blank attempts each stand alone as their own case
-    score = evaluation["aggregate_scores"]["reward"]
-    assert score["mean"] == pytest.approx(0.5)
-    assert score["count"] == 2  # per attempt, not collapsed to a single bucket
+    assert evaluation["run_count"] == 2  # the runs were ingested
+    assert evaluation["test_case_count"] == 0  # but none are attributable to a test case
+    assert not evaluation.get("aggregate_scores")  # excluded from the test-case-weighted score rollup
+    assert evaluation.get("cost_usd") is None
+    assert evaluation.get("latency_ms") is None
 
 
 def test_atif_ingest_rejects_deleted_evaluation(client: TestClient) -> None:

--- a/services/intake/tests/integration/spans/test_experiment_rollups.py
+++ b/services/intake/tests/integration/spans/test_experiment_rollups.py
@@ -107,7 +107,7 @@ def test_evaluation_response_hydrates_clickhouse_rollups(client: TestClient) -> 
 def test_evaluation_rollups_aggregate_per_test_case_before_pooling(client: TestClient) -> None:
     # Unbalanced k: test case A has 1 attempt, test case B has 3. Test-case-weighting counts each test case once, so the
     # heavily-retried test case can't dominate. Pooling all 4 attempts would give score mean 0.75; the
-    # correct two-level rollup (per-test-case pass@1, then across test cases) is 0.5.
+    # correct two-level rollup (average per test case, then across test cases) is 0.5.
     evaluation_id = "rollup-k-exp"
     group_id = _ensure_group(client)
     created = client.post(

--- a/services/intake/tests/integration/spans/test_experiment_rollups.py
+++ b/services/intake/tests/integration/spans/test_experiment_rollups.py
@@ -67,6 +67,7 @@ def test_evaluation_response_hydrates_clickhouse_rollups(client: TestClient) -> 
     evaluation = fetched.json()
 
     assert evaluation["run_count"] == 4
+    assert evaluation["test_case_count"] == 4  # 4 distinct test_case_ids, each run once
     assert evaluation["evaluator_names"] == ["reward"]
     assert evaluation["model_names"] == ["provider/sample-model"]
 
@@ -101,6 +102,113 @@ def test_evaluation_response_hydrates_clickhouse_rollups(client: TestClient) -> 
     assert listed.status_code == 200, listed.text
     listed_evaluation = next(item for item in listed.json()["data"] if item["name"] == evaluation_id)
     assert listed_evaluation["aggregate_scores"]["reward"]["mean"] == pytest.approx(0.75)
+
+
+def test_evaluation_rollups_aggregate_per_test_case_before_pooling(client: TestClient) -> None:
+    # Unbalanced k: test case A has 1 attempt, test case B has 3. Test-case-weighting counts each test case once, so the
+    # heavily-retried test case can't dominate. Pooling all 4 attempts would give score mean 0.75; the
+    # correct two-level rollup (per-test-case pass@1, then across test cases) is 0.5.
+    evaluation_id = "rollup-k-exp"
+    group_id = _ensure_group(client)
+    created = client.post(
+        EVALUATIONS,
+        json={
+            "name": evaluation_id,
+            "experiment_group_id": group_id,
+            "dataset_name": "rollup-dataset",
+            "dataset_version": "v1",
+        },
+    )
+    assert created.status_code == 201, created.text
+
+    rows = [
+        # (run_id, test_case_id, score, cost_usd, latency_ms)
+        ("run-1", "case-a", 0.0, 0.10, 1000),  # test case A: 1 attempt
+        ("run-1", "case-b", 1.0, 0.10, 1000),  # test case B: 3 attempts, differing cost/latency
+        ("run-2", "case-b", 1.0, 0.20, 2000),
+        ("run-3", "case-b", 1.0, 0.30, 3000),
+    ]
+    started_at = datetime.now(timezone.utc).replace(microsecond=0)
+    for index, (run_id, test_case_id, score, cost_usd, latency_ms) in enumerate(rows):
+        response = client.post(
+            ATIF_INGEST,
+            json=_atif_body(
+                started_at=started_at,
+                evaluation_id=evaluation_id,
+                run_id=run_id,
+                test_case_id=test_case_id,
+                score=score,
+                cost_usd=cost_usd,
+                latency_ms=latency_ms,
+                offset_seconds=index * 10,
+            ),
+        )
+        assert response.status_code == 201, response.text
+
+    evaluation = client.get(f"{EVALUATIONS}/{evaluation_id}").json()
+
+    # run_count stays the number of attempts (4); the distributions are over the 2 test cases.
+    assert evaluation["run_count"] == 4
+    assert evaluation["test_case_count"] == 2  # 2 distinct test cases (case-a, case-b)
+
+    score = evaluation["aggregate_scores"]["reward"]
+    assert score["mean"] == pytest.approx(0.5)  # per test case: A=0.0, B=1.0 -> not the pooled 0.75
+    assert score["sum"] == pytest.approx(1.0)
+    assert score["count"] == 2
+
+    cost = evaluation["cost_usd"]
+    # per-test-case cost is avg per attempt: A=0.10, B=avg(0.10, 0.20, 0.30)=0.20 -> mean 0.15 (not sum 0.60)
+    assert cost["mean"] == pytest.approx(0.15)
+    assert cost["count"] == 2
+
+    latency = evaluation["latency_ms"]
+    # per-test-case latency avg per attempt: A=1000, B=avg(1000, 2000, 3000)=2000 -> mean 1500
+    assert latency["mean"] == pytest.approx(1500.0)
+    assert latency["count"] == 2
+
+
+def test_evaluation_rollups_without_test_case_id_pool_per_attempt(client: TestClient) -> None:
+    # No test_case_id -> each attempt is its own test case, so the rollup pools per attempt exactly like a
+    # flat aggregate (count = attempts, not collapsed into a single empty-string bucket).
+    evaluation_id = "rollup-no-test-case-exp"
+    group_id = _ensure_group(client)
+    created = client.post(
+        EVALUATIONS,
+        json={
+            "name": evaluation_id,
+            "experiment_group_id": group_id,
+            "dataset_name": "rollup-dataset",
+            "dataset_version": "v1",
+        },
+    )
+    assert created.status_code == 201, created.text
+
+    rows = [
+        ("run-1", "", 0.0, 0.10, 1000),
+        ("run-2", "", 1.0, 0.30, 3000),
+    ]
+    started_at = datetime.now(timezone.utc).replace(microsecond=0)
+    for index, (run_id, test_case_id, score, cost_usd, latency_ms) in enumerate(rows):
+        response = client.post(
+            ATIF_INGEST,
+            json=_atif_body(
+                started_at=started_at,
+                evaluation_id=evaluation_id,
+                run_id=run_id,
+                test_case_id=test_case_id,
+                score=score,
+                cost_usd=cost_usd,
+                latency_ms=latency_ms,
+                offset_seconds=index * 10,
+            ),
+        )
+        assert response.status_code == 201, response.text
+
+    evaluation = client.get(f"{EVALUATIONS}/{evaluation_id}").json()
+    assert evaluation["test_case_count"] == 2  # 2 blank attempts each stand alone as their own case
+    score = evaluation["aggregate_scores"]["reward"]
+    assert score["mean"] == pytest.approx(0.5)
+    assert score["count"] == 2  # per attempt, not collapsed to a single bucket
 
 
 def test_atif_ingest_rejects_deleted_evaluation(client: TestClient) -> None:

--- a/services/intake/tests/test_experiment_rollup_repository.py
+++ b/services/intake/tests/test_experiment_rollup_repository.py
@@ -131,7 +131,7 @@ async def test_evaluation_rollups_anchor_on_root_session_membership():
     assert len(client.queries) == 3
     assert "FROM trace_index FINAL" in client.queries[0]
     assert "count() AS run_count" in client.queries[0]
-    assert "uniqExact(" in client.queries[0]
+    assert "uniqExactIf(test_case_id, test_case_id != '')" in client.queries[0]
     assert "AS test_case_count" in client.queries[0]
     assert "evaluation_id IN (%(evaluation_id_0)s)" in client.queries[0]
     assert "ORDER BY root_started_at ASC, root_span_id ASC" in client.queries[0]
@@ -146,7 +146,7 @@ async def test_evaluation_rollups_anchor_on_root_session_membership():
         "GROUP BY sessions.evaluation_id, sessions.session_id, sessions.test_case_id, results.name" in client.queries[1]
     )
     assert "test_case_scores AS" in client.queries[1]
-    assert "concat('t:', sessions.test_case_id)" in client.queries[1]
+    assert "WHERE sessions.test_case_id != ''" in client.queries[1]
     assert "test_case_metrics AS" in client.queries[2]
     assert "current_session_spans AS" in client.queries[2]
     assert "(span_versions.workspace, span_versions.session_id) IN" in client.queries[2]

--- a/services/intake/tests/test_experiment_rollup_repository.py
+++ b/services/intake/tests/test_experiment_rollup_repository.py
@@ -141,7 +141,7 @@ async def test_evaluation_rollups_anchor_on_root_session_membership():
     assert "AND (workspace, session_id) IN (" in client.queries[1]
     assert "sessions.session_id = results.session_id" in client.queries[1]
     # Scores are reduced to one value per (session, evaluator), then averaged per test case before the
-    # distribution rollup, so the mean is test-case-weighted (pass@1) and count tracks test cases.
+    # distribution rollup, so the mean is test-case-weighted and count tracks test cases.
     assert (
         "GROUP BY sessions.evaluation_id, sessions.session_id, sessions.test_case_id, results.name" in client.queries[1]
     )

--- a/services/intake/tests/test_experiment_rollup_repository.py
+++ b/services/intake/tests/test_experiment_rollup_repository.py
@@ -40,8 +40,8 @@ async def test_evaluation_rollups_anchor_on_root_session_membership():
     client = _Client(
         [
             _QueryResult(
-                [("exp-a", 3)],
-                ["evaluation_id", "run_count"],
+                [("exp-a", 3, 2)],
+                ["evaluation_id", "run_count", "test_case_count"],
             ),
             _QueryResult(
                 [("exp-a", "reward", 3.0, 0.75, 0.8, 1.0, 1.0, 1.0, 4)],
@@ -99,6 +99,7 @@ async def test_evaluation_rollups_anchor_on_root_session_membership():
 
     rollup = rollups["exp-a"]
     assert rollup.run_count == 3
+    assert rollup.test_case_count == 2
     assert rollup.evaluator_names == ["reward"]
     assert rollup.model_names == ["model-a", "model-b"]
     assert rollup.agent_names == ["agent-a"]
@@ -130,6 +131,8 @@ async def test_evaluation_rollups_anchor_on_root_session_membership():
     assert len(client.queries) == 3
     assert "FROM trace_index FINAL" in client.queries[0]
     assert "count() AS run_count" in client.queries[0]
+    assert "uniqExact(" in client.queries[0]
+    assert "AS test_case_count" in client.queries[0]
     assert "evaluation_id IN (%(evaluation_id_0)s)" in client.queries[0]
     assert "ORDER BY root_started_at ASC, root_span_id ASC" in client.queries[0]
     assert "FROM evaluator_results FINAL" in client.queries[1]
@@ -137,9 +140,14 @@ async def test_evaluation_rollups_anchor_on_root_session_membership():
     assert "quantileExact(0.99)(value) AS p99" in client.queries[1]
     assert "AND (workspace, session_id) IN (" in client.queries[1]
     assert "sessions.session_id = results.session_id" in client.queries[1]
-    # Scores are reduced to one value per (evaluation, session, evaluator) before the
-    # distribution rollup so count tracks runs and the mean is not span-weighted.
-    assert "GROUP BY sessions.evaluation_id, sessions.session_id, results.name" in client.queries[1]
+    # Scores are reduced to one value per (session, evaluator), then averaged per test case before the
+    # distribution rollup, so the mean is test-case-weighted (pass@1) and count tracks test cases.
+    assert (
+        "GROUP BY sessions.evaluation_id, sessions.session_id, sessions.test_case_id, results.name" in client.queries[1]
+    )
+    assert "test_case_scores AS" in client.queries[1]
+    assert "concat('t:', sessions.test_case_id)" in client.queries[1]
+    assert "test_case_metrics AS" in client.queries[2]
     assert "current_session_spans AS" in client.queries[2]
     assert "(span_versions.workspace, span_versions.session_id) IN" in client.queries[2]
     assert "LEFT JOIN current_session_spans AS spans" in client.queries[2]

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/MeanValueTooltipCell.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/MeanValueTooltipCell.tsx
@@ -1,25 +1,31 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { getTextWithCount } from '@nemo/common/src/utils/formatters';
 import { Text, Tooltip } from '@nvidia/foundations-react-core';
 import { tooltipClassName } from '@studio/styles/common';
 import { type FC, type ReactNode } from 'react';
 
 const aggregateMetricTooltip = (
   label: string,
-  runNoun: string,
   count: number | null | undefined,
   runCount: number | null | undefined
 ): string => {
-  const contributing = count ?? 0;
-  const total = runCount ?? 0;
-  const noun = contributing === 1 ? runNoun : `${runNoun}s`;
-  return `Mean ${label} over ${contributing} ${noun} (of ${total} total).`;
+  // `count` is the number of test cases the mean is taken over; `runCount` is the total attempts. The
+  // rollup is test-case-weighted: each test case is averaged over its attempts first, then averaged
+  // across test cases (so a test case run k times counts once, not k times).
+  const testCases = count ?? 0;
+  const attempts = runCount ?? 0;
+  // When each test case was attempted once, the test-case-weighted mean is just the plain per-attempt
+  // mean, so keep it simple. Otherwise note that each test case's repeats are averaged first.
+  if (testCases === attempts) {
+    return `Mean ${label} over ${getTextWithCount('test case', testCases)}.`;
+  }
+  return `Mean ${label} over ${getTextWithCount('test case', testCases)} — each test case averaged over its attempts.`;
 };
 
 interface MeanValueTooltipCellProps {
   label: string;
-  runNoun: string;
   count: number | null | undefined;
   runCount: number | null | undefined;
   children: ReactNode;
@@ -27,7 +33,6 @@ interface MeanValueTooltipCellProps {
 
 export const MeanValueTooltipCell: FC<MeanValueTooltipCellProps> = ({
   label,
-  runNoun,
   count,
   runCount,
   children,
@@ -38,9 +43,7 @@ export const MeanValueTooltipCell: FC<MeanValueTooltipCellProps> = ({
   return (
     <Tooltip
       slotContent={
-        <Text kind="body/regular/sm">
-          {aggregateMetricTooltip(label, runNoun, count, runCount)}
-        </Text>
+        <Text kind="body/regular/sm">{aggregateMetricTooltip(label, count, runCount)}</Text>
       }
       className={tooltipClassName}
       side="bottom"

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -46,7 +46,7 @@ const STATIC_SORT_FIELD_MAP: Readonly<Record<string, string>> = {
   created_at: 'created_at',
   cost_usd: 'cost_usd.mean',
   latency_ms: 'latency_ms.mean',
-  run_count: 'run_count',
+  test_case_count: 'test_case_count',
 };
 
 // Resolves a group's default_sort (a `sort`-param string like `-cost_usd.mean` or `-created_at`) to
@@ -55,7 +55,7 @@ const STATIC_SORT_FIELD_MAP: Readonly<Record<string, string>> = {
 // Maps one API sort field to its table column id: entity columns by exact id; metric columns by
 // family (any stat) since the column always sorts on `.mean`.
 const sortFieldToColumnId = (field: string): string | undefined => {
-  if (field === 'name' || field === 'created_at' || field === 'run_count') return field;
+  if (field === 'name' || field === 'created_at' || field === 'test_case_count') return field;
   if (field.startsWith('cost_usd.')) return 'cost_usd';
   if (field.startsWith('latency_ms.')) return 'latency_ms';
   const evaluatorMatch = field.match(/^evaluators\.(.+)\.[^.]+$/);
@@ -374,7 +374,6 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({ grou
             return (
               <MeanValueTooltipCell
                 label={title}
-                runNoun="scored run"
                 count={score?.count}
                 runCount={row.original.run_count}
               >
@@ -392,12 +391,7 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({ grou
         cell: ({ row }) => {
           const { cost_usd, run_count } = row.original;
           return (
-            <MeanValueTooltipCell
-              label="cost"
-              runNoun="run"
-              count={cost_usd?.count}
-              runCount={run_count}
-            >
+            <MeanValueTooltipCell label="cost" count={cost_usd?.count} runCount={run_count}>
               {cost_usd?.mean != null ? `$${cost_usd.mean.toFixed(3)}` : '-'}
             </MeanValueTooltipCell>
           );
@@ -411,23 +405,17 @@ export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({ grou
         cell: ({ row }) => {
           const { latency_ms, run_count } = row.original;
           return (
-            <MeanValueTooltipCell
-              label="latency"
-              runNoun="run"
-              count={latency_ms?.count}
-              runCount={run_count}
-            >
+            <MeanValueTooltipCell label="latency" count={latency_ms?.count} runCount={run_count}>
               {latency_ms?.mean != null ? formatDurationMs(latency_ms.mean) : '-'}
             </MeanValueTooltipCell>
           );
         },
       }),
-      accessor((original) => original.run_count, {
-        id: 'run_count',
-        header: 'Run Count',
+      accessor((original) => original.test_case_count, {
+        id: 'test_case_count',
+        header: 'Total test cases',
         enableSorting: true,
-        meta: { filter: numberRangeFilter('Run Count') },
-        cell: ({ row }) => <Text>{String(row.original.run_count ?? 0)}</Text>,
+        cell: ({ row }) => <Text>{String(row.original.test_case_count ?? 0)}</Text>,
       }),
       accessor('created_at', {
         header: 'Created',


### PR DESCRIPTION

<img width="502" height="240" alt="Screenshot 2026-07-17 at 2 06 18 PM" src="https://github.com/user-attachments/assets/2ece5ca1-786e-4a1f-bff4-ef1d9d710071" />


## What

Two-level ("test-case-weighted") rollups for the Experiments leaderboard — [ASE-561](https://linear.app/nvidia/issue/ASE-561).

When a test case is run k times, metrics are now rolled up **per test case first** (pass@1 = mean over its attempts), then aggregated **across test cases** — so a heavily-retried test case counts once instead of dominating the pool. This also corrects medians/percentiles, which were previously computed over the wrong distribution (all attempts vs. per-test-case values).

## Changes

**Backend** (`evaluation_rollup_repository.py`)
- Group key = `test_case_id` when set, else `session_id` — so unlabeled runs pool per-attempt exactly like the old flat rollup (no empty-string bucket collapse), and there's no hard requirement on `test_case_id`.
- Scores: pass@1 (mean over a test case's attempts) → distribution across test cases.
- Cost/latency: **avg per attempt** within a test case (so the number doesn't scale with k) → distribution across test cases; attempts missing a value are excluded, not counted as zero.
- New **`test_case_count`** rollup field (distinct test cases) on the evaluation response, sortable.

**Frontend** (Studio)
- Leaderboard **"Run Count" → "Total test cases"** (`test_case_count`), sortable.
- Avg-cell tooltip now states the calculation transparently, e.g. `Mean cost over 2 test cases — each test case averaged over its attempts.`

**SDK** regenerated for the new `test_case_count` field.

## Testing
- Unit + **integration (real ClickHouse)**, including an unbalanced-k case that proves test-case-weighting (score mean **0.5**, not the pooled **0.75**; cost avg-per-attempt) and a missing-`test_case_id` degrade case (pools per attempt).

## Note
`run_count` (total attempts) stays on the API and still feeds the tooltip's context; only the leaderboard column moved to test cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `test_case_count` to evaluation and rollup responses, exposed as a sortable “Total test cases” metric in experiment group tables.
  * Updated API sorting to support ordering by total test cases.

* **Bug Fixes**
  * Updated rollup aggregation to compute statistics using test-case-level weighting (not raw attempts).
  * Evaluations with no `test_case_id` no longer contribute to test-case-weighted metrics (`test_case_count` returns 0).

* **Tests**
  * Extended integration and repository tests to validate hydration, sorting support, and the new rollup semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->