### PR TITLE
fix: publish SPDX license metadata

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -17,6 +17,7 @@ dynamic = ["version"]
 description = "Convenience wrapper distribution for NeMo Platform Python packages"
 readme = "README.md"
 authors = [{ name = "NVIDIA Corporation" }]
+license = "Apache-2.0"
 requires-python = ">=3.11,<3.15"
 classifiers = [
   "Intended Audience :: Developers",
@@ -29,7 +30,6 @@ classifiers = [
   "Operating System :: MacOS",
   "Operating System :: POSIX :: Linux",
   "Topic :: Software Development :: Libraries :: Python Modules",
-  "License :: OSI Approved :: Apache Software License",
 ]
 
 # Base install: SDK + shared runtime (nmp-common) + plugin contract.


### PR DESCRIPTION
## Why

The `nemo-platform` wheel currently publishes only the deprecated `License :: OSI Approved :: Apache Software License` classifier. That does not create a `License` or `License-Expression` metadata field, so the release validator rejects the artifact as unlicensed.

This patch declares the SPDX expression `license = "Apache-2.0"`, which Hatchling emits as `License-Expression: Apache-2.0`, and removes the deprecated classifier.

Why remove the classifier too:

- [Setuptools: Replace license classifiers](https://setuptools.pypa.io/en/latest/userguide/license_migration.html#replace-license-classifiers) explicitly migrates from `License :: ...` classifiers to an SPDX `license` value.
- The canonical [PyPA `pyproject.toml` specification](https://packaging.python.org/en/latest/specifications/pyproject-toml/#classifiers) says license classifiers are deprecated and notes that build tools may reject projects that specify both a license expression and a `License ::` classifier.

## Proof

Before, the released wheel metadata contained:

```text
Classifier: License :: OSI Approved :: Apache Software License
```

and no `License` or `License-Expression` field.

After this patch, a fresh `nemo-platform` wheel contains:

```text
Metadata-Version: 2.4
Name: nemo-platform
Version: 0.0.0.dev0
License-Expression: Apache-2.0
```

with no `Classifier: License :: ...` entry.

## Verification

- `uv run pre-commit run -a`
- Fresh full wheel build, including the Studio UI build
- Direct assertion against the built wheel's `METADATA` that the SPDX expression is present and the deprecated classifier is absent

## Reviewer notes

This is a packaging-metadata-only change: one SPDX declaration replaces one deprecated classifier. It does not change runtime code or dependencies. The remaining end-to-end proof is the next release/nightly publishing run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package metadata to explicitly identify the software license as Apache-2.0.
  * Simplified license classification metadata for improved standards compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->