### PR TITLE
fix(studio): Fix missing readme in fileset details causing large empty space

### DIFF
--- a/web/packages/studio/src/routes/FilesetDetailRoute/FilesetCard/index.tsx
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/FilesetCard/index.tsx
@@ -84,7 +84,7 @@ export const FilesetCard: FC<FilesetCardProps> = ({
     </Stack>
   );
   if (!hasReadme) {
-    return metaPanels;
+    return <div data-testid="fileset-card">{metaPanels}</div>;
   }
 
   return (

--- a/web/packages/studio/src/routes/FilesetDetailRoute/FilesetCard/index.tsx
+++ b/web/packages/studio/src/routes/FilesetDetailRoute/FilesetCard/index.tsx
@@ -70,6 +70,22 @@ export const FilesetCard: FC<FilesetCardProps> = ({
   );
 
   const isDataset = fileset.purpose === FilesetPurpose.dataset;
+  const hasReadme = Boolean(readmePath);
+  const metaPanels = (
+    <Stack gap="density-xl" className="h-full overflow-auto">
+      <FilesetMetadataPanel
+        fileset={fileset}
+        readmeMetadata={parsed?.metadata}
+        modelEntities={isModel ? modelEntities : undefined}
+      />
+      {isDataset && (
+        <DatasetSamplePanel workspace={workspace} filesetName={filesetName} files={files} />
+      )}
+    </Stack>
+  );
+  if (!hasReadme) {
+    return metaPanels;
+  }
 
   return (
     <div
@@ -77,28 +93,15 @@ export const FilesetCard: FC<FilesetCardProps> = ({
       data-testid="fileset-card"
     >
       <div className="lg:col-span-2">
-        <Stack gap="density-md">
-          <ReadmeBody
-            isFilesError={isFilesError}
-            readmePath={readmePath}
-            isContentLoading={isContentLoading}
-            isContentError={isContentError}
-            content={parsed?.content}
-          />
-        </Stack>
+        <ReadmeBody
+          isFilesError={isFilesError}
+          readmePath={readmePath}
+          isContentLoading={isContentLoading}
+          isContentError={isContentError}
+          content={parsed?.content}
+        />
       </div>
-      <div className="lg:col-span-1">
-        <Stack gap="density-xl" className="h-full overflow-auto">
-          <FilesetMetadataPanel
-            fileset={fileset}
-            readmeMetadata={parsed?.metadata}
-            modelEntities={isModel ? modelEntities : undefined}
-          />
-          {isDataset && (
-            <DatasetSamplePanel workspace={workspace} filesetName={filesetName} files={files} />
-          )}
-        </Stack>
-      </div>
+      <div className="lg:col-span-1">{metaPanels}</div>
     </div>
   );
 };


### PR DESCRIPTION

<img width="1037" height="694" alt="Screenshot 2026-07-17 at 2 53 01 PM" src="https://github.com/user-attachments/assets/db005aa0-4575-4ba2-a714-447869ad26d0" />
Before


<img width="1037" height="698" alt="Screenshot 2026-07-17 at 2 55 06 PM" src="https://github.com/user-attachments/assets/55536aff-e124-409b-a665-f83ab70afa5f" />
After

Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fileset detail pages when no root README is available by showing metadata (and dataset sample information) without an empty content area.
  - Preserved the README-and-metadata layout for filesets that include documentation.
  - Streamlined README rendering to keep a consistent, cleaner page layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->