### PR TITLE
fix(guardrails): Ensure self-check config with retains custom base URL

### DIFF
--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/llmrails_cache.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/llmrails_cache.py
@@ -205,8 +205,7 @@ def _fill_main_model_placeholder(model_config: dict[str, Any]) -> dict[str, Any]
 
     parameters = model_config.get("parameters")
     if isinstance(parameters, dict) and (
-        _has_nonempty_model_name(parameters.get("model"))
-        or _has_nonempty_model_name(parameters.get("model_name"))
+        _has_nonempty_model_name(parameters.get("model")) or _has_nonempty_model_name(parameters.get("model_name"))
     ):
         return model_config
 

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/llmrails_cache.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/llmrails_cache.py
@@ -179,10 +179,20 @@ body's model, so this placeholder is to satisfy the schema validator.
 """
 
 
+def _has_nonempty_model_name(value: object) -> bool:
+    """``True`` when ``value`` is a non-empty (after strip) model name string."""
+    return isinstance(value, str) and bool(value.strip())
+
+
 def _fill_main_model_placeholder(model_config: dict[str, Any]) -> dict[str, Any]:
     """Given a model config from a GuardrailConfig, populates the ``model`` field with
     a placeholder value if the config represents the main model and doesn't already have
     a model name.
+
+    The upstream ``Model`` schema accepts a name in exactly one of three places:
+    top-level ``model``, ``parameters.model``, or ``parameters.model_name``. Filling a
+    placeholder when either parameters form is already set would trip the library's
+    dual-location validator, so those configs are left unchanged.
 
     This is required to satisfy the nemoguardrails library schema validator.
     We always populate the actual model name using the incoming request
@@ -190,8 +200,14 @@ def _fill_main_model_placeholder(model_config: dict[str, Any]) -> dict[str, Any]
     """
     if model_config.get("type") != MAIN_MODEL_TYPE:
         return model_config
-    model = model_config.get("model")
-    if model is not None and not (isinstance(model, str) and not model.strip()):
+    if _has_nonempty_model_name(model_config.get("model")):
+        return model_config
+
+    parameters = model_config.get("parameters")
+    if isinstance(parameters, dict) and (
+        _has_nonempty_model_name(parameters.get("model"))
+        or _has_nonempty_model_name(parameters.get("model_name"))
+    ):
         return model_config
 
     return {**model_config, "model": MAIN_MODEL_REQUEST_PLACEHOLDER}

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/llmrails_cache.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/llmrails_cache.py
@@ -171,30 +171,30 @@ EMBEDDINGS_MODEL_TYPE = "embeddings"
 """Reserved ``Model.type`` for an embeddings model."""
 
 
-def _is_stub_main_entry(raw: dict[str, Any]) -> bool:
-    """``True`` for a stub ``main`` entry — ``{"type": "main", ...}`` with
-    no model name in ``model``, ``parameters.model``, or
-    ``parameters.model_name``.
+MAIN_MODEL_REQUEST_PLACEHOLDER = "<request>"
+"""Placeholder model used as the main model entry in a GuardrailConfig.
+``model`` is a required field in the nemoguardrails library schema.
+We always populate the actual model name using the incoming request
+body's model, so this placeholder is to satisfy the schema validator.
+"""
 
-    Dropped before upstream validation: stubs carry no signal under IGW
-    (the gateway owns main-LLM routing per request) but trip nemoguardrails
-    0.21.0+'s ``Model.model_must_be_none_empty`` check. *Named* mains
-    survive this filter and are extracted as ``main_model_template``.
+
+def _fill_main_model_placeholder(model_config: dict[str, Any]) -> dict[str, Any]:
+    """Given a model config from a GuardrailConfig, populates the ``model`` field with
+    a placeholder value if the config represents the main model and doesn't already have
+    a model name.
+
+    This is required to satisfy the nemoguardrails library schema validator.
+    We always populate the actual model name using the incoming request
+    body's model, so this placeholder is to satisfy the schema validator.
     """
