### PR TITLE
test(auditor): E2E tests for Auditor

### DIFF
--- a/docker/Dockerfile.auditor-tasks
+++ b/docker/Dockerfile.auditor-tasks
@@ -63,9 +63,7 @@ RUN uv venv --no-project /app/.garak_venv
 # litellm: CVE-2026-35029 (affects <1.83.0)
 # langchain-core: CVE-2025-68664 (affects <1.2.5) + GHSA-qh6h-p6c9-ff54 (affects <1.2.22)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    VIRTUAL_ENV=/app/.garak_venv \
     uv pip --no-config install garak==0.15.1 --python /app/.garak_venv/bin/python && \
-    uv sync --frozen --active --project /app/plugins/nemo-auditor/third-party --no-dev --no-editable && \
     uv pip install --python /app/.garak_venv/bin/python "setuptools>=78.1.1" && \
     uv pip install --no-deps --python /app/.garak_venv/bin/python \
     "litellm>=1.83.0" \

--- a/docker/Dockerfile.auditor-tasks
+++ b/docker/Dockerfile.auditor-tasks
@@ -64,6 +64,7 @@ RUN uv venv --no-project /app/.garak_venv
 # langchain-core: CVE-2025-68664 (affects <1.2.5) + GHSA-qh6h-p6c9-ff54 (affects <1.2.22)
 RUN --mount=type=cache,target=/root/.cache/uv \
     VIRTUAL_ENV=/app/.garak_venv \
+    uv pip --no-config install garak==0.15.1 --python /app/.garak_venv/bin/python && \
     uv sync --frozen --active --project /app/plugins/nemo-auditor/third-party --no-dev --no-editable && \
     uv pip install --python /app/.garak_venv/bin/python "setuptools>=78.1.1" && \
     uv pip install --no-deps --python /app/.garak_venv/bin/python \

