### PR TITLE
fix(cli): fall back to a writable state dir when $HOME is unwritable

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/_process.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/_process.py
@@ -61,11 +61,95 @@ def _pause(seconds: float) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _base_state_dir() -> Path:
+# Resolved once per process (see _base_state_dir) so reads and writes agree on one
+# directory and we don't re-probe the filesystem on every call.
+_resolved_base_dir: Path | None = None
+
+
+def _preferred_base_state_dir() -> Path:
+    """The XDG-preferred base dir: ``$XDG_STATE_HOME/nmp`` or ``~/.local/state/nmp``."""
     xdg = os.environ.get("XDG_STATE_HOME")
     if xdg:
         return Path(xdg) / "nmp"
     return Path.home() / ".local" / "state" / "nmp"
+
+
+def _fallback_base_state_dir() -> Path | None:
+    """Per-uid base dir under the system temp dir, or ``None`` when no temp dir is
+    usable (e.g. a locked-down container with a read-only ``/tmp`` and no writable
+    ``TMPDIR`` -- ``tempfile.gettempdir()`` raises there).
+
+    Namespaced by uid because ``/tmp`` is shared: distinct users on one host must
+    not collide on (or contend for ownership of) a single state dir. This is the
+    escape hatch for running the ``nemo`` entrypoint under a uid that does not own
+    ``$HOME`` -- e.g. a Kubernetes pod whose securityContext forces ``runAsUser``
+    onto an image whose baked ``$HOME`` belongs to a different uid.
+    """
+    try:
+        tmp = tempfile.gettempdir()
+    except OSError:
+        return None
+    return Path(tmp) / f"nmp-state-{os.getuid()}" / "nmp"
+
+
+def _restrict_state_dir(base: Path) -> None:
+    """Best-effort: make the per-uid temp fallback owner-only (0700).
+
+    The XDG/``$HOME`` location is already user-private, but the temp fallback sits in
+    a world-writable, shared ``/tmp``; without this the instance descriptor (which
+    names a pid, port, and config path) and the service log would be world-readable.
+    Best-effort: a pre-existing dir owned by another uid can't be chmod-ed -- that
+    case is a squat and is left to fail loudly on the subsequent write.
+    """
+    with contextlib.suppress(OSError):
+        os.chmod(base.parent, 0o700)  # the `nmp-state-<uid>` dir under the temp root
+
+
+def _base_state_dir() -> Path:
+    """Resolve (and create) the base dir for instance state (``<base>/instances/``).
+
+    Prefers ``$XDG_STATE_HOME``/``$HOME`` and falls back to a per-uid temp dir when
+    the preferred location cannot be written -- the arbitrary-uid case that made the
+    LoRA sidecar crash-loop (a pod whose securityContext runs the nmp-api image
+    under a uid that does not own its baked ``$HOME``). Selection is by an actual
+    ``mkdir`` of the ``instances`` dir rather than an advisory ``os.access`` probe,
+    so it is correct even where the two disagree (NFS root-squash, SELinux) and even
+    if the fallback itself is unwritable.
+
+    Memoized: the first call creates the directory and every later call in the
+    process -- writes (``acquire_lock``/``write_descriptor``) and reads
+    (``read_descriptor``/``list_instances``) alike -- returns the same one. Across
+    processes the result is stable as long as the preferred location's writability
+    does not change between invocations.
+    """
+    global _resolved_base_dir  # noqa: PLW0603
+    if _resolved_base_dir is not None:
+        return _resolved_base_dir
+
+    preferred = _preferred_base_state_dir()
+    first_error: OSError | None = None
+    for candidate in (preferred, _fallback_base_state_dir()):
+        if candidate is None:
+            continue
+        try:
+            (candidate / "instances").mkdir(parents=True, exist_ok=True)
+        except OSError as err:
+            first_error = first_error or err
+            continue
+        if candidate is not preferred:
+            _restrict_state_dir(candidate)
+            logger.warning(
+                "State directory %s is not writable; using %s instead. Set XDG_STATE_HOME "
+                "or _NMP_STATE_DIR to a writable path to control where instance state lives.",
+                preferred,
+                candidate,
+            )
+        _resolved_base_dir = candidate
+        return candidate
+
+    # Neither location could be created -- surface the preferred one's error so the
+    # message names a path the user can act on.
+    raise first_error or OSError(f"No writable location for instance state (tried {preferred})")
 
 
 def _instances_dir(*, base_dir: Path | None = None) -> Path:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/_process.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/_process.py
@@ -27,10 +27,12 @@ import re
 import shutil
 import signal
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -61,8 +63,7 @@ def _pause(seconds: float) -> None:
 # ---------------------------------------------------------------------------
 
 
-# Resolved once per process (see _base_state_dir) so reads and writes agree on one
-# directory and we don't re-probe the filesystem on every call.
+# Resolved once per process by _base_state_dir; ``None`` until first resolved.
 _resolved_base_dir: Path | None = None
 
 
@@ -80,10 +81,8 @@ def _fallback_base_state_dir() -> Path | None:
     ``TMPDIR`` -- ``tempfile.gettempdir()`` raises there).
 
     Namespaced by uid because ``/tmp`` is shared: distinct users on one host must
