### PR TITLE
feat(evaluator-sdk): inject multiple skills into FabricAgentRuntime

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/metrics.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/metrics.py
@@ -117,12 +117,12 @@ class EvidencePresenceMetric:
 class SkillUsedMetric:
     """Emit ``skill_present`` and ``skill_used`` so an eval can flag a failure to use an injected skill.
 
-    * ``skill_present`` — ``True`` when a skill was injected into the trial. Reads the provenance a
-      skill-aware runtime stamps onto candidate metadata under the ``"skill"`` key
-      (``{"name", "hash", "mode", "adapter_id", "location", ...}``, see ``fabric.skills.SkillProvenance``);
-      baseline trials carry none.
-    * ``skill_used`` — best-effort ``True`` when the agent referenced the injected skill in its ATIF
-      trajectory. It matches the skill's staged ``location`` (a specific, low-false-positive path
+    * ``skill_present`` — ``True`` when one or more skills were injected into the trial. Reads
+      the ``"skills"`` metadata key a skill-aware runtime stamps — a list of provenance dicts
+      (``{"name", "hash", "mode", "adapter_id", "location", ...}``, see ``fabric.skills.SkillProvenance``).
+      Baseline trials carry an empty list.
+    * ``skill_used`` — best-effort ``True`` when the agent referenced *any* injected skill in its ATIF
+      trajectory. It matches each skill's staged ``location`` (a specific, low-false-positive path
       signal — e.g. a read of ``.agents/skills/<name>/SKILL.md``) against tool-call names/arguments,
       step messages, reasoning, and observations. A bare skill-*name* match is intentionally NOT
       counted (the name commonly appears in the task prompt), so ``skill_present=True, skill_used=False``
@@ -137,8 +137,8 @@ class SkillUsedMetric:
     metric_type: str = "skill_used"
     OUTPUT_PRESENT: str = "skill_present"
     OUTPUT_USED: str = "skill_used"
-    # Metadata key skill-aware runtimes stamp the provenance under (matches the fabric runtime).
-    _METADATA_KEY: str = "skill"
+    # Metadata key skill-aware runtimes stamp the provenance list under (matches the fabric runtime).
+    _SKILLS_KEY: str = "skills"
 
     def __init__(self, *, trace_evidence: str = EVIDENCE_TRACE) -> None:
         self._trace_evidence = trace_evidence
@@ -154,9 +154,9 @@ class SkillUsedMetric:
         ]
 
     async def compute_scores(self, input: MetricInput) -> MetricResult:
-        provenance = input.candidate.metadata.get(self._METADATA_KEY)
-        present = isinstance(provenance, Mapping) and bool(provenance)
-        used = await self._skill_used(input.candidate, provenance) if present else False
+        provenances = self._extract_provenances(input.candidate.metadata)
+        present = bool(provenances)
+        used = await self._any_skill_used(input.candidate, provenances) if present else False
         return MetricResult(
             outputs=[
                 MetricOutput(name=self.OUTPUT_PRESENT, value=present),
@@ -164,9 +164,15 @@ class SkillUsedMetric:
             ]
         )
 
-    async def _skill_used(self, candidate: CandidateOutput, provenance: Mapping[str, Any]) -> bool:
-        location = provenance.get("location")
-        if not isinstance(location, str) or not location:
+    def _extract_provenances(self, metadata: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+        skills = metadata.get(self._SKILLS_KEY)
+        if isinstance(skills, list):
+            return [p for p in skills if isinstance(p, Mapping) and p]
+        return []
+
+    async def _any_skill_used(self, candidate: CandidateOutput, provenances: list[Mapping[str, Any]]) -> bool:
+        locations = [loc for p in provenances if isinstance(loc := p.get("location"), str) and loc]
+        if not locations:
             return False
         evidence = candidate.evidence
         if evidence is None or evidence.get(self._trace_evidence) is None:
@@ -180,7 +186,7 @@ class SkillUsedMetric:
                 "SkillUsedMetric scored skill_used=False: could not read trace %r: %s", self._trace_evidence, exc
             )
             return False
-        return _trajectory_references(trajectory, location)
+        return any(_trajectory_references(trajectory, loc) for loc in locations)
 
 
 class TrialMeasurements(BaseModel):

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
@@ -41,7 +41,8 @@ from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import (
     SKILL_MODE_CODEX_SKILLS_DIR,
     AgentSkill,
     SkillProvenance,
-    install_skill,
+    install_skills,
+    require_unique_skill_names,
     resolve_skill_mode,
 )
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
@@ -128,7 +129,7 @@ class FabricAgentRuntime:
         timeout_s: int = DEFAULT_FABRIC_TIMEOUT_S,
         capture_trajectory: bool = True,
         runtime_name: str = _RUNTIME_NAME,
-        skill: AgentSkill | None = None,
+        skills: Sequence[AgentSkill] | None = None,
     ) -> None:
         self._config = config
         self._profiles = list(profiles or [])
@@ -138,19 +139,31 @@ class FabricAgentRuntime:
         self._timeout_s = timeout_s
         self._capture_trajectory = capture_trajectory
         self._runtime_name = runtime_name
-        self._skill = skill
+        self._skills = list(skills or [])
+        require_unique_skill_names(self._skills)
 
-    def with_skill(self, skill: AgentSkill | None) -> FabricAgentRuntime:
-        """Return a copy of this runtime with the skill replaced; ``self`` is not modified.
+    def with_skills(self, skills: Sequence[AgentSkill]) -> FabricAgentRuntime:
+        """Return a copy of this runtime with ``skills`` *added* to its skill set; ``self`` is not modified.
 
-        Lets an A/B eval run the same taskset with and without a skill by deriving both runtimes from
-        one configured instance (baseline = ``with_skill(None)``, treated = ``with_skill(the_skill)``),
-        so they differ in exactly the skill and nothing else. A shallow copy suffices — the shared
-        fields are immutable config/paths.
+        Additive and chainable: ``rt.with_skills([a]).with_skills([b])`` injects both a and b. Lets an A/B
+        eval derive a treated runtime from a skill-free baseline (``baseline.with_skills(the_skills)``) so
+        the two arms differ in exactly the injected skills. Skill names must be unique across the combined
+        set — two bundles claiming the same ``<name>/`` would collide — so re-adding a skill already
+        present raises. A shallow copy suffices — the shared fields are immutable config/paths.
         """
+        combined = [*self._skills, *skills]
+        require_unique_skill_names(combined)
         clone = copy.copy(self)
-        clone._skill = skill
+        clone._skills = combined
         return clone
