### PR TITLE
fix(inference-gateway): list VirtualModels in OpenAI /v1/models catalog

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -2488,15 +2488,17 @@ nemo inference gateway openai v1 models [OPTIONS] COMMAND [ARGS]...
 **Commands:**
 
 * `get`: Retrieve information about a specific OpenAI-compatible...
-* `list`: This endpoint aggregates models from all model entities...
+* `list`: This endpoint aggregates all routable VirtualModels and...
 
 **nemo inference gateway openai v1 models get**
 
 Retrieve information about a specific OpenAI-compatible model.
 
 Workspace is
-always taken from the URL path; name may be model_entity_name or
-workspace/model_entity_name (workspace prefix is ignored).
+always taken from the URL path; name may be the VirtualModel name or
+workspace/name (workspace prefix is ignored). Resolves against routable
+VirtualModels, including custom ones, so this route agrees with the list route
+and the inference proxy.
 
 **Usage:**
 
@@ -2522,9 +2524,11 @@ nemo inference gateway openai v1 models get [OPTIONS] NAME
 
 **nemo inference gateway openai v1 models list**
 
-This endpoint aggregates models from all model entities and returns them in
-OpenAI's list models format. Each model ID is the model entity identifier in
-format workspace/model_entity_name.
+This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
+list models format. Each model ID is the VirtualModel identifier in format
+workspace/name. This includes both autoprovisioned VirtualModels (one per served
+model entity) and custom VirtualModels, keeping the catalog in agreement with
+the inference proxy, which also resolves VirtualModels.
 
 **Usage:**
 
@@ -2801,15 +2805,17 @@ nemo inference models [OPTIONS] COMMAND [ARGS]...
 **Commands:**
 
 * `get`: Retrieve information about a specific OpenAI-compatible...
-* `list`: This endpoint aggregates models from all model entities...
+* `list`: This endpoint aggregates all routable VirtualModels and...
 
 ##### nemo inference models get
 
 Retrieve information about a specific OpenAI-compatible model.
 
 Workspace is
-always taken from the URL path; name may be model_entity_name or
-workspace/model_entity_name (workspace prefix is ignored).
+always taken from the URL path; name may be the VirtualModel name or
+workspace/name (workspace prefix is ignored). Resolves against routable
+VirtualModels, including custom ones, so this route agrees with the list route
+and the inference proxy.
 
 **Usage:**
 
@@ -2835,9 +2841,11 @@ nemo inference models get [OPTIONS] NAME
 
 ##### nemo inference models list
 
-This endpoint aggregates models from all model entities and returns them in
-OpenAI's list models format. Each model ID is the model entity identifier in
-format workspace/model_entity_name.
+This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
+list models format. Each model ID is the VirtualModel identifier in format
+workspace/name. This includes both autoprovisioned VirtualModels (one per served
+model entity) and custom VirtualModels, keeping the catalog in agreement with
+the inference proxy, which also resolves VirtualModels.
 
 **Usage:**
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -2488,7 +2488,7 @@ nemo inference gateway openai v1 models [OPTIONS] COMMAND [ARGS]...
 **Commands:**
 
 * `get`: Retrieve information about a specific OpenAI-compatible...
-* `list`: This endpoint aggregates all routable VirtualModels and...
+* `list`: This endpoint lists the routable VirtualModels in the...
 
 **nemo inference gateway openai v1 models get**
 
@@ -2524,11 +2524,12 @@ nemo inference gateway openai v1 models get [OPTIONS] NAME
 
 **nemo inference gateway openai v1 models list**
 
-This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
-list models format. Each model ID is the VirtualModel identifier in format
-workspace/name. This includes both autoprovisioned VirtualModels (one per served
-model entity) and custom VirtualModels, keeping the catalog in agreement with
-the inference proxy, which also resolves VirtualModels.
+This endpoint lists the routable VirtualModels in the requested workspace and
+returns them in OpenAI's list models format. Each model ID is the VirtualModel
+identifier in format workspace/name. This includes both autoprovisioned
+VirtualModels (one per served model entity) and custom VirtualModels, keeping
+the catalog in agreement with the inference proxy, which also resolves
+VirtualModels scoped to the request workspace.
 
 **Usage:**
 
@@ -2805,7 +2806,7 @@ nemo inference models [OPTIONS] COMMAND [ARGS]...
 **Commands:**
 
 * `get`: Retrieve information about a specific OpenAI-compatible...
-* `list`: This endpoint aggregates all routable VirtualModels and...
+* `list`: This endpoint lists the routable VirtualModels in the...
 
 ##### nemo inference models get
 
@@ -2841,11 +2842,12 @@ nemo inference models get [OPTIONS] NAME
 
 ##### nemo inference models list
 
-This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
-list models format. Each model ID is the VirtualModel identifier in format
-workspace/name. This includes both autoprovisioned VirtualModels (one per served
-model entity) and custom VirtualModels, keeping the catalog in agreement with
-the inference proxy, which also resolves VirtualModels.
+This endpoint lists the routable VirtualModels in the requested workspace and
+returns them in OpenAI's list models format. Each model ID is the VirtualModel
+identifier in format workspace/name. This includes both autoprovisioned
+VirtualModels (one per served model entity) and custom VirtualModels, keeping
+the catalog in agreement with the inference proxy, which also resolves
+VirtualModels scoped to the request workspace.
 
 **Usage:**
 

--- a/e2e/test_inference.py
+++ b/e2e/test_inference.py
@@ -231,7 +231,12 @@ def test_streaming_chat_completion(sdk: NeMoPlatform, workspace: str):
 
 
 def test_model_list_via_openai_route(sdk: NeMoPlatform, workspace: str):
