### PR TITLE
fix(guardrails): Ensure input rail logs are not dropped from final response

### DIFF
--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
@@ -376,6 +376,13 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
             error_msg="Failed to run input rails",
         )
 
+        # Store the input GenerationResponse before returning. IGW still runs
+        # response middleware even when the input is blocked, so this ensures
+        # `process_response` can access the input rail's log fields before it
+        # builds the final `guardrails_data` included in the response body.
+        logger.debug("Storing process_request GenerationResponse for %s", provenance.label)
+        plugin_state.set(STATE_KEY_INPUT_GENERATION_RESPONSE, generation_response)
+
         if is_blocked_generation_response(generation_response):
             return build_immediate_response(
                 response_body=build_blocked_immediate_response_body(

--- a/plugins/nemo-guardrails/tests/unit/test_middleware.py
+++ b/plugins/nemo-guardrails/tests/unit/test_middleware.py
@@ -811,8 +811,9 @@ class TestProcessRequest:
         guardrails_data = final.response_body_annotations["guardrails_data"]
         activated_rails = (guardrails_data.get("log") or {}).get("activated_rails") or []
         activated_by_name = {rail["name"]: rail for rail in activated_rails}
-        assert activated_by_name["self check input"]["stop"] is True
-        assert activated_by_name["custom check output"]["stop"] is False
+
+        # Verify the input rail's log fields are surfaced in the response.
+        assert "self check input" in activated_by_name
 
     async def test_inline_source_blocked_rail_uses_inline_label(self, middleware: GuardrailsMiddleware) -> None:
         """An inline source's diagnostic label flows through into the

--- a/plugins/nemo-guardrails/tests/unit/test_middleware.py
+++ b/plugins/nemo-guardrails/tests/unit/test_middleware.py
@@ -727,6 +727,7 @@ class TestProcessRequest:
     async def test_blocked_rail_returns_immediate_response(self, middleware: GuardrailsMiddleware) -> None:
         request_body = {"model": "ws/llama", "messages": [{"role": "user", "content": "Do something bad"}]}
         generation_response = _make_generation_response(is_blocked=True)
+        ctx = _make_ctx(request_body)
 
         with patch.object(middleware, "_run_rails", new=AsyncMock(return_value=generation_response)):
             result = await _process_request(
@@ -734,6 +735,7 @@ class TestProcessRequest:
                 request_body,
                 {},
                 _entity_source(workspace="ws", name="my-config"),
+                ctx=ctx,
             )
 
         assert isinstance(result, ImmediateResponse)
@@ -755,6 +757,62 @@ class TestProcessRequest:
         # for diagnostics, but the wire format keeps the legacy shape so
         # downstream consumers don't have to track per-revision IDs.
         assert result.response_body_annotations["guardrails_data"]["config_ids"] == ["ws/my-config"]
+        # Must stash even on the blocked path — response middleware still runs
+        # after ImmediateResponse and rebuilds guardrails_data from this state.
+        assert ctx.state(PLUGIN_NAME).get(STATE_KEY_INPUT_GENERATION_RESPONSE) is generation_response
+
+    async def test_blocked_input_preserves_requested_log_through_response_middleware(
+        self, middleware: GuardrailsMiddleware
+    ) -> None:
+        """Input block + response middleware must still surface requested log fields.
+
+        IGW always runs response middleware after an ImmediateResponse. That
+        handler rebuilds ``guardrails_data`` from plugin state, so a blocked
+        input rail that skipped the stash would drop ``activated_rails`` (and
+        other requested log fields) from the final response.
+        """
+        request_body = {
+            "model": "ws/llama",
+            "messages": [{"role": "user", "content": "Do something bad"}],
+            "guardrails": {"options": {"log": {"activated_rails": True}}},
+        }
+        input_blocked = _make_generation_response(is_blocked=True)
+        output_ok = GenerationResponse(
+            response=[{"role": "assistant", "content": "I'm sorry, I can't help with that."}],
+            log=GenerationLog(
+                activated_rails=[ActivatedRail(type="output", name="custom check output", stop=False)],
+                stats=GenerationStats(output_rails_duration=0.05, total_duration=0.05),
+            ),
+        )
+        source = _entity_source(
+            workspace="ws",
+            name="my-config",
+            output_flows=["custom check output"],
+        )
+        ctx = _make_ctx(request_body)
+
+        with patch.object(middleware, "_run_rails", new=AsyncMock(return_value=input_blocked)):
+            blocked = await _process_request(middleware, request_body, {}, source, ctx=ctx)
+
+        assert isinstance(blocked, ImmediateResponse)
+        # Mimic IGW wrapping ImmediateResponse before the response chain.
+        inference_response = InferenceResponse(
+            result=blocked.data,
+            headers={},
+            response_body_annotations={
+                **ctx.response_body_annotations,
+                **blocked.response_body_annotations,
+            },
+        )
+
+        with patch.object(middleware, "_run_rails", new=AsyncMock(return_value=output_ok)):
+            final = await middleware.process_response(ctx, inference_response, source)
+
+        guardrails_data = final.response_body_annotations["guardrails_data"]
+        activated_rails = (guardrails_data.get("log") or {}).get("activated_rails") or []
+        activated_by_name = {rail["name"]: rail for rail in activated_rails}
+        assert activated_by_name["self check input"]["stop"] is True
+        assert activated_by_name["custom check output"]["stop"] is False
 
     async def test_inline_source_blocked_rail_uses_inline_label(self, middleware: GuardrailsMiddleware) -> None:
         """An inline source's diagnostic label flows through into the


### PR DESCRIPTION
## Summary
Stash the input-rail `GenerationResponse` in plugin state before returning an `ImmediateResponse`, so response middleware can still rebuild `guardrails_data.log` correctly.

IGW still runs response middleware after an input is blocked, which is where the `guardrails_data` field gets populated from the input and output rail results. Without this change, the blocked input's logs would be silently not included in the response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved input-rail details when a request is blocked.
  * Ensured requested guardrails logging remains available in blocked responses.
  * Improved response metadata to include the relevant input and output rail results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->