### PR TITLE
fix(intake): prevent ATIF from propagating errors to root

### DIFF
--- a/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
+++ b/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
@@ -285,6 +285,8 @@ def _trajectory_to_span(
         raw_attributes=raw_attributes,
     )
     trajectory_started_at = _trajectory_started_at(trajectory, ingested_at)
+    # ATIF does not report a trajectory-level outcome status. Tool failures are
+    # represented by their TOOL spans and must not be rolled up to this parent.
     return IntakeSpan(
         workspace=workspace,
         session_id=trace_session_id,
@@ -294,7 +296,7 @@ def _trajectory_to_span(
         external_parent_span_id=external_parent_span_id or "",
         kind=SpanKind.AGENT,
         name=trajectory.agent.name,
-        status=SpanStatus.ERROR if _trajectory_has_error(trajectory) else SpanStatus.SUCCESS,
+        status=SpanStatus.SUCCESS,
         start_time=trajectory_started_at,
         end_time=_clamped_end(trajectory_started_at, _trajectory_ended_at(trajectory)),
         attributes_string=attribute_bags.string,
@@ -832,25 +834,6 @@ def _trajectory_output(trajectory: AtifTrajectory) -> str | None:
                 return _string_or_json(step.message)
             return _step_output(step)
     return None
-
-
-def _trajectory_has_error(trajectory: AtifTrajectory) -> bool:
-    """Return whether this trajectory directly contains a tool error.
-
-    Embedded trajectories map to independent AGENT spans. Their errors remain
-    visible on those spans and in the trace error count, but must not change the
-    status of a parent trajectory that successfully delegated and recovered.
-    """
-    for step in trajectory.steps:
-        if not isinstance(step, AtifStepAgent):
-            continue
-        observation = _step_observation(step)
-        if observation is None:
-            continue
-        for result in observation.results:
-            if _tool_result_is_error(step, result):
-                return True
-    return False
 
 
 def _step_tool_calls(step: AtifStep) -> list[AtifToolCall]:

--- a/services/intake/tests/integration/spans/test_atif_ingest.py
+++ b/services/intake/tests/integration/spans/test_atif_ingest.py
@@ -516,7 +516,7 @@ def test_atif_ingest_accepts_example_trajectory_and_reconstructs_read_side_data(
     llm_step, final_agent_step = agent_steps
     assert trajectory["kind"] == "AGENT"
     assert trajectory["source"] == "atif"
-    assert trajectory["status"] == "error"
+    assert trajectory["status"] == "success"
     assert trajectory["input"] == body["steps"][0]["message"]
     assert trajectory["output"] == body["steps"][2]["message"]
     assert trajectory["model"] == "provider/sample-model"
@@ -629,6 +629,13 @@ def test_atif_ingest_accepts_example_trajectory_and_reconstructs_read_side_data(
     tool_input = json.loads(tool_step["input"])
     assert tool_input == tool_call
     assert json.loads(tool_step["output"]) == tool_observation
+
+    trace_response = client.get(f"/apis/intake/v2/workspaces/default/traces/{body['session_id']}")
+    assert trace_response.status_code == 200, trace_response.text
+    trace = trace_response.json()
+    assert trace["root_span_id"] == trajectory["span_id"]
+    assert trace["status"] == "success"
+    assert trace["error_count"] == 1
 
     subagent_step = spans_by_name["subagent-subagents/subagent-session-1.json"]
     assert subagent_step["kind"] == "AGENT"

--- a/services/intake/tests/test_atif_v17.py
+++ b/services/intake/tests/test_atif_v17.py
@@ -236,6 +236,7 @@ def test_atif_v17_embedded_subagents_expand_recursively_in_the_parent_trace() ->
         if span.name == "research-agent" and span.external_parent_span_id == research.external_span_id
     )
     review = next(span for span in spans if span.name == "review-agent")
+    failed_tool = next(span for span in spans if span.name == "validate_research")
     external_ref = next(span for span in spans if span.name == "subagent-subagents/external-trajectory.json")
 
     assert len(spans) == 12
@@ -249,11 +250,12 @@ def test_atif_v17_embedded_subagents_expand_recursively_in_the_parent_trace() ->
     assert not any(span.name == "subagent-subagents/review-trajectory.json" for span in spans)
     assert root.start_time == datetime(2026, 5, 18, 10, tzinfo=timezone.utc)
     assert root.end_time == datetime(2026, 5, 18, 10, 0, 8, tzinfo=timezone.utc)
-    # A descendant tool error stays on the trajectory that emitted it. Parent
-    # trajectories successfully delegated, so their AGENT spans remain healthy.
+    # A tool error stays on its TOOL span. No trajectory AGENT span inherits it,
+    # regardless of where that trajectory sits in the embedded subagent tree.
     assert root.status == SpanStatus.SUCCESS
     assert research.status == SpanStatus.SUCCESS
-    assert review.status == SpanStatus.ERROR
+    assert review.status == SpanStatus.SUCCESS
+    assert failed_tool.status == SpanStatus.ERROR
 
     root_raw = json.loads(root.attributes_string["atif.raw"])
     research_raw = json.loads(research.attributes_string["atif.raw"])
@@ -689,7 +691,7 @@ def test_atif_mapping_uses_root_cost_when_step_metrics_have_tokens_only() -> Non
     assert child_response.cost_total_usd is None
 
 
-def test_atif_mapping_marks_trajectory_error_for_own_tool_error() -> None:
+def test_atif_mapping_keeps_tool_error_on_tool_span() -> None:
     trajectory = AtifTrajectory.model_validate(
         {
             "schema_version": "ATIF-v1.7",
@@ -723,10 +725,14 @@ def test_atif_mapping_marks_trajectory_error_for_own_tool_error() -> None:
     )
 
     root = spans[0]
+    llm = next(span for span in spans if span.kind == SpanKind.LLM)
+    tool = next(span for span in spans if span.kind == SpanKind.TOOL)
     assert root.name == "sample-agent"
     assert root.input == "solve the task"
     assert root.output == "final answer"
-    assert root.status == SpanStatus.ERROR
+    assert root.status == SpanStatus.SUCCESS
+    assert llm.status == SpanStatus.SUCCESS
+    assert tool.status == SpanStatus.ERROR
 
 
 def test_atif_mapping_span_ids_are_trace_native_and_ignore_evaluation_run_id() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trajectory and agent spans now remain marked as successful even when a tool operation fails.
  * Tool failures are reported on the specific tool span, improving error visibility and trace accuracy.
  * Trace summaries now correctly show successful overall status while retaining the appropriate error count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->