### PR TITLE
fix: refresh Automodel artifact pins

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -79,12 +79,12 @@ variable "BASE_TAG_PYTHON" {
 
 # Pin for nmp-automodel-base.
 variable "BASE_TAG_AUTOMODEL" {
-  default = "f0756dd64eaf2ddb9c5c962e18216b2e70ba4b64"
+  default = "2c1a9ef2535a6648a272d9b74dae97fb672b8234"
 }
 
 # The tag for base images if needed
 variable "WHEELS_TAG" {
-  default = "f0756dd64eaf2ddb9c5c962e18216b2e70ba4b64"
+  default = "2c1a9ef2535a6648a272d9b74dae97fb672b8234"
 }
 
 variable "BAKE_CACHE_SOURCE_BRANCH" {


### PR DESCRIPTION
## Why

PR #762 changed both Automodel artifact producers, including the Python 3.13 OpenCV/decord wheel set, but `WHEELS_TAG` and `BASE_TAG_AUTOMODEL` still pointed to the older `f0756dd...` build. The release source therefore consumed artifacts that did not match its Dockerfiles and failed while installing the expected Python 3.13 wheel.

## What

- Pin both Automodel artifact inputs to the validated full `2c1a9ef...` source SHA.

## Validation

- Chained GPU-wheel and Automodel build (internal access): https://github.com/NVIDIA-NeMo/Platform-Deploy/actions/runs/29840323878
  - amd64 and arm64 wheel builds passed.
  - all three wheel manifests passed.
  - chained Automodel, Unsloth, and RL builds passed.
  - Automodel smoke tests passed.
- Direct Automodel build with no wheel override or chaining (internal access): https://github.com/NVIDIA-NeMo/Platform-Deploy/actions/runs/29848601919
  - resolved the wheel artifacts at `2c1a9ef...`.
  - installed the Python 3.13 OpenCV wheel on amd64 and arm64.
  - Automodel smoke tests passed.
- `git diff --check` passed.
- Bake graph printing passed for GPU wheels, Automodel, Unsloth, and RL training.

No public runtime API changes.
