### PR TITLE
fix(evaluator): reconstruct NAT token-delta streams in agent inference

### DIFF
--- a/docs/evaluator/agent-eval/targets-and-runners.mdx
+++ b/docs/evaluator/agent-eval/targets-and-runners.mdx
@@ -67,6 +67,7 @@ pull the answer out with JSONPath. Full walkthrough:
 | `trajectory_path` | no | JSONPath selecting a trajectory to score |
 | `api_key_secret` | no | credential reference (env var locally, platform secret for a job); its value is sent as a bearer token |
 | `stream` | no | read JSON SSE `data:` frames instead of a single JSON body (default `false`) |
+| `response_aggregation` | no | how streamed `data:` frames combine: `last` keeps the final matched value (default; snapshot-per-frame endpoints), `concat` joins matched string values in order (token-delta endpoints) |
 
 ### `NemoAgentToolkitAgent`
 
@@ -79,7 +80,7 @@ workflow's URL.
 | `url` | yes | the NAT workflow endpoint |
 | `name` | yes | agent identifier, stamped on trials |
 | `format` | no | `AgentFormat.NEMO_AGENT_TOOLKIT` (the default and only value) |
-| `nat` | no | `NatAgentConfig` — endpoint / query-param / response-path overrides; defaults preserve `/generate/full` |
+| `nat` | no | `NatAgentConfig` — endpoint / query-param / response-path / aggregation overrides; defaults target `/generate/full` and `concat` token-delta frames into the full response |
 | `api_key_secret` | no | credential reference (env var locally, platform secret for a job); its value is sent as a bearer token |
 
 ## `AgentTaskRunner` (callable, Harbor, or your own)

--- a/docs/evaluator/metrics/agent-configuration.mdx
+++ b/docs/evaluator/metrics/agent-configuration.mdx
@@ -143,8 +143,9 @@ Use the `nemo_agent_toolkit` format when evaluating agents built with the [NeMo 
 
 1. Sends a POST to `{url}/generate/full?filter_steps=none` with `{"input_message": "<text>"}`.
 2. Reads the SSE (Server-Sent Events) stream.
-3. Extracts the final `value` from the last SSE `data:` chunk.
-4. Returns it as the agent response.
+3. Extracts the `value` from each SSE `data:` chunk. NAT emits token-level deltas, so the
+   values are concatenated in order to reconstruct the complete response (`concat` aggregation).
+4. Returns the reconstructed response.
 
 ### NeMo Agent Toolkit Fields
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_inference.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_inference.py
@@ -40,7 +40,13 @@ from nemo_evaluator_sdk.inference import get_logger, requests_log_var
 from nemo_evaluator_sdk.resilience.api import run_with_resilience
 from nemo_evaluator_sdk.resilience.classifier import endpoint_identity
 from nemo_evaluator_sdk.templates import render_template
-from nemo_evaluator_sdk.values.agents import Agent, GenericAgent, NatAgentConfig, NemoAgentToolkitAgent
+from nemo_evaluator_sdk.values.agents import (
+    Agent,
+    GenericAgent,
+    NatAgentConfig,
+    NemoAgentToolkitAgent,
+    StreamAggregation,
+)
 from nemo_evaluator_sdk.values.evidence import (
     EVIDENCE_FORMAT_ATIF,
     EVIDENCE_FORMAT_JSON,
@@ -101,6 +107,7 @@ class _HttpAgentInvocation(BaseModel):
     trajectory_path: str | None = None
     stream: bool = False
     response_path_field: str = "response_path"
+    response_aggregation: StreamAggregation = "last"
 
 
 # SSE field names look like ``data``, ``intermediate_data``, ``observability_trace``;
@@ -290,6 +297,7 @@ def _resolve_http_agent_invocation(agent: Agent, request: dict[str, Any]) -> _Ht
             response_path=agent.response_path,
             trajectory_path=agent.trajectory_path,
             stream=agent.stream,
+            response_aggregation=agent.response_aggregation,
         )
 
     config = agent.nat or NatAgentConfig()
@@ -302,6 +310,7 @@ def _resolve_http_agent_invocation(agent: Agent, request: dict[str, Any]) -> _Ht
         response_path=config.response_path,
         stream=True,
         response_path_field="nat.response_path",
+        response_aggregation=config.response_aggregation,
     )
 
 
