### PR TITLE
feat(agents): external NAT agents — Studio UI (stacked on #763)

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/a2a.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/a2a.py
@@ -12,6 +12,7 @@ run. See https://github.com/nvidia/nemo-agent-toolkit A2A server docs.
 
 from __future__ import annotations
 
+import codecs
 import json
 import logging
 from collections.abc import AsyncIterator
@@ -142,11 +143,13 @@ async def probe_agent_reachable(base_url: str) -> bool:
         async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
             for path in AGENT_CARD_PATHS:
                 try:
-                    resp = await client.get(_card_url(base, path))
+                    # Stream so we only wait for the status line — never read the
+                    # (potentially unbounded / slow-drip) body for a liveness check.
+                    async with client.stream("GET", _card_url(base, path)) as resp:
+                        if resp.status_code == 200:
+                            return True
                 except httpx.HTTPError:
                     continue
-                if resp.status_code == 200:
-                    return True
     except httpx.HTTPError:
         return False
     return False
@@ -275,11 +278,15 @@ async def stream_a2a_message(endpoint: str, text: str) -> AsyncIterator[str]:
                 # from a byte-capped buffer instead.
                 total = 0
                 buffer = ""
+                # Incremental decoder holds a partial multi-byte char across chunk
+                # boundaries, so a UTF-8 sequence split by the network doesn't
+                # decode to a replacement char.
+                decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
                 async for chunk in resp.aiter_bytes():
                     total += len(chunk)
                     if total > _MAX_MESSAGE_BYTES:
                         raise A2AMessageError("agent stream exceeded the size limit")
-                    buffer += chunk.decode("utf-8", errors="replace")
+                    buffer += decoder.decode(chunk)
                     while "\n" in buffer:
                         line, buffer = buffer.split("\n", 1)
                         line = line.strip()

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -283,14 +283,11 @@ async def proxy_by_deployment_name_write(
 
 
 async def _resolve_agent_endpoint(name: str, workspace: str, entity_client: NemoEntitiesClient) -> str:
-    """Find the endpoint of the first running deployment for the given agent."""
-    try:
-        await entity_client.get(Agent, name=name, workspace=workspace)
-    except NemoEntityNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"Agent '{name}' not found in workspace '{workspace}'.") from exc
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    """Find the endpoint of the first running deployment for the given agent.
 
+    The agent's existence is already validated by the caller (``_serve_agent_proxy``),
+    so this only lists deployments — no second entity fetch.
+    """
     try:
         result = await entity_client.list(AgentDeployment, workspace=workspace)
     except Exception as exc:
@@ -477,16 +474,21 @@ def _conversation_prompt(messages: Any) -> str:
     turns = [
         (m.get("role"), _message_text(m))
         for m in messages
-        if isinstance(m, dict) and m.get("role") in ("user", "assistant")
+        if isinstance(m, dict) and m.get("role") in ("system", "user", "assistant")
     ]
     turns = [(role, text) for role, text in turns if text]
-    if not turns:
+    # Anchor on the last user message (the turn being answered); everything before
+    # it — including system/developer instructions — becomes the transcript.
+    last_user = next((i for i in range(len(turns) - 1, -1, -1) if turns[i][0] == "user"), None)
+    if last_user is None:
         return ""
-    if len(turns) == 1:
-        return turns[0][1]
+    latest = turns[last_user][1]
+    prior = turns[:last_user]
+    if not prior:
+        return latest
 
-    *prior, (_, latest) = turns
-    transcript = "\n".join(f"{'User' if role == 'user' else 'Assistant'}: {text}" for role, text in prior)
+    labels = {"system": "System", "user": "User", "assistant": "Assistant"}
+    transcript = "\n".join(f"{labels.get(str(role), 'User')}: {text}" for role, text in prior)
     return f"Continue this conversation.\n\n{transcript}\n\nUser: {latest}"
 
 
@@ -517,27 +519,58 @@ def _openai_chunk(completion_id: str, created: int, model: str, delta: dict[str,
     return f"data: {json.dumps(payload)}\n\n".encode()
 
 
-async def _stream_openai_from_a2a(endpoint: str, text: str, model: str) -> AsyncIterator[bytes]:
-    """Stream an external agent's A2A reply as OpenAI chat.completion.chunk SSE.
+def _card_supports_streaming(agent: Agent) -> bool:
+    """False only when the card explicitly disables streaming; default True."""
+    caps = (agent.card or {}).get("capabilities")
+    return not (isinstance(caps, dict) and caps.get("streaming") is False)
 
-    Forwards each A2A text delta as a content chunk. A mid-stream error is
-    surfaced as content (the HTTP status is already 200 once streaming starts),
-    so the user sees it in the chat rather than a silent stall.
+
+async def _single_chunk_sse(text: str, model: str) -> AsyncIterator[bytes]:
+    """Wrap a complete (non-streamed) reply as one OpenAI SSE completion."""
+    created = int(time.time())
+    completion_id = f"chatcmpl-{uuid4().hex}"
+    yield _openai_chunk(completion_id, created, model, {"role": "assistant", "content": text}, None)
+    yield _openai_chunk(completion_id, created, model, {}, "stop")
+    yield b"data: [DONE]\n\n"
+
+
+async def _stream_openai_from_a2a(
+    agen: AsyncIterator[str],
+    first: str,
+    has_first: bool,
+    model: str,
+    name: str,
+    endpoint: str,
+) -> AsyncIterator[bytes]:
+    """Stream a *primed* A2A reply as OpenAI chat.completion.chunk SSE.
+
+    The first delta is pulled by the caller so a failure before it returns 502;
+    here the status is already 200, so a mid-stream failure is logged and ends
+    the stream WITHOUT a normal ``stop`` finish, so the client/monitoring can
+    tell it from a real completion.
     """
     created = int(time.time())
     completion_id = f"chatcmpl-{uuid4().hex}"
     role_sent = False
+    if has_first:
+        yield _openai_chunk(completion_id, created, model, {"role": "assistant", "content": first}, None)
+        role_sent = True
     try:
-        async for delta in stream_a2a_message(endpoint, text):
+        async for delta in agen:
             payload = {"content": delta} if role_sent else {"role": "assistant", "content": delta}
             role_sent = True
             yield _openai_chunk(completion_id, created, model, payload, None)
-        if not role_sent:
-            yield _openai_chunk(completion_id, created, model, {"role": "assistant", "content": ""}, None)
     except A2AMessageError as exc:
+        logger.warning(
+            "External agent '%s' chat stream failed mid-stream (%s): %s", name, _endpoint_host(endpoint), exc
+        )
         note = f"[external agent error: {exc}]"
         payload = {"content": f"\n{note}"} if role_sent else {"role": "assistant", "content": note}
         yield _openai_chunk(completion_id, created, model, payload, None)
+        yield b"data: [DONE]\n\n"  # no ``stop`` finish — signals abnormal termination
+        return
+    if not role_sent:
+        yield _openai_chunk(completion_id, created, model, {"role": "assistant", "content": ""}, None)
     yield _openai_chunk(completion_id, created, model, {}, "stop")
     yield b"data: [DONE]\n\n"
 
@@ -575,7 +608,7 @@ async def external_agent_chat_completions(
 
     endpoint = _external_a2a_endpoint(agent, name)
     body = await _read_json_object(request)
-    return await _external_openai_chat(name, endpoint, body)
+    return await _external_openai_chat(name, endpoint, body, _card_supports_streaming(agent))
 
 
 # ---------------------------------------------------------------------------
@@ -616,25 +649,43 @@ async def _read_json_object(request: Request) -> dict[str, Any]:
     return body if isinstance(body, dict) else {}
 
 
-async def _external_openai_chat(name: str, endpoint: str, body: dict[str, Any]) -> StreamingResponse | JSONResponse:
+async def _external_openai_chat(
+    name: str, endpoint: str, body: dict[str, Any], supports_streaming: bool
+) -> StreamingResponse | JSONResponse:
     """Translate an OpenAI chat/completions body to A2A and return OpenAI shape."""
     text = _conversation_prompt(body.get("messages"))
     if not text:
         raise HTTPException(status_code=400, detail="Request has no user message to send.")
 
     model = body.get("model") or name
+    wants_stream = bool(body.get("stream"))
 
-    # Streaming: forward A2A deltas as they arrive (message/stream), so the UI
-    # shows progress instead of freezing until the agent finishes.
-    if body.get("stream"):
-        return StreamingResponse(_stream_openai_from_a2a(endpoint, text, model), media_type="text/event-stream")
+    if wants_stream and supports_streaming:
+        # Prime the stream: pull the first delta before returning the response so
+        # a failure before any token becomes a 502, not a 200 whose body is an
+        # error string masquerading as the answer.
+        agen = stream_a2a_message(endpoint, text)
+        try:
+            first, has_first = await anext(agen), True
+        except StopAsyncIteration:
+            first, has_first = "", False
+        except A2AMessageError as exc:
+            logger.warning("External agent '%s' chat stream failed (%s): %s", name, _endpoint_host(endpoint), exc)
+            raise HTTPException(status_code=502, detail=f"External agent chat failed: {exc}") from exc
+        return StreamingResponse(
+            _stream_openai_from_a2a(agen, first, has_first, model, name, endpoint),
+            media_type="text/event-stream",
+        )
 
-    # Non-streaming: single message/send, returned as one OpenAI completion.
+    # Non-streaming request, or an agent whose card disables streaming: a single
+    # message/send (errors -> 502 up front), returned as JSON or one SSE chunk.
     try:
         reply = await send_a2a_message(endpoint, text)
     except A2AMessageError as exc:
         logger.warning("External agent '%s' chat failed (%s): %s", name, _endpoint_host(endpoint), exc)
         raise HTTPException(status_code=502, detail=f"External agent chat failed: {exc}") from exc
+    if wants_stream:
+        return StreamingResponse(_single_chunk_sse(reply, model), media_type="text/event-stream")
     return JSONResponse(_openai_completion(reply, model))
 
 
@@ -667,7 +718,8 @@ async def _serve_external_agent(
     """
     endpoint = _external_a2a_endpoint(agent, name)
     if trailing_uri.endswith("chat/completions"):
-        return await _external_openai_chat(name, endpoint, await _read_json_object(request))
+        body = await _read_json_object(request)
+        return await _external_openai_chat(name, endpoint, body, _card_supports_streaming(agent))
     if trailing_uri.startswith("generate"):
         return await _serve_external_generate_full(name, endpoint, request)
     raise HTTPException(

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -622,13 +622,13 @@ class TestContainerModeByAgentName:
 # ---------------------------------------------------------------------------
 
 
-def _make_external_agent(name: str = "ext", url: str = "http://host:10000") -> Agent:
+def _make_external_agent(name: str = "ext", url: str = "http://host:10000", card: dict | None = None) -> Agent:
     return Agent(
         name=name,
         workspace="default",
         source="external",
         endpoint=url,
-        card={"url": url, "name": "Ext Agent"},
+        card=card if card is not None else {"url": url, "name": "Ext Agent"},
     )
 
 
@@ -671,9 +671,11 @@ class TestExternalAgentChat:
         assert '"finish_reason": "stop"' in resp.text
         assert "[DONE]" in resp.text
 
-    def test_stream_mid_error_surfaced_as_content(
+    def test_stream_early_error_returns_502(
         self, client: TestClient, mock_entity_client: AsyncMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # A failure before the first token is primed, so it becomes a real 502 —
+        # not a 200 whose body is an error string.
         from nemo_agents_plugin.a2a import A2AMessageError
 
         mock_entity_client.get = AsyncMock(return_value=_make_external_agent())
@@ -689,8 +691,50 @@ class TestExternalAgentChat:
             json={"stream": True, "messages": [{"role": "user", "content": "hi"}]},
         )
 
+        assert resp.status_code == 502
+
+    def test_stream_mid_error_ends_without_stop(
+        self, client: TestClient, mock_entity_client: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A failure after the first token can't change the 200 status; it's
+        # surfaced as content and the stream ends WITHOUT a normal stop finish.
+        from nemo_agents_plugin.a2a import A2AMessageError
+
+        mock_entity_client.get = AsyncMock(return_value=_make_external_agent())
+
+        async def one_then_boom(endpoint: str, text: str):
+            yield "partial"
+            raise A2AMessageError("dropped")
+
+        monkeypatch.setattr(gateway_module, "stream_a2a_message", one_then_boom)
+
+        resp = client.post(
+            self._URL,
+            json={"stream": True, "messages": [{"role": "user", "content": "hi"}]},
+        )
+
         assert resp.status_code == 200
+        assert "partial" in resp.text
         assert "external agent error" in resp.text
+        assert '"finish_reason": "stop"' not in resp.text
+
+    def test_streaming_disabled_card_uses_send(
+        self, client: TestClient, mock_entity_client: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Card disables streaming → a streaming request is served via a single
+        # message/send wrapped as one SSE chunk (not message/stream).
+        agent = _make_external_agent(card={"url": "http://host:10000", "capabilities": {"streaming": False}})
+        mock_entity_client.get = AsyncMock(return_value=agent)
+        monkeypatch.setattr(gateway_module, "send_a2a_message", AsyncMock(return_value="full reply"))
+
+        resp = client.post(
+            self._URL,
+            json={"stream": True, "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        assert '"content": "full reply"' in resp.text
         assert "[DONE]" in resp.text
 
     def test_single_turn_forwards_verbatim(
@@ -730,6 +774,28 @@ class TestExternalAgentChat:
         assert "User: first" in sent
         assert "Assistant: reply" in sent
         assert "User: second" in sent
+
+    def test_system_message_preserved_and_anchored_on_last_user(
+        self, client: TestClient, mock_entity_client: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_entity_client.get = AsyncMock(return_value=_make_external_agent())
+        send = AsyncMock(return_value="ok")
+        monkeypatch.setattr(gateway_module, "send_a2a_message", send)
+
+        client.post(
+            self._URL,
+            json={
+                "messages": [
+                    {"role": "system", "content": "be terse"},
+                    {"role": "user", "content": "hello"},
+                ]
+            },
+        )
+
+        assert send.await_args is not None
+        sent = send.await_args.args[1]
+        assert "System: be terse" in sent
+        assert sent.rstrip().endswith("User: hello")
 
     def test_managed_agent_returns_400(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         mock_entity_client.get = AsyncMock(return_value=_make_agent("calc"))

--- a/web/packages/studio/src/components/dataViews/AgentsDataView/index.test.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentsDataView/index.test.tsx
@@ -109,9 +109,11 @@ describe('CombinedAgentsTable', () => {
       renderTable();
 
       expect(
-        await screen.findByText('No Agents Found', undefined, { timeout: XL_SELECTOR_TIMEOUT })
+        await screen.findByText('No agents yet', undefined, { timeout: XL_SELECTOR_TIMEOUT })
       ).toBeInTheDocument();
-      expect(screen.getByText('No agents have been created yet.')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Register an existing NAT agent by its endpoint URL/)
+      ).toBeInTheDocument();
     });
   });
 

--- a/web/packages/studio/src/components/dataViews/AgentsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentsDataView/index.tsx
@@ -25,14 +25,15 @@ import {
 } from '@nemo/sdk/generated/agents/api';
 import type { Agent } from '@nemo/sdk/generated/agents/schema/Agent';
 import type { AgentDeployment } from '@nemo/sdk/generated/agents/schema/AgentDeployment';
-import { Button, Divider, Flex, Text } from '@nvidia/foundations-react-core';
+import { Badge, Button, Divider, Flex, Text } from '@nvidia/foundations-react-core';
 import { getAgentModelNames } from '@studio/components/dataViews/AgentsDataView/utils';
 import { DeleteConfirmationModal } from '@studio/components/DeleteConfirmationModal';
 import { DocumentationButton } from '@studio/components/DocumentationButton';
 import { MODEL_COMPARE_ENABLED } from '@studio/constants/environment';
-import { LINK_DOCS_STUDIO } from '@studio/constants/links';
+import { LINK_DOCS_AGENTS } from '@studio/constants/links';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { getModelCompareRoute } from '@studio/routes/utils';
+import { isExternalAgent } from '@studio/util/agents';
 import { keepPreviousData, useQueryClient } from '@tanstack/react-query';
 import { HatGlasses, Trash, X } from 'lucide-react';
 import { ComponentProps, FC, useEffect, useMemo, useState } from 'react';
@@ -73,6 +74,8 @@ export type AgentTableRow = {
   description?: string;
   config?: AgentConfig;
   config_format?: string;
+  source?: string;
+  endpoint?: string;
   created_at?: string;
   models: string[];
   deploymentsStatus: string;
@@ -92,6 +95,8 @@ export interface CombinedAgentsTableProps {
   onCreateDeployment?: (agentName: string) => void;
   onCloneAgent?: (agent: AgentTableRow) => void;
   onAgentsLoaded?: (agents: Agent[]) => void;
+  onRegisterAgent?: () => void;
+  onCreateExampleAgent?: () => void;
   canTestModels?: boolean;
 }
 
@@ -100,6 +105,8 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
   onCreateDeployment,
   onCloneAgent,
   onAgentsLoaded,
+  onRegisterAgent,
+  onCreateExampleAgent,
   canTestModels = MODEL_COMPARE_ENABLED,
 }) => {
   const workspace = useWorkspaceFromPath();
@@ -169,6 +176,8 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
         description: agent.description,
         config,
         config_format: agent.config_format,
+        source: agent.source,
+        endpoint: agent.endpoint,
         created_at: agent.created_at,
         models: getAgentModelNames(config),
         deploymentsStatus,
@@ -248,6 +257,12 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
     accessor('name', {
       header: 'Name',
       enableSorting: true,
+      cell: ({ row }) => (
+        <Flex align="center" gap="2">
+          <Text>{row.original.name}</Text>
+          {isExternalAgent(row.original) && <Badge kind="outline">External</Badge>}
+        </Flex>
+      ),
     }),
     accessor('description', {
       header: 'Description',
@@ -283,35 +298,43 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
     rowActionsColumn({
       size: ROW_ACTIONS_COLUMN_SIZE,
       enableResizing: false,
-      rowActions: (row: AgentTableRow) => [
-        {
-          children: 'Deploy',
-          onSelect: () => onCreateDeployment?.(row.name),
-        },
-        ...(canTestModels
-          ? [
+      rowActions: (row: AgentTableRow) => {
+        // External agents run outside NeMo Platform — deploy/test/clone don't apply.
+        const managedActions = isExternalAgent(row)
+          ? []
+          : [
               {
-                children: 'Test models',
-                onSelect: () => {
-                  const target = getModelCompareRoute(workspace);
-                  const model = row.models[0];
-                  const urn = model ? `${row.workspace}/${model}` : null;
-                  navigate(urn ? `${target}?model=${encodeURIComponent(urn)}` : target);
-                },
+                children: 'Deploy',
+                onSelect: () => onCreateDeployment?.(row.name),
               },
-            ]
-          : []),
-        {
-          children: 'Clone',
-          onSelect: () => onCloneAgent?.(row),
-        },
-        { kind: 'divider' as const },
-        {
-          children: 'Delete',
-          danger: true,
-          onSelect: () => setDeleteState({ kind: 'agent', item: row }),
-        },
-      ],
+              ...(canTestModels
+                ? [
+                    {
+                      children: 'Test models',
+                      onSelect: () => {
+                        const target = getModelCompareRoute(workspace);
+                        const model = row.models[0];
+                        const urn = model ? `${row.workspace}/${model}` : null;
+                        navigate(urn ? `${target}?model=${encodeURIComponent(urn)}` : target);
+                      },
+                    },
+                  ]
+                : []),
+              {
+                children: 'Clone',
+                onSelect: () => onCloneAgent?.(row),
+              },
+              { kind: 'divider' as const },
+            ];
+        return [
+          ...managedActions,
+          {
+            children: 'Delete',
+            danger: true,
+            onSelect: () => setDeleteState({ kind: 'agent', item: row }),
+          },
+        ];
+      },
     }),
   ];
 
@@ -359,10 +382,24 @@ export const AgentsTable: FC<CombinedAgentsTableProps> = ({
           DataViewTableContent: {
             renderEmptyState: () => (
               <TableEmptyState
-                header="No Agents Found"
-                emptyMessage="No agents have been created yet."
+                header="No agents yet"
+                emptyMessage="Register an existing NAT agent by its endpoint URL, or spin up a ready-made example to explore the platform."
                 icon={<HatGlasses className="m-0 size-24" />}
-                actions={<DocumentationButton href={LINK_DOCS_STUDIO} />}
+                actions={
+                  <Flex gap="density-md" align="center">
+                    {onRegisterAgent && (
+                      <Button kind="secondary" onClick={onRegisterAgent}>
+                        Register Existing Agent
+                      </Button>
+                    )}
+                    {onCreateExampleAgent && (
+                      <Button color="brand" onClick={onCreateExampleAgent}>
+                        Create Example Agent
+                      </Button>
+                    )}
+                    <DocumentationButton href={LINK_DOCS_AGENTS} />
+                  </Flex>
+                }
               />
             ),
           },

--- a/web/packages/studio/src/components/dataViews/JobsDataView/index.test.tsx
+++ b/web/packages/studio/src/components/dataViews/JobsDataView/index.test.tsx
@@ -13,7 +13,6 @@ import { workspace1 } from '@studio/mocks/entity-store/projects';
 import { server } from '@studio/mocks/node';
 import { getWorkspaceJobsRoute } from '@studio/routes/utils';
 import { renderRoute, screen, waitFor } from '@studio/tests/util/render';
-import { fireEvent } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 
 vi.mock('use-debounce', () => ({
@@ -106,21 +105,6 @@ describe('JobsDataView', () => {
     for (const header of ['Name', 'Source', 'Status', 'Created']) {
       expect(await screen.findByRole('columnheader', { name: header })).toBeInTheDocument();
     }
-  });
-
-  it('adds a returned plugin source to the source filter options', async () => {
-    const jobs = [
-      makeJob({ name: 'agents-run-1', source: 'nemo-agents-plugin' }),
-      makeJob({ name: 'eval-run-2', source: 'evaluator-metrics', id: 'job-id-2' }),
-    ];
-    server.use(http.get(JOBS_URL, () => HttpResponse.json(makeJobsPage(jobs))));
-
-    renderComponent();
-
-    fireEvent.click(await screen.findByTestId('open-filters-button'));
-    fireEvent.click(await screen.findByTestId('column-filter-source'));
-
-    expect(await screen.findByRole('option', { name: 'nemo-agents-plugin' })).toBeInTheDocument();
   });
 
   it('shows error panel when API returns an error', async () => {
@@ -226,23 +210,6 @@ describe('JobsDataView', () => {
         expect(params.has('search')).toBe(false);
         expect(Array.from(params.keys()).some((k) => k.startsWith('search['))).toBe(false);
       }
-    });
-
-    it('sends sort=source when the Source header is clicked', async () => {
-      const requestUrls: string[] = [];
-      server.use(
-        http.get(JOBS_URL, ({ request }) => {
-          requestUrls.push(request.url);
-          return HttpResponse.json(makeJobsPage([makeJob()]));
-        })
-      );
-      renderComponent();
-
-      fireEvent.click(await screen.findByRole('button', { name: /^Source/ }));
-
-      await waitFor(() =>
-        expect(requestUrls.some((u) => new URL(u).searchParams.get('sort') === 'source')).toBe(true)
-      );
     });
   });
 });

--- a/web/packages/studio/src/components/dataViews/JobsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/JobsDataView/index.tsx
@@ -11,8 +11,8 @@ import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataView
 import { getSortParam } from '@nemo/common/src/utils/query';
 import { useJobsListJobs } from '@nemo/sdk/generated/platform/api';
 import type {
-  PlatformJobListSortField,
   PlatformJobResponse,
+  PlatformJobSortField,
   PlatformJobsListFilter,
 } from '@nemo/sdk/generated/platform/schema';
 import { Button, Flex, StatusMessage } from '@nvidia/foundations-react-core';
@@ -32,7 +32,7 @@ import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { iconColorClass } from '@studio/routes/constants';
 import { keepPreviousData } from '@tanstack/react-query';
 import { ChartBar, Cog, LayoutList, ListChecks, Sliders, Sparkles } from 'lucide-react';
-import { ComponentProps, type ReactNode, useRef } from 'react';
+import { ComponentProps, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const SOURCE_DISPLAY: Record<string, { label: string; icon: ReactNode }> = {
@@ -86,7 +86,7 @@ export const JobsDataView = () => {
     {
       page: dataViewState.pagination.state.pageIndex + 1,
       page_size: dataViewState.pagination.state.pageSize,
-      sort: getSortParam(dataViewState.sorting.state) as PlatformJobListSortField,
+      sort: getSortParam(dataViewState.sorting.state) as PlatformJobSortField,
       filter: {
         ...userFilter,
         ...(hasUserSourceFilter
@@ -113,19 +113,6 @@ export const JobsDataView = () => {
       ? (jobsData?.data ?? [])
       : jobsData.data.filter((job) => job.source !== JOB_SOURCE.CUSTOMIZATION);
 
-  // Surface plugin sources not in the static list (e.g. nemo-agents-plugin).
-  const seenSourcesRef = useRef<Set<string>>(new Set());
-  for (const job of jobsData?.data ?? []) {
-    if (job.source) seenSourcesRef.current.add(job.source);
-  }
-
-  const staticSourceValues = new Set(sourceFilterOptions.map((option) => option.value));
-  const dynamicSourceOptions = [...seenSourcesRef.current]
-    .filter((source) => !staticSourceValues.has(source) && !hiddenJobSources.includes(source))
-    .sort()
-    .map((source) => ({ label: SOURCE_DISPLAY[source]?.label ?? source, value: source }));
-  const mergedSourceOptions = [...sourceFilterOptions, ...dynamicSourceOptions];
-
   const makeColumns: ComponentProps<typeof StudioDataView<PlatformJobResponse>>['makeColumns'] = ({
     accessor,
   }) => [
@@ -137,12 +124,11 @@ export const JobsDataView = () => {
       id: 'source',
       header: 'Source',
       size: 200,
-      enableSorting: true,
       meta: {
         filter: {
           type: 'single-select' as const,
           label: 'Source',
-          options: mergedSourceOptions,
+          options: sourceFilterOptions,
         },
       },
       cell: ({ row, column: col }) => {

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/AgentDetailsContent.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/AgentDetailsContent.tsx
@@ -18,11 +18,13 @@ import {
 } from '@nvidia/foundations-react-core';
 import type { AgentConfig } from '@studio/components/dataViews/AgentsDataView';
 import { getAgentModelNames } from '@studio/components/dataViews/AgentsDataView/utils';
+import { ExternalAgentStatus } from '@studio/components/sidePanels/AgentPanels/AgentPanel/ExternalAgentStatus';
 import { deploymentStatusColor } from '@studio/components/sidePanels/AgentPanels/AgentPanel/helpers';
 import { NoHealthyDeploymentsBanner } from '@studio/components/sidePanels/AgentPanels/AgentPanel/NoHealthyDeploymentsBanner';
 import type { WalkthroughStep } from '@studio/components/sidePanels/AgentPanels/AgentPanel/walkthrough';
 import type { AgentEvalJob } from '@studio/routes/agents/AgentEvaluationsRoute/api';
 import { getAgentEvaluationDetailRoute, getAgentEvaluationsListRoute } from '@studio/routes/utils';
+import { isExternalAgent } from '@studio/util/agents';
 import type { FC, RefObject } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -56,176 +58,205 @@ export const AgentDetailsContent: FC<AgentDetailsContentProps> = ({
   onDeploy,
   onSwitchToChat,
   onDeleteDeployment,
-}) => (
-  <Stack className="overflow-auto">
-    <Block padding="4">
-      <Stack gap="3">
-        <Text kind="body/semibold/xl">{agentName}</Text>
-        {isDefined(agent?.description) && agent.description && (
-          <Text kind="body/regular/sm" color="secondary">
-            {agent.description}
-          </Text>
-        )}
-        <Flex gap="2" align="center">
-          <Button className="flex-1" kind="primary" onClick={onSubmitEval} disabled={!agentName}>
-            Evaluate this Agent
-          </Button>
-          <div
-            ref={deployButtonRef}
-            className={`flex-1 rounded-md ${
-              walkthroughStep === 'deploy' ? 'ring-2 ring-brand ring-offset-2 animate-pulse' : ''
-            }`}
-          >
-            <Button
-              className="w-full"
-              kind="secondary"
-              onClick={onDeploy}
-              disabled={!agentName || isDeploying}
-            >
-              {isDeploying ? 'Deploying…' : 'Deploy this Agent'}
+}) => {
+  const isExternal = isExternalAgent(agent);
+  return (
+    <Stack className="overflow-auto">
+      <Block padding="4">
+        <Stack gap="3">
+          <Text kind="body/semibold/xl">{agentName}</Text>
+          {isDefined(agent?.description) && agent.description && (
+            <Text kind="body/regular/sm" color="secondary">
+              {agent.description}
+            </Text>
+          )}
+          <Flex gap="2" align="center">
+            <Button className="flex-1" kind="primary" onClick={onSubmitEval} disabled={!agentName}>
+              Evaluate this Agent
             </Button>
-          </div>
-        </Flex>
-      </Stack>
-    </Block>
-    <Accordion
-      multiple
-      className="w-full border-t border-base"
-      defaultValue={['agent-details', 'deployments', 'evaluations']}
-      items={[
-        {
-          chevronPosition: 'start',
-          slotTrigger: 'Agent Details',
-          slotContent: (
+            {!isExternal && (
+              <div
+                ref={deployButtonRef}
+                className={`flex-1 rounded-md ${
+                  walkthroughStep === 'deploy'
+                    ? 'ring-2 ring-brand ring-offset-2 animate-pulse'
+                    : ''
+                }`}
+              >
+                <Button
+                  className="w-full"
+                  kind="secondary"
+                  onClick={onDeploy}
+                  disabled={!agentName || isDeploying}
+                >
+                  {isDeploying ? 'Deploying…' : 'Deploy this Agent'}
+                </Button>
+              </div>
+            )}
+          </Flex>
+          {isExternal && agentName && (
             <Stack gap="2">
-              <KVPair label="Name" value={agent?.name ?? agentName} />
-              <KVPair label="Workspace" value={agent?.workspace ?? workspace} />
-              {isDefined(agent?.description) && (
-                <KVPair label="Description" value={agent.description || '-'} />
-              )}
-              {(() => {
-                const models = getAgentModelNames(agent?.config as AgentConfig | undefined);
-                return models.length > 0 ? (
-                  <KVPair label="Model" value={models.join(', ')} />
-                ) : null;
-              })()}
-              {isDefined(agent?.config_format) && (
-                <KVPair label="Config Format" value={agent.config_format} />
-              )}
+              <ExternalAgentStatus workspace={workspace} agentName={agentName} />
+              <Text kind="body/regular/sm" color="secondary">
+                Runs outside NeMo Platform. Deploy is unavailable; evaluation runs against the
+                agent's endpoint.
+              </Text>
             </Stack>
-          ),
-          value: 'agent-details',
-        },
-        {
-          chevronPosition: 'start',
-          slotTrigger: 'Deployments',
-          slotContent:
-            !isDeploymentsLoading && agentDeployments.length === 0 ? (
-              <NoHealthyDeploymentsBanner
-                agentName={agentName}
-                isDeploying={isDeploying}
-                onDeploy={onDeploy}
-                message="No deployments for this agent."
-              />
-            ) : (
-              <Stack gap="0" className="-mx-4 -mb-4">
-                {agentDeployments.map((deployment) => (
-                  <Flex
-                    key={deployment.name}
-                    align="center"
-                    gap="2"
-                    className="px-4 py-3 border-b border-base last:border-b-0"
-                  >
-                    <StatusIndicator
-                      color={deploymentStatusColor(deployment.status)}
-                      size="small"
-                    />
-                    <Stack gap="0" className="flex-1 min-w-0">
-                      <Text kind="body/semibold/sm">{deployment.name}</Text>
-                      {deployment.endpoint && (
-                        <Text kind="body/regular/xs" color="secondary" className="truncate">
-                          {deployment.endpoint}
-                        </Text>
-                      )}
-                      {deployment.error && (
-                        <Text kind="body/regular/xs" color="danger" className="truncate">
-                          {deployment.error}
-                        </Text>
-                      )}
-                    </Stack>
-                    <StatusBadge status={deployment.status} />
-                    <Flex gap="1" className="shrink-0">
-                      <Button
-                        kind="tertiary"
-                        size="small"
-                        disabled={deployment.status !== 'running'}
-                        onClick={() => onSwitchToChat(deployment)}
-                      >
-                        Chat
-                      </Button>
-                      <Button
-                        kind="tertiary"
-                        size="small"
-                        color="danger"
-                        onClick={() => onDeleteDeployment(deployment)}
-                      >
-                        Delete
-                      </Button>
-                    </Flex>
-                  </Flex>
-                ))}
-              </Stack>
-            ),
-          value: 'deployments',
-        },
-        {
-          chevronPosition: 'start' as const,
-          slotTrigger: 'Recent Evaluations',
-          slotContent:
-            agentEvals.length === 0 ? (
+          )}
+        </Stack>
+      </Block>
+      <Accordion
+        multiple
+        className="w-full border-t border-base"
+        defaultValue={['agent-details', 'deployments', 'evaluations']}
+        items={[
+          {
+            chevronPosition: 'start',
+            slotTrigger: 'Agent Details',
+            slotContent: (
               <Stack gap="2">
-                <Text color="secondary">No evaluation jobs found for this agent.</Text>
-                <Block>
-                  <Link to={getAgentEvaluationsListRoute(workspace)} className="text-xs">
-                    View all evaluations →
-                  </Link>
-                </Block>
-              </Stack>
-            ) : (
-              <Stack gap="0" className="-mx-4 -mb-4">
-                {agentEvals.map((job) => (
-                  <Link
-                    key={job.name}
-                    to={getAgentEvaluationDetailRoute(workspace, job.name)}
-                    className="no-underline text-inherit"
-                  >
-                    <Flex
-                      align="center"
-                      gap="2"
-                      className="px-4 py-3 border-b border-base last:border-b-0 hover:bg-surface-hover"
-                    >
-                      <Stack gap="0" className="flex-1 min-w-0">
-                        <Text kind="body/semibold/sm" className="truncate">
-                          {job.name}
-                        </Text>
-                        <Text kind="body/regular/xs" color="secondary">
-                          <RelativeTime datetime={job.created_at} />
-                        </Text>
-                      </Stack>
-                      <StatusBadge status={job.status} />
-                    </Flex>
-                  </Link>
-                ))}
-                <Block className="px-4 py-3 border-t border-base">
-                  <Link to={getAgentEvaluationsListRoute(workspace)} className="text-xs">
-                    View all evaluations →
-                  </Link>
-                </Block>
+                <KVPair label="Name" value={agent?.name ?? agentName} />
+                <KVPair label="Workspace" value={agent?.workspace ?? workspace} />
+                {isDefined(agent?.description) && (
+                  <KVPair label="Description" value={agent.description || '-'} />
+                )}
+                {(() => {
+                  const models = getAgentModelNames(agent?.config as AgentConfig | undefined);
+                  return models.length > 0 ? (
+                    <KVPair label="Model" value={models.join(', ')} />
+                  ) : null;
+                })()}
+                {isExternal ? (
+                  <>
+                    <KVPair label="Source" value="External" />
+                    {isDefined(agent?.endpoint) && agent.endpoint && (
+                      <KVPair label="Endpoint" value={agent.endpoint} />
+                    )}
+                  </>
+                ) : (
+                  isDefined(agent?.config_format) && (
+                    <KVPair label="Config Format" value={agent.config_format} />
+                  )
+                )}
               </Stack>
             ),
-          value: 'evaluations',
-        },
-      ]}
-    />
-  </Stack>
-);
+            value: 'agent-details',
+          },
+          ...(isExternal
+            ? []
+            : [
+                {
+                  chevronPosition: 'start' as const,
+                  slotTrigger: 'Deployments',
+                  slotContent:
+                    !isDeploymentsLoading && agentDeployments.length === 0 ? (
+                      <NoHealthyDeploymentsBanner
+                        agentName={agentName}
+                        isDeploying={isDeploying}
+                        onDeploy={onDeploy}
+                        message="No deployments for this agent."
+                      />
+                    ) : (
+                      <Stack gap="0" className="-mx-4 -mb-4">
+                        {agentDeployments.map((deployment) => (
+                          <Flex
+                            key={deployment.name}
+                            align="center"
+                            gap="2"
+                            className="px-4 py-3 border-b border-base last:border-b-0"
+                          >
+                            <StatusIndicator
+                              color={deploymentStatusColor(deployment.status)}
+                              size="small"
+                            />
+                            <Stack gap="0" className="flex-1 min-w-0">
+                              <Text kind="body/semibold/sm">{deployment.name}</Text>
+                              {deployment.endpoint && (
+                                <Text kind="body/regular/xs" color="secondary" className="truncate">
+                                  {deployment.endpoint}
+                                </Text>
+                              )}
+                              {deployment.error && (
+                                <Text kind="body/regular/xs" color="danger" className="truncate">
+                                  {deployment.error}
+                                </Text>
+                              )}
+                            </Stack>
+                            <StatusBadge status={deployment.status} />
+                            <Flex gap="1" className="shrink-0">
+                              <Button
+                                kind="tertiary"
+                                size="small"
+                                disabled={deployment.status !== 'running'}
+                                onClick={() => onSwitchToChat(deployment)}
+                              >
+                                Chat
+                              </Button>
+                              <Button
+                                kind="tertiary"
+                                size="small"
+                                color="danger"
+                                onClick={() => onDeleteDeployment(deployment)}
+                              >
+                                Delete
+                              </Button>
+                            </Flex>
+                          </Flex>
+                        ))}
+                      </Stack>
+                    ),
+                  value: 'deployments',
+                },
+              ]),
+          {
+            chevronPosition: 'start' as const,
+            slotTrigger: 'Recent Evaluations',
+            slotContent:
+              agentEvals.length === 0 ? (
+                <Stack gap="2">
+                  <Text color="secondary">No evaluation jobs found for this agent.</Text>
+                  <Block>
+                    <Link to={getAgentEvaluationsListRoute(workspace)} className="text-xs">
+                      View all evaluations →
+                    </Link>
+                  </Block>
+                </Stack>
+              ) : (
+                <Stack gap="0" className="-mx-4 -mb-4">
+                  {agentEvals.map((job) => (
+                    <Link
+                      key={job.name}
+                      to={getAgentEvaluationDetailRoute(workspace, job.name)}
+                      className="no-underline text-inherit"
+                    >
+                      <Flex
+                        align="center"
+                        gap="2"
+                        className="px-4 py-3 border-b border-base last:border-b-0 hover:bg-surface-hover"
+                      >
+                        <Stack gap="0" className="flex-1 min-w-0">
+                          <Text kind="body/semibold/sm" className="truncate">
+                            {job.name}
+                          </Text>
+                          <Text kind="body/regular/xs" color="secondary">
+                            <RelativeTime datetime={job.created_at} />
+                          </Text>
+                        </Stack>
+                        <StatusBadge status={job.status} />
+                      </Flex>
+                    </Link>
+                  ))}
+                  <Block className="px-4 py-3 border-t border-base">
+                    <Link to={getAgentEvaluationsListRoute(workspace)} className="text-xs">
+                      View all evaluations →
+                    </Link>
+                  </Block>
+                </Stack>
+              ),
+            value: 'evaluations',
+          },
+        ]}
+      />
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/AgentWorkflowContent.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/AgentWorkflowContent.tsx
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Agent } from '@nemo/sdk/generated/agents/schema/Agent';
+import { Accordion, Badge, Block, Flex, Stack, Text } from '@nvidia/foundations-react-core';
+import type { AgentConfig } from '@studio/components/dataViews/AgentsDataView';
+import { redactSecrets } from '@studio/components/sidePanels/AgentPanels/AgentPanel/redactSecrets';
+import { summarizeAgentCard } from '@studio/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentCard';
+import { summarizeAgentWorkflow } from '@studio/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentWorkflow';
+import { isExternalAgent } from '@studio/util/agents';
+import { Globe, Workflow, Wrench } from 'lucide-react';
+import type { FC } from 'react';
+import YAML from 'yaml';
+
+interface AgentWorkflowContentProps {
+  agent?: Agent;
+}
+
+export const AgentWorkflowContent: FC<AgentWorkflowContentProps> = ({ agent }) => {
+  if (agent && isExternalAgent(agent)) {
+    return <ExternalAgentWorkflow agent={agent} />;
+  }
+
+  const config = agent?.config as AgentConfig | undefined;
+  const summary = summarizeAgentWorkflow(config);
+
+  if (!config || (!summary.workflowType && summary.tools.length === 0)) {
+    return (
+      <Block padding="4">
+        <Text color="secondary">This agent has no workflow config to visualize.</Text>
+      </Block>
+    );
+  }
+
+  let yamlText = '';
+  try {
+    yamlText = YAML.stringify(redactSecrets(config));
+  } catch {
+    yamlText = 'Unable to render config as YAML.';
+  }
+
+  const wiredTools = summary.tools.filter((t) => t.wired);
+  const unwiredTools = summary.tools.filter((t) => !t.wired);
+
+  return (
+    <Stack className="overflow-auto" gap="4">
+      <Block padding="4">
+        <Stack gap="4">
+          <Flex align="center" gap="2">
+            <Workflow className="size-4 text-brand" />
+            <Text kind="body/semibold/md">{summary.workflowType ?? 'workflow'}</Text>
+            {summary.models.map((model) => (
+              <Badge key={model} kind="outline">
+                {model}
+              </Badge>
+            ))}
+          </Flex>
+
+          <Stack gap="2" align="center">
+            <WorkflowNode label={summary.workflowType ?? 'workflow'} sub={summary.llmName} root />
+            {wiredTools.length > 0 && (
+              <>
+                <div className="h-4 w-px bg-base" />
+                <Flex gap="2" wrap="wrap" className="justify-center">
+                  {wiredTools.map((tool) => (
+                    <WorkflowNode key={tool.name} label={tool.name} sub={tool.type} />
+                  ))}
+                </Flex>
+              </>
+            )}
+          </Stack>
+
+          {unwiredTools.length > 0 && (
+            <Text kind="body/regular/xs" color="secondary">
+              Declared but not wired as tools: {unwiredTools.map((t) => t.name).join(', ')}
+            </Text>
+          )}
+        </Stack>
+      </Block>
+
+      <Accordion
+        multiple
+        className="w-full border-t border-base"
+        items={[
+          {
+            chevronPosition: 'start',
+            value: 'config',
+            slotTrigger: <Text kind="body/semibold/sm">Workflow config (YAML)</Text>,
+            slotContent: (
+              <Block>
+                <pre className="font-mono text-xs whitespace-pre-wrap break-all max-h-96 overflow-auto bg-surface-subtle p-density-lg rounded leading-relaxed">
+                  {yamlText}
+                </pre>
+              </Block>
+            ),
+          },
+        ]}
+      />
+    </Stack>
+  );
+};
+
+interface WorkflowNodeProps {
+  label: string;
+  sub?: string;
+  root?: boolean;
+}
+
+const WorkflowNode: FC<WorkflowNodeProps> = ({ label, sub, root }) => (
+  <Flex
+    align="center"
+    gap="2"
+    className={`rounded-md border px-3 py-2 ${
+      root ? 'border-brand bg-surface-subtle' : 'border-base'
+    }`}
+  >
+    {!root && <Wrench className="size-3 text-subtle" />}
+    <Stack gap="0">
+      <Text kind="body/semibold/sm">{label}</Text>
+      {sub && (
+        <Text kind="body/regular/xs" color="secondary">
+          {sub}
+        </Text>
+      )}
+    </Stack>
+  </Flex>
+);
+
+const ExternalAgentWorkflow: FC<{ agent: Agent }> = ({ agent }) => {
+  const summary = summarizeAgentCard(agent.card);
+
+  return (
+    <Stack className="overflow-auto" gap="4">
+      <Block padding="4">
+        <Stack gap="4">
+          <Flex align="center" gap="2">
+            <Globe className="size-4 text-brand" />
+            <Text kind="body/semibold/md">{summary.name ?? agent.name}</Text>
+            <Badge kind="outline">External</Badge>
+          </Flex>
+          {agent.endpoint && (
+            <Text kind="body/regular/xs" color="secondary" className="break-all">
+              {agent.endpoint}
+            </Text>
+          )}
+
+          {summary.skills.length > 0 ? (
+            <Stack gap="2" align="center">
+              <WorkflowNode label={summary.name ?? agent.name ?? 'agent'} root />
+              <div className="h-4 w-px bg-base" />
+              <Flex gap="2" wrap="wrap" className="justify-center">
+                {summary.skills.map((skill) => (
+                  <WorkflowNode key={skill.id} label={skill.name} sub={skill.description} />
+                ))}
+              </Flex>
+            </Stack>
+          ) : (
+            <Text color="secondary">
+              The agent card exposed no skills. This agent runs outside NeMo Platform.
+            </Text>
+          )}
+        </Stack>
+      </Block>
+
+      <Accordion
+        multiple
+        className="w-full border-t border-base"
+        items={[
+          {
+            chevronPosition: 'start',
+            value: 'card',
+            slotTrigger: <Text kind="body/semibold/sm">Agent card (JSON)</Text>,
+            slotContent: (
+              <Block>
+                <pre className="font-mono text-xs whitespace-pre-wrap break-all max-h-96 overflow-auto bg-surface-subtle p-density-lg rounded leading-relaxed">
+                  {JSON.stringify(redactSecrets(agent.card ?? {}), null, 2)}
+                </pre>
+              </Block>
+            ),
+          },
+        ]}
+      />
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/ChatPlaygroundContent.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/ChatPlaygroundContent.tsx
@@ -15,6 +15,7 @@ interface ChatPlaygroundContentProps {
   healthyDeployments: AgentDeployment[];
   isDeploymentsLoading: boolean;
   isDeploying: boolean;
+  isExternal?: boolean;
   chatAreaRef: RefObject<HTMLDivElement | null>;
   onSelectDeployment: (name: string) => void;
   onDeploy: () => void;
@@ -27,6 +28,7 @@ export const ChatPlaygroundContent: FC<ChatPlaygroundContentProps> = ({
   healthyDeployments,
   isDeploymentsLoading,
   isDeploying,
+  isExternal,
   chatAreaRef,
   onSelectDeployment,
   onDeploy,
@@ -43,6 +45,28 @@ export const ChatPlaygroundContent: FC<ChatPlaygroundContentProps> = ({
   );
   const noHealthyDeployments = !isDeploymentsLoading && healthyDeployments.length === 0;
 
+  // External agents run outside NeMo Platform: there's no NMP deployment. Chat
+  // is bridged to the agent's A2A endpoint by the gateway's external-chat route,
+  // which speaks OpenAI chat/completions on `.../agents/{name}/chat/completions`.
+  if (isExternal) {
+    return (
+      <div ref={chatAreaRef} className="flex flex-col h-full min-h-0">
+        <Block className="flex-1 min-h-0" padding="4">
+          <ModelChat
+            model={agentName ?? ''}
+            workspace={workspace}
+            baseURL={
+              agentName
+                ? `${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/${workspace}/agents/${agentName}`
+                : undefined
+            }
+            disabled={!agentName}
+          />
+        </Block>
+      </div>
+    );
+  }
+
   return (
     <div ref={chatAreaRef} className="flex flex-col h-full min-h-0">
       {!noHealthyDeployments && healthyDeployments.length > 1 && (
@@ -54,7 +78,7 @@ export const ChatPlaygroundContent: FC<ChatPlaygroundContentProps> = ({
           />
         </Block>
       )}
-      {noHealthyDeployments && (
+      {noHealthyDeployments ? (
         <Block padding="4" className="shrink-0">
           <NoHealthyDeploymentsBanner
             agentName={agentName}
@@ -62,19 +86,20 @@ export const ChatPlaygroundContent: FC<ChatPlaygroundContentProps> = ({
             onDeploy={onDeploy}
           />
         </Block>
+      ) : (
+        <Block className="flex-1 min-h-0" padding="4">
+          <ModelChat
+            model={chatDeployment?.name ?? agentName ?? ''}
+            workspace={workspace}
+            baseURL={
+              chatDeployment
+                ? `${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/${workspace}/deployments/${chatDeployment.name}/-/v1`
+                : undefined
+            }
+            disabled={isDeploymentsLoading || !chatDeployment}
+          />
+        </Block>
       )}
-      <Block className="flex-1 min-h-0" padding="4">
-        <ModelChat
-          model={chatDeployment?.name ?? agentName ?? ''}
-          workspace={workspace}
-          baseURL={
-            chatDeployment
-              ? `${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/${workspace}/deployments/${chatDeployment.name}/-/v1`
-              : undefined
-          }
-          disabled={isDeploymentsLoading || noHealthyDeployments || !chatDeployment}
-        />
-      </Block>
     </div>
   );
 };

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/ExternalAgentNotice.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/ExternalAgentNotice.tsx
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Block, Stack, Text } from '@nvidia/foundations-react-core';
+import { Globe } from 'lucide-react';
+import type { FC, ReactNode } from 'react';
+
+/** Shared heading for external-agent empty states, so the phrasing lives in one place. */
+export const EXTERNAL_AGENT_HEADING = 'This agent runs outside NeMo Platform';
+
+/** Centered notice used where an external agent has no NMP-managed surface (e.g. Logs). */
+export const ExternalAgentNotice: FC<{ detail: ReactNode }> = ({ detail }) => (
+  <Block padding="4">
+    <Stack gap="2" align="center" className="pt-8 text-center">
+      <Globe className="size-8 text-subtle" />
+      <Text kind="body/semibold/md">{EXTERNAL_AGENT_HEADING}</Text>
+      <Text kind="body/regular/sm" color="secondary">
+        {detail}
+      </Text>
+    </Stack>
+  </Block>
+);

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/ExternalAgentStatus.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/ExternalAgentStatus.tsx
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import {
+  getAgentsExternalAgentReachabilityQueryKey,
+  getAgentsGetAgentQueryKey,
+  useAgentsExternalAgentReachability,
+  useAgentsRefreshExternalAgent,
+} from '@nemo/sdk/generated/agents/api';
+import { Button, Flex, StatusIndicator, Text } from '@nvidia/foundations-react-core';
+import { getErrorMessage } from '@studio/api/common/utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { RotateCw } from 'lucide-react';
+import type { FC } from 'react';
+
+const REACHABILITY_POLL_MS = 30_000;
+
+interface ExternalAgentStatusProps {
+  workspace: string;
+  agentName: string;
+}
+
+/**
+ * Reachability badge + card-refresh for an external agent. The card is captured
+ * once at registration, so refresh re-fetches it; the badge polls a lightweight
+ * liveness probe so a dead endpoint isn't invisible until you try to chat.
+ */
+export const ExternalAgentStatus: FC<ExternalAgentStatusProps> = ({ workspace, agentName }) => {
+  const toast = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: reachability, isLoading } = useAgentsExternalAgentReachability(
+    workspace,
+    agentName,
+    { query: { enabled: !!agentName, refetchInterval: REACHABILITY_POLL_MS } }
+  );
+
+  const { mutate: refresh, isPending } = useAgentsRefreshExternalAgent({
+    mutation: {
+      onSuccess: () => {
+        toast.success('Agent card refreshed');
+        void queryClient.invalidateQueries({
+          queryKey: getAgentsGetAgentQueryKey(workspace, agentName),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getAgentsExternalAgentReachabilityQueryKey(workspace, agentName),
+        });
+      },
+      onError: (error) =>
+        toast.error(getErrorMessage(error as Error, 'Failed to refresh agent card')),
+    },
+  });
+
+  const status = isLoading ? 'checking' : reachability?.reachable ? 'reachable' : 'unreachable';
+  const label =
+    status === 'checking' ? 'Checking…' : status === 'reachable' ? 'Reachable' : 'Unreachable';
+  const color = status === 'reachable' ? 'green' : status === 'unreachable' ? 'red' : 'yellow';
+
+  return (
+    <Flex gap="2" align="center">
+      <StatusIndicator color={color} size="small" />
+      <Text kind="body/regular/sm" color="secondary">
+        {label}
+      </Text>
+      <Button
+        kind="tertiary"
+        size="small"
+        disabled={isPending}
+        onClick={() => refresh({ workspace, name: agentName })}
+      >
+        <RotateCw className="size-3" /> {isPending ? 'Refreshing…' : 'Refresh card'}
+      </Button>
+    </Flex>
+  );
+};

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/index.test.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/index.test.tsx
@@ -79,8 +79,8 @@ describe('AgentPanel', () => {
       renderPanel(MOCK_AGENT_WITH_DEPLOYMENTS);
 
       expect(
-        await screen.findAllByText('meta-llama-3-1-70b-instruct', {}, { timeout: 5000 })
-      ).toHaveLength(2);
+        await screen.findByText('meta-llama-3-1-70b-instruct', {}, { timeout: 5000 })
+      ).toBeInTheDocument();
     });
 
     it('renders a non-empty description when present', async () => {

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/index.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/index.tsx
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { AgentDeployment } from '@nemo/sdk/generated/agents/schema/AgentDeployment';
-import { Block, SegmentedControl, SidePanel, Stack, Text } from '@nvidia/foundations-react-core';
-import type { AgentConfig } from '@studio/components/dataViews/AgentsDataView';
-import { getAgentModelNames } from '@studio/components/dataViews/AgentsDataView/utils';
+import { Block, SegmentedControl, SidePanel } from '@nvidia/foundations-react-core';
 import { DeleteConfirmationModal } from '@studio/components/DeleteConfirmationModal';
 import { AgentDetailsContent } from '@studio/components/sidePanels/AgentPanels/AgentPanel/AgentDetailsContent';
+import { AgentWorkflowContent } from '@studio/components/sidePanels/AgentPanels/AgentPanel/AgentWorkflowContent';
 import { ChatPlaygroundContent } from '@studio/components/sidePanels/AgentPanels/AgentPanel/ChatPlaygroundContent';
 import { DeploymentLogsView } from '@studio/components/sidePanels/AgentPanels/AgentPanel/DeploymentLogsView';
+import { ExternalAgentNotice } from '@studio/components/sidePanels/AgentPanels/AgentPanel/ExternalAgentNotice';
 import type { AgentPanelTab } from '@studio/components/sidePanels/AgentPanels/AgentPanel/types';
 import { useAgentPanel } from '@studio/components/sidePanels/AgentPanels/AgentPanel/useAgentPanel';
 import { deriveWalkthroughStep } from '@studio/components/sidePanels/AgentPanels/AgentPanel/walkthrough';
@@ -19,6 +19,7 @@ import {
 } from '@studio/components/sidePanels/AgentPanels/AgentPanel/walkthroughStorage';
 import { CreateDeploymentModal } from '@studio/routes/agents/AgentDeploymentsListRoute/CreateDeploymentModal';
 import { SubmitEvaluationModal } from '@studio/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal';
+import { isExternalAgent } from '@studio/util/agents';
 import { type ComponentProps, type FC, useEffect, useMemo, useRef, useState } from 'react';
 
 export type { AgentPanelTab };
@@ -61,6 +62,7 @@ export const AgentPanel: FC<AgentPanelProps> = ({
   const tabItems = useMemo(
     () => [
       { value: 'agent-details', children: 'Details' },
+      { value: 'agent-workflow', children: 'Workflow' },
       { value: 'chat-playground', children: 'Chat Playground' },
       { value: 'deployment-logs', children: 'Logs' },
     ],
@@ -74,6 +76,7 @@ export const AgentPanel: FC<AgentPanelProps> = ({
   useEffect(() => {
     setSelectedDeploymentName(undefined);
     setWalkthroughDismissed(false);
+    // Start the walkthrough only for the agent it was queued for (just created).
     setWalkthroughActive(!!agentName && isAgentWalkthroughPending(agentName));
   }, [agentName]);
 
@@ -108,12 +111,16 @@ export const AgentPanel: FC<AgentPanelProps> = ({
     onTabChange?.('chat-playground');
   };
 
-  const agentModelNames = getAgentModelNames(agent?.config as AgentConfig | undefined);
-
   let content: React.ReactNode;
 
   if (selectedTab === 'deployment-logs') {
-    content = <DeploymentLogsView workspace={workspace} deployments={agentDeployments} />;
+    content = isExternalAgent(agent) ? (
+      <ExternalAgentNotice detail="There is no NeMo deployment to read logs from. Logs are available on the host where the agent runs." />
+    ) : (
+      <DeploymentLogsView workspace={workspace} deployments={agentDeployments} />
+    );
+  } else if (selectedTab === 'agent-workflow') {
+    content = <AgentWorkflowContent agent={agent} />;
   } else if (selectedTab === 'chat-playground') {
     content = (
       <ChatPlaygroundContent
@@ -123,6 +130,7 @@ export const AgentPanel: FC<AgentPanelProps> = ({
         healthyDeployments={healthyDeployments}
         isDeploymentsLoading={isDeploymentsLoading}
         isDeploying={isDeploying}
+        isExternal={isExternalAgent(agent)}
         chatAreaRef={chatAreaRef}
         onSelectDeployment={(v) => setSelectedDeploymentName(v)}
         onDeploy={() => setCreateDeploymentOpen(true)}
@@ -153,16 +161,7 @@ export const AgentPanel: FC<AgentPanelProps> = ({
       <SidePanel
         open={open}
         onOpenChange={onOpenChange}
-        slotHeading={
-          <Stack gap="1">
-            <Text kind="inherit">{agentName}</Text>
-            {agentModelNames.length > 0 && (
-              <Text kind="body/regular/sm" className="text-secondary">
-                {agentModelNames.join(', ')}
-              </Text>
-            )}
-          </Stack>
-        }
+        slotHeading={agentName}
         bordered
         modal
         className="[&.nv-side-panel-content]:w-full [&.nv-side-panel-content]:max-w-[50vw] [&_.nv-side-panel-main]:gap-4 [&_.nv-side-panel-main]:p-0"

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/redactSecrets.test.ts
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/redactSecrets.test.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { redactSecrets } from '@studio/components/sidePanels/AgentPanels/AgentPanel/redactSecrets';
+
+describe('redactSecrets', () => {
+  it('masks credential-like keys anywhere in the tree', () => {
+    expect(
+      redactSecrets({
+        llms: { llm: { _type: 'openai', model_name: 'gpt-4o', api_key: 'sk-secret' } },
+        auth: { token: 'abc', bearer_secret: 'xyz' },
+        password: 'hunter2',
+      })
+    ).toEqual({
+      llms: { llm: { _type: 'openai', model_name: 'gpt-4o', api_key: '***' } },
+      auth: { token: '***', bearer_secret: '***' },
+      password: '***',
+    });
+  });
+
+  it('leaves non-secret values and structure intact', () => {
+    const input = { workflow: { _type: 'react_agent', tool_names: ['a', 'b'] } };
+    expect(redactSecrets(input)).toEqual(input);
+  });
+
+  it('handles arrays and primitives', () => {
+    expect(redactSecrets([{ api_key: 'k' }, 'plain'])).toEqual([{ api_key: '***' }, 'plain']);
+    expect(redactSecrets(undefined)).toBeUndefined();
+  });
+});

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/redactSecrets.ts
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/redactSecrets.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const SECRET_KEY = /(api[_-]?key|token|secret|password|credential|authorization)/i;
+const MASK = '***';
+
+/**
+ * Deep-copy a config/card object with credential-like values masked, so the
+ * Workflow tab never renders inline secrets (e.g. `llms.*.api_key`) to anyone
+ * who can view the agent. Only scalar values under a secret-looking key are
+ * masked; structure is preserved.
+ */
+export const redactSecrets = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(redactSecrets);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, val]) => {
+        if (SECRET_KEY.test(key) && (typeof val === 'string' || typeof val === 'number')) {
+          return [key, MASK];
+        }
+        return [key, redactSecrets(val)];
+      })
+    );
+  }
+  return value;
+};

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentCard.test.ts
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentCard.test.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { summarizeAgentCard } from '@studio/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentCard';
+
+describe('summarizeAgentCard', () => {
+  it('extracts name, description, and skills', () => {
+    expect(
+      summarizeAgentCard({
+        name: 'Calculator Agent',
+        description: 'does math',
+        skills: [
+          { id: 'calculator__add', name: 'add', description: 'Add numbers' },
+          { id: 'calculator__divide', name: 'divide' },
+        ],
+      })
+    ).toEqual({
+      name: 'Calculator Agent',
+      description: 'does math',
+      skills: [
+        { id: 'calculator__add', name: 'add', description: 'Add numbers' },
+        { id: 'calculator__divide', name: 'divide', description: undefined },
+      ],
+    });
+  });
+
+  it('returns empty skills for undefined or malformed card', () => {
+    expect(summarizeAgentCard(undefined).skills).toEqual([]);
+    expect(summarizeAgentCard({ skills: 'nope' }).skills).toEqual([]);
+    expect(summarizeAgentCard({ skills: [null, 42, {}] }).skills).toEqual([]);
+  });
+
+  it('falls back to id when a skill has no name', () => {
+    expect(summarizeAgentCard({ skills: [{ id: 'only_id' }] }).skills).toEqual([
+      { id: 'only_id', name: 'only_id', description: undefined },
+    ]);
+  });
+});

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentCard.ts
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentCard.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AgentCard } from '@nemo/sdk/generated/agents/schema/AgentCard';
+
+export interface AgentCardSkill {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface AgentCardSummary {
+  name?: string;
+  description?: string;
+  skills: AgentCardSkill[];
+}
+
+const asString = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
+
+/**
+ * Reads the display-relevant fields out of a fetched A2A agent card. The card
+ * is stored loosely (a plain dict), so every access is defensive; unknown
+ * shapes degrade to an empty skills list rather than throwing.
+ */
+export const summarizeAgentCard = (card: AgentCard | undefined): AgentCardSummary => {
+  const rawSkills = Array.isArray((card as { skills?: unknown } | undefined)?.skills)
+    ? ((card as { skills: unknown[] }).skills as unknown[])
+    : [];
+
+  const skills: AgentCardSkill[] = rawSkills.flatMap((entry, i) => {
+    if (!entry || typeof entry !== 'object') return [];
+    const s = entry as Record<string, unknown>;
+    const name = asString(s.name) ?? asString(s.id);
+    if (!name) return [];
+    return [{ id: asString(s.id) ?? `skill-${i}`, name, description: asString(s.description) }];
+  });
+
+  return {
+    name: asString((card as Record<string, unknown> | undefined)?.name),
+    description: asString((card as Record<string, unknown> | undefined)?.description),
+    skills,
+  };
+};

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentWorkflow.test.ts
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentWorkflow.test.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AgentConfig } from '@studio/components/dataViews/AgentsDataView';
+import { summarizeAgentWorkflow } from '@studio/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentWorkflow';
+
+describe('summarizeAgentWorkflow', () => {
+  it('returns empty summary for undefined config', () => {
+    expect(summarizeAgentWorkflow(undefined)).toEqual({
+      workflowType: undefined,
+      llmName: undefined,
+      models: [],
+      tools: [],
+    });
+  });
+
+  it('extracts workflow type, model, and flags wired tools', () => {
+    const config: AgentConfig = {
+      functions: {
+        calculator: { _type: 'calculator' },
+        current_datetime: { _type: 'current_datetime' },
+        unused: { _type: 'internet_search' },
+      },
+      llms: { llm: { _type: 'openai', model_name: 'gpt-4o' } },
+      workflow: {
+        _type: 'react_agent',
+        llm_name: 'llm',
+        tool_names: ['calculator', 'current_datetime'],
+      },
+    };
+    expect(summarizeAgentWorkflow(config)).toEqual({
+      workflowType: 'react_agent',
+      llmName: 'llm',
+      models: ['gpt-4o'],
+      tools: [
+        { name: 'calculator', type: 'calculator', wired: true },
+        { name: 'current_datetime', type: 'current_datetime', wired: true },
+        { name: 'unused', type: 'internet_search', wired: false },
+      ],
+    });
+  });
+
+  it('dedupes repeated model names across llms', () => {
+    const config: AgentConfig = {
+      llms: {
+        a: { _type: 'openai', model_name: 'gpt-4o' },
+        b: { _type: 'openai', model_name: 'gpt-4o' },
+      },
+      workflow: { _type: 'react_agent' },
+    };
+    expect(summarizeAgentWorkflow(config).models).toEqual(['gpt-4o']);
+  });
+});

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentWorkflow.ts
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/summarizeAgentWorkflow.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AgentConfig } from '@studio/components/dataViews/AgentsDataView';
+
+export interface WorkflowToolNode {
+  name: string;
+  type: string;
+  /** True when the workflow's tool_names wires this function in as a tool. */
+  wired: boolean;
+}
+
+export interface AgentWorkflowSummary {
+  workflowType?: string;
+  llmName?: string;
+  models: string[];
+  tools: WorkflowToolNode[];
+}
+
+/**
+ * Derives a display-friendly view of a NAT workflow config: the top-level
+ * workflow type, its LLM/model, and the functions declared in the config —
+ * flagging which are wired into the agent via `workflow.tool_names`. Purely a
+ * read model over the stored config; it does not validate the NAT schema.
+ */
+export const summarizeAgentWorkflow = (config: AgentConfig | undefined): AgentWorkflowSummary => {
+  const workflow = config?.workflow;
+  const wiredNames = new Set(workflow?.tool_names ?? []);
+
+  const models = Object.values(config?.llms ?? {})
+    .map((llm) => llm?.model_name)
+    .filter((m): m is string => !!m);
+
+  const tools: WorkflowToolNode[] = Object.entries(config?.functions ?? {}).map(([name, fn]) => ({
+    name,
+    type: fn?._type ?? 'unknown',
+    wired: wiredNames.has(name),
+  }));
+
+  return {
+    workflowType: workflow?._type,
+    llmName: workflow?.llm_name,
+    models: [...new Set(models)],
+    tools,
+  };
+};

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/types.ts
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/types.ts
@@ -1,4 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export type AgentPanelTab = 'agent-details' | 'chat-playground' | 'deployment-logs';
+export type AgentPanelTab =
+  | 'agent-details'
+  | 'agent-workflow'
+  | 'chat-playground'
+  | 'deployment-logs';

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/useAgentPanel.ts
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/useAgentPanel.ts
@@ -6,7 +6,7 @@ import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import {
   getAgentsListDeploymentsQueryKey,
   useAgentsDeleteDeployment,
-  useAgentsListAgents,
+  useAgentsGetAgent,
   useAgentsListDeployments,
 } from '@nemo/sdk/generated/agents/api';
 import { RECENT_EVAL_LIMIT } from '@studio/components/sidePanels/AgentPanels/AgentPanel/constants';
@@ -28,7 +28,10 @@ export const useAgentPanel = ({
   const queryClient = useQueryClient();
   const toast = useToast();
 
-  const { data: agentsResponse } = useAgentsListAgents(workspace, undefined, {
+  // Fetch the specific agent directly — a list query only returns the first
+  // page, so an agent selected from a later table page would resolve to
+  // undefined and be mis-rendered as managed.
+  const { data: agent } = useAgentsGetAgent(workspace, agentName ?? '', {
     query: { enabled: !!agentName },
   });
 
@@ -54,7 +57,6 @@ export const useAgentPanel = ({
     }
   );
 
-  const agentsData = agentsResponse?.data;
   const deploymentsData = deploymentsResponse?.data;
 
   // Recent evaluations targeting this agent. The platform's job filter API
@@ -80,7 +82,6 @@ export const useAgentPanel = ({
     },
   });
 
-  const agent = agentName ? (agentsData ?? []).find((a) => a.name === agentName) : undefined;
   const agentDeployments = useMemo(
     () => (deploymentsData ?? []).filter((d) => d.agent === agentName),
     [deploymentsData, agentName]

--- a/web/packages/studio/src/constants/links.ts
+++ b/web/packages/studio/src/constants/links.ts
@@ -6,6 +6,7 @@ const GITHUB_REPO_URL = 'https://github.com/NVIDIA-NeMo/nemo-platform';
 
 // Studio documentation links
 export const LINK_DOCS_STUDIO = `${DOCS_BASE_URL}studio`;
+export const LINK_DOCS_AGENTS = `${DOCS_BASE_URL}studio/agents`;
 export const LINK_DOCS_STUDIO_CUSTOMIZATION = `${DOCS_BASE_URL}customizer-reference`;
 export const LINK_DOCS_STUDIO_EVALUATION = `${DOCS_BASE_URL}evaluate-models`;
 export const LINK_DOCS_PROJECT = `${DOCS_BASE_URL}get-started/core-concepts/projects`;

--- a/web/packages/studio/src/mocks/handlers.ts
+++ b/web/packages/studio/src/mocks/handlers.ts
@@ -622,6 +622,39 @@ export const handlers = [
       });
     }
   ),
+  http.get(
+    `${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/:workspace/agents/:name`,
+    ({ params }) => {
+      const name = String(params['name']);
+      if (name !== 'react-agent' && name !== 'react-agent2') {
+        return new HttpResponse(null, { status: 404 });
+      }
+      return HttpResponse.json({
+        name,
+        workspace: params['workspace'],
+        description: name === 'react-agent2' ? 'Second react agent' : '',
+        source: 'managed',
+        config: {
+          functions: { wiki: { _type: 'wiki_search' }, clock: { _type: 'current_datetime' } },
+          llms: {
+            llm: {
+              _type: 'openai',
+              api_key: 'not-used',
+              model_name: 'meta-llama-3-1-70b-instruct',
+              temperature: 0,
+            },
+          },
+          workflow: {
+            _type: 'react_agent',
+            tool_names: ['wiki', 'clock'],
+            llm_name: 'llm',
+          },
+        },
+        config_format: 'nat-workflow-v1',
+        created_at: '2026-04-20T10:00:00Z',
+      });
+    }
+  ),
   http.delete(
     `${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/:workspace/agents/:name`,
     () => new HttpResponse(null, { status: 204 })

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/RegisterAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/RegisterAgentModal/index.tsx
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { FormModal } from '@nemo/common/src/components/FormModal';
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import { getAgentsListAgentsQueryKey, useAgentsCreateAgent } from '@nemo/sdk/generated/agents/api';
+import { Block, Text } from '@nvidia/foundations-react-core';
+import { getErrorMessage } from '@studio/api/common/utils';
+import {
+  registerAgentFormSchema,
+  type RegisterAgentFormData,
+  type RegisterAgentModalProps,
+} from '@studio/routes/agents/AgentsListRoute/RegisterAgentModal/type';
+import { getAgentDetailRoute } from '@studio/routes/utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { type FC, useState } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+const DEFAULT_VALUES: RegisterAgentFormData = { name: '', description: '', url: '' };
+
+export const RegisterAgentModal: FC<RegisterAgentModalProps> = ({ open, onClose, workspace }) => {
+  const toast = useToast();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [submitError, setSubmitError] = useState<string | undefined>(undefined);
+
+  const {
+    mutateAsync: createAgent,
+    error: createError,
+    isPending,
+    reset: resetMutation,
+  } = useAgentsCreateAgent({
+    mutation: {
+      onSuccess: (agent) => {
+        toast.success(`Agent "${agent.name}" registered`);
+        void queryClient.invalidateQueries({ queryKey: getAgentsListAgentsQueryKey(workspace) });
+        resetAndClose();
+        if (agent.name) navigate(getAgentDetailRoute(workspace, agent.name));
+      },
+    },
+  });
+
+  const {
+    control,
+    reset: resetForm,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(registerAgentFormSchema),
+    defaultValues: DEFAULT_VALUES,
+    disabled: isPending,
+    mode: 'onChange',
+  });
+
+  const resetAndClose = () => {
+    resetMutation();
+    setSubmitError(undefined);
+    resetForm(DEFAULT_VALUES);
+    onClose();
+  };
+
+  const onSubmit: SubmitHandler<RegisterAgentFormData> = async (formData) => {
+    setSubmitError(undefined);
+    try {
+      await createAgent({
+        workspace,
+        data: {
+          name: formData.name.trim(),
+          description: formData.description?.trim() || '',
+          url: formData.url.trim(),
+        },
+      });
+    } catch {
+      // surfaced via errorText
+    }
+  };
+
+  const errorMessage =
+    submitError ??
+    (createError ? getErrorMessage(createError as Error, 'Failed to register agent') : undefined);
+
+  return (
+    <FormModal
+      open={open}
+      onClose={resetAndClose}
+      title="Register Existing Agent"
+      submitButtonText="Register"
+      onSubmit={handleSubmit(onSubmit)}
+      disabled={isPending}
+      loading={isPending}
+      errorText={errorMessage}
+    >
+      <ControlledTextInput
+        useControllerProps={{ control, name: 'name' }}
+        label="Name"
+        required
+        placeholder="my-nat-agent"
+        formFieldProps={{ slotError: errors.name?.message }}
+      />
+      <ControlledTextInput
+        useControllerProps={{ control, name: 'description' }}
+        label="Description"
+        placeholder="Optional"
+        formFieldProps={{ slotError: errors.description?.message }}
+      />
+      <ControlledTextInput
+        useControllerProps={{ control, name: 'url' }}
+        label="Agent endpoint URL"
+        required
+        placeholder="http://localhost:10000"
+        formFieldProps={{
+          slotError: errors.url?.message,
+          slotHelp: (
+            <Block>
+              <Text kind="body/regular/xs" color="secondary">
+                Points at a NAT agent already running (A2A). NeMo Platform fetches its agent card
+                and does not run it.
+              </Text>
+            </Block>
+          ),
+        }}
+      />
+    </FormModal>
+  );
+};

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/RegisterAgentModal/type.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/RegisterAgentModal/type.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FormModalProps } from '@nemo/common/src/components/FormModal';
+import { z } from 'zod';
+
+const isHttpUrl = (value: string): boolean => {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export const registerAgentFormSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  description: z.string().optional(),
+  url: z
+    .string()
+    .trim()
+    .min(1, 'Endpoint URL is required')
+    .refine(isHttpUrl, 'Enter a valid http(s) URL, e.g. http://localhost:10000'),
+});
+
+export type RegisterAgentFormData = z.infer<typeof registerAgentFormSchema>;
+
+export interface RegisterAgentModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
+  workspace: string;
+}

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/index.test.tsx
@@ -48,7 +48,9 @@ const renderList = () =>
   });
 
 const openModal = async (user: ReturnType<typeof userEvent.setup>): Promise<HTMLElement> => {
-  await user.click(await screen.findByRole('button', { name: 'Create Example Agent' }));
+  // The empty state repeats the header CTA, so there can be two identical
+  // buttons; click the header one (rendered first).
+  await user.click((await screen.findAllByRole('button', { name: 'Create Example Agent' }))[0]);
   const dialog = await screen.findByRole('dialog');
   await within(dialog).findByRole('combobox', { name: 'Model' });
   return dialog;

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Agent } from '@nemo/sdk/generated/agents/schema/Agent';
-import { Button, PageHeader, Stack } from '@nvidia/foundations-react-core';
+import { Button, Flex, PageHeader, Stack } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { AgentsTable, type AgentTableRow } from '@studio/components/dataViews/AgentsDataView';
 import {
@@ -15,6 +15,7 @@ import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { CreateDeploymentModal } from '@studio/routes/agents/AgentDeploymentsListRoute/CreateDeploymentModal';
 import { CloneAgentModal } from '@studio/routes/agents/AgentsListRoute/CloneAgentModal';
 import { CreateExampleAgentModal } from '@studio/routes/agents/AgentsListRoute/CreateExampleAgentModal';
+import { RegisterAgentModal } from '@studio/routes/agents/AgentsListRoute/RegisterAgentModal';
 import { getAgentDetailRoute, getAgentsListRoute } from '@studio/routes/utils';
 import { type FC, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
@@ -27,6 +28,7 @@ export const AgentsListRoute: FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [createDeploymentAgent, setCreateDeploymentAgent] = useState<string | null>(null);
   const [isCreateExampleOpen, setCreateExampleOpen] = useState(false);
+  const [isRegisterOpen, setRegisterOpen] = useState(false);
   const [cloneSource, setCloneSource] = useState<AgentTableRow | null>(null);
   const [loadedAgents, setLoadedAgents] = useState<Agent[]>([]);
   const { [ROUTE_PARAMS.agentName]: agentNameParam } = useParams<{ agentName?: string }>();
@@ -55,9 +57,14 @@ export const AgentsListRoute: FC = () => {
           slotHeading="Agents"
           slotDescription="View and manage AI agents and their deployments."
           slotActions={
-            <Button color="brand" onClick={() => setCreateExampleOpen(true)}>
-              Create Example Agent
-            </Button>
+            <Flex gap="density-md">
+              <Button kind="secondary" onClick={() => setRegisterOpen(true)}>
+                Register Existing Agent
+              </Button>
+              <Button color="brand" onClick={() => setCreateExampleOpen(true)}>
+                Create Example Agent
+              </Button>
+            </Flex>
           }
         />
         <AgentsTable
@@ -65,6 +72,8 @@ export const AgentsListRoute: FC = () => {
           onCreateDeployment={(agentName) => setCreateDeploymentAgent(agentName)}
           onCloneAgent={setCloneSource}
           onAgentsLoaded={setLoadedAgents}
+          onRegisterAgent={() => setRegisterOpen(true)}
+          onCreateExampleAgent={() => setCreateExampleOpen(true)}
         />
       </Stack>
       <CreateExampleAgentModal
@@ -72,6 +81,11 @@ export const AgentsListRoute: FC = () => {
         onClose={() => setCreateExampleOpen(false)}
         workspace={workspace}
         existingAgents={loadedAgents}
+      />
+      <RegisterAgentModal
+        open={isRegisterOpen}
+        onClose={() => setRegisterOpen(false)}
+        workspace={workspace}
       />
       <CloneAgentModal
         open={cloneSource !== null}

--- a/web/packages/studio/src/util/agents.ts
+++ b/web/packages/studio/src/util/agents.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Single predicate for the managed/external agent branch, so callers don't
+ * repeat the `source === 'external'` string comparison. Accepts anything with a
+ * `source` field (the SDK `Agent` or a table row).
+ */
+export const isExternalAgent = (agent?: { source?: string | null }): boolean =>
+  agent?.source === 'external';


### PR DESCRIPTION
## Summary

Studio UI for **external NAT agents** (agents that run outside NeMo Platform, registered by URL).

> ⚠️ **Stacked on #763 (backend).** This PR is based on the backend branch and needs its `Agent` fields (`source`/`endpoint`/`card`), config-XOR-url create, and the `refresh`/`reachability` endpoints. **Merge #763 first**, then this retargets to `main`.

## What's included
- **Register modal:** Connect running agent by endpoint URL (structural validation).
- **Agents table:** `External` badge; onboarding empty state + NAT docs link.
- **Agent panel:**
  - **Workflow** tab — managed: config graph + YAML (credentials redacted); external: A2A card skills + endpoint.
  - **Chat** wired to the external chat bridge (streaming, multi-turn).
  - **Details:** Source/Endpoint, reachability badge + **Refresh card** button.
  - Deploy/Logs gated for external; Evaluate available (via the bridge).
  - Resolves the panel agent via `GET /agents/{name}` (not a page-1 list scan — external agents past page 1 were mis-rendered as managed).
- Shared `isExternalAgent` predicate + `ExternalAgentNotice`.

## Testing
Unit tests for the read models (`summarizeAgentCard`, `summarizeAgentWorkflow`) + credential redaction; agent suites green; typecheck (our files) + lint clean.

## CI note
The `web-typecheck` job may fail on **pre-existing** intake/eval-session errors (`Trace.input/output`, `@axe-core/playwright`) authored on `main` — untouched by this branch; clears when main's typecheck is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