+
+    def with_skill(self, skill: AgentSkill) -> FabricAgentRuntime:
+        """Return a copy of this runtime with ``skill`` *added*; ``self`` is not modified.
+
+        Thin wrapper over :meth:`with_skills` for the common single-skill case; equally chainable
+        (``rt.with_skill(a).with_skill(b)`` injects both).
+        """
+        return self.with_skills([skill])
 
     async def run_tasks(
         self,
@@ -193,14 +206,14 @@ class FabricAgentRuntime:
         # rather than silently run a skill-free trial mislabeled as "with skill", which would corrupt an
         # A/B comparison. Only touched when a skill is set, so the no-skill path is unaffected.
         skill_mode: str | None = None
-        if self._skill is not None:
+        if self._skills:
             skill_mode = self._resolve_skill_mode(client, agent_config, base_profiles)
             if skill_mode is None:
                 adapter_id = agent_config.harness.adapter_id
                 raise RuntimeError(
-                    f"FabricAgentRuntime received a skill but adapter {adapter_id!r} has no known "
+                    f"FabricAgentRuntime received one or more skills but adapter {adapter_id!r} has no known "
                     "skill-injection strategy: Fabric does not route skills to it natively and it is not a "
-                    "codex harness. Use a skills-native or codex harness, or drop the skill."
+                    "codex harness. Use a skills-native or codex harness, or drop the skills."
                 )
 
         semaphore = asyncio.Semaphore(resolved_config.parallelism)
@@ -273,27 +286,28 @@ class FabricAgentRuntime:
         # downloads), so it is offloaded off the shared event loop.
         workspace_dir = evidence_dir / _WORKSPACE_SUBDIR
         workspace_dir.mkdir(parents=True, exist_ok=True)
-        skill_provenance: SkillProvenance | None = None
+        skill_provenances: list[SkillProvenance] = []
         try:
             # Stage seed files into the workspace for their on-disk side effect; the prompt is the task
             # instruction only, so the returned paths are unused.
             await asyncio.to_thread(seed_workspace, workspace_dir, task.inputs.get(SEED_FILES_INPUT_KEY))
 
-            # Inject the skill (if any) for this task. A native harness gets a per-task ``skills`` profile
-            # overlay; codex self-injection stages the bundle into the workspace and emits no overlay.
-            # Provenance is stamped on the trial for the A/B diff. Blocking file I/O, off the event loop.
+            # Inject the skill set (if any) for this task. A native harness gets ONE ``skills`` profile
+            # overlay listing every staged bundle; codex self-injection stages each bundle into the
+            # workspace and emits no overlay. One provenance per skill is stamped on the trial for the A/B
+            # diff. Blocking file I/O, off the event loop.
             skill_profiles: list[FabricProfileConfig] = []
-            if self._skill is not None and skill_mode is not None:
+            if self._skills and skill_mode is not None:
                 installation = await asyncio.to_thread(
-                    install_skill,
-                    skill=self._skill,
+                    install_skills,
+                    skills=self._skills,
                     adapter_id=agent_config.harness.adapter_id,
                     mode=skill_mode,
                     workspace_dir=workspace_dir,
                     skill_stage_dir=(evidence_dir / _SKILL_SUBDIR).resolve(),
                     existing_skill_paths=self._existing_skill_paths(),
                 )
-                skill_provenance = installation.provenance
+                skill_provenances = installation.provenances
                 skill_profiles = [FabricProfileConfig.from_mapping(p) for p in installation.profiles]
 
             task_config = self._compose_config(agent_config, evidence_dir, workspace_dir)
@@ -316,17 +330,31 @@ class FabricAgentRuntime:
                 timeout=self._timeout_s,
             )
         except TimeoutError as exc:
-            return self._failed_trial(task, evidence_dir, exc, extra_metadata={"skill": skill_provenance})
+            return self._failed_trial(task, evidence_dir, exc, extra_metadata=self._skill_metadata(skill_provenances))
         except Exception as exc:  # noqa: BLE001 - a task failure must not abort the whole run
-            return self._failed_trial(task, evidence_dir, exc, extra_metadata={"skill": skill_provenance})
+            return self._failed_trial(task, evidence_dir, exc, extra_metadata=self._skill_metadata(skill_provenances))
+        finally:
+            # Codex self-injection staged each bundle *inside* the workspace so the harness could discover
+            # it. Remove them once the run is over (it is already captured in the trajectory) so the injected
+            # files don't linger in the durable workspace and, on any path that exposes it as filesystem
+            # evidence, read as agent output and skew workspace-reading metrics. In ``finally`` so a
+            # timed-out or errored run cleans up too, not just the success path. Best-effort per
+            # ``_remove_injected_bundle``; a no-op for native mode and when nothing was staged.
+            if skill_mode == SKILL_MODE_CODEX_SKILLS_DIR:
+                for provenance in skill_provenances:
+                    await asyncio.to_thread(_remove_injected_bundle, workspace_dir, provenance["location"])
 
-        # Codex self-injection staged the bundle *inside* the workspace so the harness could discover it.
-        # Now that the run is done (and captured in the trajectory), remove it before the workspace is
-        # exposed as filesystem evidence — otherwise the injected files read as agent output and skew
-        # workspace-reading metrics (a treated run with no agent-created files would look non-empty).
-        if skill_mode == SKILL_MODE_CODEX_SKILLS_DIR and skill_provenance is not None:
-            await asyncio.to_thread(_remove_injected_bundle, workspace_dir, skill_provenance["location"])
-        return self._to_trial(task, result, evidence_dir, workspace_dir, skill_provenance=skill_provenance)
+        return self._to_trial(task, result, evidence_dir, workspace_dir, skill_provenances=skill_provenances)
+
+    @staticmethod
+    def _skill_metadata(provenances: list[SkillProvenance]) -> dict[str, Any]:
+        """Trial-metadata fields describing the injected skill set (the A/B provenance).
+
+        ``skills`` is the full list of injected-skill provenances (empty = baseline). ``skill`` keeps the
+        historical single-provenance field — the lone provenance for a one-skill run, else ``None`` — so
+        single-skill consumers (e.g. ``SkillUsedMetric``) and existing trials keep working unchanged.
+        """
+        return {"skill": provenances[0] if len(provenances) == 1 else None, "skills": provenances}
 
     def _to_trial(
         self,
@@ -335,7 +363,7 @@ class FabricAgentRuntime:
         evidence_dir: Path,
         workspace_dir: Path,
         *,
-        skill_provenance: SkillProvenance | None = None,
+        skill_provenances: list[SkillProvenance] | None = None,
     ) -> AgentEvalTrial:
         # Persist the full normalized Fabric result so graders (and debugging) can see the raw
         # envelope, and expose it as an evidence descriptor.
@@ -349,8 +377,8 @@ class FabricAgentRuntime:
             "adapter_kind": result.adapter_kind,
             "invocation_id": result.invocation_id,
             "agent_model": self._model,
