### PR TITLE
fix(auth): seed Authentik blueprint before compose gateway

### DIFF
--- a/contrib/auth/authentik/compose/docker-compose.yml
+++ b/contrib/auth/authentik/compose/docker-compose.yml
@@ -58,6 +58,8 @@ services:
     depends_on:
       gateway-tls-init:
         condition: service_completed_successfully
+      authentik-blueprint-init:
+        condition: service_completed_successfully
       nemo:
         condition: service_healthy
     networks:
@@ -123,7 +125,6 @@ services:
     command: server
     environment: *authentik-env
     volumes:
-      - ${AUTHENTIK_BLUEPRINT_DIR:-../helm/files/blueprints}:/blueprints/custom:ro
       - authentik-media:/media
     depends_on:
       authentik-postgres:
@@ -139,12 +140,43 @@ services:
     command: worker
     environment: *authentik-env
     volumes:
-      - ${AUTHENTIK_BLUEPRINT_DIR:-../helm/files/blueprints}:/blueprints/custom:ro
       - authentik-media:/media
     depends_on:
       authentik-postgres:
         condition: service_healthy
       authentik-redis:
+        condition: service_healthy
+    networks:
+      - nemo-internal
+
+  authentik-blueprint-init:
+    image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2024.12}
+    # Authentik health can be reported before default blueprints finish, while
+    # nemo.yaml depends on their built-in provider flows and scope mappings.
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        attempt=1
+        while [ "$$attempt" -le 30 ]; do
+          if ak apply_blueprint /blueprints/custom/nemo.yaml; then
+            exit 0
+          fi
+          if [ "$$attempt" -eq 30 ]; then
+            exit 1
+          fi
+          echo "Waiting for Authentik default blueprints before applying NeMo blueprint (attempt $$attempt/30)"
+          attempt=$$((attempt + 1))
+          sleep 2
+        done
+    environment: *authentik-env
+    volumes:
+      - ${AUTHENTIK_BLUEPRINT_DIR:-../helm/files/blueprints}:/blueprints/custom:ro
+      - authentik-media:/media
+    depends_on:
+      authentik-server:
+        condition: service_healthy
+      authentik-worker:
         condition: service_healthy
     networks:
       - nemo-internal

--- a/contrib/auth/authentik/compose/implementation-details.md
+++ b/contrib/auth/authentik/compose/implementation-details.md
@@ -17,7 +17,7 @@ the parent directory:
 
 - `../config/platform-compose-authentik.yaml` as the NeMo Platform config.
 - `../gateway/envoy.yaml` as the local gateway config.
-- `../helm/files/blueprints` as Authentik's custom blueprint directory.
+- `../helm/files/blueprints` as the |product-name| blueprint source.
 - `../.generated` for local generated keys and certificates.
 
 The shared tutorial does not build NeMo images for Compose. It runs
@@ -33,6 +33,8 @@ The stack contains:
 - `gateway`: Envoy terminating local HTTPS on host port `18080`.
 - `gateway-tls-init`: a small init container that copies local TLS material into
   the named `gateway-tls` volume with permissions suitable for Envoy.
+- `authentik-blueprint-init`: a one-shot init container that applies the shared
+  |product-name| blueprint before the gateway starts.
 - `authentik-postgres`: PostgreSQL for Authentik.
 - `authentik-redis`: Redis for Authentik.
 - `authentik-server` and `authentik-worker`: Authentik itself.
@@ -68,10 +70,15 @@ only.
 
 ## Authentik Blueprint
 
-Compose mounts the shared blueprint directory
-`../helm/files/blueprints` directly into Authentik at `/blueprints/custom`.
-Authentik applies `nemo.yaml` from that directory to create the demo OIDC
-providers, demo user, demo groups, workload identity, and E2E setup identity.
+Compose applies the shared `../helm/files/blueprints/nemo.yaml` file with the
+one-shot `authentik-blueprint-init` service. The gateway depends on that init
+service, so `/health/gateway/ready` is checked only after the demo OIDC
+providers, demo user, demo groups, workload identity, and E2E setup identity
+have been seeded.
+
+The init service retries blueprint application for up to about a minute because
+Authentik can report healthy before its built-in default blueprints have created
+the provider flows and OAuth scope mappings referenced by the shared blueprint.
 
 The blueprint reads `AUTHENTIK_WORKLOAD_IDENTITY_PASSWORD` when creating the
 `svc-nemo` app-password token. Compose provides a local-development default,

--- a/tests/auth_idp/static/test_provider_layout.py
+++ b/tests/auth_idp/static/test_provider_layout.py
@@ -66,8 +66,21 @@ def test_authentik_compose_defaults_support_direct_docker_compose_start():
         "${AUTHENTIK_GATEWAY_TLS_DIR:-../.generated/gateway-tls}:/source/tls:ro"
         in compose["services"]["gateway-tls-init"]["volumes"]
     )