@@ -380,6 +389,11 @@ async def _invoke_http_agent(
 
     async def _invoke_stream() -> _StreamCapture:
         capture = _StreamCapture()
+        # In "concat" mode each data frame carries a token-level delta, so the
+        # final output is the ordered join of every matched value rather than
+        # the last one. Accumulate parts here and materialize after the stream.
+        aggregate = invocation.response_aggregation == "concat"
+        value_parts: list[str] = []
         try:
             async with inference_client.stream(
                 "POST",
@@ -411,10 +425,13 @@ async def _invoke_http_agent(
                         required=False,
                     )
                     if value is not None:
-                        capture.final_value = value
-                        # Preserve the original type in the response; expose
-                        # ``output_text`` only when the value is already textual.
-                        capture.output_text = value if isinstance(value, str) else None
+                        if aggregate:
+                            value_parts.append(value if isinstance(value, str) else str(value))
+                        else:
+                            capture.final_value = value
+                            # Preserve the original type in the response; expose
+                            # ``output_text`` only when the value is already textual.
+                            capture.output_text = value if isinstance(value, str) else None
                     if invocation.trajectory_path:
                         trajectory = _extract_jsonpath(
                             frame.payload,
@@ -429,6 +446,9 @@ async def _invoke_http_agent(
             if capture.event_count == 0:
                 raise
             capture.error = f"{type(exc).__name__}: {exc}"
+        if aggregate and value_parts:
+            capture.final_value = "".join(value_parts)
+            capture.output_text = capture.final_value
         return capture
 
     log.info("Making streaming agent request to %s", invocation.endpoint)

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/agents.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/agents.py
@@ -24,6 +24,16 @@ def _require_format_in_json_schema(schema: dict[str, Any]) -> None:
         required.append("format")
 
 
+# How matched data-frame values are combined into one final output when a
+# target is streamed as JSON SSE:
+#   - "last":   keep only the final matched value. Correct for endpoints that
+#               emit a complete response snapshot per frame.
+#   - "concat": join matched string values in arrival order. Correct for
+#               token-delta endpoints (e.g. NAT /generate/full emits one token
+#               per frame), where the last frame is only the final token.
+StreamAggregation: TypeAlias = Literal["last", "concat"]
+
+
 class NatAgentConfig(BaseModel):
     """NeMo Agent Toolkit request and stream handling configuration."""
 
@@ -43,7 +53,15 @@ class NatAgentConfig(BaseModel):
     )
     response_path: str = Field(
         default="$.value",
-        description="JSONPath applied to data-channel payloads; the last match is the final output.",
+        description="JSONPath applied to each data-channel payload to extract its emitted value.",
+    )
+    response_aggregation: StreamAggregation = Field(
+        default="concat",
+        description=(
+            "How to combine matched data-frame values into the final output. NAT /generate/full "
+            "emits token-level deltas, so 'concat' reconstructs the complete response; 'last' keeps "
+            "only the final matched value (for endpoints that emit a full snapshot per frame)."
+        ),
     )
 
 
@@ -91,6 +109,14 @@ class GenericAgent(AgentBase):
     stream: bool = Field(
         default=False,
         description="Read JSON SSE data frames instead of a single JSON response body.",
+    )
+    response_aggregation: StreamAggregation = Field(
+        default="last",
+        description=(
+            "How to combine matched data-frame values when 'stream' is true. 'last' keeps the final "
+            "matched value (endpoints that emit a full snapshot per frame); 'concat' joins matched "
+            "string values in arrival order (token-delta endpoints)."
+        ),
     )
 
 

--- a/packages/nemo_evaluator_sdk/tests/test_agent_inference.py
+++ b/packages/nemo_evaluator_sdk/tests/test_agent_inference.py
@@ -1317,8 +1317,13 @@ class TestNATAgentExecutor:
 
     @pytest.mark.asyncio
     async def test_uses_last_value_from_stream(self):
-        """When multiple chunks have 'value', the last one wins."""
-        agent = NemoAgentToolkitAgent(url="http://nat.test", name="nat-agent", format=AgentFormat.NEMO_AGENT_TOOLKIT)
+        """With ``response_aggregation='last'``, the last chunk with 'value' wins."""
+        agent = NemoAgentToolkitAgent(
+            url="http://nat.test",
+            name="nat-agent",
+            format=AgentFormat.NEMO_AGENT_TOOLKIT,
+            nat=NatAgentConfig(response_aggregation="last"),
+        )
 
         sse_lines = [
             'data: {"value": "partial answer"}',
@@ -1355,6 +1360,110 @@ class TestNATAgentExecutor:
             result = await _make_nat_agent_request(agent, {"prompt": "hi"})
 
         assert result["choices"][0]["message"]["content"] == "complete final answer"
+
+    def test_default_nat_aggregation_is_concat(self):
+        """NAT targets reconstruct token deltas by default (see NVBug 6486650)."""
+        assert NatAgentConfig().response_aggregation == "concat"
+
+    @pytest.mark.asyncio
+    async def test_concat_reconstructs_token_delta_stream(self):
+        """NAT /generate/full emits one token per frame; concat rebuilds the full answer.
+
+        Regression test for NVBug 6486650: a correct answer ``15.0`` was previously
+        persisted as only the final delta token ``"0"``.
+        """
+        agent = NemoAgentToolkitAgent(url="http://nat.test", name="nat-agent", format=AgentFormat.NEMO_AGENT_TOOLKIT)
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=(
+                    'data: {"value": "Final Answer: "}\n'
+                    'data: {"value": "15"}\n'
+                    'data: {"value": "."}\n'
+                    'data: {"value": "0"}\n'
+                    "data: [DONE]\n"
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+            result = await invoke_agent(agent, {"prompt": "Calculate 7 + 8."}, client=client)
+
+        assert result.status is AgentInvocationStatus.COMPLETED
+        assert result.output_text == "Final Answer: 15.0"
+        assert result.response["choices"][0]["message"]["content"] == "Final Answer: 15.0"
+
+    @pytest.mark.asyncio
+    async def test_concat_stream_error_frame_yields_partial(self):
+        """A terminal error frame keeps the trial PARTIAL even when deltas were seen."""
+        agent = NemoAgentToolkitAgent(url="http://nat.test", name="nat-agent", format=AgentFormat.NEMO_AGENT_TOOLKIT)
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=(
+                    'data: {"value": "15"}\n'
+                    'data: {"value": "."}\n'
+                    'data: {"error": {"code": "workflow_error", "message": "boom"}}\n'
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+            result = await invoke_agent(agent, {"prompt": "hi"}, client=client)
+
+        assert result.status is AgentInvocationStatus.PARTIAL
+        assert result.metadata["stream_error"] == "workflow_error: boom"
+
+    @pytest.mark.asyncio
+    async def test_generic_agent_opts_into_concat_aggregation(self):
+        """GenericAgent can reconstruct token-delta endpoints via response_aggregation='concat'."""
+        agent = GenericAgent(
+            url="http://agent.test/invoke",
+            name="streaming-generic",
+            body={"question": "{{ prompt }}"},
+            response_path="$.value",
+            stream=True,
+            response_aggregation="concat",
+        )
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=('data: {"value": "4"}\ndata: {"value": "2"}\ndata: [DONE]\n'),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+            result = await invoke_agent(agent, {"prompt": "answer"}, client=client)
+
+        assert result.status is AgentInvocationStatus.COMPLETED
+        assert result.output_text == "42"
+
+    @pytest.mark.asyncio
+    async def test_generic_agent_defaults_to_last_aggregation(self):
+        """GenericAgent keeps snapshot-per-frame ('last') semantics by default."""
+        agent = GenericAgent(
+            url="http://agent.test/invoke",
+            name="streaming-generic",
+            body={"question": "{{ prompt }}"},
+            response_path="$.answer",
+            stream=True,
+        )
+        assert agent.response_aggregation == "last"
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=('data: {"answer": "draft"}\ndata: {"answer": "final"}\ndata: [DONE]\n'),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+            result = await invoke_agent(agent, {"prompt": "answer"}, client=client)
+
+        assert result.output_text == "final"
 
     @pytest.mark.asyncio
     async def test_nat_agent_request_includes_default_headers(self):
@@ -1406,8 +1515,13 @@ class TestNATAgentExecutor:
         ],
     )
     async def test_preserves_non_string_value_type(self, data_line, expected_content):
-        """Default ``$.value`` path keeps the raw value type in OpenAI content."""
-        agent = NemoAgentToolkitAgent(url="http://nat.test", name="nat-agent", format=AgentFormat.NEMO_AGENT_TOOLKIT)
+        """The ``last`` aggregation on ``$.value`` keeps the raw value type in OpenAI content."""
+        agent = NemoAgentToolkitAgent(
+            url="http://nat.test",
+            name="nat-agent",
+            format=AgentFormat.NEMO_AGENT_TOOLKIT,
+            nat=NatAgentConfig(response_aggregation="last"),
+        )
 
         async def fake_aiter_lines():
             yield data_line

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_inference.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_inference.py
@@ -40,7 +40,13 @@ from nemo_platform.beta.evaluator.inference import get_logger, requests_log_var
 from nemo_platform.beta.evaluator.resilience.api import run_with_resilience
 from nemo_platform.beta.evaluator.resilience.classifier import endpoint_identity
 from nemo_platform.beta.evaluator.templates import render_template
-from nemo_platform.beta.evaluator.values.agents import Agent, GenericAgent, NatAgentConfig, NemoAgentToolkitAgent
+from nemo_platform.beta.evaluator.values.agents import (
+    Agent,
+    GenericAgent,
+    NatAgentConfig,
+    NemoAgentToolkitAgent,
+    StreamAggregation,
+)
 from nemo_platform.beta.evaluator.values.evidence import (
     EVIDENCE_FORMAT_ATIF,
     EVIDENCE_FORMAT_JSON,
@@ -101,6 +107,7 @@ class _HttpAgentInvocation(BaseModel):
     trajectory_path: str | None = None
     stream: bool = False
     response_path_field: str = "response_path"
+    response_aggregation: StreamAggregation = "last"
 
 
 # SSE field names look like ``data``, ``intermediate_data``, ``observability_trace``;
@@ -290,6 +297,7 @@ def _resolve_http_agent_invocation(agent: Agent, request: dict[str, Any]) -> _Ht
             response_path=agent.response_path,
             trajectory_path=agent.trajectory_path,
             stream=agent.stream,
+            response_aggregation=agent.response_aggregation,
         )
 
     config = agent.nat or NatAgentConfig()
@@ -302,6 +310,7 @@ def _resolve_http_agent_invocation(agent: Agent, request: dict[str, Any]) -> _Ht
         response_path=config.response_path,
         stream=True,
         response_path_field="nat.response_path",
+        response_aggregation=config.response_aggregation,
     )
 
 
@@ -380,6 +389,11 @@ async def _invoke_http_agent(
 
     async def _invoke_stream() -> _StreamCapture:
         capture = _StreamCapture()
+        # In "concat" mode each data frame carries a token-level delta, so the
+        # final output is the ordered join of every matched value rather than
+        # the last one. Accumulate parts here and materialize after the stream.
+        aggregate = invocation.response_aggregation == "concat"
+        value_parts: list[str] = []
         try:
             async with inference_client.stream(
                 "POST",
@@ -411,10 +425,13 @@ async def _invoke_http_agent(
                         required=False,
                     )
                     if value is not None:
-                        capture.final_value = value
-                        # Preserve the original type in the response; expose
-                        # ``output_text`` only when the value is already textual.
-                        capture.output_text = value if isinstance(value, str) else None
+                        if aggregate:
+                            value_parts.append(value if isinstance(value, str) else str(value))
+                        else:
+                            capture.final_value = value
+                            # Preserve the original type in the response; expose
+                            # ``output_text`` only when the value is already textual.
+                            capture.output_text = value if isinstance(value, str) else None
                     if invocation.trajectory_path:
                         trajectory = _extract_jsonpath(
                             frame.payload,
@@ -429,6 +446,9 @@ async def _invoke_http_agent(
             if capture.event_count == 0:
                 raise
             capture.error = f"{type(exc).__name__}: {exc}"
+        if aggregate and value_parts:
+            capture.final_value = "".join(value_parts)
+            capture.output_text = capture.final_value
         return capture
 
     log.info("Making streaming agent request to %s", invocation.endpoint)

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/agents.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/agents.py
@@ -24,6 +24,16 @@ def _require_format_in_json_schema(schema: dict[str, Any]) -> None:
         required.append("format")
 
 
+# How matched data-frame values are combined into one final output when a
+# target is streamed as JSON SSE:
+#   - "last":   keep only the final matched value. Correct for endpoints that
+#               emit a complete response snapshot per frame.
+#   - "concat": join matched string values in arrival order. Correct for
+#               token-delta endpoints (e.g. NAT /generate/full emits one token
+#               per frame), where the last frame is only the final token.
+StreamAggregation: TypeAlias = Literal["last", "concat"]
+
+
 class NatAgentConfig(BaseModel):
     """NeMo Agent Toolkit request and stream handling configuration."""
 
@@ -43,7 +53,15 @@ class NatAgentConfig(BaseModel):
     )
     response_path: str = Field(
         default="$.value",
-        description="JSONPath applied to data-channel payloads; the last match is the final output.",
+        description="JSONPath applied to each data-channel payload to extract its emitted value.",
+    )
+    response_aggregation: StreamAggregation = Field(
+        default="concat",
+        description=(
+            "How to combine matched data-frame values into the final output. NAT /generate/full "
+            "emits token-level deltas, so 'concat' reconstructs the complete response; 'last' keeps "
+            "only the final matched value (for endpoints that emit a full snapshot per frame)."
+        ),
     )
 
 
@@ -91,6 +109,14 @@ class GenericAgent(AgentBase):
     stream: bool = Field(
         default=False,
         description="Read JSON SSE data frames instead of a single JSON response body.",
+    )
+    response_aggregation: StreamAggregation = Field(
+        default="last",
+        description=(
+            "How to combine matched data-frame values when 'stream' is true. 'last' keeps the final "
+            "matched value (endpoints that emit a full snapshot per frame); 'concat' joins matched "
+            "string values in arrival order (token-delta endpoints)."
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

Fixes **NVBug [6486650](https://nvbugspro.nvidia.com/bug/6486650)** (P0): agent evaluation persisted only the final NAT SSE delta token as the output.

NAT `/generate/full` emits **token-level SSE deltas** — e.g. `{"value":"15"}`, `{"value":"."}`, `{"value":"0"}` — but `_invoke_stream()` overwrote the captured value on every `data:` frame and kept only the last match. A correct answer such as `15.0` was persisted as just `"0"`. Trials were reported as **completed** (HTTP 200, `stream_error=null`) while metrics scored the truncated output, so correct answers silently failed. This affected both `NemoAgentToolkitAgent` and `GenericAgent(stream=True)`, with no config-only workaround for the NAT target.

## Fix

Add a `response_aggregation` policy (`"last" | "concat"`) to the streaming path:

- **`NatAgentConfig` defaults to `concat`** — NAT deltas are rejoined in arrival order into the complete response (NAT-compatible reconstruction by default).
- **`GenericAgent` defaults to `last`** — preserves snapshot-per-frame behavior for endpoints that emit a complete value per frame.

`_invoke_stream()` accumulates matched string values and materializes them after the stream, so a mid-stream failure still yields a **PARTIAL** trial with the tokens seen so far. Terminal error frames continue to downgrade a trial to PARTIAL rather than COMPLETED.

## Tests

- `["15", ".", "0"] -> "15.0"` end-to-end reconstruction (regression for this bug)
- concat + terminal error frame → PARTIAL with `stream_error`
- `GenericAgent` concat opt-in
- `last`-mode defaults and non-string type preservation (converted existing tests)

`packages/nemo_evaluator_sdk` suite: **1122 passed, 2 skipped**. Ruff + `ty` clean.

## Notes

- Docs updated (`targets-and-runners.mdx`, `agent-configuration.mdx`) — the NAT section previously documented the buggy "last chunk" behavior.
- Vendored SDK mirror (`sdk/python/...`) regenerated via `make vendor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable streaming response aggregation for HTTP agent targets.
  * Choose `last` to use the final streamed value or `concat` to reconstruct responses from token-delta streams.
  * NeMo Agent Toolkit streaming responses now support complete response reconstruction by default.

* **Documentation**
  * Updated configuration and metrics guidance to explain streaming aggregation behavior and defaults.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->