### PR TITLE
fix: add job.logs.create to Editor role

### DIFF
--- a/docs/auth/authorization/permissions-reference.mdx
+++ b/docs/auth/authorization/permissions-reference.mdx
@@ -64,7 +64,7 @@ PlatformAdmin is omitted — it bypasses permission checks entirely at the polic
 | ------------ | ------------- | :------: | :------: | :------: | :------: |
 | <code>jobs.(read &#124; list)</code> | Read, list jobs | ✓ | ✓ | ✓ |  |
 | <code>jobs.(create &#124; update &#124; delete &#124; cancel)</code> | Create, update, delete, cancel jobs |  | ✓ | ✓ |  |
-| `jobs.logs.create` | Upload job logs |  |  |  | ✓ |
+| `jobs.logs.create` | Upload job logs |  | ✓ | ✓ | ✓ |
 
 ## Models API
 

--- a/services/core/auth/src/nmp/core/auth/assets/static-authz.yaml
+++ b/services/core/auth/src/nmp/core/auth/assets/static-authz.yaml
@@ -364,6 +364,7 @@ authz:
       - jobs.cancel
       - jobs.create
       - jobs.delete
+      - jobs.logs.create
       - jobs.update
       - models.adapters.create
       - models.adapters.delete

--- a/services/core/auth/tests/test_embedded_pdp.py
+++ b/services/core/auth/tests/test_embedded_pdp.py
@@ -532,7 +532,7 @@ class TestWithStaticAuthzData:
         )
         assert result["allowed"] is True
 
-    def test_job_runner_can_upload_otlp_logs_without_editor(self, static_authz_data):
+    def test_editor_and_job_runner_can_upload_otlp_logs(self, static_authz_data):
         static_authz_data["authz"]["principals"] = {
             "viewer@test.com": {"workspaces": {"my-ws": ["Viewer"]}},
             "editor@test.com": {"workspaces": {"my-ws": ["Editor"]}},
@@ -567,7 +567,7 @@ class TestWithStaticAuthzData:
         )
 
         assert viewer_result["allowed"] is False
-        assert editor_result["allowed"] is False
+        assert editor_result["allowed"] is True
         assert job_runner_result["allowed"] is True
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editors can now upload job logs through the Jobs API.
  * Job runners retain permission to upload job logs, while viewers remain restricted.

* **Documentation**
  * Updated the permissions reference to reflect job log upload access for editors and administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->