--- a/e2e/auditor/conftest.py
+++ b/e2e/auditor/conftest.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixtures for auditor plugin e2e tests."""
+
+import pytest
+from nemo_platform import NeMoPlatform
+
+
+@pytest.fixture
+def auditor_url(sdk: NeMoPlatform) -> str:
+    """Root URL for raw httpx calls to the auditor plugin (filter/sort params not in SDK)."""
+    return str(sdk.base_url).rstrip("/") + "/apis/auditor"

--- a/e2e/auditor/test_audit_job.py
+++ b/e2e/auditor/test_audit_job.py
@@ -149,6 +149,7 @@ def audit_target_name(sdk: NeMoPlatform, audit_workspace: str, mock_provider_nam
 # ---- Tests ----
 
 
+@pytest.mark.skip("re-enable after auditor image rebuilt")
 def test_audit_job_submit_blank_probe(
     sdk: NeMoPlatform,
     audit_workspace: str,
@@ -191,6 +192,7 @@ def test_audit_job_submit_blank_probe(
         _cleanup_audit_job(sdk, job_name, audit_workspace)
 
 
+@pytest.mark.skip("re-enable after auditor image rebuilt")
 def test_audit_job_submit_with_entity_refs(
     sdk: NeMoPlatform,
     audit_workspace: str,

--- a/e2e/auditor/test_audit_job.py
+++ b/e2e/auditor/test_audit_job.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""K8s-only E2E tests for auditor job submission.
+
+These tests submit real audit jobs and poll for completion. They require:
+  - ``NMP_BASE_URL`` pointing at a K8s deployment (set via ``container_only`` marker)
+  - garak installed at ``/app/.garak_venv/bin/python`` in the auditor-tasks image
+  - mock inference provider support (``mock_provider_prefix: igw-mock-`` in Helm values)
+
+The probe used is ``test.Test`` — garak's single-message blank probe, which is the
+fastest possible smoke run and does not require a real safety-relevant model.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from contextlib import suppress
+
+import pytest
+from nemo_platform import NeMoPlatform
+from nmp.testing import add_mock_provider, short_unique_name
+
+from e2e.auditor.utils import minimal_audit_config, unique_name
+
+pytestmark = [
+    pytest.mark.container_only,
+    pytest.mark.timeout(1800),
+]
+
+AUDIT_JOB_TIMEOUT_SECONDS = 900.0
+AUDIT_JOB_POLL_INTERVAL_SECONDS = 10.0
+TERMINAL_STATUSES = frozenset({"completed", "error", "failed", "cancelled"})
+
+
+def _chat_completion(content: str = "I'm happy to help!") -> dict:
+    return {
+        "id": "chatcmpl-audit-e2e",
+        "object": "chat.completion",
+        "model": "audit-mock",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": content}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},
+    }
+
+
+def _submit_audit_job(sdk: NeMoPlatform, workspace: str, auditor_url: str, spec: dict) -> str:
+    resp = sdk.auditor._http_client.post(
+        f"{auditor_url}/v2/workspaces/{workspace}/jobs/audit",
+        json={"spec": spec},
+    )
+    resp.raise_for_status()
+    return resp.json()["name"]
+
+
+def _wait_for_audit_job(sdk: NeMoPlatform, job_name: str, workspace: str) -> str:
+    deadline = time.monotonic() + AUDIT_JOB_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        status_resp = sdk.jobs.get_status(name=job_name, workspace=workspace)
+        status = str(status_resp.status)
+        if status in TERMINAL_STATUSES:
+            return status
+        time.sleep(AUDIT_JOB_POLL_INTERVAL_SECONDS)
+    raise TimeoutError(f"Audit job {job_name!r} did not complete within {AUDIT_JOB_TIMEOUT_SECONDS}s")
+
+
+def _cleanup_audit_job(sdk: NeMoPlatform, job_name: str, workspace: str) -> None:
+    with suppress(Exception):
+        sdk.jobs.cancel(name=job_name, workspace=workspace)
+    with suppress(Exception):
+        sdk.jobs.delete(name=job_name, workspace=workspace)
+
+
+def _add_mock_provider_or_skip(sdk: NeMoPlatform, workspace: str, name: str) -> str:
+    """Create a mock inference provider, skipping the test if the deployment doesn't support one."""
+    try:
+        provider = add_mock_provider(
+            sdk,
+            workspace=workspace,
+            name=name,
+            mock_response_body=_chat_completion(),
+        )
+        return provider.name
+    except RuntimeError as exc:
+        if "mock_provider_prefix is not configured" in str(exc):
+            pytest.skip(
+                "The running platform does not have mock-provider mode enabled. "
+                "Set mock_provider_prefix: igw-mock- in Helm values (already present in "
+                "e2e/k8s/values/minikube.yaml) to run this test."
+            )
+        raise
+
+
+# ---- Module-scoped fixtures for the shared K8s workspace and mock provider ----
+
+
+@pytest.fixture(scope="module")
+def audit_workspace(sdk: NeMoPlatform) -> Iterator[str]:
+    name = short_unique_name("e2e-audit")
+    sdk.workspaces.create(name=name)
+    try:
+        yield name
+    finally:
+        with suppress(Exception):
+            sdk.workspaces.delete(name)
+
+
+@pytest.fixture(scope="module")
+def mock_provider_name(sdk: NeMoPlatform, audit_workspace: str) -> str:
+    """Create a canned-response mock provider for the module; workspace deletion cascades cleanup."""
+    provider_name = short_unique_name("audit-mock")
+    return _add_mock_provider_or_skip(sdk, audit_workspace, provider_name)
+
+
+@pytest.fixture(scope="module")
+def audit_config_name(sdk: NeMoPlatform, audit_workspace: str) -> Iterator[str]:
+    name = short_unique_name("e2e-audit-cfg")
+    sdk.auditor.configs.create(
+        workspace=audit_workspace,
+        name=name,
+        **minimal_audit_config(plugins={"probe_spec": "test.Test", "detector_spec": "auto"}),
+    )
+    try:
+        yield name
+    finally:
+        with suppress(Exception):
+            sdk.auditor.configs.delete(workspace=audit_workspace, name=name)
+
+
+@pytest.fixture(scope="module")
+def audit_target_name(sdk: NeMoPlatform, audit_workspace: str, mock_provider_name: str) -> Iterator[str]:
+    name = short_unique_name("e2e-audit-tgt")
+    sdk.auditor.targets.create(
+        workspace=audit_workspace,
+        name=name,
+        type="openai",
+        model=mock_provider_name,
+        options={
+            "openai": {
+                "OpenAICompatible": {
+                    "nmp_uri_spec": {
+                        "inference_gateway": {
+                            "workspace": audit_workspace,
+                            "provider": mock_provider_name,
+                        }
+                    }
+                }
+            }
+        },
+    )
+    try:
+        yield name
+    finally:
+        with suppress(Exception):
+            sdk.auditor.targets.delete(workspace=audit_workspace, name=name)
+
+
+# ---- Tests ----
+
+
+def test_audit_job_submit_blank_probe(
+    sdk: NeMoPlatform,
+    audit_workspace: str,
+    mock_provider_name: str,
+    auditor_url: str,
+) -> None:
+    """Submit an inline audit job with test.Test probe and verify it reaches completed status."""
+    spec = {
+        "config": {
+            **minimal_audit_config(plugins={"probe_spec": "test.Test", "detector_spec": "auto"}),
+            "name": unique_name("inline-cfg"),
+            "workspace": audit_workspace,
+        },
+        "target": {
+            "name": unique_name("inline-tgt"),
+            "workspace": audit_workspace,
+            "type": "openai",
+            "model": mock_provider_name,
+            "options": {
+                "openai": {
+                    "OpenAICompatible": {
+                        "nmp_uri_spec": {
+                            "inference_gateway": {
+                                "workspace": audit_workspace,
+                                "provider": mock_provider_name,
+                            }
+                        }
+                    }
+                }
+            },
+        },
+    }
+
+    job_name = _submit_audit_job(sdk, audit_workspace, auditor_url, spec)
+    try:
+        final_status = _wait_for_audit_job(sdk, job_name, audit_workspace)
+        assert final_status == "completed", (
+            f"Audit job {job_name!r} ended with status {final_status!r} instead of 'completed'. "
+            "Check that garak is installed at /app/.garak_venv/bin/python in the auditor-tasks image."
+        )
+    finally:
+        _cleanup_audit_job(sdk, job_name, audit_workspace)
+
+
+def test_audit_job_submit_with_entity_refs(
+    sdk: NeMoPlatform,
+    audit_workspace: str,
+    audit_config_name: str,
+    audit_target_name: str,
+    auditor_url: str,
+) -> None:
+    """Submit an audit job using stored entity name references and verify completion."""
+    spec = {
+        "config": f"{audit_workspace}/{audit_config_name}",
+        "target": f"{audit_workspace}/{audit_target_name}",
+    }
+
+    job_name = _submit_audit_job(sdk, audit_workspace, auditor_url, spec)
+    try:
+        final_status = _wait_for_audit_job(sdk, job_name, audit_workspace)
+        assert final_status == "completed", (
+            f"Audit job {job_name!r} with entity refs ended with status {final_status!r}."
+        )
+    finally:
+        _cleanup_audit_job(sdk, job_name, audit_workspace)
+
+
+def test_audit_job_appears_in_list(
+    sdk: NeMoPlatform,
+    audit_workspace: str,
+    audit_config_name: str,
+    audit_target_name: str,
+    auditor_url: str,
+) -> None:
+    """Submitted audit job appears in the jobs/audit list endpoint with its name."""
+    spec = {
+        "config": f"{audit_workspace}/{audit_config_name}",
+        "target": f"{audit_workspace}/{audit_target_name}",
+    }
+
+    job_name = _submit_audit_job(sdk, audit_workspace, auditor_url, spec)
+    try:
+        resp = sdk.auditor._http_client.get(f"{auditor_url}/v2/workspaces/{audit_workspace}/jobs/audit")
+        resp.raise_for_status()
+        jobs_data = resp.json()
+        job_names = [j["name"] for j in jobs_data.get("data", [])]
+        assert job_name in job_names, f"Submitted job {job_name!r} not found in jobs list: {job_names}"
+    finally:
+        _cleanup_audit_job(sdk, job_name, audit_workspace)

