### PR TITLE
feat(studio): Support images in chat from b64 encoded responses

### DIFF
--- a/web/packages/common/src/components/AssistantChat/completionUtils.test.ts
+++ b/web/packages/common/src/components/AssistantChat/completionUtils.test.ts
@@ -4,7 +4,7 @@
 import type { ChatCompletionChunk } from 'openai/resources/index.mjs';
 import type { Stream } from 'openai/streaming.mjs';
 
-import { isChatCompletionStream } from './completionUtils';
+import { getCompletionImages, isChatCompletionStream } from './completionUtils';
 
 describe('isChatCompletionStream', () => {
   it('returns false for nullish values', () => {
@@ -21,5 +21,34 @@ describe('isChatCompletionStream', () => {
     } as unknown as Stream<ChatCompletionChunk>;
 
     expect(isChatCompletionStream(stream)).toBe(true);
+  });
+});
+
+describe('getCompletionImages', () => {
+  it('extracts base64 image URLs from an image-model stream delta', () => {
+    const imageUrl = 'data:image/png;base64,iVBORw0KGgo=';
+
+    expect(
+      getCompletionImages({
+        choices: [{ delta: { images: [{ image_url: { url: imageUrl } }] } }],
+      })
+    ).toEqual([{ type: 'image', image: imageUrl }]);
+  });
+
+  it('ignores non-image and non-data URLs', () => {
+    expect(
+      getCompletionImages({
+        choices: [
+          {
+            delta: {
+              images: [
+                { image_url: { url: 'https://example.com/image.png' } },
+                { image_url: { url: 'data:text/plain;base64,SGVsbG8=' } },
+              ],
+            },
+          },
+        ],
+      })
+    ).toEqual([]);
   });
 });

--- a/web/packages/common/src/components/AssistantChat/completionUtils.test.ts
+++ b/web/packages/common/src/components/AssistantChat/completionUtils.test.ts
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  getCompletionImages,
+  isChatCompletionStream,
+} from '@nemo/common/src/components/AssistantChat/completionUtils';
 import type { ChatCompletionChunk } from 'openai/resources/index.mjs';
 import type { Stream } from 'openai/streaming.mjs';