+    if model_config.get("type") != MAIN_MODEL_TYPE:
+        return model_config
+    model = model_config.get("model")
+    if model is not None and not (isinstance(model, str) and not model.strip()):
+        return model_config
 
-    def is_missing(value: Any) -> bool:
-        return value is None or (isinstance(value, str) and not value.strip())
-
-    if raw.get("type") != MAIN_MODEL_TYPE:
-        return False
-    if not is_missing(raw.get("model")):
-        return False
-    params = raw.get("parameters")
-    if params is None:
-        return True
-    if not isinstance(params, dict):
-        return False
-    return all(is_missing(params.get(key)) for key in ("model", "model_name"))
+    return {**model_config, "model": MAIN_MODEL_REQUEST_PLACEHOLDER}
 
 
 def _is_missing_model_name_error(err: ValidationError) -> bool:
@@ -220,7 +220,10 @@ class StableRailsConfig:
       ``None`` in the production case — under the IGW Plugin model the
       gateway owns main-LLM routing, so configs typically declare only task
       LLMs (content-safety, topic-control, embeddings). The template is
-      retained for self-check / demo configs that pin a specific main model.
+      retained whenever a config declares a ``main`` entry at all, whether
+      to pin a specific model (self-check / demo configs) or just to
+      override ``engine``/``parameters`` (ex. a custom ``base_url``) while
+      leaving the model name to the request body.
     - Non-main ``base_url`` values are resolved against the IGW route table.
     - Static ``default_headers`` are preserved; platform service headers are
       added by the header-aware NIM client at call time.
@@ -259,9 +262,12 @@ def stabilize(
     warning and proceeds; the per-request main is then injected via
     ``update_llm`` from :func:`rails.build_main_llm`.
 
-    Stub ``main`` entries (no model name in any location) are stripped
-    before library validation — see :func:`_is_stub_main_entry`. Named
-    main entries pass through and become ``main_model_template``.
+    ``main`` entries never need a ``model`` name — IGW always supplies the
+    real model from the request body. However, the upstream validator
+    requires a non-empty model name on every entry, so nameless ``main``
+    entries get a placeholder filled in first. This keeps configs that pin
+    other fields on the main entry (e.g. `parameters.base_url`) from being
+    lost.
 
     Non-main models with empty ``model`` are rejected by the library
     ``Model`` validator during ``model_validate`` below, so
@@ -272,33 +278,15 @@ def stabilize(
     # optional under the IGW Plugin architecture. Coerce here so a user can
     # post the minimum-viable config (e.g. just ``{"rails": {...}}``).
     payload.setdefault("models", [])
-
-    raw_models: list[dict[str, Any]] = payload["models"]
-    filtered_models = [m for m in raw_models if not _is_stub_main_entry(m)]
-    dropped = len(raw_models) - len(filtered_models)
-    if dropped:
-        logger.info(
-            "Dropping stub 'main' model entries from guardrails config; "
-            "IGW owns main-LLM routing per request. Set a non-empty `model:` "
-            "(for engine/parameters templates or self-check rails) or omit "
-            "the entry to silence this message.",
-        )
-    payload["models"] = filtered_models
+    payload["models"] = [_fill_main_model_placeholder(m) for m in payload["models"]]
 
     try:
         library_rails = LibraryRailsConfig.model_validate(payload)
     except ValidationError as exc:
-        # Wrap the cryptic upstream "Model name must be specified..." error
-        # with an IGW-aware message. ``ValueError`` → 400 via
-        # ``InferenceMiddleware._run_rails`` so the friendlier message reaches
-        # the client. Anything else propagates unchanged so callers see the
-        # original (also ``ValueError``-shaped → 400) diagnostic.
+        # Wrap the cryptic upstream error with an IGW-aware message.
+        # ``ValueError`` → 400 via ``InferenceMiddleware._run_rails``.
         if _is_missing_model_name_error(exc):
-            raise ValueError(
-                "Guardrails config has a model entry with no `model:` name. "
-                "Set a non-empty `model:` — for 'main' entries this pins the "
-                "engine/parameters template or enables self-check rails."
-            ) from exc
+            raise ValueError("Guardrails config has a model entry with a missing `model` name.") from exc
         raise
     stripped: list[Model] = []
     main_template: Model | None = None

--- a/plugins/nemo-guardrails/tests/integration/test_middleware_config_caching.py
+++ b/plugins/nemo-guardrails/tests/integration/test_middleware_config_caching.py
@@ -45,7 +45,6 @@ class TestMiddlewareConfigCaching:
                 {
                     "type": "main",
                     "engine": "nim",
-                    "model": "rail-main-placeholder",
                     "parameters": {"base_url": main_base_url},
                 }
             ],

--- a/plugins/nemo-guardrails/tests/integration/test_self_check_rails.py
+++ b/plugins/nemo-guardrails/tests/integration/test_self_check_rails.py
@@ -101,7 +101,6 @@ class TestSelfCheck:
                 {
                     "type": "main",
                     "engine": "nim",
-                    "model": "rail-main-placeholder",
                     "parameters": {"base_url": main_base_url},
                 }
             )