-    """The OpenAI /v1/models endpoint lists models served by mock providers."""
+    """The OpenAI /v1/models endpoint lists routable VirtualModels.
+
+    Adding a mock provider creates a model entity, for which the reconciler
+    autoprovisions a VirtualModel of the same name — so it appears in the catalog
+    (as ``workspace/name``).
+    """
     entity_name = _unique_name("listable-model")
     add_mock_provider(
         sdk,
@@ -242,7 +247,7 @@ def test_model_list_via_openai_route(sdk: NeMoPlatform, workspace: str):
 
     models = sdk.inference.gateway.openai.v1.models.list(workspace=workspace)
     model_ids = [m.id for m in models.data]
-    # The model entity should appear (as workspace/entity_name)
+    # The autoprovisioned VirtualModel should appear (as workspace/entity_name)
     assert any(entity_name in mid for mid in model_ids)
 
 

--- a/e2e/test_inference.py
+++ b/e2e/test_inference.py
@@ -248,7 +248,7 @@ def test_model_list_via_openai_route(sdk: NeMoPlatform, workspace: str):
     models = sdk.inference.gateway.openai.v1.models.list(workspace=workspace)
     model_ids = [m.id for m in models.data]
     # The autoprovisioned VirtualModel should appear (as workspace/entity_name)
-    assert any(entity_name in mid for mid in model_ids)
+    assert f"{workspace}/{entity_name}" in model_ids
 
 
 # ---------------------------------------------------------------------------

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -2365,16 +2365,18 @@ paths:
       tags:
       - Inference Gateway
       summary: OpenAI List Models
-      description: 'This endpoint aggregates all routable VirtualModels and returns
-        them in
+      description: 'This endpoint lists the routable VirtualModels in the requested
+        workspace and
 
-        OpenAI''s list models format. Each model ID is the VirtualModel identifier
+        returns them in OpenAI''s list models format. Each model ID is the VirtualModel
 
-        in format workspace/name. This includes both autoprovisioned VirtualModels
+        identifier in format workspace/name. This includes both autoprovisioned
 
-        (one per served model entity) and custom VirtualModels, keeping the catalog
+        VirtualModels (one per served model entity) and custom VirtualModels, keeping
 
-        in agreement with the inference proxy, which also resolves VirtualModels.'
+        the catalog in agreement with the inference proxy, which also resolves
+
+        VirtualModels scoped to the request workspace.'
       operationId: openai_proxy_list_models
       parameters:
       - name: workspace

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -2365,12 +2365,16 @@ paths:
       tags:
       - Inference Gateway
       summary: OpenAI List Models
-      description: 'This endpoint aggregates models from all model entities and returns
-        them
+      description: 'This endpoint aggregates all routable VirtualModels and returns
+        them in
 
-        in OpenAI''s list models format. Each model ID is the model entity identifier
+        OpenAI''s list models format. Each model ID is the VirtualModel identifier
 
-        in format workspace/model_entity_name.'
+        in format workspace/name. This includes both autoprovisioned VirtualModels
+
+        (one per served model entity) and custom VirtualModels, keeping the catalog
+
+        in agreement with the inference proxy, which also resolves VirtualModels.'
       operationId: openai_proxy_list_models
       parameters:
       - name: workspace
@@ -2399,9 +2403,13 @@ paths:
       summary: OpenAI Get Model
       description: 'Retrieve information about a specific OpenAI-compatible model.
 
-        Workspace is always taken from the URL path; name may be model_entity_name
+        Workspace is always taken from the URL path; name may be the VirtualModel
 
-        or workspace/model_entity_name (workspace prefix is ignored).'
+        name or workspace/name (workspace prefix is ignored). Resolves against
+
+        routable VirtualModels, including custom ones, so this route agrees with
+
+        the list route and the inference proxy.'
       operationId: openai_proxy_get_model
       parameters:
       - name: workspace

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -2365,16 +2365,18 @@ paths:
       tags:
       - Inference Gateway
       summary: OpenAI List Models
-      description: 'This endpoint aggregates all routable VirtualModels and returns
-        them in
+      description: 'This endpoint lists the routable VirtualModels in the requested
+        workspace and
 
-        OpenAI''s list models format. Each model ID is the VirtualModel identifier
+        returns them in OpenAI''s list models format. Each model ID is the VirtualModel
 
-        in format workspace/name. This includes both autoprovisioned VirtualModels
+        identifier in format workspace/name. This includes both autoprovisioned
 
-        (one per served model entity) and custom VirtualModels, keeping the catalog
+        VirtualModels (one per served model entity) and custom VirtualModels, keeping
 
-        in agreement with the inference proxy, which also resolves VirtualModels.'
+        the catalog in agreement with the inference proxy, which also resolves
+
+        VirtualModels scoped to the request workspace.'
       operationId: openai_proxy_list_models
       parameters:
       - name: workspace

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -2365,12 +2365,16 @@ paths:
       tags:
       - Inference Gateway
       summary: OpenAI List Models
-      description: 'This endpoint aggregates models from all model entities and returns
-        them
+      description: 'This endpoint aggregates all routable VirtualModels and returns
+        them in
 
-        in OpenAI''s list models format. Each model ID is the model entity identifier
+        OpenAI''s list models format. Each model ID is the VirtualModel identifier
 
-        in format workspace/model_entity_name.'
+        in format workspace/name. This includes both autoprovisioned VirtualModels
+
+        (one per served model entity) and custom VirtualModels, keeping the catalog
+
+        in agreement with the inference proxy, which also resolves VirtualModels.'
       operationId: openai_proxy_list_models
       parameters:
       - name: workspace
@@ -2399,9 +2403,13 @@ paths:
       summary: OpenAI Get Model
       description: 'Retrieve information about a specific OpenAI-compatible model.
 
-        Workspace is always taken from the URL path; name may be model_entity_name
+        Workspace is always taken from the URL path; name may be the VirtualModel
 
-        or workspace/model_entity_name (workspace prefix is ignored).'
+        name or workspace/name (workspace prefix is ignored). Resolves against
+
+        routable VirtualModels, including custom ones, so this route agrees with
+
+        the list route and the inference proxy.'
       operationId: openai_proxy_get_model
       parameters:
       - name: workspace

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2365,16 +2365,18 @@ paths:
       tags:
       - Inference Gateway
       summary: OpenAI List Models
-      description: 'This endpoint aggregates all routable VirtualModels and returns
-        them in
+      description: 'This endpoint lists the routable VirtualModels in the requested
+        workspace and
 
-        OpenAI''s list models format. Each model ID is the VirtualModel identifier
+        returns them in OpenAI''s list models format. Each model ID is the VirtualModel
 
-        in format workspace/name. This includes both autoprovisioned VirtualModels
+        identifier in format workspace/name. This includes both autoprovisioned
 
-        (one per served model entity) and custom VirtualModels, keeping the catalog
+        VirtualModels (one per served model entity) and custom VirtualModels, keeping
 
-        in agreement with the inference proxy, which also resolves VirtualModels.'
+        the catalog in agreement with the inference proxy, which also resolves
+
+        VirtualModels scoped to the request workspace.'
       operationId: openai_proxy_list_models
       parameters:
       - name: workspace

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2365,12 +2365,16 @@ paths:
       tags:
       - Inference Gateway
       summary: OpenAI List Models
-      description: 'This endpoint aggregates models from all model entities and returns
-        them
+      description: 'This endpoint aggregates all routable VirtualModels and returns
+        them in
 
-        in OpenAI''s list models format. Each model ID is the model entity identifier
+        OpenAI''s list models format. Each model ID is the VirtualModel identifier
 
-        in format workspace/model_entity_name.'
+        in format workspace/name. This includes both autoprovisioned VirtualModels
+
+        (one per served model entity) and custom VirtualModels, keeping the catalog
+
+        in agreement with the inference proxy, which also resolves VirtualModels.'
       operationId: openai_proxy_list_models
       parameters:
       - name: workspace
@@ -2399,9 +2403,13 @@ paths:
       summary: OpenAI Get Model
       description: 'Retrieve information about a specific OpenAI-compatible model.
 
-        Workspace is always taken from the URL path; name may be model_entity_name
+        Workspace is always taken from the URL path; name may be the VirtualModel
 
-        or workspace/model_entity_name (workspace prefix is ignored).'
+        name or workspace/name (workspace prefix is ignored). Resolves against
+
+        routable VirtualModels, including custom ones, so this route agrees with
+
+        the list route and the inference proxy.'
       operationId: openai_proxy_get_model
       parameters:
       - name: workspace

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/v1/models.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/v1/models.py
@@ -71,11 +71,12 @@ def list_models(
     no_truncate: NoTruncateOption = None,
     columns: OutputColumnsOption = None,
 ) -> None:
-    """This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
-    list models format. Each model ID is the VirtualModel identifier in format
-    workspace/name. This includes both autoprovisioned VirtualModels (one per served
-    model entity) and custom VirtualModels, keeping the catalog in agreement with
-    the inference proxy, which also resolves VirtualModels."""
+    """This endpoint lists the routable VirtualModels in the requested workspace and
+    returns them in OpenAI's list models format. Each model ID is the VirtualModel
+    identifier in format workspace/name. This includes both autoprovisioned
+    VirtualModels (one per served model entity) and custom VirtualModels, keeping
+    the catalog in agreement with the inference proxy, which also resolves
+    VirtualModels scoped to the request workspace."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/v1/models.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/gateway/openai/v1/models.py
@@ -36,8 +36,10 @@ def get_models(
     """Retrieve information about a specific OpenAI-compatible model.
 
     Workspace is
-    always taken from the URL path; name may be model_entity_name or
-    workspace/model_entity_name (workspace prefix is ignored)."""
+    always taken from the URL path; name may be the VirtualModel name or
+    workspace/name (workspace prefix is ignored). Resolves against routable
+    VirtualModels, including custom ones, so this route agrees with the list route
+    and the inference proxy."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 
@@ -69,9 +71,11 @@ def list_models(
     no_truncate: NoTruncateOption = None,
     columns: OutputColumnsOption = None,
 ) -> None:
-    """This endpoint aggregates models from all model entities and returns them in
-    OpenAI's list models format. Each model ID is the model entity identifier in
-    format workspace/model_entity_name."""
+    """This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
+    list models format. Each model ID is the VirtualModel identifier in format
+    workspace/name. This includes both autoprovisioned VirtualModels (one per served
+    model entity) and custom VirtualModels, keeping the catalog in agreement with
+    the inference proxy, which also resolves VirtualModels."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/models.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/models.py
@@ -71,11 +71,12 @@ def list_models(
     no_truncate: NoTruncateOption = None,
     columns: OutputColumnsOption = None,
 ) -> None:
-    """This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
-    list models format. Each model ID is the VirtualModel identifier in format
-    workspace/name. This includes both autoprovisioned VirtualModels (one per served
-    model entity) and custom VirtualModels, keeping the catalog in agreement with
-    the inference proxy, which also resolves VirtualModels."""
+    """This endpoint lists the routable VirtualModels in the requested workspace and
+    returns them in OpenAI's list models format. Each model ID is the VirtualModel
+    identifier in format workspace/name. This includes both autoprovisioned
+    VirtualModels (one per served model entity) and custom VirtualModels, keeping
+    the catalog in agreement with the inference proxy, which also resolves
+    VirtualModels scoped to the request workspace."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/models.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/models.py
@@ -36,8 +36,10 @@ def get_models(
     """Retrieve information about a specific OpenAI-compatible model.
 
     Workspace is
-    always taken from the URL path; name may be model_entity_name or
-    workspace/model_entity_name (workspace prefix is ignored)."""
+    always taken from the URL path; name may be the VirtualModel name or
+    workspace/name (workspace prefix is ignored). Resolves against routable
+    VirtualModels, including custom ones, so this route agrees with the list route
+    and the inference proxy."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 
@@ -69,9 +71,11 @@ def list_models(
     no_truncate: NoTruncateOption = None,
     columns: OutputColumnsOption = None,
 ) -> None:
-    """This endpoint aggregates models from all model entities and returns them in
-    OpenAI's list models format. Each model ID is the model entity identifier in
-    format workspace/model_entity_name."""
+    """This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
+    list models format. Each model ID is the VirtualModel identifier in format
+    workspace/name. This includes both autoprovisioned VirtualModels (one per served
+    model entity) and custom VirtualModels, keeping the catalog in agreement with
+    the inference proxy, which also resolves VirtualModels."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 

--- a/sdk/python/nemo-platform/.github/workflows/ci.yml
+++ b/sdk/python/nemo-platform/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     timeout-minutes: 10
     name: lint
-    runs-on: ${{ github.repository == 'stainless-sdks/nemo-platform-python' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -41,7 +41,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ${{ github.repository == 'stainless-sdks/nemo-platform-python' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -78,7 +78,7 @@ jobs:
   test:
     timeout-minutes: 10
     name: test
-    runs-on: ${{ github.repository == 'stainless-sdks/nemo-platform-python' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -2365,16 +2365,18 @@ paths:
       tags:
       - Inference Gateway
       summary: OpenAI List Models
-      description: 'This endpoint aggregates all routable VirtualModels and returns
-        them in
+      description: 'This endpoint lists the routable VirtualModels in the requested
+        workspace and
 
-        OpenAI''s list models format. Each model ID is the VirtualModel identifier
+        returns them in OpenAI''s list models format. Each model ID is the VirtualModel
 
-        in format workspace/name. This includes both autoprovisioned VirtualModels
+        identifier in format workspace/name. This includes both autoprovisioned
 
-        (one per served model entity) and custom VirtualModels, keeping the catalog
+        VirtualModels (one per served model entity) and custom VirtualModels, keeping
 
-        in agreement with the inference proxy, which also resolves VirtualModels.'
+        the catalog in agreement with the inference proxy, which also resolves
+
+        VirtualModels scoped to the request workspace.'
       operationId: openai_proxy_list_models
       parameters:
       - name: workspace

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -2365,12 +2365,16 @@ paths:
       tags:
       - Inference Gateway
       summary: OpenAI List Models
-      description: 'This endpoint aggregates models from all model entities and returns
-        them
+      description: 'This endpoint aggregates all routable VirtualModels and returns
+        them in
 
-        in OpenAI''s list models format. Each model ID is the model entity identifier
+        OpenAI''s list models format. Each model ID is the VirtualModel identifier
 
-        in format workspace/model_entity_name.'
+        in format workspace/name. This includes both autoprovisioned VirtualModels
+
+        (one per served model entity) and custom VirtualModels, keeping the catalog
+
+        in agreement with the inference proxy, which also resolves VirtualModels.'
       operationId: openai_proxy_list_models
       parameters:
       - name: workspace
@@ -2399,9 +2403,13 @@ paths:
       summary: OpenAI Get Model
       description: 'Retrieve information about a specific OpenAI-compatible model.
 
-        Workspace is always taken from the URL path; name may be model_entity_name
+        Workspace is always taken from the URL path; name may be the VirtualModel
 
-        or workspace/model_entity_name (workspace prefix is ignored).'
+        name or workspace/name (workspace prefix is ignored). Resolves against
+
+        routable VirtualModels, including custom ones, so this route agrees with
+
+        the list route and the inference proxy.'
       operationId: openai_proxy_get_model
       parameters:
       - name: workspace

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/v1/models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/v1/models.py
@@ -71,11 +71,12 @@ def list_models(
     no_truncate: NoTruncateOption = None,
     columns: OutputColumnsOption = None,
 ) -> None:
-    """This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
-    list models format. Each model ID is the VirtualModel identifier in format
-    workspace/name. This includes both autoprovisioned VirtualModels (one per served
-    model entity) and custom VirtualModels, keeping the catalog in agreement with
-    the inference proxy, which also resolves VirtualModels."""
+    """This endpoint lists the routable VirtualModels in the requested workspace and
+    returns them in OpenAI's list models format. Each model ID is the VirtualModel
+    identifier in format workspace/name. This includes both autoprovisioned
+    VirtualModels (one per served model entity) and custom VirtualModels, keeping
+    the catalog in agreement with the inference proxy, which also resolves
+    VirtualModels scoped to the request workspace."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/v1/models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/gateway/openai/v1/models.py
@@ -36,8 +36,10 @@ def get_models(
     """Retrieve information about a specific OpenAI-compatible model.
 
     Workspace is
-    always taken from the URL path; name may be model_entity_name or
-    workspace/model_entity_name (workspace prefix is ignored)."""
+    always taken from the URL path; name may be the VirtualModel name or
+    workspace/name (workspace prefix is ignored). Resolves against routable
+    VirtualModels, including custom ones, so this route agrees with the list route
+    and the inference proxy."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 
@@ -69,9 +71,11 @@ def list_models(
     no_truncate: NoTruncateOption = None,
     columns: OutputColumnsOption = None,
 ) -> None:
-    """This endpoint aggregates models from all model entities and returns them in
-    OpenAI's list models format. Each model ID is the model entity identifier in
-    format workspace/model_entity_name."""
+    """This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
+    list models format. Each model ID is the VirtualModel identifier in format
+    workspace/name. This includes both autoprovisioned VirtualModels (one per served
+    model entity) and custom VirtualModels, keeping the catalog in agreement with
+    the inference proxy, which also resolves VirtualModels."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/models.py
@@ -71,11 +71,12 @@ def list_models(
     no_truncate: NoTruncateOption = None,
     columns: OutputColumnsOption = None,
 ) -> None:
-    """This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
-    list models format. Each model ID is the VirtualModel identifier in format
-    workspace/name. This includes both autoprovisioned VirtualModels (one per served
-    model entity) and custom VirtualModels, keeping the catalog in agreement with
-    the inference proxy, which also resolves VirtualModels."""
+    """This endpoint lists the routable VirtualModels in the requested workspace and
+    returns them in OpenAI's list models format. Each model ID is the VirtualModel
+    identifier in format workspace/name. This includes both autoprovisioned
+    VirtualModels (one per served model entity) and custom VirtualModels, keeping
+    the catalog in agreement with the inference proxy, which also resolves
+    VirtualModels scoped to the request workspace."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/models.py
@@ -36,8 +36,10 @@ def get_models(
     """Retrieve information about a specific OpenAI-compatible model.
 
     Workspace is
-    always taken from the URL path; name may be model_entity_name or
-    workspace/model_entity_name (workspace prefix is ignored)."""
+    always taken from the URL path; name may be the VirtualModel name or
+    workspace/name (workspace prefix is ignored). Resolves against routable
+    VirtualModels, including custom ones, so this route agrees with the list route
+    and the inference proxy."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 
@@ -69,9 +71,11 @@ def list_models(
     no_truncate: NoTruncateOption = None,
     columns: OutputColumnsOption = None,
 ) -> None:
-    """This endpoint aggregates models from all model entities and returns them in
-    OpenAI's list models format. Each model ID is the model entity identifier in
-    format workspace/model_entity_name."""
+    """This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
+    list models format. Each model ID is the VirtualModel identifier in format
+    workspace/name. This includes both autoprovisioned VirtualModels (one per served
+    model entity) and custom VirtualModels, keeping the catalog in agreement with
+    the inference proxy, which also resolves VirtualModels."""
     state: CLIContext = ctx.obj
     output_format = state.get_output_format(output_format)
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/inference/gateway/openai/v1/models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/inference/gateway/openai/v1/models.py
@@ -68,9 +68,11 @@ class ModelsResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> OpenAIListModelsResp:
         """
-        This endpoint aggregates models from all model entities and returns them in
-        OpenAI's list models format. Each model ID is the model entity identifier in
-        format workspace/model_entity_name.
+        This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
+        list models format. Each model ID is the VirtualModel identifier in format
+        workspace/name. This includes both autoprovisioned VirtualModels (one per served
+        model entity) and custom VirtualModels, keeping the catalog in agreement with
+        the inference proxy, which also resolves VirtualModels.
 
         Args:
           extra_headers: Send extra headers
@@ -108,8 +110,10 @@ class ModelsResource(SyncAPIResource):
         """Retrieve information about a specific OpenAI-compatible model.
 
         Workspace is
-        always taken from the URL path; name may be model_entity_name or
-        workspace/model_entity_name (workspace prefix is ignored).
+        always taken from the URL path; name may be the VirtualModel name or
+        workspace/name (workspace prefix is ignored). Resolves against routable
+        VirtualModels, including custom ones, so this route agrees with the list route
+        and the inference proxy.
 
         Args:
           extra_headers: Send extra headers
@@ -171,9 +175,11 @@ class AsyncModelsResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> OpenAIListModelsResp:
         """
-        This endpoint aggregates models from all model entities and returns them in
-        OpenAI's list models format. Each model ID is the model entity identifier in
-        format workspace/model_entity_name.
+        This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
+        list models format. Each model ID is the VirtualModel identifier in format
+        workspace/name. This includes both autoprovisioned VirtualModels (one per served
+        model entity) and custom VirtualModels, keeping the catalog in agreement with
+        the inference proxy, which also resolves VirtualModels.
 
         Args:
           extra_headers: Send extra headers
@@ -211,8 +217,10 @@ class AsyncModelsResource(AsyncAPIResource):
         """Retrieve information about a specific OpenAI-compatible model.
 
         Workspace is
-        always taken from the URL path; name may be model_entity_name or
-        workspace/model_entity_name (workspace prefix is ignored).
+        always taken from the URL path; name may be the VirtualModel name or
+        workspace/name (workspace prefix is ignored). Resolves against routable
+        VirtualModels, including custom ones, so this route agrees with the list route
+        and the inference proxy.
 
         Args:
           extra_headers: Send extra headers

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/inference/gateway/openai/v1/models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/inference/gateway/openai/v1/models.py
@@ -68,11 +68,12 @@ class ModelsResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> OpenAIListModelsResp:
         """
-        This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
-        list models format. Each model ID is the VirtualModel identifier in format
-        workspace/name. This includes both autoprovisioned VirtualModels (one per served
-        model entity) and custom VirtualModels, keeping the catalog in agreement with
-        the inference proxy, which also resolves VirtualModels.
+        This endpoint lists the routable VirtualModels in the requested workspace and
+        returns them in OpenAI's list models format. Each model ID is the VirtualModel
+        identifier in format workspace/name. This includes both autoprovisioned
+        VirtualModels (one per served model entity) and custom VirtualModels, keeping
+        the catalog in agreement with the inference proxy, which also resolves
+        VirtualModels scoped to the request workspace.
 
         Args:
           extra_headers: Send extra headers
@@ -175,11 +176,12 @@ class AsyncModelsResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> OpenAIListModelsResp:
         """
-        This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
-        list models format. Each model ID is the VirtualModel identifier in format
-        workspace/name. This includes both autoprovisioned VirtualModels (one per served
-        model entity) and custom VirtualModels, keeping the catalog in agreement with
-        the inference proxy, which also resolves VirtualModels.
+        This endpoint lists the routable VirtualModels in the requested workspace and
+        returns them in OpenAI's list models format. Each model ID is the VirtualModel
+        identifier in format workspace/name. This includes both autoprovisioned
+        VirtualModels (one per served model entity) and custom VirtualModels, keeping
+        the catalog in agreement with the inference proxy, which also resolves
+        VirtualModels scoped to the request workspace.
 
         Args:
           extra_headers: Send extra headers

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/inference/models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/inference/models.py
@@ -68,9 +68,11 @@ class ModelsResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> OpenAIListModelsResp:
         """
-        This endpoint aggregates models from all model entities and returns them in
-        OpenAI's list models format. Each model ID is the model entity identifier in
-        format workspace/model_entity_name.
+        This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
+        list models format. Each model ID is the VirtualModel identifier in format
+        workspace/name. This includes both autoprovisioned VirtualModels (one per served
+        model entity) and custom VirtualModels, keeping the catalog in agreement with
+        the inference proxy, which also resolves VirtualModels.
 
         Args:
           extra_headers: Send extra headers
@@ -108,8 +110,10 @@ class ModelsResource(SyncAPIResource):
         """Retrieve information about a specific OpenAI-compatible model.
 
         Workspace is
-        always taken from the URL path; name may be model_entity_name or
-        workspace/model_entity_name (workspace prefix is ignored).
+        always taken from the URL path; name may be the VirtualModel name or
+        workspace/name (workspace prefix is ignored). Resolves against routable
+        VirtualModels, including custom ones, so this route agrees with the list route
+        and the inference proxy.
 
         Args:
           extra_headers: Send extra headers
@@ -171,9 +175,11 @@ class AsyncModelsResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> OpenAIListModelsResp:
         """
-        This endpoint aggregates models from all model entities and returns them in
-        OpenAI's list models format. Each model ID is the model entity identifier in
-        format workspace/model_entity_name.
+        This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
+        list models format. Each model ID is the VirtualModel identifier in format
+        workspace/name. This includes both autoprovisioned VirtualModels (one per served
+        model entity) and custom VirtualModels, keeping the catalog in agreement with
+        the inference proxy, which also resolves VirtualModels.
 
         Args:
           extra_headers: Send extra headers
@@ -211,8 +217,10 @@ class AsyncModelsResource(AsyncAPIResource):
         """Retrieve information about a specific OpenAI-compatible model.
 
         Workspace is
-        always taken from the URL path; name may be model_entity_name or
-        workspace/model_entity_name (workspace prefix is ignored).
+        always taken from the URL path; name may be the VirtualModel name or
+        workspace/name (workspace prefix is ignored). Resolves against routable
+        VirtualModels, including custom ones, so this route agrees with the list route
+        and the inference proxy.
 
         Args:
           extra_headers: Send extra headers

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/inference/models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/inference/models.py
@@ -68,11 +68,12 @@ class ModelsResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> OpenAIListModelsResp:
         """
-        This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
-        list models format. Each model ID is the VirtualModel identifier in format
-        workspace/name. This includes both autoprovisioned VirtualModels (one per served
-        model entity) and custom VirtualModels, keeping the catalog in agreement with
-        the inference proxy, which also resolves VirtualModels.
+        This endpoint lists the routable VirtualModels in the requested workspace and
+        returns them in OpenAI's list models format. Each model ID is the VirtualModel
+        identifier in format workspace/name. This includes both autoprovisioned
+        VirtualModels (one per served model entity) and custom VirtualModels, keeping
+        the catalog in agreement with the inference proxy, which also resolves
+        VirtualModels scoped to the request workspace.
 
         Args:
           extra_headers: Send extra headers
@@ -175,11 +176,12 @@ class AsyncModelsResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> OpenAIListModelsResp:
         """
-        This endpoint aggregates all routable VirtualModels and returns them in OpenAI's
-        list models format. Each model ID is the VirtualModel identifier in format
-        workspace/name. This includes both autoprovisioned VirtualModels (one per served
-        model entity) and custom VirtualModels, keeping the catalog in agreement with
-        the inference proxy, which also resolves VirtualModels.
+        This endpoint lists the routable VirtualModels in the requested workspace and
+        returns them in OpenAI's list models format. Each model ID is the VirtualModel
+        identifier in format workspace/name. This includes both autoprovisioned
+        VirtualModels (one per served model entity) and custom VirtualModels, keeping
+        the catalog in agreement with the inference proxy, which also resolves
+        VirtualModels scoped to the request workspace.
 
         Args:
           extra_headers: Send extra headers

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/openai.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/openai.py
@@ -14,7 +14,6 @@ from nmp.core.inference_gateway.api.dependencies import (
     global_virtual_model_cache,
 )
 from nmp.core.inference_gateway.api.errors import (
-    raise_model_entity_not_found,
     raise_virtual_model_not_found,
 )
 from nmp.core.inference_gateway.api.middleware_registry import (
@@ -104,17 +103,24 @@ class OpenAIListModelsResp(BaseModel):
 )
 async def openai_get_models(
     workspace: str,
-    model_cache: Annotated[ModelCache, Depends(global_model_cache)],
+    virtual_model_cache: Annotated[VirtualModelCache, Depends(global_virtual_model_cache)],
 ) -> OpenAIListModelsResp:
     """
-    This endpoint aggregates models from all model entities and returns them
-    in OpenAI's list models format. Each model ID is the model entity identifier
-    in format workspace/model_entity_name.
+    This endpoint aggregates all routable VirtualModels and returns them in
+    OpenAI's list models format. Each model ID is the VirtualModel identifier
+    in format workspace/name.
+
+    VirtualModels are the routable targets for inference: the platform's provider
+    reconciler auto-creates an implicit ``autoprovisioned`` VirtualModel for every
+    served model entity, and operators can create custom VirtualModels (Switchyard
+    routing, plugin chains, LoRA escape-hatches, etc.). Listing VirtualModels keeps
+    this catalog in agreement with the ``/v1/chat/completions`` proxy path, which
+    also resolves against the VirtualModel cache.
     """
     all_oai_models: list[OpenAIModelResp] = []
 
-    for (entity_workspace, model_name), _ in model_cache.model_entity_info_map.items():
-        all_oai_models.append(OpenAIModelResp(id=f"{entity_workspace}/{model_name}", owned_by=entity_workspace))
+    for (vm_workspace, vm_name), _ in virtual_model_cache.virtual_model_map.items():
+        all_oai_models.append(OpenAIModelResp(id=f"{vm_workspace}/{vm_name}", owned_by=vm_workspace))
 
     return OpenAIListModelsResp(data=all_oai_models)
 
@@ -129,19 +135,24 @@ async def openai_get_models(
 async def openai_get_model(
     workspace: str,
     name: str,
-    model_cache: Annotated[ModelCache, Depends(global_model_cache)],
+    virtual_model_cache: Annotated[VirtualModelCache, Depends(global_virtual_model_cache)],
 ) -> OpenAIModelResp:
     """
     Retrieve information about a specific OpenAI-compatible model.
-    Workspace is always taken from the URL path; name may be model_entity_name
-    or workspace/model_entity_name (workspace prefix is ignored).
+    Workspace is always taken from the URL path; name may be the VirtualModel
+    name or workspace/name (workspace prefix is ignored).
+
+    Resolves against the VirtualModel cache so this route agrees with both the
+    ``/v1/models`` list route and the ``/v1/chat/completions`` proxy path: any
+    VirtualModel that can serve inference is discoverable here, including custom
+    (e.g. Switchyard) VirtualModels.
     """
     model_name = name.removeprefix(f"{workspace}/")
 
     validate_entity_name(workspace, field_name="workspace")
     validate_model_entity_name(model_name, field_name="model")
-    if (workspace, model_name) not in model_cache.model_entity_info_map:
-        raise_model_entity_not_found(workspace, model_name)
+    if virtual_model_cache.get(workspace, model_name) is None:
+        raise_virtual_model_not_found(workspace, model_name)
 
     return OpenAIModelResp(
         id=f"{workspace}/{model_name}",

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/openai.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/openai.py
@@ -108,14 +108,9 @@ async def openai_get_models(
     """
     This endpoint aggregates all routable VirtualModels and returns them in
     OpenAI's list models format. Each model ID is the VirtualModel identifier
-    in format workspace/name.
-
-    VirtualModels are the routable targets for inference: the platform's provider
-    reconciler auto-creates an implicit ``autoprovisioned`` VirtualModel for every
-    served model entity, and operators can create custom VirtualModels (Switchyard
-    routing, plugin chains, LoRA escape-hatches, etc.). Listing VirtualModels keeps
-    this catalog in agreement with the ``/v1/chat/completions`` proxy path, which
-    also resolves against the VirtualModel cache.
+    in format workspace/name. This includes both autoprovisioned VirtualModels
+    (one per served model entity) and custom VirtualModels, keeping the catalog
+    in agreement with the inference proxy, which also resolves VirtualModels.
     """
     all_oai_models: list[OpenAIModelResp] = []
 
@@ -140,12 +135,9 @@ async def openai_get_model(
     """
     Retrieve information about a specific OpenAI-compatible model.
     Workspace is always taken from the URL path; name may be the VirtualModel
-    name or workspace/name (workspace prefix is ignored).
-
-    Resolves against the VirtualModel cache so this route agrees with both the
-    ``/v1/models`` list route and the ``/v1/chat/completions`` proxy path: any
-    VirtualModel that can serve inference is discoverable here, including custom
-    (e.g. Switchyard) VirtualModels.
+    name or workspace/name (workspace prefix is ignored). Resolves against
+    routable VirtualModels, including custom ones, so this route agrees with
+    the list route and the inference proxy.
     """
     model_name = name.removeprefix(f"{workspace}/")
 

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/openai.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/openai.py
@@ -106,15 +106,20 @@ async def openai_get_models(
     virtual_model_cache: Annotated[VirtualModelCache, Depends(global_virtual_model_cache)],
 ) -> OpenAIListModelsResp:
     """
-    This endpoint aggregates all routable VirtualModels and returns them in
-    OpenAI's list models format. Each model ID is the VirtualModel identifier
-    in format workspace/name. This includes both autoprovisioned VirtualModels
-    (one per served model entity) and custom VirtualModels, keeping the catalog
-    in agreement with the inference proxy, which also resolves VirtualModels.
+    This endpoint lists the routable VirtualModels in the requested workspace and
+    returns them in OpenAI's list models format. Each model ID is the VirtualModel
+    identifier in format workspace/name. This includes both autoprovisioned
+    VirtualModels (one per served model entity) and custom VirtualModels, keeping
+    the catalog in agreement with the inference proxy, which also resolves
+    VirtualModels scoped to the request workspace.
     """
+    validate_entity_name(workspace, field_name="workspace")
+
     all_oai_models: list[OpenAIModelResp] = []
 
     for (vm_workspace, vm_name), _ in virtual_model_cache.virtual_model_map.items():
+        if vm_workspace != workspace:
+            continue
         all_oai_models.append(OpenAIModelResp(id=f"{vm_workspace}/{vm_name}", owned_by=vm_workspace))
 
     return OpenAIListModelsResp(data=all_oai_models)

--- a/services/core/inference-gateway/tests/unit/test_openai_router.py
+++ b/services/core/inference-gateway/tests/unit/test_openai_router.py
@@ -30,14 +30,53 @@ from nmp.core.inference_gateway.api.model_cache import ModelCache, ModelEntityIn
 from nmp.core.inference_gateway.api.v2.openai import ParseOpenAIModelError, parse_igw_openai_model
 from nmp.core.inference_gateway.api.virtual_model_cache import VirtualModelCache
 
+
+def _autoprovisioned_vms_for_cache(model_cache: ModelCache) -> list[SDKVirtualModel]:
+    """Mirror conftest.autoprovisioned_vms_for_cache for tests that build a custom ModelCache.
+
+    Local copy because the unit tests directory has no ``__init__.py`` so the
+    conftest helper isn't importable.
+    """
+    return [
+        SDKVirtualModel(
+            id=f"{workspace}/{name}",
+            entity_id=f"{workspace}/{name}",
+            workspace=workspace,
+            name=name,
+            parent=workspace,
+            default_model_entity=f"{workspace}/{name}",
+            autoprovisioned=True,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        for (workspace, name) in model_cache.model_entity_info_map.keys()
+        if "&adapters/" not in name
+    ]
+
+
+def _custom_vm(workspace: str, name: str, default_model_entity: str | None = None) -> SDKVirtualModel:
+    """Build a non-autoprovisioned (operator/Switchyard-style) VirtualModel."""
+    return SDKVirtualModel(
+        id=f"{workspace}/{name}",
+        entity_id=f"{workspace}/{name}",
+        workspace=workspace,
+        name=name,
+        parent=workspace,
+        default_model_entity=default_model_entity,
+        autoprovisioned=False,
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+
+
 # OpenAI List Models Tests
 
 
 def test_list_models_empty_cache(app: FastAPI, client: TestClient):
-    """Test listing models when cache is empty."""
+    """Test listing models when the VirtualModel cache is empty."""
 
-    empty_cache = ModelCache()
-    app.dependency_overrides[global_model_cache] = lambda: empty_cache
+    empty_cache = VirtualModelCache()
+    app.dependency_overrides[global_virtual_model_cache] = lambda: empty_cache
 
     response = client.get("/v2/workspaces/default/openai/-/v1/models")
     assert response.status_code == 200
@@ -48,68 +87,71 @@ def test_list_models_empty_cache(app: FastAPI, client: TestClient):
 
 
 def test_list_models_with_single_provider(client: TestClient):
-    """Test listing models with a single provider in cache."""
+    """Test listing models with a single autoprovisioned VM in cache."""
     response = client.get("/v2/workspaces/default/openai/-/v1/models")
     assert response.status_code == 200
 
     data = response.json()
     assert data["object"] == "list"
-    # One model entity from default fixture, returns 2-part ID
+    # One autoprovisioned VM from default fixture, returns 2-part ID
     assert len(data["data"]) >= 1
-    # Verify IDs are workspace/model_entity_name (at least 2 parts; model_entity_name may contain / for LoRA)
+    # Verify IDs are workspace/name (at least 2 parts; name may contain / for LoRA)
     for model in data["data"]:
         parts = model["id"].split("/", 1)
-        assert len(parts) >= 2, f"Expected workspace/model_entity_name, got: {model['id']}"
+        assert len(parts) >= 2, f"Expected workspace/name, got: {model['id']}"
 
 
-def test_list_models_multiple_providers_same_entity(app: FastAPI, client: TestClient):
-    """Test listing models when multiple providers serve the same model entity."""
+def test_list_models_lists_virtual_models(app: FastAPI, client: TestClient):
+    """The list endpoint aggregates VirtualModels (not model entities)."""
 
-    cache = ModelCache()
-    # Add multiple providers serving the same model entity
-    provider1 = ModelProviderInfo(
-        model_provider=ModelProvider(
-            workspace="ns1",
-            name="provider1",
-            host_url="http://provider1.com",
-            created_at=datetime.now(),
-            updated_at=datetime.now(),
-            served_models=[
-                ServedModelMapping(
-                    model_entity_id="ns1/model-a",
-                    served_model_name="model-a-v1",
-                )
-            ],
-        ),
-    )
-    provider2 = ModelProviderInfo(
-        model_provider=ModelProvider(
-            workspace="ns1",
-            name="provider2",
-            host_url="http://provider2.com",
-            created_at=datetime.now(),
-            updated_at=datetime.now(),
-            served_models=[
-                ServedModelMapping(
-                    model_entity_id="ns1/model-a",
-                    served_model_name="model-a-v2",
-                )
-            ],
-        ),
-    )
-    cache.update_model_info(provider1)
-    cache.update_model_info(provider2)
-    cache.rebuild_model_entity_map()
-
-    app.dependency_overrides[global_model_cache] = lambda: cache
+    vm_cache = VirtualModelCache()
+    vm_cache.rebuild([_custom_vm("ns1", "model-a")])
+    app.dependency_overrides[global_virtual_model_cache] = lambda: vm_cache
 
     response = client.get("/v2/workspaces/default/openai/-/v1/models")
     assert response.status_code == 200
 
     data = response.json()
-    # Model entity should be listed once with 2-part ID (deduped by entity)
+    # VirtualModel listed once with a 2-part ID
     assert len(data["data"]) == 1
     assert data["data"][0]["id"] == "ns1/model-a"
+    assert data["data"][0]["owned_by"] == "ns1"
+
+
+def test_list_models_includes_custom_switchyard_vm(app: FastAPI, client: TestClient):
+    """Regression: a custom (Switchyard-style) VirtualModel — one with no backing
+    model entity of the same name — must appear in the OpenAI ``/v1/models`` catalog.
+
+    Reproduces the reported gap where a routable VirtualModel served
+    ``/v1/chat/completions`` but was undiscoverable from ``/v1/models`` because the
+    list endpoint read model entities instead of VirtualModels.
+    """
+
+    vm_cache = VirtualModelCache()
+    vm_cache.rebuild([_custom_vm("default", "qa-agent-eval-swy-8238f441")])
+    app.dependency_overrides[global_virtual_model_cache] = lambda: vm_cache
+
+    response = client.get("/v2/workspaces/default/openai/-/v1/models")
+    assert response.status_code == 200
+
+    ids = {model["id"] for model in response.json()["data"]}
+    assert "default/qa-agent-eval-swy-8238f441" in ids
+
+
+def test_get_custom_switchyard_vm(app: FastAPI, client: TestClient):
+    """Regression: a custom (Switchyard-style) VirtualModel is retrievable via
+    ``GET /v1/models/{name}`` even though no model entity of that name exists."""
+
+    vm_cache = VirtualModelCache()
+    vm_cache.rebuild([_custom_vm("default", "qa-agent-eval-swy-8238f441")])
+    app.dependency_overrides[global_virtual_model_cache] = lambda: vm_cache
+
+    response = client.get("/v2/workspaces/default/openai/-/v1/models/qa-agent-eval-swy-8238f441")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == "default/qa-agent-eval-swy-8238f441"
+    assert data["owned_by"] == "default"
+    assert data["object"] == "model"
 
 
 # OpenAI Get Model Tests
@@ -139,7 +181,7 @@ def test_get_model_entity_not_found_single_segment(client: TestClient):
     """Test GET model with single-segment name (model only); lookup uses path workspace."""
     response = client.get("/v2/workspaces/default/openai/-/v1/models/nonexistent-entity")
     assert response.status_code == 404
-    assert "Model entity not found" in response.json()["detail"]
+    assert "No VirtualModel" in response.json()["detail"]
 
 
 def test_get_model_invalid_path_workspace_returns_422(client: TestClient):
@@ -150,23 +192,31 @@ def test_get_model_invalid_path_workspace_returns_422(client: TestClient):
 
 
 def test_get_model_entity_not_found_matching_workspace_prefix(client: TestClient):
-    """404 is raised when a path-workspace-prefixed name points at a missing entity."""
+    """404 is raised when a path-workspace-prefixed name points at a missing VirtualModel."""
     response = client.get("/v2/workspaces/default/openai/-/v1/models/default/nonexistent-entity")
     assert response.status_code == 404
-    assert "Model entity not found" in response.json()["detail"]
+    assert "No VirtualModel" in response.json()["detail"]
 
 
 def test_get_model_entity_exists_without_providers(app: FastAPI, client: TestClient):
-    """Test getting a model when entity exists in cache (even without providers)."""
+    """Test getting a model when an autoprovisioned VM exists (even without providers).
+
+    The GET route resolves against the VirtualModel cache, so an autoprovisioned VM
+    for an entity with no providers is still discoverable — provider resolution only
+    happens at proxy (inference) time.
+    """
 
     cache = ModelCache()
-    # Model entity exists in cache - get model should succeed
+    # Model entity exists in cache but has no providers (edge case)
     cache.model_entity_info_map[("ns1", "orphan-model")] = ModelEntityInfo(
         workspace="ns1",
         name="orphan-model",
         model_providers=[],
     )
     app.dependency_overrides[global_model_cache] = lambda: cache
+    vm_cache = VirtualModelCache()
+    vm_cache.rebuild(_autoprovisioned_vms_for_cache(cache))
+    app.dependency_overrides[global_virtual_model_cache] = lambda: vm_cache
 
     response = client.get("/v2/workspaces/ns1/openai/-/v1/models/orphan-model")
     assert response.status_code == 200
@@ -180,28 +230,13 @@ def test_get_model_lora_compound_name_in_path(app: FastAPI, client: TestClient):
 
     The URL contains two "/" characters after the base workspace prefix, so FastAPI delivers
     ``name="ws/base&adapters/ws/adder"`` to the handler. The handler must strip only the first
-    segment ("ws/") and look up the cache under ``(ws, "base&adapters/ws/adder")`` — matching the
-    key produced by ``ModelCache.rebuild_model_entity_map``'s ``split("/", 1)``.
+    segment ("ws/") and look up the VirtualModel cache under ``(ws, "base&adapters/ws/adder")``.
+    Operators associate composite LoRA ids with an explicit VirtualModel, so the VM cache is
+    the source of truth here.
     """
-    cache = ModelCache()
-    provider = ModelProviderInfo(
-        model_provider=ModelProvider(
-            workspace="ws",
-            name="nim-provider",
-            host_url="http://nim.example.com",
-            created_at=datetime.now(),
-            updated_at=datetime.now(),
-            served_models=[
-                ServedModelMapping(
-                    model_entity_id="ws/base&adapters/ws/adder",
-                    served_model_name="adder",
-                ),
-            ],
-        )
-    )
-    cache.update_model_info(provider)
-    cache.rebuild_model_entity_map()
-    app.dependency_overrides[global_model_cache] = lambda: cache
+    vm_cache = VirtualModelCache()
+    vm_cache.rebuild([_custom_vm("ws", "base&adapters/ws/adder")])
+    app.dependency_overrides[global_virtual_model_cache] = lambda: vm_cache
 
     response = client.get("/v2/workspaces/ws/openai/-/v1/models/ws/base&adapters/ws/adder")
     assert response.status_code == 200
@@ -212,26 +247,9 @@ def test_get_model_lora_compound_name_in_path(app: FastAPI, client: TestClient):
 
 def test_get_model_lora_compound_bare_name_in_path(app: FastAPI, client: TestClient):
     """Bare LoRA composite ``{base}&adapters/{ws}/{adapter}`` resolves via ``GET /v1/models/{name:path}``."""
-    cache = ModelCache()
-    cache.update_model_info(
-        ModelProviderInfo(
-            model_provider=ModelProvider(
-                workspace="ws",
-                name="nim-provider",
-                host_url="http://nim.example.com",
-                created_at=datetime.now(),
-                updated_at=datetime.now(),
-                served_models=[
-                    ServedModelMapping(
-                        model_entity_id="ws/base&adapters/ws/adder",
-                        served_model_name="adder",
-                    ),
-                ],
-            )
-        )
-    )
-    cache.rebuild_model_entity_map()
-    app.dependency_overrides[global_model_cache] = lambda: cache
+    vm_cache = VirtualModelCache()
+    vm_cache.rebuild([_custom_vm("ws", "base&adapters/ws/adder")])
+    app.dependency_overrides[global_virtual_model_cache] = lambda: vm_cache
 
     response = client.get("/v2/workspaces/ws/openai/-/v1/models/base&adapters/ws/adder")
     assert response.status_code == 200
@@ -241,7 +259,7 @@ def test_get_model_lora_compound_bare_name_in_path(app: FastAPI, client: TestCli
 
 
 def test_get_model_success_with_custom_provider(app: FastAPI, client: TestClient):
-    """Test getting a model with a custom provider setup."""
+    """Test getting a model backed by a custom provider (via its autoprovisioned VM)."""
 
     cache = ModelCache()
     provider = ModelProviderInfo(
@@ -263,6 +281,9 @@ def test_get_model_success_with_custom_provider(app: FastAPI, client: TestClient
     cache.rebuild_model_entity_map()
 
     app.dependency_overrides[global_model_cache] = lambda: cache
+    vm_cache = VirtualModelCache()
+    vm_cache.rebuild(_autoprovisioned_vms_for_cache(cache))
+    app.dependency_overrides[global_virtual_model_cache] = lambda: vm_cache
 
     response = client.get("/v2/workspaces/ns1/openai/-/v1/models/my-model")
     assert response.status_code == 200
@@ -562,28 +583,12 @@ def test_get_model_cross_workspace_lora(app: FastAPI, client: TestClient):
 
     Complements the same-workspace tests at ``test_get_model_lora_compound_name_in_path``
     and ``test_get_model_lora_compound_bare_name_in_path``. The handler must strip
-    only the leading ``ws-a/`` segment and look up ``("ws-a", "base&adapters/ws-b/adapter")``.
+    only the leading ``ws-a/`` segment and look up ``("ws-a", "base&adapters/ws-b/adapter")``
+    in the VirtualModel cache.
     """
-    cache = ModelCache()
-    cache.update_model_info(
-        ModelProviderInfo(
-            model_provider=ModelProvider(
-                workspace="ws-a",
-                name="nim-provider",
-                host_url="http://nim.workspace-a.example.com",
-                created_at=datetime.now(),
-                updated_at=datetime.now(),
-                served_models=[
-                    ServedModelMapping(
-                        model_entity_id="ws-a/base&adapters/ws-b/adapter",
-                        served_model_name="ws-b--adapter",
-                    ),
-                ],
-            )
-        )
-    )
-    cache.rebuild_model_entity_map()
-    app.dependency_overrides[global_model_cache] = lambda: cache
+    vm_cache = VirtualModelCache()
+    vm_cache.rebuild([_custom_vm("ws-a", "base&adapters/ws-b/adapter")])
+    app.dependency_overrides[global_virtual_model_cache] = lambda: vm_cache
 
     response = client.get("/v2/workspaces/ws-a/openai/-/v1/models/ws-a/base&adapters/ws-b/adapter")
     assert response.status_code == 200

--- a/services/core/inference-gateway/tests/unit/test_openai_router.py
+++ b/services/core/inference-gateway/tests/unit/test_openai_router.py
@@ -87,8 +87,13 @@ def test_list_models_empty_cache(app: FastAPI, client: TestClient):
 
 
 def test_list_models_with_single_provider(client: TestClient):
-    """Test listing models with a single autoprovisioned VM in cache."""
-    response = client.get("/v2/workspaces/default/openai/-/v1/models")
+    """Test listing models with a single autoprovisioned VM in cache.
+
+    The default fixture serves ``e2e-test/meta_llama-3.2-1b-instruct``, so the
+    autoprovisioned VM lives in the ``e2e-test`` workspace; the list is
+    workspace-scoped, so query that workspace.
+    """
+    response = client.get("/v2/workspaces/e2e-test/openai/-/v1/models")
     assert response.status_code == 200
 
     data = response.json()
@@ -108,7 +113,7 @@ def test_list_models_lists_virtual_models(app: FastAPI, client: TestClient):
     vm_cache.rebuild([_custom_vm("ns1", "model-a")])
     app.dependency_overrides[global_virtual_model_cache] = lambda: vm_cache
 
-    response = client.get("/v2/workspaces/default/openai/-/v1/models")
+    response = client.get("/v2/workspaces/ns1/openai/-/v1/models")
     assert response.status_code == 200
 
     data = response.json()
@@ -116,6 +121,29 @@ def test_list_models_lists_virtual_models(app: FastAPI, client: TestClient):
     assert len(data["data"]) == 1
     assert data["data"][0]["id"] == "ns1/model-a"
     assert data["data"][0]["owned_by"] == "ns1"
+
+
+def test_list_models_is_workspace_scoped(app: FastAPI, client: TestClient):
+    """The list endpoint only returns VirtualModels in the request's workspace.
+
+    Foreign-workspace VirtualModels must not leak into another workspace's catalog.
+    """
+
+    vm_cache = VirtualModelCache()
+    vm_cache.rebuild(
+        [
+            _custom_vm("ns1", "model-a"),
+            _custom_vm("ns2", "model-b"),
+        ]
+    )
+    app.dependency_overrides[global_virtual_model_cache] = lambda: vm_cache
+
+    response = client.get("/v2/workspaces/ns1/openai/-/v1/models")
+    assert response.status_code == 200
+
+    ids = {model["id"] for model in response.json()["data"]}
+    assert ids == {"ns1/model-a"}
+    assert "ns2/model-b" not in ids
 
 
 def test_list_models_includes_custom_switchyard_vm(app: FastAPI, client: TestClient):


### PR DESCRIPTION
## Problem

The platform's OpenAI-compatible model catalog does not list custom Switchyard VirtualModels even after the VirtualModel is persisted and routable through `/v1/chat/completions`. This blocks agent-eval runtime model paths that validate/discover the selected runtime model through `/v1/models`.

## Root cause

The IGW OpenAI catalog routes (`GET /v1/models`, `GET /v1/models/{name}`) were left reading **model entities** from `ModelCache`, while the inference/proxy routes were ported to route on **VirtualModels** (`VirtualModelCache`). Custom VirtualModels (e.g. Switchyard `random_routing` + `translate`) served `/v1/chat/completions` but were invisible to `/v1/models` — an undiscoverable-but-routable state. This gap was missed when the OpenAI and `model` gateway routes were ported to VirtualModel routing.

## Fix

- `openai_get_models` now aggregates `virtual_model_cache.virtual_model_map` instead of `model_cache.model_entity_info_map`. This lists all routable VMs: autoprovisioned VMs (one per served entity) **and** custom VMs, keeping the catalog in agreement with the proxy path (which already resolves against the VM cache).
- `openai_get_model` now resolves against the VM cache and returns the VirtualModel-not-found `404` on miss, matching the proxy path's semantics.

Behavior note: the get-single-model route previously returned `200` for an entity with no serving provider; it now returns `200` only if a VM exists (which in production tracks served entities). This intentionally aligns discovery with routability.

## Tests

- Updated affected unit tests in `test_openai_router.py` to populate/override the VirtualModel cache and expect the VM `404` message.
- Added regression tests: a custom Switchyard-style VM (no same-named entity) must be listable (`/v1/models`) and retrievable (`/v1/models/{name}`).
- Updated the (currently-disabled) e2e list test docstring to reflect VM-based listing.

## Verification

- `test_openai_router.py`: 54 passed
- Full inference-gateway unit suite: 445 passed, 5 skipped
- `ruff check`, `ruff format --check`, `ty check` clean on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAI-compatible `/v1/models` and `/v1/models/{name}` now list and resolve routable VirtualModels.
  * Model IDs use the `workspace/name` format.
  * Listings include both autoprovisioned and custom VirtualModels.
  * Lookups resolve consistently even when `{name}` is workspace-prefixed.
* **Documentation**
  * Updated OpenAPI and CLI reference text to reflect the VirtualModel-based routing contract.
* **Tests**
  * Updated unit and e2e expectations to validate VirtualModel discovery and updated not-found behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->