-            # Skill provenance (name + content hash + injection mode) for the A/B diff; None baseline.
-            "skill": skill_provenance,
+            # Skill provenance (name + content hash + injection mode) for the A/B diff.
+            **self._skill_metadata(skill_provenances or []),
         }
 
         if result.status != "succeeded":

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/skills.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/skills.py
@@ -224,6 +224,110 @@ def install_skill(
     raise SkillInjectionError(f"unknown skill injection mode {mode!r} for adapter {adapter_id!r}")
 
 
+@dataclass
+class SkillsInstallation:
+    """Result of installing several skills for one task (see :func:`install_skills`).
+
+    ``profiles`` is the Fabric profile-overlay stack the runtime appends: at most ONE merged native
+    ``skills`` overlay listing every staged bundle (Fabric applies profile ``skills.paths`` last-wins, so
+    all skills must ride in a single overlay or all but the last would be dropped); the Codex branch emits
+    none because workspace placement is the delivery mechanism. ``provenances`` is one entry per skill, in
+    the given order, stamped into trial metadata so a multi-skill A/B comparison is auditable.
+    """
+
+    profiles: list[dict[str, object]]
+    provenances: list[SkillProvenance]
+
+
+def require_unique_skill_names(skills: Sequence[AgentSkill]) -> None:
+    """Raise if two skills share a name — their ``<name>/`` bundles would collide when staged.
+
+    Each skill stages into its own ``<name>/`` directory (native stage dir or ``.agents/skills/``), so a
+    repeated name would clobber (or fail to stage over) an earlier bundle. Checked up front so a
+    misconfigured runtime fails before any task runs, not mid-stage on the second collision.
+    """
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for skill in skills:
+        if skill.name in seen and skill.name not in duplicates:
+            duplicates.append(skill.name)
+        seen.add(skill.name)
+    if duplicates:
+        raise SkillInjectionError(
+            f"duplicate skill name(s) {duplicates}: each skill stages to its own '<name>/' bundle, so "
+            "skill names must be unique within one runtime"
+        )
+
+
+def install_skills(
+    *,
+    skills: Sequence[AgentSkill],
+    adapter_id: str,
+    mode: str,
+    workspace_dir: Path,
+    skill_stage_dir: Path,
+    existing_skill_paths: Sequence[str] = (),
+) -> SkillsInstallation:
+    """Stage every skill in ``skills`` for one task and wire them all into the harness per ``mode``.
+
+    Loops :func:`install_skill` — each skill stages into its own namespaced ``<name>/`` bundle — then, for
+    the native mode, merges the per-skill paths into a SINGLE ``skills`` overlay: Fabric applies profile
+    ``skills.paths`` last-wins, so emitting one overlay per skill would silently drop all but the last.
+    Pre-existing ``existing_skill_paths`` are preserved ahead of the injected skills (same reason). Skill
+    names must be unique (their ``<name>/`` bundles would otherwise collide). Blocking file I/O — call via
+    ``asyncio.to_thread`` from the async runtime.
+
+    Installation is all-or-nothing: if any skill fails to stage, the bundles already staged in this call
+    are rolled back before the error propagates, so a partial skill set never lingers on disk (the caller
+    raises before it ever sees provenances, so it cannot clean up itself). Only bundles this call staged
+    are removed, so a reserved-path collision can never delete a pre-existing task-seeded file.
+    """
+    require_unique_skill_names(skills)
+    provenances: list[SkillProvenance] = []
+    staged_roots: list[Path] = []
+    try:
+        for skill in skills:
+            provenance = install_skill(
+                skill=skill,
+                adapter_id=adapter_id,
+                mode=mode,
+                workspace_dir=workspace_dir,
+                skill_stage_dir=skill_stage_dir,
+                existing_skill_paths=existing_skill_paths,
+            ).provenance
+            provenances.append(provenance)
+            # A native provenance ``location`` is the absolute staged root; a codex one is
+            # workspace-relative (``.agents/skills/<name>``). Record it only after a successful stage.
+            staged_roots.append(_provenance_stage_root(provenance, workspace_dir))
+    except Exception:
+        for root in staged_roots:
+            shutil.rmtree(root, ignore_errors=True)
+        raise
+
+    profiles: list[dict[str, object]] = []
+    if mode == SKILL_MODE_NATIVE and provenances:
+        # One merged overlay: pre-existing skills first, then each staged bundle (a native provenance's
+        # ``location`` is its absolute staged skill root), order-preserved and de-duplicated.
+        paths = list(dict.fromkeys([*existing_skill_paths, *(prov["location"] for prov in provenances)]))
+        profiles = [
+            {
+                "name": SKILL_PROFILE_NAME,
+                "description": "Make the evaluation skills available via the native Fabric skills config.",
+                "skills": {"paths": paths},
+            }
+        ]
+    return SkillsInstallation(profiles=profiles, provenances=provenances)
+
+
+def _provenance_stage_root(provenance: SkillProvenance, workspace_dir: Path) -> Path:
+    """Absolute on-disk root of a staged bundle, for rollback. Native ``location`` is already absolute;
+    codex ``location`` is workspace-relative (``.agents/skills/<name>``)."""
+    location = provenance["location"]
+    if provenance["mode"] == SKILL_MODE_CODEX_SKILLS_DIR:
+        return workspace_dir / location
+    return Path(location)
+
+
 def _stage_bundle(directory: Path, skill_root: Path, *, reserved: bool) -> None:
     """Stage the skill ``directory`` as an *exact* copy at ``skill_root`` (the ``<name>/`` bundle dir).
 

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
@@ -667,7 +667,7 @@ async def test_fabric_runtime_native_skill_adds_overlay_and_provenance(
 
     client_cls = _install_fake_fabric(monkeypatch, handler)
     skill = AgentSkill.from_directory(_skill_bundle(tmp_path, body="# Code Review\n\nBe thorough."))
-    runtime = fabric_runtime.FabricAgentRuntime(config=_HERMES_CONFIG, work_root=tmp_path / "fabric", skill=skill)
+    runtime = fabric_runtime.FabricAgentRuntime(config=_HERMES_CONFIG, work_root=tmp_path / "fabric", skills=[skill])
 
     trials = await runtime.run_tasks([_TASK])
 
@@ -704,7 +704,7 @@ async def test_fabric_runtime_native_skill_preserves_preconfigured_skills(
     runtime = fabric_runtime.FabricAgentRuntime(
         config=config,
         work_root=tmp_path / "fabric",
-        skill=skill,
+        skills=[skill],
         profiles=[{"name": "caller", "skills": {"paths": ["/pre/existing-b"]}}],
     )
 
@@ -732,7 +732,7 @@ async def test_fabric_runtime_native_skill_on_runtime_discovered_adapter(
     client_cls = _install_fake_fabric(monkeypatch, handler)
     custom = {"metadata": {"name": "a"}, "harness": {"adapter_id": "acme.custom.native"}}
     skill = AgentSkill.from_directory(_skill_bundle(tmp_path))
-    runtime = fabric_runtime.FabricAgentRuntime(config=custom, work_root=tmp_path / "fabric", skill=skill)
+    runtime = fabric_runtime.FabricAgentRuntime(config=custom, work_root=tmp_path / "fabric", skills=[skill])
 
     trials = await runtime.run_tasks([_TASK])
 
@@ -757,7 +757,7 @@ async def test_fabric_runtime_codex_skill_staged_for_run_then_excluded_from_evid
 
     client_cls = _install_fake_fabric(monkeypatch, handler)
     skill = AgentSkill.from_directory(_skill_bundle(tmp_path))
-    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric", skill=skill)
+    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric", skills=[skill])
 
     trials = await runtime.run_tasks([_TASK])
 
@@ -787,7 +787,7 @@ async def test_fabric_runtime_skill_on_unsupported_adapter_fails_fast(
     runtime = fabric_runtime.FabricAgentRuntime(
         config=unsupported,
         work_root=tmp_path / "fabric",
-        skill=AgentSkill.from_directory(_skill_bundle(tmp_path, name="s")),
+        skills=[AgentSkill.from_directory(_skill_bundle(tmp_path, name="s"))],
     )
 
     with pytest.raises(RuntimeError, match="no known skill-injection strategy"):
@@ -819,5 +819,173 @@ def test_with_skill_returns_independent_copy() -> None:
 
     # A new instance is returned; the original is untouched.
     assert treated is not base
-    assert base._skill is None
-    assert treated._skill is skill
+    assert base._skills == []
+    assert treated._skills == [skill]
+
+
+def test_with_skills_returns_independent_copy_of_the_set() -> None:
+    from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import AgentSkill
+
+    base = fabric_runtime.FabricAgentRuntime(config=_HERMES_CONFIG, model="m", work_root="/tmp/x")
+    skills = [
+        AgentSkill(name="docx", directory=Path("/skills/docx")),
+        AgentSkill(name="pptx", directory=Path("/skills/pptx")),
+    ]
+
+    treated = base.with_skills(skills)
+
+    # A new instance carries the added set; the original is untouched.
+    assert treated is not base
+    assert base._skills == []
+    assert treated._skills == skills
+
+
+def test_with_skill_is_additive_and_chainable() -> None:
+    # Regression: with_skill must ADD, not replace. Chaining injects every skill, not just the last.
+    from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import AgentSkill
+
+    base = fabric_runtime.FabricAgentRuntime(config=_HERMES_CONFIG, model="m", work_root="/tmp/x")
+    a = AgentSkill(name="docx", directory=Path("/skills/docx"))
+    b = AgentSkill(name="pptx", directory=Path("/skills/pptx"))
+
+    chained = base.with_skill(a).with_skill(b)
+
+    # Both skills are present, in order; each intermediate runtime is left untouched.
+    assert chained._skills == [a, b]
+    assert base._skills == []
+    assert base.with_skill(a)._skills == [a]
+    # with_skills extends the same way (equivalent to chaining the single-skill calls).
+    assert base.with_skills([a, b])._skills == [a, b]
+    assert base.with_skill(a).with_skills([b])._skills == [a, b]
+
+
+def test_with_skills_rejects_duplicate_names() -> None:
+    from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import AgentSkill
+
+    base = fabric_runtime.FabricAgentRuntime(config=_HERMES_CONFIG, work_root="/tmp/x")
+    dupes = [AgentSkill(name="docx", directory=Path("/a/docx")), AgentSkill(name="docx", directory=Path("/b/docx"))]
+
+    # Two bundles claiming the same <name>/ would collide when staged, so it is rejected up front.
+    with pytest.raises(ValueError, match="duplicate skill name"):
+        base.with_skills(dupes)
+
+
+def test_with_skill_rejects_re_adding_same_name() -> None:
+    # Adding a skill whose name is already present collides on the combined set — rejected, not silently
+    # deduped, so a caller notices the double-add.
+    from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import AgentSkill
+
+    base = fabric_runtime.FabricAgentRuntime(config=_HERMES_CONFIG, work_root="/tmp/x")
+    first = base.with_skill(AgentSkill(name="docx", directory=Path("/a/docx")))
+
+    with pytest.raises(ValueError, match="duplicate skill name"):
+        first.with_skill(AgentSkill(name="docx", directory=Path("/b/docx")))
+
+
+def test_constructor_rejects_duplicate_skill_names(tmp_path: Path) -> None:
+    from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import AgentSkill
+
+    # Same name, distinct source directories — still a <name>/ bundle collision; fail before any run.
+    dup_a = AgentSkill.from_directory(_skill_bundle(tmp_path / "a", name="docx"))
+    dup_b = AgentSkill.from_directory(_skill_bundle(tmp_path / "b", name="docx"))
+
+    with pytest.raises(ValueError, match="duplicate skill name"):
+        fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric", skills=[dup_a, dup_b])
+
+
+@pytest.mark.asyncio
+async def test_fabric_runtime_multiple_native_skills_merge_into_single_overlay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # LAB hands the agent all of its skills on every task. A native harness must stage each skill into its
+    # own <name>/ bundle and list them ALL in ONE overlay — Fabric applies profile skills.paths last-wins,
+    # so a per-skill overlay would silently drop all but the last.
+    from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import AgentSkill
+
+    def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
+        return _FakeResult(status="succeeded", output={"response": "ok"})
+
+    client_cls = _install_fake_fabric(monkeypatch, handler)
+    skills = [AgentSkill.from_directory(_skill_bundle(tmp_path, name=name)) for name in ("docx", "pptx", "xlsx")]
+    runtime = fabric_runtime.FabricAgentRuntime(config=_HERMES_CONFIG, work_root=tmp_path / "fabric", skills=skills)
+
+    trials = await runtime.run_tasks([_TASK])
+
+    # Exactly one native skills overlay reaches client.run, listing every staged <name>/ bundle in order.
+    overlays = [p for p in client_cls.recorded[0]["profiles"] if p.name == "eval_skill"]
+    assert len(overlays) == 1
+    paths = overlays[0].mapping["skills"]["paths"]
+    assert [Path(p).name for p in paths] == ["docx", "pptx", "xlsx"]
+    # Each bundle is staged on disk under its own <name>/ dir with its SKILL.md.
+    for path in paths:
+        assert (Path(path) / "SKILL.md").is_file()
+    # One provenance per skill is stamped for the A/B diff; the single-skill `skill` field is None (multi).
+    provs = trials[0].metadata["skills"]
+    assert [prov["name"] for prov in provs] == ["docx", "pptx", "xlsx"]
+    assert all(prov["mode"] == "native" for prov in provs)
+    assert trials[0].metadata["skill"] is None
+
+
+@pytest.mark.asyncio
+async def test_fabric_runtime_multiple_codex_skills_each_staged_then_excluded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Codex self-discovers each bundle from .agents/skills/<name>/ in its workspace during the run; all are
+    # then removed before the workspace is exposed as evidence so they don't read as agent output.
+    from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import AgentSkill
+
+    names = ("docx", "pptx", "xlsx")
+    seen: dict[str, bool] = {}
+
+    def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
+        workspace = Path(agent.environment.workspace)
+        seen["all_present_during_run"] = all(
+            (workspace / ".agents" / "skills" / name / "SKILL.md").is_file() for name in names
+        )
+        return _FakeResult(status="succeeded", output={"response": "ok"})
+
+    client_cls = _install_fake_fabric(monkeypatch, handler)
+    skills = [AgentSkill.from_directory(_skill_bundle(tmp_path, name=name)) for name in names]
+    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric", skills=skills)
+
+    trials = await runtime.run_tasks([_TASK])
+
+    # Every bundle was discoverable at its own .agents/skills/<name>/ path during the run...
+    assert seen["all_present_during_run"] is True
+    # ...then all removed (with the emptied .agents parent) before the workspace is exposed as evidence.
+    workspace = next((tmp_path / "fabric").glob("*/000000-task-1/workspace"))
+    assert not (workspace / ".agents").exists()
+    # Codex mode emits no overlay; one provenance per skill records the injection.
+    assert "eval_skill" not in [p.name for p in client_cls.recorded[0]["profiles"]]
+    provs = trials[0].metadata["skills"]
+    assert [prov["name"] for prov in provs] == list(names)
+    assert all(prov["mode"] == "codex_skills_dir" for prov in provs)
+
+
+@pytest.mark.asyncio
+async def test_fabric_runtime_codex_skills_removed_even_when_run_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Cleanup runs in a `finally`, so a failed/errored run still removes the injected bundles from the
+    # durable workspace — they must not linger and read as agent output on any path that exposes it.
+    from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import AgentSkill
+
+    names = ("docx", "pptx")
+
+    def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
+        # The bundles were staged before the run; blow up mid-run to hit the except/finally path.
+        assert all((Path(agent.environment.workspace) / ".agents" / "skills" / n / "SKILL.md").is_file() for n in names)
+        raise RuntimeError("harness blew up")
+
+    _install_fake_fabric(monkeypatch, handler)
+    skills = [AgentSkill.from_directory(_skill_bundle(tmp_path, name=name)) for name in names]
+    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric", skills=skills)
+
+    trials = await runtime.run_tasks([_TASK])
+
+    # Failed trial, but every injected bundle (and the emptied .agents parent) was still cleaned up.
+    assert trials[0].status == "failed"
+    workspace = next((tmp_path / "fabric").glob("*/000000-task-1/workspace"))
+    assert not (workspace / ".agents").exists()
+    # Provenance is still stamped on the failed trial for the A/B diff.
+    assert [prov["name"] for prov in trials[0].metadata["skills"]] == list(names)

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_skills.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_skills.py
@@ -16,6 +16,7 @@ from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import (
     AgentSkill,
     SkillInjectionError,
     install_skill,
+    install_skills,
     native_skills_route,
     resolve_skill_mode,
 )
@@ -265,3 +266,49 @@ def test_hash_is_content_sensitive(tmp_path: Path) -> None:
         skill_stage_dir=tmp_path / "sb",
     )
     assert a.provenance["hash"] != b.provenance["hash"]
+
+
+def test_install_skills_rolls_back_staged_bundles_on_failure(tmp_path: Path) -> None:
+    # All-or-nothing: a later skill failing to stage rolls back the bundles already staged in this call,
+    # so a partial skill set never lingers on disk.
+    good = AgentSkill.from_directory(_make_bundle(tmp_path / "src", name="good"))
+    (tmp_path / "missing").mkdir()
+    bad = AgentSkill(name="bad", directory=tmp_path / "missing")  # no SKILL.md -> stages fail
+    stage_dir = tmp_path / "stage"
+
+    with pytest.raises(SkillInjectionError):
+        install_skills(
+            skills=[good, bad],
+            adapter_id="nvidia.fabric.hermes.sdk",
+            mode=SKILL_MODE_NATIVE,
+            workspace_dir=tmp_path / "ws",
+            skill_stage_dir=stage_dir,
+        )
+
+    # The first skill was staged, then rolled back when the second failed.
+    assert not (stage_dir / "good").exists()
+
+
+def test_install_skills_rollback_never_deletes_preexisting_seed_file(tmp_path: Path) -> None:
+    # Codex reserved-path collision: the second skill's target already holds a task-seeded file. Rollback
+    # must remove only the bundle THIS call staged (the first skill), never the pre-existing seed file.
+    good = AgentSkill.from_directory(_make_bundle(tmp_path / "src", name="good"))
+    collide = AgentSkill.from_directory(_make_bundle(tmp_path / "src2", name="collide"))
+    workspace = tmp_path / "ws"
+    seeded = workspace / CODEX_SKILLS_DIR / "collide"  # a task-seeded file on the reserved codex path
+    seeded.mkdir(parents=True)
+    (seeded / "seed.txt").write_text("task data", encoding="utf-8")
+
+    with pytest.raises(SkillInjectionError):
+        install_skills(
+            skills=[good, collide],
+            adapter_id="nvidia.fabric.codex.cli",
+            mode=SKILL_MODE_CODEX_SKILLS_DIR,
+            workspace_dir=workspace,
+            skill_stage_dir=tmp_path / "stage",
+        )
+
+    # The staged first bundle is rolled back...
+    assert not (workspace / CODEX_SKILLS_DIR / "good").exists()
+    # ...but the pre-existing task-seeded file is untouched.
+    assert (seeded / "seed.txt").read_text(encoding="utf-8") == "task data"

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_skill_used_metric.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_skill_used_metric.py
@@ -21,6 +21,15 @@ _PROV = {
     "location": _LOCATION,
 }
 
+_LOCATION_B = ".agents/skills/summarize"
+_PROV_B = {
+    "name": "summarize",
+    "hash": "cafebabe",
+    "mode": "codex_skills_dir",
+    "adapter_id": "nvidia.fabric.codex.cli",
+    "location": _LOCATION_B,
+}
+
 
 def _atif(*, tool_path: str | None = None, message: str = "working") -> dict[str, Any]:
     step: dict[str, Any] = {"source": "agent", "message": message}
@@ -50,23 +59,61 @@ async def test_no_skill_present_both_false() -> None:
 
 @pytest.mark.asyncio
 async def test_present_and_used_when_trajectory_reads_the_skill() -> None:
-    sample = {"skill": _PROV, "evidence": _evidence(_atif(tool_path=f"{_LOCATION}/SKILL.md"))}
+    sample = {"skills": [_PROV], "evidence": _evidence(_atif(tool_path=f"{_LOCATION}/SKILL.md"))}
     assert await _score(sample) == {"skill_present": True, "skill_used": True}
 
 
 @pytest.mark.asyncio
 async def test_present_not_used_when_trajectory_ignores_the_skill() -> None:
-    sample = {"skill": _PROV, "evidence": _evidence(_atif(tool_path="README.md"))}
+    sample = {"skills": [_PROV], "evidence": _evidence(_atif(tool_path="README.md"))}
     assert await _score(sample) == {"skill_present": True, "skill_used": False}
 
 
 @pytest.mark.asyncio
 async def test_present_not_used_without_a_trace() -> None:
-    assert await _score({"skill": _PROV}) == {"skill_present": True, "skill_used": False}
+    assert await _score({"skills": [_PROV]}) == {"skill_present": True, "skill_used": False}
 
 
 @pytest.mark.asyncio
 async def test_bare_name_mention_is_not_counted_as_used() -> None:
     # The skill *name* appears in a message, but not its staged location — not counted as used.
-    sample = {"skill": _PROV, "evidence": _evidence(_atif(message="starting the code-review task"))}
+    sample = {"skills": [_PROV], "evidence": _evidence(_atif(message="starting the code-review task"))}
     assert (await _score(sample))["skill_used"] is False
+
+
+# --- multi-skill ("skills" list) ---
+
+
+@pytest.mark.asyncio
+async def test_multi_skill_present_and_first_used() -> None:
+    # "skill" is absent (multi-skill run); trajectory reads the first skill's location.
+    sample = {
+        "skills": [_PROV, _PROV_B],
+        "evidence": _evidence(_atif(tool_path=f"{_LOCATION}/SKILL.md")),
+    }
+    assert await _score(sample) == {"skill_present": True, "skill_used": True}
+
+
+@pytest.mark.asyncio
+async def test_multi_skill_present_and_second_used() -> None:
+    # Trajectory reads the second skill's location — any-skill-used wins.
+    sample = {
+        "skills": [_PROV, _PROV_B],
+        "evidence": _evidence(_atif(tool_path=f"{_LOCATION_B}/SKILL.md")),
+    }
+    assert await _score(sample) == {"skill_present": True, "skill_used": True}
+
+
+@pytest.mark.asyncio
+async def test_multi_skill_present_none_used() -> None:
+    # Trajectory references neither skill's location.
+    sample = {
+        "skills": [_PROV, _PROV_B],
+        "evidence": _evidence(_atif(tool_path="README.md")),
+    }
+    assert await _score(sample) == {"skill_present": True, "skill_used": False}
+
+
+@pytest.mark.asyncio
+async def test_empty_skills_list_scores_not_present() -> None:
+    assert await _score({"skills": []}) == {"skill_present": False, "skill_used": False}

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/metrics.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/metrics.py
@@ -117,12 +117,12 @@ class EvidencePresenceMetric:
 class SkillUsedMetric:
     """Emit ``skill_present`` and ``skill_used`` so an eval can flag a failure to use an injected skill.
 
-    * ``skill_present`` — ``True`` when a skill was injected into the trial. Reads the provenance a
-      skill-aware runtime stamps onto candidate metadata under the ``"skill"`` key
-      (``{"name", "hash", "mode", "adapter_id", "location", ...}``, see ``fabric.skills.SkillProvenance``);
-      baseline trials carry none.
-    * ``skill_used`` — best-effort ``True`` when the agent referenced the injected skill in its ATIF
-      trajectory. It matches the skill's staged ``location`` (a specific, low-false-positive path
+    * ``skill_present`` — ``True`` when one or more skills were injected into the trial. Reads
+      the ``"skills"`` metadata key a skill-aware runtime stamps — a list of provenance dicts
+      (``{"name", "hash", "mode", "adapter_id", "location", ...}``, see ``fabric.skills.SkillProvenance``).
+      Baseline trials carry an empty list.
+    * ``skill_used`` — best-effort ``True`` when the agent referenced *any* injected skill in its ATIF
+      trajectory. It matches each skill's staged ``location`` (a specific, low-false-positive path
       signal — e.g. a read of ``.agents/skills/<name>/SKILL.md``) against tool-call names/arguments,
       step messages, reasoning, and observations. A bare skill-*name* match is intentionally NOT
       counted (the name commonly appears in the task prompt), so ``skill_present=True, skill_used=False``
