### PR TITLE
feat(agents): Support fileset configuration in optimize agent job

### DIFF
--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -3384,23 +3384,21 @@ components:
         optimize_config:
           type: string
           title: Optimize Config
-          description: Path to the NAT optimization YAML config file.  When ``optimize_config_fileset``
-            is set, this is interpreted relative to the downloaded fileset's contents.
+          description: Path to the NAT optimization YAML config file, interpreted
+            relative to the downloaded fileset when ``optimize_config_fileset`` is
+            set.
         optimize_config_fileset:
           title: Optimize Config Fileset
-          description: Optional fileset reference (``name`` or ``workspace/name``)
-            that pre-stages the optimize YAML and any sibling files (e.g. dataset).  Used
-            by platform-managed submissions where the config is uploaded to a fileset
-            before the job is submitted; local CLI runs leave this ``None`` and let
-            ``optimize_config`` be a real local path.
+          description: Optional fileset (``name`` or ``workspace/name``) that pre-stages
+            the optimize YAML and its sibling inputs for remote submissions; leave
+            unset for local CLI runs where ``optimize_config`` is a real path.
           type: string
         output:
           title: Output
-          description: "Where to write optimizer outputs (best params, per-trial results)\
-            \ \u2014 either a local directory (path-shaped: starts with '/', './',\
-            \ '../', '~/') or a NeMo Platform fileset reference ('name' or 'workspace/name').\
-            \  Filesets are created on demand if missing.  Defaults to <ctx.storage.persistent>/results\
-            \ (the platform-injected persistent volume) when not provided."
+          description: "Where to write optimizer outputs \u2014 a local directory\
+            \ (path-shaped: '/', './', '../', '~/') or a NeMo Platform fileset ('name'\
+            \ or 'workspace/name', auto-created), defaulting to the platform-persistent\
+            \ results dir when unset."
           type: string
         workspace:
           type: string

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -3384,7 +3384,24 @@ components:
         optimize_config:
           type: string
           title: Optimize Config
-          description: Path to the NAT optimization YAML config file.
+          description: Path to the NAT optimization YAML config file.  When ``optimize_config_fileset``
+            is set, this is interpreted relative to the downloaded fileset's contents.
+        optimize_config_fileset:
+          title: Optimize Config Fileset
+          description: Optional fileset reference (``name`` or ``workspace/name``)
+            that pre-stages the optimize YAML and any sibling files (e.g. dataset).  Used
+            by platform-managed submissions where the config is uploaded to a fileset
+            before the job is submitted; local CLI runs leave this ``None`` and let
+            ``optimize_config`` be a real local path.
+          type: string
+        output:
+          title: Output
+          description: "Where to write optimizer outputs (best params, per-trial results)\
+            \ \u2014 either a local directory (path-shaped: starts with '/', './',\
+            \ '../', '~/') or a NeMo Platform fileset reference ('name' or 'workspace/name').\
+            \  Filesets are created on demand if missing.  Defaults to <ctx.storage.persistent>/results\
+            \ (the platform-injected persistent volume) when not provided."
+          type: string
         workspace:
           type: string
           title: Workspace