-    not collide on (or contend for ownership of) a single state dir. This is the
-    escape hatch for running the ``nemo`` entrypoint under a uid that does not own
-    ``$HOME`` -- e.g. a Kubernetes pod whose securityContext forces ``runAsUser``
-    onto an image whose baked ``$HOME`` belongs to a different uid.
+    not collide on (or contend for ownership of) a single state dir. See
+    ``_base_state_dir`` for when and why this fallback is used.
     """
     try:
         tmp = tempfile.gettempdir()
@@ -92,17 +91,36 @@ def _fallback_base_state_dir() -> Path | None:
     return Path(tmp) / f"nmp-state-{os.getuid()}" / "nmp"
 
 
-def _restrict_state_dir(base: Path) -> None:
-    """Best-effort: make the per-uid temp fallback owner-only (0700).
+def _secure_fallback_root(per_uid: Path) -> None:
+    """Create the per-uid temp root (``nmp-state-<uid>``) as an owner-only (0700)
+    directory this uid owns, or raise ``OSError`` so the caller rejects the fallback.
 
-    The XDG/``$HOME`` location is already user-private, but the temp fallback sits in
-    a world-writable, shared ``/tmp``; without this the instance descriptor (which
-    names a pid, port, and config path) and the service log would be world-readable.
-    Best-effort: a pre-existing dir owned by another uid can't be chmod-ed -- that
-    case is a squat and is left to fail loudly on the subsequent write.
+    The temp fallback sits under a world-writable, shared ``/tmp``, so another user can
+    pre-create ``nmp-state-<uid>``. If we wrote state into a directory we do not own,
+    the instance descriptor (pid, port, config path) and the service log would land
+    under that user's control -- an information leak and a symlink-swap foothold. So
+    reject any root we cannot make private:
+
+    - a symlink or non-directory: ``lstat`` does not follow, so a symlink fails the
+      ``S_ISDIR`` check -- it points somewhere we did not create;
+    - one owned by another uid: ``os.chmod`` alone misses this when we run as root,
+      since root can chmod a file it does not own, so check the owner explicitly;
+    - one we cannot lock down to 0700.
+
+    ``mkdir(mode=0o700)`` creates it private with no world-readable window; the explicit
+    ``chmod`` re-tightens a dir we made earlier under a laxer umask and, on a squatter's
+    dir we somehow own-but-cannot-chmod, propagates its EPERM -- the rejection we want.
     """
-    with contextlib.suppress(OSError):
-        os.chmod(base.parent, 0o700)  # the `nmp-state-<uid>` dir under the temp root
+    per_uid.mkdir(mode=0o700, exist_ok=True)
+    info = per_uid.lstat()
+    if not stat.S_ISDIR(info.st_mode):
+        raise OSError(errno.ENOTDIR, f"{per_uid} is not a directory")
+    if info.st_uid != os.getuid():
+        raise OSError(errno.EPERM, f"{per_uid} is owned by uid {info.st_uid}, not {os.getuid()}")
+    os.chmod(per_uid, 0o700)
+    mode = stat.S_IMODE(os.stat(per_uid).st_mode)
+    if mode & 0o077:
+        raise OSError(errno.EPERM, f"{per_uid} is not owner-only (mode {mode:#o})")
 
 
 def _base_state_dir() -> Path:
@@ -114,7 +132,9 @@ def _base_state_dir() -> Path:
     under a uid that does not own its baked ``$HOME``). Selection is by an actual
     ``mkdir`` of the ``instances`` dir rather than an advisory ``os.access`` probe,
     so it is correct even where the two disagree (NFS root-squash, SELinux) and even
-    if the fallback itself is unwritable.
+    if the fallback itself is unwritable. The temp fallback is additionally rejected
+    unless it is a directory this uid owns and can lock down to 0700 (see
+    ``_secure_fallback_root``), so another user cannot pre-create it and capture state.
 
     Memoized: the first call creates the directory and every later call in the
     process -- writes (``acquire_lock``/``write_descriptor``) and reads
@@ -127,20 +147,31 @@ def _base_state_dir() -> Path:
         return _resolved_base_dir
 
     preferred = _preferred_base_state_dir()
+
+    def _candidates() -> Iterator[tuple[Path, bool]]:
+        # (dir, is_fallback). Lazy: the temp fallback -- and its gettempdir() /tmp
+        # probe -- is computed only if the preferred location fails, so the common
+        # path never touches /tmp. Only the fallback can be absent (no usable temp dir).
+        yield preferred, False
+        fallback = _fallback_base_state_dir()
+        if fallback is not None:
+            yield fallback, True
+
     first_error: OSError | None = None
-    for candidate in (preferred, _fallback_base_state_dir()):
-        if candidate is None:
-            continue
+    for candidate, is_fallback in _candidates():
         try:
+            # Vet ownership of and lock down the shared-/tmp root before creating any
+            # state under it, so a squatted fallback is rejected, not written into.
+            if is_fallback:
+                _secure_fallback_root(candidate.parent)
             (candidate / "instances").mkdir(parents=True, exist_ok=True)
         except OSError as err:
             first_error = first_error or err
             continue