-
-import { getCompletionImages, isChatCompletionStream } from './completionUtils';
 
 describe('isChatCompletionStream', () => {
   it('returns false for nullish values', () => {
@@ -35,6 +37,16 @@ describe('getCompletionImages', () => {
     ).toEqual([{ type: 'image', image: imageUrl }]);
   });
 
+  it('extracts base64 image URLs from a non-stream message payload', () => {
+    const imageUrl = 'data:image/png;base64,iVBORw0KGgo=';
+
+    expect(
+      getCompletionImages({
+        choices: [{ message: { images: [{ image_url: { url: imageUrl } }] } }],
+      })
+    ).toEqual([{ type: 'image', image: imageUrl }]);
+  });
+
   it('ignores non-image and non-data URLs', () => {
     expect(
       getCompletionImages({
@@ -44,6 +56,23 @@ describe('getCompletionImages', () => {
               images: [
                 { image_url: { url: 'https://example.com/image.png' } },
                 { image_url: { url: 'data:text/plain;base64,SGVsbG8=' } },
+              ],
+            },
+          },
+        ],
+      })
+    ).toEqual([]);
+  });
+
+  it('ignores image data URLs with malformed base64 payloads', () => {
+    expect(
+      getCompletionImages({
+        choices: [
+          {
+            delta: {
+              images: [
+                { image_url: { url: 'data:image/png;base64,not base64!' } },
+                { image_url: { url: 'data:image/png;base64,' } },
               ],
             },
           },

--- a/web/packages/common/src/components/AssistantChat/completionUtils.ts
+++ b/web/packages/common/src/components/AssistantChat/completionUtils.ts
@@ -4,6 +4,53 @@
 import type { ChatCompletion, ChatCompletionChunk } from 'openai/resources/index.mjs';
 import type { Stream } from 'openai/streaming.mjs';
 
+interface ImageResponsePart {
+  type: 'image';
+  image: string;
+}
+
+const isImageDataUrl = (value: unknown): value is string =>
+  typeof value === 'string' && /^data:image\/[a-z0-9.+-]+;base64,/i.test(value);
+
+/**
+ * Extracts image data URLs from OpenAI-compatible image-model extensions.
+ *
+ * Some image providers return generated images in `images[].image_url.url`,
+ * which is not part of the OpenAI SDK's ChatCompletionChunk type. Keep this
+ * narrow so arbitrary provider extensions cannot become renderable image URLs.
+ */
+export const getCompletionImages = (completion: unknown): ImageResponsePart[] => {
+  if (typeof completion !== 'object' || completion === null || !('choices' in completion)) {
+    return [];
+  }
+
+  const firstChoice = Array.isArray(completion.choices) ? completion.choices[0] : undefined;
+  if (typeof firstChoice !== 'object' || firstChoice === null) {
+    return [];
+  }
+
+  const responsePart =
+    'delta' in firstChoice
+      ? firstChoice.delta
+      : 'message' in firstChoice
+        ? firstChoice.message
+        : null;
+  if (typeof responsePart !== 'object' || responsePart === null || !('images' in responsePart)) {
+    return [];
+  }
+
+  const images = responsePart.images;
+  if (!Array.isArray(images)) return [];
+
+  return images.flatMap((image) => {
+    if (typeof image !== 'object' || image === null || !('image_url' in image)) return [];
+    const imageUrl = image.image_url;
+    if (typeof imageUrl !== 'object' || imageUrl === null || !('url' in imageUrl)) return [];
+
+    return isImageDataUrl(imageUrl.url) ? [{ type: 'image', image: imageUrl.url }] : [];
+  });
+};
+
 export const isChatCompletionStream = (
   value: ChatCompletion | Stream<ChatCompletionChunk> | null | undefined
 ): value is Stream<ChatCompletionChunk> =>

--- a/web/packages/common/src/components/AssistantChat/completionUtils.ts
+++ b/web/packages/common/src/components/AssistantChat/completionUtils.ts
@@ -5,12 +5,14 @@ import type { ChatCompletion, ChatCompletionChunk } from 'openai/resources/index
 import type { Stream } from 'openai/streaming.mjs';
 
 interface ImageResponsePart {
-  type: 'image';
-  image: string;
+  readonly type: 'image';
+  readonly image: string;
 }
 
+const IMAGE_DATA_URL_PATTERN = /^data:image\/[a-z0-9.+-]+;base64,([A-Za-z0-9+/]+={0,2})$/i;
+
 const isImageDataUrl = (value: unknown): value is string =>
-  typeof value === 'string' && /^data:image\/[a-z0-9.+-]+;base64,/i.test(value);
+  typeof value === 'string' && IMAGE_DATA_URL_PATTERN.test(value);
 
 /**
  * Extracts image data URLs from OpenAI-compatible image-model extensions.

--- a/web/packages/common/src/components/AssistantChat/index.test.tsx
+++ b/web/packages/common/src/components/AssistantChat/index.test.tsx
@@ -64,6 +64,22 @@ const createCompletionChunk = (content: string): ChatCompletionChunk => ({
   ],
 });
 
+const createImageCompletionChunk = (imageUrl: string): ChatCompletionChunk =>
+  ({
+    id: 'completion-id',
+    object: 'chat.completion.chunk',
+    created: 1740419165,
+    model: 'test-image-model',
+    choices: [
+      {
+        index: 0,
+        delta: { images: [{ image_url: { url: imageUrl } }] },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  }) as unknown as ChatCompletionChunk;
+
 const createHangingStream = (content: string): Stream<ChatCompletionChunk> => {
   const controller = new AbortController();
   const waitForAbort = () =>
@@ -178,6 +194,27 @@ describe('AssistantChat', () => {
     },
     interactionTimeoutMs
   );
+
+  it('renders base64 images returned by an image model stream', async () => {
+    const imageUrl = 'data:image/png;base64,iVBORw0KGgo=';
+    const stream = {
+      controller: new AbortController(),
+      async *[Symbol.asyncIterator]() {
+        yield createImageCompletionChunk(imageUrl);
+      },
+    } as unknown as Stream<ChatCompletionChunk>;
+    mocks.createChatCompletion.mockResolvedValueOnce(stream);
+
+    renderAssistantChat(<AssistantChat model="test-image-model" workspace="default" />);
+
+    await userEvent.type(screen.getByRole('textbox', { name: /Task prompt/i }), 'Make an image');
+    await userEvent.click(screen.getByRole('button', { name: /Submit/i }));
+
+    expect(await screen.findByRole('img', { name: /Attached image/i })).toHaveAttribute(
+      'src',
+      imageUrl
+    );
+  });
 
   it(
     'clears the current thread',

--- a/web/packages/common/src/components/AssistantChat/useAssistantChatRuntime.ts
+++ b/web/packages/common/src/components/AssistantChat/useAssistantChatRuntime.ts
@@ -8,24 +8,27 @@ import {
   SimpleImageAttachmentAdapter,
   useExternalStoreRuntime,
 } from '@assistant-ui/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
-
 import {
   getCompletionImages,
   getCompletionText,
   isAbortError,
   isChatCompletionStream,
-} from './completionUtils';
-import { CANCELLED_STATUS, COMPLETE_STATUS, RUNNING_STATUS } from './constants';
+} from '@nemo/common/src/components/AssistantChat/completionUtils';
+import {
+  CANCELLED_STATUS,
+  COMPLETE_STATUS,
+  RUNNING_STATUS,
+} from '@nemo/common/src/components/AssistantChat/constants';
 import {
   appendMessageToThreadMessage,
   createTextMessage,
   getEditedMessageIndex,
   getOpenAIMessages,
   getUserMessageContent,
-} from './messageUtils';
-import type { AssistantChatProps } from './types';
-import { useChatCompletion } from '../../hooks/useChatCompletion';
+} from '@nemo/common/src/components/AssistantChat/messageUtils';
+import type { AssistantChatProps } from '@nemo/common/src/components/AssistantChat/types';
+import { useChatCompletion } from '@nemo/common/src/hooks/useChatCompletion';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const imageAttachmentAdapter = new SimpleImageAttachmentAdapter();
 

--- a/web/packages/common/src/components/AssistantChat/useAssistantChatRuntime.ts
+++ b/web/packages/common/src/components/AssistantChat/useAssistantChatRuntime.ts
@@ -10,7 +10,12 @@ import {
 } from '@assistant-ui/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { getCompletionText, isAbortError, isChatCompletionStream } from './completionUtils';
+import {
+  getCompletionImages,
+  getCompletionText,
+  isAbortError,
+  isChatCompletionStream,
+} from './completionUtils';
 import { CANCELLED_STATUS, COMPLETE_STATUS, RUNNING_STATUS } from './constants';
 import {
   appendMessageToThreadMessage,
@@ -70,13 +75,18 @@ export const useAssistantChatRuntime = ({
   }, []);
 
   const updateAssistantMessage = useCallback(
-    (assistantMessageId: string, text: string, status: MessageStatus) => {
+    (
+      assistantMessageId: string,
+      text: string,
+      images: readonly { type: 'image'; image: string }[],
+      status: MessageStatus
+    ) => {
       setThreadMessages(
         messagesRef.current.map((message) =>
           message.id === assistantMessageId
             ? {
                 ...message,
-                content: [{ type: 'text', text }],
+                content: [{ type: 'text', text }, ...images],
                 status,
               }
             : message
@@ -99,6 +109,7 @@ export const useAssistantChatRuntime = ({
       setThreadMessages([...conversationMessages, assistantMessage]);
       setIsRunning(true);
       let responseText = '';
+      const responseImages: { type: 'image'; image: string }[] = [];
       // Timing for per-message metrics (TTFT, total, tokens/sec). Emitted via
       // onMessageComplete so callers (e.g. Studio's Chat route) can render a
       // stats badge without owning the runtime.
@@ -121,7 +132,12 @@ export const useAssistantChatRuntime = ({
         });
 
         if (runController.signal.aborted || !isCurrentRun()) {
-          updateAssistantMessage(assistantMessage.id!, responseText, CANCELLED_STATUS);
+          updateAssistantMessage(
+            assistantMessage.id!,
+            responseText,
+            responseImages,
+            CANCELLED_STATUS
+          );
           return;
         }
 
@@ -134,16 +150,24 @@ export const useAssistantChatRuntime = ({
           for await (const chunk of result) {
             if (runController.signal.aborted || !isCurrentRun()) break;
             const delta = chunk.choices[0]?.delta.content ?? '';
-            if (delta) {
+            const images = getCompletionImages(chunk);
+            if (delta || images.length > 0) {
               if (ttftMs === 0) ttftMs = Math.round(performance.now() - startMs);
               responseText += delta;
+              responseImages.push(...images);
               chunkCount += 1;
-              updateAssistantMessage(assistantMessage.id!, responseText, RUNNING_STATUS);
+              updateAssistantMessage(
+                assistantMessage.id!,
+                responseText,
+                responseImages,
+                RUNNING_STATUS
+              );
             }
           }
           updateAssistantMessage(
             assistantMessage.id!,
             responseText,
+            responseImages,
             runController.signal.aborted ? CANCELLED_STATUS : COMPLETE_STATUS
           );
           if (!runController.signal.aborted && onMessageComplete) {
@@ -166,7 +190,12 @@ export const useAssistantChatRuntime = ({
           }
         } else {
           const text = getCompletionText(result);
-          updateAssistantMessage(assistantMessage.id!, text, COMPLETE_STATUS);
+          updateAssistantMessage(
+            assistantMessage.id!,
+            text,
+            getCompletionImages(result),
+            COMPLETE_STATUS
+          );
           if (onMessageComplete) {
             const totalMs = Math.round(performance.now() - startMs);
             const completionTokens = Math.round(text.length / 4);
@@ -183,7 +212,12 @@ export const useAssistantChatRuntime = ({
         }
       } catch (error: unknown) {
         if (runController.signal.aborted || isAbortError(error)) {
-          updateAssistantMessage(assistantMessage.id!, responseText, CANCELLED_STATUS);
+          updateAssistantMessage(
+            assistantMessage.id!,
+            responseText,
+            responseImages,
+            CANCELLED_STATUS
+          );
           return;
         }
 
@@ -193,7 +227,7 @@ export const useAssistantChatRuntime = ({
           reason: 'error',
           error: errorMessage,
         };
-        updateAssistantMessage(assistantMessage.id!, errorMessage, status);
+        updateAssistantMessage(assistantMessage.id!, errorMessage, responseImages, status);
         onError?.(error instanceof Error ? error : new Error(errorMessage));
       } finally {
         if (abortControllerRef.current === runController) {


### PR DESCRIPTION
<img width="593" height="845" alt="Screenshot 2026-07-22 at 4 58 53 PM" src="https://github.com/user-attachments/assets/5d8bad41-88b2-4705-a5b6-8af6ad602dd0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant responses can now include and display images alongside text.
  * Image attachments are supported for both streaming and non-streaming completions.
  * Images are only rendered when they are valid `data:image/<type>;base64,...` URLs, improving safety and resilience (including during cancellation/error updates).

* **Tests**
  * Added coverage for image extraction from both streaming and non-stream payloads.
  * Added tests for filtering invalid image URLs and handling malformed base64.
  * Added rendering verification to ensure images appear in chat responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->