@@ -3408,9 +3425,13 @@ components:
         \ (sweeps don't affect the remote agent \u2014 see\n        module docstring).\
         \  When ``None`` the optimize config is\n        expected to include an inline\
         \ agent workflow.\n    optimize_config: Path to the NAT optimization YAML\
-        \ config file.\n        The output path is controlled by ``optimizer.output_path``\n\
-        \        inside the YAML.\n    workspace: NeMo Platform workspace used to\
-        \ scope the agent fetch and the\n        gateway URL injection."
+        \ config file.\n    optimize_config_fileset: Optional fileset containing the\
+        \ optimization\n        YAML and its sibling inputs.\n    output: Local directory\
+        \ or fileset where optimizer artifacts are\n        written. The relative\
+        \ suffixes from ``eval.general.output_dir``\n        and ``optimizer.output_path``\
+        \ inside the YAML are preserved under\n        this output base.\n    workspace:\
+        \ NeMo Platform workspace used to scope the agent fetch and the\n        gateway\
+        \ URL injection, and as the default workspace for bare\n        fileset references."
     OptimizeJob:
       properties:
         id:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/fileset_io.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/fileset_io.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared fileset staging helpers for agents jobs.
+
+Platform jobs run as host subprocesses that stage nothing into their work
+dir, so a config file (and its sibling data) must either already exist on the
+host (absolute-path mode, used by the co-located CLI) or be delivered through
+a NeMo Platform fileset that the job downloads at runtime.  These helpers
+implement the fileset path so a remote client (e.g. Studio) can submit a job
+without touching the platform host's filesystem.
+
+:class:`~nemo_agents_plugin.jobs.evaluate_agent.EvaluateAgentJob` predates this
+module and still carries its own private copies of the same logic; new jobs
+should use these functions instead, and evaluate can migrate here later.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import tempfile
+from pathlib import Path
+from typing import Iterator
+
+from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.job_context import JobContext
+from nemo_platform_plugin.refs import (
+    FilesetRef,
+    LocalDir,
+    OutputTarget,
+    classify_output_target,
+    parse_entity_ref,
+)
+from nemo_platform_plugin.run_dependencies import LocalRunError
+
+logger = logging.getLogger(__name__)
+
+
+def split_fileset_ref(ref: str, default_workspace: str) -> tuple[str, str]:
+    """Split a ``workspace/name`` (or bare ``name``) fileset ref into ``(ws, name)``."""
+    parsed = parse_entity_ref(ref, default_workspace=default_workspace)
+    return parsed.workspace, parsed.name
+
+
+@contextlib.contextmanager
+def resolve_staged_config(
+    config_rel_path: str,
+    fileset_ref: str | None,
+    *,
+    workspace: str,
+    ctx: JobContext,
+    sdk: NeMoPlatform | None,
+    kind: str,
+) -> Iterator[Path]:
+    """Yield a local path to a config file, staging it from a fileset if requested.
+
+    When ``fileset_ref`` is set, download the fileset into a tempdir under
+    ``ctx.storage.ephemeral`` and resolve ``config_rel_path`` inside it (with a
+    path-escape guard).  Otherwise treat ``config_rel_path`` as a real local
+    path and pass it through verbatim.  ``kind`` is a short slug used in the
+    tempdir prefix and log lines (e.g. ``"optimize-config"``).
+    """
+    if fileset_ref is None:
+        yield Path(config_rel_path)
+        return
+
+    ref = FilesetRef(fileset_ref)
+    ws, name = split_fileset_ref(ref, workspace)
+
+    if sdk is None:
+        raise LocalRunError(
+            f"Staging {kind} from a fileset requires a 'sdk: NeMoPlatform', but no "
+            "platform SDK was available.  Set NMP_BASE_URL or pass sdk via "
+            "NemoJobScheduler.run_local(sdk=...)."
+        )
+
+    with tempfile.TemporaryDirectory(prefix=f".{kind}-{name}-", dir=str(ctx.storage.ephemeral)) as tmp:
+        tmp_path = Path(tmp)
+        logger.info("Downloading fileset %s/%s into %s for %s.", ws, name, tmp_path, kind)
+        sdk.files.download(local_path=str(tmp_path), fileset=name, workspace=ws)
+        # ``config_rel_path`` is caller-controlled — confirm it stays inside the
+        # downloaded fileset so an absolute path or ``..`` segment can't make the
+        # subprocess read arbitrary files from the task host.
+        root = tmp_path.resolve()
+        local_config = (tmp_path / config_rel_path).resolve()
+        if not local_config.is_relative_to(root):
+            raise ValueError(f"{kind} {config_rel_path!r} resolves outside the downloaded fileset")
+        if not local_config.is_file():
+            raise FileNotFoundError(
+                f"{kind} '{config_rel_path}' was not found in fileset '{ws}/{name}' after download.  "
+                f"Available files: {sorted(p.name for p in tmp_path.iterdir())}"
+            )
+        yield local_config
+
+
+@contextlib.contextmanager
+def resolve_output(
+    output: OutputTarget | None,
+    *,
+    workspace: str,
+    ctx: JobContext,
+    sdk: NeMoPlatform | None,
+    kind: str,
+) -> Iterator[Path]:
+    """Yield a local base directory for job outputs, uploading to a fileset on success.
+
+    Branches on the union shape:
+
+    - ``None`` → ``ctx.storage.persistent / "results"`` (no upload).
+    - :class:`LocalDir` → that directory, ``mkdir -p``-ed (no upload).
+    - :class:`FilesetRef` → a fresh tempdir under ``ctx.storage.ephemeral``;
+      on a clean exit the tempdir contents are uploaded to the named fileset
+      (auto-created if missing).  A body that raises skips the upload so
+      partial/broken runs don't pollute the fileset.
+    """
+    if output is None:
+        local = ctx.storage.persistent / "results"
+        local.mkdir(parents=True, exist_ok=True)
+        logger.info("Writing %s outputs to platform-persistent dir %s", kind, local)
+        yield local
+        return
+
+    if classify_output_target(output) is LocalDir:
+        local = Path(str(output)).expanduser().resolve()
+        local.mkdir(parents=True, exist_ok=True)
+        logger.info("Writing %s outputs to local dir %s", kind, local)
+        yield local
+        return
+
+    ref = FilesetRef(output)
+    ws, name = split_fileset_ref(ref, workspace)
+
+    if sdk is None:
+        raise LocalRunError(
+            f"Uploading {kind} results to a fileset requires a 'sdk: NeMoPlatform', but no "
+            "platform SDK was available.  Set NMP_BASE_URL, pass sdk via "
+            "NemoJobScheduler.run_local(sdk=...), or use a local output directory instead."
+        )
+
+    with tempfile.TemporaryDirectory(prefix=f".{kind}-output-{name}-", dir=str(ctx.storage.ephemeral)) as tmp:
+        tmp_path = Path(tmp)
+        logger.info("Staging %s outputs in %s; will upload to fileset %s/%s on success.", kind, tmp_path, ws, name)
+        should_upload = True
+        try:
+            yield tmp_path
+        except BaseException:
+            should_upload = False
+            raise
+        finally:
+            if should_upload:
+                upload_to_fileset(tmp_path, fileset=name, workspace=ws, sdk=sdk)
+
+
+def upload_to_fileset(local_dir: Path, *, fileset: str, workspace: str, sdk: NeMoPlatform) -> None:
+    """Upload *local_dir*'s contents recursively to the named fileset (auto-created)."""
+    # Trailing slash uploads contents, not the dir itself.
+    result = sdk.files.upload(
+        local_path=str(local_dir) + "/",
+        fileset=fileset,
+        workspace=workspace,
+        fileset_auto_create=True,
+    )
+    logger.info("Uploaded outputs from %s to fileset %s/%s.", local_dir, workspace, result.name)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_agent.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_agent.py
@@ -50,10 +50,12 @@ config's LLMs are injected with the platform Inference Gateway URL via
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import subprocess
+import tempfile
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Iterator
 
 from nemo_agents_plugin.refs import AgentRef, AgentTarget, classify_agent_target
 from nemo_agents_plugin.utils import (
@@ -64,7 +66,7 @@ from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
-from nemo_platform_plugin.refs import EndpointURL
+from nemo_platform_plugin.refs import EndpointURL, FilesetRef
 from nemo_platform_plugin.run_dependencies import LocalRunError
 from pydantic import BaseModel, Field
 
@@ -109,7 +111,21 @@ class OptimizeAgentSpec(BaseModel):
         "parameter sweeps don't reach the remote agent).  When omitted, the "
         "optimize config must include an inline agent workflow.",
     )
-    optimize_config: str = Field(description="Path to the NAT optimization YAML config file.")
+    optimize_config: str = Field(
+        description="Path to the NAT optimization YAML config file.  When "
+        "``optimize_config_fileset`` is set, this is interpreted relative to the "
+        "downloaded fileset's contents.",
+    )
+    optimize_config_fileset: FilesetRef | None = Field(
+        default=None,
+        description=(
+            "Optional fileset reference (``name`` or ``workspace/name``) that "
+            "pre-stages the optimize YAML and any sibling files (e.g. dataset).  "
+            "Used by platform-managed submissions where the config is uploaded to a "
+            "fileset before the job is submitted; local CLI runs leave this ``None`` "
+            "and let ``optimize_config`` be a real local path."
+        ),
+    )
     workspace: str = Field(
         default="default",
         description="Workspace name used to fetch the agent's stored config when "
@@ -130,7 +146,7 @@ class OptimizeAgentJob(NemoJob):
     spec_schema: ClassVar[type[BaseModel]] = OptimizeAgentSpec
 
     @classmethod
-    async def compile(  # type: ignore[override]
+    async def compile(  # ty: ignore[invalid-method-override]
         cls,
         *,
         workspace: str,
@@ -153,7 +169,8 @@ class OptimizeAgentJob(NemoJob):
             PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
         )
 
-        _require_absolute(spec.optimize_config, "optimize_config")
+        if not spec.optimize_config_fileset:
+            _require_absolute(spec.optimize_config, "optimize_config")
 
         spec_dict = spec.model_dump(mode="json")
         # URL workspace is the auth boundary; overwrites any spec workspace.
@@ -211,58 +228,109 @@ class OptimizeAgentJob(NemoJob):
             Dict with ``status`` and ``returncode`` keys.
         """
         cfg = OptimizeAgentSpec.model_validate(config)
-        optimize_config_path = Path(cfg.optimize_config)
 
         agent_config, endpoint = self._resolve_agent(cfg.agent, workspace=cfg.workspace, sdk=sdk)
-
-        # Pre-flight: surface a missing-VirtualModel error before the
-        # ``nat optimize`` subprocess starts.  ``agent_config`` is merged
-        # under the YAML in the same shape ``temp_injected_config`` will
-        # use, so an agent-fetched LLM gets validated alongside the
-        # optimize-side judge.  No-op when ``sdk`` is None
-        # (URL/inline-workflow modes have nothing to look up against).
-        preflight_validate_llm_models(
-            optimize_config_path,
-            workspace=cfg.workspace,
-            sdk=sdk,
-            agent_config=agent_config,
-        )
 
         output_base = ctx.storage.persistent / "results"
         output_base.mkdir(parents=True, exist_ok=True)
 
-        with temp_injected_config(
-            optimize_config_path,
-            cfg.workspace,
-            extra_config=agent_config,
-            output_base=output_base,
-        ) as injected_path:
-            cwd = injected_path.parent
-            cmd = ["nat", "optimize", "--config_file", injected_path.name]
+        with self._resolve_optimize_config(cfg, sdk=sdk, ctx=ctx) as optimize_config_path:
+            # Pre-flight: surface a missing-VirtualModel error before the
+            # ``nat optimize`` subprocess starts.  ``agent_config`` is merged
+            # under the YAML in the same shape ``temp_injected_config`` will
+            # use, so an agent-fetched LLM gets validated alongside the
+            # optimize-side judge.  No-op when ``sdk`` is None
+            # (URL/inline-workflow modes have nothing to look up against).
+            preflight_validate_llm_models(
+                optimize_config_path,
+                workspace=cfg.workspace,
+                sdk=sdk,
+                agent_config=agent_config,
+            )
 
-            # Only the explicit URL mode hands ``--endpoint`` to NAT.  The
-            # AgentRef mode merges the agent's workflow into the config so
-            # ``nat optimize`` runs it locally and per-trial param overrides
-            # actually take effect; the inline-workflow mode (agent=None)
-            # similarly relies on the user's config to declare a workflow.
-            if endpoint is not None:
-                cmd.extend(["--endpoint", endpoint])
-                logger.info("Optimizing against agent endpoint %s (opaque service mode)", endpoint)
+            with temp_injected_config(
+                optimize_config_path,
+                cfg.workspace,
+                extra_config=agent_config,
+                output_base=output_base,
+            ) as injected_path:
+                cwd = injected_path.parent
+                cmd = ["nat", "optimize", "--config_file", injected_path.name]
 
-            logger.info("Writing optimize outputs to platform-persistent dir %s", output_base)
-            logger.info("Running: %s (cwd=%s)", " ".join(cmd), cwd)
-            try:
-                result = subprocess.run(cmd, check=True, cwd=cwd)
-                logger.info("OptimizeAgentJob completed (returncode=%d).", result.returncode)
-                return {"status": "completed", "returncode": result.returncode}
-            except subprocess.CalledProcessError as exc:
-                logger.error("Optimization failed (returncode=%d).", exc.returncode)
-                return {"status": "failed", "returncode": exc.returncode}
-            except FileNotFoundError as exc:
-                raise RuntimeError(
-                    "'nat optimize' command not found.  Install the NAT config optimizer: "
-                    "uv pip install 'nvidia-nat-config-optimizer>=1.5.0,<2.0'"
-                ) from exc
+                # Only the explicit URL mode hands ``--endpoint`` to NAT.  The
+                # AgentRef mode merges the agent's workflow into the config so
+                # ``nat optimize`` runs it locally and per-trial param overrides
+                # actually take effect; the inline-workflow mode (agent=None)
+                # similarly relies on the user's config to declare a workflow.
+                if endpoint is not None:
+                    cmd.extend(["--endpoint", endpoint])
+                    logger.info("Optimizing against agent endpoint %s (opaque service mode)", endpoint)
+
+                logger.info("Writing optimize outputs to platform-persistent dir %s", output_base)
+                logger.info("Running: %s (cwd=%s)", " ".join(cmd), cwd)
+                try:
+                    result = subprocess.run(cmd, check=True, cwd=cwd)
+                    logger.info("OptimizeAgentJob completed (returncode=%d).", result.returncode)
+                    return {"status": "completed", "returncode": result.returncode}
+                except subprocess.CalledProcessError as exc:
+                    logger.error("Optimization failed (returncode=%d).", exc.returncode)
+                    return {"status": "failed", "returncode": exc.returncode}
+                except FileNotFoundError as exc:
+                    raise RuntimeError(
+                        "'nat optimize' command not found.  Install the NAT config optimizer: "
+                        "uv pip install 'nvidia-nat-config-optimizer>=1.5.0,<2.0'"
+                    ) from exc
+
+    @contextlib.contextmanager
+    def _resolve_optimize_config(
+        self,
+        cfg: OptimizeAgentSpec,
+        *,
+        ctx: JobContext,
+        sdk: NeMoPlatform | None,
+    ) -> Iterator[Path]:
+        """Yield a local path to the optimize YAML.
+
+        When ``cfg.optimize_config_fileset`` is set, download the fileset into a
+        tempdir under ``ctx.storage.ephemeral`` and resolve ``cfg.optimize_config``
+        relative to it.  Otherwise pass through verbatim as a local path.
+        ``sdk`` is required on the fileset branch — when it is missing, raise
+        :class:`LocalRunError` so the caller sees an actionable error.
+        """
+        if not cfg.optimize_config_fileset:
+            yield Path(cfg.optimize_config)
+            return
+
+        if sdk is None:
+            raise LocalRunError(
+                "OptimizeAgentJob.run requires a 'sdk: NeMoPlatform' to download "
+                "optimize_config_fileset contents, but no platform SDK was available. "
+                "Set NMP_BASE_URL or pass sdk via NemoJobScheduler.run_local(sdk=...)."
+            )
+
+        ref = FilesetRef(cfg.optimize_config_fileset)
+        if "/" in ref:
+            ws, name = ref.split("/", 1)
+        else:
+            ws, name = cfg.workspace, ref
+
+        with tempfile.TemporaryDirectory(
+            prefix=f".optimize-config-{name}-",
+            dir=str(ctx.storage.ephemeral),
+        ) as tmp:
+            tmp_path = Path(tmp)
+            logger.info("Downloading fileset %s/%s into %s for optimize config.", ws, name, tmp_path)
+            sdk.files.download(local_path=str(tmp_path), fileset=name, workspace=ws)
+            root = tmp_path.resolve()
+            local_optimize_config = (tmp_path / cfg.optimize_config).resolve()
+            if not local_optimize_config.is_relative_to(root):
+                raise ValueError(f"optimize_config {cfg.optimize_config!r} resolves outside the downloaded fileset")
+            if not local_optimize_config.is_file():
+                raise FileNotFoundError(
+                    f"optimize_config '{cfg.optimize_config}' was not found in fileset '{ws}/{name}' "
+                    f"after download.  Available files: {sorted(p.name for p in tmp_path.iterdir())}"
+                )
+            yield local_optimize_config
 
     @staticmethod
     def _resolve_agent(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_agent.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_agent.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from pathlib import Path
 from typing import Any, ClassVar
 
 from nemo_agents_plugin.jobs.fileset_io import resolve_output, resolve_staged_config, split_fileset_ref
@@ -115,27 +116,20 @@ class OptimizeAgentSpec(BaseModel):
         "optimize config must include an inline agent workflow.",
     )
     optimize_config: str = Field(
-        description="Path to the NAT optimization YAML config file.  When "
-        "``optimize_config_fileset`` is set, this is interpreted relative to the "
-        "downloaded fileset's contents.",
+        description="Path to the NAT optimization YAML config file, interpreted relative "
+        "to the downloaded fileset when ``optimize_config_fileset`` is set.",
     )
     optimize_config_fileset: FilesetRef | None = Field(
         default=None,
-        description=(
-            "Optional fileset reference (``name`` or ``workspace/name``) that "
-            "pre-stages the optimize YAML and any sibling files (e.g. dataset).  "
-            "Used by platform-managed submissions where the config is uploaded to a "
-            "fileset before the job is submitted; local CLI runs leave this ``None`` "
-            "and let ``optimize_config`` be a real local path."
-        ),
+        description="Optional fileset (``name`` or ``workspace/name``) that pre-stages the "
+        "optimize YAML and its sibling inputs for remote submissions; leave unset for local "
+        "CLI runs where ``optimize_config`` is a real path.",
     )
     output: OutputTarget | None = Field(
         default=None,
-        description="Where to write optimizer outputs (best params, per-trial results) — "
-        "either a local directory (path-shaped: starts with '/', './', '../', '~/') or a "
-        "NeMo Platform fileset reference ('name' or 'workspace/name').  Filesets are "
-        "created on demand if missing.  Defaults to <ctx.storage.persistent>/results "
-        "(the platform-injected persistent volume) when not provided.",
+        description="Where to write optimizer outputs — a local directory (path-shaped: "
+        "'/', './', '../', '~/') or a NeMo Platform fileset ('name' or 'workspace/name', "
+        "auto-created), defaulting to the platform-persistent results dir when unset.",
     )
     workspace: str = Field(
         default="default",
@@ -197,9 +191,16 @@ class OptimizeAgentJob(NemoJob):
         # A fileset-staged config is resolved inside the downloaded tempdir at
         # runtime, so only demand an absolute host path in the (CLI) local-file
         # mode.  Mirrors EvaluateAgentJob, which likewise skips the check when a
-        # fileset is supplied.
+        # fileset is supplied.  With a fileset the path is resolved *within* it,
+        # so reject an absolute path here rather than letting it fail later with
+        # an opaque "resolves outside the downloaded fileset" runtime error.
         if spec.optimize_config_fileset is None:
             _require_absolute(spec.optimize_config, "optimize_config")
+        elif Path(spec.optimize_config).is_absolute():
+            raise ValueError(
+                "optimize_config must be a relative path when optimize_config_fileset is set "
+                "(it is resolved inside the downloaded fileset)."
+            )
 
         spec_dict = spec.model_dump(mode="json")
         # URL workspace is the auth boundary; overwrites any spec workspace.
@@ -304,32 +305,45 @@ class OptimizeAgentJob(NemoJob):
                     extra_config=agent_config,
                     output_base=output_base,
                 ) as injected_path:
-                    cwd = injected_path.parent
-                    cmd = ["nat", "optimize", "--config_file", injected_path.name]
-
-                    # Only the explicit URL mode hands ``--endpoint`` to NAT.  The
-                    # AgentRef mode merges the agent's workflow into the config so
-                    # ``nat optimize`` runs it locally and per-trial param overrides
-                    # actually take effect; the inline-workflow mode (agent=None)
-                    # similarly relies on the user's config to declare a workflow.
-                    if endpoint is not None:
-                        cmd.extend(["--endpoint", endpoint])
-                        logger.info("Optimizing against agent endpoint %s (opaque service mode)", endpoint)
-
                     logger.info("Writing optimize outputs to %s", output_base)
-                    logger.info("Running: %s (cwd=%s)", " ".join(cmd), cwd)
-                    try:
-                        result = subprocess.run(cmd, check=True, cwd=cwd)
-                    except FileNotFoundError as exc:
-                        raise RuntimeError(
-                            "'nat optimize' command not found.  Install the NAT config optimizer: "
-                            "uv pip install 'nvidia-nat-config-optimizer>=1.5.0,<2.0'"
-                        ) from exc
-                    logger.info("OptimizeAgentJob completed (returncode=%d).", result.returncode)
-                    return {"status": "completed", "returncode": result.returncode}
+                    returncode = self._run_nat_optimize(injected_path, endpoint=endpoint)
+                    logger.info("OptimizeAgentJob completed (returncode=%d).", returncode)
+                    return {"status": "completed", "returncode": returncode}
         except subprocess.CalledProcessError as exc:
             logger.error("Optimization failed (returncode=%d); output upload was skipped.", exc.returncode)
             return {"status": "failed", "returncode": exc.returncode}
+
+    @staticmethod
+    def _run_nat_optimize(injected_path: Path, *, endpoint: str | None) -> int:
+        """Invoke ``nat optimize`` on the injected config and return its exit code.
+
+        The config file's name is passed as ``--config_file`` with the subprocess
+        ``cwd`` set to its parent so relative paths (datasets, output dirs) resolve.
+        A non-zero exit raises :class:`subprocess.CalledProcessError`, which the
+        caller catches to skip the output-fileset upload; a missing ``nat`` CLI is
+        re-raised as a :class:`RuntimeError` with install guidance.
+        """
+        cwd = injected_path.parent
+        cmd = ["nat", "optimize", "--config_file", injected_path.name]
+
+        # Only the explicit URL mode hands ``--endpoint`` to NAT.  The AgentRef
+        # mode merges the agent's workflow into the config so ``nat optimize`` runs
+        # it locally and per-trial param overrides actually take effect; the
+        # inline-workflow mode (agent=None) similarly relies on the user's config
+        # to declare a workflow.
+        if endpoint is not None:
+            cmd.extend(["--endpoint", endpoint])
+            logger.info("Optimizing against agent endpoint %s (opaque service mode)", endpoint)
+
+        logger.info("Running: %s (cwd=%s)", " ".join(cmd), cwd)
+        try:
+            result = subprocess.run(cmd, check=True, cwd=cwd)
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "'nat optimize' command not found.  Install the NAT config optimizer: "
+                "uv pip install 'nvidia-nat-config-optimizer>=1.5.0,<2.0'"
+            ) from exc
+        return result.returncode
 
     @staticmethod
     def _resolve_agent(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_agent.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/optimize_agent.py
@@ -50,13 +50,11 @@ config's LLMs are injected with the platform Inference Gateway URL via
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import subprocess
-import tempfile
-from pathlib import Path
-from typing import Any, ClassVar, Iterator
+from typing import Any, ClassVar
 
+from nemo_agents_plugin.jobs.fileset_io import resolve_output, resolve_staged_config, split_fileset_ref
 from nemo_agents_plugin.refs import AgentRef, AgentTarget, classify_agent_target
 from nemo_agents_plugin.utils import (
     preflight_validate_llm_models,
@@ -66,9 +64,9 @@ from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec
-from nemo_platform_plugin.refs import EndpointURL, FilesetRef
+from nemo_platform_plugin.refs import EndpointURL, FilesetRef, LocalDir, OutputTarget, classify_output_target
 from nemo_platform_plugin.run_dependencies import LocalRunError
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -91,10 +89,15 @@ class OptimizeAgentSpec(BaseModel):
             module docstring).  When ``None`` the optimize config is
             expected to include an inline agent workflow.
         optimize_config: Path to the NAT optimization YAML config file.
-            The output path is controlled by ``optimizer.output_path``
-            inside the YAML.
+        optimize_config_fileset: Optional fileset containing the optimization
+            YAML and its sibling inputs.
+        output: Local directory or fileset where optimizer artifacts are
+            written. The relative suffixes from ``eval.general.output_dir``
+            and ``optimizer.output_path`` inside the YAML are preserved under
+            this output base.
         workspace: NeMo Platform workspace used to scope the agent fetch and the
-            gateway URL injection.
+            gateway URL injection, and as the default workspace for bare
+            fileset references.
     """
 
     # Field order is intentional — it's also the order the auto-generated
@@ -126,12 +129,34 @@ class OptimizeAgentSpec(BaseModel):
             "and let ``optimize_config`` be a real local path."
         ),
     )
+    output: OutputTarget | None = Field(
+        default=None,
+        description="Where to write optimizer outputs (best params, per-trial results) — "
+        "either a local directory (path-shaped: starts with '/', './', '../', '~/') or a "
+        "NeMo Platform fileset reference ('name' or 'workspace/name').  Filesets are "
+        "created on demand if missing.  Defaults to <ctx.storage.persistent>/results "
+        "(the platform-injected persistent volume) when not provided.",
+    )
     workspace: str = Field(
         default="default",
         description="Workspace name used to fetch the agent's stored config when "
         "--agent is a bare name, and to construct the Inference Gateway URL when "
         "injecting base_url into LLMs that have none set.",
     )
+
+    @field_validator("optimize_config_fileset")
+    @classmethod
+    def _validate_optimize_config_fileset(cls, value: FilesetRef | None) -> FilesetRef | None:
+        if value is not None:
+            split_fileset_ref(value, "default")
+        return value
+
+    @field_validator("output")
+    @classmethod
+    def _validate_output(cls, value: OutputTarget | None) -> OutputTarget | None:
+        if value is not None and classify_output_target(value) is not LocalDir:
+            split_fileset_ref(value, "default")
+        return value
 
 
 class OptimizeAgentJob(NemoJob):
@@ -169,7 +194,11 @@ class OptimizeAgentJob(NemoJob):
             PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
         )
 
