### PR TITLE
fix(evaluator-sdk): persist metric diagnostics on the success path

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
@@ -538,6 +538,17 @@ async def _score_metric(
         metric_type=metric_type,
         status=AgentEvalScoreStatus.COMPLETED,
         outputs=metric_result.outputs,
+        # Persist the metric's own diagnostics (e.g. per-criterion judge verdicts) — the failure path
+        # already records diagnostics; the success path dropped them.
+        diagnostics=[
+            AgentEvalDiagnostic(
+                severity=AgentEvalDiagnosticSeverity.INFO,
+                message=diagnostic.message,
+                source=metric_type,
+                details=diagnostic.details or {},
+            )
+            for diagnostic in metric_result.diagnostics
+        ],
         metadata={
             "row_index": row_index,
             "trial_metadata": trial.metadata,

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
@@ -16,7 +16,11 @@ from nemo_evaluator_sdk.agent_eval.evaluator import (
     _trial_from_sample,
 )
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalSummary
-from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
+from nemo_evaluator_sdk.agent_eval.scores import (
+    AgentEvalDiagnosticSeverity,
+    AgentEvalScoreStatus,
+    AgentEvalTaskScore,
+)
 from nemo_evaluator_sdk.agent_eval.tasks import (
     AgentEvalRunConfig,
     AgentEvalTask,
@@ -27,7 +31,13 @@ from nemo_evaluator_sdk.agent_eval.tasks import (
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
 from nemo_evaluator_sdk.agent_inference import AgentInferenceContext, AgentInvocationResult, AgentInvocationStatus
 from nemo_evaluator_sdk.enums import AgentFormat, ModelFormat
-from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
+from nemo_evaluator_sdk.metrics.protocol import (
+    MetricDiagnostic,
+    MetricInput,
+    MetricOutput,
+    MetricOutputSpec,
+    MetricResult,
+)
 from nemo_evaluator_sdk.values import (
     Agent,
     GenericAgent,
@@ -194,6 +204,23 @@ class _FailingMetric:
 
     async def compute_scores(self, input: MetricInput) -> MetricResult:
         raise RuntimeError("missing final_state evidence")
+
+
+class _DiagnosticMetric:
+    @property
+    def type(self) -> str:
+        return "diagnostic_metric"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.continuous_score("score")]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:
+        return MetricResult(
+            outputs=[MetricOutput(name="score", value=0.5)],
+            diagnostics=[
+                MetricDiagnostic(message="criterion C-001 passed", details={"verdict": "pass", "id": "C-001"})
+            ],
+        )
 
 
 def _task(metric: Any | None = None, *, task_id: str = "task-1") -> AgentEvalTask:
@@ -422,6 +449,21 @@ async def test_metric_failure_records_failed_score_and_does_not_stop_other_metri
     assert completed.outputs[0].value == 0.25
     assert result.summary.metric_coverage["failing_metric"]["score"].failed == 1
     assert result.summary.metric_coverage["other_metric"]["quality"].scored == 1
+
+
+@pytest.mark.asyncio
+async def test_success_metric_diagnostics_are_persisted() -> None:
+    # A successful metric's own diagnostics (e.g. per-criterion judge verdicts) must reach the score:
+    # previously only the failure path recorded diagnostics and the success path dropped them.
+    result = await AgentEvaluator().run(tasks=[_task(_DiagnosticMetric())], trials=[_candidate_trial()])
+
+    (score,) = result.scores
+    assert score.status.value == "completed"
+    (diagnostic,) = score.diagnostics
+    assert diagnostic.severity == AgentEvalDiagnosticSeverity.INFO
+    assert diagnostic.message == "criterion C-001 passed"
+    assert diagnostic.source == "diagnostic_metric"
+    assert diagnostic.details == {"verdict": "pass", "id": "C-001"}
 
 
 @pytest.mark.asyncio

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
@@ -538,6 +538,17 @@ async def _score_metric(
         metric_type=metric_type,
         status=AgentEvalScoreStatus.COMPLETED,
         outputs=metric_result.outputs,
+        # Persist the metric's own diagnostics (e.g. per-criterion judge verdicts) — the failure path
+        # already records diagnostics; the success path dropped them.
+        diagnostics=[
+            AgentEvalDiagnostic(
+                severity=AgentEvalDiagnosticSeverity.INFO,
+                message=diagnostic.message,
+                source=metric_type,
+                details=diagnostic.details or {},
+            )
+            for diagnostic in metric_result.diagnostics
+        ],
         metadata={
             "row_index": row_index,
             "trial_metadata": trial.metadata,


### PR DESCRIPTION
## What

The evaluator's success path (`_score_metric`) built the completed `AgentEvalTaskScore` with `outputs=...` but omitted `diagnostics`, so a metric's own diagnostics were silently dropped on success — while the *failure* path (`_failed_metric_score`) recorded them. This converts `MetricResult.diagnostics` → `AgentEvalDiagnostic(severity=info, source=metric_type)` on the success path too, so they persist to `scores.jsonl`.

## Why

Metrics that surface component-level detail (e.g. per-criterion LLM-judge verdicts + reasoning) had that signal computed and then discarded on success. This is the mechanism for surfacing it.

## Tests

New `test_success_metric_diagnostics_are_persisted`; the existing `diagnostics == []` assertion for a no-diagnostics metric still holds. Includes the re-vendored SDK mirror (`sdk/python/nemo-platform/...`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Successful metric evaluations now retain diagnostic information in the resulting score, including severity, message, source, and details.
  * Diagnostic details are preserved consistently, with empty details provided when none are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->