### PR TITLE
feat(studio): tables for agent eval list and details

### DIFF
--- a/web/packages/common/src/components/DataView/TableExpandableCell/index.tsx
+++ b/web/packages/common/src/components/DataView/TableExpandableCell/index.tsx
@@ -2,15 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Text } from '@nvidia/foundations-react-core';
-import type { ExpandedCellState } from '@studio/components/ModelComparePrompts/types';
 import { Maximize2 } from 'lucide-react';
 import type { FC, ReactNode } from 'react';
 
-/** Table cell with vertical scroll and an expand-to-modal button */
-export const ExpandableCell: FC<{
+export interface TableExpandableCellState {
+  title: string;
+  content: string;
+}
+
+export const TableExpandableCell: FC<{
   content: string;
   title: string;
-  onExpand: (state: ExpandedCellState) => void;
+  onExpand: (state: TableExpandableCellState) => void;
   footer?: ReactNode;
   boldContent?: boolean;
 }> = ({ content, title, onExpand, footer, boldContent }) => {

--- a/web/packages/studio/src/api/evaluation/agent-evaluations.test.ts
+++ b/web/packages/studio/src/api/evaluation/agent-evaluations.test.ts
@@ -7,8 +7,10 @@ import {
   type AgentEvalResult,
   agentNameForJob,
   aggregateScoresOf,
+  evalConfigName,
   fetchAgentEvalJob,
   fetchAgentEvalJobs,
+  fetchAgentEvalResultsForJobs,
   joinBundleByTask,
   parseBundleRef,
 } from '@studio/api/evaluation/agent-evaluations';
@@ -85,6 +87,48 @@ describe('agentNameForJob', () => {
 
   it('returns null when no target agent is set', () => {
     expect(agentNameForJob(baseJob({ spec: {} as AgentEvaluateJob['spec'] }))).toBeNull();
+  });
+});
+
+describe('evalConfigName', () => {
+  it('reads the fileset name from spec.benchmark.eval_config', () => {
+    const job = baseJob({
+      spec: {
+        target: { kind: 'agent', agent: { name: 'a' } },
+        tasks: [{}],
+        benchmark: { eval_config_fileset: 'wise-blue' },
+      } as unknown as AgentEvaluateJob['spec'],
+    });
+    expect(evalConfigName(job)).toBe('wise-blue');
+  });
+
+  it('returns null when benchmark is absent, ignoring any description', () => {
+    expect(evalConfigName(baseJob({ description: 'legacy-desc' }))).toBeNull();
+  });
+});
+
+describe('fetchAgentEvalResultsForJobs', () => {
+  it('returns an empty map without fetching when there are no job names', async () => {
+    const map = await fetchAgentEvalResultsForJobs('ws-a', [], new AbortController().signal);
+    expect(map.size).toBe(0);
+    expect(customFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keys results by name for the requested jobs', async () => {
+    customFetchMock.mockResolvedValue({
+      data: [
+        { name: 'eval-1', scores: { scores: [] } },
+        { name: 'eval-2', scores: { scores: [] } },
+      ],
+    });
+    const map = await fetchAgentEvalResultsForJobs(
+      'ws-a',
+      ['eval-1', 'eval-2'],
+      new AbortController().signal
+    );
+    expect(map.get('eval-1')?.name).toBe('eval-1');
+    expect(map.get('eval-2')?.name).toBe('eval-2');
+    expect(map.size).toBe(2);
   });
 });
 

--- a/web/packages/studio/src/api/evaluation/agent-evaluations.ts
+++ b/web/packages/studio/src/api/evaluation/agent-evaluations.ts
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { withOperators } from '@nemo/common/src/api/filterOperators';
 import {
   evaluatorCancelAgentEvaluateJob,
   evaluatorCreateAgentEvaluateJob,
   evaluatorGetAgentEvalResult,
   evaluatorGetAgentEvaluateJob,
+  evaluatorListAgentEvalResults,
   evaluatorListAgentEvaluateJobs,
 } from '@nemo/sdk/generated/evaluator/api';
 import type {
@@ -15,6 +17,7 @@ import type {
   AgentEvaluateJobRequest,
   AgentEvalResult,
   AgentEvaluateJobsSortField,
+  ResultFilter,
 } from '@nemo/sdk/generated/evaluator/schema';
 import { filesDownloadFile } from '@nemo/sdk/generated/platform/api';
 
@@ -30,12 +33,21 @@ export type { AgentEvalResult };
  *  Strips only this job's own ``workspace/`` prefix so the result compares equal to a
  *  bare agent name; any other ``/`` in the name is left intact. */
 export const agentNameForJob = (job: AgentEvaluateJob): string | null => {
-  const target = job.spec.target as { kind?: string; agent?: { name?: string } } | null | undefined;
+  const target = job.spec?.target as
+    | { kind?: string; agent?: { name?: string } }
+    | null
+    | undefined;
   if (!target || target.kind !== 'agent') return null;
   const name = target.agent?.name;
   if (typeof name !== 'string' || name.length === 0) return null;
   const prefix = job.workspace ? `${job.workspace}/` : '';
   return prefix && name.startsWith(prefix) ? name.slice(prefix.length) : name;
+};
+
+export const evalConfigName = (job: AgentEvaluateJob): string | null => {
+  const benchmark = job.spec?.benchmark as { eval_config_fileset?: unknown } | null | undefined;
+  const name = benchmark?.eval_config_fileset;
+  return typeof name === 'string' && name.length > 0 ? name : null;
 };
 
 export const fetchAgentEvalJobs = async (
@@ -106,6 +118,26 @@ export const fetchAgentEvalResult = async (
     if (e?.response?.status === 404 || e?.status === 404) return null;
     throw err;
   }
+};
+
+const RESULTS_PAGE_MAX = 100;
+
+export const fetchAgentEvalResultsForJobs = async (
+  workspace: string,
+  jobNames: string[],
+  signal: AbortSignal
+): Promise<Map<string, AgentEvalResult>> => {
+  if (jobNames.length === 0) return new Map();
+  const page = await evaluatorListAgentEvalResults(
+    workspace,
+    {
+      page: 1,
+      page_size: Math.min(jobNames.length, RESULTS_PAGE_MAX),
+      filter: withOperators<ResultFilter>({ name: { $in: jobNames } }),
+    },
+    signal
+  );
+  return new Map((page?.data ?? []).map((result) => [result.name, result]));
 };
 
 /** One trial row from trials.jsonl — the agent's response to a task. */

--- a/web/packages/studio/src/api/evaluation/agent-evaluations.ts
+++ b/web/packages/studio/src/api/evaluation/agent-evaluations.ts
@@ -45,8 +45,7 @@ export const agentNameForJob = (job: AgentEvaluateJob): string | null => {
 };
 
 export const evalConfigName = (job: AgentEvaluateJob): string | null => {
-  const benchmark = job.spec?.benchmark as { eval_config_fileset?: unknown } | null | undefined;
-  const name = benchmark?.eval_config_fileset;
+  const name = job.spec?.benchmark?.eval_config_fileset;
   return typeof name === 'string' && name.length > 0 ? name : null;
 };
 

--- a/web/packages/studio/src/components/ModelComparePrompts/ModelCompareTable.tsx
+++ b/web/packages/studio/src/components/ModelComparePrompts/ModelCompareTable.tsx
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ModelWorkspaceGroup } from '@nemo/common/src/api/models/useModels';
+import { TableExpandableCell } from '@nemo/common/src/components/DataView/TableExpandableCell';
 import { getPartsFromReference } from '@nemo/common/src/namedEntity';
 import type { FileSampleMethod } from '@nemo/common/src/utils/sampleTextLines';
 import { Button, Flex, Select, Text } from '@nvidia/foundations-react-core';
 import { StatsBadge } from '@studio/components/chat/StatsBadge';
 import type { DatasetInputFileResult } from '@studio/components/DatasetInputFile';
 import { FileSamplingMethodSelect } from '@studio/components/FileSamplingSnippet/FileSamplingMethodSelect';
-import { ExpandableCell } from '@studio/components/ModelComparePrompts/ExpandableCell';
 import { ModelColumnSelect } from '@studio/components/ModelComparePrompts/ModelColumnSelect';
 import type {
   ExpandedCellState,
@@ -221,7 +221,7 @@ export const ModelCompareTable: FC<ModelCompareTableProps> = ({
           return (
             <tr key={row.sourceIndex} className="bg-surface-raised">
               <td className={`${rowBottom}border-r border-base p-0 align-top`}>
-                <ExpandableCell
+                <TableExpandableCell
                   content={row.prompt}
                   title={`Prompt (dataset row ${row.sourceIndex})`}
                   onExpand={setExpandedCell}
@@ -258,7 +258,7 @@ export const ModelCompareTable: FC<ModelCompareTableProps> = ({
                 }
                 return (
                   <td key={m.id} className={`${rowBottom}${colBorder}border-base p-0 align-top`}>
-                    <ExpandableCell
+                    <TableExpandableCell
                       content={response.text}
                       title={`${modelName} response (dataset row ${row.sourceIndex})`}
                       onExpand={(state) => setExpandedCell({ ...state, stats: response.stats })}

--- a/web/packages/studio/src/components/ModelComparePrompts/types.ts
+++ b/web/packages/studio/src/components/ModelComparePrompts/types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ModelWorkspaceGroup } from '@nemo/common/src/api/models/useModels';
+import type { TableExpandableCellState } from '@nemo/common/src/components/DataView/TableExpandableCell';
 import type { SharedModelEntry } from '@studio/routes/ModelCompareRoute/types';
 
 export interface ResponseStats {
@@ -27,9 +28,7 @@ export interface PromptRow {
   responses: Record<number, ResponseResult | null | undefined>;
 }
 
-export interface ExpandedCellState {
-  title: string;
-  content: string;
+export interface ExpandedCellState extends TableExpandableCellState {
   stats?: ResponseStats;
 }
 

--- a/web/packages/studio/src/components/dataViews/AgentEvaluationsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentEvaluationsDataView/index.tsx
@@ -36,6 +36,7 @@ import { STATUS_FILTER_OPTIONS } from '@studio/constants/platformJobs';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { formatScore } from '@studio/routes/agents/AgentEvaluationsRoute/evalScores';
 import { getAgentEvaluationDetailRoute, getFilesetDetailRoute } from '@studio/routes/utils';
+import { getTextWithCount } from '@studio/util/strings';
 import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Trash } from 'lucide-react';
 import { ComponentProps, useMemo, useState } from 'react';
@@ -284,7 +285,7 @@ export const AgentEvaluationsDataView = () => {
         items={deleteJobs}
         open={deleteJobs.length > 0}
         onDelete={handleDeleteJobs}
-        title={(count) => `Delete ${count} Evaluation${count !== 1 ? 's' : ''}`}
+        title={(count) => `Delete ${getTextWithCount('Evaluation', count)}`}
         onClose={() => {
           setDeleteJobs([]);
           dataViewState.rowSelection.set({});

--- a/web/packages/studio/src/components/dataViews/AgentEvaluationsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentEvaluationsDataView/index.tsx
@@ -69,17 +69,21 @@ export const AgentEvaluationsDataView = () => {
   });
 
   const handleDeleteJobs = async (jobsToDelete: AgentEvalJobRow[]) => {
-    await Promise.all(
-      jobsToDelete.map(async (job) => {
-        try {
-          await deleteJobMutation.mutateAsync({ workspace, name: job.name });
-        } catch (error) {
-          throw new Error(
-            `Failed to delete "${job.name}": ${error instanceof Error ? error.message : 'Unknown error'}`
-          );
-        }
-      })
+    const results = await Promise.allSettled(
+      jobsToDelete.map((job) => deleteJobMutation.mutateAsync({ workspace, name: job.name }))
     );
+    const failures = results.flatMap((result, i) =>
+      result.status === 'rejected'
+        ? [
+            `"${jobsToDelete[i].name}": ${result.reason instanceof Error ? result.reason.message : 'Unknown error'}`,
+          ]
+        : []
+    );
+    if (failures.length > 0) {
+      throw new Error(
+        `Failed to delete ${failures.length} evaluation${failures.length !== 1 ? 's' : ''}: ${failures.join('; ')}`
+      );
+    }
   };
 
   const {

--- a/web/packages/studio/src/components/dataViews/AgentEvaluationsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentEvaluationsDataView/index.tsx
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { withOperators } from '@nemo/common/src/api/filterOperators';
+import {
+  ROW_ACTIONS_COLUMN_SIZE,
+  ROW_SELECTION_COLUMN_SIZE,
+  StudioDataView,
+} from '@nemo/common/src/components/DataView/StudioDataView';
+import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
+import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
+import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
+import { JOB_POLLING_INTERVAL_MS } from '@nemo/common/src/constants';
+import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
+import { getSortParamWithWhitelist } from '@nemo/common/src/utils/query';
+import {
+  getEvaluatorListAgentEvaluateJobsQueryKey,
+  useEvaluatorDeleteAgentEvaluateJob,
+  useEvaluatorListAgentEvaluateJobs,
+} from '@nemo/sdk/generated/evaluator/api';
+import {
+  type AgentEvaluateJob,
+  type AgentEvaluateJobsListFilter,
+  AgentEvaluateJobsSortField,
+} from '@nemo/sdk/generated/evaluator/schema';
+import { Button, Stack, Text } from '@nvidia/foundations-react-core';
+import {
+  aggregateScoresOf,
+  agentNameForJob,
+  evalConfigName,
+  fetchAgentEvalResultsForJobs,
+} from '@studio/api/evaluation/agent-evaluations';
+import { BulkDeleteModal } from '@studio/components/BulkDeleteModal';
+import { QuickActionsMenuRoot } from '@studio/components/QuickActionsMenu/QuickActionsMenuRoot';
+import { STATUS_FILTER_OPTIONS } from '@studio/constants/platformJobs';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { formatScore } from '@studio/routes/agents/AgentEvaluationsRoute/evalScores';
+import { getAgentEvaluationDetailRoute, getFilesetDetailRoute } from '@studio/routes/utils';
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Trash } from 'lucide-react';
+import { ComponentProps, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+
+type AgentEvalJobRow = AgentEvaluateJob & { id: string };
+
+const STATUS_OPTIONS_WITH_ALL = [{ value: '', label: 'All' }, ...STATUS_FILTER_OPTIONS];
+
+const SORTABLE_FIELDS = Object.values(AgentEvaluateJobsSortField).filter((v) => !v.startsWith('-'));
+const DEFAULT_SORT = AgentEvaluateJobsSortField['-created_at'];
+
+export const AgentEvaluationsDataView = () => {
+  const workspace = useWorkspaceFromPath();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [deleteJobs, setDeleteJobs] = useState<AgentEvalJobRow[]>([]);
+
+  const dataViewState = useStudioDataViewState<AgentEvaluateJobsListFilter>({
+    defaultSort: [{ id: 'created_at', desc: true }],
+  });
+
+  const deleteJobMutation = useEvaluatorDeleteAgentEvaluateJob({
+    mutation: {
+      onSuccess: () =>
+        queryClient.resetQueries({
+          queryKey: getEvaluatorListAgentEvaluateJobsQueryKey(workspace),
+        }),
+    },
+  });
+
+  const handleDeleteJobs = async (jobsToDelete: AgentEvalJobRow[]) => {
+    await Promise.all(
+      jobsToDelete.map(async (job) => {
+        try {
+          await deleteJobMutation.mutateAsync({ workspace, name: job.name });
+        } catch (error) {
+          throw new Error(
+            `Failed to delete "${job.name}": ${error instanceof Error ? error.message : 'Unknown error'}`
+          );
+        }
+      })
+    );
+  };
+
+  const {
+    data: jobsData,
+    isLoading,
+    error,
+  } = useEvaluatorListAgentEvaluateJobs(
+    workspace,
+    {
+      page: dataViewState.pagination.state.pageIndex + 1,
+      page_size: dataViewState.pagination.state.pageSize,
+      sort: getSortParamWithWhitelist(
+        dataViewState.sorting.state,
+        SORTABLE_FIELDS,
+        DEFAULT_SORT
+      ) as AgentEvaluateJobsSortField,
+      filter: {
+        ...dataViewState.apiFilter.filter,
+        ...(dataViewState.apiFilter.searchText
+          ? withOperators<AgentEvaluateJobsListFilter>({
+              name: { $like: dataViewState.apiFilter.searchText },
+            })
+          : {}),
+      },
+    },
+    {
+      query: {
+        placeholderData: keepPreviousData,
+        staleTime: 0,
+        refetchOnWindowFocus: true,
+        refetchInterval: JOB_POLLING_INTERVAL_MS,
+      },
+    }
+  );
+
+  const jobs = useMemo<AgentEvalJobRow[]>(
+    () => (jobsData?.data ?? []).map((job) => ({ ...job, id: job.id || job.name })),
+    [jobsData?.data]
+  );
+
+  const jobNames = useMemo(() => jobs.map((job) => job.name).filter(Boolean), [jobs]);
+
+  const { data: resultsByName } = useQuery({
+    queryKey: ['agent-eval-results-for-jobs', workspace, jobNames] as const,
+    queryFn: ({ signal }) => fetchAgentEvalResultsForJobs(workspace, jobNames, signal),
+    enabled: jobNames.length > 0,
+    placeholderData: keepPreviousData,
+    refetchInterval: JOB_POLLING_INTERVAL_MS,
+  });
+
+  const makeColumns: ComponentProps<typeof StudioDataView<AgentEvalJobRow>>['makeColumns'] = (
+    { accessor },
+    { rowSelectionColumn, rowActionsColumn }
+  ) => [
+    rowSelectionColumn({ size: ROW_SELECTION_COLUMN_SIZE }),
+    accessor((original) => (original ? (evalConfigName(original) ?? '') : ''), {
+      id: 'eval_config',
+      header: 'Eval Config',
+      size: 200,
+      enableSorting: false,
+      cell: ({ row }) => {
+        const configName = evalConfigName(row.original);
+        return configName ? (
+          <Link
+            to={getFilesetDetailRoute(workspace, configName)}
+            className="text-primary underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {configName}
+          </Link>
+        ) : null;
+      },
+    }),
+    accessor((original) => (original ? (agentNameForJob(original) ?? '') : ''), {
+      id: 'agent',
+      header: 'Agent',
+      size: 200,
+      enableSorting: false,
+    }),
+    accessor((original) => original?.name || '', {
+      id: 'name',
+      header: 'Job Name',
+    }),
+    accessor((original) => original?.status || '', {
+      id: 'status',
+      header: 'Status',
+      size: 160,
+      meta: {
+        filter: {
+          type: 'single-select' as const,
+          label: 'Status',
+          options: STATUS_OPTIONS_WITH_ALL,
+        },
+      },
+      cell: ({ row }) => <StatusBadge status={row.original.status} />,
+    }),
+    accessor(() => '', {
+      id: 'score',
+      header: 'Score',
+      size: 220,
+      enableSorting: false,
+      cell: ({ row }) => {
+        const scores = aggregateScoresOf(resultsByName?.get(row.original.name) ?? null);
+        if (scores.length === 0) return null;
+        return (
+          <Stack gap="density-xs">
+            {scores.map((s) => (
+              <Text key={s.name} kind="body/semibold/md" className="whitespace-nowrap">
+                {s.name}: {formatScore(s.mean)}
+              </Text>
+            ))}
+          </Stack>
+        );
+      },
+    }),
+    accessor((original) => original?.created_at || '', {
+      id: 'created_at',
+      header: 'Created',
+      size: 200,
+      enableSorting: true,
+      cell: ({ row }) => <RelativeTime datetime={row.original.created_at ?? ''} />,
+    }),
+    rowActionsColumn({
+      size: ROW_ACTIONS_COLUMN_SIZE,
+      enableResizing: false,
+      cell: ({ row }) => (
+        <QuickActionsMenuRoot
+          actions={[{ label: 'Delete', onSelect: () => setDeleteJobs([row.original]) }]}
+        />
+      ),
+    }),
+  ];
+
+  const hasActiveFilters =
+    !!dataViewState.debouncedSearchBar || dataViewState.debouncedColumnFilters.length > 0;
+  const isInitialEmpty = jobs.length === 0 && !isLoading && !error && !hasActiveFilters;
+
+  if (error) {
+    return (
+      <TableEmptyState
+        header="Failed to fetch evaluations"
+        emptyMessage="An error occurred while loading evaluation jobs."
+      />
+    );
+  }
+
+  return (
+    <>
+      <StudioDataView<AgentEvalJobRow>
+        dataViewState={dataViewState}
+        searchField="name"
+        makeColumns={makeColumns}
+        onRowClick={(row) => {
+          if (!row.name) return;
+          navigate(getAgentEvaluationDetailRoute(workspace, row.name));
+        }}
+        renderBulkActions={({ selectedRows }) => (
+          <Button
+            kind="tertiary"
+            aria-label="Delete selected jobs"
+            onClick={() => setDeleteJobs(selectedRows)}
+          >
+            <Trash /> Delete
+          </Button>
+        )}
+        attributes={{
+          DataViewSearchBar: {
+            placeholder: 'Search by name',
+          },
+          DataViewRoot: {
+            data: jobs,
+            totalCount: jobsData?.pagination?.total_results ?? 0,
+            requestStatus: isLoading && !jobsData ? 'loading' : undefined,
+          },
+          DataViewTableContent: {
+            renderEmptyState: () =>
+              isInitialEmpty ? (
+                <TableEmptyState
+                  header="No evaluation jobs yet"
+                  emptyMessage="Apply a model_optimization suggestion or submit an evaluate-agent job to see results here."
+                />
+              ) : (
+                <TableEmptyState
+                  header="No Results Found"
+                  emptyMessage="No evaluation jobs match your search or filters."
+                  actions={
+                    <Button kind="tertiary" onClick={dataViewState.resetFilters}>
+                      Clear Filters
+                    </Button>
+                  }
+                />
+              ),
+          },
+        }}
+      />
+
+      <BulkDeleteModal
+        items={deleteJobs}
+        open={deleteJobs.length > 0}
+        onDelete={handleDeleteJobs}
+        title={(count) => `Delete ${count} Evaluation${count !== 1 ? 's' : ''}`}
+        onClose={() => {
+          setDeleteJobs([]);
+          dataViewState.rowSelection.set({});
+        }}
+      />
+    </>
+  );
+};

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationDetailRoute.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationDetailRoute.tsx
@@ -23,10 +23,12 @@ import {
   aggregateScoresOf,
   agentNameForJob,
   cancelAgentEvalJob,
+  evalConfigName,
   fetchAgentEvalBundle,
   fetchAgentEvalJob,
   fetchAgentEvalResult,
   joinBundleByTask,
+  parseBundleRef,
 } from '@studio/api/evaluation/agent-evaluations';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { StatusLogsContent } from '@studio/components/evaluation/Jobs/StatusLogsContent';
@@ -142,6 +144,9 @@ export const AgentEvaluationDetailRoute: FC = () => {
     typeof job.error_details?.message === 'string' ? job.error_details.message : null;
   const scores = aggregateScoresOf(result ?? null);
   const taskDetails = joinBundleByTask(bundle ?? null);
+  const artifactsFileset = result?.bundle_ref
+    ? (parseBundleRef(result.bundle_ref)?.fileset ?? null)
+    : null;
 
   return (
     <AccessibleTitle title={`Evaluation - ${jobName}`}>
@@ -182,15 +187,15 @@ export const AgentEvaluationDetailRoute: FC = () => {
                 value={String(job.spec.tasks?.length ?? '-')}
                 loading={isLoadingJob}
               />
-              {job.description && (
+              {evalConfigName(job) && (
                 <KVPair
                   label="Eval Config"
                   value={
                     <Link
-                      to={getFilesetDetailRoute(workspace, job.description)}
+                      to={getFilesetDetailRoute(workspace, evalConfigName(job) ?? '')}
                       className="text-primary underline"
                     >
-                      {job.description}
+                      {evalConfigName(job)}
                     </Link>
                   }
                 />
@@ -205,6 +210,19 @@ export const AgentEvaluationDetailRoute: FC = () => {
                 value={job.updated_at ? <RelativeTime datetime={job.updated_at} /> : ''}
                 loading={isLoadingJob}
               />
+              {artifactsFileset && (
+                <KVPair
+                  label="Artifacts"
+                  value={
+                    <Link
+                      to={getFilesetDetailRoute(workspace, artifactsFileset)}
+                      className="text-primary underline"
+                    >
+                      View files
+                    </Link>
+                  }
+                />
+              )}
               {(errorMessage ?? statusMessage) && (
                 <KVPair
                   label="Response"

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationsListRoute.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationsListRoute.tsx
@@ -1,72 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
-import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
-import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
-import {
-  Badge,
-  Block,
-  Button,
-  Card,
-  Flex,
-  PageHeader,
-  Select,
-  Spinner,
-  Stack,
-  Text,
-  TextInput,
-} from '@nvidia/foundations-react-core';
-import { agentNameForJob, fetchAgentEvalJobs } from '@studio/api/evaluation/agent-evaluations';
+import { Button, PageHeader, Stack } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { AgentEvaluationsDataView } from '@studio/components/dataViews/AgentEvaluationsDataView';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { SubmitEvaluationModal } from '@studio/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal';
-import { getAgentEvaluationDetailRoute, getAgentsListRoute } from '@studio/routes/utils';
-import { useQuery } from '@tanstack/react-query';
-import { useMemo, useState, type FC } from 'react';
-import { Link } from 'react-router-dom';
-
-const AGENT_EVAL_JOBS_QUERY_KEY = (workspace: string) => ['agent-eval-jobs', workspace] as const;
-
-const STATUS_FILTER_OPTIONS = [
-  { value: '', children: 'All statuses' },
-  { value: 'running', children: 'Running' },
-  { value: 'queued', children: 'Queued' },
-  { value: 'completed', children: 'Completed' },
-  { value: 'failed', children: 'Failed' },
-  { value: 'cancelled', children: 'Cancelled' },
-];
-
-const SORT_OPTIONS = [
-  { value: 'created_desc', children: 'Newest first' },
-  { value: 'created_asc', children: 'Oldest first' },
-  { value: 'name_asc', children: 'Name (A→Z)' },
-  { value: 'name_desc', children: 'Name (Z→A)' },
-];
-
-type SortKey = 'created_desc' | 'created_asc' | 'name_asc' | 'name_desc';
-
-const STATUS_BUCKETS: Record<string, string[]> = {
-  running: ['running'],
-  queued: ['queued', 'pending', 'created'],
-  completed: ['completed', 'succeeded', 'success'],
-  failed: ['failed', 'error'],
-  cancelled: ['cancelled', 'canceled'],
-};
-
-const matchesStatus = (status: string, filter: string): boolean => {
-  if (!filter) return true;
-  const bucket = STATUS_BUCKETS[filter] ?? [filter];
-  return bucket.includes((status ?? '').toLowerCase());
-};
+import { getAgentsListRoute } from '@studio/routes/utils';
+import { useState, type FC } from 'react';
 
 export const AgentEvaluationsListRoute: FC = () => {
   const workspace = useWorkspaceFromPath();
   const [submitOpen, setSubmitOpen] = useState(false);
-  const [statusFilter, setStatusFilter] = useState('');
-  const [agentSearch, setAgentSearch] = useState('');
-  const [sortKey, setSortKey] = useState<SortKey>('created_desc');
   useBreadcrumbs({
     items: [
       { slotLabel: 'Agents', href: getAgentsListRoute(workspace) },
@@ -74,47 +20,9 @@ export const AgentEvaluationsListRoute: FC = () => {
     ],
   });
 
-  const { data, isLoading, error, refetch } = useQuery({
-    queryKey: AGENT_EVAL_JOBS_QUERY_KEY(workspace),
-    queryFn: ({ signal }) => fetchAgentEvalJobs(workspace, signal),
-    enabled: !!workspace,
-    // Eval jobs transition through queued → running → completed; refetch
-    // every 10s while the user is on the page so the list reflects state
-    // changes without a manual reload.
-    refetchInterval: 10_000,
-  });
-
-  const jobs = useMemo(() => {
-    const all = data ?? [];
-    const search = agentSearch.trim().toLowerCase();
-    const filtered = all.filter((job) => {
-      if (!matchesStatus(job.status ?? '', statusFilter)) return false;
-      if (search) {
-        const agent = (agentNameForJob(job) ?? '').toLowerCase();
-        const name = job.name.toLowerCase();
-        if (!agent.includes(search) && !name.includes(search)) return false;
-      }
-      return true;
-    });
-    const sorted = [...filtered].sort((a, b) => {
-      switch (sortKey) {
-        case 'created_asc':
-          return (a.created_at ?? '').localeCompare(b.created_at ?? '');
-        case 'name_asc':
-          return a.name.localeCompare(b.name);
-        case 'name_desc':
-          return b.name.localeCompare(a.name);
-        case 'created_desc':
-        default:
-          return (b.created_at ?? '').localeCompare(a.created_at ?? '');
-      }
-    });
-    return sorted;
-  }, [data, statusFilter, agentSearch, sortKey]);
-
   return (
     <AccessibleTitle title={`Agent Evaluations for ${workspace}`}>
-      <Stack className="min-h-full" gap="density-2xl" padding="density-2xl">
+      <Stack className="h-full overflow-hidden" gap="density-2xl" padding="density-2xl">
         <PageHeader
           className="p-0"
           slotHeading="Agent Evaluations"
@@ -125,100 +33,7 @@ export const AgentEvaluationsListRoute: FC = () => {
             </Button>
           }
         />
-
-        {isLoading && (
-          <Flex align="center" justify="center" className="min-h-[200px]">
-            <Spinner size="medium" aria-label="Loading evaluation jobs..." />
-          </Flex>
-        )}
-
-        {error && !isLoading && (
-          <Stack gap="density-md">
-            <ErrorMessage
-              header="Failed to load evaluation jobs"
-              message={error instanceof Error ? error.message : 'Unknown error'}
-              slotFooter={
-                <Button kind="secondary" size="small" onClick={() => void refetch()}>
-                  Retry
-                </Button>
-              }
-            />
-          </Stack>
-        )}
-
-        {!isLoading && !error && (data ?? []).length > 0 && (
-          <Flex gap="density-md" wrap="wrap" align="end">
-            <Block className="flex-1 min-w-[200px]">
-              <TextInput
-                placeholder="Search by agent or job name"
-                value={agentSearch}
-                onChange={(e) => setAgentSearch(e.target.value)}
-              />
-            </Block>
-            <Block className="min-w-[180px]">
-              <Select
-                value={statusFilter}
-                items={STATUS_FILTER_OPTIONS}
-                onValueChange={(v) => setStatusFilter(v)}
-              />
-            </Block>
-            <Block className="min-w-[180px]">
-              <Select
-                value={sortKey}
-                items={SORT_OPTIONS}
-                onValueChange={(v) => setSortKey(v as SortKey)}
-              />
-            </Block>
-          </Flex>
-        )}
-
-        {!isLoading && !error && (data ?? []).length === 0 && (
-          <ErrorMessage
-            header="No evaluation jobs yet"
-            message="Apply a model_optimization suggestion or submit an evaluate-agent job to see results here."
-          />
-        )}
-
-        {!isLoading && !error && (data ?? []).length > 0 && jobs.length === 0 && (
-          <Block className="text-subtle">No evaluations match the current filters.</Block>
-        )}
-
-        {!isLoading && !error && jobs.length > 0 && (
-          <Stack gap="density-md">
-            {jobs.map((job) => (
-              <Link
-                key={job.name}
-                to={getAgentEvaluationDetailRoute(workspace, job.name)}
-                className="no-underline text-inherit"
-              >
-                <Card className="hover:bg-surface-hover">
-                  <Flex justify="between" align="center" gap="density-md" wrap="wrap">
-                    <Stack gap="density-xs" className="flex-1 min-w-0">
-                      <Text kind="title/xs" className="truncate">
-                        {job.name}
-                      </Text>
-                      <Flex gap="density-md" wrap="wrap">
-                        {agentNameForJob(job) && (
-                          <Badge kind="outline" color="gray">
-                            Agent: {agentNameForJob(job)}
-                          </Badge>
-                        )}
-                      </Flex>
-                    </Stack>
-                    <Stack gap="density-xs" className="text-right">
-                      <Block>
-                        <StatusBadge status={job.status} />
-                      </Block>
-                      <Text kind="body/regular/sm" color="secondary">
-                        Created {job.created_at ? <RelativeTime datetime={job.created_at} /> : '—'}
-                      </Text>
-                    </Stack>
-                  </Flex>
-                </Card>
-              </Link>
-            ))}
-          </Stack>
-        )}
+        <AgentEvaluationsDataView />
       </Stack>
       <SubmitEvaluationModal
         open={submitOpen}

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/AgentEvalTaskResultsPanel.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/AgentEvalTaskResultsPanel.test.tsx
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AgentEvalTaskDetail } from '@studio/api/evaluation/agent-evaluations';
+import { AgentEvalTaskResultsPanel } from '@studio/routes/agents/AgentEvaluationsRoute/components/AgentEvalTaskResultsPanel';
+import { fireEvent, render, screen } from '@studio/tests/util/render';
+
+const task: AgentEvalTaskDetail = {
+  taskId: 'email-0',
+  instruction: 'Subject: Test Email\nClick this suspicious link.',
+  reference: { label: 'phishing' },
+  metadata: {},
+  status: 'completed',
+  responseText: 'phishing — the message asks the user to click a suspicious link.',
+  scores: [{ name: 'llm-judge.accuracy', value: 1 }],
+  diagnostics: [],
+};
+
+describe('AgentEvalTaskResultsPanel', () => {
+  it('shows the empty state when there are no tasks', () => {
+    render(<AgentEvalTaskResultsPanel tasks={[]} />);
+    expect(
+      screen.getByText('No per-task results recorded for this evaluation.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders a task row and opens a cell in a modal', async () => {
+    render(<AgentEvalTaskResultsPanel tasks={[task]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Task Results \(1\)/ }));
+
+    expect(await screen.findByText('llm-judge.accuracy: 1.000')).toBeInTheDocument();
+
+    const expandButtons = screen.getAllByLabelText('Expand cell');
+    fireEvent.click(expandButtons[expandButtons.length - 1]);
+
+    expect(await screen.findByText('Task 1 — Agent Response')).toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/AgentEvalTaskResultsPanel.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/AgentEvalTaskResultsPanel.tsx
@@ -2,22 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AccordionPanel } from '@nemo/common/src/components/AccordionPanel';
+import * as DataView from '@nemo/common/src/components/DataView/internal';
+import {
+  TableExpandableCell,
+  type TableExpandableCellState,
+} from '@nemo/common/src/components/DataView/TableExpandableCell';
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
-import { Badge, Block, Card, Flex, Stack, Text } from '@nvidia/foundations-react-core';
+import { Badge, Block, Button, Flex, Modal, Stack, Text } from '@nvidia/foundations-react-core';
 import type { AgentEvalTaskDetail } from '@studio/api/evaluation/agent-evaluations';
-import { formatScore, scoreColor } from '@studio/routes/agents/AgentEvaluationsRoute/evalScores';
+import { formatScore } from '@studio/routes/agents/AgentEvaluationsRoute/evalScores';
 import { ListChecks } from 'lucide-react';
-import { type FC } from 'react';
+import { type ComponentProps, type FC, useCallback, useState } from 'react';
 
 interface AgentEvalTaskResultsPanelProps {
   tasks: AgentEvalTaskDetail[];
 }
-
-const headingFor = (task: AgentEvalTaskDetail): string => {
-  const firstLine = (task.instruction ?? '').split('\n', 1)[0] ?? '';
-  const match = /^\s*subject:\s*(.+)$/i.exec(firstLine);
-  return match ? match[1].trim() : task.taskId;
-};
 
 const referenceText = (reference?: Record<string, unknown>): string | null => {
   if (!reference || Object.keys(reference).length === 0) return null;
@@ -26,107 +25,150 @@ const referenceText = (reference?: Record<string, unknown>): string | null => {
   return JSON.stringify(reference);
 };
 
-const metadataEntries = (metadata?: Record<string, unknown>): Array<[string, string]> =>
-  Object.entries(metadata ?? {}).map(([k, v]) => [
-    k,
-    typeof v === 'string' ? v : JSON.stringify(v),
-  ]);
+const diagnosticsText = (diagnostics: unknown[]): string =>
+  diagnostics.map((d) => JSON.stringify(d)).join('\n');
+
+const LongCell: FC<{
+  content: string;
+  title: string;
+  onExpand: (state: TableExpandableCellState) => void;
+}> = ({ content, title, onExpand }) =>
+  content ? (
+    <TableExpandableCell content={content} title={title} onExpand={onExpand} />
+  ) : (
+    <Text kind="body/regular/sm" color="secondary">
+      —
+    </Text>
+  );
 
 export const AgentEvalTaskResultsPanel: FC<AgentEvalTaskResultsPanelProps> = ({ tasks }) => {
+  const [expandedCell, setExpandedCell] = useState<TableExpandableCellState | null>(null);
+  const dataViewState = DataView.useDataViewState();
+
+  const makeColumns = useCallback<
+    ComponentProps<typeof DataView.Root<AgentEvalTaskDetail>>['makeColumns']
+  >(
+    (col) => [
+      col.display({
+        id: 'task',
+        header: 'Task',
+        size: 80,
+        cell: ({ row }) => <Text kind="body/semibold/sm">{row.index + 1}</Text>,
+      }),
+      col.display({
+        id: 'score',
+        header: 'Score',
+        size: 150,
+        cell: ({ row }) => (
+          <Stack gap="density-xs">
+            {row.original.scores.map((s) => (
+              <Text key={s.name} kind="body/semibold/md" className="whitespace-nowrap">
+                {s.name}: {formatScore(s.value)}
+              </Text>
+            ))}
+          </Stack>
+        ),
+      }),
+      col.display({
+        id: 'input',
+        header: 'Input',
+        size: 280,
+        cell: ({ row }) => (
+          <LongCell
+            content={row.original.instruction ?? ''}
+            title={`Task ${row.index + 1} — Input`}
+            onExpand={setExpandedCell}
+          />
+        ),
+      }),
+      col.display({
+        id: 'expected',
+        header: 'Expected',
+        size: 140,
+        cell: ({ row }) => {
+          const expected = referenceText(row.original.reference);
+          return expected ? (
+            <Badge kind="outline" color="gray">
+              {expected}
+            </Badge>
+          ) : (
+            <Text kind="body/regular/sm" color="secondary">
+              —
+            </Text>
+          );
+        },
+      }),
+      col.display({
+        id: 'response',
+        header: 'Agent Response',
+        size: 280,
+        cell: ({ row }) => (
+          <LongCell
+            content={row.original.responseText ?? ''}
+            title={`Task ${row.index + 1} — Agent Response`}
+            onExpand={setExpandedCell}
+          />
+        ),
+      }),
+      col.display({
+        id: 'status',
+        header: 'Status',
+        size: 110,
+        cell: ({ row }) => <StatusBadge status={row.original.status} />,
+      }),
+      col.display({
+        id: 'diagnostics',
+        header: 'Diagnostics',
+        size: 220,
+        cell: ({ row }) => (
+          <LongCell
+            content={diagnosticsText(row.original.diagnostics)}
+            title={`Task ${row.index + 1} — Diagnostics`}
+            onExpand={setExpandedCell}
+          />
+        ),
+      }),
+    ],
+    []
+  );
+
   if (tasks.length === 0) {
     return <Block className="text-subtle">No per-task results recorded for this evaluation.</Block>;
   }
 
   return (
     <AccordionPanel slotHeading={`Task Results (${tasks.length})`} slotIcon={<ListChecks />}>
-      <Stack gap="density-lg">
-        {tasks.map((task) => {
-          const expected = referenceText(task.reference);
-          const metadata = metadataEntries(task.metadata);
-          return (
-            <Card key={task.taskId} className="relative">
-              <Flex
-                gap="density-sm"
-                className="absolute right-density-lg top-density-lg"
-                wrap="wrap"
-              >
-                {task.scores.map((s) => (
-                  <Badge key={s.name} kind="solid" color={scoreColor(s.value)}>
-                    {s.name}: {formatScore(s.value)}
-                  </Badge>
-                ))}
-              </Flex>
-
-              <Stack gap="density-md" className="pr-density-3xl">
-                <Stack gap="density-xs">
-                  <Text kind="body/semibold/md" className="min-w-0 break-words">
-                    {headingFor(task)}
-                  </Text>
-                  <Flex gap="density-sm" align="center" wrap="wrap">
-                    {expected && (
-                      <Badge kind="outline" color="gray">
-                        Expected: {expected}
-                      </Badge>
-                    )}
-                    <StatusBadge status={task.status} />
-                  </Flex>
-                </Stack>
-
-                <Stack gap="density-xs">
-                  <Text kind="label/bold/sm" color="secondary">
-                    Agent response
-                  </Text>
-                  <Text kind="body/regular/sm" className="whitespace-pre-wrap">
-                    {task.responseText ?? '—'}
-                  </Text>
-                </Stack>
-
-                {task.instruction && (
-                  <Stack gap="density-xs">
-                    <Text kind="label/bold/sm" color="secondary">
-                      Input
-                    </Text>
-                    <Text kind="body/regular/sm" color="secondary" className="whitespace-pre-wrap">
-                      {task.instruction}
-                    </Text>
-                  </Stack>
-                )}
-
-                {metadata.length > 0 && (
-                  <Stack gap="density-xs">
-                    <Text kind="label/bold/sm" color="secondary">
-                      Metadata
-                    </Text>
-                    <Stack gap="density-xs">
-                      {metadata.map(([key, value]) => (
-                        <Flex key={key} gap="density-sm" wrap="wrap">
-                          <Text kind="body/semibold/sm" color="secondary">
-                            {key}:
-                          </Text>
-                          <Text kind="body/regular/sm" color="secondary" className="break-words">
-                            {value}
-                          </Text>
-                        </Flex>
-                      ))}
-                    </Stack>
-                  </Stack>
-                )}
-
-                {task.diagnostics.length > 0 && (
-                  <Stack gap="density-xs">
-                    <Text kind="label/bold/sm" color="secondary">
-                      Diagnostics
-                    </Text>
-                    <Text kind="body/regular/sm" color="danger" className="whitespace-pre-wrap">
-                      {task.diagnostics.map((d) => JSON.stringify(d)).join('\n')}
-                    </Text>
-                  </Stack>
-                )}
-              </Stack>
-            </Card>
-          );
-        })}
-      </Stack>
+      <div className="border border-base rounded-md overflow-hidden">
+        <DataView.Root
+          data={tasks}
+          state={dataViewState}
+          makeColumns={makeColumns}
+          reactTableOptions={{ getRowId: (row) => row.taskId }}
+        >
+          <DataView.TableContent />
+        </DataView.Root>
+      </div>
+      <Modal
+        open={expandedCell !== null}
+        onOpenChange={(open) => {
+          if (!open) setExpandedCell(null);
+        }}
+        slotHeading={expandedCell?.title ?? 'Cell Content'}
+        className="w-[90vw] max-w-[1000px]"
+        slotFooter={
+          <Flex justify="end" align="center" className="w-full">
+            <Button kind="tertiary" onClick={() => setExpandedCell(null)}>
+              Close
+            </Button>
+          </Flex>
+        }
+      >
+        <div className="max-h-[70vh] overflow-auto">
+          <Text kind="body/regular/md" className="whitespace-pre-wrap">
+            {expandedCell?.content}
+          </Text>
+        </div>
+      </Modal>
     </AccordionPanel>
   );
 };

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/AgentEvalTaskResultsPanel.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/AgentEvalTaskResultsPanel.tsx
@@ -2,17 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AccordionPanel } from '@nemo/common/src/components/AccordionPanel';
-import * as DataView from '@nemo/common/src/components/DataView/internal';
+import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
 import {
   TableExpandableCell,
   type TableExpandableCellState,
 } from '@nemo/common/src/components/DataView/TableExpandableCell';
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
+import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
 import { Badge, Block, Button, Flex, Modal, Stack, Text } from '@nvidia/foundations-react-core';
 import type { AgentEvalTaskDetail } from '@studio/api/evaluation/agent-evaluations';
 import { formatScore } from '@studio/routes/agents/AgentEvaluationsRoute/evalScores';
 import { ListChecks } from 'lucide-react';
-import { type ComponentProps, type FC, useCallback, useState } from 'react';
+import { type ComponentProps, type FC, useCallback, useMemo, useState } from 'react';
 
 interface AgentEvalTaskResultsPanelProps {
   tasks: AgentEvalTaskDetail[];
@@ -43,17 +44,25 @@ const LongCell: FC<{
 
 export const AgentEvalTaskResultsPanel: FC<AgentEvalTaskResultsPanelProps> = ({ tasks }) => {
   const [expandedCell, setExpandedCell] = useState<TableExpandableCellState | null>(null);
-  const dataViewState = DataView.useDataViewState();
+  const dataViewState = useStudioDataViewState();
+
+  const { pageIndex, pageSize } = dataViewState.pagination.state;
+  const pageRows = useMemo(
+    () => tasks.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize),
+    [tasks, pageIndex, pageSize]
+  );
 
   const makeColumns = useCallback<
-    ComponentProps<typeof DataView.Root<AgentEvalTaskDetail>>['makeColumns']
+    ComponentProps<typeof StudioDataView<AgentEvalTaskDetail>>['makeColumns']
   >(
     (col) => [
       col.display({
         id: 'task',
         header: 'Task',
         size: 80,
-        cell: ({ row }) => <Text kind="body/semibold/sm">{row.index + 1}</Text>,
+        cell: ({ row }) => (
+          <Text kind="body/semibold/sm">{pageIndex * pageSize + row.index + 1}</Text>
+        ),
       }),
       col.display({
         id: 'score',
@@ -76,7 +85,7 @@ export const AgentEvalTaskResultsPanel: FC<AgentEvalTaskResultsPanelProps> = ({ 
         cell: ({ row }) => (
           <LongCell
             content={row.original.instruction ?? ''}
-            title={`Task ${row.index + 1} — Input`}
+            title={`Task ${pageIndex * pageSize + row.index + 1} — Input`}
             onExpand={setExpandedCell}
           />
         ),
@@ -105,7 +114,7 @@ export const AgentEvalTaskResultsPanel: FC<AgentEvalTaskResultsPanelProps> = ({ 
         cell: ({ row }) => (
           <LongCell
             content={row.original.responseText ?? ''}
-            title={`Task ${row.index + 1} — Agent Response`}
+            title={`Task ${pageIndex * pageSize + row.index + 1} — Agent Response`}
             onExpand={setExpandedCell}
           />
         ),
@@ -123,13 +132,13 @@ export const AgentEvalTaskResultsPanel: FC<AgentEvalTaskResultsPanelProps> = ({ 
         cell: ({ row }) => (
           <LongCell
             content={diagnosticsText(row.original.diagnostics)}
-            title={`Task ${row.index + 1} — Diagnostics`}
+            title={`Task ${pageIndex * pageSize + row.index + 1} — Diagnostics`}
             onExpand={setExpandedCell}
           />
         ),
       }),
     ],
-    []
+    [pageIndex, pageSize]
   );
 
   if (tasks.length === 0) {
@@ -138,15 +147,19 @@ export const AgentEvalTaskResultsPanel: FC<AgentEvalTaskResultsPanelProps> = ({ 
 
   return (
     <AccordionPanel slotHeading={`Task Results (${tasks.length})`} slotIcon={<ListChecks />}>
-      <div className="border border-base rounded-md overflow-hidden">
-        <DataView.Root
-          data={tasks}
-          state={dataViewState}
+      <div className="flex flex-col min-h-[400px] max-h-[640px]">
+        <StudioDataView
+          dataViewState={dataViewState}
           makeColumns={makeColumns}
-          reactTableOptions={{ getRowId: (row) => row.taskId }}
-        >
-          <DataView.TableContent />
-        </DataView.Root>
+          maxTwoLines={false}
+          attributes={{
+            DataViewRoot: {
+              data: pageRows,
+              totalCount: tasks.length,
+              reactTableOptions: { getRowId: (row) => row.taskId },
+            },
+          }}
+        />
       </div>
       <Modal
         open={expandedCell !== null}

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/SubmitEvaluationModal.tsx
@@ -9,6 +9,7 @@ import { ControlledTextInput } from '@nemo/common/src/components/form/Controlled
 import { FormModal, type FormModalProps } from '@nemo/common/src/components/FormModal';
 import { getURNFromNamedEntityRef } from '@nemo/common/src/namedEntity';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import { FILESET_NAME_REGEXP } from '@nemo/common/src/utils/filesetName';
 import { useAgentsListAgents } from '@nemo/sdk/generated/agents/api';
 import type { AgentEvaluateJobRequest } from '@nemo/sdk/generated/evaluator/schema';
 import { filesDownloadFile, filesListFilesetFiles } from '@nemo/sdk/generated/platform/api';
@@ -37,6 +38,7 @@ import {
   parsePersistedSpec,
   type PersistedEvalSpec,
 } from '@studio/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec';
+import { DATASET_NAME_PATTERN_MESSAGE } from '@studio/routes/FilesetNewRoute/constants';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { type FC, useEffect, useRef, useState } from 'react';
 import { FormProvider, type SubmitHandler, useForm, useWatch } from 'react-hook-form';
@@ -78,10 +80,10 @@ const makeSubmitEvaluationSchema = (requiresJudgeModel: () => boolean) =>
           message: 'Name is required',
           path: ['newName'],
         });
-      } else if (!/^[a-zA-Z0-9_.-]+$/.test(name)) {
+      } else if (!FILESET_NAME_REGEXP.test(name)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: 'Use only letters, digits, dots, hyphens, and underscores',
+          message: DATASET_NAME_PATTERN_MESSAGE,
           path: ['newName'],
         });
       }

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.test.ts
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.test.ts
@@ -5,6 +5,7 @@ import {
   bareName,
   buildAgentEvalRequestBody,
   buildAgentTarget,
+  buildEvalJobName,
   buildPersistedSpec,
   type EvalConfig,
   fanMetricOntoTasks,
@@ -132,13 +133,42 @@ describe('buildAgentEvalRequestBody', () => {
     expect(body.spec.tasks[0].metrics[0].payload.metric.model).toBe('ws-a/judge');
   });
 
-  it('sets the fileset name as the job description when provided', () => {
+  it('sets benchmark and a fileset-prefixed job name when provided', () => {
     const body = buildAgentEvalRequestBody(persisted(), {
       workspace: 'ws-a',
       agent: 'a',
       filesetName: 'wise-blue',
     });
-    expect(body.description).toBe('wise-blue');
+    expect(body.spec.benchmark).toEqual({ eval_config_fileset: 'wise-blue' });
+    expect(body.name).toMatch(/^wise-blue-[a-z0-9]{8}$/);
+  });
+
+  it('omits benchmark and name when no fileset name is provided', () => {
+    const body = buildAgentEvalRequestBody(persisted(), { workspace: 'ws-a', agent: 'a' });
+    expect(body.spec.benchmark).toBeUndefined();
+    expect(body.name).toBeUndefined();
+  });
+});
+
+describe('buildEvalJobName', () => {
+  it('prefixes with the fileset name and appends a random suffix', () => {
+    expect(buildEvalJobName('wise-blue')).toMatch(/^wise-blue-[a-z0-9]{8}$/);
+  });
+
+  it('lowercases and preserves valid characters', () => {
+    expect(buildEvalJobName('My_Config.v2')).toMatch(/^my_config\.v2-[a-z0-9]{8}$/);
+  });
+
+  it('strips leading non-letter characters so the name starts with a letter', () => {
+    expect(buildEvalJobName('123-config')).toMatch(/^config-[a-z0-9]{8}$/);
+  });
+
+  it('collapses double hyphens and trims edges', () => {
+    expect(buildEvalJobName('--a--b--')).toMatch(/^a-b-[a-z0-9]{8}$/);
+  });
+
+  it('stays within the 63-character limit', () => {
+    expect(buildEvalJobName('a'.repeat(200)).length).toBeLessThanOrEqual(63);
   });
 });
 

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.ts
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.ts
@@ -77,7 +77,7 @@ export interface SubmitSelections {
   workspace: string;
   /** Agent (bare name) to evaluate; used to build the generic target. */
   agent: string;
-  /** Eval-config fileset name, stored under spec.benchmark.eval_config for display. */
+  /** Eval-config fileset name, stored under spec.benchmark.eval_config_fileset for display. */
   filesetName?: string;
 }
 

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.ts
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/components/submitEvaluationSpec.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { FILESET_NAME_MAX_LENGTH, toValidFilesetName } from '@nemo/common/src/utils/filesetName';
 import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
 import { PLATFORM_BASE_URL } from '@studio/constants/environment';
 
@@ -15,6 +16,14 @@ export const generateEvalConfigName = (): string => generateDefaultName({ length
 
 /** Default parallelism for a submitted eval (Studio default; the config value is a hint). */
 export const DEFAULT_MAX_CONCURRENT_TASKS = 1;
+
+export const buildEvalJobName = (filesetName: string): string => {
+  const suffix = Math.random().toString(36).slice(2, 10).padEnd(8, '0');
+  const base = toValidFilesetName(filesetName)
+    .slice(0, FILESET_NAME_MAX_LENGTH - suffix.length - 1)
+    .replace(/-+$/, '');
+  return `${base}-${suffix}`;
+};
 
 // ---------------------------------------------------------------------------
 // eval-config.json shape (stored in a fileset, read at submit)
@@ -68,7 +77,7 @@ export interface SubmitSelections {
   workspace: string;
   /** Agent (bare name) to evaluate; used to build the generic target. */
   agent: string;
-  /** Eval-config fileset name, stored as the job description for display in the detail view. */
+  /** Eval-config fileset name, stored under spec.benchmark.eval_config for display. */
   filesetName?: string;
 }
 
@@ -127,11 +136,14 @@ export const buildAgentEvalRequestBody = (
   spec: PersistedEvalSpec,
   selections: SubmitSelections
 ) => ({
-  ...(selections.filesetName ? { description: selections.filesetName } : {}),
+  ...(selections.filesetName ? { name: buildEvalJobName(selections.filesetName) } : {}),
   spec: {
     tasks: spec.tasks,
     target: buildAgentTarget(selections.workspace, selections.agent),
     max_concurrent_tasks: spec.max_concurrent_tasks ?? DEFAULT_MAX_CONCURRENT_TASKS,
+    ...(selections.filesetName
+      ? { benchmark: { eval_config_fileset: selections.filesetName } }
+      : {}),
   },
 });
 


### PR DESCRIPTION

<img width="1480" height="417" alt="Screenshot 2026-07-22 at 9 43 39 AM" src="https://github.com/user-attachments/assets/2b37fbec-8a49-4d23-822d-4f2637ba9ec1" />

<img width="1470" height="1204" alt="Screenshot 2026-07-22 at 9 43 23 AM" src="https://github.com/user-attachments/assets/8aa85466-8b2f-4622-bbf8-65e460028623" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Agent Evaluations data view with filtering/sorting, live polling, score summaries, expandable task panels, and bulk/job deletion.
  - Enhanced the evaluation detail page with conditional Artifacts linking and improved Eval Config navigation.
  - Updated expandable table cells to support richer rendering options (e.g., optional footer and bolded content).
- **Bug Fixes**
  - Standardized eval-config fileset name validation and messaging.
- **Tests**
  - Added/expanded unit tests for evaluation helpers and task results panel interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->