-        if not spec.optimize_config_fileset:
+        # A fileset-staged config is resolved inside the downloaded tempdir at
+        # runtime, so only demand an absolute host path in the (CLI) local-file
+        # mode.  Mirrors EvaluateAgentJob, which likewise skips the check when a
+        # fileset is supplied.
+        if spec.optimize_config_fileset is None:
             _require_absolute(spec.optimize_config, "optimize_config")
 
         spec_dict = spec.model_dump(mode="json")
@@ -206,9 +235,11 @@ class OptimizeAgentJob(NemoJob):
         continue to resolve.
 
         Output paths in the config (``eval.general.output_dir`` and
-        ``optimizer.output_path``) are rebased to write under
-        ``ctx.storage.persistent / "results"`` instead of the source tree,
-        preventing unstaged git changes during local CLI runs.
+        ``optimizer.output_path``) are rebased under ``cfg.output`` when it is
+        provided. A local-directory target writes there directly; a fileset
+        target stages under ``ctx.storage.ephemeral`` and uploads on success.
+        Without ``cfg.output``, artifacts are written under
+        ``ctx.storage.persistent / "results"``.
 
         Args:
             config: Dict matching :class:`OptimizeAgentSpec`.
@@ -217,12 +248,14 @@ class OptimizeAgentJob(NemoJob):
                 artifacts should be written.
             sdk: Platform SDK handle, injected by
                 :class:`~nemo_platform_plugin.scheduler.NemoJobScheduler` from the
