### PR TITLE
feat(studio): Dedicated Agent Details Page

### DIFF
--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/DeploymentLogsView.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/DeploymentLogsView.tsx
@@ -19,9 +19,18 @@ interface DeploymentLogsViewProps {
   workspace: string;
   /** All known deployments for the active agent — any status. */
   deployments: AgentDeployment[];
+  /** Controlled selection — when provided, the picker reflects this deployment. */
+  selectedDeploymentName?: string;
+  /** Called when the user (or a caller) changes the selected deployment. */
+  onSelectDeployment?: (name: string) => void;
 }
 
-export const DeploymentLogsView: FC<DeploymentLogsViewProps> = ({ workspace, deployments }) => {
+export const DeploymentLogsView: FC<DeploymentLogsViewProps> = ({
+  workspace,
+  deployments,
+  selectedDeploymentName,
+  onSelectDeployment,
+}) => {
   const sortedDeployments = useMemo(
     () =>
       [...deployments].sort((a, b) => {
@@ -31,18 +40,25 @@ export const DeploymentLogsView: FC<DeploymentLogsViewProps> = ({ workspace, dep
       }),
     [deployments]
   );
-  const [selectedName, setSelectedName] = useState<string | undefined>(
-    () => sortedDeployments[0]?.name
+  const [internalName, setInternalName] = useState<string | undefined>(
+    () => selectedDeploymentName ?? sortedDeployments[0]?.name
   );
+  const isControlled = selectedDeploymentName !== undefined;
+  const selectedName = isControlled ? selectedDeploymentName : internalName;
+  const setSelectedName = (name: string) => {
+    if (!isControlled) setInternalName(name);
+    onSelectDeployment?.(name);
+  };
 
   useEffect(() => {
-    if (!selectedName) {
-      setSelectedName(sortedDeployments[0]?.name);
+    if (isControlled) return;
+    if (!internalName) {
+      setInternalName(sortedDeployments[0]?.name);
       return;
     }
-    const stillPresent = sortedDeployments.some((d) => d.name === selectedName);
-    if (!stillPresent) setSelectedName(sortedDeployments[0]?.name);
-  }, [sortedDeployments, selectedName]);
+    const stillPresent = sortedDeployments.some((d) => d.name === internalName);
+    if (!stillPresent) setInternalName(sortedDeployments[0]?.name);
+  }, [sortedDeployments, internalName, isControlled]);
 
   if (sortedDeployments.length === 0) {
     return (

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/DeploymentLogsView.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/DeploymentLogsView.tsx
@@ -72,7 +72,7 @@ export const DeploymentLogsView: FC<DeploymentLogsViewProps> = ({
   const pOffset = '2';
 
   return (
-    <Stack className="h-full min-h-0" gap="2">
+    <Stack className="h-full min-h-0 w-full" gap="2">
       {sortedDeployments.length > 1 && (
         <Block className="shrink-0" paddingX={pOffset}>
           <Select
@@ -91,7 +91,7 @@ export const DeploymentLogsView: FC<DeploymentLogsViewProps> = ({
           />
         </Block>
       )}
-      <Block className="flex-1 min-h-0 overflow-auto" paddingX={pOffset}>
+      <Block className="flex-1 min-h-0" paddingX={pOffset}>
         {selectedName ? (
           <LogsForDeployment workspace={workspace} deploymentName={selectedName} />
         ) : null}
@@ -106,7 +106,6 @@ interface LogsForDeploymentProps {
 }
 
 const TAIL_LINES = 500;
-// Cap the live buffer so a long-lived, noisy stream can't grow state unbounded.
 const MAX_STREAMED_LINES = 5000;
 
 const LogsForDeployment: FC<LogsForDeploymentProps> = ({ workspace, deploymentName }) => {
@@ -114,24 +113,18 @@ const LogsForDeployment: FC<LogsForDeploymentProps> = ({ workspace, deploymentNa
     workspace,
     deploymentName,
     { tail: TAIL_LINES },
-    // Short staleTime: the live SSE stream keeps logs current after mount, so we
-    // only need a fresh tail baseline, not a refetch on every quick tab toggle.
     { query: { staleTime: 5000 } }
   );
 
   const [streamedLines, setStreamedLines] = useState<PlatformJobLog[]>([]);
-  // Reset on deployment change so we don't stitch one process's tail onto another.
   useEffect(() => {
     setStreamedLines([]);
   }, [deploymentName]);
 
   const accessToken = useAuth()?.user?.access_token;
-  // Byte offset just past the tail; resume the stream from here so lines written
-  // between the tail fetch and the stream opening aren't dropped.
   const tailOffset = data?.next_offset;
 
   useEffect(() => {
-    // Wait for the tail query to settle so the stream can resume from tailOffset.
     if (!deploymentName || isLoading) return;
     const url = `${PLATFORM_BASE_URL}${getAgentsStreamDeploymentLogsQueryKey(workspace, deploymentName)[0]}`;
     const controller = new AbortController();

--- a/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/DeploymentLogsView.tsx
+++ b/web/packages/studio/src/components/sidePanels/AgentPanels/AgentPanel/DeploymentLogsView.tsx
@@ -53,11 +53,12 @@ export const DeploymentLogsView: FC<DeploymentLogsViewProps> = ({ workspace, dep
       </Stack>
     );
   }
+  const pOffset = '2';
 
   return (
-    <Stack className="h-full min-h-0" gap="0">
+    <Stack className="h-full min-h-0" gap="2">
       {sortedDeployments.length > 1 && (
-        <Block padding="4" className="border-b border-base shrink-0">
+        <Block className="shrink-0" paddingX={pOffset}>
           <Select
             value={selectedName ?? ''}
             items={sortedDeployments.flatMap((d) =>
@@ -74,7 +75,7 @@ export const DeploymentLogsView: FC<DeploymentLogsViewProps> = ({ workspace, dep
           />
         </Block>
       )}
-      <Block className="flex-1 min-h-0 overflow-auto" padding="4">
+      <Block className="flex-1 min-h-0 overflow-auto" paddingX={pOffset}>
         {selectedName ? (
           <LogsForDeployment workspace={workspace} deploymentName={selectedName} />
         ) : null}

--- a/web/packages/studio/src/routes/WorkspaceLayout/WorkspaceSideNav.tsx
+++ b/web/packages/studio/src/routes/WorkspaceLayout/WorkspaceSideNav.tsx
@@ -5,7 +5,6 @@ import SafeSynthesizerLogo from '@nemo/common/src/svgs/safe_synthesizer_logo.svg
 import { NavigationDrawer } from '@studio/components/Layouts/NavigationDrawer';
 import { DataDesignerIconFc } from '@studio/constants/constants';
 import {
-  AGENTS_ENABLED,
   BASE_MODELS_ENABLED,
   CODING_AGENT_STUDIO_ENABLED,
   CUSTOMIZER_ENABLED,
@@ -24,11 +23,8 @@ import {
 } from '@studio/constants/environment';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { iconColorClass } from '@studio/routes/constants';
+import { getAgentSideNavItems } from '@studio/routes/groups/agentRoutes';
 import {
-  getAgentEvaluationsListRoute,
-  getAgentsListRoute,
-  getAgentMonitorRoute,
-  getAgentOptimizationsRoute,
   getDataDesignerJobListRoute,
   getModelCompareRoute,
   getEvaluationResultsRoute,
@@ -50,7 +46,6 @@ import {
   Boxes,
   ChartBar,
   Database,
-  HatGlasses,
   ListChecks,
   Home,
   ShieldCheck,
@@ -59,9 +54,6 @@ import {
   Cog,
   Columns3,
   Rocket,
-  Lightbulb,
-  Activity,
-  FlaskConical,
   Waypoints,
 } from 'lucide-react';
 import { useMemo } from 'react';
@@ -157,35 +149,7 @@ export const WorkspaceSideNav = ({ collapsed }: { collapsed?: boolean }) => {
         ]
       : [];
 
-    const agentsNav = AGENTS_ENABLED
-      ? [
-          {
-            id: 'agents',
-            slotIcon: <HatGlasses className={iconColorClass} />,
-            slotLabel: 'Agents',
-            href: getAgentsListRoute(workspace),
-          },
-          {
-            id: 'agent-evaluations',
-            slotIcon: <FlaskConical className={iconColorClass} />,
-            slotLabel: 'Evaluations',
-            href: getAgentEvaluationsListRoute(workspace),
-          },
-          {
-            id: 'agent-monitor',
-            slotIcon: <Activity className={iconColorClass} />,
-            slotLabel: 'Monitor',
-            href: getAgentMonitorRoute(workspace),
-          },
-
-          {
-            id: 'agent-optimizations',
-            slotIcon: <Lightbulb className={iconColorClass} />,
-            slotLabel: 'Suggestions',
-            href: getAgentOptimizationsRoute(workspace),
-          },
-        ]
-      : [];
+    const agentItems = getAgentSideNavItems(workspace);
 
     const virtualModelsNav = [
       {
@@ -237,11 +201,11 @@ export const WorkspaceSideNav = ({ collapsed }: { collapsed?: boolean }) => {
     return [
       ...dashboardNav,
       ...modelCompareNav,
-      ...(agentsNav.length > 0
+      ...(agentItems.length > 0
         ? [
             {
               group: 'Agents',
-              items: agentsNav,
+              items: agentItems,
             },
           ]
         : []),

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/ConfigurationTab.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/ConfigurationTab.tsx
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { KVPair } from '@nemo/common/src/components/KVPair';
+import { isDefined } from '@nemo/common/src/utils/list';
+import type { Agent } from '@nemo/sdk/generated/agents/schema/Agent';
+import { Stack } from '@nvidia/foundations-react-core';
+import type { AgentConfig } from '@studio/components/dataViews/AgentsDataView';
+import { getAgentModelNames } from '@studio/components/dataViews/AgentsDataView/utils';
+import { DetailPanel } from '@studio/routes/agents/AgentDetailRoute/overview/DetailPanel';
+import type { FC } from 'react';
+
+interface ConfigurationTabProps {
+  workspace: string;
+  agentName?: string;
+  agent?: Agent;
+}
+
+/** Read-only view of the agent's configuration metadata. */
+export const ConfigurationTab: FC<ConfigurationTabProps> = ({ workspace, agentName, agent }) => {
+  const models = getAgentModelNames(agent?.config as AgentConfig | undefined);
+
+  return (
+    <DetailPanel title="Configuration">
+      <Stack gap="2">
+        <KVPair label="Name" value={agent?.name ?? agentName} />
+        <KVPair label="Workspace" value={agent?.workspace ?? workspace} />
+        {isDefined(agent?.description) && (
+          <KVPair label="Description" value={agent.description || '-'} />
+        )}
+        {models.length > 0 && <KVPair label="Model" value={models.join(', ')} />}
+        {isDefined(agent?.config_format) && (
+          <KVPair label="Config Format" value={agent.config_format} />
+        )}
+      </Stack>
+    </DetailPanel>
+  );
+};

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/DeploymentsTab.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/DeploymentsTab.tsx
@@ -4,14 +4,12 @@
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
 import type { AgentDeployment } from '@nemo/sdk/generated/agents/schema/AgentDeployment';
 import { Button, Flex, Stack, StatusIndicator, Text } from '@nvidia/foundations-react-core';
-import { DeploymentLogsView } from '@studio/components/sidePanels/AgentPanels/AgentPanel/DeploymentLogsView';
 import { deploymentStatusColor } from '@studio/components/sidePanels/AgentPanels/AgentPanel/helpers';
 import { NoHealthyDeploymentsBanner } from '@studio/components/sidePanels/AgentPanels/AgentPanel/NoHealthyDeploymentsBanner';
 import { DetailPanel } from '@studio/routes/agents/AgentDetailRoute/overview/DetailPanel';
 import type { FC } from 'react';
 
 interface DeploymentsTabProps {
-  workspace: string;
   agentName?: string;
   deployments: AgentDeployment[];
   isDeploymentsLoading: boolean;
@@ -19,11 +17,11 @@ interface DeploymentsTabProps {
   onDeploy: () => void;
   onChat: (deployment: AgentDeployment) => void;
   onDelete: (deployment: AgentDeployment) => void;
+  onViewLogs: (deployment: AgentDeployment) => void;
 }
 
-/** Deployments list with per-deployment actions, plus live deployment logs. */
+/** Deployments list with per-deployment actions. */
 export const DeploymentsTab: FC<DeploymentsTabProps> = ({
-  workspace,
   agentName,
   deployments,
   isDeploymentsLoading,
@@ -31,6 +29,7 @@ export const DeploymentsTab: FC<DeploymentsTabProps> = ({
   onDeploy,
   onChat,
   onDelete,
+  onViewLogs,
 }) => (
   <Stack gap="5" className="w-full">
     <DetailPanel title="Deployments" flush>
@@ -76,6 +75,9 @@ export const DeploymentsTab: FC<DeploymentsTabProps> = ({
                 >
                   Chat
                 </Button>
+                <Button kind="tertiary" size="small" onClick={() => onViewLogs(deployment)}>
+                  Logs
+                </Button>
                 <Button
                   kind="tertiary"
                   size="small"
@@ -90,8 +92,5 @@ export const DeploymentsTab: FC<DeploymentsTabProps> = ({
         </Stack>
       )}
     </DetailPanel>
-    {deployments.length > 0 && (
-      <DeploymentLogsView workspace={workspace} deployments={deployments} />
-    )}
   </Stack>
 );

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/DeploymentsTab.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/DeploymentsTab.tsx
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
+import type { AgentDeployment } from '@nemo/sdk/generated/agents/schema/AgentDeployment';
+import { Button, Flex, Stack, StatusIndicator, Text } from '@nvidia/foundations-react-core';
+import { DeploymentLogsView } from '@studio/components/sidePanels/AgentPanels/AgentPanel/DeploymentLogsView';
+import { deploymentStatusColor } from '@studio/components/sidePanels/AgentPanels/AgentPanel/helpers';
+import { NoHealthyDeploymentsBanner } from '@studio/components/sidePanels/AgentPanels/AgentPanel/NoHealthyDeploymentsBanner';
+import { DetailPanel } from '@studio/routes/agents/AgentDetailRoute/overview/DetailPanel';
+import type { FC } from 'react';
+
+interface DeploymentsTabProps {
+  workspace: string;
+  agentName?: string;
+  deployments: AgentDeployment[];
+  isDeploymentsLoading: boolean;
+  isDeploying: boolean;
+  onDeploy: () => void;
+  onChat: (deployment: AgentDeployment) => void;
+  onDelete: (deployment: AgentDeployment) => void;
+}
+
+/** Deployments list with per-deployment actions, plus live deployment logs. */
+export const DeploymentsTab: FC<DeploymentsTabProps> = ({
+  workspace,
+  agentName,
+  deployments,
+  isDeploymentsLoading,
+  isDeploying,
+  onDeploy,
+  onChat,
+  onDelete,
+}) => (
+  <Stack gap="5" className="w-full">
+    <DetailPanel title="Deployments" flush>
+      {!isDeploymentsLoading && deployments.length === 0 ? (
+        <div className="p-4">
+          <NoHealthyDeploymentsBanner
+            agentName={agentName}
+            isDeploying={isDeploying}
+            onDeploy={onDeploy}
+            message="No deployments for this agent."
+          />
+        </div>
+      ) : (
+        <Stack gap="0">
+          {deployments.map((deployment, index) => (
+            <Flex
+              key={deployment.name}
+              align="center"
+              gap="2"
+              className={`px-4 py-3 ${index > 0 ? 'border-t border-base' : ''}`}
+            >
+              <StatusIndicator color={deploymentStatusColor(deployment.status)} size="small" />
+              <Stack gap="0" className="min-w-0 flex-1">
+                <Text kind="body/semibold/sm">{deployment.name}</Text>
+                {deployment.endpoint && (
+                  <Text kind="body/regular/xs" color="secondary" className="truncate">
+                    {deployment.endpoint}
+                  </Text>
+                )}
+                {deployment.error && (
+                  <Text kind="body/regular/xs" color="danger" className="truncate">
+                    {deployment.error}
+                  </Text>
+                )}
+              </Stack>
+              <StatusBadge status={deployment.status} />
+              <Flex gap="1" className="shrink-0">
+                <Button
+                  kind="tertiary"
+                  size="small"
+                  disabled={deployment.status !== 'running'}
+                  onClick={() => onChat(deployment)}
+                >
+                  Chat
+                </Button>
+                <Button
+                  kind="tertiary"
+                  size="small"
+                  color="danger"
+                  onClick={() => onDelete(deployment)}
+                >
+                  Delete
+                </Button>
+              </Flex>
+            </Flex>
+          ))}
+        </Stack>
+      )}
+    </DetailPanel>
+    {deployments.length > 0 && (
+      <DeploymentLogsView workspace={workspace} deployments={deployments} />
+    )}
+  </Stack>
+);

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/EvaluationsTab.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/EvaluationsTab.tsx
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
+import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
+import { Button, Flex, Stack, Text } from '@nvidia/foundations-react-core';
+import { DetailPanel } from '@studio/routes/agents/AgentDetailRoute/overview/DetailPanel';
+import type { AgentEvalJob } from '@studio/routes/agents/AgentEvaluationsRoute/api';
+import { getAgentEvaluationDetailRoute, getAgentEvaluationsListRoute } from '@studio/routes/utils';
+import type { FC } from 'react';
+import { Link } from 'react-router-dom';
+
+interface EvaluationsTabProps {
+  workspace: string;
+  evals: AgentEvalJob[];
+  onRunEvaluation: () => void;
+}
+
+/** Recent evaluation jobs for the agent, linking through to each run. */
+export const EvaluationsTab: FC<EvaluationsTabProps> = ({ workspace, evals, onRunEvaluation }) => (
+  <DetailPanel
+    title="Recent evaluations"
+    flush
+    slotAction={
+      <Button kind="secondary" size="small" onClick={onRunEvaluation}>
+        Run evaluation
+      </Button>
+    }
+  >
+    {evals.length === 0 ? (
+      <Stack gap="2" className="p-4">
+        <Text color="secondary">No evaluation jobs found for this agent.</Text>
+        <Link to={getAgentEvaluationsListRoute(workspace)} className="text-xs">
+          View all evaluations →
+        </Link>
+      </Stack>
+    ) : (
+      <Stack gap="0">
+        {evals.map((job, index) => (
+          <Link
+            key={job.name}
+            to={getAgentEvaluationDetailRoute(workspace, job.name)}
+            className="text-inherit no-underline"
+          >
+            <Flex
+              align="center"
+              gap="2"
+              className={`px-4 py-3 hover:bg-surface-hover ${index > 0 ? 'border-t border-base' : ''}`}
+            >
+              <Stack gap="0" className="min-w-0 flex-1">
+                <Text kind="body/semibold/sm" className="truncate">
+                  {job.name}
+                </Text>
+                <Text kind="body/regular/xs" color="secondary">
+                  <RelativeTime datetime={job.created_at} />
+                </Text>
+              </Stack>
+              <StatusBadge status={job.status} />
+            </Flex>
+          </Link>
+        ))}
+        <div className="border-t border-base px-4 py-3">
+          <Link to={getAgentEvaluationsListRoute(workspace)} className="text-xs">
+            View all evaluations →
+          </Link>
+        </div>
+      </Stack>
+    )}
+  </DetailPanel>
+);

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/EvaluationsTab.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/EvaluationsTab.tsx
@@ -3,16 +3,16 @@
 
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
+import type { AgentEvaluateJob } from '@nemo/sdk/generated/evaluator/schema';
 import { Button, Flex, Stack, Text } from '@nvidia/foundations-react-core';
 import { DetailPanel } from '@studio/routes/agents/AgentDetailRoute/overview/DetailPanel';
-import type { AgentEvalJob } from '@studio/routes/agents/AgentEvaluationsRoute/api';
 import { getAgentEvaluationDetailRoute, getAgentEvaluationsListRoute } from '@studio/routes/utils';
 import type { FC } from 'react';
 import { Link } from 'react-router-dom';
 
 interface EvaluationsTabProps {
   workspace: string;
-  evals: AgentEvalJob[];
+  evals: AgentEvaluateJob[];
   onRunEvaluation: () => void;
 }
 
@@ -52,7 +52,7 @@ export const EvaluationsTab: FC<EvaluationsTabProps> = ({ workspace, evals, onRu
                   {job.name}
                 </Text>
                 <Text kind="body/regular/xs" color="secondary">
-                  <RelativeTime datetime={job.created_at} />
+                  {job.created_at ? <RelativeTime datetime={job.created_at} /> : '—'}
                 </Text>
               </Stack>
               <StatusBadge status={job.status} />

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/TabPlaceholder.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/TabPlaceholder.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flex, Stack, Text } from '@nvidia/foundations-react-core';
+import type { ComponentType, FC } from 'react';
+
+interface TabPlaceholderProps {
+  icon: ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+}
+
+/** Empty-state card for tabs whose backing data/experience isn't built yet. */
+export const TabPlaceholder: FC<TabPlaceholderProps> = ({ icon: Icon, title, description }) => (
+  <Flex
+    align="center"
+    justify="center"
+    className="min-h-full w-full rounded-xl border border-dashed border-base bg-surface-raised px-6 py-16"
+  >
+    <Stack gap="2" align="center" className="max-w-md text-center">
+      <Flex
+        align="center"
+        justify="center"
+        className="size-11 rounded-full bg-surface-subtle text-secondary"
+      >
+        <Icon className="size-12" aria-hidden />
+      </Flex>
+      <Text kind="body/bold/md">{title}</Text>
+      <Text kind="body/regular/sm" color="secondary">
+        {description}
+      </Text>
+    </Stack>
+  </Flex>
+);

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/index.test.tsx
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ROUTES } from '@studio/constants/routes';
+import { workspace1 } from '@studio/mocks/entity-store/projects';
+import { AgentDetailRoute } from '@studio/routes/agents/AgentDetailRoute';
+import { getAgentDetailRoute } from '@studio/routes/utils';
+import { renderRoute, screen } from '@studio/tests/util/render';
+import userEvent from '@testing-library/user-event';
+
+const agentName = 'react-agent';
+const workspace = workspace1.workspace;
+
+const renderDetail = () =>
+  renderRoute(undefined, {
+    history: getAgentDetailRoute(workspace, agentName),
+    routes: [{ path: ROUTES.workspace.agentDetail, element: <AgentDetailRoute /> }],
+  });
+
+describe('AgentDetailRoute', () => {
+  it('renders the agent as a full page with tabs and header actions', async () => {
+    renderDetail();
+
+    expect(await screen.findByTestId('nv-page-header-heading')).toHaveTextContent(agentName);
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Evaluations' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Deployments' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Configuration' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Chat' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open traces' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run evaluation' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Deploy' })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('switches to the chat tab', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    await user.click(await screen.findByRole('tab', { name: 'Chat' }));
+
+    expect(screen.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
+    expect(await screen.findByRole('textbox', { name: /Task prompt/i })).toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/index.test.tsx
@@ -22,11 +22,15 @@ describe('AgentDetailRoute', () => {
     renderDetail();
 
     expect(await screen.findByTestId('nv-page-header-heading')).toHaveTextContent(agentName);
-    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Deployments' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
     expect(screen.getByRole('tab', { name: 'Evaluations' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Deployments' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Configuration' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Logs' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Chat' })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Overview' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Configuration' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Open traces' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Run evaluation' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Deploy' })).toBeInTheDocument();

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/index.tsx
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
+import type { AgentDeployment } from '@nemo/sdk/generated/agents/schema/AgentDeployment';
+import {
+  Button,
+  Flex,
+  PageHeader,
+  Stack,
+  TabsContent,
+  TabsList,
+  TabsRoot,
+  TabsTrigger,
+  Text,
+  Tooltip,
+} from '@nvidia/foundations-react-core';
+import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { DeleteConfirmationModal } from '@studio/components/DeleteConfirmationModal';
+import { ChatPlaygroundContent } from '@studio/components/sidePanels/AgentPanels/AgentPanel/ChatPlaygroundContent';
+import { useAgentPanel } from '@studio/components/sidePanels/AgentPanels/AgentPanel/useAgentPanel';
+import { ROUTE_PARAMS } from '@studio/constants/routes';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { CreateDeploymentModal } from '@studio/routes/agents/AgentDeploymentsListRoute/CreateDeploymentModal';
+import { ConfigurationTab } from '@studio/routes/agents/AgentDetailRoute/ConfigurationTab';
+import { DeploymentsTab } from '@studio/routes/agents/AgentDetailRoute/DeploymentsTab';
+import { EvaluationsTab } from '@studio/routes/agents/AgentDetailRoute/EvaluationsTab';
+import { TabPlaceholder } from '@studio/routes/agents/AgentDetailRoute/TabPlaceholder';
+import { SubmitEvaluationModal } from '@studio/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal';
+import { getAgentMonitorRoute, getAgentsListRoute } from '@studio/routes/utils';
+import {
+  Activity,
+  ClipboardCheck,
+  LayoutDashboard,
+  Rocket,
+  Sparkles,
+  Waypoints,
+} from 'lucide-react';
+import { type FC, useRef, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+
+const TAB_SEARCH_PARAM = 'tab';
+const DETAIL_TABS = [
+  'overview',
+  'traces',
+  'evaluations',
+  'improvements',
+  'deployments',
+  'configuration',
+  'chat',
+] as const;
+
+type AgentDetailTab = (typeof DETAIL_TABS)[number];
+
+const isAgentDetailTab = (value: string | null): value is AgentDetailTab =>
+  !!value && DETAIL_TABS.includes(value as AgentDetailTab);
+
+export const AgentDetailRoute: FC = () => {
+  const workspace = useWorkspaceFromPath();
+  const navigate = useNavigate();
+  const { [ROUTE_PARAMS.agentName]: agentName } = useParams<{ agentName: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [selectedDeploymentName, setSelectedDeploymentName] = useState<string | undefined>();
+  const [createDeploymentOpen, setCreateDeploymentOpen] = useState(false);
+  const [submitEvalOpen, setSubmitEvalOpen] = useState(false);
+  const [deleteDeploymentTarget, setDeleteDeploymentTarget] = useState<AgentDeployment | null>(
+    null
+  );
+  const chatAreaRef = useRef<HTMLDivElement>(null);
+  const tabFromUrl = searchParams.get(TAB_SEARCH_PARAM);
+  const selectedTab: AgentDetailTab = isAgentDetailTab(tabFromUrl) ? tabFromUrl : 'overview';
+
+  const {
+    agent,
+    agentDeployments,
+    agentEvals,
+    chatDeployment,
+    deleteDeploymentMutation,
+    healthyDeployments,
+    isDeploying,
+    isDeploymentsLoading,
+  } = useAgentPanel({ workspace, agentName, selectedDeploymentName });
+
+  useBreadcrumbs({
+    items: [
+      { slotLabel: 'Agents', href: getAgentsListRoute(workspace) },
+      { slotLabel: agentName ?? 'Agent details' },
+    ],
+  });
+
+  const setSelectedTab = (tab: AgentDetailTab) => {
+    setSearchParams({ [TAB_SEARCH_PARAM]: tab }, { replace: true });
+  };
+
+  const switchToChat = (deployment: AgentDeployment) => {
+    setSelectedDeploymentName(deployment.name);
+    setSelectedTab('chat');
+  };
+
+  const status = healthyDeployments.length > 0 ? 'running' : agentDeployments[0]?.status;
+  const statusPillLabel =
+    healthyDeployments.length > 0
+      ? 'Healthy'
+      : status === 'pending' || status === 'starting'
+        ? 'Deploying'
+        : status === 'deleting'
+          ? 'Deleting'
+          : status === 'failed'
+            ? 'Failed'
+            : agentDeployments.length === 0
+              ? 'No deployments'
+              : (status ?? 'Unknown');
+  const totalDeployments = agentDeployments.length;
+  const statusDetail =
+    totalDeployments === 0
+      ? undefined
+      : `${healthyDeployments.length} healthy · ${totalDeployments} total deployment${totalDeployments === 1 ? '' : 's'}`;
+
+  return (
+    <AccessibleTitle title={`${agentName ?? 'Agent'} details for ${workspace}`}>
+      <Stack className="h-full min-h-0" gap="density-2xl" padding="density-2xl">
+        <PageHeader
+          className="shrink-0 p-0"
+          slotHeading={agent?.name ?? agentName ?? 'Agent details'}
+          slotDescription={
+            agent?.description ?? 'View and manage this agent, its deployments, and evaluations.'
+          }
+          slotActions={
+            <Flex gap="2" wrap="wrap" justify="end">
+              <Button kind="secondary" onClick={() => navigate(getAgentMonitorRoute(workspace))}>
+                <Activity className="size-4" aria-hidden />
+                Open traces
+              </Button>
+              <Button
+                kind="secondary"
+                onClick={() => setSubmitEvalOpen(true)}
+                disabled={!agentName}
+              >
+                <ClipboardCheck className="size-4" aria-hidden />
+                Run evaluation
+              </Button>
+              <Button
+                color="brand"
+                onClick={() => setCreateDeploymentOpen(true)}
+                disabled={!agentName || isDeploying}
+              >
+                <Rocket className="size-4" aria-hidden />
+                {isDeploying ? 'Deploying...' : 'Deploy'}
+              </Button>
+            </Flex>
+          }
+        >
+          <Flex align="center" gap="2">
+            {statusDetail ? (
+              <Tooltip
+                side="bottom"
+                slotContent={<Text kind="body/regular/sm">{statusDetail}</Text>}
+              >
+                <span className="cursor-help" role="status">
+                  <StatusBadge status={status} label={statusPillLabel} />
+                </span>
+              </Tooltip>
+            ) : (
+              <StatusBadge status={status} label={statusPillLabel} />
+            )}
+          </Flex>
+        </PageHeader>
+
+        <TabsRoot
+          className="flex min-h-0 flex-1 flex-col"
+          value={selectedTab}
+          onValueChange={(value) => {
+            if (isAgentDetailTab(value)) setSelectedTab(value);
+          }}
+        >
+          <TabsList className="shrink-0">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="traces">Traces</TabsTrigger>
+            <TabsTrigger value="evaluations">Evaluations</TabsTrigger>
+            <TabsTrigger value="improvements">Improvements</TabsTrigger>
+            <TabsTrigger value="deployments">Deployments</TabsTrigger>
+            <TabsTrigger value="configuration">Configuration</TabsTrigger>
+            <TabsTrigger value="chat">Chat</TabsTrigger>
+          </TabsList>
+
+          <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="overview">
+            <TabPlaceholder
+              icon={LayoutDashboard}
+              title="Overview is coming soon"
+              description="A summary of this agent's health, recent activity, and open findings will appear here."
+            />
+          </TabsContent>
+
+          <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="traces">
+            <TabPlaceholder
+              icon={Waypoints}
+              title="Traces are coming soon"
+              description="Inspect clustered request traces and drill into failures for this agent. Use Open traces to view them in the monitor for now."
+            />
+          </TabsContent>
+
+          <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="evaluations">
+            <EvaluationsTab
+              workspace={workspace}
+              evals={agentEvals}
+              onRunEvaluation={() => setSubmitEvalOpen(true)}
+            />
+          </TabsContent>
+
+          <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="improvements">
+            <TabPlaceholder
+              icon={Sparkles}
+              title="Improvements are coming soon"
+              description="Validated candidates from optimization runs will show up here for review, comparison, and promotion."
+            />
+          </TabsContent>
+
+          <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="deployments">
+            <DeploymentsTab
+              workspace={workspace}
+              agentName={agentName}
+              deployments={agentDeployments}
+              isDeploymentsLoading={isDeploymentsLoading}
+              isDeploying={isDeploying}
+              onDeploy={() => setCreateDeploymentOpen(true)}
+              onChat={switchToChat}
+              onDelete={setDeleteDeploymentTarget}
+            />
+          </TabsContent>
+
+          <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="configuration">
+            <ConfigurationTab workspace={workspace} agentName={agentName} agent={agent} />
+          </TabsContent>
+
+          <TabsContent className="min-h-0 flex-1 overflow-hidden p-0 pt-6" value="chat">
+            <div className="mx-auto flex h-full w-full max-w-4xl flex-col">
+              <ChatPlaygroundContent
+                workspace={workspace}
+                agentName={agentName}
+                chatDeployment={chatDeployment}
+                healthyDeployments={healthyDeployments}
+                isDeploymentsLoading={isDeploymentsLoading}
+                isDeploying={isDeploying}
+                chatAreaRef={chatAreaRef}
+                onSelectDeployment={setSelectedDeploymentName}
+                onDeploy={() => setCreateDeploymentOpen(true)}
+              />
+            </div>
+          </TabsContent>
+        </TabsRoot>
+      </Stack>
+      <SubmitEvaluationModal
+        open={submitEvalOpen}
+        onClose={() => setSubmitEvalOpen(false)}
+        workspace={workspace}
+        agent={agentName}
+      />
+      {createDeploymentOpen && (
+        <CreateDeploymentModal
+          open
+          agent={agentName}
+          workspace={workspace}
+          onClose={() => setCreateDeploymentOpen(false)}
+        />
+      )}
+      {deleteDeploymentTarget && (
+        <DeleteConfirmationModal
+          open
+          title="Delete Deployment"
+          successText="Successfully queued deployment for deletion."
+          onDelete={async () => {
+            try {
+              if (!deleteDeploymentTarget.name) return false;
+              await deleteDeploymentMutation.mutateAsync({
+                workspace,
+                name: deleteDeploymentTarget.name,
+              });
+              return true;
+            } catch {
+              return false;
+            }
+          }}
+          onClose={() => setDeleteDeploymentTarget(null)}
+          simpleConfirm
+        />
+      )}
+    </AccessibleTitle>
+  );
+};

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/index.tsx
@@ -13,43 +13,28 @@ import {
   TabsRoot,
   TabsTrigger,
   Text,
-  Tooltip,
 } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { getAgentModelNames } from '@studio/components/dataViews/AgentsDataView/utils';
 import { DeleteConfirmationModal } from '@studio/components/DeleteConfirmationModal';
 import { ChatPlaygroundContent } from '@studio/components/sidePanels/AgentPanels/AgentPanel/ChatPlaygroundContent';
+import { DeploymentLogsView } from '@studio/components/sidePanels/AgentPanels/AgentPanel/DeploymentLogsView';
 import { useAgentPanel } from '@studio/components/sidePanels/AgentPanels/AgentPanel/useAgentPanel';
 import { ROUTE_PARAMS } from '@studio/constants/routes';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { CreateDeploymentModal } from '@studio/routes/agents/AgentDeploymentsListRoute/CreateDeploymentModal';
-import { ConfigurationTab } from '@studio/routes/agents/AgentDetailRoute/ConfigurationTab';
 import { DeploymentsTab } from '@studio/routes/agents/AgentDetailRoute/DeploymentsTab';
 import { EvaluationsTab } from '@studio/routes/agents/AgentDetailRoute/EvaluationsTab';
-import { TabPlaceholder } from '@studio/routes/agents/AgentDetailRoute/TabPlaceholder';
 import { SubmitEvaluationModal } from '@studio/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal';
 import { getAgentMonitorRoute, getAgentsListRoute } from '@studio/routes/utils';
-import {
-  Activity,
-  ClipboardCheck,
-  LayoutDashboard,
-  Rocket,
-  Sparkles,
-  Waypoints,
-} from 'lucide-react';
+import { Activity, ClipboardCheck, Dot, Rocket } from 'lucide-react';
 import { type FC, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 const TAB_SEARCH_PARAM = 'tab';
-const DETAIL_TABS = [
-  'overview',
-  'traces',
-  'evaluations',
-  'improvements',
-  'deployments',
-  'configuration',
-  'chat',
-] as const;
+const DETAIL_TABS = ['deployments', 'logs', 'chat', 'evaluations'] as const;
+const DEFAULT_TAB = 'deployments';
 
 type AgentDetailTab = (typeof DETAIL_TABS)[number];
 
@@ -62,6 +47,7 @@ export const AgentDetailRoute: FC = () => {
   const { [ROUTE_PARAMS.agentName]: agentName } = useParams<{ agentName: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedDeploymentName, setSelectedDeploymentName] = useState<string | undefined>();
+  const [logsDeploymentName, setLogsDeploymentName] = useState<string | undefined>();
   const [createDeploymentOpen, setCreateDeploymentOpen] = useState(false);
   const [submitEvalOpen, setSubmitEvalOpen] = useState(false);
   const [deleteDeploymentTarget, setDeleteDeploymentTarget] = useState<AgentDeployment | null>(
@@ -69,7 +55,7 @@ export const AgentDetailRoute: FC = () => {
   );
   const chatAreaRef = useRef<HTMLDivElement>(null);
   const tabFromUrl = searchParams.get(TAB_SEARCH_PARAM);
-  const selectedTab: AgentDetailTab = isAgentDetailTab(tabFromUrl) ? tabFromUrl : 'overview';
+  const selectedTab: AgentDetailTab = isAgentDetailTab(tabFromUrl) ? tabFromUrl : DEFAULT_TAB;
 
   const {
     agent,
@@ -98,6 +84,13 @@ export const AgentDetailRoute: FC = () => {
     setSelectedTab('chat');
   };
 
+  const viewLogs = (deployment: AgentDeployment) => {
+    setLogsDeploymentName(deployment.name);
+    setSelectedTab('logs');
+  };
+
+  const modelNames = getAgentModelNames(agent?.config);
+
   const status = healthyDeployments.length > 0 ? 'running' : agentDeployments[0]?.status;
   const statusPillLabel =
     healthyDeployments.length > 0
@@ -111,20 +104,32 @@ export const AgentDetailRoute: FC = () => {
             : agentDeployments.length === 0
               ? 'No deployments'
               : (status ?? 'Unknown');
-  const totalDeployments = agentDeployments.length;
-  const statusDetail =
-    totalDeployments === 0
-      ? undefined
-      : `${healthyDeployments.length} healthy · ${totalDeployments} total deployment${totalDeployments === 1 ? '' : 's'}`;
 
   return (
     <AccessibleTitle title={`${agentName ?? 'Agent'} details for ${workspace}`}>
       <Stack className="h-full min-h-0" gap="density-2xl" padding="density-2xl">
         <PageHeader
           className="shrink-0 p-0"
-          slotHeading={agent?.name ?? agentName ?? 'Agent details'}
-          slotDescription={
-            agent?.description ?? 'View and manage this agent, its deployments, and evaluations.'
+          slotHeading={
+            <Stack gap="1">
+              <Flex align="baseline" gap="3">
+                <Text kind="title/md">{agent?.name ?? agentName ?? 'Agent details'}</Text>
+                <StatusBadge status={status} label={statusPillLabel} />
+              </Flex>
+              <Flex align="center" gap="1">
+                <Text kind="body/regular/sm" className="text-secondary">
+                  {modelNames.join(', ')}
+                </Text>
+                {agent?.description && (
+                  <>
+                    <Dot className="size-2" aria-hidden />
+                    <Text kind="body/regular/sm" className="text-secondary">
+                      {agent.description}
+                    </Text>
+                  </>
+                )}
+              </Flex>
+            </Stack>
           }
           slotActions={
             <Flex gap="2" wrap="wrap" justify="end">
@@ -150,22 +155,7 @@ export const AgentDetailRoute: FC = () => {
               </Button>
             </Flex>
           }
-        >
-          <Flex align="center" gap="2">
-            {statusDetail ? (
-              <Tooltip
-                side="bottom"
-                slotContent={<Text kind="body/regular/sm">{statusDetail}</Text>}
-              >
-                <span className="cursor-help" role="status">
-                  <StatusBadge status={status} label={statusPillLabel} />
-                </span>
-              </Tooltip>
-            ) : (
-              <StatusBadge status={status} label={statusPillLabel} />
-            )}
-          </Flex>
-        </PageHeader>
+        ></PageHeader>
 
         <TabsRoot
           className="flex min-h-0 flex-1 flex-col"
@@ -175,30 +165,11 @@ export const AgentDetailRoute: FC = () => {
           }}
         >
           <TabsList className="shrink-0">
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="traces">Traces</TabsTrigger>
-            <TabsTrigger value="evaluations">Evaluations</TabsTrigger>
-            <TabsTrigger value="improvements">Improvements</TabsTrigger>
             <TabsTrigger value="deployments">Deployments</TabsTrigger>
-            <TabsTrigger value="configuration">Configuration</TabsTrigger>
+            <TabsTrigger value="logs">Logs</TabsTrigger>
             <TabsTrigger value="chat">Chat</TabsTrigger>
+            <TabsTrigger value="evaluations">Evaluations</TabsTrigger>
           </TabsList>
-
-          <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="overview">
-            <TabPlaceholder
-              icon={LayoutDashboard}
-              title="Overview is coming soon"
-              description="A summary of this agent's health, recent activity, and open findings will appear here."
-            />
-          </TabsContent>
-
-          <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="traces">
-            <TabPlaceholder
-              icon={Waypoints}
-              title="Traces are coming soon"
-              description="Inspect clustered request traces and drill into failures for this agent. Use Open traces to view them in the monitor for now."
-            />
-          </TabsContent>
 
           <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="evaluations">
             <EvaluationsTab
@@ -208,17 +179,8 @@ export const AgentDetailRoute: FC = () => {
             />
           </TabsContent>
 
-          <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="improvements">
-            <TabPlaceholder
-              icon={Sparkles}
-              title="Improvements are coming soon"
-              description="Validated candidates from optimization runs will show up here for review, comparison, and promotion."
-            />
-          </TabsContent>
-
           <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="deployments">
             <DeploymentsTab
-              workspace={workspace}
               agentName={agentName}
               deployments={agentDeployments}
               isDeploymentsLoading={isDeploymentsLoading}
@@ -226,11 +188,17 @@ export const AgentDetailRoute: FC = () => {
               onDeploy={() => setCreateDeploymentOpen(true)}
               onChat={switchToChat}
               onDelete={setDeleteDeploymentTarget}
+              onViewLogs={viewLogs}
             />
           </TabsContent>
 
-          <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="configuration">
-            <ConfigurationTab workspace={workspace} agentName={agentName} agent={agent} />
+          <TabsContent className="min-h-0 flex-1 overflow-auto p-0 pt-6" value="logs">
+            <DeploymentLogsView
+              workspace={workspace}
+              deployments={agentDeployments}
+              selectedDeploymentName={logsDeploymentName}
+              onSelectDeployment={setLogsDeploymentName}
+            />
           </TabsContent>
 
           <TabsContent className="min-h-0 flex-1 overflow-hidden p-0 pt-6" value="chat">

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/overview/DetailPanel.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/overview/DetailPanel.tsx
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flex, Stack, Text } from '@nvidia/foundations-react-core';
+import type { FC, ReactNode } from 'react';
+
+interface DetailPanelProps {
+  title: string;
+  /** Rendered on the right of the header (e.g. a count or a "View all" link). */
+  slotAction?: ReactNode;
+  /** When true, the body has no padding so rows can own their own dividers. */
+  flush?: boolean;
+  children: ReactNode;
+}
+
+/** Bordered raised-surface card with a titled header, matching the overview panels. */
+export const DetailPanel: FC<DetailPanelProps> = ({ title, slotAction, flush, children }) => (
+  <Stack className="w-full rounded-xl border border-base bg-surface-raised">
+    <Flex align="center" justify="between" className="px-4 py-3.5">
+      <Text kind="body/bold/sm">{title}</Text>
+      {slotAction}
+    </Flex>
+    <div className="h-px w-full bg-base" />
+    <div className={flush ? '' : 'p-4'}>{children}</div>
+  </Stack>
+);

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
@@ -5,47 +5,29 @@ import type { Agent } from '@nemo/sdk/generated/agents/schema/Agent';
 import { Button, PageHeader, Stack } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { AgentsTable, type AgentTableRow } from '@studio/components/dataViews/AgentsDataView';
-import {
-  AgentPanel,
-  type AgentPanelTab,
-} from '@studio/components/sidePanels/AgentPanels/AgentPanel';
-import { ROUTE_PARAMS } from '@studio/constants/routes';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { CreateDeploymentModal } from '@studio/routes/agents/AgentDeploymentsListRoute/CreateDeploymentModal';
 import { CloneAgentModal } from '@studio/routes/agents/AgentsListRoute/CloneAgentModal';
 import { CreateExampleAgentModal } from '@studio/routes/agents/AgentsListRoute/CreateExampleAgentModal';
-import { getAgentDetailRoute, getAgentsListRoute } from '@studio/routes/utils';
+import { getAgentDetailRoute } from '@studio/routes/utils';
 import { type FC, useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-
-const TAB_SEARCH_PARAM = 'tab';
+import { useNavigate } from 'react-router-dom';
 
 export const AgentsListRoute: FC = () => {
   const workspace = useWorkspaceFromPath();
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
   const [createDeploymentAgent, setCreateDeploymentAgent] = useState<string | null>(null);
   const [isCreateExampleOpen, setCreateExampleOpen] = useState(false);
   const [cloneSource, setCloneSource] = useState<AgentTableRow | null>(null);
   const [loadedAgents, setLoadedAgents] = useState<Agent[]>([]);
-  const { [ROUTE_PARAMS.agentName]: agentNameParam } = useParams<{ agentName?: string }>();
-  const tabFromUrl: AgentPanelTab =
-    (searchParams.get(TAB_SEARCH_PARAM) as AgentPanelTab) || 'agent-details';
 
   useBreadcrumbs({
     items: [{ slotLabel: 'Agents' }],
   });
 
-  const handleOpenPanel = (agent: AgentTableRow) => {
-    navigate(`${getAgentDetailRoute(workspace, agent.name)}?${TAB_SEARCH_PARAM}=agent-details`, {
-      replace: true,
-    });
-  };
-
-  const handleClosePanel = () => {
-    navigate(getAgentsListRoute(workspace), { replace: true });
-  };
+  const handleOpenDetails = (agent: AgentTableRow) =>
+    navigate(getAgentDetailRoute(workspace, agent.name));
 
   return (
     <AccessibleTitle title={`Agents for ${workspace}`}>
@@ -61,7 +43,7 @@ export const AgentsListRoute: FC = () => {
           }
         />
         <AgentsTable
-          onAgentRowClick={handleOpenPanel}
+          onAgentRowClick={handleOpenDetails}
           onCreateDeployment={(agentName) => setCreateDeploymentAgent(agentName)}
           onCloneAgent={setCloneSource}
           onAgentsLoaded={setLoadedAgents}
@@ -84,24 +66,6 @@ export const AgentsListRoute: FC = () => {
         agent={createDeploymentAgent || undefined}
         onClose={() => setCreateDeploymentAgent(null)}
         workspace={workspace}
-      />
-      <AgentPanel
-        open={!!agentNameParam}
-        agentName={agentNameParam}
-        workspace={workspace}
-        defaultTab={tabFromUrl}
-        onTabChange={(tab) =>
-          setSearchParams(
-            (prev) => {
-              prev.set(TAB_SEARCH_PARAM, tab);
-              return prev;
-            },
-            { replace: true }
-          )
-        }
-        onOpenChange={(open) => {
-          if (!open) handleClosePanel();
-        }}
       />
     </AccessibleTitle>
   );

--- a/web/packages/studio/src/routes/groups/agentRoutes.tsx
+++ b/web/packages/studio/src/routes/groups/agentRoutes.tsx
@@ -4,7 +4,14 @@
 import { ErrorPanel } from '@studio/components/ErrorPanel';
 import { AGENTS_ENABLED } from '@studio/constants/environment';
 import { ROUTES } from '@studio/constants/routes';
-import { agentsRoutes } from '@studio/routes/utils';
+import { iconColorClass } from '@studio/routes/constants';
+import {
+  agentsRoutes,
+  getAgentEvaluationsListRoute,
+  getAgentMonitorRoute,
+  getAgentsListRoute,
+} from '@studio/routes/utils';
+import { Activity, FlaskConical, HatGlasses } from 'lucide-react';
 import { lazy } from 'react';
 import type { RouteObject } from 'react-router-dom';
 
@@ -71,3 +78,27 @@ export const agentRoutes: RouteObject[] = agentsRoutes([
     errorElement: <ErrorPanel title="Agent details" />,
   },
 ]);
+
+export const getAgentSideNavItems = (workspace: string) =>
+  AGENTS_ENABLED
+    ? [
+        {
+          id: 'agents',
+          slotIcon: <HatGlasses className={iconColorClass} />,
+          slotLabel: 'Agents',
+          href: getAgentsListRoute(workspace),
+        },
+        {
+          id: 'agent-evaluations',
+          slotIcon: <FlaskConical className={iconColorClass} />,
+          slotLabel: 'Evaluations',
+          href: getAgentEvaluationsListRoute(workspace),
+        },
+        {
+          id: 'agent-monitor',
+          slotIcon: <Activity className={iconColorClass} />,
+          slotLabel: 'Monitor',
+          href: getAgentMonitorRoute(workspace),
+        },
+      ]
+    : [];

--- a/web/packages/studio/src/routes/groups/agentRoutes.tsx
+++ b/web/packages/studio/src/routes/groups/agentRoutes.tsx
@@ -15,6 +15,13 @@ const AgentsListRoute =
       default: m.AgentsListRoute,
     }))
   );
+const AgentDetailRoute =
+  AGENTS_ENABLED &&
+  lazy(() =>
+    import('@studio/routes/agents/AgentDetailRoute').then((m) => ({
+      default: m.AgentDetailRoute,
+    }))
+  );
 const AgentMonitorRoute =
   AGENTS_ENABLED &&
   lazy(() =>
@@ -60,7 +67,7 @@ export const agentRoutes: RouteObject[] = agentsRoutes([
   },
   {
     path: ROUTES.workspace.agentDetail,
-    element: AgentsListRoute ? <AgentsListRoute /> : null,
-    errorElement: <ErrorPanel title="Agents" />,
+    element: AgentDetailRoute ? <AgentDetailRoute /> : null,
+    errorElement: <ErrorPanel title="Agent details" />,
   },
 ]);


### PR DESCRIPTION
 
<img width="1031" height="371" alt="Screenshot 2026-07-21 at 12 13 45 PM" src="https://github.com/user-attachments/assets/d0dfc394-eafd-4be1-bd05-d9aacee54afd" />

Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an agent details page with tabs for **Evaluations, Deployments, Logs, Chat**, plus a **read-only Configuration** view.
  - Deployment rows now include a **Logs** action; page header includes **Open traces** and **Run evaluation**.
- **Navigation**
  - Agent list now navigates directly to the agent details page.
  - Side navigation includes agent-related items when enabled.
- **Improvements**
  - Enhanced deployment selection behavior in the deployment logs view and refined log/deployment spacing/alignment; improved tab empty-state rendering.
- **Tests**
  - Added UI coverage for default tab selection and Chat tab rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->