### PR TITLE
docs(evaluator): fix LLM-as-a-judge tutorial section numbering (AALGO-357)

### DIFF
--- a/docs/evaluator/tutorials/run-llm-judge-evaluation.mdx
+++ b/docs/evaluator/tutorials/run-llm-judge-evaluation.mdx
@@ -649,7 +649,7 @@ If your judge's distribution looks very different from humans, such as always sc
 
 ---
 
-## 13. Clean Up
+## 10. Clean Up
 
 To delete the workspace, you must first delete all resources within it. Delete jobs first, then filesets, secrets, and the workspace.
 


### PR DESCRIPTION
## Summary

The published LLM-as-a-Judge evaluator tutorial jumps from step 9 straight to step 13, with no steps 10-12. The sections were simply misnumbered — no content is missing. This renumbers the final section from `13. Clean Up` to `10. Clean Up` so the walkthrough reads sequentially (sections 1-10).

## Source

`docs/evaluator/tutorials/run-llm-judge-evaluation.mdx`

## Tracking

- Linear: AALGO-357
- NVBug: [6479003](https://nvbugspro.nvidia.com/bug/6479003)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the cleanup section numbering in the LLM judge evaluation tutorial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->