-        if candidate is not preferred:
-            _restrict_state_dir(candidate)
+        if is_fallback:
             logger.warning(
-                "State directory %s is not writable; using %s instead. Set XDG_STATE_HOME "
-                "or _NMP_STATE_DIR to a writable path to control where instance state lives.",
+                "State directory %s is not writable; using %s instead. Set XDG_STATE_HOME to a "
+                "writable path to control where instance state lives.",
                 preferred,
                 candidate,
             )

--- a/packages/nemo_platform_ext/tests/cli/commands/test_services_process.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_services_process.py
@@ -141,6 +141,22 @@ class TestBaseStateDir:
         _process._resolved_base_dir = None
         _process._scope_prefix_cache = None
 
+    @pytest.fixture()
+    def fallback_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Force resolution onto the temp fallback and return that root.
+
+        Points the preferred dir under a regular file so its mkdir raises for every uid
+        (root-proof, unlike a chmod-based block), then aims ``gettempdir`` at a fresh dir
+        -- the resolved base becomes ``<root>/nmp-state-<uid>/nmp``.
+        """
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("x")
+        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
+        root = tmp_path / "tmp"
+        root.mkdir()
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(root))
+        return root
+
     def test_resolves_and_creates_under_preferred(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
         base = _base_state_dir()
@@ -154,32 +170,67 @@ class TestBaseStateDir:
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "other"))
         assert _base_state_dir() == first
 
-    def test_falls_back_when_preferred_uncreatable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Preferred points under a regular file, so mkdir raises NotADirectoryError
-        # (an OSError) for every uid -- root-proof, unlike a chmod-based block.
-        blocker = tmp_path / "not-a-dir"
-        blocker.write_text("x")
-        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
-        fallback_root = tmp_path / "tmp"
-        fallback_root.mkdir()
-        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_root))
-
+    def test_falls_back_when_preferred_uncreatable(self, fallback_root: Path) -> None:
         base = _base_state_dir()
         assert base == fallback_root / f"nmp-state-{os.getuid()}" / "nmp"
         assert (base / "instances").is_dir()
 
-    def test_fallback_dir_is_owner_only(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_fallback_dir_is_owner_only(self, fallback_root: Path) -> None:
         # The per-uid dir under shared /tmp must not be world-traversable/readable,
         # or another user could read the descriptor (pid/port/config) and the log.
-        blocker = tmp_path / "not-a-dir"
-        blocker.write_text("x")
-        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
-        fallback_root = tmp_path / "tmp"
-        fallback_root.mkdir()
-        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_root))
-
         _base_state_dir()
         per_uid = fallback_root / f"nmp-state-{os.getuid()}"
+        assert os.stat(per_uid).st_mode & 0o777 == 0o700
+
+    def test_rejects_squatted_fallback_owned_by_other_uid(
+        self, fallback_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Simulate a squat without a second real user: make the process *believe* it is a
+        # different uid than the one that owns the temp root it creates. _secure_fallback_root
+        # must refuse to write state into a directory it does not own -- and this holds even
+        # as root, where a chmod-only check would not (root can chmod a foreign dir).
+        real_uid = os.getuid()
+        monkeypatch.setattr(_process.os, "getuid", lambda: real_uid + 1)
+
+        with pytest.raises(OSError):
+            _base_state_dir()
+
+        # The per-uid root gets created (empty) but no state subtree is written under it.
+        squatted = fallback_root / f"nmp-state-{real_uid + 1}"
+        assert not (squatted / "nmp").exists()
+
+    def test_rejects_fallback_it_cannot_lock_down(self, fallback_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The per-uid temp root exists and we own it, but the chmod that would make it
+        # owner-only fails (EPERM). The fallback must be rejected -- never written into --
+        # rather than silently swallowing the chmod error.
+        per_uid = fallback_root / f"nmp-state-{os.getuid()}"
+        per_uid.mkdir(mode=0o755)  # a pre-existing, too-permissive root
+
+        real_chmod = os.chmod
+
+        def deny_chmod(path, *args, **kwargs):
+            if Path(path) == per_uid:
+                raise PermissionError("Operation not permitted")
+            return real_chmod(path, *args, **kwargs)
+
+        monkeypatch.setattr(_process.os, "chmod", deny_chmod)
+
+        with pytest.raises(OSError):
+            _base_state_dir()
+        assert not (per_uid / "nmp").exists()  # no state written under the unsecurable root
+
+    def test_reuses_and_tightens_own_loose_fallback_dir(self, fallback_root: Path) -> None:
+        # A per-uid root we already own but that is too permissive -- e.g. a plain mkdir
+        # under the default umask, left by an older build -- is not a squat: accept it and
+        # tighten it to 0700, don't reject it.
+        per_uid = fallback_root / f"nmp-state-{os.getuid()}"
+        per_uid.mkdir()
+        os.chmod(per_uid, 0o755)  # group/other-readable; _secure_fallback_root must clamp it
+
+        base = _base_state_dir()
+        assert base == per_uid / "nmp"
+        assert (base / "instances").is_dir()
+        # _secure_fallback_root ran an absolute chmod(0o700), overriding the 0o755 above.
         assert os.stat(per_uid).st_mode & 0o777 == 0o700
 
     def test_fallback_is_none_without_tempdir(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/nemo_platform_ext/tests/cli/commands/test_services_process.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_services_process.py
@@ -8,17 +8,21 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import psutil
 import pytest
+from nemo_platform_ext.cli.commands.services import _process
 from nemo_platform_ext.cli.commands.services._process import (
     ForegroundInstanceError,
     InstanceAlreadyRunningError,
     InstanceDescriptor,
     InstanceStillRunningError,
+    _base_state_dir,
+    _fallback_base_state_dir,
     _pid_alive,
     _snapshot_children,
     _sweep_orphans,
@@ -122,6 +126,105 @@ class TestInstanceDir:
         d1 = instance_dir("test-scope", base_dir=base_dir)
         d2 = instance_dir("test-scope", base_dir=base_dir)
         assert d1 == d2
+
+
+class TestBaseStateDir:
+    """Resolution + creation + unwritable-``$HOME`` fallback for the state dir."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_state_globals(self):
+        # _base_state_dir memoizes its resolved dir and compute_scope caches a
+        # prefix; reset both around every test so neither leaks between tests.
+        _process._resolved_base_dir = None
+        _process._scope_prefix_cache = None
+        yield
+        _process._resolved_base_dir = None
+        _process._scope_prefix_cache = None
+
+    def test_resolves_and_creates_under_preferred(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        base = _base_state_dir()
+        assert base == tmp_path / "nmp"
+        assert (base / "instances").is_dir()  # resolution creates the instances dir
+
+    def test_memoized_within_process(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        first = _base_state_dir()
+        # A later env change is ignored: the resolved dir is cached for the process.
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "other"))
+        assert _base_state_dir() == first
+
+    def test_falls_back_when_preferred_uncreatable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Preferred points under a regular file, so mkdir raises NotADirectoryError
+        # (an OSError) for every uid -- root-proof, unlike a chmod-based block.
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("x")
+        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
+        fallback_root = tmp_path / "tmp"
+        fallback_root.mkdir()
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_root))
+
+        base = _base_state_dir()
+        assert base == fallback_root / f"nmp-state-{os.getuid()}" / "nmp"
+        assert (base / "instances").is_dir()
+
+    def test_fallback_dir_is_owner_only(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The per-uid dir under shared /tmp must not be world-traversable/readable,
+        # or another user could read the descriptor (pid/port/config) and the log.
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("x")
+        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
+        fallback_root = tmp_path / "tmp"
+        fallback_root.mkdir()
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_root))
+
+        _base_state_dir()
+        per_uid = fallback_root / f"nmp-state-{os.getuid()}"
+        assert os.stat(per_uid).st_mode & 0o777 == 0o700
+
+    def test_fallback_is_none_without_tempdir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _no_tempdir() -> str:
+            raise FileNotFoundError("No usable temporary directory found")
+
+        monkeypatch.setattr(tempfile, "gettempdir", _no_tempdir)
+        assert _fallback_base_state_dir() is None
+
+    def test_raises_when_no_location_writable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("x")
+        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
+        monkeypatch.setattr(_process, "_fallback_base_state_dir", lambda: None)
+        with pytest.raises(OSError):
+            _base_state_dir()
+
+    @pytest.mark.skipif(os.getuid() == 0, reason="root bypasses the DAC write check this test relies on")
+    def test_unwritable_home_does_not_crash(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression for the LoRA-sidecar crash: ``nemo services run`` under a uid
+        that cannot write ``$HOME`` must fall back instead of raising PermissionError.
+
+        Faithfully reproduces the container condition -- ``$HOME`` exists but is not
+        writable by the running uid, ``~/.local`` is absent, and ``XDG_STATE_HOME``
+        is unset -- which crashed ``instance_dir`` at ``mkdir('$HOME/.local')``
+        before the fix.
+        """
+        fake_home = tmp_path / "home" / "nvs"
+        fake_home.mkdir(parents=True)
+        fallback_tmp = tmp_path / "tmp"
+        fallback_tmp.mkdir()
+
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.delenv("_NMP_STATE_DIR", raising=False)
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_tmp))
+
+        os.chmod(fake_home, 0o500)  # r-x for owner only: cannot create
+        try:
+            d = instance_dir(compute_scope(port=8080))  # base_dir=None; must not raise
+            assert d.is_dir()
+            assert fake_home not in d.parents  # did NOT land under the unwritable HOME
+            assert d.is_relative_to(fallback_tmp)
+        finally:
+            os.chmod(fake_home, 0o700)  # owner-only access; sufficient for pytest cleanup
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/_process.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/_process.py
@@ -61,11 +61,95 @@ def _pause(seconds: float) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _base_state_dir() -> Path:
+# Resolved once per process (see _base_state_dir) so reads and writes agree on one
+# directory and we don't re-probe the filesystem on every call.
+_resolved_base_dir: Path | None = None
+
+
+def _preferred_base_state_dir() -> Path:
+    """The XDG-preferred base dir: ``$XDG_STATE_HOME/nmp`` or ``~/.local/state/nmp``."""
     xdg = os.environ.get("XDG_STATE_HOME")
     if xdg:
         return Path(xdg) / "nmp"
     return Path.home() / ".local" / "state" / "nmp"
+
+
+def _fallback_base_state_dir() -> Path | None:
+    """Per-uid base dir under the system temp dir, or ``None`` when no temp dir is
+    usable (e.g. a locked-down container with a read-only ``/tmp`` and no writable
+    ``TMPDIR`` -- ``tempfile.gettempdir()`` raises there).
+
+    Namespaced by uid because ``/tmp`` is shared: distinct users on one host must
+    not collide on (or contend for ownership of) a single state dir. This is the
+    escape hatch for running the ``nemo`` entrypoint under a uid that does not own
+    ``$HOME`` -- e.g. a Kubernetes pod whose securityContext forces ``runAsUser``
+    onto an image whose baked ``$HOME`` belongs to a different uid.
+    """
+    try:
+        tmp = tempfile.gettempdir()
+    except OSError:
+        return None
+    return Path(tmp) / f"nmp-state-{os.getuid()}" / "nmp"
+
+
+def _restrict_state_dir(base: Path) -> None:
+    """Best-effort: make the per-uid temp fallback owner-only (0700).
+
+    The XDG/``$HOME`` location is already user-private, but the temp fallback sits in
+    a world-writable, shared ``/tmp``; without this the instance descriptor (which
+    names a pid, port, and config path) and the service log would be world-readable.
+    Best-effort: a pre-existing dir owned by another uid can't be chmod-ed -- that
+    case is a squat and is left to fail loudly on the subsequent write.
+    """
+    with contextlib.suppress(OSError):
+        os.chmod(base.parent, 0o700)  # the `nmp-state-<uid>` dir under the temp root
+
+
+def _base_state_dir() -> Path:
+    """Resolve (and create) the base dir for instance state (``<base>/instances/``).
+
+    Prefers ``$XDG_STATE_HOME``/``$HOME`` and falls back to a per-uid temp dir when
+    the preferred location cannot be written -- the arbitrary-uid case that made the
+    LoRA sidecar crash-loop (a pod whose securityContext runs the nmp-api image
+    under a uid that does not own its baked ``$HOME``). Selection is by an actual
+    ``mkdir`` of the ``instances`` dir rather than an advisory ``os.access`` probe,
+    so it is correct even where the two disagree (NFS root-squash, SELinux) and even
+    if the fallback itself is unwritable.
+
+    Memoized: the first call creates the directory and every later call in the
+    process -- writes (``acquire_lock``/``write_descriptor``) and reads
+    (``read_descriptor``/``list_instances``) alike -- returns the same one. Across
+    processes the result is stable as long as the preferred location's writability
+    does not change between invocations.
+    """
+    global _resolved_base_dir  # noqa: PLW0603
+    if _resolved_base_dir is not None:
+        return _resolved_base_dir
+
+    preferred = _preferred_base_state_dir()
+    first_error: OSError | None = None
+    for candidate in (preferred, _fallback_base_state_dir()):
+        if candidate is None:
+            continue
+        try:
+            (candidate / "instances").mkdir(parents=True, exist_ok=True)
+        except OSError as err:
+            first_error = first_error or err
+            continue
+        if candidate is not preferred:
+            _restrict_state_dir(candidate)
+            logger.warning(
+                "State directory %s is not writable; using %s instead. Set XDG_STATE_HOME "
+                "or _NMP_STATE_DIR to a writable path to control where instance state lives.",
+                preferred,
+                candidate,
+            )
+        _resolved_base_dir = candidate
+        return candidate
+
+    # Neither location could be created -- surface the preferred one's error so the
+    # message names a path the user can act on.
+    raise first_error or OSError(f"No writable location for instance state (tried {preferred})")
 
 
 def _instances_dir(*, base_dir: Path | None = None) -> Path:

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/_process.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/services/_process.py
@@ -27,10 +27,12 @@ import re
 import shutil
 import signal
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -61,8 +63,7 @@ def _pause(seconds: float) -> None:
 # ---------------------------------------------------------------------------
 
 
-# Resolved once per process (see _base_state_dir) so reads and writes agree on one
-# directory and we don't re-probe the filesystem on every call.
+# Resolved once per process by _base_state_dir; ``None`` until first resolved.
 _resolved_base_dir: Path | None = None
 
 
@@ -80,10 +81,8 @@ def _fallback_base_state_dir() -> Path | None:
     ``TMPDIR`` -- ``tempfile.gettempdir()`` raises there).
 
     Namespaced by uid because ``/tmp`` is shared: distinct users on one host must
-    not collide on (or contend for ownership of) a single state dir. This is the
-    escape hatch for running the ``nemo`` entrypoint under a uid that does not own
-    ``$HOME`` -- e.g. a Kubernetes pod whose securityContext forces ``runAsUser``
-    onto an image whose baked ``$HOME`` belongs to a different uid.
+    not collide on (or contend for ownership of) a single state dir. See
+    ``_base_state_dir`` for when and why this fallback is used.
     """
     try:
         tmp = tempfile.gettempdir()
@@ -92,17 +91,36 @@ def _fallback_base_state_dir() -> Path | None:
     return Path(tmp) / f"nmp-state-{os.getuid()}" / "nmp"
 
 
-def _restrict_state_dir(base: Path) -> None:
-    """Best-effort: make the per-uid temp fallback owner-only (0700).
+def _secure_fallback_root(per_uid: Path) -> None:
+    """Create the per-uid temp root (``nmp-state-<uid>``) as an owner-only (0700)
+    directory this uid owns, or raise ``OSError`` so the caller rejects the fallback.
 
-    The XDG/``$HOME`` location is already user-private, but the temp fallback sits in
-    a world-writable, shared ``/tmp``; without this the instance descriptor (which
-    names a pid, port, and config path) and the service log would be world-readable.
-    Best-effort: a pre-existing dir owned by another uid can't be chmod-ed -- that
-    case is a squat and is left to fail loudly on the subsequent write.
+    The temp fallback sits under a world-writable, shared ``/tmp``, so another user can
+    pre-create ``nmp-state-<uid>``. If we wrote state into a directory we do not own,
+    the instance descriptor (pid, port, config path) and the service log would land
+    under that user's control -- an information leak and a symlink-swap foothold. So
+    reject any root we cannot make private:
+
+    - a symlink or non-directory: ``lstat`` does not follow, so a symlink fails the
+      ``S_ISDIR`` check -- it points somewhere we did not create;
+    - one owned by another uid: ``os.chmod`` alone misses this when we run as root,
+      since root can chmod a file it does not own, so check the owner explicitly;
+    - one we cannot lock down to 0700.
+
+    ``mkdir(mode=0o700)`` creates it private with no world-readable window; the explicit
+    ``chmod`` re-tightens a dir we made earlier under a laxer umask and, on a squatter's
+    dir we somehow own-but-cannot-chmod, propagates its EPERM -- the rejection we want.
     """
-    with contextlib.suppress(OSError):
-        os.chmod(base.parent, 0o700)  # the `nmp-state-<uid>` dir under the temp root
+    per_uid.mkdir(mode=0o700, exist_ok=True)
+    info = per_uid.lstat()
+    if not stat.S_ISDIR(info.st_mode):
+        raise OSError(errno.ENOTDIR, f"{per_uid} is not a directory")
+    if info.st_uid != os.getuid():
+        raise OSError(errno.EPERM, f"{per_uid} is owned by uid {info.st_uid}, not {os.getuid()}")
+    os.chmod(per_uid, 0o700)
+    mode = stat.S_IMODE(os.stat(per_uid).st_mode)
+    if mode & 0o077:
+        raise OSError(errno.EPERM, f"{per_uid} is not owner-only (mode {mode:#o})")
 
 
 def _base_state_dir() -> Path:
@@ -114,7 +132,9 @@ def _base_state_dir() -> Path:
     under a uid that does not own its baked ``$HOME``). Selection is by an actual
     ``mkdir`` of the ``instances`` dir rather than an advisory ``os.access`` probe,
     so it is correct even where the two disagree (NFS root-squash, SELinux) and even
-    if the fallback itself is unwritable.
+    if the fallback itself is unwritable. The temp fallback is additionally rejected
+    unless it is a directory this uid owns and can lock down to 0700 (see
+    ``_secure_fallback_root``), so another user cannot pre-create it and capture state.
 
     Memoized: the first call creates the directory and every later call in the
     process -- writes (``acquire_lock``/``write_descriptor``) and reads
@@ -127,20 +147,31 @@ def _base_state_dir() -> Path:
         return _resolved_base_dir
 
     preferred = _preferred_base_state_dir()
+
+    def _candidates() -> Iterator[tuple[Path, bool]]:
+        # (dir, is_fallback). Lazy: the temp fallback -- and its gettempdir() /tmp
+        # probe -- is computed only if the preferred location fails, so the common
+        # path never touches /tmp. Only the fallback can be absent (no usable temp dir).
+        yield preferred, False
+        fallback = _fallback_base_state_dir()
+        if fallback is not None:
+            yield fallback, True
+
     first_error: OSError | None = None
-    for candidate in (preferred, _fallback_base_state_dir()):
-        if candidate is None:
-            continue
+    for candidate, is_fallback in _candidates():
         try:
+            # Vet ownership of and lock down the shared-/tmp root before creating any
+            # state under it, so a squatted fallback is rejected, not written into.
+            if is_fallback:
+                _secure_fallback_root(candidate.parent)
             (candidate / "instances").mkdir(parents=True, exist_ok=True)
         except OSError as err:
             first_error = first_error or err
             continue
-        if candidate is not preferred:
-            _restrict_state_dir(candidate)
+        if is_fallback:
             logger.warning(
-                "State directory %s is not writable; using %s instead. Set XDG_STATE_HOME "
-                "or _NMP_STATE_DIR to a writable path to control where instance state lives.",
+                "State directory %s is not writable; using %s instead. Set XDG_STATE_HOME to a "
+                "writable path to control where instance state lives.",
                 preferred,
                 candidate,
             )

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_process.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_process.py
@@ -141,6 +141,22 @@ class TestBaseStateDir:
         _process._resolved_base_dir = None
         _process._scope_prefix_cache = None
 
+    @pytest.fixture()
+    def fallback_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Force resolution onto the temp fallback and return that root.
+
+        Points the preferred dir under a regular file so its mkdir raises for every uid
+        (root-proof, unlike a chmod-based block), then aims ``gettempdir`` at a fresh dir
+        -- the resolved base becomes ``<root>/nmp-state-<uid>/nmp``.
+        """
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("x")
+        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
+        root = tmp_path / "tmp"
+        root.mkdir()
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(root))
+        return root
+
     def test_resolves_and_creates_under_preferred(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
         base = _base_state_dir()
@@ -154,32 +170,67 @@ class TestBaseStateDir:
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "other"))
         assert _base_state_dir() == first
 