@@ -137,8 +137,8 @@ class SkillUsedMetric:
     metric_type: str = "skill_used"
     OUTPUT_PRESENT: str = "skill_present"
     OUTPUT_USED: str = "skill_used"
-    # Metadata key skill-aware runtimes stamp the provenance under (matches the fabric runtime).
-    _METADATA_KEY: str = "skill"
+    # Metadata key skill-aware runtimes stamp the provenance list under (matches the fabric runtime).
+    _SKILLS_KEY: str = "skills"
 
     def __init__(self, *, trace_evidence: str = EVIDENCE_TRACE) -> None:
         self._trace_evidence = trace_evidence
@@ -154,9 +154,9 @@ class SkillUsedMetric:
         ]
 
     async def compute_scores(self, input: MetricInput) -> MetricResult:
-        provenance = input.candidate.metadata.get(self._METADATA_KEY)
-        present = isinstance(provenance, Mapping) and bool(provenance)
-        used = await self._skill_used(input.candidate, provenance) if present else False
+        provenances = self._extract_provenances(input.candidate.metadata)
+        present = bool(provenances)
+        used = await self._any_skill_used(input.candidate, provenances) if present else False
         return MetricResult(
             outputs=[
                 MetricOutput(name=self.OUTPUT_PRESENT, value=present),
@@ -164,9 +164,15 @@ class SkillUsedMetric:
             ]
         )
 
