### PR TITLE
docs(evaluator): drop notebook bang syntax from LLM-as-a-judge bash blocks (AALGO-358)

### DIFF
--- a/docs/evaluator/tutorials/run-llm-judge-evaluation.mdx
+++ b/docs/evaluator/tutorials/run-llm-judge-evaluation.mdx
@@ -39,14 +39,14 @@ This tutorial takes approximately **20 minutes** to complete.
 For PyPI installs, use the `nemo-platform` wrapper package. If you are working from a source checkout, run `make bootstrap` from the repository root instead.
 
 ```bash
-! pip install "nemo-platform[all]"
-! nemo setup
+pip install "nemo-platform[all]"
+nemo setup
 ```
 
 2. Install the Python libraries used in this tutorial:
 
 ```bash
-! pip install pandas scipy matplotlib
+pip install pandas scipy matplotlib
 ```
 
 ---


### PR DESCRIPTION
## Summary

The LLM-as-a-Judge evaluator tutorial's **Prerequisites** section renders install/setup commands as `bash`, but the commands use notebook/IPython bang syntax (`! pip ...`, `! nemo setup`). In bash, `! command` is logical negation and reverses the exit code — so a command that succeeds when copied into a real shell or CI script reports failure.

This removes the leading `!` from the two `bash` fenced blocks so they are valid shell:

```bash
pip install "nemo-platform[all]"
nemo setup
```
```bash
pip install pandas scipy matplotlib
```

## Source

`docs/evaluator/tutorials/run-llm-judge-evaluation.mdx`

## Tracking

- Linear: AALGO-358
- NVBug: [6478826](https://nvbugspro.nvidia.com/bug/6478826)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated evaluation tutorial command examples to use standard shell syntax.
  * Clarified prerequisite installation steps for improved copy-and-paste usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->