### PR TITLE
fix(agents): resolve default model in SDK-created agents

### DIFF
--- a/docs/agents/deploy-agents.mdx
+++ b/docs/agents/deploy-agents.mdx
@@ -323,8 +323,10 @@ conventions apply to the agent's workflow YAML:
   credentials.
 - **Reference models by their Inference Gateway entity name**, with slashes and
   dots converted to hyphens (`meta/llama-3.1-8b-instruct` becomes
-  `default/meta-llama-3-1-8b-instruct`). Use `${NEMO_DEFAULT_MODEL}` to defer to
-  the platform's configured default model.
+  `default/meta-llama-3-1-8b-instruct`). Use `${NEMO_DEFAULT_MODEL}` in agent
+  config files to defer to the SDK or CLI context's configured default model at
+  agent registration time. If you call the REST API directly, replace the
+  placeholder with an explicit VirtualModel name before creating the agent.
 
 To make an external model available to the agent, register a provider first —
 see [Deploy Models](/documentation/models-and-inference/tutorials/deploy-models#add-external-providers)

--- a/docs/requirements.mdx
+++ b/docs/requirements.mdx
@@ -2,9 +2,13 @@
 title: "Hardware and Software Requirements for NeMo Platform"
 description: ""
 ---
-This page lists the requirements for the OSS local-install path and self-managed Kubernetes path for NeMo Platform 0.3.0. For the full compatibility table, see the [Support Matrix](/documentation/reference/support-matrix).
 
-The OSS 0.3.0 documentation covers local setup with the Python package and `nemo setup`, plus self-managed Kubernetes deployment with Helm. Docker Compose deployment guides are not part of this release scope.
+This page lists the requirements for the OSS local-install path and
+self-managed Kubernetes deployments. For the full compatibility table, see the
+[Support Matrix](/documentation/reference/support-matrix).
+
+For local setup, use the Python package and `nemo setup`. For self-managed
+clusters, use the NeMo Platform Helm chart on Kubernetes.
 
 ## Local Setup Requirements
 
@@ -19,15 +23,14 @@ The OSS 0.3.0 documentation covers local setup with the Python package and `nemo
 | Model provider | NVIDIA Build, OpenAI, Anthropic, Google Gemini, Ollama, or a custom OpenAI-compatible endpoint | `nemo setup` configures one provider as part of the setup flow. |
 | Browser | Current Chrome, Edge, Firefox, or Safari | Required for the Studio UI. |
 
-## Kubernetes Requirements
+## Self-Managed Kubernetes Requirements
 
 | Component | Requirement | Notes |
 |-----------|-------------|-------|
-| Kubernetes | User-managed conformant cluster | You need permission to create namespaces, secrets, services, deployments, jobs, and persistent volumes. |
-| Helm | Helm 3 | Used to install and upgrade the NeMo Platform chart. |
-| kubectl | Version compatible with your cluster | Used for deployment verification, log collection, and local Kind workflows. |
-| Storage | Dynamic persistent volume provisioning | Required for platform state and job artifacts. |
-| Ingress or port forwarding | Cluster ingress controller or `kubectl port-forward` | Required to reach the API and Studio UI from your workstation. |
+| Kubernetes | minikube, kind, EKS, AKS, GKE, OKE, OpenShift, or on-prem Kubernetes | Use a cluster with storage, networking, and image-pull access configured before installing the chart. |
+| Helm | Helm 3 | Required to install and upgrade the NeMo Platform chart. |
+| Storage | ReadWriteMany-capable persistent storage | Required for shared files and job storage in multi-pod deployments. |
+| Image access | NGC credentials and Kubernetes image pull secrets | Required to pull NeMo Platform container images. |
 
 ## GPU Requirements
 

--- a/docs/support-matrix.mdx
+++ b/docs/support-matrix.mdx
@@ -2,21 +2,22 @@
 title: "Support Matrix"
 description: ""
 ---
-This matrix defines the supported OSS targets for NeMo Platform 0.3.0. It applies to the Python package, CLI, SDK, local services started by `nemo setup`, and self-managed Kubernetes deployments documented for this release.
 
-Helm and Kubernetes deployment paths are documented for self-managed clusters, including OpenShift-specific notes. Docker Compose deployment guides are not part of the OSS 0.3.0 documentation scope.
+This matrix defines the supported OSS targets for NeMo Platform. It covers the
+Python package, CLI, SDK, local services started by `nemo setup`, and
+self-managed Kubernetes deployments installed with the NeMo Platform Helm chart.
 
 ## Host Platforms
 
 | Area | Supported | Notes |
 |------|-----------|-------|
-| Deployment mode | `nemo setup` local install; self-managed Helm/Kubernetes | Setup starts local services, registers a model provider, and configures the CLI and SDK. Helm deploys platform services to a user-managed Kubernetes cluster. |
+| Deployment mode | `nemo setup` local install; Helm chart on Kubernetes | `nemo setup` starts local services, registers a model provider, and configures the CLI and SDK. The Helm chart is the supported path for self-managed Kubernetes clusters. |
 | Python | 3.11, 3.12, 3.13, 3.14 (`>=3.11,<3.15`) | Use an isolated virtual environment. On Python 3.14, prefix `pip install "nemo-platform[all]"` with `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` while the transitive `litellm` Rust extension catches up to Python 3.14. Python 3.11 is the lowest supported Python version and Python 3.14 is the highest supported Python version for the OSS local install path. |
 | Linux | Ubuntu 22.04 LTS, Ubuntu 24.04 LTS, RHEL 9, Rocky Linux 9, Debian 12 | Supported for CLI, SDK, local services, and NVIDIA GPU workloads. |
 | macOS | [macOS Tahoe 26](https://support.apple.com/en-us/122868) and macOS Sequoia 15 | Supported for CLI, SDK, local services, and cloud/provider workflows. Local NVIDIA GPU workloads are not supported on macOS. |
 | Architecture | x86_64 Linux; Apple Silicon and Intel macOS | NVIDIA GPU workloads require x86_64 Linux. |
-| Windows and WSL | Not in the OSS 0.3.0 support matrix | Use a supported Linux or macOS host for the local install path. |
-| Kubernetes | User-managed clusters with Helm | Use a conformant Kubernetes cluster where you can create namespaces, secrets, services, deployments, jobs, and persistent volumes. Kind is suitable for local development and smoke tests. |
+| Windows and WSL | Not supported for the OSS local install path | Use a supported Linux or macOS host for the local install path. |
+| Kubernetes clusters | minikube, kind, EKS, AKS, GKE, OKE, OpenShift, and on-prem Kubernetes | See [Install NeMo Platform with Helm](/documentation/self-managed-deployment/helm) for prerequisites and cluster-specific notes. |
 
 ## Local Runtime
 
@@ -56,7 +57,7 @@ Helm and Kubernetes deployment paths are documented for self-managed clusters, i
 
 ## Out of Scope
 
-The following are not part of the OSS 0.3.0 support matrix:
+The following are not part of the OSS support matrix:
 
 - Native Windows local install.
 - Docker Compose deployment guides.

--- a/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
@@ -33,6 +33,7 @@ Usage (once the SDK hub is wired up)::
 
 from __future__ import annotations
 
+import re
 from typing import Any, List
 
 import httpx
@@ -40,6 +41,19 @@ from nemo_platform_plugin.sdk import NemoPluginSDKResources
 
 _DEFAULT_WORKSPACE = "default"
 _DEFAULT_TIMEOUT = 30
+_DEFAULT_MODEL_PLACEHOLDER = re.compile(r"\$(?:\{NEMO_DEFAULT_MODEL\}|NEMO_DEFAULT_MODEL(?![A-Za-z0-9_]))")
+
+
+def _contains_default_model_placeholder(value: Any) -> bool:
+    """Return True when *value* still contains an unresolved default-model placeholder."""
+    if isinstance(value, str):
+        protected = value.replace("$$", "\0DOLLAR\0")
+        return _DEFAULT_MODEL_PLACEHOLDER.search(protected) is not None
+    if isinstance(value, dict):
+        return any(_contains_default_model_placeholder(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_contains_default_model_placeholder(v) for v in value)
+    return False
 
 
 class AgentsResource:
@@ -65,7 +79,7 @@ class AgentsResource:
         config: dict[str, Any],
         description: str = "",
         config_format: str = "nat-workflow-v1",
-        workspace: str = _DEFAULT_WORKSPACE,
+        workspace: str | None = None,
     ) -> dict[str, Any]:
         """Create a new agent.
 
@@ -74,30 +88,41 @@ class AgentsResource:
             config: NAT workflow config dict.
             description: Optional human-readable description.
             config_format: Config format identifier (default: ``"nat-workflow-v1"``).
-            workspace: Target workspace.
+            workspace: Target workspace. Defaults to the workspace configured
+                on the platform client, or ``"default"`` when the client has no
+                workspace.
 
         Returns:
             The created agent as a dict.
         """
+        from nemo_agents_plugin.utils import inject_default_model
+
+        resolved_config = inject_default_model(config)
+        if _contains_default_model_placeholder(resolved_config):
+            raise ValueError(
+                "Agent config references ${NEMO_DEFAULT_MODEL}, but no default model is selected. "
+                "Run `nemo setup`, set NEMO_DEFAULT_MODEL, or replace the placeholder with an explicit "
+                "VirtualModel name."
+            )
         payload = {
             "name": name,
-            "config": config,
+            "config": resolved_config,
             "description": description,
             "config_format": config_format,
         }
-        return self._post(f"/v2/workspaces/{workspace}/agents", payload)
+        return self._post(f"/v2/workspaces/{self._workspace(workspace)}/agents", payload)
 
-    def list(self, workspace: str = _DEFAULT_WORKSPACE) -> List[dict[str, Any]]:
+    def list(self, workspace: str | None = None) -> List[dict[str, Any]]:
         """List agents in *workspace*."""
-        return self._get(f"/v2/workspaces/{workspace}/agents")
+        return self._get(f"/v2/workspaces/{self._workspace(workspace)}/agents")
 
-    def get(self, name: str, workspace: str = _DEFAULT_WORKSPACE) -> dict[str, Any]:
+    def get(self, name: str, workspace: str | None = None) -> dict[str, Any]:
         """Get an agent by name."""
-        return self._get(f"/v2/workspaces/{workspace}/agents/{name}")
+        return self._get(f"/v2/workspaces/{self._workspace(workspace)}/agents/{name}")
 
-    def delete(self, name: str, workspace: str = _DEFAULT_WORKSPACE) -> None:
+    def delete(self, name: str, workspace: str | None = None) -> None:
         """Delete an agent by name."""
-        self._delete(f"/v2/workspaces/{workspace}/agents/{name}")
+        self._delete(f"/v2/workspaces/{self._workspace(workspace)}/agents/{name}")
 
     # ------------------------------------------------------------------
     # Deployment sub-resource
@@ -120,7 +145,7 @@ class AgentsResource:
         input: str,
         agent: str | None = None,
         deployment: str | None = None,
-        workspace: str = _DEFAULT_WORKSPACE,
+        workspace: str | None = None,
         timeout: int = 300,
     ) -> dict[str, Any]:
         """Send a single request to an agent via the gateway.
@@ -135,10 +160,11 @@ class AgentsResource:
         Returns:
             The agent's response as a dict.
         """
+        resolved_workspace = self._workspace(workspace)
         if agent:
-            path = f"/v2/workspaces/{workspace}/agents/{agent}/-/v1/chat/completions"
+            path = f"/v2/workspaces/{resolved_workspace}/agents/{agent}/-/v1/chat/completions"
         elif deployment:
-            path = f"/v2/workspaces/{workspace}/deployments/{deployment}/-/v1/chat/completions"
+            path = f"/v2/workspaces/{resolved_workspace}/deployments/{deployment}/-/v1/chat/completions"
         else:
             raise ValueError("Provide either agent= or deployment=.")
 
@@ -154,7 +180,7 @@ class AgentsResource:
         eval_config: str,
         agent: str | None = None,
         endpoint: str | None = None,
-        workspace: str = _DEFAULT_WORKSPACE,
+        workspace: str | None = None,
     ) -> dict[str, Any]:
         """Trigger an evaluation run.
 
@@ -181,6 +207,9 @@ class AgentsResource:
     def _base_url(self) -> str:
         base = getattr(self._platform, "base_url", "http://localhost:8000")
         return str(base).rstrip("/")
+
+    def _workspace(self, workspace: str | None) -> str:
+        return workspace or getattr(self._platform, "workspace", None) or _DEFAULT_WORKSPACE
 
     def _agents_url(self, path: str) -> str:
         return self._base_url() + "/apis/agents" + path
@@ -216,7 +245,7 @@ class _DeploymentResource:
         name: str | None = None,
         deployment_mode: str = "subprocess",
         image: str | None = None,
-        workspace: str = _DEFAULT_WORKSPACE,
+        workspace: str | None = None,
     ) -> dict[str, Any]:
         """Create a deployment for *agent*.
 
@@ -242,19 +271,19 @@ class _DeploymentResource:
             payload["name"] = name
         if image:
             payload["image"] = image
-        return self._parent._post(f"/v2/workspaces/{workspace}/deployments", payload)
+        return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/deployments", payload)
 
-    def list(self, workspace: str = _DEFAULT_WORKSPACE) -> List[dict[str, Any]]:
+    def list(self, workspace: str | None = None) -> List[dict[str, Any]]:
         """List all deployments in *workspace*."""
-        return self._parent._get(f"/v2/workspaces/{workspace}/deployments")
+        return self._parent._get(f"/v2/workspaces/{self._parent._workspace(workspace)}/deployments")
 
-    def get(self, name: str, workspace: str = _DEFAULT_WORKSPACE) -> dict[str, Any]:
+    def get(self, name: str, workspace: str | None = None) -> dict[str, Any]:
         """Get a deployment by name."""
-        return self._parent._get(f"/v2/workspaces/{workspace}/deployments/{name}")
+        return self._parent._get(f"/v2/workspaces/{self._parent._workspace(workspace)}/deployments/{name}")
 
-    def delete(self, name: str, workspace: str = _DEFAULT_WORKSPACE) -> None:
+    def delete(self, name: str, workspace: str | None = None) -> None:
         """Mark a deployment for deletion."""
-        self._parent._delete(f"/v2/workspaces/{workspace}/deployments/{name}")
+        self._parent._delete(f"/v2/workspaces/{self._parent._workspace(workspace)}/deployments/{name}")
 
 
 agents_sdk_resources = NemoPluginSDKResources(sync_resource=AgentsResource)

--- a/plugins/nemo-agents/tests/unit/test_sdk.py
+++ b/plugins/nemo-agents/tests/unit/test_sdk.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from contextlib import AbstractContextManager
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from nemo_agents_plugin.sdk import AgentsResource
+
+
+def _install_mock_transport(handler) -> AbstractContextManager[Any]:
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    return patch("nemo_agents_plugin.sdk.httpx.Client", _factory)
+
+
+def test_create_resolves_default_model_placeholder_before_post() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["path"] = req.url.path
+        captured["body"] = json.loads(req.read())
+        return httpx.Response(201, json={"name": "calc"})
+
+    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    config = {"llms": {"llm": {"_type": "openai", "model_name": "${NEMO_DEFAULT_MODEL}"}}}
+
+    with (
+        _install_mock_transport(handler),
+        patch("nemo_agents_plugin.utils.get_default_model", return_value="team-a/nemotron"),
+    ):
+        result = client.create(name="calc", config=config)
+
+    assert result == {"name": "calc"}
+    assert captured["path"] == "/apis/agents/v2/workspaces/team-a/agents"
+    assert captured["body"]["config"]["llms"]["llm"]["model_name"] == "team-a/nemotron"
+    assert config["llms"]["llm"]["model_name"] == "${NEMO_DEFAULT_MODEL}"
+
+
+def test_create_rejects_unresolved_default_model_placeholder() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        raise AssertionError("should not POST unresolved agent config")
+
+    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    config = {"llms": {"llm": {"_type": "openai", "model_name": "$NEMO_DEFAULT_MODEL"}}}
+
+    with (
+        _install_mock_transport(handler),
+        patch("nemo_agents_plugin.utils.get_default_model", return_value=None),
+        pytest.raises(ValueError, match="NEMO_DEFAULT_MODEL"),
+    ):
+        client.create(name="calc", config=config)
+
+
+def test_deployments_create_uses_client_workspace_by_default() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["path"] = req.url.path
+        captured["body"] = json.loads(req.read())
+        return httpx.Response(201, json={"name": "calc-dep"})
+
+    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+
+    with _install_mock_transport(handler):
+        result = client.deployments.create(agent="calc", deployment_mode="k8s", image="repo/calc:1.0")
+
+    assert result == {"name": "calc-dep"}
+    assert captured["path"] == "/apis/agents/v2/workspaces/team-a/deployments"
+    assert captured["body"] == {"agent": "calc", "deployment_mode": "k8s", "image": "repo/calc:1.0"}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Agent configs can include `${NEMO_DEFAULT_MODEL}`, which is resolved when creating agents via the SDK/CLI.
  - Agent and deployment operations now consistently derive the effective workspace when it’s not explicitly provided.

- **Bug Fixes**
  - Agent creation now fails fast with a clear error when `${NEMO_DEFAULT_MODEL}` cannot be resolved.

- **Documentation**
  - Clarified REST API guidance for substituting the `${NEMO_DEFAULT_MODEL}` placeholder with an explicit VirtualModel name.
  - Updated local-install, self-managed Kubernetes requirements, and broadened the OSS support matrix.

- **Tests**
  - Added unit coverage for default-model resolution, error handling, and workspace URL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->