-    async def _skill_used(self, candidate: CandidateOutput, provenance: Mapping[str, Any]) -> bool:
-        location = provenance.get("location")
-        if not isinstance(location, str) or not location:
+    def _extract_provenances(self, metadata: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+        skills = metadata.get(self._SKILLS_KEY)
+        if isinstance(skills, list):
+            return [p for p in skills if isinstance(p, Mapping) and p]
+        return []
+
+    async def _any_skill_used(self, candidate: CandidateOutput, provenances: list[Mapping[str, Any]]) -> bool:
+        locations = [loc for p in provenances if isinstance(loc := p.get("location"), str) and loc]
+        if not locations:
             return False
         evidence = candidate.evidence
         if evidence is None or evidence.get(self._trace_evidence) is None:
@@ -180,7 +186,7 @@ class SkillUsedMetric:
                 "SkillUsedMetric scored skill_used=False: could not read trace %r: %s", self._trace_evidence, exc
             )
             return False
-        return _trajectory_references(trajectory, location)
+        return any(_trajectory_references(trajectory, loc) for loc in locations)
 
 
 class TrialMeasurements(BaseModel):

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/runtime.py
@@ -41,7 +41,8 @@ from nemo_platform.beta.evaluator.agent_eval.runtimes.fabric.skills import (
     SKILL_MODE_CODEX_SKILLS_DIR,
     AgentSkill,
     SkillProvenance,
-    install_skill,
+    install_skills,
+    require_unique_skill_names,
     resolve_skill_mode,
 )
 from nemo_platform.beta.evaluator.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
