### PR TITLE
fix(studio): Remove unsupported name sorting in Guardrails grid

### DIFF
--- a/web/packages/studio/src/components/dataViews/GuardrailsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/GuardrailsDataView/index.tsx
@@ -63,7 +63,7 @@ export const GuardrailsDataView: FC<GuardrailsDataViewProps> = ({
       ({ accessor }, { rowActionsColumn }) => [
         accessor('name', {
           header: 'Name',
-          enableSorting: true,
+          enableSorting: false,
           size: 180,
           cell({ row }) {
             return <Text className="font-bold">{row.original.name}</Text>;


### PR DESCRIPTION
https://nvbugspro.nvidia.com/bug/6478705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled sorting for the Guardrails “Name” column to prevent unsupported sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->