### PR TITLE
test(evaluator): Keep Evaluator mock VirtualModels out of orphan cleanup

### DIFF
--- a/e2e/test_evaluator_plugin.py
+++ b/e2e/test_evaluator_plugin.py
@@ -105,6 +105,8 @@ def _add_mock_provider_or_skip(
             workspace=workspace,
             name=name,
             mock_response_body=mock_response_body,
+            # Keep test VMs out of controller orphan cleanup between readiness wait and job scoring.
+            should_autoprovision_virtual_model=False,
         )
     except RuntimeError as exc:
         if "mock_provider_prefix is not configured" in str(exc):
@@ -258,8 +260,20 @@ def _create_ready_mock_model(
         model_providers=[f"{workspace}/{provider.name}"],
         exist_ok=True,
     )
-    wait_for_model_entity(sdk, workspace, name, ensure_virtual_model=True)
-    ensure_passthrough_virtual_model(sdk, workspace, name, timeout=IGW_ROUTE_TIMEOUT_SECONDS)
+    wait_for_model_entity(
+        sdk,
+        workspace,
+        name,
+        ensure_virtual_model=True,
+        should_autoprovision_virtual_model=False,
+    )
+    ensure_passthrough_virtual_model(
+        sdk,
+        workspace,
+        name,
+        timeout=IGW_ROUTE_TIMEOUT_SECONDS,
+        autoprovisioned=False,
+    )
     _wait_for_stable_model_chat_route(sdk, workspace, name)
 
 


### PR DESCRIPTION
**Issue:** Autoprovisioned VMs can be deleted mid-job by the models controller, causing flaky llm-judge ModelRef failures with VirtualModel 404s.

**Fix:** Creates test VirtualModels with `autoprovisioned=False` so they survive for the lifetime of the job.

Example test failure: https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/29863264284/job/88746335863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated evaluator end-to-end test setup to use explicitly configured virtual models.
  * Improved test reliability by preventing test resources from being incorrectly treated as orphaned during evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->