@@ -128,7 +129,7 @@ class FabricAgentRuntime:
         timeout_s: int = DEFAULT_FABRIC_TIMEOUT_S,
         capture_trajectory: bool = True,
         runtime_name: str = _RUNTIME_NAME,
-        skill: AgentSkill | None = None,
+        skills: Sequence[AgentSkill] | None = None,
     ) -> None:
         self._config = config
         self._profiles = list(profiles or [])
@@ -138,19 +139,31 @@ class FabricAgentRuntime:
         self._timeout_s = timeout_s
         self._capture_trajectory = capture_trajectory
         self._runtime_name = runtime_name
-        self._skill = skill
+        self._skills = list(skills or [])
+        require_unique_skill_names(self._skills)
 
-    def with_skill(self, skill: AgentSkill | None) -> FabricAgentRuntime:
-        """Return a copy of this runtime with the skill replaced; ``self`` is not modified.
+    def with_skills(self, skills: Sequence[AgentSkill]) -> FabricAgentRuntime:
+        """Return a copy of this runtime with ``skills`` *added* to its skill set; ``self`` is not modified.
 
-        Lets an A/B eval run the same taskset with and without a skill by deriving both runtimes from
-        one configured instance (baseline = ``with_skill(None)``, treated = ``with_skill(the_skill)``),
-        so they differ in exactly the skill and nothing else. A shallow copy suffices — the shared
-        fields are immutable config/paths.
+        Additive and chainable: ``rt.with_skills([a]).with_skills([b])`` injects both a and b. Lets an A/B
+        eval derive a treated runtime from a skill-free baseline (``baseline.with_skills(the_skills)``) so
+        the two arms differ in exactly the injected skills. Skill names must be unique across the combined
+        set — two bundles claiming the same ``<name>/`` would collide — so re-adding a skill already
+        present raises. A shallow copy suffices — the shared fields are immutable config/paths.
         """
+        combined = [*self._skills, *skills]
+        require_unique_skill_names(combined)
         clone = copy.copy(self)
-        clone._skill = skill
+        clone._skills = combined
         return clone
+
+    def with_skill(self, skill: AgentSkill) -> FabricAgentRuntime:
+        """Return a copy of this runtime with ``skill`` *added*; ``self`` is not modified.
+
+        Thin wrapper over :meth:`with_skills` for the common single-skill case; equally chainable
+        (``rt.with_skill(a).with_skill(b)`` injects both).
+        """
+        return self.with_skills([skill])
 
     async def run_tasks(
         self,
@@ -193,14 +206,14 @@ class FabricAgentRuntime:
         # rather than silently run a skill-free trial mislabeled as "with skill", which would corrupt an
         # A/B comparison. Only touched when a skill is set, so the no-skill path is unaffected.
         skill_mode: str | None = None
-        if self._skill is not None:
+        if self._skills:
             skill_mode = self._resolve_skill_mode(client, agent_config, base_profiles)
             if skill_mode is None:
                 adapter_id = agent_config.harness.adapter_id
                 raise RuntimeError(
-                    f"FabricAgentRuntime received a skill but adapter {adapter_id!r} has no known "
+                    f"FabricAgentRuntime received one or more skills but adapter {adapter_id!r} has no known "
                     "skill-injection strategy: Fabric does not route skills to it natively and it is not a "
-                    "codex harness. Use a skills-native or codex harness, or drop the skill."
+                    "codex harness. Use a skills-native or codex harness, or drop the skills."
                 )
 
         semaphore = asyncio.Semaphore(resolved_config.parallelism)
@@ -273,27 +286,28 @@ class FabricAgentRuntime:
         # downloads), so it is offloaded off the shared event loop.
         workspace_dir = evidence_dir / _WORKSPACE_SUBDIR
         workspace_dir.mkdir(parents=True, exist_ok=True)
-        skill_provenance: SkillProvenance | None = None
+        skill_provenances: list[SkillProvenance] = []
         try:
             # Stage seed files into the workspace for their on-disk side effect; the prompt is the task
             # instruction only, so the returned paths are unused.
             await asyncio.to_thread(seed_workspace, workspace_dir, task.inputs.get(SEED_FILES_INPUT_KEY))
 
-            # Inject the skill (if any) for this task. A native harness gets a per-task ``skills`` profile
-            # overlay; codex self-injection stages the bundle into the workspace and emits no overlay.
-            # Provenance is stamped on the trial for the A/B diff. Blocking file I/O, off the event loop.
+            # Inject the skill set (if any) for this task. A native harness gets ONE ``skills`` profile
+            # overlay listing every staged bundle; codex self-injection stages each bundle into the
+            # workspace and emits no overlay. One provenance per skill is stamped on the trial for the A/B
+            # diff. Blocking file I/O, off the event loop.
             skill_profiles: list[FabricProfileConfig] = []
-            if self._skill is not None and skill_mode is not None:
+            if self._skills and skill_mode is not None:
                 installation = await asyncio.to_thread(
-                    install_skill,
-                    skill=self._skill,
+                    install_skills,
+                    skills=self._skills,
                     adapter_id=agent_config.harness.adapter_id,
                     mode=skill_mode,
                     workspace_dir=workspace_dir,
                     skill_stage_dir=(evidence_dir / _SKILL_SUBDIR).resolve(),
                     existing_skill_paths=self._existing_skill_paths(),
                 )
-                skill_provenance = installation.provenance
+                skill_provenances = installation.provenances
                 skill_profiles = [FabricProfileConfig.from_mapping(p) for p in installation.profiles]
 
             task_config = self._compose_config(agent_config, evidence_dir, workspace_dir)
@@ -316,17 +330,31 @@ class FabricAgentRuntime:
                 timeout=self._timeout_s,
             )
         except TimeoutError as exc:
-            return self._failed_trial(task, evidence_dir, exc, extra_metadata={"skill": skill_provenance})
+            return self._failed_trial(task, evidence_dir, exc, extra_metadata=self._skill_metadata(skill_provenances))
         except Exception as exc:  # noqa: BLE001 - a task failure must not abort the whole run
-            return self._failed_trial(task, evidence_dir, exc, extra_metadata={"skill": skill_provenance})
+            return self._failed_trial(task, evidence_dir, exc, extra_metadata=self._skill_metadata(skill_provenances))
+        finally:
+            # Codex self-injection staged each bundle *inside* the workspace so the harness could discover
+            # it. Remove them once the run is over (it is already captured in the trajectory) so the injected
+            # files don't linger in the durable workspace and, on any path that exposes it as filesystem
+            # evidence, read as agent output and skew workspace-reading metrics. In ``finally`` so a
+            # timed-out or errored run cleans up too, not just the success path. Best-effort per
+            # ``_remove_injected_bundle``; a no-op for native mode and when nothing was staged.
+            if skill_mode == SKILL_MODE_CODEX_SKILLS_DIR:
+                for provenance in skill_provenances:
+                    await asyncio.to_thread(_remove_injected_bundle, workspace_dir, provenance["location"])
 
-        # Codex self-injection staged the bundle *inside* the workspace so the harness could discover it.
-        # Now that the run is done (and captured in the trajectory), remove it before the workspace is
-        # exposed as filesystem evidence — otherwise the injected files read as agent output and skew
-        # workspace-reading metrics (a treated run with no agent-created files would look non-empty).
-        if skill_mode == SKILL_MODE_CODEX_SKILLS_DIR and skill_provenance is not None:
-            await asyncio.to_thread(_remove_injected_bundle, workspace_dir, skill_provenance["location"])
-        return self._to_trial(task, result, evidence_dir, workspace_dir, skill_provenance=skill_provenance)
+        return self._to_trial(task, result, evidence_dir, workspace_dir, skill_provenances=skill_provenances)
+
+    @staticmethod
+    def _skill_metadata(provenances: list[SkillProvenance]) -> dict[str, Any]:
+        """Trial-metadata fields describing the injected skill set (the A/B provenance).
+
+        ``skills`` is the full list of injected-skill provenances (empty = baseline). ``skill`` keeps the
+        historical single-provenance field — the lone provenance for a one-skill run, else ``None`` — so
+        single-skill consumers (e.g. ``SkillUsedMetric``) and existing trials keep working unchanged.
+        """
+        return {"skill": provenances[0] if len(provenances) == 1 else None, "skills": provenances}
 
     def _to_trial(
         self,
@@ -335,7 +363,7 @@ class FabricAgentRuntime:
         evidence_dir: Path,
         workspace_dir: Path,
         *,
-        skill_provenance: SkillProvenance | None = None,
+        skill_provenances: list[SkillProvenance] | None = None,
     ) -> AgentEvalTrial:
         # Persist the full normalized Fabric result so graders (and debugging) can see the raw
         # envelope, and expose it as an evidence descriptor.
@@ -349,8 +377,8 @@ class FabricAgentRuntime:
             "adapter_kind": result.adapter_kind,
             "invocation_id": result.invocation_id,
             "agent_model": self._model,
-            # Skill provenance (name + content hash + injection mode) for the A/B diff; None baseline.
-            "skill": skill_provenance,
+            # Skill provenance (name + content hash + injection mode) for the A/B diff.
+            **self._skill_metadata(skill_provenances or []),
         }
 
         if result.status != "succeeded":

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/skills.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/skills.py
@@ -224,6 +224,110 @@ def install_skill(
     raise SkillInjectionError(f"unknown skill injection mode {mode!r} for adapter {adapter_id!r}")
 
 
+@dataclass
+class SkillsInstallation:
+    """Result of installing several skills for one task (see :func:`install_skills`).
+
+    ``profiles`` is the Fabric profile-overlay stack the runtime appends: at most ONE merged native
+    ``skills`` overlay listing every staged bundle (Fabric applies profile ``skills.paths`` last-wins, so
+    all skills must ride in a single overlay or all but the last would be dropped); the Codex branch emits
+    none because workspace placement is the delivery mechanism. ``provenances`` is one entry per skill, in
+    the given order, stamped into trial metadata so a multi-skill A/B comparison is auditable.
+    """
+
+    profiles: list[dict[str, object]]
+    provenances: list[SkillProvenance]
+
+
+def require_unique_skill_names(skills: Sequence[AgentSkill]) -> None:
+    """Raise if two skills share a name — their ``<name>/`` bundles would collide when staged.
+
+    Each skill stages into its own ``<name>/`` directory (native stage dir or ``.agents/skills/``), so a
+    repeated name would clobber (or fail to stage over) an earlier bundle. Checked up front so a
+    misconfigured runtime fails before any task runs, not mid-stage on the second collision.
+    """
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for skill in skills:
+        if skill.name in seen and skill.name not in duplicates:
+            duplicates.append(skill.name)
+        seen.add(skill.name)
+    if duplicates:
+        raise SkillInjectionError(
+            f"duplicate skill name(s) {duplicates}: each skill stages to its own '<name>/' bundle, so "
+            "skill names must be unique within one runtime"
+        )
+
+
+def install_skills(
+    *,
+    skills: Sequence[AgentSkill],
+    adapter_id: str,
+    mode: str,
+    workspace_dir: Path,
+    skill_stage_dir: Path,
+    existing_skill_paths: Sequence[str] = (),
+) -> SkillsInstallation:
+    """Stage every skill in ``skills`` for one task and wire them all into the harness per ``mode``.
+
+    Loops :func:`install_skill` — each skill stages into its own namespaced ``<name>/`` bundle — then, for
+    the native mode, merges the per-skill paths into a SINGLE ``skills`` overlay: Fabric applies profile
+    ``skills.paths`` last-wins, so emitting one overlay per skill would silently drop all but the last.
+    Pre-existing ``existing_skill_paths`` are preserved ahead of the injected skills (same reason). Skill
+    names must be unique (their ``<name>/`` bundles would otherwise collide). Blocking file I/O — call via
+    ``asyncio.to_thread`` from the async runtime.
+
+    Installation is all-or-nothing: if any skill fails to stage, the bundles already staged in this call
+    are rolled back before the error propagates, so a partial skill set never lingers on disk (the caller
+    raises before it ever sees provenances, so it cannot clean up itself). Only bundles this call staged
+    are removed, so a reserved-path collision can never delete a pre-existing task-seeded file.
+    """
+    require_unique_skill_names(skills)
+    provenances: list[SkillProvenance] = []
+    staged_roots: list[Path] = []
+    try:
+        for skill in skills:
+            provenance = install_skill(
+                skill=skill,
+                adapter_id=adapter_id,
+                mode=mode,
+                workspace_dir=workspace_dir,
+                skill_stage_dir=skill_stage_dir,
+                existing_skill_paths=existing_skill_paths,
+            ).provenance
+            provenances.append(provenance)
+            # A native provenance ``location`` is the absolute staged root; a codex one is
+            # workspace-relative (``.agents/skills/<name>``). Record it only after a successful stage.
+            staged_roots.append(_provenance_stage_root(provenance, workspace_dir))
+    except Exception:
+        for root in staged_roots:
+            shutil.rmtree(root, ignore_errors=True)
+        raise
+
+    profiles: list[dict[str, object]] = []
+    if mode == SKILL_MODE_NATIVE and provenances:
+        # One merged overlay: pre-existing skills first, then each staged bundle (a native provenance's
+        # ``location`` is its absolute staged skill root), order-preserved and de-duplicated.
+        paths = list(dict.fromkeys([*existing_skill_paths, *(prov["location"] for prov in provenances)]))
+        profiles = [
+            {
+                "name": SKILL_PROFILE_NAME,
+                "description": "Make the evaluation skills available via the native Fabric skills config.",
+                "skills": {"paths": paths},
+            }
+        ]
+    return SkillsInstallation(profiles=profiles, provenances=provenances)
+
+
+def _provenance_stage_root(provenance: SkillProvenance, workspace_dir: Path) -> Path:
+    """Absolute on-disk root of a staged bundle, for rollback. Native ``location`` is already absolute;
+    codex ``location`` is workspace-relative (``.agents/skills/<name>``)."""
+    location = provenance["location"]
+    if provenance["mode"] == SKILL_MODE_CODEX_SKILLS_DIR:
+        return workspace_dir / location
+    return Path(location)
+
+
 def _stage_bundle(directory: Path, skill_root: Path, *, reserved: bool) -> None:
     """Stage the skill ``directory`` as an *exact* copy at ``skill_root`` (the ``<name>/`` bundle dir).
 


