### PR TITLE
feat(evaluator-sdk): add read_trials bundle loader + self-contained bundle refs

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/persistence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/persistence.py
@@ -6,11 +6,12 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Any
 
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
 from pydantic import BaseModel
 
 
@@ -21,7 +22,7 @@ def persist_run(result: AgentEvalResult, output_dir: str | Path) -> AgentEvalRes
 
     _write_json(path / "benchmark.json", result.benchmark)
     _write_jsonl(path / "tasks.jsonl", result.tasks)
-    _write_jsonl(path / "trials.jsonl", result.trials)
+    _write_trials(path / "trials.jsonl", result.trials, base=path)
     _write_jsonl(path / "scores.jsonl", result.scores)
     _write_json(path / "summary.json", result.summary)
 
@@ -59,3 +60,93 @@ def _write_jsonl(path: Path, rows: Sequence[BaseModel]) -> None:
         for row in rows:
             handle.write(json.dumps(row.model_dump(mode="json"), sort_keys=True))
             handle.write("\n")
+
+
+def _write_trials(path: Path, trials: Sequence[BaseModel], *, base: Path) -> None:
+    """Write trials, rewriting evidence refs bundle-relative so the bundle is self-contained.
+
+    A trial's evidence lives under the bundle (``<output_dir>/evidence/...``); storing the ref relative to
+    the bundle (rather than the launch CWD) means a moved or copied bundle re-scores without any path fixups.
+    Refs that point outside the bundle (rare) are left verbatim.
+    """
+    resolved_base = base.resolve()
+    with path.open("w", encoding="utf-8") as handle:
+        row: dict[str, Any]
+        for trial in trials:
+            row = trial.model_dump(mode="json")
+            for descriptor in ((row.get("evidence") or {}).get("descriptors") or {}).values():
+                descriptor["ref"] = _relativize_ref(descriptor.get("ref"), resolved_base)
+            handle.write(json.dumps(row, sort_keys=True))
+            handle.write("\n")
+
+
+def _relativize_ref(ref: str | None, base: Path) -> str | None:
+    """Make an evidence ref relative to the bundle dir when it lives under it; else leave it verbatim."""
+    if not ref:
+        return ref
+    try:
+        return Path(ref).resolve().relative_to(base).as_posix()
+    except ValueError:
+        return ref  # evidence written outside the bundle — cannot relativize
+
+
+def read_trials(run_dir: str | Path) -> list[AgentEvalTrial]:
+    """Hydrate the persisted trials of a run bundle — the inverse of the ``trials.jsonl`` ``persist_run`` writes.
+
+    Each row is loaded back into an ``AgentEvalTrial`` with its evidence pointing at the on-disk
+    deliverables, so a stored run can be **re-scored** — ``AgentEvaluator().run(tasks=…, trials=…)`` with
+    fresh metrics/judge — without re-running the agent. Evidence refs are resolved relative to ``run_dir``
+    when the stored (launch-relative) ref no longer resolves, so a moved or copied bundle still works.
+    """
+    directory = Path(run_dir)
+    trials: list[AgentEvalTrial] = []
+    for row in _read_jsonl(directory / "trials.jsonl"):
+        for descriptor in ((row.get("evidence") or {}).get("descriptors") or {}).values():
+            descriptor["ref"] = _resolve_evidence_ref(directory, descriptor.get("ref"))
+        trials.append(AgentEvalTrial.model_validate(row))
+    return trials
+
+
+def _resolve_evidence_ref(run_dir: Path, ref: str | None) -> str | None:
+    """Resolve a persisted evidence ref against the bundle dir.
+
+    Self-contained bundles store refs relative to the bundle (see ``_write_trials``), so those resolve
+    directly under ``run_dir``. Falls back for still-valid absolute refs, and for moved bundles / legacy
+    absolute refs (rebuilt under ``run_dir`` from the ``evidence/`` tail).
+    """
+    if not ref:
+        return ref
+    base = run_dir.resolve()
+    candidate = Path(ref)
+    if not candidate.is_absolute():
+        rebuilt = run_dir / candidate
+        if _resolves_within(base, rebuilt):
+            return str(rebuilt)
+    elif candidate.exists():
+        return ref
+    parts = candidate.parts
+    if "evidence" in parts:
+        rebuilt = run_dir / Path(*parts[parts.index("evidence") :])
+        if _resolves_within(base, rebuilt):
+            return str(rebuilt)
+    return ref
+
+
+def _resolves_within(base: Path, path: Path) -> bool:
+    """Whether ``path`` exists and stays inside ``base`` after resolving — no ``..``/symlink escape.
+
+    Rebuilt refs are joined onto ``run_dir``; a bundle is designed to be moved/copied, so a ref with ``..``
+    (or a symlink) must not be allowed to point the hydrated evidence outside the bundle it was loaded from.
+    """
+    resolved = path.resolve()
+    if not resolved.exists():
+        return False
+    return resolved == base or base in resolved.parents
+
+
+def _read_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                yield json.loads(stripped)

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_persistence.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_persistence.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the run-bundle loader (`read_trials`) — the inverse of `persist_run`."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from nemo_evaluator_sdk.agent_eval.persistence import persist_run, read_trials
+from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSummary
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+
+
+def _write_trial(run_dir: Path, trial: AgentEvalTrial) -> None:
+    (run_dir / "trials.jsonl").write_text(json.dumps(trial.model_dump(mode="json")) + "\n", encoding="utf-8")
+
+
+def _trial_with_workspace(ref: str) -> AgentEvalTrial:
+    return AgentEvalTrial(
+        id="taskA:fabric",
+        task_id="taskA",
+        status=AgentEvalTrialStatus.COMPLETED,
+        output=AgentOutput(output_text="done"),
+        evidence=CandidateEvidence(descriptors={"workspace": EvidenceDescriptor(kind="filesystem", ref=ref)}),
+        metadata={"agent_ok": True},
+    )
+
+
+def test_read_trials_hydrates_trial_and_keeps_valid_evidence_ref(tmp_path: Path) -> None:
+    # A stored bundle whose workspace evidence ref still resolves as-is (re-scoring reads the deliverables).
+    workspace = tmp_path / "evidence" / "fabric" / "run" / "000000-taskA" / "workspace"
+    (workspace / "output").mkdir(parents=True)
+    (workspace / "output" / "memo.txt").write_text("deliverable", encoding="utf-8")
+    _write_trial(tmp_path, _trial_with_workspace(str(workspace)))
+
+    (trial,) = read_trials(tmp_path)
+    assert trial.task_id == "taskA" and trial.status == AgentEvalTrialStatus.COMPLETED
+    ws = trial.evidence.require("workspace")
+    assert ws.kind == "filesystem" and Path(ws.ref).is_dir()  # type: ignore[arg-type]
+
+
+def test_read_trials_rebuilds_evidence_ref_for_a_moved_bundle(tmp_path: Path) -> None:
+    # The stored ref points at the (now gone) launch dir, but the evidence exists under the given run_dir —
+    # read_trials rebuilds the ref under run_dir from the evidence/ tail so a moved/copied bundle still works.
+    workspace = tmp_path / "evidence" / "fabric" / "run" / "000000-taskA" / "workspace"
+    workspace.mkdir(parents=True)
+    stale = "/some/old/launch/dir/evidence/fabric/run/000000-taskA/workspace"
+    _write_trial(tmp_path, _trial_with_workspace(stale))
+
+    (trial,) = read_trials(tmp_path)
+    ws = trial.evidence.require("workspace")
+    assert Path(ws.ref) == workspace and Path(ws.ref).is_dir()  # type: ignore[arg-type]
+
+
+def test_persist_run_writes_bundle_relative_refs_that_survive_a_move(tmp_path: Path) -> None:
+    # persist_run stores evidence refs RELATIVE to the bundle, so the bundle is self-contained: copy it
+    # anywhere and read_trials still resolves the deliverables — no launch-CWD dependency.
+    bundle = tmp_path / "run"
+    workspace = bundle / "evidence" / "fabric" / "r" / "000000-taskA" / "workspace"
+    (workspace / "output").mkdir(parents=True)
+    (workspace / "output" / "memo.txt").write_text("deliverable", encoding="utf-8")
+
+    result = AgentEvalResult(
+        run_id="r",
+        tasks=[],
+        trials=[_trial_with_workspace(str(workspace))],  # absolute ref under the bundle
+        scores=[],
+        summary=AgentEvalSummary.from_scores([], tasks=[]),
+        benchmark={},
+    )
+    persist_run(result, bundle)
+
+    stored = json.loads((bundle / "trials.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    assert stored["evidence"]["descriptors"]["workspace"]["ref"] == "evidence/fabric/r/000000-taskA/workspace"
+
+    moved = tmp_path / "moved-bundle"
+    shutil.copytree(bundle, moved)
+    (trial,) = read_trials(moved)
+    resolved = Path(trial.evidence.require("workspace").ref)  # type: ignore[arg-type]
+    assert resolved.is_dir() and resolved == moved / "evidence" / "fabric" / "r" / "000000-taskA" / "workspace"
+
+
+def test_read_trials_rejects_evidence_ref_that_escapes_the_bundle(tmp_path: Path) -> None:
+    # A copied/untrusted bundle whose ref uses `..` to escape the bundle must NOT be resolved to the
+    # outside path: the rebuilt ref is accepted only when it stays inside run_dir.
+    (tmp_path / "outside_secret").mkdir()  # a real dir outside the bundle
+    bundle = tmp_path / "run"
+    bundle.mkdir()
+    escaping = "evidence/../../outside_secret"  # bundle/evidence/../../outside_secret -> tmp_path/outside_secret
+    _write_trial(bundle, _trial_with_workspace(escaping))
+
+    (trial,) = read_trials(bundle)
+    # left as the stored ref — never rewritten to the escaped (but existing) outside path
+    assert trial.evidence.require("workspace").ref == escaping
+
+
+def test_persist_and_read_keep_external_evidence_refs_absolute(tmp_path: Path) -> None:
+    # Evidence that lives OUTSIDE the bundle (e.g. a re-scored bundle referencing the ORIGINAL run's
+    # deliverables) must keep its absolute ref through persist + read — not relativized, not dropped.
+    external = tmp_path / "original-run" / "evidence" / "fabric" / "r" / "000000-taskA" / "workspace"
+    (external / "output").mkdir(parents=True)
+    (external / "output" / "memo.txt").write_text("deliverable", encoding="utf-8")
+    external_ref = str(external.resolve())
+
+    bundle = tmp_path / "rescored"  # a DIFFERENT bundle that references the external deliverables
+    result = AgentEvalResult(
+        run_id="r",
+        tasks=[],
+        trials=[_trial_with_workspace(external_ref)],
+        scores=[],
+        summary=AgentEvalSummary.from_scores([], tasks=[]),
+        benchmark={},
+    )
+    persist_run(result, bundle)
+
+    stored = json.loads((bundle / "trials.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    assert stored["evidence"]["descriptors"]["workspace"]["ref"] == external_ref  # absolute, unchanged
+
+    (trial,) = read_trials(bundle)
+    assert trial.evidence.require("workspace").ref == external_ref  # retained as-is

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/persistence.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/persistence.py
@@ -6,11 +6,12 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Any
 
 from nemo_platform.beta.evaluator.agent_eval.results import AgentEvalResult
+from nemo_platform.beta.evaluator.agent_eval.trials import AgentEvalTrial
 from pydantic import BaseModel
 
 
@@ -21,7 +22,7 @@ def persist_run(result: AgentEvalResult, output_dir: str | Path) -> AgentEvalRes
 
     _write_json(path / "benchmark.json", result.benchmark)
     _write_jsonl(path / "tasks.jsonl", result.tasks)
-    _write_jsonl(path / "trials.jsonl", result.trials)
+    _write_trials(path / "trials.jsonl", result.trials, base=path)
     _write_jsonl(path / "scores.jsonl", result.scores)
     _write_json(path / "summary.json", result.summary)
 
@@ -59,3 +60,93 @@ def _write_jsonl(path: Path, rows: Sequence[BaseModel]) -> None:
         for row in rows:
             handle.write(json.dumps(row.model_dump(mode="json"), sort_keys=True))
             handle.write("\n")
+
+
+def _write_trials(path: Path, trials: Sequence[BaseModel], *, base: Path) -> None:
+    """Write trials, rewriting evidence refs bundle-relative so the bundle is self-contained.
+
+    A trial's evidence lives under the bundle (``<output_dir>/evidence/...``); storing the ref relative to
+    the bundle (rather than the launch CWD) means a moved or copied bundle re-scores without any path fixups.
+    Refs that point outside the bundle (rare) are left verbatim.
+    """
+    resolved_base = base.resolve()
+    with path.open("w", encoding="utf-8") as handle:
+        row: dict[str, Any]
+        for trial in trials:
+            row = trial.model_dump(mode="json")
+            for descriptor in ((row.get("evidence") or {}).get("descriptors") or {}).values():
+                descriptor["ref"] = _relativize_ref(descriptor.get("ref"), resolved_base)
+            handle.write(json.dumps(row, sort_keys=True))
+            handle.write("\n")
+
+
+def _relativize_ref(ref: str | None, base: Path) -> str | None:
+    """Make an evidence ref relative to the bundle dir when it lives under it; else leave it verbatim."""
+    if not ref:
+        return ref
+    try:
+        return Path(ref).resolve().relative_to(base).as_posix()
+    except ValueError:
+        return ref  # evidence written outside the bundle — cannot relativize
+
+
+def read_trials(run_dir: str | Path) -> list[AgentEvalTrial]:
+    """Hydrate the persisted trials of a run bundle — the inverse of the ``trials.jsonl`` ``persist_run`` writes.
+
+    Each row is loaded back into an ``AgentEvalTrial`` with its evidence pointing at the on-disk
+    deliverables, so a stored run can be **re-scored** — ``AgentEvaluator().run(tasks=…, trials=…)`` with
+    fresh metrics/judge — without re-running the agent. Evidence refs are resolved relative to ``run_dir``
+    when the stored (launch-relative) ref no longer resolves, so a moved or copied bundle still works.
+    """
+    directory = Path(run_dir)
+    trials: list[AgentEvalTrial] = []
+    for row in _read_jsonl(directory / "trials.jsonl"):
+        for descriptor in ((row.get("evidence") or {}).get("descriptors") or {}).values():
+            descriptor["ref"] = _resolve_evidence_ref(directory, descriptor.get("ref"))
+        trials.append(AgentEvalTrial.model_validate(row))
+    return trials
+
+
+def _resolve_evidence_ref(run_dir: Path, ref: str | None) -> str | None:
+    """Resolve a persisted evidence ref against the bundle dir.
+
+    Self-contained bundles store refs relative to the bundle (see ``_write_trials``), so those resolve
+    directly under ``run_dir``. Falls back for still-valid absolute refs, and for moved bundles / legacy
+    absolute refs (rebuilt under ``run_dir`` from the ``evidence/`` tail).
+    """
+    if not ref:
+        return ref
+    base = run_dir.resolve()
+    candidate = Path(ref)
+    if not candidate.is_absolute():
+        rebuilt = run_dir / candidate
+        if _resolves_within(base, rebuilt):
+            return str(rebuilt)
+    elif candidate.exists():
+        return ref
+    parts = candidate.parts
+    if "evidence" in parts:
+        rebuilt = run_dir / Path(*parts[parts.index("evidence") :])
+        if _resolves_within(base, rebuilt):
+            return str(rebuilt)
+    return ref
+
+
+def _resolves_within(base: Path, path: Path) -> bool:
+    """Whether ``path`` exists and stays inside ``base`` after resolving — no ``..``/symlink escape.
+
+    Rebuilt refs are joined onto ``run_dir``; a bundle is designed to be moved/copied, so a ref with ``..``
+    (or a symlink) must not be allowed to point the hydrated evidence outside the bundle it was loaded from.
+    """
+    resolved = path.resolve()
+    if not resolved.exists():
+        return False
+    return resolved == base or base in resolved.parents
+
+
+def _read_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                yield json.loads(stripped)


### PR DESCRIPTION
## What

Adds the inverse of `persist_run`, so a persisted agent-eval run bundle can be loaded back and **re-scored with a different metric/judge without re-running the agent**:

- **`read_trials(run_dir)`** — hydrates `trials.jsonl` into `AgentEvalTrial` objects with their evidence, resolving each evidence `ref` against the bundle dir. Feed the result to `AgentEvaluator().run(tasks=…, trials=…)` to re-score.
- **`persist_run` now writes bundle-relative evidence refs** (`_write_trials`) — a trial's evidence lives under the bundle, so storing the ref relative to the bundle (not the launch CWD) makes a **moved or copied bundle re-score with no path fixups**. Refs pointing outside the bundle are left verbatim.

## Why

`persist_run` had no loader, so re-scoring a stored run (e.g. with a cheaper/faster or corrected judge) meant re-running the agent — expensive and often impossible after the fact. This makes "run once, re-grade later / elsewhere" a first-class, generic capability (any runner's bundle, not tied to a specific benchmark).

## Compatibility

`read_trials` is backward-compatible: it resolves bundle-relative refs (new), still-valid absolute refs, and legacy/moved bundles (rebuilt under `run_dir` from the `evidence/` tail). Existing bundles keep working.

## Tests

`test_persistence.py`: hydrate + valid ref, moved-bundle ref rebuild, and a `persist_run` → assert-relative-ref → `copytree` → `read_trials` round-trip proving self-containment. `pytest` green; existing evaluator persist/imported-trials tests unaffected. Includes the re-vendored SDK mirror.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end persistence and retrieval of evaluation trials via `trials.jsonl` within run bundles.
  * Evidence references are written in a portable way so they continue to resolve after bundle copy/move; external absolute evidence refs are preserved.
* **Bug Fixes**
  * Improved hydration by rebuilding evidence refs when a bundle is relocated and workspace paths must be re-associated.
* **Tests**
  * Expanded coverage for moved-bundle behavior, external absolute refs, and a security check preventing evidence refs from escaping the bundle via path traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->