### PR TITLE
fix(models): redirect LoRA sidecar XDG_DATA_HOME to a writable volume

### DIFF
--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
@@ -62,12 +62,16 @@ from nmp.core.models.controllers.backends.vllm_compiler import (
 _WEIGHTS_MOUNT = "/model-store"
 _SCRATCH_MOUNT = "/scratch"
 _LORA_MOUNT = "/scratch/loras"
-# The adapters sidecar's `nemo services run` writes instance state under $XDG_STATE_HOME
-# (default ~/.local/state), but the pod runs it as the vLLM uid (2000), which does not own
-# the nmp-api image's $HOME (/home/nvs, uid 1000) -- so the default path is unwritable and
-# the sidecar crash-loops. Redirect it to the writable scratch volume, outside the
-# /scratch/loras subtree the adapters controller GCs.
-_LORA_SIDECAR_STATE_DIR = f"{_SCRATCH_MOUNT}/.nmp-state"
+# The adapters sidecar's `nemo services run` writes to two XDG homes: instance
+# lock/descriptor state under $XDG_STATE_HOME (default ~/.local/state, -> .../nmp/) and its
+# local SQLite/data dir under $XDG_DATA_HOME (default ~/.local/share, -> .../nemo/, via
+# nmp_user_data_dir()). The pod runs the sidecar as the vLLM uid (2000), which does not own
+# the nmp-api image's baked $HOME (/home/nvs, uid 1000), so both defaults are unwritable and
+# the sidecar crash-loops (PermissionError creating ~/.local). Point both XDG homes at this
+# writable scratch dir -- named for the ~/.local the XDG homes normally live under -- outside
+# the /scratch/loras subtree the adapters controller GCs. State (nmp/) and data (nemo/) land
+# in distinct leaves, so a single base holds both without collision.
+_LORA_SIDECAR_XDG_HOME = f"{_SCRATCH_MOUNT}/.local"
 _SCRATCH_VOLUME_SIZE = "1Gi"
 
 
@@ -151,7 +155,8 @@ def _lora_sidecar(
         "NMP_MODEL_ENTITY_WORKSPACE": entity_workspace,
         "NMP_MODEL_ENTITY_NAME": entity_name,
         "NMP_BASE_URL": platform.base_url,
-        "XDG_STATE_HOME": _LORA_SIDECAR_STATE_DIR,
+        "XDG_STATE_HOME": _LORA_SIDECAR_XDG_HOME,
+        "XDG_DATA_HOME": _LORA_SIDECAR_XDG_HOME,
     }
     if engine == ENGINE_VLLM:
         sidecar_env["VLLM_LORA_BASE_MODEL_OVERRIDE"] = MODEL_STORE_PATH

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
@@ -62,15 +62,12 @@ from nmp.core.models.controllers.backends.vllm_compiler import (
 _WEIGHTS_MOUNT = "/model-store"
 _SCRATCH_MOUNT = "/scratch"
 _LORA_MOUNT = "/scratch/loras"
-# The adapters sidecar's `nemo services run` writes to two XDG homes: instance
-# lock/descriptor state under $XDG_STATE_HOME (default ~/.local/state, -> .../nmp/) and its
-# local SQLite/data dir under $XDG_DATA_HOME (default ~/.local/share, -> .../nemo/, via
-# nmp_user_data_dir()). The pod runs the sidecar as the vLLM uid (2000), which does not own
-# the nmp-api image's baked $HOME (/home/nvs, uid 1000), so both defaults are unwritable and
-# the sidecar crash-loops (PermissionError creating ~/.local). Point both XDG homes at this
-# writable scratch dir -- named for the ~/.local the XDG homes normally live under -- outside
-# the /scratch/loras subtree the adapters controller GCs. State (nmp/) and data (nemo/) land
-# in distinct leaves, so a single base holds both without collision.
+# The adapters sidecar's `nemo services run` writes state under $XDG_STATE_HOME (default
+# ~/.local/state) and its local data dir under $XDG_DATA_HOME (default ~/.local/share, via
+# nmp_user_data_dir()). The pod runs it as the vLLM uid (2000), which does not own the
+# nmp-api image's $HOME (/home/nvs, uid 1000), so both defaults are unwritable and the
+# sidecar crash-loops. Redirect both to the writable scratch volume, outside the
+# /scratch/loras subtree the adapters controller GCs.
 _LORA_SIDECAR_XDG_HOME = f"{_SCRATCH_MOUNT}/.local"
 _SCRATCH_VOLUME_SIZE = "1Gi"
 

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
@@ -300,9 +300,12 @@ def test_lora_uses_native_sidecar_on_k8s_and_container_on_docker() -> None:
     assert sidecar.image == "registry/nmp-api:tag"
     env = {item.name: item.value for item in sidecar.env}
     assert env["NIM_PEFT_SOURCE"] == "/scratch/loras"
-    # Sidecar `nemo services run` state must land on the writable scratch volume, not the
-    # nmp-api image's $HOME (unwritable under the pod's vLLM uid). See _lora_sidecar.
-    assert env["XDG_STATE_HOME"] == "/scratch/.nmp-state"
+    # Sidecar `nemo services run` writes both its instance state ($XDG_STATE_HOME) and its
+    # local data dir ($XDG_DATA_HOME, via nmp_user_data_dir) -- both must land on the
+    # writable scratch volume, not the nmp-api image's $HOME (unwritable under the pod's
+    # vLLM uid, so the sidecar crash-loops on PermissionError). See _lora_sidecar.
+    assert env["XDG_STATE_HOME"] == "/scratch/.local"
+    assert env["XDG_DATA_HOME"] == "/scratch/.local"
     assert env["VLLM_LORA_BASE_MODEL_OVERRIDE"] == "/model-store"
     assert env["NMP_BASE_URL"] == "http://platform.example:8080"
     assert env["VLLM_ENDPOINT"] == "http://127.0.0.1:8000"


### PR DESCRIPTION
Follow-up to #798, which redirected only `$XDG_STATE_HOME`. The adapters sidecar's `nemo services run` also resolves its local data dir via `$XDG_DATA_HOME` (default `~/.local/share/nemo`). This leads to the same class of permission issue surfaced previously.

Point both XDG homes at a single writable scratch base (`/scratch/.local`). State lands under `.../nmp/` and data under `.../nemo/`, so one base holds both without collision, and it stays outside the `/scratch/loras` subtree the adapters controller GCs. Covered by the deployments_plugin compiler unit test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved writable storage configuration for adapters sidecars on LoRA scratch mounts.
  * Sidecar directory handling now aligns both `XDG_STATE_HOME` and `XDG_DATA_HOME` to the same writable scratch-backed base location, reducing permission-related issues.
* **Tests**
  * Updated LoRA sidecar Kubernetes assertions to reflect the new XDG environment variable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->