### PR TITLE
fix: include wheel versions in deployment handoff

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -837,7 +837,8 @@ jobs:
     if: >-
       !cancelled() &&
       needs.poll-final-release.result == 'success' &&
-      needs.plan-release.outputs.include_helm == 'true' &&
+      (needs.plan-release.outputs.include_helm == 'true' ||
+        needs.plan-release.outputs.has_wheels == 'true') &&
       needs.plan-release.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
     steps:
@@ -848,6 +849,7 @@ jobs:
           SOURCE_SHA: ${{ needs.plan-release.outputs.source_sha }}
           RELEASE_TYPE: ${{ needs.plan-release.outputs.release_type }}
           HAS_WHEELS: ${{ needs.plan-release.outputs.has_wheels }}
+          HAS_HELM: ${{ needs.plan-release.outputs.include_helm }}
           RELEASE_LABEL: ${{ needs.plan-release.outputs.release_label }}
           HELM_VERSION: ${{ needs.stage-helm.outputs.chart_version }}
           WHEEL_IDS: ${{ needs.plan-release.outputs.wheel_ids }}
@@ -869,7 +871,7 @@ jobs:
                 ref: process.env.SOURCE_SHA,
                 cadence: process.env.RELEASE_TYPE === "stable" ? "release" : "nightly",
                 release_label: process.env.RELEASE_LABEL,
-                helm_version: process.env.HELM_VERSION,
+                helm_version: process.env.HAS_HELM === "true" ? process.env.HELM_VERSION : null,
                 sdk_versions: sdkVersions,
               },
             });

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -835,8 +835,12 @@ jobs:
     name: Signal deployment
     needs: [plan-release, stage-helm, poll-final-release]
     if: >-
+      always() &&
       !cancelled() &&
+      needs.plan-release.result == 'success' &&
       needs.poll-final-release.result == 'success' &&
+      (needs.plan-release.outputs.include_helm != 'true' ||
+        needs.stage-helm.result == 'success') &&
       (needs.plan-release.outputs.include_helm == 'true' ||
         needs.plan-release.outputs.has_wheels == 'true') &&
       needs.plan-release.outputs.dry_run != 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -863,7 +863,7 @@ jobs:
           script: |
             const [owner, repo] = process.env.DISPATCH_REPO.split("/");
             const wheelIds = JSON.parse(process.env.WHEEL_IDS);
-            const sdkVersions = process.env.HAS_WHEELS === "true"
+            const wheelVersions = process.env.HAS_WHEELS === "true"
               ? Object.fromEntries(wheelIds.map((id) => [id, process.env.WHEEL_VERSION]))
               : {};
 
@@ -876,7 +876,7 @@ jobs:
                 cadence: process.env.RELEASE_TYPE === "stable" ? "release" : "nightly",
                 release_label: process.env.RELEASE_LABEL,
                 helm_version: process.env.HAS_HELM === "true" ? process.env.HELM_VERSION : null,
-                sdk_versions: sdkVersions,
+                wheel_versions: wheelVersions,
               },
             });
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -847,7 +847,7 @@ jobs:
           DISPATCH_REPO: ${{ secrets.CI_DISPATCH_REPO }}
           SOURCE_SHA: ${{ needs.plan-release.outputs.source_sha }}
           RELEASE_TYPE: ${{ needs.plan-release.outputs.release_type }}
-          RELEASE_SCOPE: ${{ needs.plan-release.outputs.release_scope }}
+          HAS_WHEELS: ${{ needs.plan-release.outputs.has_wheels }}
           RELEASE_LABEL: ${{ needs.plan-release.outputs.release_label }}
           HELM_VERSION: ${{ needs.stage-helm.outputs.chart_version }}
           WHEEL_IDS: ${{ needs.plan-release.outputs.wheel_ids }}
@@ -857,7 +857,7 @@ jobs:
           script: |
             const [owner, repo] = process.env.DISPATCH_REPO.split("/");
             const wheelIds = JSON.parse(process.env.WHEEL_IDS);
-            const sdkVersions = process.env.RELEASE_SCOPE === "all"
+            const sdkVersions = process.env.HAS_WHEELS === "true"
               ? Object.fromEntries(wheelIds.map((id) => [id, process.env.WHEEL_VERSION]))
               : {};
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -847,12 +847,19 @@ jobs:
           DISPATCH_REPO: ${{ secrets.CI_DISPATCH_REPO }}
           SOURCE_SHA: ${{ needs.plan-release.outputs.source_sha }}
           RELEASE_TYPE: ${{ needs.plan-release.outputs.release_type }}
+          RELEASE_SCOPE: ${{ needs.plan-release.outputs.release_scope }}
           RELEASE_LABEL: ${{ needs.plan-release.outputs.release_label }}
           HELM_VERSION: ${{ needs.stage-helm.outputs.chart_version }}
+          WHEEL_IDS: ${{ needs.plan-release.outputs.wheel_ids }}
+          WHEEL_VERSION: ${{ needs.plan-release.outputs.wheel_version }}
         with:
           github-token: ${{ secrets.CI_DISPATCH_TOKEN }}
           script: |
             const [owner, repo] = process.env.DISPATCH_REPO.split("/");
+            const wheelIds = JSON.parse(process.env.WHEEL_IDS);
+            const sdkVersions = process.env.RELEASE_SCOPE === "all"
+              ? Object.fromEntries(wheelIds.map((id) => [id, process.env.WHEEL_VERSION]))
+              : {};
 
             await github.rest.repos.createDispatchEvent({
               owner,
@@ -863,6 +870,7 @@ jobs:
                 cadence: process.env.RELEASE_TYPE === "stable" ? "release" : "nightly",
                 release_label: process.env.RELEASE_LABEL,
                 helm_version: process.env.HELM_VERSION,
+                sdk_versions: sdkVersions,
               },
             });
 


### PR DESCRIPTION
## Summary

Release deployment events currently omit the wheel versions associated with the release, and wheel-only releases do not emit the handoff.

This change:

- includes a `wheel_versions` map for every release containing wheels;
- sends an empty map when a release contains no wheels; and
- allows the handoff to run when wheels are available without a Helm chart.

This only adds release metadata. It does not change which wheels are selected, built, or published.

## Testing

- `actionlint .github/workflows/release.yaml`
- cross-repository handoff contract tests
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release deployment flow so deployments can proceed when Helm staging is skipped, while still requiring successful planning and final polling.
  * Deployment creation events now more accurately reflect Helm availability (setting Helm version to `null` when Helm isn’t included).
  * Wheel-related metadata is now passed with the dispatch event, including per-wheel version details when wheels are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->