### PR TITLE
fix(models): make docker weights volume writable for the HF weight-puller

### DIFF
--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
@@ -426,14 +426,25 @@ class DockerDeploymentBackend(DeploymentBackend):
     ) -> VolumeStatusUpdate:
         del size, access_modes
         driver = "local"
+        init_chmod: str | None = None
+        init_image: str | None = None
         docker_section = backend_config.get("docker") or {}
-        if isinstance(docker_section, dict) and docker_section.get("driver"):
-            driver = str(docker_section["driver"])
+        if isinstance(docker_section, dict):
+            if docker_section.get("driver"):
+                driver = str(docker_section["driver"])
+            # initChmod/initImage let the compiler request the volume be made
+            # writable by non-root workloads (docker analogue of k8s fsGroup).
+            if docker_section.get("initChmod"):
+                init_chmod = str(docker_section["initChmod"])
+            if docker_section.get("initImage"):
+                init_image = str(docker_section["initImage"])
         return await volume_ops.create_volume(
             self._client,
             workspace=workspace,
             name=name,
             driver=driver,
+            init_chmod=init_chmod,
+            init_image=init_image,
         )
 
     async def read_volume_status(

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/volumes.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/volumes.py
@@ -29,35 +29,47 @@ async def create_volume(
     vol_name = docker_volume_name(workspace, name)
     labels = volume_identity_labels(workspace, name)
 
-    def _create() -> Any:
+    def _create() -> bool:
+        """Create the volume if missing. Returns True if newly created."""
         from docker.errors import NotFound
 
         try:
             existing = client.volumes.get(vol_name)
             existing.reload()
-            return existing
+            return False
         except NotFound:
-            return client.volumes.create(name=vol_name, driver=driver, labels=labels)
+            client.volumes.create(name=vol_name, driver=driver, labels=labels)
+            return True
 
     def _init_permissions() -> None:
-        # Docker named volumes are created root-owned (0755). Run a one-shot
+        # Docker named volumes are created root-owned (0755). Run an init
         # container to relax the mode so a non-root workload (e.g. the HF
         # weight-puller running as the image's default user) can write to it.
-        # This is the docker analogue of a k8s fsGroup. chmod is idempotent, so
-        # re-running on a reconcile is harmless.
+        # This is the docker analogue of a k8s fsGroup.
+        #
+        # chmod (rather than chown to the puller's uid) is deliberate: it keeps
+        # this backend uid-agnostic — the puller runs as whatever user its image
+        # declares, so there is no fixed uid to chown to. World-writable is an
+        # acceptable posture for the single-node docker dev/test runtime.
+        #
+        # Invoke chmod directly (no `sh -c`) so a mode value is never shell-
+        # interpolated, keeping this safe even if a future caller supplies an
+        # untrusted mode.
         image = init_image or "docker.io/library/busybox"
         client.containers.run(
             image,
-            entrypoint=["sh", "-c"],
-            command=[f"chmod {init_chmod} /vol"],
+            entrypoint=["chmod"],
+            command=[init_chmod, "/vol"],
             volumes={vol_name: {"bind": "/vol", "mode": "rw"}},
             remove=True,
             detach=False,
         )
 
     try:
-        await asyncio.to_thread(_create)
-        if init_chmod:
+        created = await asyncio.to_thread(_create)
+        # Only initialize permissions on a fresh create; an already-initialized
+        # volume does not need the init container re-run on every reconcile.
+        if created and init_chmod:
             await asyncio.to_thread(_init_permissions)
         return VolumeStatusUpdate(status="BOUND", status_message=f"Volume {vol_name} is bound")
     except Exception as exc:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/volumes.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/volumes.py
@@ -23,6 +23,8 @@ async def create_volume(
     workspace: str,
     name: str,
     driver: str = "local",
+    init_chmod: str | None = None,
+    init_image: str | None = None,
 ) -> VolumeStatusUpdate:
     vol_name = docker_volume_name(workspace, name)
     labels = volume_identity_labels(workspace, name)
@@ -37,8 +39,26 @@ async def create_volume(
         except NotFound:
             return client.volumes.create(name=vol_name, driver=driver, labels=labels)
 
+    def _init_permissions() -> None:
+        # Docker named volumes are created root-owned (0755). Run a one-shot
+        # container to relax the mode so a non-root workload (e.g. the HF
+        # weight-puller running as the image's default user) can write to it.
+        # This is the docker analogue of a k8s fsGroup. chmod is idempotent, so
+        # re-running on a reconcile is harmless.
+        image = init_image or "docker.io/library/busybox"
+        client.containers.run(
+            image,
+            entrypoint=["sh", "-c"],
+            command=[f"chmod {init_chmod} /vol"],
+            volumes={vol_name: {"bind": "/vol", "mode": "rw"}},
+            remove=True,
+            detach=False,
+        )
+
     try:
         await asyncio.to_thread(_create)
+        if init_chmod:
+            await asyncio.to_thread(_init_permissions)
         return VolumeStatusUpdate(status="BOUND", status_message=f"Volume {vol_name} is bound")
     except Exception as exc:
         logger.exception("Failed to create volume %s", vol_name)

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
@@ -170,16 +170,15 @@ class DockerVolumeConfig(BaseModel):
         default=None,
         alias="initChmod",
         description=(
-            "When set, the docker backend runs a one-shot init container to `chmod` "
-            "the freshly created (root-owned) named volume to this mode (e.g. '0777'). "
-            "This is the docker analogue of a k8s fsGroup: it lets a non-root "
-            "container (e.g. the HF weight-puller) write to the volume. No-op on k8s."
+            "When set, an init container chmods the freshly created (root-owned) "
+            "named volume to this mode (e.g. '0777') so a non-root workload (e.g. "
+            "the HF weight-puller) can write to it — the docker analogue of a k8s fsGroup."
         ),
     )
     init_image: str | None = Field(
         default=None,
         alias="initImage",
-        description="Image used for the init_chmod one-shot container (e.g. busybox).",
+        description="Image used for the init_chmod container (e.g. busybox).",
     )
 
     model_config = {"populate_by_name": True}

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
@@ -166,6 +166,23 @@ class DeploymentBackendConfig(BaseModel):
 class DockerVolumeConfig(BaseModel):
     driver: str = "local"
     mount_point: str | None = None
+    init_chmod: str | None = Field(
+        default=None,
+        alias="initChmod",
+        description=(
+            "When set, the docker backend runs a one-shot init container to `chmod` "
+            "the freshly created (root-owned) named volume to this mode (e.g. '0777'). "
+            "This is the docker analogue of a k8s fsGroup: it lets a non-root "
+            "container (e.g. the HF weight-puller) write to the volume. No-op on k8s."
+        ),
+    )
+    init_image: str | None = Field(
+        default=None,
+        alias="initImage",
+        description="Image used for the init_chmod one-shot container (e.g. busybox).",
+    )
+
+    model_config = {"populate_by_name": True}
 
 
 class K8sVolumeConfig(BaseModel):

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
@@ -74,6 +74,56 @@ async def test_create_deployment_maps_command_to_entrypoint(
 
 
 @pytest.mark.asyncio
+async def test_create_volume_runs_init_chmod_container(
+    docker_backend: DockerDeploymentBackend,
+    mock_docker_client: MagicMock,
+) -> None:
+    """initChmod/initImage in the docker volume backend_config trigger a one-shot
+    chmod container so a non-root workload (the HF weight-puller) can write the
+    otherwise root-owned named volume. This is the docker analogue of k8s fsGroup.
+    """
+    mock_docker_client.volumes.get.side_effect = NotFound("missing")
+    mock_docker_client.volumes.create.return_value = MagicMock(name="vol")
+
+    update = await docker_backend.create_volume(
+        workspace="default",
+        name="weights",
+        size="40Gi",
+        access_modes=["ReadWriteOnce"],
+        backend_config={"docker": {"initChmod": "0777", "initImage": "docker.io/library/busybox"}},
+    )
+
+    assert update.status == "BOUND"
+    mock_docker_client.containers.run.assert_called_once()
+    args, run_kwargs = mock_docker_client.containers.run.call_args
+    assert args[0] == "docker.io/library/busybox"
+    assert run_kwargs["command"] == ["chmod 0777 /vol"]
+    assert run_kwargs["remove"] is True
+    # the init container must mount the volume it is fixing up
+    assert any(b.get("bind") == "/vol" for b in run_kwargs["volumes"].values())
+
+
+@pytest.mark.asyncio
+async def test_create_volume_without_init_chmod_skips_container(
+    docker_backend: DockerDeploymentBackend,
+    mock_docker_client: MagicMock,
+) -> None:
+    mock_docker_client.volumes.get.side_effect = NotFound("missing")
+    mock_docker_client.volumes.create.return_value = MagicMock(name="vol")
+
+    update = await docker_backend.create_volume(
+        workspace="default",
+        name="weights",
+        size="40Gi",
+        access_modes=["ReadWriteOnce"],
+        backend_config={},
+    )
+
+    assert update.status == "BOUND"
+    mock_docker_client.containers.run.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_read_status_ready_when_running_without_probe(
     docker_backend: DockerDeploymentBackend,
     mock_entities: AsyncMock,

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
@@ -78,7 +78,7 @@ async def test_create_volume_runs_init_chmod_container(
     docker_backend: DockerDeploymentBackend,
     mock_docker_client: MagicMock,
 ) -> None:
-    """initChmod/initImage in the docker volume backend_config trigger a one-shot
+    """initChmod/initImage in the docker volume backend_config trigger an init
     chmod container so a non-root workload (the HF weight-puller) can write the
     otherwise root-owned named volume. This is the docker analogue of k8s fsGroup.
     """
@@ -97,7 +97,9 @@ async def test_create_volume_runs_init_chmod_container(
     mock_docker_client.containers.run.assert_called_once()
     args, run_kwargs = mock_docker_client.containers.run.call_args
     assert args[0] == "docker.io/library/busybox"
-    assert run_kwargs["command"] == ["chmod 0777 /vol"]
+    # chmod is invoked directly (no `sh -c`) so the mode is never shell-interpolated
+    assert run_kwargs["entrypoint"] == ["chmod"]
+    assert run_kwargs["command"] == ["0777", "/vol"]
     assert run_kwargs["remove"] is True
     # the init container must mount the volume it is fixing up
     assert any(b.get("bind") == "/vol" for b in run_kwargs["volumes"].values())
@@ -120,6 +122,29 @@ async def test_create_volume_without_init_chmod_skips_container(
     )
 
     assert update.status == "BOUND"
+    mock_docker_client.containers.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_volume_skips_init_chmod_when_volume_exists(
+    docker_backend: DockerDeploymentBackend,
+    mock_docker_client: MagicMock,
+) -> None:
+    """The init chmod container runs only on a fresh create, not when reusing an
+    already-initialized volume — otherwise every reconcile would spin one up.
+    """
+    mock_docker_client.volumes.get.return_value = MagicMock(name="vol")  # already exists
+
+    update = await docker_backend.create_volume(
+        workspace="default",
+        name="weights",
+        size="40Gi",
+        access_modes=["ReadWriteOnce"],
+        backend_config={"docker": {"initChmod": "0777", "initImage": "docker.io/library/busybox"}},
+    )
+
+    assert update.status == "BOUND"
+    mock_docker_client.volumes.create.assert_not_called()
     mock_docker_client.containers.run.assert_not_called()
 
 

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
@@ -14,6 +14,7 @@ from nemo_deployments_plugin.entities import (
     ContainerPort,
     DeploymentBackendConfig,
     DeploymentConfig,
+    DockerVolumeConfig,
     EnvVar,
     HTTPGetAction,
     K8sVolumeConfig,
@@ -198,11 +199,25 @@ def compile_model_deployment(
     scratch_volume = None
     puller_config = None
     if weighted:
+        # On docker, a freshly created named volume is root-owned (0755) and there
+        # is no fs_group equivalent, so the puller image's default non-root user
+        # (e.g. `nvs`/uid 1000) cannot create its HF cache under --local-dir
+        # (/model-store/.cache). Ask the docker backend to make the volume
+        # world-writable on create (busybox `chmod 0777`), the docker analogue of
+        # k8s fs_group. No-op on k8s, where pod securityContext/fs_group handles it.
+        docker_volume_config = (
+            DockerVolumeConfig(initChmod="0777", initImage=_busybox_image(config))
+            if resolved.runtime == Runtime.DOCKER
+            else None
+        )
         volume = Volume(
             name=names.volume,
             workspace=resolved.deployment.workspace,
             size=resolved.view.disk_size or config.default_pvc_size,
-            backendConfig=VolumeBackendConfig(k8s=K8sVolumeConfig(storageClass=config.default_storage_class)),
+            backendConfig=VolumeBackendConfig(
+                docker=docker_volume_config,
+                k8s=K8sVolumeConfig(storageClass=config.default_storage_class),
+            ),
         )
         puller_env = {"HF_ENDPOINT": resolved.files_hf_url, "HF_TOKEN": "service:models"}
         puller_args = ["download", f"{resolved.model_namespace}/{resolved.model_name}", "--local-dir", _WEIGHTS_MOUNT]

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
@@ -39,6 +39,26 @@ def test_vllm_weighted_chain_has_on_failure_puller_and_always_server() -> None:
     assert compiled.server_config.containers[0].volume_mounts[0].read_only is True
 
 
+def test_docker_weights_volume_requests_init_chmod() -> None:
+    # Docker named volumes are root-owned with no fs_group, so the weights volume
+    # must be made writable (chmod) for the non-root puller. The compiler requests
+    # this on the volume's docker backend config (docker analogue of k8s fsGroup).
+    compiled = compile_model_deployment(_resolved("vllm", runtime=Runtime.DOCKER), DeploymentsPluginConfig())
+    assert compiled.volume is not None
+    docker_cfg = compiled.volume.backend_config.docker
+    assert docker_cfg is not None
+    assert docker_cfg.init_chmod == "0777"
+    assert docker_cfg.init_image  # busybox image is set
+
+
+def test_k8s_weights_volume_has_no_docker_init_chmod() -> None:
+    # On k8s, pod securityContext/fs_group handles volume ownership, so no docker
+    # init-chmod is emitted.
+    compiled = compile_model_deployment(_resolved("vllm", runtime=Runtime.KUBERNETES), DeploymentsPluginConfig())
+    assert compiled.volume is not None
+    assert compiled.volume.backend_config.docker is None
+
+
 def test_vllm_server_command_image_args_and_gpu() -> None:
     resolved = _resolved("vllm")
     resolved = ResolvedPluginDeployment(

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
@@ -8,7 +8,7 @@ from nemo_platform.types.inference.k8s_nim_operator_config import K8sNIMOperator
 from nmp.common.config import Runtime
 from nmp.core.models.app import ModelWeightsType
 from nmp.core.models.controllers.backends.common import DeploymentConfigView
-from nmp.core.models.controllers.backends.deployments_plugin.compiler import compile_model_deployment
+from nmp.core.models.controllers.backends.deployments_plugin.compiler import _busybox_image, compile_model_deployment
 from nmp.core.models.controllers.backends.deployments_plugin.config import DeploymentsPluginConfig
 from nmp.core.models.controllers.backends.deployments_plugin.resolve import ResolvedPluginDeployment
 from nmp.core.models.controllers.backends.vllm_compiler import MODEL_STORE_PATH
@@ -43,12 +43,13 @@ def test_docker_weights_volume_requests_init_chmod() -> None:
     # Docker named volumes are root-owned with no fs_group, so the weights volume
     # must be made writable (chmod) for the non-root puller. The compiler requests
     # this on the volume's docker backend config (docker analogue of k8s fsGroup).
-    compiled = compile_model_deployment(_resolved("vllm", runtime=Runtime.DOCKER), DeploymentsPluginConfig())
+    config = DeploymentsPluginConfig()
+    compiled = compile_model_deployment(_resolved("vllm", runtime=Runtime.DOCKER), config)
     assert compiled.volume is not None
     docker_cfg = compiled.volume.backend_config.docker
     assert docker_cfg is not None
     assert docker_cfg.init_chmod == "0777"
-    assert docker_cfg.init_image  # busybox image is set
+    assert docker_cfg.init_image == _busybox_image(config)
 
 
 def test_k8s_weights_volume_has_no_docker_init_chmod() -> None:


### PR DESCRIPTION
## Summary

The deployments-plugin **docker** backend created the model weights volume as a plain docker named volume, which the daemon creates **root-owned (0755)**. The HF weight-puller runs as its image's default **non-root** user (e.g. `nvs`, uid 1000), so `hf download --local-dir /model-store` failed creating `/model-store/.cache` with `PermissionError [Errno 13]`, and the deployment errored with `Prerequisite '<dep>-puller' failed`.

Docker has no `fs_group` equivalent (that is k8s-only), so the volume stayed unwritable. This blocked **all** docker vLLM/NIM deployments that pull weights from the files service.

## Fix

Docker analogue of a k8s `fsGroup`, keeping the puller **non-root** (least privilege):

- **`entities.py`** — add `DockerVolumeConfig.init_chmod` / `init_image`.
- **`backends/docker/volumes.py` + `backend.py`** — in `create_volume`, when `init_chmod` is set, run a one-shot **busybox** container that `chmod`s the freshly created volume so non-root workloads can write it. Idempotent, so re-running on a reconcile is harmless.
- **`deployments_plugin/compiler.py`** — on the **docker runtime only**, set the weights volume's docker backend config to `initChmod=0777` with the configured busybox image. On k8s the volume is unchanged and pod `securityContext`/`fs_group` continues to handle it.

busybox is already a first-class dependency of this plugin (used by the existing `lora-cache-init` container), so this introduces no new concept.

## Tests

New unit tests (full deployments-plugin unit suite: **273 passed**; models deployments_plugin suite green):
- docker backend: `test_create_volume_runs_init_chmod_container`, `test_create_volume_without_init_chmod_skips_container`
- compiler: `test_docker_weights_volume_requests_init_chmod`, `test_k8s_weights_volume_has_no_docker_init_chmod`

## Manual verification (dev pod, docker backend)

- **docker + vLLM (base):** busybox chmods the volume → puller runs as its default **non-root** user (`nvs`) and exits 0 (all files downloaded) → server READY (http probe 200) → gateway chat-completion works. Previously blocked.
- **docker + NIM (base):** same puller path succeeds → NIM selects a vLLM profile, loads weights → READY → gateway chat-completion works.

k8s vLLM/NIM (base + LoRA) were already working and are unaffected (no `initChmod` emitted on k8s).

## Notes

- docker + LoRA remains a deliberate guardrail (ERROR "LoRA serving is not supported on the docker runtime yet …") — unchanged.
- Branch name is a leftover from the exploration session; the change itself is the puller/volume fix above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Docker volume initialization settings to support permission mode and an init helper image (including `initChmod` / `initImage` aliases).
  - Docker deployments now initialize permissions for newly created weighted-puller volumes during volume creation.

- **Bug Fixes**
  - Ensures permission initialization runs only for newly created volumes and is skipped when the volume already exists.
  - Kubernetes behavior for weighted-puller volume initialization remains unchanged.

- **Tests**
  - Added unit tests covering Docker init-container behavior, skip logic, and Docker-vs-Kubernetes compile-time expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->