-                ambient SDK handle.  Required only when ``cfg.agent`` is
-                a platform-managed :class:`AgentRef` (the agent-fetch
-                mode); URL and ``None`` modes don't need it.  When
-                missing in a mode that requires it, we raise
-                :class:`LocalRunError` early so the user gets an
-                actionable error before the subprocess runs.
+                ambient SDK handle. Required when ``cfg.agent`` is a
+                platform-managed :class:`AgentRef`, when
+                ``cfg.optimize_config_fileset`` must be downloaded, or when
+                ``cfg.output`` names a fileset. URL/inline-agent modes with
+                local config and output paths do not need it. When missing in
+                a mode that requires it, we raise :class:`LocalRunError` early
+                so the user gets an actionable error before the subprocess
+                runs.
 
         Returns:
             Dict with ``status`` and ``returncode`` keys.
@@ -231,106 +264,72 @@ class OptimizeAgentJob(NemoJob):
 
         agent_config, endpoint = self._resolve_agent(cfg.agent, workspace=cfg.workspace, sdk=sdk)
 
-        output_base = ctx.storage.persistent / "results"
-        output_base.mkdir(parents=True, exist_ok=True)
+        # Catch CalledProcessError outside the `with` so ``resolve_output``'s
+        # except-clause fires and skips the fileset upload on failed runs —
+        # we don't publish partial/broken optimizer output.
+        try:
+            with (
+                resolve_staged_config(
+                    cfg.optimize_config,
+                    cfg.optimize_config_fileset,
+                    workspace=cfg.workspace,
+                    ctx=ctx,
+                    sdk=sdk,
+                    kind="optimize-config",
+                ) as optimize_config_path,
+                resolve_output(
+                    cfg.output,
+                    workspace=cfg.workspace,
+                    ctx=ctx,
+                    sdk=sdk,
+                    kind="optimize",
+                ) as output_base,
+            ):
+                # Pre-flight: surface a missing-VirtualModel error before the
+                # ``nat optimize`` subprocess starts.  ``agent_config`` is merged
+                # under the YAML in the same shape ``temp_injected_config`` will
+                # use, so an agent-fetched LLM gets validated alongside the
+                # optimize-side judge.  No-op when ``sdk`` is None
+                # (URL/inline-workflow modes have nothing to look up against).
+                preflight_validate_llm_models(
+                    optimize_config_path,
+                    workspace=cfg.workspace,
+                    sdk=sdk,
+                    agent_config=agent_config,
+                )
 
