### PR TITLE
fix(evaluator): preserve non-string stream values

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_inference.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_inference.py
@@ -394,6 +394,7 @@ async def _invoke_http_agent(
         # the last one. Accumulate parts here and materialize after the stream.
         aggregate = invocation.response_aggregation == "concat"
         value_parts: list[str] = []
+        non_string_value: Any | None = None
         try:
             async with inference_client.stream(
                 "POST",
@@ -426,7 +427,22 @@ async def _invoke_http_agent(
                     )
                     if value is not None:
                         if aggregate:
-                            value_parts.append(value if isinstance(value, str) else str(value))
+                            # ``concat`` is a text-delta policy: ["15", ".", "0"] -> "15.0".
+                            # A lone non-string result is not a delta, so preserve its JSON type.
+                            if isinstance(value, str):
+                                if non_string_value is not None:
+                                    raise ValueError(
+                                        "response_aggregation='concat' accepts string deltas or one non-string "
+                                        "value; use 'last' for multi-frame non-string streams"
+                                    )
+                                value_parts.append(value)
+                            else:
+                                if value_parts or non_string_value is not None:
+                                    raise ValueError(
+                                        "response_aggregation='concat' accepts string deltas or one non-string "
+                                        "value; use 'last' for multi-frame non-string streams"
+                                    )
+                                non_string_value = value
                         else:
                             capture.final_value = value
                             # Preserve the original type in the response; expose
@@ -446,9 +462,13 @@ async def _invoke_http_agent(
             if capture.event_count == 0:
                 raise
             capture.error = f"{type(exc).__name__}: {exc}"
-        if aggregate and value_parts:
-            capture.final_value = "".join(value_parts)
-            capture.output_text = capture.final_value
+        if aggregate:
+            if value_parts:
+                capture.final_value = "".join(value_parts)
+                capture.output_text = capture.final_value
+            elif non_string_value is not None:
+                capture.final_value = non_string_value
+                capture.output_text = None
         return capture
 
     log.info("Making streaming agent request to %s", invocation.endpoint)

--- a/packages/nemo_evaluator_sdk/tests/test_agent_inference.py
+++ b/packages/nemo_evaluator_sdk/tests/test_agent_inference.py
@@ -1508,19 +1508,21 @@ class TestNATAgentExecutor:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("data_line", "expected_content"),
+        ("response_aggregation", "data_line", "expected_content"),
         [
-            ('data: {"value": {"answer": 7}}', {"answer": 7}),
-            ('data: {"value": 7}', 7),
+            ("last", 'data: {"value": {"answer": 7}}', {"answer": 7}),
+            ("last", 'data: {"value": 7}', 7),
+            ("concat", 'data: {"value": {"answer": 7}}', {"answer": 7}),
+            ("concat", 'data: {"value": 7}', 7),
         ],
     )
-    async def test_preserves_non_string_value_type(self, data_line, expected_content):
-        """The ``last`` aggregation on ``$.value`` keeps the raw value type in OpenAI content."""
+    async def test_preserves_non_string_value_type(self, response_aggregation, data_line, expected_content):
+        """A single non-string value keeps its raw type under either aggregation policy."""
         agent = NemoAgentToolkitAgent(
             url="http://nat.test",
             name="nat-agent",
             format=AgentFormat.NEMO_AGENT_TOOLKIT,
-            nat=NatAgentConfig(response_aggregation="last"),
+            nat=NatAgentConfig(response_aggregation=response_aggregation),
         )
 
         async def fake_aiter_lines():
@@ -1552,6 +1554,28 @@ class TestNATAgentExecutor:
 
         # Raw type preserved, not stringified.
         assert result["choices"][0]["message"]["content"] == expected_content
+
+    @pytest.mark.asyncio
+    async def test_concat_rejects_mixed_string_and_non_string_values(self):
+        """Concat reports a partial result instead of silently dropping or stringifying a mixed value."""
+        agent = NemoAgentToolkitAgent(url="http://nat.test", name="nat-agent")
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=('data: {"value": "partial"}\ndata: {"value": {"answer": 7}}\n'),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+            result = await invoke_agent(agent, {"prompt": "answer"}, client=client)
+
+        assert result.status is AgentInvocationStatus.PARTIAL
+        assert result.output_text == "partial"
+        assert result.metadata["stream_error"] == (
+            "ValueError: response_aggregation='concat' accepts string deltas or one non-string value; "
+            "use 'last' for multi-frame non-string streams"
+        )
 
     @pytest.mark.asyncio
     async def test_empty_string_final_value_is_partial(self):

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_inference.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_inference.py
@@ -394,6 +394,7 @@ async def _invoke_http_agent(
         # the last one. Accumulate parts here and materialize after the stream.
         aggregate = invocation.response_aggregation == "concat"
         value_parts: list[str] = []
+        non_string_value: Any | None = None
         try:
             async with inference_client.stream(
                 "POST",
@@ -426,7 +427,22 @@ async def _invoke_http_agent(
                     )
                     if value is not None:
                         if aggregate:
-                            value_parts.append(value if isinstance(value, str) else str(value))
+                            # ``concat`` is a text-delta policy: ["15", ".", "0"] -> "15.0".
+                            # A lone non-string result is not a delta, so preserve its JSON type.
+                            if isinstance(value, str):
+                                if non_string_value is not None:
+                                    raise ValueError(
+                                        "response_aggregation='concat' accepts string deltas or one non-string "
+                                        "value; use 'last' for multi-frame non-string streams"
+                                    )
+                                value_parts.append(value)
+                            else:
+                                if value_parts or non_string_value is not None:
+                                    raise ValueError(
+                                        "response_aggregation='concat' accepts string deltas or one non-string "
+                                        "value; use 'last' for multi-frame non-string streams"
+                                    )
+                                non_string_value = value
                         else:
                             capture.final_value = value
                             # Preserve the original type in the response; expose
@@ -446,9 +462,13 @@ async def _invoke_http_agent(
             if capture.event_count == 0:
                 raise
             capture.error = f"{type(exc).__name__}: {exc}"
-        if aggregate and value_parts:
-            capture.final_value = "".join(value_parts)
-            capture.output_text = capture.final_value
+        if aggregate:
+            if value_parts:
+                capture.final_value = "".join(value_parts)
+                capture.output_text = capture.final_value
+            elif non_string_value is not None:
+                capture.final_value = non_string_value
+                capture.output_text = None
         return capture
 
     log.info("Making streaming agent request to %s", invocation.endpoint)


### PR DESCRIPTION
## Summary

- preserve a lone non-string SSE value under `concat` instead of coercing it with `str()`
- continue concatenating string token deltas in arrival order
- reject mixed string/non-string or multi-frame non-string `concat` streams as partial results with an actionable error
- regenerate the vendored Python SDK mirror

## Root cause

PR #812 changed NAT stream aggregation to `concat`. Its accumulator converted every matched non-string value to a Python string representation.

For example:

```text
SSE:      data: {"value": {"answer": 7}}
Before:   "{'answer': 7}"
After:    {"answer": 7}
```

A single structured result is not a token delta, so this patch preserves its original JSON type. Text deltas such as `["15", ".", "0"]` still become `"15.0"`.

## Validation

- `uv run --frozen pytest packages/nemo_evaluator_sdk/tests -q`: 1125 passed, 2 skipped
- post-rebase focused inference suite: 75 passed
- staged `uv run --frozen pre-commit run`: passed
- scoped Ruff, Ruff format, and ty checks: passed
- `tools/lint/lint-sdk-vendored.sh`: passed
- `git diff --check origin/main...HEAD`: passed
