### PR TITLE
feat(evaluator-sdk): allow a prebuilt image for FabricContainerRuntime

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/container_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/container_runtime.py
@@ -93,6 +93,7 @@ class FabricContainerRuntime:
         provider: SandboxProvider,
         profiles: Sequence[FabricProfileConfig | Mapping[str, Any]] = (),
         secrets: Mapping[str, SecretRef] = {},
+        image: str | None = None,
     ) -> None:
         # The Fabric agent is fully described by its ``FabricConfig`` (harness + model + runtime); it is
         # consumed structurally as a mapping to cross the sandbox boundary as JSON.
@@ -105,8 +106,9 @@ class FabricContainerRuntime:
         self._secrets = dict(secrets)
         self._resolved_env: dict[str, str] = {}
         self._secrets_resolved = False
-        # Provisioned opaquely on first run (build-if-missing from the config's harness).
-        self._image: str | None = None
+        # Optional prebuilt image: the trial runs inside it, so it must contain the Fabric CLI + adapter.
+        # None -> stock harness-agnostic image built on first run.
+        self._image: str | None = image
 
     async def resolve_secrets(self, secret_resolver: SecretResolver) -> None:
         """Resolve declared ``SecretRef``\\ s to values, keyed by the env var each harness reads.
@@ -143,7 +145,8 @@ class FabricContainerRuntime:
             # Provision the harness-agnostic Fabric image once, build-if-missing (a first build compiles
             # nemo-fabric — minutes); keep the blocking build off the shared event loop. Inside the guard
             # so the provider is disposed even if provisioning or secret resolution raises.
-            self._image = await asyncio.to_thread(ensure_fabric_image)
+            if self._image is None:
+                self._image = await asyncio.to_thread(ensure_fabric_image)
             if self._secrets and not self._secrets_resolved:
                 # No orchestrator resolved our secrets (standalone run) — fall back to local env resolution.
                 await self.resolve_secrets(LocalSecretResolver())
@@ -173,7 +176,8 @@ class FabricContainerRuntime:
                 await sandbox.download_dir(_OUT_DIR, out_dir)
             return self._to_trial(task, out_dir, evidence_dir, result)
         except Exception as exc:  # noqa: BLE001 - a task failure must not abort the whole run
-            return self._failed_trial(task, evidence_dir, exc)
+            # Stamp runtime + image even on failures before _to_trial (startup/seeding/download).
+            return self._failed_trial(task, evidence_dir, exc, extra_metadata=self._base_metadata())
 
     def _fabric_command(self, profile_paths: Sequence[str]) -> str:
         """The ``fabric run`` invocation: pre-create the /out dirs Fabric chdirs into, run, capture stdout."""
@@ -232,14 +236,14 @@ class FabricContainerRuntime:
             await asyncio.to_thread(seed_workspace, staging, seeds)
             await sandbox.upload_dir(staging, _WORKSPACE_DIR)
 
+    def _base_metadata(self) -> dict[str, object]:
+        """Metadata stamped on every trial from this runtime (success or failure), incl. the resolved image."""
+        return {"runtime": _RUNTIME_NAME, "image": self._image, "sandbox_provider": self._provider.name}
+
     def _to_trial(
         self, task: AgentEvalTask, out_dir: Path, evidence_dir: Path, result: SandboxExecResult
     ) -> AgentEvalTrial:
-        base_metadata: dict[str, object] = {
-            "runtime": _RUNTIME_NAME,
-            "image": self._image,
-            "sandbox_provider": self._provider.name,
-        }
+        base_metadata = self._base_metadata()
 
         # Gate on the exec outcome first: a timed-out or non-zero ``fabric run`` is untrustworthy even
         # when a stale/partial fabric_result.json is left behind (the shell ``>`` redirect truncates the

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_container_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_container_runtime.py
@@ -68,6 +68,7 @@ class _FakeProvider:
         self._atif = atif
         self.seeded: dict[str, str] = {}
         self.env: dict[str, str] = {}
+        self.image: str | None = None
         self.uploaded_dirs: list[tuple[Path, str]] = []
         self.execs: list[str] = []
         self.closed = 0
@@ -76,6 +77,7 @@ class _FakeProvider:
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
         self.seeded = dict(spec.files)
         self.env = dict(spec.env)
+        self.image = spec.image
         return SandboxHandle(sandbox_id="fake-1", provider_name=self.name, raw=None)
 
     async def exec(self, handle: SandboxHandle, command: str, **kwargs: object) -> SandboxExecResult:
@@ -221,6 +223,45 @@ async def test_secrets_are_resolved_and_injected_as_env(tmp_path: Path) -> None:
     await runtime.resolve_secrets(_FakeResolver("nvapi-xyz"))
     await _run(runtime, [_task()], tmp_path)
     assert provider.env == {"NVIDIA_API_KEY": "nvapi-xyz"}  # resolved value, keyed by the harness env var
+
+
+async def test_supplied_image_is_used_verbatim_without_building(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A caller-supplied image (an escape hatch for sandboxes needing extra tooling, e.g. a
+    # document-processing image) is used verbatim and short-circuits the build-if-missing path.
+    builds: list[bool] = []
+    monkeypatch.setattr(crt, "ensure_fabric_image", lambda **_kwargs: builds.append(True) or "unused")
+    provider = _FakeProvider()
+    (trial,) = await _run(_runtime(provider, image="doc-tools:1.0"), [_task()], tmp_path)
+
+    assert trial.status == AgentEvalTrialStatus.COMPLETED
+    assert builds == []  # the supplied tag is used; ensure_fabric_image is never called
+    assert provider.image == "doc-tools:1.0"  # and it reaches the SandboxSpec
+    assert trial.metadata["image"] == "doc-tools:1.0"  # surfaced on the trial metadata
+
+
+async def test_default_provisions_build_if_missing_image(tmp_path: Path) -> None:
+    # Without an override, the runtime provisions the harness-agnostic Fabric image (build-if-missing);
+    # the autouse fixture stubs that build to "fabric-img:test".
+    provider = _FakeProvider()
+    (trial,) = await _run(_runtime(provider), [_task()], tmp_path)
+    assert provider.image == "fabric-img:test"
+    assert trial.metadata["image"] == "fabric-img:test"
+
+
+async def test_early_failure_trial_carries_image_metadata(tmp_path: Path) -> None:
+    # A failure BEFORE _to_trial (here: download_dir raises) must still stamp the runtime + selected image
+    # on the trial, matching what _to_trial records on the success and late-failure paths.
+    class _BrokenProvider(_FakeProvider):
+        async def download_dir(self, handle: SandboxHandle, source_dir: str, target_dir: Path) -> None:
+            raise RuntimeError("sandbox died mid-download")
+
+    provider = _BrokenProvider()
+    (trial,) = await _run(_runtime(provider, image="doc-tools:1.0"), [_task()], tmp_path)
+    assert trial.status == AgentEvalTrialStatus.FAILED
+    assert trial.metadata["image"] == "doc-tools:1.0"
+    assert trial.metadata["runtime"] == "fabric_container"
 
 
 async def test_no_run_result_fails_trial(tmp_path: Path) -> None:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/container_runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/container_runtime.py
@@ -93,6 +93,7 @@ class FabricContainerRuntime:
         provider: SandboxProvider,
         profiles: Sequence[FabricProfileConfig | Mapping[str, Any]] = (),
         secrets: Mapping[str, SecretRef] = {},
+        image: str | None = None,
     ) -> None:
         # The Fabric agent is fully described by its ``FabricConfig`` (harness + model + runtime); it is
         # consumed structurally as a mapping to cross the sandbox boundary as JSON.
@@ -105,8 +106,9 @@ class FabricContainerRuntime:
         self._secrets = dict(secrets)
         self._resolved_env: dict[str, str] = {}
         self._secrets_resolved = False
-        # Provisioned opaquely on first run (build-if-missing from the config's harness).
-        self._image: str | None = None
+        # Optional prebuilt image: the trial runs inside it, so it must contain the Fabric CLI + adapter.
+        # None -> stock harness-agnostic image built on first run.
+        self._image: str | None = image
 
     async def resolve_secrets(self, secret_resolver: SecretResolver) -> None:
         """Resolve declared ``SecretRef``\\ s to values, keyed by the env var each harness reads.
