### PR TITLE
feat: add preview badge to Experiments

### DIFF
--- a/web/packages/studio/src/routes/ExperimentRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/index.tsx
@@ -34,6 +34,7 @@ import {
 } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { ExperimentGroupCreateModal } from '@studio/components/ExperimentGroupCreateModal';
+import { FeatureFlagBadge } from '@studio/components/FeatureFlagBadge';
 import { Loading } from '@studio/components/Layouts/Loading';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
@@ -116,7 +117,12 @@ export const ExperimentRoute: FC = () => {
       <Stack className="h-full min-h-0" gap="density-2xl" padding="density-2xl">
         <PageHeader
           className="p-0 shrink-0"
-          slotHeading="Experiment groups"
+          slotHeading={
+            <>
+              Experiment groups
+              <FeatureFlagBadge flag="experiment" />
+            </>
+          }
           slotDescription="Manage groups for online optimization. Review reports down to the frame level."
           slotActions={
             <Button color="brand" onClick={() => setIsCreateModalOpen(true)}>


### PR DESCRIPTION
<img width="1126" height="482" alt="Screenshot 2026-07-21 at 11 09 53 AM" src="https://github.com/user-attachments/assets/72f41b56-8220-428f-b506-2297b4be3797" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a feature flag badge beside the “Experiment groups” heading for clearer visibility of feature status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->