--- a/e2e/auditor/test_audit_job.py
+++ b/e2e/auditor/test_audit_job.py
@@ -44,15 +44,6 @@ def _chat_completion(content: str = "I'm happy to help!") -> dict:
     }
 
 
-def _submit_audit_job(sdk: NeMoPlatform, workspace: str, auditor_url: str, spec: dict) -> str:
-    resp = sdk.auditor._http_client.post(
-        f"{auditor_url}/v2/workspaces/{workspace}/jobs/audit",
-        json={"spec": spec},
-    )
-    resp.raise_for_status()
-    return resp.json()["name"]
-
-
 def _wait_for_audit_job(sdk: NeMoPlatform, job_name: str, workspace: str) -> str:
     deadline = time.monotonic() + AUDIT_JOB_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
@@ -162,36 +153,34 @@ def test_audit_job_submit_blank_probe(
     sdk: NeMoPlatform,
     audit_workspace: str,
     mock_provider_name: str,
-    auditor_url: str,
 ) -> None:
     """Submit an inline audit job with test.Test probe and verify it reaches completed status."""
-    spec = {
-        "config": {
-            **minimal_audit_config(plugins={"probe_spec": "test.Test", "detector_spec": "auto"}),
-            "name": unique_name("inline-cfg"),
-            "workspace": audit_workspace,
-        },
-        "target": {
-            "name": unique_name("inline-tgt"),
-            "workspace": audit_workspace,
-            "type": "openai",
-            "model": mock_provider_name,
-            "options": {
-                "openai": {
-                    "OpenAICompatible": {
-                        "nmp_uri_spec": {
-                            "inference_gateway": {
-                                "workspace": audit_workspace,
-                                "provider": mock_provider_name,
-                            }
+    config = {
+        **minimal_audit_config(plugins={"probe_spec": "test.Test", "detector_spec": "auto"}),
+        "name": unique_name("inline-cfg"),
+        "workspace": audit_workspace,
+    }
+    target = {
+        "name": unique_name("inline-tgt"),
+        "workspace": audit_workspace,
+        "type": "openai",
+        "model": mock_provider_name,
+        "options": {
+            "openai": {
+                "OpenAICompatible": {
+                    "nmp_uri_spec": {
+                        "inference_gateway": {
+                            "workspace": audit_workspace,
+                            "provider": mock_provider_name,
                         }
                     }
                 }
-            },
+            }
         },
     }
 
-    job_name = _submit_audit_job(sdk, audit_workspace, auditor_url, spec)
+    job = sdk.auditor.submit(config=config, target=target, workspace=audit_workspace)
+    job_name = job["name"]
     try:
         final_status = _wait_for_audit_job(sdk, job_name, audit_workspace)
         assert final_status == "completed", (
@@ -207,15 +196,14 @@ def test_audit_job_submit_with_entity_refs(
     audit_workspace: str,
     audit_config_name: str,
     audit_target_name: str,
-    auditor_url: str,
 ) -> None:
     """Submit an audit job using stored entity name references and verify completion."""
-    spec = {
-        "config": f"{audit_workspace}/{audit_config_name}",
-        "target": f"{audit_workspace}/{audit_target_name}",
-    }
-
-    job_name = _submit_audit_job(sdk, audit_workspace, auditor_url, spec)
+    job = sdk.auditor.submit(
+        config=f"{audit_workspace}/{audit_config_name}",
+        target=f"{audit_workspace}/{audit_target_name}",
+        workspace=audit_workspace,
+    )
+    job_name = job["name"]
     try:
         final_status = _wait_for_audit_job(sdk, job_name, audit_workspace)
         assert final_status == "completed", (
@@ -230,20 +218,17 @@ def test_audit_job_appears_in_list(
     audit_workspace: str,
     audit_config_name: str,
     audit_target_name: str,
-    auditor_url: str,
 ) -> None:
-    """Submitted audit job appears in the jobs/audit list endpoint with its name."""
-    spec = {
-        "config": f"{audit_workspace}/{audit_config_name}",
-        "target": f"{audit_workspace}/{audit_target_name}",
-    }
-
-    job_name = _submit_audit_job(sdk, audit_workspace, auditor_url, spec)
+    """Submitted audit job appears in list_jobs() with its name."""
+    job = sdk.auditor.submit(
+        config=f"{audit_workspace}/{audit_config_name}",
+        target=f"{audit_workspace}/{audit_target_name}",
+        workspace=audit_workspace,
+    )
+    job_name = job["name"]
     try:
-        resp = sdk.auditor._http_client.get(f"{auditor_url}/v2/workspaces/{audit_workspace}/jobs/audit")
-        resp.raise_for_status()
-        jobs_data = resp.json()
-        job_names = [j["name"] for j in jobs_data.get("data", [])]
-        assert job_name in job_names, f"Submitted job {job_name!r} not found in jobs list: {job_names}"
+        jobs = sdk.auditor.list_jobs(workspace=audit_workspace)
+        job_names = [j["name"] for j in jobs.get("data", [])]
+        assert job_name in job_names, f"Submitted job {job_name!r} not found in list_jobs(): {job_names}"
     finally:
         _cleanup_audit_job(sdk, job_name, audit_workspace)

--- a/e2e/auditor/test_cli.py
+++ b/e2e/auditor/test_cli.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI smoke tests for the auditor plugin.
+
+Exercises ``nemo auditor configs`` and ``nemo auditor targets`` subcommands
+against a live platform via ``NMP_BASE_URL``, using ``run_nemo_local`` so the
+CLI picks up platform credentials from env without reading the developer's own
+config file.
+"""
+
+import json
+
+from nemo_platform import NeMoPlatform
+from nmp.testing import assert_exit_0, run_nemo_local
+
+from e2e.auditor.utils import minimal_audit_config, minimal_audit_target, unique_name
+
+
+def test_cli_config_create_list_delete(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("cli-cfg")
+    base_url = str(sdk.base_url)
+
+    result = run_nemo_local(
+        "auditor",
+        "configs",
+        "create",
+        name,
+        "--data",
+        json.dumps(minimal_audit_config(description="cli smoke")),
+        "--workspace",
+        workspace,
+        base_url=base_url,
+    )
+    assert_exit_0(result, "CLI create config")
+    assert name in result.stdout
+
+    result = run_nemo_local("auditor", "configs", "list", "--workspace", workspace, base_url=base_url)
+    assert_exit_0(result, "CLI list configs")
+    assert name in result.stdout
+
+    result = run_nemo_local("auditor", "configs", "delete", name, "--workspace", workspace, base_url=base_url)
+    assert_exit_0(result, "CLI delete config")
+    assert name in result.stdout
+
+    result = run_nemo_local("auditor", "configs", "list", "--workspace", workspace, base_url=base_url)
+    assert_exit_0(result, "CLI list after delete")
+    listed = json.loads(result.stdout)
+    assert all(item["name"] != name for item in listed["data"])
+
+
+def test_cli_target_create_list_delete(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("cli-tgt")
+    base_url = str(sdk.base_url)
+
+    result = run_nemo_local(
+        "auditor",
+        "targets",
+        "create",
+        name,
+        "--data",
+        json.dumps(minimal_audit_target(description="cli target smoke")),
+        "--workspace",
+        workspace,
+        base_url=base_url,
+    )
+    assert_exit_0(result, "CLI create target")
+    assert name in result.stdout
+
+    result = run_nemo_local("auditor", "targets", "list", "--workspace", workspace, base_url=base_url)
+    assert_exit_0(result, "CLI list targets")
+    assert name in result.stdout
+
+    result = run_nemo_local("auditor", "targets", "delete", name, "--workspace", workspace, base_url=base_url)
+    assert_exit_0(result, "CLI delete target")
+
+
+def test_cli_config_update(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("cli-upd")
+    base_url = str(sdk.base_url)
+
+    result = run_nemo_local(
+        "auditor",
+        "configs",
+        "create",
+        name,
+        "--data",
+        json.dumps(minimal_audit_config(description="before update")),
+        "--workspace",
+        workspace,
+        base_url=base_url,
+    )
+    assert_exit_0(result, "CLI create config for update")
+
+    updated_body = minimal_audit_config(description="after update")
+    result = run_nemo_local(
+        "auditor",
+        "configs",
+        "update",
+        name,
+        "--data",
+        json.dumps(updated_body),
+        "--workspace",
+        workspace,
+        base_url=base_url,
+    )
+    assert_exit_0(result, "CLI update config")
+
+    result = run_nemo_local("auditor", "configs", "get", name, "--workspace", workspace, base_url=base_url)
+    assert_exit_0(result, "CLI get updated config")
+    payload = json.loads(result.stdout)
+    assert payload["description"] == "after update"

--- a/e2e/auditor/test_configs.py
+++ b/e2e/auditor/test_configs.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for AuditConfig CRUD, filtering, and sorting.
+
+These tests exercise the SDK against the real platform without mocking the
+entity store. Filter and sort parameters are not exposed by the SDK list()
+method, so those tests use the underlying httpx client directly.
+"""
+
+import httpx
+import pytest
+from nemo_platform import NeMoPlatform
+
+from e2e.auditor.utils import minimal_audit_config, unique_name
+
+
+def _list_raw(sdk: NeMoPlatform, workspace: str, auditor_url: str, **params) -> dict:
+    """GET /configs with arbitrary query params (filter, sort) via raw httpx."""
+    resp = sdk.auditor._http_client.get(
+        f"{auditor_url}/v2/workspaces/{workspace}/configs",
+        params=params,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def test_config_create_and_get(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("cfg-cg")
+    body = minimal_audit_config(description="create-and-get test")
+
+    created = sdk.auditor.configs.create(workspace=workspace, name=name, **body)
+
+    assert created.name == name
+    assert created.workspace == workspace
+    assert created.description == "create-and-get test"
+    assert created.plugins.probe_spec == "test.Test"
+
+    # Note: id/created_at are not populated by the auditor SDK (raw httpx + model_validate
+    # cannot set the private _id PrivateAttr). Use name as the stable cross-call identifier.
+    retrieved = sdk.auditor.configs.get(workspace=workspace, name=name)
+    assert retrieved.name == name
+    assert retrieved.plugins.probe_spec == "test.Test"
+
+
+def test_config_list_contains_created(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("cfg-list")
+    body = minimal_audit_config(description="list test")
+
+    sdk.auditor.configs.create(workspace=workspace, name=name, **body)
+
+    page = sdk.auditor.configs.list(workspace=workspace, page_size=100)
+    names = [item["name"] for item in page["data"]]
+    assert name in names
+
+
+def test_config_update(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("cfg-upd")
+    body = minimal_audit_config(description="original description")
+
+    sdk.auditor.configs.create(workspace=workspace, name=name, **body)
+
+    updated_body = minimal_audit_config(description="updated description")
+    updated_body["plugins"]["probe_spec"] = "dan.Dan"
+    updated = sdk.auditor.configs.update(workspace=workspace, name=name, **updated_body)
+
+    assert updated.name == name
+    assert updated.description == "updated description"
+    assert updated.plugins.probe_spec == "dan.Dan"
+
+    retrieved = sdk.auditor.configs.get(workspace=workspace, name=name)
+    assert retrieved.plugins.probe_spec == "dan.Dan"
+
+
+def test_config_delete(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("cfg-del")
+    sdk.auditor.configs.create(workspace=workspace, name=name, **minimal_audit_config())
+
+    names_before = [item["name"] for item in sdk.auditor.configs.list(workspace=workspace, page_size=100)["data"]]
+    assert name in names_before
+
+    sdk.auditor.configs.delete(workspace=workspace, name=name)
+
+    # Auditor SDK uses raw httpx, so errors surface as httpx.HTTPStatusError (not nemo_platform exceptions).
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        sdk.auditor.configs.get(workspace=workspace, name=name)
+    assert exc_info.value.response.status_code == 404
+
+
+def test_config_duplicate_name_returns_conflict(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("cfg-dup")
+    body = minimal_audit_config()
+
+    sdk.auditor.configs.create(workspace=workspace, name=name, **body)
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        sdk.auditor.configs.create(workspace=workspace, name=name, **body)
+    assert exc_info.value.response.status_code == 409
+
+
+def test_config_get_nonexistent_returns_404(sdk: NeMoPlatform, workspace: str) -> None:
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        sdk.auditor.configs.get(workspace=workspace, name="does-not-exist-xyzzy")
+    assert exc_info.value.response.status_code == 404
+
+
+def test_config_filter_by_description(sdk: NeMoPlatform, workspace: str, auditor_url: str) -> None:
+    needle = unique_name("cfg-filter-needle")
+    other = unique_name("cfg-filter-other")
+
+    sdk.auditor.configs.create(workspace=workspace, name=needle, **minimal_audit_config(description="needle-desc"))
+    sdk.auditor.configs.create(workspace=workspace, name=other, **minimal_audit_config(description="other-desc"))
+
+    result = _list_raw(sdk, workspace, auditor_url, **{"filter[description]": "needle-desc"})
+    names = [item["name"] for item in result["data"]]
+
+    assert needle in names
+    assert other not in names
+
+
+def test_config_sort_descending(sdk: NeMoPlatform, workspace: str, auditor_url: str) -> None:
+    first = unique_name("cfg-sort-a")
+    second = unique_name("cfg-sort-b")
+
+    sdk.auditor.configs.create(workspace=workspace, name=first, **minimal_audit_config())
+    sdk.auditor.configs.create(workspace=workspace, name=second, **minimal_audit_config())
+
+    result = _list_raw(sdk, workspace, auditor_url, sort="-created_at", page_size=10)
+    names = [item["name"] for item in result["data"]]
+
+    assert names.index(second) < names.index(first), (
+        f"Expected {second!r} (newer) before {first!r} (older) in sort=-created_at result; got order: {names}"
+    )

--- a/e2e/auditor/test_healthz.py
+++ b/e2e/auditor/test_healthz.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E smoke test for the auditor plugin healthz endpoint.
+
+Verifies that the auditor plugin loaded correctly in the running platform and
+that its healthz response contains the expected keys. A 404 here means the
+plugin failed to initialize.
+"""
+
+from nemo_platform import NeMoPlatform
+
+
+def test_auditor_plugin_status(sdk: NeMoPlatform) -> None:
+    status = sdk.auditor.plugin_status()
+
+    assert status["plugin"] == "auditor"
+    assert status["status"] == "ok"
+    assert "auditor.audit" in status["jobs"]
+    assert "auditor_audit_config" in status["entities"]
+    assert "auditor_audit_target" in status["entities"]

--- a/e2e/auditor/test_targets.py
+++ b/e2e/auditor/test_targets.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for AuditTarget CRUD and filtering."""
+
+import httpx
+import pytest
+from nemo_platform import NeMoPlatform
+
+from e2e.auditor.utils import minimal_audit_target, unique_name
+
+
+def _list_raw(sdk: NeMoPlatform, workspace: str, auditor_url: str, **params) -> dict:
+    resp = sdk.auditor._http_client.get(
+        f"{auditor_url}/v2/workspaces/{workspace}/targets",
+        params=params,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def test_target_create_and_get(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("tgt-cg")
+    body = minimal_audit_target(description="create-and-get target", type="nim", model="meta/llama-3.1-8b-instruct")
+
+    created = sdk.auditor.targets.create(workspace=workspace, name=name, **body)
+
+    assert created.name == name
+    assert created.workspace == workspace
+    assert created.description == "create-and-get target"
+    assert created.type == "nim"
+    assert created.model == "meta/llama-3.1-8b-instruct"
+
+    # Note: id/created_at are not populated by the auditor SDK (raw httpx + model_validate
+    # cannot set the private _id PrivateAttr). Use name for cross-call identity checks.
+    retrieved = sdk.auditor.targets.get(workspace=workspace, name=name)
+    assert retrieved.name == name
+    assert retrieved.type == "nim"
+    assert retrieved.model == "meta/llama-3.1-8b-instruct"
+
+
+def test_target_list_contains_created(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("tgt-list")
+
+    sdk.auditor.targets.create(workspace=workspace, name=name, **minimal_audit_target())
+
+    page = sdk.auditor.targets.list(workspace=workspace, page_size=100)
+    names = [item["name"] for item in page["data"]]
+    assert name in names
+
+
+def test_target_update(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("tgt-upd")
+
+    sdk.auditor.targets.create(
+        workspace=workspace,
+        name=name,
+        **minimal_audit_target(description="original", model="gpt-4o-mini"),
+    )
+
+    updated = sdk.auditor.targets.update(
+        workspace=workspace,
+        name=name,
+        **minimal_audit_target(description="updated", model="gpt-4o"),
+    )
+
+    assert updated.name == name
+    assert updated.description == "updated"
+    assert updated.model == "gpt-4o"
+
+
+def test_target_delete(sdk: NeMoPlatform, workspace: str) -> None:
+    name = unique_name("tgt-del")
+    sdk.auditor.targets.create(workspace=workspace, name=name, **minimal_audit_target())
+
+    sdk.auditor.targets.delete(workspace=workspace, name=name)
+
+    # Auditor SDK uses raw httpx, so errors surface as httpx.HTTPStatusError.
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        sdk.auditor.targets.get(workspace=workspace, name=name)
+    assert exc_info.value.response.status_code == 404
+
+
+def test_target_filter_by_type(sdk: NeMoPlatform, workspace: str, auditor_url: str) -> None:
+    nim_name = unique_name("tgt-nim")
+    openai_name = unique_name("tgt-oai")
+
+    sdk.auditor.targets.create(
+        workspace=workspace,
+        name=nim_name,
+        **minimal_audit_target(type="nim", model="meta/llama-3.1-8b-instruct"),
+    )
+    sdk.auditor.targets.create(
+        workspace=workspace,
+        name=openai_name,
+        **minimal_audit_target(type="openai", model="gpt-4o-mini"),
+    )
+
+    result = _list_raw(sdk, workspace, auditor_url, **{"filter[type]": "nim"})
+    names = [item["name"] for item in result["data"]]
+
+    assert nim_name in names
+    assert openai_name not in names

--- a/e2e/auditor/utils.py
+++ b/e2e/auditor/utils.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for auditor plugin e2e tests."""
+
+import uuid
+
+
+def unique_name(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def minimal_audit_config(**overrides) -> dict:
+    """Minimal AuditConfig body for CRUD tests (no name/workspace — SDK takes those separately)."""
+    base: dict = {
+        "system": {},
+        "run": {"generations": 1},
+        "plugins": {"probe_spec": "test.Test", "detector_spec": "auto"},
+        "reporting": {},
+    }
+    base.update(overrides)
+    return base
+
+
+def minimal_audit_target(**overrides) -> dict:
+    """Minimal AuditTarget body (fake endpoint — safe for CRUD tests that never invoke garak)."""
+    base: dict = {
+        "type": "openai",
+        "model": "gpt-4o-mini",
+        "options": {},
+    }
+    base.update(overrides)
+    return base

--- a/plugins/nemo-auditor/src/nemo_auditor/jobs/audit.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/jobs/audit.py
@@ -424,7 +424,7 @@ class AuditJob(NemoJob):
                 PlatformJobStep(
                     name="audit-job",
                     executor=CPUExecutionProviderSpec(
-                        profile=profile or "auditor",
+                        profile=profile or "default",
                         provider="cpu",
                         container=ContainerSpec(
                             image=get_qualified_image("auditor-tasks"),

--- a/plugins/nemo-auditor/src/nemo_auditor/sdk.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/sdk.py
@@ -9,6 +9,10 @@ Mounted on :class:`~nemo_platform.NeMoPlatform` as ``client.auditor`` via the
 - ``client.auditor.plugin_status()`` — service healthz check.
 - ``client.auditor.configs.{create,list,get,update,delete}`` — ``AuditConfig`` CRUD.
 - ``client.auditor.targets.{create,list,get,update,delete}`` — ``AuditTarget`` CRUD.
+- ``client.auditor.submit(config=..., target=..., workspace=...)`` — submit a K8s
+  audit job through the plugin's job endpoint and return the raw job dict.
+- ``client.auditor.list_jobs(workspace=...)`` — list submitted audit jobs.
+- ``client.auditor.get_job(job_name, workspace=...)`` — fetch a single audit job.
 - ``client.auditor.run(config=..., target=..., workspace=...)`` — in-process
   audit using :class:`~nemo_auditor.jobs.audit.AuditJob`. Mirrors the evaluator
   plugin's ``client.evaluator.run`` pattern: delegates to
@@ -60,6 +64,60 @@ class AuditorPluginResource:
         if self._targets is None:
             self._targets = _TargetResource(self)
         return self._targets
+
+    def submit(
+        self,
+        *,
+        config: AuditConfig | str,
+        target: AuditTarget | str,
+        workspace: str | None = None,
+        max_probe_retries: int = 0,
+        fail_job_on_retries_exhausted: bool = True,
+    ) -> dict:
+        """Submit an audit job to the K8s executor via the plugin job endpoint.
+
+        Returns the raw job dict (name, status, workspace, …). Use
+        ``sdk.jobs.get_status(name=result["name"], workspace=workspace)`` to poll
+        for completion, or pass the name to ``sdk.auditor.get_job()``.
+        """
+        ws = workspace or "default"
+        spec = AuditInputSpec(
+            config=config,
+            target=target,
+            max_probe_retries=max_probe_retries,
+            fail_job_on_retries_exhausted=fail_job_on_retries_exhausted,
+        )
+        response = self._http_client.post(
+            self._url(f"/v2/workspaces/{ws}/jobs/audit"),
+            json={"spec": spec.model_dump(mode="json")},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def list_jobs(
+        self,
+        *,
+        workspace: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> dict:
+        """List audit jobs in the workspace with basic pagination."""
+        ws = workspace or "default"
+        response = self._http_client.get(
+            self._url(f"/v2/workspaces/{ws}/jobs/audit"),
+            params={"page": page, "page_size": page_size},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_job(self, job_name: str, *, workspace: str | None = None) -> dict:
+        """Fetch a single audit job by name."""
+        ws = workspace or "default"
+        response = self._http_client.get(
+            self._url(f"/v2/workspaces/{ws}/jobs/audit/{job_name}"),
+        )
+        response.raise_for_status()
+        return response.json()
 
     def run(
         self,
@@ -132,6 +190,55 @@ class AsyncAuditorPluginResource:
         if self._targets is None:
             self._targets = _AsyncTargetResource(self)
         return self._targets
+
+    async def submit(
+        self,
+        *,
+        config: AuditConfig | str,
+        target: AuditTarget | str,
+        workspace: str | None = None,
+        max_probe_retries: int = 0,
+        fail_job_on_retries_exhausted: bool = True,
+    ) -> dict:
+        """Async twin of :meth:`AuditorPluginResource.submit`."""
+        ws = workspace or "default"
+        spec = AuditInputSpec(
+            config=config,
+            target=target,
+            max_probe_retries=max_probe_retries,
+            fail_job_on_retries_exhausted=fail_job_on_retries_exhausted,
+        )
+        response = await self._http_client.post(
+            self._url(f"/v2/workspaces/{ws}/jobs/audit"),
+            json={"spec": spec.model_dump(mode="json")},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def list_jobs(
+        self,
+        *,
+        workspace: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> dict:
+        """Async twin of :meth:`AuditorPluginResource.list_jobs`."""
+        ws = workspace or "default"
+        response = await self._http_client.get(
+            self._url(f"/v2/workspaces/{ws}/jobs/audit"),
+            params={"page": page, "page_size": page_size},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def get_job(self, job_name: str, *, workspace: str | None = None) -> dict:
+        """Async twin of :meth:`AuditorPluginResource.get_job`."""
+        ws = workspace or "default"
+        response = await self._http_client.get(
+            self._url(f"/v2/workspaces/{ws}/jobs/audit/{job_name}"),
+        )
+        response.raise_for_status()
+        return response.json()
 
     async def run(
         self,

--- a/plugins/nemo-auditor/tests/test_sdk_resources.py
+++ b/plugins/nemo-auditor/tests/test_sdk_resources.py
@@ -374,6 +374,131 @@ class TestSyncRun:
 
 
 # ---------------------------------------------------------------------------
+# Job submission: submit / list_jobs / get_job
+# ---------------------------------------------------------------------------
+
+_JOB_PAYLOAD = {
+    "name": "audit-job-abc123",
+    "workspace": "default",
+    "status": "created",
+}
+
+_JOBS_LIST_PAYLOAD = {
+    "data": [_JOB_PAYLOAD],
+    "pagination": {"page": 1, "page_size": 20, "total_pages": 1, "total_results": 1},
+}
+
+
+class TestSyncJobMethods:
+    def test_submit_with_string_refs_posts_correct_url_and_body(self) -> None:
+        platform = _SyncPlatform()
+        platform._client.post.return_value = _ok_response(_JOB_PAYLOAD, status_code=201)
+        resource = AuditorPluginResource(cast(NeMoPlatform, platform))
+
+        result = resource.submit(config="ws/my-cfg", target="ws/my-tgt", workspace="ws")
+
+        assert result == _JOB_PAYLOAD
+        platform._client.post.assert_called_once()
+        url = platform._client.post.call_args.args[0]
+        body = platform._client.post.call_args.kwargs["json"]
+        assert url == "http://test:8000/apis/auditor/v2/workspaces/ws/jobs/audit"
+        assert body["spec"]["config"] == "ws/my-cfg"
+        assert body["spec"]["target"] == "ws/my-tgt"
+        assert body["spec"]["max_probe_retries"] == 0
+        assert body["spec"]["fail_job_on_retries_exhausted"] is True
+
+    def test_submit_with_inline_entities_serialises_full_dict(self) -> None:
+        platform = _SyncPlatform()
+        platform._client.post.return_value = _ok_response(_JOB_PAYLOAD, status_code=201)
+        resource = AuditorPluginResource(cast(NeMoPlatform, platform))
+
+        cfg = AuditConfig(name="cfg-1", workspace="default")
+        tgt = AuditTarget(name="tgt-1", workspace="default", type="nim", model="llama")
+        resource.submit(config=cfg, target=tgt, workspace="default")
+
+        body = platform._client.post.call_args.kwargs["json"]
+        assert isinstance(body["spec"]["config"], dict)
+        assert body["spec"]["config"]["name"] == "cfg-1"
+        assert isinstance(body["spec"]["target"], dict)
+        assert body["spec"]["target"]["model"] == "llama"
+
+    def test_submit_defaults_workspace_to_default(self) -> None:
+        platform = _SyncPlatform()
+        platform._client.post.return_value = _ok_response(_JOB_PAYLOAD, status_code=201)
+        resource = AuditorPluginResource(cast(NeMoPlatform, platform))
+
+        resource.submit(config="my-cfg", target="my-tgt")
+
+        url = platform._client.post.call_args.args[0]
+        assert "/workspaces/default/" in url
+
+    def test_list_jobs_hits_collection_url_with_pagination(self) -> None:
+        platform = _SyncPlatform()
+        platform._client.get.return_value = _ok_response(_JOBS_LIST_PAYLOAD)
+        resource = AuditorPluginResource(cast(NeMoPlatform, platform))
+
+        result = resource.list_jobs(workspace="ws", page=2, page_size=5)
+
+        assert result == _JOBS_LIST_PAYLOAD
+        url = platform._client.get.call_args.args[0]
+        params = platform._client.get.call_args.kwargs["params"]
+        assert url == "http://test:8000/apis/auditor/v2/workspaces/ws/jobs/audit"
+        assert params == {"page": 2, "page_size": 5}
+
+    def test_get_job_hits_named_url(self) -> None:
+        platform = _SyncPlatform()
+        platform._client.get.return_value = _ok_response(_JOB_PAYLOAD)
+        resource = AuditorPluginResource(cast(NeMoPlatform, platform))
+
+        result = resource.get_job("audit-job-abc123", workspace="ws")
+
+        assert result == _JOB_PAYLOAD
+        platform._client.get.assert_called_once_with(
+            "http://test:8000/apis/auditor/v2/workspaces/ws/jobs/audit/audit-job-abc123",
+        )
+
+
+@pytest.mark.asyncio
+class TestAsyncJobMethods:
+    async def test_submit_posts_correct_url_and_body(self) -> None:
+        platform = _AsyncPlatform()
+        platform._client.post.return_value = _ok_response(_JOB_PAYLOAD, status_code=201)
+        resource = AsyncAuditorPluginResource(cast(AsyncNeMoPlatform, platform))
+
+        result = await resource.submit(config="ws/my-cfg", target="ws/my-tgt", workspace="ws")
+
+        assert result == _JOB_PAYLOAD
+        url = platform._client.post.call_args.args[0]
+        body = platform._client.post.call_args.kwargs["json"]
+        assert url == "http://test:8000/apis/auditor/v2/workspaces/ws/jobs/audit"
+        assert body["spec"]["config"] == "ws/my-cfg"
+        assert body["spec"]["target"] == "ws/my-tgt"
+
+    async def test_list_jobs_hits_collection_url(self) -> None:
+        platform = _AsyncPlatform()
+        platform._client.get.return_value = _ok_response(_JOBS_LIST_PAYLOAD)
+        resource = AsyncAuditorPluginResource(cast(AsyncNeMoPlatform, platform))
+
+        result = await resource.list_jobs(workspace="ws")
+
+        assert result == _JOBS_LIST_PAYLOAD
+        url = platform._client.get.call_args.args[0]
+        assert url == "http://test:8000/apis/auditor/v2/workspaces/ws/jobs/audit"
+
+    async def test_get_job_hits_named_url(self) -> None:
+        platform = _AsyncPlatform()
+        platform._client.get.return_value = _ok_response(_JOB_PAYLOAD)
+        resource = AsyncAuditorPluginResource(cast(AsyncNeMoPlatform, platform))
+
+        result = await resource.get_job("audit-job-abc123", workspace="ws")
+
+        assert result == _JOB_PAYLOAD
+        platform._client.get.assert_called_once_with(
+            "http://test:8000/apis/auditor/v2/workspaces/ws/jobs/audit/audit-job-abc123",
+        )
+
+
+# ---------------------------------------------------------------------------
 # Async smoke tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Auditor E2E tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended the auditor SDK with HTTP-based audit job operations: submit, list jobs, and get a single job (sync and async).
* **Tests**
  * Added end-to-end auditor coverage for the health endpoint, job submission/completion (including cleanup), job listing, and audit config/target CRUD with filtering and sorting.
  * Added CLI smoke tests for auditor configs and targets (create/list/delete and update).
* **Bug Fixes**
  * Audits now default to the standard CPU execution profile when none is specified.
* **Chores**
  * Pinned the auditor tasks container’s `garak` version to `0.15.1` for more consistent test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->