@@ -143,7 +145,8 @@ class FabricContainerRuntime:
             # Provision the harness-agnostic Fabric image once, build-if-missing (a first build compiles
             # nemo-fabric — minutes); keep the blocking build off the shared event loop. Inside the guard
             # so the provider is disposed even if provisioning or secret resolution raises.
-            self._image = await asyncio.to_thread(ensure_fabric_image)
+            if self._image is None:
+                self._image = await asyncio.to_thread(ensure_fabric_image)
             if self._secrets and not self._secrets_resolved:
                 # No orchestrator resolved our secrets (standalone run) — fall back to local env resolution.
                 await self.resolve_secrets(LocalSecretResolver())
@@ -173,7 +176,8 @@ class FabricContainerRuntime:
                 await sandbox.download_dir(_OUT_DIR, out_dir)
             return self._to_trial(task, out_dir, evidence_dir, result)
         except Exception as exc:  # noqa: BLE001 - a task failure must not abort the whole run
-            return self._failed_trial(task, evidence_dir, exc)
+            # Stamp runtime + image even on failures before _to_trial (startup/seeding/download).
+            return self._failed_trial(task, evidence_dir, exc, extra_metadata=self._base_metadata())
 
     def _fabric_command(self, profile_paths: Sequence[str]) -> str:
         """The ``fabric run`` invocation: pre-create the /out dirs Fabric chdirs into, run, capture stdout."""
