### PR TITLE
feat(studio): add multi-column sort to evaluation sessions table [ASE-591]

### DIFF
--- a/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
@@ -72,31 +72,68 @@ const listEvaluationSessionsWithModeFallback = async (
   }
 };
 
+// Column id → API sort field. All session sort fields are direct 1:1 matches so no
+// translation is needed beyond listing the sortable ids.
+const SESSION_SORT_FIELD_MAP: Readonly<Record<string, string>> = {
+  test_case_id: 'test_case_id',
+  started_at: 'started_at',
+  ended_at: 'ended_at',
+  latency_ms: 'latency_ms',
+  status: 'status',
+  tokens: 'tokens',
+  cost_total_usd: 'cost_total_usd',
+};
+
+// Converts the table's multi-column sorting state to the comma-separated `sort` API param.
+// Returns undefined when nothing is sorted so the endpoint uses its default order.
+const getSessionSortParam = (
+  sortingState: { id: string; desc: boolean }[]
+): string | undefined => {
+  if (sortingState.length === 0) return undefined;
+  const fields = sortingState
+    .map(({ id, desc }) => {
+      const field = SESSION_SORT_FIELD_MAP[id];
+      return field ? `${desc ? '-' : ''}${field}` : undefined;
+    })
+    .filter((f): f is string => f !== undefined);
+  return fields.length > 0 ? fields.join(',') : undefined;
+};
+
 export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = ({
   evaluationName,
   experimentGroupName,
 }) => {
   const workspace = useWorkspaceFromPath();
   const navigate = useNavigate();
-  const dataViewState = useStudioDataViewState<EvaluationSessionFilter>({ columnVisibility: {} });
+  const dataViewState = useStudioDataViewState<EvaluationSessionFilter>({
+    columnVisibility: {},
+    multiSort: true,
+  });
   const { data: experiment } = useGetEvaluation(workspace, evaluationName);
 
   const page = dataViewState.pagination.state.pageIndex + 1;
   const pageSize = dataViewState.pagination.state.pageSize;
-  const sessionParams = useMemo<ListEvaluationSessionsParams>(
-    () => ({
+  const sessionParams = useMemo<ListEvaluationSessionsParams>(() => {
+    const sort = getSessionSortParam(dataViewState.sorting.state);
+    return {
       page,
       page_size: pageSize,
       mode: 'preview',
+      ...(sort && { sort }),
       filter: {
         ...dataViewState.apiFilter.filter,
         ...(dataViewState.debouncedSearchBar && {
           test_case_id: dataViewState.debouncedSearchBar,
         }),
       },
-    }),
-    [dataViewState.apiFilter.filter, dataViewState.debouncedSearchBar, page, pageSize]
-  );
+    };
+  }, [
+    dataViewState.apiFilter.filter,
+    dataViewState.debouncedSearchBar,
+    dataViewState.sorting.state,
+    page,
+    pageSize,
+  ]);
 
   const { data: sessionsResponse, isLoading } = useListEvaluationSessions(
     workspace,
@@ -153,7 +190,7 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
   }) => [
     accessor('test_case_id', {
       header: 'Test case',
-      enableSorting: false,
+      enableSorting: true,
       size: 200,
       cell: ({ row }) => {
         const value = row.original.test_case_id;
@@ -179,7 +216,7 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
     }),
     accessor('started_at', {
       header: 'Started at',
-      enableSorting: false,
+      enableSorting: true,
       cell: ({ row }) =>
         row.original.started_at ? (
           <RelativeTime datetime={row.original.started_at} />
@@ -189,13 +226,13 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
     }),
     accessor('ended_at', {
       header: 'Ended at',
-      enableSorting: false,
+      enableSorting: true,
       cell: ({ row }) =>
         row.original.ended_at ? <RelativeTime datetime={row.original.ended_at} /> : <Text>-</Text>,
     }),
     accessor('latency_ms', {
       header: 'Latency',
-      enableSorting: false,
+      enableSorting: true,
       meta: { alignment: 'right' },
       cell: ({ row }) => {
         const ms = row.original.latency_ms;
@@ -204,7 +241,7 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
     }),
     accessor('status', {
       header: 'Status',
-      enableSorting: false,
+      enableSorting: true,
       meta: {
         filter: {
           type: 'single-select',
@@ -227,7 +264,7 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
       {
         id: 'tokens',
         header: 'Tokens',
-        enableSorting: false,
+        enableSorting: true,
         meta: { alignment: 'right' },
         cell: ({ row }) => {
           const { input_tokens, output_tokens } = row.original;
@@ -238,7 +275,7 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
     ),
     accessor('cost_total_usd', {
       header: 'Cost',
-      enableSorting: false,
+      enableSorting: true,
       meta: { alignment: 'right' },
       cell: ({ row }) => {
         const cost = row.original.cost_total_usd;

--- a/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
@@ -86,9 +86,7 @@ const SESSION_SORT_FIELD_MAP: Readonly<Record<string, string>> = {
 
 // Converts the table's multi-column sorting state to the comma-separated `sort` API param.
 // Returns undefined when nothing is sorted so the endpoint uses its default order.
-const getSessionSortParam = (
-  sortingState: { id: string; desc: boolean }[]
-): string | undefined => {
+const getSessionSortParam = (sortingState: { id: string; desc: boolean }[]): string | undefined => {
   if (sortingState.length === 0) return undefined;
   const fields = sortingState
     .map(({ id, desc }) => {


### PR DESCRIPTION
## Summary

Wires the FE sort UI to the sessions endpoint added in #780.

## Changes

- ****: column id → API sort field (all 1:1 for sessions)
- **`getSessionSortParam`**: converts TanStack Table sorting state to the comma-separated `sort` param; returns `undefined` when nothing is sorted so the API uses its default order
- **`multiSort: true`** on `useStudioDataViewState` — enables shift-click for secondary sort keys
- **7 columns enabled** for sorting: `test_case_id`, `started_at`, `ended_at`, `latency_ms`, `status`, `tokens`, `cost_total_usd`
- `input`, `output`, and evaluator score columns remain non-sortable (out of scope per ticket)
- `sort` included in `sessionParams` when non-empty; `dataViewState.sorting.state` added to `useMemo` deps

## Depends on

#780 (BE endpoint) must be merged before this branch is merged. This branch is cut from `nwalston/ase-591-column-sorting` — once #780 lands on main, rebase onto main before merging.

Closes ASE-591 (FE)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-column sorting for evaluation session tables in preview mode.
  * Enabled sorting for test case, timing, status, token, and cost columns.

* **Bug Fixes**
  * Corrected latency values to display the proper formatted duration, with a fallback when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->