-        with self._resolve_optimize_config(cfg, sdk=sdk, ctx=ctx) as optimize_config_path:
-            # Pre-flight: surface a missing-VirtualModel error before the
-            # ``nat optimize`` subprocess starts.  ``agent_config`` is merged
-            # under the YAML in the same shape ``temp_injected_config`` will
-            # use, so an agent-fetched LLM gets validated alongside the
-            # optimize-side judge.  No-op when ``sdk`` is None
-            # (URL/inline-workflow modes have nothing to look up against).
-            preflight_validate_llm_models(
-                optimize_config_path,
-                workspace=cfg.workspace,
-                sdk=sdk,
-                agent_config=agent_config,
-            )
+                with temp_injected_config(
+                    optimize_config_path,
+                    cfg.workspace,
+                    extra_config=agent_config,
+                    output_base=output_base,
+                ) as injected_path:
+                    cwd = injected_path.parent
+                    cmd = ["nat", "optimize", "--config_file", injected_path.name]
 
-            with temp_injected_config(
-                optimize_config_path,
-                cfg.workspace,
-                extra_config=agent_config,
-                output_base=output_base,
-            ) as injected_path:
-                cwd = injected_path.parent
-                cmd = ["nat", "optimize", "--config_file", injected_path.name]
+                    # Only the explicit URL mode hands ``--endpoint`` to NAT.  The
+                    # AgentRef mode merges the agent's workflow into the config so
+                    # ``nat optimize`` runs it locally and per-trial param overrides
+                    # actually take effect; the inline-workflow mode (agent=None)
+                    # similarly relies on the user's config to declare a workflow.
+                    if endpoint is not None:
+                        cmd.extend(["--endpoint", endpoint])
+                        logger.info("Optimizing against agent endpoint %s (opaque service mode)", endpoint)
 
-                # Only the explicit URL mode hands ``--endpoint`` to NAT.  The
-                # AgentRef mode merges the agent's workflow into the config so
-                # ``nat optimize`` runs it locally and per-trial param overrides
-                # actually take effect; the inline-workflow mode (agent=None)
-                # similarly relies on the user's config to declare a workflow.
-                if endpoint is not None:
-                    cmd.extend(["--endpoint", endpoint])
-                    logger.info("Optimizing against agent endpoint %s (opaque service mode)", endpoint)
-
-                logger.info("Writing optimize outputs to platform-persistent dir %s", output_base)
-                logger.info("Running: %s (cwd=%s)", " ".join(cmd), cwd)
-                try:
-                    result = subprocess.run(cmd, check=True, cwd=cwd)
+                    logger.info("Writing optimize outputs to %s", output_base)
+                    logger.info("Running: %s (cwd=%s)", " ".join(cmd), cwd)
+                    try:
+                        result = subprocess.run(cmd, check=True, cwd=cwd)
+                    except FileNotFoundError as exc:
+                        raise RuntimeError(
+                            "'nat optimize' command not found.  Install the NAT config optimizer: "
+                            "uv pip install 'nvidia-nat-config-optimizer>=1.5.0,<2.0'"
+                        ) from exc
                     logger.info("OptimizeAgentJob completed (returncode=%d).", result.returncode)
                     return {"status": "completed", "returncode": result.returncode}