### PR DESCRIPTION
## What

`FabricAgentRuntime` (the Fabric **host** runtime) held a single skill and `with_skill` *replaced* it, so one runtime could not inject more than one agent skill. This is gap identified from the LAB-examples analysis: LAB hands the agent all three of its skills (docx/pptx/xlsx) on every task, and a single-skill runtime can only mirror it by running three separate single-skill arms — which is semantically wrong (LAB is not a per-skill benchmark).

This lets one runtime stage a **set** of skills.

## Changes

- **`runtime.py`** — replace `self._skill` with `self._skills: list[AgentSkill]`. The constructor takes a single `skills=` argument (a lone skill is just a one-element set). `with_skills(skills)` derives a configured clone; `with_skill` is kept as a thin wrapper for the single-skill A/B pattern the skill-eval example uses. A/B semantics preserved: baseline = `with_skills([])`, treated = the set. Duplicate skill names are rejected up front (before any task runs) since two bundles claiming the same `<name>/` would collide.
- **`skills.py`** — add `install_skills(...)`, which loops the existing `install_skill` per skill (each bundle is already namespaced under `<name>/`) and, for the **native** mode, merges the per-skill paths into **one** `skills` overlay. Fabric applies profile `skills.paths` last-wins, so a per-skill overlay would silently drop all but the last. Codex self-injection stages and later removes every bundle. Also adds `require_unique_skill_names`.
- **Trial metadata** — new `skills` list (one provenance per injected skill). The historical `skill` field stays the lone provenance for a one-skill run (else `None`), so `SkillUsedMetric` and existing single-skill trials/tests are byte-for-byte unchanged.

