### PR TITLE
feat(studio): Split file into training set in DD details

### DIFF
--- a/web/packages/studio/src/api/datasets/useSplitDatasetFile.ts
+++ b/web/packages/studio/src/api/datasets/useSplitDatasetFile.ts
@@ -55,11 +55,12 @@ export const useSplitDatasetFile = ({ onError, onSuccess }: Props) => {
           ? splitRandomDistribution(rows, splits, seed)
           : splitSequentialDistribution(rows, splits, { key: sortKey });
 
-      // Upload files to fileset
-      const filename = filepath.split('/').pop() ?? filepath;
+      const isJson = filepath.endsWith('json');
+      const sourceName = filepath.split('/').pop() ?? filepath;
+      const baseName = sourceName.replace(/\.[^./]+$/, '');
+      const outputName = `${baseName}.${isJson ? 'json' : 'jsonl'}`;
       const toUpload = splits
         .map((_, index) => {
-          const isJson = filepath.endsWith('json');
           let content = splitList[index]
             .map((row) => JSON.stringify(row))
             .join(isJson ? ',\n' : '\n');
@@ -70,7 +71,7 @@ export const useSplitDatasetFile = ({ onError, onSuccess }: Props) => {
             return undefined;
           }
           return {
-            path: `${fileSuffix[index]}/${filename}`,
+            path: `${fileSuffix[index]}/${outputName}`,
             content,
           };
         })

--- a/web/packages/studio/src/api/datasets/useSplitDatasetFile.ts
+++ b/web/packages/studio/src/api/datasets/useSplitDatasetFile.ts
@@ -40,7 +40,6 @@ export const useSplitDatasetFile = ({ onError, onSuccess }: Props) => {
       seed,
       sortKey,
     }: FileSplitsProps) => {
-      // Parse JSON objects
       const { rows, failures } = parseFileContent({
         content: fileContent,
         fileType: getFileExtension(filepath) ?? '',
@@ -49,13 +48,12 @@ export const useSplitDatasetFile = ({ onError, onSuccess }: Props) => {
         toast.error(`${failures.length} Line(s) had parsing errors.`);
       }
 
-      // Split rows into randomly distributed lists
       const splitList =
         distributionType === 'random'
           ? splitRandomDistribution(rows, splits, seed)
           : splitSequentialDistribution(rows, splits, { key: sortKey });
 
-      const isJson = filepath.endsWith('json');
+      const isJson = filepath.toLowerCase().endsWith('json');
       const sourceName = filepath.split('/').pop() ?? filepath;
       const baseName = sourceName.replace(/\.[^./]+$/, '');
       const outputName = `${baseName}.${isJson ? 'json' : 'jsonl'}`;
@@ -77,7 +75,6 @@ export const useSplitDatasetFile = ({ onError, onSuccess }: Props) => {
         })
         .filter(isDefined);
 
-      // Upload each file using v2 API
       const results = await Promise.all(
         toUpload.map(async (details) => {
           const blob = new Blob([details.content], { type: 'application/json' });

--- a/web/packages/studio/src/components/DataDesignerJobActionsMenu/index.tsx
+++ b/web/packages/studio/src/components/DataDesignerJobActionsMenu/index.tsx
@@ -23,6 +23,8 @@ interface DataDesignerJobActionsMenuProps {
   job: DataDesignerJob;
   /** Include a "View details" entry. Used in the table row, omitted on the details page. */
   includeViewDetails?: boolean;
+  /** When provided, adds a "View config" entry that invokes this callback. */
+  onViewConfig?: () => void;
   /** Called after the job is successfully deleted, e.g. to navigate away from the details page. */
   onDeleted?: () => void;
   /** Surface a cancel error (or `undefined` to clear) so the caller can render it. */
@@ -37,6 +39,7 @@ interface DataDesignerJobActionsMenuProps {
 export const DataDesignerJobActionsMenu: FC<DataDesignerJobActionsMenuProps> = ({
   job,
   includeViewDetails = false,
+  onViewConfig,
   onDeleted,
   onCancelError,
 }) => {
@@ -89,6 +92,14 @@ export const DataDesignerJobActionsMenu: FC<DataDesignerJobActionsMenuProps> = (
                 navigate(getDataDesignerJobDetailsRoute(workspace, job.name));
               }
             },
+          },
+        ]
+      : []),
+    ...(onViewConfig
+      ? [
+          {
+            label: 'View config',
+            onSelect: onViewConfig,
           },
         ]
       : []),

--- a/web/packages/studio/src/components/FileRowEditor/FileHeader.tsx
+++ b/web/packages/studio/src/components/FileRowEditor/FileHeader.tsx
@@ -9,10 +9,6 @@ import { type ChangeEvent, type FC, type ReactNode, type RefObject } from 'react
 
 export interface FileHeaderProps {
   fileName: string;
-  /**
-   * Replaces the static file name with a custom node (e.g. a file picker) so the header
-   * doubles as the file selector. The format tag and stats still reflect {@link fileName}.
-   */
   slotFileName?: ReactNode;
   fileFormat: DataFileFormat;
   rowCount: number;

--- a/web/packages/studio/src/components/FileRowEditor/FileHeader.tsx
+++ b/web/packages/studio/src/components/FileRowEditor/FileHeader.tsx
@@ -5,10 +5,15 @@ import { Button, Flex, Spinner, Stack, Tag, Text } from '@nvidia/foundations-rea
 import { FILE_FORMAT_TAG_COLOR } from '@studio/components/FileRowEditor/constants';
 import type { DataFileFormat } from '@studio/components/FileRowEditor/parse';
 import { Download, FileSpreadsheet, FolderOpen, Plus, Save } from 'lucide-react';
-import { type ChangeEvent, type FC, type RefObject } from 'react';
+import { type ChangeEvent, type FC, type ReactNode, type RefObject } from 'react';
 
 export interface FileHeaderProps {
   fileName: string;
+  /**
+   * Replaces the static file name with a custom node (e.g. a file picker) so the header
+   * doubles as the file selector. The format tag and stats still reflect {@link fileName}.
+   */
+  slotFileName?: ReactNode;
   fileFormat: DataFileFormat;
   rowCount: number;
   columnCount: number;
@@ -42,6 +47,7 @@ export interface FileHeaderProps {
 /** Header summary + toolbar for the {@link FileRowEditor}: file identity, stats, actions. */
 export const FileHeader: FC<FileHeaderProps> = ({
   fileName,
+  slotFileName,
   fileFormat,
   rowCount,
   columnCount,
@@ -62,13 +68,15 @@ export const FileHeader: FC<FileHeaderProps> = ({
 }) => (
   <Flex align="center" gap="density-md" className="w-full shrink-0">
     <Flex align="center" justify="center" className="size-10 shrink-0 rounded-md bg-surface-sunken">
-      <FileSpreadsheet size={20} className="text-secondary" />
+      <FileSpreadsheet className="size-20 text-secondary" />
     </Flex>
     <Stack gap="density-xs" className="min-w-0 flex-1">
-      <Flex align="center" gap="density-sm">
-        <Text kind="title/xs" className="truncate">
-          {fileName}
-        </Text>
+      <Flex align="center" gap="density-sm" className="min-w-0">
+        {slotFileName ?? (
+          <Text kind="title/xs" className="truncate">
+            {fileName}
+          </Text>
+        )}
         <Tag kind="solid" color={FILE_FORMAT_TAG_COLOR[fileFormat]} readOnly>
           {fileFormat === 'unknown' ? 'FILE' : fileFormat.toUpperCase()}
         </Tag>

--- a/web/packages/studio/src/components/FileRowEditor/index.tsx
+++ b/web/packages/studio/src/components/FileRowEditor/index.tsx
@@ -32,11 +32,24 @@ import {
   type DataFileRow,
 } from '@studio/components/FileRowEditor/types';
 import { Trash } from 'lucide-react';
-import { type ChangeEvent, type FC, useCallback, useMemo, useRef, useState } from 'react';
+import {
+  type ChangeEvent,
+  type FC,
+  type ReactNode,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 export interface FileRowEditorProps {
   /** File name shown in the header. Its extension drives the format chip. */
   fileName?: string;
+  /**
+   * Replaces the header's static file name with a custom node (e.g. a file picker), letting
+   * the header double as the file selector. The format chip and stats still track `fileName`.
+   */
+  slotFileName?: ReactNode;
   /** File size label shown in the header summary. */
   fileSizeLabel?: string;
   /**
@@ -81,6 +94,7 @@ export interface FileRowEditorProps {
  */
 export const FileRowEditor: FC<FileRowEditorProps> = ({
   fileName: fileNameProp = 'qa-sft-dataset-v1.parquet',
+  slotFileName,
   fileSizeLabel: fileSizeLabelProp = '4.2 MB',
   columns: columnsProp,
   initialRows = [],
@@ -227,8 +241,6 @@ export const FileRowEditor: FC<FileRowEditorProps> = ({
   const handleOpenFileClick = () => fileInputRef.current?.click();
 
   const handleDownload = () => {
-    // Parquet/unknown files have no in-browser binary form, so export the current rows as
-    // JSON; text formats round-trip to their own extension.
     const downloadFormat: DataFileFormat = TEXT_PARSEABLE_FORMATS.includes(fileFormat)
       ? fileFormat
       : 'json';
@@ -247,7 +259,6 @@ export const FileRowEditor: FC<FileRowEditorProps> = ({
 
   const handleFileSelected = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    // Reset the input so selecting the same file again re-triggers change.
     event.target.value = '';
     if (!file) {
       return;
@@ -282,6 +293,7 @@ export const FileRowEditor: FC<FileRowEditorProps> = ({
     <Stack gap="density-xl" className={`h-full w-full min-w-0 ${className ?? ''}`}>
       <FileHeader
         fileName={fileName}
+        slotFileName={slotFileName}
         fileFormat={fileFormat}
         rowCount={rows.length}
         columnCount={columns.length}

--- a/web/packages/studio/src/components/FilesTable/CreateFileSplitsModal/FileSplitsSliders/index.tsx
+++ b/web/packages/studio/src/components/FilesTable/CreateFileSplitsModal/FileSplitsSliders/index.tsx
@@ -104,6 +104,7 @@ export const FileSplitsSliders: FC = () => {
         render={({ field }) => (
           <Flex gap="density-sm" align="center" className="*:flex-1">
             <SliderWithTextInput
+              size="compact"
               field={field}
               defaultValue={field.value}
               min={0}
@@ -140,7 +141,6 @@ export const FileSplitsSliders: FC = () => {
                   className: 'max-w-[64px]',
                   onFocus: () => setIsFocused(fieldName),
                   onBlur: () => setIsFocused(null),
-                  // Prevent the user from submitting form on enter
                   onKeyDown: (e) => {
                     if (e.key === 'Enter') {
                       e.preventDefault();

--- a/web/packages/studio/src/components/FilesTable/CreateFileSplitsModal/index.tsx
+++ b/web/packages/studio/src/components/FilesTable/CreateFileSplitsModal/index.tsx
@@ -249,7 +249,7 @@ export const CreateFileSplitsModal: FC<Props> = ({
               <ControlledRadioGroup
                 orientation="horizontal"
                 defaultValue="random"
-                className="flex w-full! [&>*]:flex-1"
+                className="flex w-full! *:flex-1"
                 items={[
                   { children: 'Random', value: 'random' },
                   { children: 'Sequential', value: 'sequential' },

--- a/web/packages/studio/src/components/FilesTable/CreateFileSplitsModal/index.tsx
+++ b/web/packages/studio/src/components/FilesTable/CreateFileSplitsModal/index.tsx
@@ -20,6 +20,7 @@ import {
   CreateFileSplitsFormFields,
   createFileSplitsSchema,
 } from '@studio/components/FilesTable/CreateFileSplitsModal/types';
+import { LeftTruncatedText } from '@studio/components/LeftTruncatedText';
 import { ValueWithLabel } from '@studio/components/ValueWithLabel';
 import { useSelectedDatasetId } from '@studio/hooks/useSelectedDatasetId';
 import { tooltipClassName } from '@studio/styles/common';
@@ -31,23 +32,46 @@ import { ComponentProps, FC, useMemo } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 
 interface Props extends Pick<ComponentProps<typeof FormModal>, 'open' | 'onClose'> {
+  /** Fixed source file. When set, the file is shown read-only. */
   filepath?: string;
+  /**
+   * Dataset/fileset reference (`workspace/name`) whose files are being split.
+   * Falls back to the route's selected dataset when omitted.
+   */
+  datasetId?: string;
+  /**
+   * Selectable source files. When provided (and no fixed `filepath`), the modal
+   * renders a picker so the user chooses which file to split.
+   */
+  fileOptions?: string[];
 }
 
 /**
  * This modal is used to handle splitting a larger file
  * into smaller files for training/validation/evaluation.
  */
-export const CreateFileSplitsModal: FC<Props> = ({ open, onClose, filepath }) => {
+export const CreateFileSplitsModal: FC<Props> = ({
+  open,
+  onClose,
+  filepath,
+  datasetId,
+  fileOptions,
+}) => {
   const toast = useToast();
-  const datasetId = useSelectedDatasetId();
-  const datasetNameSplit = getPartsFromReference(datasetId);
+  const resolvedDatasetId = useSelectedDatasetId({ datasetId });
+  const datasetNameSplit = getPartsFromReference(resolvedDatasetId);
+
+  const defaultFilepath =
+    filepath ??
+    fileOptions?.find((path) => /\.(json|jsonl|parquet)$/i.test(path)) ??
+    fileOptions?.[0] ??
+    '';
 
   const formMethods = useForm<CreateFileSplitsFormFields>({
     mode: 'onChange',
     resolver: zodResolver(createFileSplitsSchema),
     defaultValues: {
-      filepath,
+      filepath: defaultFilepath,
       splitDescriptor: SELECT_SPLIT_OPTIONS[0],
       training: 80,
       testing: 20,
@@ -64,9 +88,14 @@ export const CreateFileSplitsModal: FC<Props> = ({ open, onClose, filepath }) =>
     onClose();
   };
 
-  const { data: fileContent, isLoading: isLoadingFileContent } = useDatasetFileContent({
+  const {
+    data: fileContent,
+    isLoading: isLoadingFileContent,
+    error: fileContentError,
+  } = useDatasetFileContent({
     ...datasetNameSplit,
     path: filepathForm,
+    fullContent: true,
   });
   const { total_rows } = useMemo(() => {
     const contentSchema = getContentSchema(fileContent, {
@@ -127,7 +156,7 @@ export const CreateFileSplitsModal: FC<Props> = ({ open, onClose, filepath }) =>
         )}
         onClose={resetAndClose}
         disabled={isPending}
-        submitDisabled={isLoadingFileContent}
+        submitDisabled={isLoadingFileContent || Boolean(fileContentError)}
         loading={isPending}
       >
         <Stack gap="density-xl">
@@ -135,13 +164,36 @@ export const CreateFileSplitsModal: FC<Props> = ({ open, onClose, filepath }) =>
             To fine-tune and evaluate a model, you need to split a dataset into three subsets:
             training data, validation data, and test data.
           </Text>
-          <ValueWithLabel
-            labelProps={{ className: 'font-bold' }}
-            label="Source File"
-            value={filepath}
-          />
+          {filepath || !fileOptions?.length ? (
+            <ValueWithLabel
+              labelProps={{ className: 'font-bold' }}
+              label="Source File"
+              value={filepathForm}
+            />
+          ) : (
+            <ControlledSelect
+              items={fileOptions.map((path) => ({
+                value: path,
+                children: <LeftTruncatedText>{path}</LeftTruncatedText>,
+              }))}
+              renderValue={(value) => <LeftTruncatedText>{value}</LeftTruncatedText>}
+              formFieldProps={{
+                attributes: { Popover: { className: tooltipClassName } },
+                slotLabel: <Label className="font-bold">Source File</Label>,
+              }}
+              useControllerProps={{ control, name: 'filepath' }}
+            />
+          )}
           <Divider />
-          {isLoadingFileContent ? (
+          {fileContentError ? (
+            <Banner
+              kind="inline"
+              status="error"
+              attributes={{ BannerIcon: { className: 'self-start' } }}
+            >
+              {fileContentError.message}
+            </Banner>
+          ) : isLoadingFileContent ? (
             <Flex justify="center" align="center" className="h-full py-[80px]">
               <Spinner description="Loading file content..." />
             </Flex>

--- a/web/packages/studio/src/components/FilesTable/CreateFileSplitsModal/index.tsx
+++ b/web/packages/studio/src/components/FilesTable/CreateFileSplitsModal/index.tsx
@@ -32,17 +32,8 @@ import { ComponentProps, FC, useMemo } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 
 interface Props extends Pick<ComponentProps<typeof FormModal>, 'open' | 'onClose'> {
-  /** Fixed source file. When set, the file is shown read-only. */
   filepath?: string;
-  /**
-   * Dataset/fileset reference (`workspace/name`) whose files are being split.
-   * Falls back to the route's selected dataset when omitted.
-   */
   datasetId?: string;
-  /**
-   * Selectable source files. When provided (and no fixed `filepath`), the modal
-   * renders a picker so the user chooses which file to split.
-   */
   fileOptions?: string[];
 }
 

--- a/web/packages/studio/src/components/LeftTruncatedText/index.tsx
+++ b/web/packages/studio/src/components/LeftTruncatedText/index.tsx
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Text } from '@nvidia/foundations-react-core';
+import cn from 'classnames';
+import { ComponentProps, FC } from 'react';
+
+interface LeftTruncatedTextProps extends ComponentProps<typeof Text> {
+  /** The string to render with left-side truncation (ellipsis at the start). */
+  children: string;
+}
+
+/**
+ * Renders text that truncates from the left, keeping the end of the string
+ * (e.g. the file name at the tail of a long path) visible. The `<bdi>` wrapper
+ * preserves the string's natural character order despite the RTL flip that
+ * moves the ellipsis to the start.
+ *
+ * Defaults to `kind="inherit"` so it adopts the surrounding text style; pass
+ * `kind` (or any other Text prop) to override.
+ */
+export const LeftTruncatedText: FC<LeftTruncatedTextProps> = ({
+  children,
+  className,
+  kind = 'inherit',
+  ...props
+}) => (
+  <Text {...props} kind={kind} dir="rtl" className={cn('block truncate text-left', className)}>
+    <bdi>{children}</bdi>
+  </Text>
+);

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
@@ -12,7 +12,6 @@ import {
   SelectTrigger,
   Spinner,
   Stack,
-  Text,
 } from '@nvidia/foundations-react-core';
 import {
   EDITOR_MAX_BYTES,
@@ -73,7 +72,6 @@ export const JobDatasetEditorSection: FC = () => {
   const { filesetWorkspace, filesetName, files, isResultsLoading, isFilesLoading } =
     useDataDesignerArtifactsFileset();
 
-  // Data files only — exclude the builder config and any non-row formats.
   const dataFiles = useMemo(
     () =>
       files.filter(
@@ -190,40 +188,46 @@ export const JobDatasetEditorSection: FC = () => {
 
   const isResolving = isResultsLoading || isFilesLoading;
 
+  // Rendered inside the editor's header (as `slotFileName`) so the file picker and the file
+  // identity share one row; falls back to a slim bar above the centered states below.
   const fileSelector =
     dataFiles.length > 1 ? (
-      <Flex align="center" gap="density-sm" className="shrink-0">
-        <Text kind="label/semibold/sm" className="text-secondary">
-          File
-        </Text>
-        <SelectRoot
-          value={selectedPath ?? defaultPath ?? undefined}
-          onValueChange={(value: string) => setSelectedPath(value)}
-        >
-          <SelectTrigger
-            placeholder="Select a file"
-            renderValue={(value) =>
-              typeof value === 'string' ? (
-                <span className="block max-w-[200px] truncate text-left [direction:rtl]">
-                  {getFileNameFromPath(value)}
-                </span>
-              ) : null
-            }
-          />
-          <SelectContent className="w-(--radix-popper-anchor-width)">
-            <SelectListbox>
-              {dataFiles.map((file) => (
-                <SelectItem key={file.path} value={file.path}>
-                  {getFileNameFromPath(file.path)}
-                </SelectItem>
-              ))}
-            </SelectListbox>
-          </SelectContent>
-        </SelectRoot>
-      </Flex>
+      <SelectRoot
+        value={selectedPath ?? defaultPath ?? undefined}
+        onValueChange={(value: string) => setSelectedPath(value)}
+      >
+        <SelectTrigger
+          placeholder="Select a file"
+          className="max-w-[280px]"
+          renderValue={(value) =>
+            typeof value === 'string' ? (
+              <span className="block truncate text-left [direction:rtl]">
+                {getFileNameFromPath(value)}
+              </span>
+            ) : null
+          }
+        />
+        <SelectContent className="w-(--radix-popper-anchor-width)">
+          <SelectListbox>
+            {dataFiles.map((file) => (
+              <SelectItem key={file.path} value={file.path}>
+                {getFileNameFromPath(file.path)}
+              </SelectItem>
+            ))}
+          </SelectListbox>
+        </SelectContent>
+      </SelectRoot>
     ) : null;
 
-  const renderBody = () => {
+  const showEditor =
+    dataFiles.length > 0 &&
+    !isTooLargeToEdit &&
+    !isContentLoading &&
+    parsed != null &&
+    !isContentError &&
+    !parsed.error;
+
+  const renderCenteredState = () => {
     if (isResolving && dataFiles.length === 0) {
       return centered(<Spinner aria-label="Loading job data" description="Loading job data..." />);
     }
@@ -259,31 +263,28 @@ export const JobDatasetEditorSection: FC = () => {
       );
     }
 
-    if (parsed.error) {
-      return centered(<Empty title="Could not parse file" description={parsed.error} />);
-    }
-
-    return (
-      <FileRowEditor
-        key={selectedPath}
-        fileName={selectedPath ?? undefined}
-        fileSizeLabel={selectedFile ? getHumanReadableFileSize(selectedFile.size) : undefined}
-        initialRows={parsed.rows}
-        showOpenFile={false}
-        onSaveFile={handleSaveFile}
-        isSaving={isSaving}
-      />
-    );
+    return centered(<Empty title="Could not parse file" description={parsed.error ?? undefined} />);
   };
 
   return (
     <Stack gap="density-md" className="h-full min-h-0 min-w-0 w-full">
-      {fileSelector ? (
-        <Flex align="center" justify="start" className="shrink-0">
-          {fileSelector}
-        </Flex>
-      ) : null}
-      <Stack className="min-h-0 min-w-0 w-full flex-1">{renderBody()}</Stack>
+      {showEditor ? (
+        <FileRowEditor
+          key={selectedPath}
+          slotFileName={fileSelector}
+          fileName={selectedPath ?? undefined}
+          fileSizeLabel={selectedFile ? getHumanReadableFileSize(selectedFile.size) : undefined}
+          initialRows={parsed?.rows ?? []}
+          showOpenFile={false}
+          onSaveFile={handleSaveFile}
+          isSaving={isSaving}
+        />
+      ) : (
+        <>
+          {fileSelector ? <Flex className="shrink-0">{fileSelector}</Flex> : null}
+          <Stack className="min-h-0 min-w-0 w-full flex-1">{renderCenteredState()}</Stack>
+        </>
+      )}
     </Stack>
   );
 };

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection.tsx
@@ -188,8 +188,6 @@ export const JobDatasetEditorSection: FC = () => {
 
   const isResolving = isResultsLoading || isFilesLoading;
 
-  // Rendered inside the editor's header (as `slotFileName`) so the file picker and the file
-  // identity share one row; falls back to a slim bar above the centered states below.
   const fileSelector =
     dataFiles.length > 1 ? (
       <SelectRoot

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
@@ -16,16 +16,18 @@ import {
 } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { DataDesignerJobActionsMenu } from '@studio/components/DataDesignerJobActionsMenu';
+import { CreateFileSplitsModal } from '@studio/components/FilesTable/CreateFileSplitsModal';
 import { Loading } from '@studio/components/Layouts/Loading';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { DataDesignerConfigPanel } from '@studio/routes/DataDesignerJobDetailsRoute/DataDesignerConfigPanel';
 import { DatasetProfilerSection } from '@studio/routes/DataDesignerJobDetailsRoute/DatasetProfilerSection';
 import { JobDatasetEditorSection } from '@studio/routes/DataDesignerJobDetailsRoute/JobDatasetEditorSection';
 import { JobOutputFilesetSection } from '@studio/routes/DataDesignerJobDetailsRoute/JobOutputFilesetSection';
+import { useDataDesignerArtifactsFileset } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerArtifactsFileset';
 import { useDataDesignerJobFromRoute } from '@studio/routes/DataDesignerJobDetailsRoute/useDataDesignerJobFromRoute';
 import { getDataDesignerJobListRoute } from '@studio/routes/utils';
 import { formatDateTime } from '@studio/util/date';
-import { ArrowLeft, FileJson } from 'lucide-react';
+import { ArrowLeft, Split } from 'lucide-react';
 import { useState, type FC } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
@@ -41,7 +43,14 @@ export const DataDesignerJobDetailsRoute: FC = () => {
 
   const navigate = useNavigate();
   const [isConfigPanelOpen, setIsConfigPanelOpen] = useState(false);
+  const [isSplitModalOpen, setIsSplitModalOpen] = useState(false);
   const [cancelError, setCancelError] = useState<string | undefined>(undefined);
+
+  const { filesetWorkspace, filesetName, files } = useDataDesignerArtifactsFileset();
+  const splitDatasetId =
+    filesetWorkspace && filesetName ? `${filesetWorkspace}/${filesetName}` : undefined;
+  const splitFileOptions = files.map((file) => file.path);
+  const canSplit = Boolean(splitDatasetId) && splitFileOptions.length > 0;
 
   useBreadcrumbs({
     items: [
@@ -92,11 +101,18 @@ export const DataDesignerJobDetailsRoute: FC = () => {
               {job.status ? <StatusBadge status={job.status} /> : null}
             </Flex>
             <Flex gap="density-md" align="center">
-              <Button type="button" kind="secondary" onClick={() => setIsConfigPanelOpen(true)}>
-                <FileJson /> View config
+              <Button
+                type="button"
+                kind="primary"
+                color="brand"
+                disabled={!canSplit}
+                onClick={() => setIsSplitModalOpen(true)}
+              >
+                <Split /> Split
               </Button>
               <DataDesignerJobActionsMenu
                 job={job}
+                onViewConfig={() => setIsConfigPanelOpen(true)}
                 onDeleted={() => navigate(getDataDesignerJobListRoute(workspace))}
                 onCancelError={setCancelError}
               />
@@ -151,6 +167,15 @@ export const DataDesignerJobDetailsRoute: FC = () => {
         open={isConfigPanelOpen}
         onClose={() => setIsConfigPanelOpen(false)}
       />
+
+      {isSplitModalOpen && (
+        <CreateFileSplitsModal
+          open
+          onClose={() => setIsSplitModalOpen(false)}
+          datasetId={splitDatasetId}
+          fileOptions={splitFileOptions}
+        />
+      )}
     </AccessibleTitle>
   );
 };

--- a/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobDetailsRoute/index.tsx
@@ -49,7 +49,9 @@ export const DataDesignerJobDetailsRoute: FC = () => {
   const { filesetWorkspace, filesetName, files } = useDataDesignerArtifactsFileset();
   const splitDatasetId =
     filesetWorkspace && filesetName ? `${filesetWorkspace}/${filesetName}` : undefined;
-  const splitFileOptions = files.map((file) => file.path);
+  const splitFileOptions = files
+    .map((file) => file.path)
+    .filter((path) => /\.(json|jsonl|parquet)$/i.test(path));
   const canSplit = Boolean(splitDatasetId) && splitFileOptions.length > 0;
 
   useBreadcrumbs({


### PR DESCRIPTION
<img width="1505" height="781" alt="Screenshot 2026-07-22 at 3 17 14 PM" src="https://github.com/user-attachments/assets/04f54d39-9a38-4a2c-a373-8df5e0af8b44" />

feat(studio): Split file into training set in DD details

Signed-off-by: Sean Teramae <steramae@nvidia.com>

fix lint

Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added “Split” support on the job details view, including a split modal with source-file selection and validation.
  - Added an optional “View config” quick action for data designer jobs.

- **Improvements**
  - Split uploads now generate consistent `.json`/`.jsonl` output names per split.
  - Enhanced file editing experience with improved loading/error/empty states and selectable source handling.
  - Added header customization via `slotFileName` and improved long-name rendering with left-side truncation.
  - Updated split sliders to a more compact layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->