--- a/plugins/nemo-guardrails/tests/unit/test_llmrails_cache.py
+++ b/plugins/nemo-guardrails/tests/unit/test_llmrails_cache.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from nemo_guardrails_plugin.llmrails_cache import (
+    MAIN_MODEL_REQUEST_PLACEHOLDER,
     PROVENANCE_HISTORY_LEN,
     EntityGuardrailConfigSource,
     InlineGuardrailConfigSource,
@@ -34,8 +35,8 @@ from nemo_guardrails_plugin.llmrails_cache import (
     Provenance,
     StabilizedRailsConfigCache,
     StableRailsConfig,
+    _fill_main_model_placeholder,
     _is_missing_model_name_error,
-    _is_stub_main_entry,
     _resolve_model_target,
     extract_output_rails_streaming_config,
     provenance_of,
@@ -503,18 +504,30 @@ class TestStabilizeMainModelTemplate:
             stabilize(rails, _resolve_target)
 
 
-class TestStabilizeStubMainStripping:
-    """Stub ``main`` entries — ``{"type": "main", ...}`` with no model
-    name in any location — are dropped at the platform→library boundary
-    so the upstream ``Model.model_must_be_none_empty`` validator (in
-    nemoguardrails 0.21.0+) doesn't fail otherwise-valid configs. Under
-    the IGW Plugin architecture, IGW owns main-LLM routing per request,
-    so these entries carry no information once stored.
-    """
+class TestStabilizeNamelessMainTemplate:
+    """A ``main`` entry with no ``model`` name is still kept as
+    ``main_model_template`` after stabilization, not dropped."""
 
-    def test_stub_main_with_no_model_field_is_dropped(self) -> None:
-        """``{"type": "main", "engine": "nim"}`` with no ``model`` field
-        must stabilize cleanly. This is the user-visible bug the strip fixes."""
+    def test_nameless_main_with_base_url_is_kept_as_template(self) -> None:
+        """The regression case: a ``main`` entry with no ``model`` but a
+        populated ``parameters`` must survive as ``main_model_template`` instead
+        of being dropped (which would silently discard the ``base_url``)."""
+        rails = _platform_rails(
+            models=[
+                {"type": "main", "engine": "nim", "parameters": {"base_url": "https://rails.example.com"}},
+                {"type": "content_safety", "engine": "nim", "model": "default/safety"},
+            ]
+        )
+        stable = stabilize(rails, _resolve_target)
+        assert stable.main_model_template is not None
+        assert stable.main_model_template.engine == "nim"
+        assert stable.main_model_template.parameters["base_url"] == "https://rails.example.com"
+        assert {m.type for m in stable.rails.models} == {"content_safety"}
+
+    def test_nameless_main_with_no_content_is_still_kept_as_template(self) -> None:
+        """Even a fully empty ``{"type": "main", "engine": "nim"}`` becomes
+        a template (not ``None``) — harmless, since :func:`rails.build_main_llm`
+        falls back to the same defaults either way."""
         rails = _platform_rails(
             models=[
                 {"type": "main", "engine": "nim"},
@@ -522,7 +535,8 @@ class TestStabilizeStubMainStripping:
             ]
         )
         stable = stabilize(rails, _resolve_target)
-        assert stable.main_model_template is None
+        assert stable.main_model_template is not None
+        assert stable.main_model_template.engine == "nim"
         assert {m.type for m in stable.rails.models} == {"content_safety"}
 
     @pytest.mark.parametrize(
@@ -530,55 +544,25 @@ class TestStabilizeStubMainStripping:
         [None, "", "   "],
         ids=["none", "empty_string", "whitespace_only"],
     )
-    def test_stub_main_with_empty_model_field_is_dropped(self, model_value: str | None) -> None:
+    def test_nameless_main_wire_shapes_are_all_kept(self, model_value: str | None) -> None:
         """Pin the equivalence of all "missing model name" wire shapes:
         absent, explicit None, empty string, whitespace-only string. All
-        four should drop without erroring."""
+        four must get a placeholder filled in and stabilize without
+        erroring."""
         rails = _platform_rails(
             models=[{"type": "main", "engine": "nim", "model": model_value}],
         )
         stable = stabilize(rails, _resolve_target)
-        assert stable.main_model_template is None
+        assert stable.main_model_template is not None
         assert stable.rails.models == []
 
-    @pytest.mark.parametrize(
-        "params",
-        [
-            {},
-            {"model": ""},
-            {"model_name": ""},
-            {"model": None, "model_name": None},
-        ],
-        ids=[
-            "empty_params",
-            "empty_model_in_params",
-            "empty_model_name_in_params",
-            "explicit_none_in_params",
-        ],
-    )
-    def test_stub_main_with_empty_parameters_is_dropped(self, params: dict[str, Any]) -> None:
-        """``parameters.model`` and ``parameters.model_name`` are upstream's
-        alternate locations for the model name. A main entry where every
-        location is empty/missing is still a stub and gets dropped."""
-        rails = _platform_rails(
-            models=[{"type": "main", "engine": "nim", "parameters": params}],
-        )
-        stable = stabilize(rails, _resolve_target)
-        assert stable.main_model_template is None
-        assert stable.rails.models == []
-
-    def test_named_main_in_parameters_survives_filter(self) -> None:
-        """A main entry whose model name lives in ``parameters.model_name``
-        is *not* a stub. The upstream pre-validator lifts it into the
-        ``model`` field; we keep it as ``main_model_template``.
-        """
+    def test_top_level_model_is_the_only_recognized_name_location(self) -> None:
+        """Only the top-level ``model`` field counts as "named". A ``main``
+        entry naming its model via ``model:`` directly passes through
+        unchanged and keeps that name."""
         rails = _platform_rails(
             models=[
-                {
-                    "type": "main",
-                    "engine": "nim",
-                    "parameters": {"model_name": "ws/llama"},
-                }
+                {"type": "main", "engine": "nim", "model": "ws/llama"},
             ]
         )
         stable = stabilize(rails, _resolve_target)
@@ -586,9 +570,10 @@ class TestStabilizeStubMainStripping:
         assert stable.main_model_template.engine == "nim"
         assert stable.main_model_template.model == "ws/llama"
 
-    def test_stub_main_alongside_named_main_keeps_named(self) -> None:
-        """Mixed config: stub main + named main. Stub gets dropped before
-        duplicate-detection, so the named main flows through normally."""
+    def test_nameless_main_alongside_named_main_raises(self) -> None:
+        """Two ``main`` entries — nameless or not — still trip the
+        at-most-one-main invariant; filling in a placeholder doesn't change
+        duplicate detection."""
         rails = _platform_rails(
             models=[
                 {"type": "main", "engine": "nim"},
@@ -596,67 +581,41 @@ class TestStabilizeStubMainStripping:
                 {"type": "content_safety", "engine": "nim", "model": "default/safety"},
             ]
         )
-        stable = stabilize(rails, _resolve_target)
-        assert stable.main_model_template is not None
-        assert stable.main_model_template.engine == "openai"
-        assert stable.main_model_template.model == "ws/llama"
-        assert {m.type for m in stable.rails.models} == {"content_safety"}
+        with pytest.raises(ValueError, match="at most one 'main' model"):
+            stabilize(rails, _resolve_target)
 
-    def test_dropped_stub_preserves_content_hash(self) -> None:
-        """The strip is observationally invisible to cache identity:
-        a config with a stub main hashes the same as the same config
-        without the stub. Cross-source determinism depends on this — two
-        callers that supplied the same task-LLM config but differed only
-        in whether they kept a stub main entry must share a pool.
+    def test_nameless_main_never_affects_content_hash(self) -> None:
+        """``main`` entries are pulled out of the hashed model list
+        regardless of whether they name a model, so two configs that
+        differ only in a nameless ``main`` entry's presence must share a
+        cache key.
         """
-        with_stub = _platform_rails(
+        with_nameless_main = _platform_rails(
             models=[
-                {"type": "main", "engine": "nim"},
+                {"type": "main", "engine": "nim", "parameters": {"base_url": "https://rails.example.com"}},
                 {"type": "content_safety", "engine": "nim", "model": "default/safety"},
             ]
         )
         without_main = _platform_rails(models=[{"type": "content_safety", "engine": "nim", "model": "default/safety"}])
         assert (
-            stabilize(with_stub, _resolve_target).content_hash == stabilize(without_main, _resolve_target).content_hash
+            stabilize(with_nameless_main, _resolve_target).content_hash
+            == stabilize(without_main, _resolve_target).content_hash
         )
 
-    def test_dropped_stub_emits_info_log(self, caplog: pytest.LogCaptureFixture) -> None:
-        """The drop is silent in error semantics but visible in logs so
-        operators investigating "why did my main model not engage?" find
-        a one-line breadcrumb pointing at the IGW contract."""
-        rails = _platform_rails(
-            models=[
-                {"type": "main", "engine": "nim"},
-                {"type": "content_safety", "engine": "nim", "model": "default/safety"},
-            ]
-        )
-        with caplog.at_level("INFO", logger="nemo_guardrails_plugin.llmrails_cache"):
-            stabilize(rails, _resolve_target)
-        infos = [r for r in caplog.records if r.levelname == "INFO"]
-        assert any("stub 'main' model" in r.getMessage() for r in infos)
+    def test_fill_placeholder_only_touches_nameless_main_entries(self) -> None:
+        """:func:`_fill_main_model_placeholder` passes non-``main`` entries
+        and already-named ``main`` entries through unchanged, and only
+        fills in a model on genuinely nameless ``main`` entries."""
+        content_safety = {"type": "content_safety", "engine": "nim"}
+        named_main = {"type": "main", "engine": "nim", "model": "ws/llama"}
+        nameless_main = {"type": "main", "engine": "nim"}
 
-    def test_no_log_when_no_stub_present(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Don't emit the stub-drop log on configs that had no stubs to begin with."""
-        rails = _platform_rails(models=[{"type": "content_safety", "engine": "nim", "model": "default/safety"}])
-        with caplog.at_level("INFO", logger="nemo_guardrails_plugin.llmrails_cache"):
-            stabilize(rails, _resolve_target)
-        assert not any("stub 'main' model" in r.getMessage() for r in caplog.records)
-
-    def test_predicate_treats_non_string_model_as_non_stub(self) -> None:
-        """Type mismatches (``{"model": 123}``) are *not* stubs — we let
-        the upstream type validator emit a precise error rather than
-        silently swallow the typo. Tested at the predicate level because
-        the platform-side wire schema (``Model.model: str | None``) would
-        reject this before ``stabilize`` runs in production."""
-        assert _is_stub_main_entry({"type": "main", "model": 123}) is False
-        assert _is_stub_main_entry({"type": "main", "parameters": {"model_name": 42}}) is False
-
-    def test_predicate_only_matches_main_type(self) -> None:
-        """Empty-name entries on non-main types are *not* stubs — they
-        should surface as validation errors via the upstream Model
-        validator, not be silently dropped."""
-        assert _is_stub_main_entry({"type": "content_safety", "engine": "nim"}) is False
-        assert _is_stub_main_entry({"type": "embeddings", "model": ""}) is False
+        assert _fill_main_model_placeholder(content_safety) == content_safety
+        assert _fill_main_model_placeholder(named_main) == named_main
+        assert _fill_main_model_placeholder(nameless_main) == {
+            **nameless_main,
+            "model": MAIN_MODEL_REQUEST_PLACEHOLDER,
+        }
 
 
 class TestStabilizeMissingModelNameWrapping:
@@ -665,10 +624,10 @@ class TestStabilizeMissingModelNameWrapping:
     message with an IGW-aware diagnostic so the 400 reaching the client
     tells the user what's actually wrong.
 
-    The stub filter catches all current-known main-stub shapes, so this
-    wrap rarely fires in practice. It exists to keep the user-facing
-    error message accurate across upstream version changes that might
-    surface missing-model-name errors through different code paths.
+    ``main`` entries always get a placeholder filled in before validation
+    (see :func:`_fill_main_model_placeholder`), so in practice this only
+    fires for non-``main`` entries (content-safety, topic-control, etc.)
+    that genuinely omit ``model``.
     """
 
     def test_recognizes_missing_model_name_error(self) -> None:

--- a/plugins/nemo-guardrails/tests/unit/test_llmrails_cache.py
+++ b/plugins/nemo-guardrails/tests/unit/test_llmrails_cache.py
@@ -556,15 +556,21 @@ class TestStabilizeNamelessMainTemplate:
         assert stable.main_model_template is not None
         assert stable.rails.models == []
 
-    def test_top_level_model_is_the_only_recognized_name_location(self) -> None:
-        """Only the top-level ``model`` field counts as "named". A ``main``
-        entry naming its model via ``model:`` directly passes through
-        unchanged and keeps that name."""
-        rails = _platform_rails(
-            models=[
-                {"type": "main", "engine": "nim", "model": "ws/llama"},
-            ]
-        )
+    @pytest.mark.parametrize(
+        "models",
+        [
+            [{"type": "main", "engine": "nim", "model": "ws/llama"}],
+            [{"type": "main", "engine": "nim", "parameters": {"model": "ws/llama"}}],
+            [{"type": "main", "engine": "nim", "parameters": {"model_name": "ws/llama"}}],
+        ],
+        ids=["top_level_model", "parameters_model", "parameters_model_name"],
+    )
+    def test_named_main_keeps_library_recognized_name(self, models: list[dict[str, Any]]) -> None:
+        """A ``main`` entry already named via any library-honoured location
+        (top-level ``model``, ``parameters.model``, or ``parameters.model_name``)
+        must not get a placeholder filled in — the upstream validator rejects
+        dual specification — and must keep that name after stabilize."""
+        rails = _platform_rails(models=models)
         stable = stabilize(rails, _resolve_target)
         assert stable.main_model_template is not None
         assert stable.main_model_template.engine == "nim"
@@ -604,14 +610,27 @@ class TestStabilizeNamelessMainTemplate:
 
     def test_fill_placeholder_only_touches_nameless_main_entries(self) -> None:
         """:func:`_fill_main_model_placeholder` passes non-``main`` entries
-        and already-named ``main`` entries through unchanged, and only
-        fills in a model on genuinely nameless ``main`` entries."""
+        and already-named ``main`` entries through unchanged (including names
+        under ``parameters.model`` / ``parameters.model_name``), and only fills
+        in a model on genuinely nameless ``main`` entries."""
         content_safety = {"type": "content_safety", "engine": "nim"}
         named_main = {"type": "main", "engine": "nim", "model": "ws/llama"}
+        named_via_parameters_model = {
+            "type": "main",
+            "engine": "nim",
+            "parameters": {"model": "ws/llama", "base_url": "https://rails.example.com"},
+        }
+        named_via_parameters_model_name = {
+            "type": "main",
+            "engine": "nim",
+            "parameters": {"model_name": "ws/llama"},
+        }
         nameless_main = {"type": "main", "engine": "nim"}
 
         assert _fill_main_model_placeholder(content_safety) == content_safety
         assert _fill_main_model_placeholder(named_main) == named_main
+        assert _fill_main_model_placeholder(named_via_parameters_model) == named_via_parameters_model
+        assert _fill_main_model_placeholder(named_via_parameters_model_name) == named_via_parameters_model_name
         assert _fill_main_model_placeholder(nameless_main) == {
             **nameless_main,
             "model": MAIN_MODEL_REQUEST_PLACEHOLDER,


### PR DESCRIPTION
## Summary

Fixes a bug where a guardrail config's `main` model entry was silently dropped if it didn't specify a `model` name, even when it set other fields like `parameters.base_url` to point the main LLM at a custom
endpoint.

This addresses an edge case for configs relying on custom base URLs: requests would fail with a 503 "Failed to run input rails" instead of routing requests to the configured URL.

## Root cause

Under the IGW Plugin model, a `main` entry's `model` name is never actually used; the real model always comes from the request body (see `rails.build_main_llm`). To avoid tripping nemoguardrails' `Model` validator (which requires a non-empty `model` on every entry), `stabilize()` used to strip out any `main` entry that didn't name a
model in `model`, `parameters.model`, or `parameters.model_name`, including ones that only existed to pin `engine`/`parameters.base_url`. Stripping those entries silently discarded the `parameters.base_url` override.

## Fix

Instead of dropping nameless `main` entries, `stabilize()` now fills in a placeholder (`MAIN_MODEL_REQUEST_PLACEHOLDER = "<request>"`) on the `model` field before handing the config to the upstream validator. The entry (with its real `engine`/`parameters`) is kept and surfaced as `main_model_template`, and the placeholder itself is never used for an actual call. `build_main_llm` still populates the real model name from the incoming request body.

**NOTE:** Only the top-level `model` field is treated as canonical for naming a `main` entry going forward. The code previously supported alternative ways of populating the model `parameters.model` / `parameters.model_name`, but
these were an artifact of the legacy codebase and were never documented or formally supported, so I removed support for these.

## Testing

- Added/updated unit tests in `test_llmrails_cache.py` covering: a
  nameless `main` entry with only `base_url` surviving as
  `main_model_template`, all "missing model name" wire shapes (absent,
  `None`, empty string, whitespace), duplicate-`main` detection, and
  content-hash stability.
- Removed a pre-existing `"model": "rail-main-placeholder"` workaround
  from `test_self_check_rails.py` and `test_middleware_config_caching.py`.
  Both configs only set `parameters.base_url` on their `main` entry,
  so they now exercise the real fix end-to-end instead of masking the
  underlying bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Guardrails configurations where the `main` entry omits a model name, ensuring it’s retained and normalized using a request placeholder during validation.
  * Preserved `main` templates and non-model overrides (such as connection/base URL settings) instead of dropping nameless `main` entries.
  * Aligned missing-model-name validation and error messaging with the updated normalization flow.
  * Kept middleware config caching behavior consistent, including entity-backed updates and duplicate `main` detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->