## Coordination with L1 (container runtime)

Skill injection for `FabricContainerRuntime`, staging into the sandbox seed set has **not landed** on `main` (yet). Per the task's fallback, this is scoped to the **host** runtime; applying the same multi-skill shape to the container runtime is a **follow-up** once the new work for fabric in a container merges.

## Tests

Extended `test_fabric_runtime.py`:
- multiple native skills → each staged under its own `<name>/`, all listed in a single merged `eval_skill` overlay, in order;
- multiple codex skills → each discoverable at `.agents/skills/<name>/` during the run, all removed before the workspace is exposed as evidence;
- duplicate names rejected at construction and via `with_skills`;
- existing single-skill tests updated to `skills=[skill]`.

`pytest` green (56/56 across `test_fabric_runtime.py` + `test_fabric_skills.py`); `ruff check` / `ruff format --check` clean; vendored SDK mirror regenerated and committed alongside the source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and injecting multiple skills in a single evaluation run.
  * Introduced chainable helpers to add one skill or multiple skills to the runtime, without altering the original instance.
  * Updated trial metadata to include per-skill provenance and an aggregated skills list for multi-skill runs.
* **Bug Fixes**
  * Rejects duplicate skill names during staging to avoid collisions.
  * Improved multi-skill overlay merging and Codex skill staging/cleanup, including when runs fail.
* **Tests**
  * Expanded unit and async integration coverage for multi-skill behavior, duplicate-name handling, and failure cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->