### PR TITLE
test(auditor): re-enable tests

### DIFF
--- a/e2e/auditor/test_audit_job.py
+++ b/e2e/auditor/test_audit_job.py
@@ -149,7 +149,6 @@ def audit_target_name(sdk: NeMoPlatform, audit_workspace: str, mock_provider_nam
 # ---- Tests ----
 
 
-@pytest.mark.skip("re-enable after auditor image rebuilt")
 def test_audit_job_submit_blank_probe(
     sdk: NeMoPlatform,
     audit_workspace: str,
@@ -192,7 +191,6 @@ def test_audit_job_submit_blank_probe(
         _cleanup_audit_job(sdk, job_name, audit_workspace)
 
 
-@pytest.mark.skip("re-enable after auditor image rebuilt")
 def test_audit_job_submit_with_entity_refs(
     sdk: NeMoPlatform,
     audit_workspace: str,


### PR DESCRIPTION
Previously disabled some e2e tests that depended on the Auditor image being rebuilt. Re-enabling to test the updated image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled end-to-end audit job submission coverage.
  * Tests now submit audit jobs, wait for completion, and clean up created jobs automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->