-    def test_falls_back_when_preferred_uncreatable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Preferred points under a regular file, so mkdir raises NotADirectoryError
-        # (an OSError) for every uid -- root-proof, unlike a chmod-based block.
-        blocker = tmp_path / "not-a-dir"
-        blocker.write_text("x")
-        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
-        fallback_root = tmp_path / "tmp"
-        fallback_root.mkdir()
-        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_root))
-
+    def test_falls_back_when_preferred_uncreatable(self, fallback_root: Path) -> None:
         base = _base_state_dir()
         assert base == fallback_root / f"nmp-state-{os.getuid()}" / "nmp"
         assert (base / "instances").is_dir()
 
-    def test_fallback_dir_is_owner_only(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_fallback_dir_is_owner_only(self, fallback_root: Path) -> None:
         # The per-uid dir under shared /tmp must not be world-traversable/readable,
         # or another user could read the descriptor (pid/port/config) and the log.
-        blocker = tmp_path / "not-a-dir"
-        blocker.write_text("x")
-        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
-        fallback_root = tmp_path / "tmp"
-        fallback_root.mkdir()
-        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_root))
-
         _base_state_dir()
         per_uid = fallback_root / f"nmp-state-{os.getuid()}"
+        assert os.stat(per_uid).st_mode & 0o777 == 0o700
+
+    def test_rejects_squatted_fallback_owned_by_other_uid(
+        self, fallback_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Simulate a squat without a second real user: make the process *believe* it is a
+        # different uid than the one that owns the temp root it creates. _secure_fallback_root
+        # must refuse to write state into a directory it does not own -- and this holds even
+        # as root, where a chmod-only check would not (root can chmod a foreign dir).
+        real_uid = os.getuid()
+        monkeypatch.setattr(_process.os, "getuid", lambda: real_uid + 1)
+
+        with pytest.raises(OSError):
+            _base_state_dir()
+
+        # The per-uid root gets created (empty) but no state subtree is written under it.
+        squatted = fallback_root / f"nmp-state-{real_uid + 1}"
+        assert not (squatted / "nmp").exists()
+
+    def test_rejects_fallback_it_cannot_lock_down(self, fallback_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The per-uid temp root exists and we own it, but the chmod that would make it
+        # owner-only fails (EPERM). The fallback must be rejected -- never written into --
+        # rather than silently swallowing the chmod error.
+        per_uid = fallback_root / f"nmp-state-{os.getuid()}"
+        per_uid.mkdir(mode=0o755)  # a pre-existing, too-permissive root
+
+        real_chmod = os.chmod
+
+        def deny_chmod(path, *args, **kwargs):
+            if Path(path) == per_uid:
+                raise PermissionError("Operation not permitted")
+            return real_chmod(path, *args, **kwargs)
+
+        monkeypatch.setattr(_process.os, "chmod", deny_chmod)
+
+        with pytest.raises(OSError):
+            _base_state_dir()
+        assert not (per_uid / "nmp").exists()  # no state written under the unsecurable root
+
+    def test_reuses_and_tightens_own_loose_fallback_dir(self, fallback_root: Path) -> None:
+        # A per-uid root we already own but that is too permissive -- e.g. a plain mkdir
+        # under the default umask, left by an older build -- is not a squat: accept it and
+        # tighten it to 0700, don't reject it.
+        per_uid = fallback_root / f"nmp-state-{os.getuid()}"
+        per_uid.mkdir()
+        os.chmod(per_uid, 0o755)  # group/other-readable; _secure_fallback_root must clamp it
+
+        base = _base_state_dir()
+        assert base == per_uid / "nmp"
+        assert (base / "instances").is_dir()
+        # _secure_fallback_root ran an absolute chmod(0o700), overriding the 0o755 above.
         assert os.stat(per_uid).st_mode & 0o777 == 0o700
 
     def test_fallback_is_none_without_tempdir(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_process.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_process.py
@@ -8,17 +8,21 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import psutil
 import pytest
+from nemo_platform.cli.commands.services import _process
 from nemo_platform.cli.commands.services._process import (
     ForegroundInstanceError,
     InstanceAlreadyRunningError,
     InstanceDescriptor,
     InstanceStillRunningError,
+    _base_state_dir,
+    _fallback_base_state_dir,
     _pid_alive,
     _snapshot_children,
     _sweep_orphans,
@@ -122,6 +126,105 @@ class TestInstanceDir:
         d1 = instance_dir("test-scope", base_dir=base_dir)
         d2 = instance_dir("test-scope", base_dir=base_dir)
         assert d1 == d2
+
+
+class TestBaseStateDir:
+    """Resolution + creation + unwritable-``$HOME`` fallback for the state dir."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_state_globals(self):
+        # _base_state_dir memoizes its resolved dir and compute_scope caches a
+        # prefix; reset both around every test so neither leaks between tests.
+        _process._resolved_base_dir = None
+        _process._scope_prefix_cache = None
+        yield
+        _process._resolved_base_dir = None
+        _process._scope_prefix_cache = None
+
+    def test_resolves_and_creates_under_preferred(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        base = _base_state_dir()
+        assert base == tmp_path / "nmp"
+        assert (base / "instances").is_dir()  # resolution creates the instances dir
+
+    def test_memoized_within_process(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        first = _base_state_dir()
+        # A later env change is ignored: the resolved dir is cached for the process.
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "other"))
+        assert _base_state_dir() == first
+
+    def test_falls_back_when_preferred_uncreatable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Preferred points under a regular file, so mkdir raises NotADirectoryError
+        # (an OSError) for every uid -- root-proof, unlike a chmod-based block.
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("x")
+        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
+        fallback_root = tmp_path / "tmp"
+        fallback_root.mkdir()
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_root))
+
+        base = _base_state_dir()
+        assert base == fallback_root / f"nmp-state-{os.getuid()}" / "nmp"
+        assert (base / "instances").is_dir()
+
+    def test_fallback_dir_is_owner_only(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The per-uid dir under shared /tmp must not be world-traversable/readable,
+        # or another user could read the descriptor (pid/port/config) and the log.
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("x")
+        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
+        fallback_root = tmp_path / "tmp"
+        fallback_root.mkdir()
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_root))
+
+        _base_state_dir()
+        per_uid = fallback_root / f"nmp-state-{os.getuid()}"
+        assert os.stat(per_uid).st_mode & 0o777 == 0o700
+
+    def test_fallback_is_none_without_tempdir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _no_tempdir() -> str:
+            raise FileNotFoundError("No usable temporary directory found")
+
+        monkeypatch.setattr(tempfile, "gettempdir", _no_tempdir)
+        assert _fallback_base_state_dir() is None
+
+    def test_raises_when_no_location_writable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("x")
+        monkeypatch.setattr(_process, "_preferred_base_state_dir", lambda: blocker / "nmp")
+        monkeypatch.setattr(_process, "_fallback_base_state_dir", lambda: None)
+        with pytest.raises(OSError):
+            _base_state_dir()
+
+    @pytest.mark.skipif(os.getuid() == 0, reason="root bypasses the DAC write check this test relies on")
+    def test_unwritable_home_does_not_crash(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression for the LoRA-sidecar crash: ``nemo services run`` under a uid
+        that cannot write ``$HOME`` must fall back instead of raising PermissionError.
+
+        Faithfully reproduces the container condition -- ``$HOME`` exists but is not
+        writable by the running uid, ``~/.local`` is absent, and ``XDG_STATE_HOME``
+        is unset -- which crashed ``instance_dir`` at ``mkdir('$HOME/.local')``
+        before the fix.
+        """
+        fake_home = tmp_path / "home" / "nvs"
+        fake_home.mkdir(parents=True)
+        fallback_tmp = tmp_path / "tmp"
+        fallback_tmp.mkdir()
+
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.delenv("_NMP_STATE_DIR", raising=False)
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_tmp))
+
+        os.chmod(fake_home, 0o500)  # r-x for owner only: cannot create
+        try:
+            d = instance_dir(compute_scope(port=8080))  # base_dir=None; must not raise
+            assert d.is_dir()
+            assert fake_home not in d.parents  # did NOT land under the unwritable HOME
+            assert d.is_relative_to(fallback_tmp)
+        finally:
+            os.chmod(fake_home, 0o700)  # owner-only access; sufficient for pytest cleanup
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`nemo services run` writes per-instance lock/descriptor state under `$XDG_STATE_HOME` (default `~/.local/state/nmp`). When the `nmp-api` entrypoint runs under a uid that does not own `$HOME` -- a common Kubernetes/OpenShift hardening pattern (arbitrary `runAsUser`) -- that location is unwritable and the command crashes with PermissionError before starting.

Make `_base_state_dir()` resilient: probe writability non-destructively and fall back to a per-uid dir under the system temp dir when the `XDG/$HOME` location cannot be written. The probe tolerates an unsearchable parent (a $HOME created mode 0700 for a different uid raises EACCES on stat) so it never propagates the very error the fallback exists to avoid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened service state-directory resolution by checking the preferred location is writable/creatable before using it.
  * Added a secure per-user temporary fallback when the preferred path can’t be created, with strict validation (owner-only permissions, rejection of non-directories/symlinks, and mismatched ownership).
  * Emits a warning when the fallback is used and raises a clear error when no writable location is available (including when home is unwritable).
* **Tests**
  * Added coverage for preference selection, memoized behavior, fallback security checks, and warning/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->