-                except subprocess.CalledProcessError as exc:
-                    logger.error("Optimization failed (returncode=%d).", exc.returncode)
-                    return {"status": "failed", "returncode": exc.returncode}
-                except FileNotFoundError as exc:
-                    raise RuntimeError(
-                        "'nat optimize' command not found.  Install the NAT config optimizer: "
-                        "uv pip install 'nvidia-nat-config-optimizer>=1.5.0,<2.0'"
-                    ) from exc
-
-    @contextlib.contextmanager
-    def _resolve_optimize_config(
-        self,
-        cfg: OptimizeAgentSpec,
-        *,
-        ctx: JobContext,
-        sdk: NeMoPlatform | None,
-    ) -> Iterator[Path]:
-        """Yield a local path to the optimize YAML.
-
-        When ``cfg.optimize_config_fileset`` is set, download the fileset into a
-        tempdir under ``ctx.storage.ephemeral`` and resolve ``cfg.optimize_config``
-        relative to it.  Otherwise pass through verbatim as a local path.
-        ``sdk`` is required on the fileset branch — when it is missing, raise
-        :class:`LocalRunError` so the caller sees an actionable error.
-        """
-        if not cfg.optimize_config_fileset:
-            yield Path(cfg.optimize_config)
-            return
-
-        if sdk is None:
-            raise LocalRunError(
-                "OptimizeAgentJob.run requires a 'sdk: NeMoPlatform' to download "
-                "optimize_config_fileset contents, but no platform SDK was available. "
-                "Set NMP_BASE_URL or pass sdk via NemoJobScheduler.run_local(sdk=...)."
-            )
-
-        ref = FilesetRef(cfg.optimize_config_fileset)
-        if "/" in ref:
-            ws, name = ref.split("/", 1)
-        else:
-            ws, name = cfg.workspace, ref
-
-        with tempfile.TemporaryDirectory(
-            prefix=f".optimize-config-{name}-",
-            dir=str(ctx.storage.ephemeral),
-        ) as tmp:
-            tmp_path = Path(tmp)
-            logger.info("Downloading fileset %s/%s into %s for optimize config.", ws, name, tmp_path)
-            sdk.files.download(local_path=str(tmp_path), fileset=name, workspace=ws)
-            root = tmp_path.resolve()
-            local_optimize_config = (tmp_path / cfg.optimize_config).resolve()
-            if not local_optimize_config.is_relative_to(root):
-                raise ValueError(f"optimize_config {cfg.optimize_config!r} resolves outside the downloaded fileset")
-            if not local_optimize_config.is_file():
-                raise FileNotFoundError(
-                    f"optimize_config '{cfg.optimize_config}' was not found in fileset '{ws}/{name}' "
-                    f"after download.  Available files: {sorted(p.name for p in tmp_path.iterdir())}"
-                )
-            yield local_optimize_config
+        except subprocess.CalledProcessError as exc:
+            logger.error("Optimization failed (returncode=%d); output upload was skipped.", exc.returncode)
+            return {"status": "failed", "returncode": exc.returncode}
 
     @staticmethod
     def _resolve_agent(

--- a/plugins/nemo-agents/tests/unit/test_fileset_io.py
+++ b/plugins/nemo-agents/tests/unit/test_fileset_io.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared fileset staging helpers used by agents jobs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from nemo_agents_plugin.jobs.fileset_io import resolve_output, resolve_staged_config, split_fileset_ref
+from nemo_platform_plugin.job_context import JobContext
+from nemo_platform_plugin.refs import FilesetRef
+
+
+def test_resolve_staged_config_local_pass_through(tmp_path: Path, ctx: JobContext) -> None:
+    target = str(tmp_path / "optimize.yml")
+    with resolve_staged_config(target, None, workspace="default", ctx=ctx, sdk=None, kind="optimize-config") as p:
+        assert p == Path(target)
+
+
+@pytest.mark.parametrize("ref", ["", "/name", "workspace/", "workspace/name/extra"])
+def test_split_fileset_ref_rejects_invalid_refs(ref: str) -> None:
+    with pytest.raises(ValueError, match="invalid entity reference"):
+        split_fileset_ref(ref, "default")
+
+
+def test_resolve_staged_config_fileset_downloads_via_sdk(tmp_path: Path, ctx: JobContext) -> None:
+    sdk = MagicMock()
+
+    def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
+        Path(local_path, "optimize.yml").write_text("optimizer: {}")
+
+    sdk.files.download.side_effect = _fake_download
+
+    with resolve_staged_config(
+        "optimize.yml",
+        FilesetRef("nemo-agent-optimize-calc"),
+        workspace="default",
+        ctx=ctx,
+        sdk=sdk,
+        kind="optimize-config",
+    ) as resolved:
+        assert resolved.is_file()
+        assert resolved.name == "optimize.yml"
+        assert resolved.read_text() == "optimizer: {}"
+
+    sdk.files.download.assert_called_once()
+    kwargs = sdk.files.download.call_args.kwargs
+    assert kwargs["fileset"] == "nemo-agent-optimize-calc"
+    assert kwargs["workspace"] == "default"
+
+
+def test_resolve_staged_config_fileset_without_sdk_raises(ctx: JobContext) -> None:
+    with pytest.raises(Exception) as exc:
+        with resolve_staged_config(
+            "optimize.yml",
+            FilesetRef("fs"),
+            workspace="default",
+            ctx=ctx,
+            sdk=None,
+            kind="optimize-config",
+        ):
+            pass
+    assert "sdk" in str(exc.value).lower()
+
+
+def test_resolve_staged_config_empty_fileset_ref_is_invalid(ctx: JobContext) -> None:
+    with pytest.raises(ValueError, match="invalid entity reference"):
+        with resolve_staged_config(
+            "optimize.yml",
+            FilesetRef(""),
+            workspace="default",
+            ctx=ctx,
+            sdk=None,
+            kind="optimize-config",
+        ):
+            pass
+
+
+def test_resolve_staged_config_rejects_path_escape(ctx: JobContext) -> None:
+    sdk = MagicMock()
+    sdk.files.download.side_effect = lambda local_path, fileset, workspace: None
+    with pytest.raises(ValueError, match="outside the downloaded fileset"):
+        with resolve_staged_config(
+            "../evil.yml",
+            FilesetRef("fs"),
+            workspace="default",
+            ctx=ctx,
+            sdk=sdk,
+            kind="optimize-config",
+        ):
+            pass
+
+
+def test_resolve_output_none_uses_persistent_results(ctx: JobContext) -> None:
+    with resolve_output(None, workspace="default", ctx=ctx, sdk=None, kind="optimize") as base:
+        assert base == ctx.storage.persistent / "results"
+        assert base.is_dir()
+
+
+def test_resolve_output_fileset_uploads_on_clean_exit(ctx: JobContext) -> None:
+    sdk = MagicMock()
+    sdk.files.upload.return_value = MagicMock(name="fake-fileset")
+
+    with resolve_output(FilesetRef("optimize-out"), workspace="default", ctx=ctx, sdk=sdk, kind="optimize"):
+        pass
+
+    sdk.files.upload.assert_called_once()
+    kwargs = sdk.files.upload.call_args.kwargs
+    assert kwargs["fileset"] == "optimize-out"
+    assert kwargs["workspace"] == "default"
+    assert kwargs["fileset_auto_create"] is True
+    assert kwargs["local_path"].endswith("/")
+
+
+def test_resolve_output_fileset_skips_upload_when_body_raises(ctx: JobContext) -> None:
+    sdk = MagicMock()
+    with pytest.raises(RuntimeError, match="boom"):
+        with resolve_output(FilesetRef("optimize-out"), workspace="default", ctx=ctx, sdk=sdk, kind="optimize"):
+            raise RuntimeError("boom")
+    sdk.files.upload.assert_not_called()
+
+
+def test_resolve_output_empty_fileset_ref_is_invalid(ctx: JobContext) -> None:
+    sdk = MagicMock()
+    with pytest.raises(ValueError, match="invalid entity reference"):
+        with resolve_output(FilesetRef(""), workspace="default", ctx=ctx, sdk=sdk, kind="optimize"):
+            pass
+    sdk.files.upload.assert_not_called()

--- a/plugins/nemo-agents/tests/unit/test_optimize_agent_job.py
+++ b/plugins/nemo-agents/tests/unit/test_optimize_agent_job.py
@@ -15,7 +15,6 @@ import yaml
 from nemo_agents_plugin.jobs.optimize_agent import OptimizeAgentJob, OptimizeAgentSpec
 from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.refs import FilesetRef
-from nemo_platform_plugin.run_dependencies import LocalRunError
 
 
 def test_run_repoints_outputs_to_persistent_results(tmp_path: Path, ctx: JobContext) -> None:
@@ -64,109 +63,147 @@ optimizer:
     )
 
 