@@ -232,14 +236,14 @@ class FabricContainerRuntime:
             await asyncio.to_thread(seed_workspace, staging, seeds)
             await sandbox.upload_dir(staging, _WORKSPACE_DIR)
 
+    def _base_metadata(self) -> dict[str, object]:
+        """Metadata stamped on every trial from this runtime (success or failure), incl. the resolved image."""
+        return {"runtime": _RUNTIME_NAME, "image": self._image, "sandbox_provider": self._provider.name}
+
     def _to_trial(
         self, task: AgentEvalTask, out_dir: Path, evidence_dir: Path, result: SandboxExecResult
     ) -> AgentEvalTrial:
-        base_metadata: dict[str, object] = {
-            "runtime": _RUNTIME_NAME,
-            "image": self._image,
-            "sandbox_provider": self._provider.name,
-        }
+        base_metadata = self._base_metadata()
 
         # Gate on the exec outcome first: a timed-out or non-zero ``fabric run`` is untrustworthy even
         # when a stale/partial fabric_result.json is left behind (the shell ``>`` redirect truncates the


### PR DESCRIPTION
## What

`FabricContainerRuntime` always provisioned the harness-agnostic Fabric image (build-if-missing). This adds an optional keyword-only `image` parameter so a caller can supply a prebuilt image tag when the sandbox needs extra tooling — e.g. a document-processing image (pandoc/libreoffice), a pinned base, or an image from an air-gapped registry.

## Behavior

- **Backward-compatible.** `image` defaults to `None`; when unset, behavior is unchanged (`ensure_fabric_image()` build-if-missing on first run).
- When provided, the tag is used verbatim and the build step is skipped. Image *building* remains a client concern, as before.

## Tests

Two new cases in `test_fabric_container_runtime.py` (existing fake-provider harness):
- a supplied image reaches the `SandboxSpec` and short-circuits `ensure_fabric_image`;
- the default path still provisions the build-if-missing image.

`pytest` green (17/17 in the file); `ruff check` and `ruff format --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional custom Fabric container image override for evaluation runs.
  * Caller-provided image tags are used as-is and stored in `trial` metadata.
  * When no image is provided, the runtime provisions the default image automatically.
* **Bug Fixes**
  * Failed trials now consistently include the selected image in `trial` metadata.
* **Tests**
  * Added coverage for supplied-image usage, default image provisioning, and early-failure metadata behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->