-    assert blueprint_mount in compose["services"]["authentik-server"]["volumes"]
-    assert blueprint_mount in compose["services"]["authentik-worker"]["volumes"]
+    assert blueprint_mount not in compose["services"]["authentik-server"]["volumes"]
+    assert blueprint_mount not in compose["services"]["authentik-worker"]["volumes"]
+    blueprint_init = compose["services"]["authentik-blueprint-init"]
+    assert blueprint_init["image"] == "ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2024.12}"
+    assert blueprint_init["environment"] == compose["x-authentik-env"]
+    assert blueprint_mount in blueprint_init["volumes"]
+    assert blueprint_init["depends_on"]["authentik-server"]["condition"] == "service_healthy"
+    assert blueprint_init["depends_on"]["authentik-worker"]["condition"] == "service_healthy"
+    assert blueprint_init["entrypoint"][:2] == ["sh", "-euc"]
+    blueprint_script = blueprint_init["entrypoint"][2]
+    assert "ak apply_blueprint /blueprints/custom/nemo.yaml" in blueprint_script
+    assert 'while [ "$$attempt" -le 30 ]' in blueprint_script
+    assert "attempt $$attempt/30" in blueprint_script
+    assert "attempt=$$((attempt + 1))" in blueprint_script
+    assert "sleep 2" in blueprint_script
     assert "./.generated/blueprints" not in compose_text
 
 
@@ -162,6 +175,7 @@ def test_authentik_compose_uses_https_gateway_for_workloads():
     nemo = compose["services"]["nemo"]
     gateway = compose["services"]["gateway"]
     gateway_tls_init = compose["services"]["gateway-tls-init"]
+    blueprint_init = compose["services"]["authentik-blueprint-init"]
 
     assert config["platform"]["base_url"] == "https://nemo-gateway:8080"
     assert config["auth"]["policy_decision_point_base_url"] == "http://127.0.0.1:8080"
@@ -188,7 +202,9 @@ def test_authentik_compose_uses_https_gateway_for_workloads():
     assert gateway["networks"]["nemo-internal"]["aliases"] == ["nemo-gateway"]
     assert gateway["networks"]["workload"]["aliases"] == ["nemo-gateway"]
     assert gateway["depends_on"]["gateway-tls-init"]["condition"] == "service_completed_successfully"
+    assert gateway["depends_on"]["authentik-blueprint-init"]["condition"] == "service_completed_successfully"
     assert "gateway-tls:/etc/envoy/tls:ro" in gateway["volumes"]
+    assert blueprint_init["networks"] == ["nemo-internal"]
     assert gateway_tls_init["image"] == (
         "docker.io/library/busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"
     )


### PR DESCRIPTION
## Summary

Fix the Authentik Compose startup races seen while validating #631:

- Apply `contrib/auth/authentik/helm/files/blueprints/nemo.yaml` with a dedicated one-shot `authentik-blueprint-init` service instead of relying on Authentik custom blueprint auto-discovery from the long-running server/worker containers.
- Gate Envoy startup on `authentik-blueprint-init` completing successfully, so `/health/gateway/ready` is not polled until the NeMo Authentik applications/providers/users are seeded.
- Keep a bounded retry around `ak apply_blueprint` because Authentik can report server/worker health before its built-in default blueprints have created the provider flows and OAuth scope mappings referenced by `nemo.yaml`.
- Update the Compose implementation notes and static layout assertions to match.

## CI Failures

- `29758464168` / `88408033334`: gateway readiness returned HTTP 503 because Envoy saw Authentik return 404 for `/application/o/nemo/.well-known/openid-configuration` during startup.
- `29762432224` / `88421559941`: after simplifying the init service to one direct `ak apply_blueprint` call, `authentik-blueprint-init` exited 1 with blueprint validation errors for missing default provider flows and OAuth scope mappings. That confirmed Authentik container health alone is not a sufficient gate.

## Testing

- `docker compose -f contrib/auth/authentik/compose/docker-compose.yml config --quiet`
- `git diff --check`
- `uv run --frozen pytest tests/auth_idp/static/test_provider_layout.py tests/auth_idp/static/test_docs_links.py -q`
- Targeted Compose startup for `authentik-blueprint-init` with `--exit-code-from authentik-blueprint-init` exited 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an initialization step that applies the shared Authentik blueprint automatically.
  * Gateway readiness now waits until blueprint setup completes successfully.
  * Blueprint setup retries automatically when Authentik is still initializing.

* **Documentation**
  * Updated Compose implementation guidance to describe the new blueprint setup flow.

* **Tests**
  * Added coverage for initialization, service readiness dependencies, networking, and blueprint mounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->