-def test_resolve_optimize_config_local_path_pass_through(tmp_path: Path, ctx: JobContext) -> None:
-    job = OptimizeAgentJob()
-    spec = OptimizeAgentSpec(optimize_config=str(tmp_path / "config.yml"), optimize_config_fileset=None)
-    with job._resolve_optimize_config(spec, ctx=ctx, sdk=None) as resolved:
-        assert resolved == Path(str(tmp_path / "config.yml"))
+_MINIMAL_OPTIMIZE_YAML = """
+llms:
+  llm:
+    _type: openai
+    model_name: test-model
+eval:
+  general:
+    output_dir: eval/calculator
+optimizer:
+  output_path: optimizer_results/calculator
+""".strip()
 
 
-def test_resolve_optimize_config_fileset_downloads_via_sdk(tmp_path: Path, ctx: JobContext) -> None:
-    job = OptimizeAgentJob()
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("optimize_config_fileset", ""),
+        ("optimize_config_fileset", "workspace/"),
+        ("output", ""),
+        ("output", "workspace/"),
+    ],
+)
+def test_spec_rejects_invalid_fileset_refs(field: str, value: str) -> None:
+    with pytest.raises(ValueError, match="invalid entity reference"):
+        OptimizeAgentSpec.model_validate({"optimize_config": "/tmp/optimize.yml", field: value})
+
+
+def test_spec_allows_local_output_path() -> None:
+    spec = OptimizeAgentSpec.model_validate({"optimize_config": "/tmp/optimize.yml", "output": "./results"})
+    assert str(spec.output) == "./results"
+
+
+@pytest.mark.asyncio
+async def test_compile_requires_absolute_without_fileset() -> None:
+    spec = OptimizeAgentSpec(optimize_config="relative.yml", workspace="default")
+    with pytest.raises(Exception, match="absolute"):
+        await OptimizeAgentJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_compile_allows_relative_config_with_fileset() -> None:
     spec = OptimizeAgentSpec(
-        optimize_config="config.yml",
-        optimize_config_fileset=FilesetRef("nemo-agent-optimizer-configs"),
+        optimize_config="optimize.yml",
+        optimize_config_fileset=FilesetRef("nemo-agent-optimize-calc"),
         workspace="default",
     )
+    platform_spec = await OptimizeAgentJob.compile(
+        workspace="default",
+        spec=spec,
+        entity_client=MagicMock(),
+        job_name=None,
+        async_sdk=MagicMock(),
+    )
+    config = next(iter(platform_spec["steps"]))["config"]
+    assert config["optimize_config"] == "optimize.yml"
+    assert config["optimize_config_fileset"] == "nemo-agent-optimize-calc"
 
+
+def test_run_stages_config_from_fileset(tmp_path: Path, ctx: JobContext) -> None:
     sdk = MagicMock()
 
     def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
-        Path(local_path, "config.yml").write_text("optimizer: {}")
+        Path(local_path, "optimize.yml").write_text(_MINIMAL_OPTIMIZE_YAML)
 
     sdk.files.download.side_effect = _fake_download
 
-    with job._resolve_optimize_config(spec, ctx=ctx, sdk=sdk) as resolved:
-        assert resolved.exists()
-        assert resolved.name == "config.yml"
-        assert resolved.read_text() == "optimizer: {}"
+    captured: dict[str, Any] = {}
 
+    def _fake_run(cmd: list[str], *, check: bool, cwd: Path) -> subprocess.CompletedProcess[str]:
+        captured["cwd"] = cwd
+        return subprocess.CompletedProcess(cmd, 0)
+
+    with (
+        patch("nemo_agents_plugin.jobs.optimize_agent.subprocess.run", side_effect=_fake_run),
+        patch("nemo_agents_plugin.jobs.optimize_agent.preflight_validate_llm_models"),
+    ):
+        result = OptimizeAgentJob().run(
+            {
+                "optimize_config": "optimize.yml",
+                "optimize_config_fileset": "nemo-agent-optimize-calc",
+                "workspace": "default",
+            },
+            ctx=ctx,
+            sdk=sdk,
+        )
+
+    assert result == {"status": "completed", "returncode": 0}
     sdk.files.download.assert_called_once()
-    kwargs = sdk.files.download.call_args.kwargs
-    assert kwargs["fileset"] == "nemo-agent-optimizer-configs"
-    assert kwargs["workspace"] == "default"
+    # nat optimize ran with cwd inside the downloaded fileset tempdir, not the source tree.
+    assert str(captured["cwd"]).startswith(str(ctx.storage.ephemeral))
 
 
-def test_resolve_optimize_config_fileset_without_sdk_raises(tmp_path: Path, ctx: JobContext) -> None:
-    job = OptimizeAgentJob()
-    spec = OptimizeAgentSpec(
-        optimize_config="config.yml",
-        optimize_config_fileset=FilesetRef("nemo-agent-optimizer-configs"),
-    )
-    with pytest.raises(LocalRunError, match="sdk"):
-        with job._resolve_optimize_config(spec, ctx=ctx, sdk=None):
-            pass
+def test_run_uploads_output_to_fileset_on_success(tmp_path: Path, ctx: JobContext) -> None:
+    optimize_yaml = tmp_path / "optimize.yml"
+    optimize_yaml.write_text(_MINIMAL_OPTIMIZE_YAML)
+
+    sdk = MagicMock()
+    sdk.files.upload.return_value = MagicMock(name="fake-fileset")
+
+    with (
+        patch(
+            "nemo_agents_plugin.jobs.optimize_agent.subprocess.run",
+            side_effect=lambda cmd, *, check, cwd: subprocess.CompletedProcess(cmd, 0),
+        ),
+        patch("nemo_agents_plugin.jobs.optimize_agent.preflight_validate_llm_models"),
+    ):
+        result = OptimizeAgentJob().run(
+            {"optimize_config": str(optimize_yaml), "output": "optimizer-out", "workspace": "default"},
+            ctx=ctx,
+            sdk=sdk,
+        )
+
+    assert result == {"status": "completed", "returncode": 0}
+    sdk.files.upload.assert_called_once()
+    assert sdk.files.upload.call_args.kwargs["fileset"] == "optimizer-out"
 
 
-def test_resolve_optimize_config_fileset_tempdir_lands_under_ctx_ephemeral(tmp_path: Path, ctx: JobContext) -> None:
-    job = OptimizeAgentJob()
-    spec = OptimizeAgentSpec(
-        optimize_config="config.yml",
-        optimize_config_fileset=FilesetRef("nemo-agent-optimizer-configs"),
-        workspace="default",
-    )
+def test_run_failed_subprocess_skips_output_upload(tmp_path: Path, ctx: JobContext) -> None:
+    optimize_yaml = tmp_path / "optimize.yml"
+    optimize_yaml.write_text(_MINIMAL_OPTIMIZE_YAML)
+
     sdk = MagicMock()
 
-    seen: dict[str, Path] = {}
+    def _boom(cmd: list[str], *, check: bool, cwd: Path) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(returncode=2, cmd=cmd)
 
-    def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
-        seen["local_path"] = Path(local_path)
-        Path(local_path, "config.yml").write_text("optimizer: {}")
+    with (
+        patch("nemo_agents_plugin.jobs.optimize_agent.subprocess.run", side_effect=_boom),
+        patch("nemo_agents_plugin.jobs.optimize_agent.preflight_validate_llm_models"),
+    ):
+        result = OptimizeAgentJob().run(
+            {"optimize_config": str(optimize_yaml), "output": "optimizer-out", "workspace": "default"},
+            ctx=ctx,
+            sdk=sdk,
+        )
 
-    sdk.files.download.side_effect = _fake_download
-
-    with job._resolve_optimize_config(spec, ctx=ctx, sdk=sdk):
-        pass
-
-    assert seen["local_path"].parent == ctx.storage.ephemeral
-
-
-def test_resolve_optimize_config_fileset_rejects_path_traversal(tmp_path: Path, ctx: JobContext) -> None:
-    job = OptimizeAgentJob()
-    spec = OptimizeAgentSpec(
-        optimize_config="../escape.yml",
-        optimize_config_fileset=FilesetRef("nemo-agent-optimizer-configs"),
-        workspace="default",
-    )
-    sdk = MagicMock()
-
-    def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
-        # Plant the traversal target outside the download dir so the guard,
-        # not a missing file, is what rejects it.
-        Path(local_path).parent.joinpath("escape.yml").write_text("optimizer: {}")
-
-    sdk.files.download.side_effect = _fake_download
-
-    with pytest.raises(ValueError, match="resolves outside the downloaded fileset"):
-        with job._resolve_optimize_config(spec, ctx=ctx, sdk=sdk):
-            pass
-
-
-def test_resolve_optimize_config_fileset_missing_file_raises(tmp_path: Path, ctx: JobContext) -> None:
-    job = OptimizeAgentJob()
-    spec = OptimizeAgentSpec(
-        optimize_config="config.yml",
-        optimize_config_fileset=FilesetRef("nemo-agent-optimizer-configs"),
-        workspace="default",
-    )
-    sdk = MagicMock()
-
-    def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
-        # Fileset downloads, but the requested config isn't among its files.
-        Path(local_path, "other.yml").write_text("optimizer: {}")
-
-    sdk.files.download.side_effect = _fake_download
-
-    with pytest.raises(FileNotFoundError, match="was not found in fileset"):
-        with job._resolve_optimize_config(spec, ctx=ctx, sdk=sdk):
-            pass
+    assert result == {"status": "failed", "returncode": 2}
+    sdk.files.upload.assert_not_called()

--- a/plugins/nemo-agents/tests/unit/test_optimize_agent_job.py
+++ b/plugins/nemo-agents/tests/unit/test_optimize_agent_job.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import pytest
 import yaml
-from nemo_agents_plugin.jobs.optimize_agent import OptimizeAgentJob
+from nemo_agents_plugin.jobs.optimize_agent import OptimizeAgentJob, OptimizeAgentSpec
 from nemo_platform_plugin.job_context import JobContext
+from nemo_platform_plugin.refs import FilesetRef
+from nemo_platform_plugin.run_dependencies import LocalRunError
 
 
 def test_run_repoints_outputs_to_persistent_results(tmp_path: Path, ctx: JobContext) -> None:
@@ -59,3 +62,111 @@ optimizer:
     assert injected_config["optimizer"]["output_path"] == str(
         ctx.storage.persistent / "results" / "optimizer_results" / "calculator"
     )
+
+
+def test_resolve_optimize_config_local_path_pass_through(tmp_path: Path, ctx: JobContext) -> None:
+    job = OptimizeAgentJob()
+    spec = OptimizeAgentSpec(optimize_config=str(tmp_path / "config.yml"), optimize_config_fileset=None)
+    with job._resolve_optimize_config(spec, ctx=ctx, sdk=None) as resolved:
+        assert resolved == Path(str(tmp_path / "config.yml"))
+
+
+def test_resolve_optimize_config_fileset_downloads_via_sdk(tmp_path: Path, ctx: JobContext) -> None:
+    job = OptimizeAgentJob()
+    spec = OptimizeAgentSpec(
+        optimize_config="config.yml",
+        optimize_config_fileset=FilesetRef("nemo-agent-optimizer-configs"),
+        workspace="default",
+    )
+
+    sdk = MagicMock()
+
+    def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
+        Path(local_path, "config.yml").write_text("optimizer: {}")
+
+    sdk.files.download.side_effect = _fake_download
+
+    with job._resolve_optimize_config(spec, ctx=ctx, sdk=sdk) as resolved:
+        assert resolved.exists()
+        assert resolved.name == "config.yml"
+        assert resolved.read_text() == "optimizer: {}"
+
+    sdk.files.download.assert_called_once()
+    kwargs = sdk.files.download.call_args.kwargs
+    assert kwargs["fileset"] == "nemo-agent-optimizer-configs"
+    assert kwargs["workspace"] == "default"
+
+
+def test_resolve_optimize_config_fileset_without_sdk_raises(tmp_path: Path, ctx: JobContext) -> None:
+    job = OptimizeAgentJob()
+    spec = OptimizeAgentSpec(
+        optimize_config="config.yml",
+        optimize_config_fileset=FilesetRef("nemo-agent-optimizer-configs"),
+    )
+    with pytest.raises(LocalRunError, match="sdk"):
+        with job._resolve_optimize_config(spec, ctx=ctx, sdk=None):
+            pass
+
+
+def test_resolve_optimize_config_fileset_tempdir_lands_under_ctx_ephemeral(tmp_path: Path, ctx: JobContext) -> None:
+    job = OptimizeAgentJob()
+    spec = OptimizeAgentSpec(
+        optimize_config="config.yml",
+        optimize_config_fileset=FilesetRef("nemo-agent-optimizer-configs"),
+        workspace="default",
+    )
+    sdk = MagicMock()
+
+    seen: dict[str, Path] = {}
+
+    def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
+        seen["local_path"] = Path(local_path)
+        Path(local_path, "config.yml").write_text("optimizer: {}")
+
+    sdk.files.download.side_effect = _fake_download
+
+    with job._resolve_optimize_config(spec, ctx=ctx, sdk=sdk):
+        pass
+
+    assert seen["local_path"].parent == ctx.storage.ephemeral
+
+
+def test_resolve_optimize_config_fileset_rejects_path_traversal(tmp_path: Path, ctx: JobContext) -> None:
+    job = OptimizeAgentJob()
+    spec = OptimizeAgentSpec(
+        optimize_config="../escape.yml",
+        optimize_config_fileset=FilesetRef("nemo-agent-optimizer-configs"),
+        workspace="default",
+    )
+    sdk = MagicMock()
+
+    def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
+        # Plant the traversal target outside the download dir so the guard,
+        # not a missing file, is what rejects it.
+        Path(local_path).parent.joinpath("escape.yml").write_text("optimizer: {}")
+
+    sdk.files.download.side_effect = _fake_download
+
+    with pytest.raises(ValueError, match="resolves outside the downloaded fileset"):
+        with job._resolve_optimize_config(spec, ctx=ctx, sdk=sdk):
+            pass
+
+
+def test_resolve_optimize_config_fileset_missing_file_raises(tmp_path: Path, ctx: JobContext) -> None:
+    job = OptimizeAgentJob()
+    spec = OptimizeAgentSpec(
+        optimize_config="config.yml",
+        optimize_config_fileset=FilesetRef("nemo-agent-optimizer-configs"),
+        workspace="default",
+    )
+    sdk = MagicMock()
+
+    def _fake_download(local_path: str, fileset: str, workspace: str) -> None:
+        # Fileset downloads, but the requested config isn't among its files.
+        Path(local_path, "other.yml").write_text("optimizer: {}")
+
+    sdk.files.download.side_effect = _fake_download
+
+    with pytest.raises(FileNotFoundError, match="was not found in fileset"):
+        with job._resolve_optimize_config(spec, ctx=ctx, sdk=sdk):
+            pass

--- a/plugins/nemo-agents/tests/unit/test_optimize_agent_job.py
+++ b/plugins/nemo-agents/tests/unit/test_optimize_agent_job.py
@@ -127,6 +127,23 @@ async def test_compile_allows_relative_config_with_fileset() -> None:
     assert config["optimize_config_fileset"] == "nemo-agent-optimize-calc"
 
 
+@pytest.mark.asyncio
+async def test_compile_rejects_absolute_config_with_fileset() -> None:
+    spec = OptimizeAgentSpec(
+        optimize_config="/abs/optimize.yml",
+        optimize_config_fileset=FilesetRef("nemo-agent-optimize-calc"),
+        workspace="default",
+    )
+    with pytest.raises(ValueError, match="relative"):
+        await OptimizeAgentJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )
+
+
 def test_run_stages_config_from_fileset(tmp_path: Path, ctx: JobContext) -> None:
     sdk = MagicMock()
 


### PR DESCRIPTION
Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimize agent jobs can now source the optimization YAML and related inputs from a platform fileset via `optimize_config_fileset`.
  * Output destination now supports clearer `output` semantics, including fileset-based output staging.
* **Bug Fixes**
  * Improved validation for `optimize_config` and destination references, including safer relative-path handling.
  * Optimization output is only uploaded on successful completion; failures skip upload.
  * Endpoint handling for the underlying optimizer is now applied only in the explicit endpoint mode.
* **Documentation**
  * OpenAPI schema descriptions updated for `optimize_config`, `optimize_config_fileset`, and `output`.
* **Tests**
  * Expanded unit coverage for spec validation and staged download/upload behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->