### PR TITLE
feat(studio): Support cloning a DD job

### DIFF
--- a/web/packages/studio/src/components/DataDesignerJobActionsMenu/index.tsx
+++ b/web/packages/studio/src/components/DataDesignerJobActionsMenu/index.tsx
@@ -14,7 +14,7 @@ import {
   QuickActionsMenuRoot,
 } from '@studio/components/QuickActionsMenu/QuickActionsMenuRoot';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
-import { getDataDesignerJobDetailsRoute, getNewDataDesignerJobRoute } from '@studio/routes/utils';
+import { getDataDesignerJobBuildRoute, getDataDesignerJobDetailsRoute } from '@studio/routes/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { type FC, useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -62,7 +62,7 @@ export const DataDesignerJobActionsMenu: FC<DataDesignerJobActionsMenuProps> = (
   const handleClone = useCallback(() => {
     const cloneJobRequest = buildClonedJobRequest(job);
     if (!cloneJobRequest) return;
-    navigate(getNewDataDesignerJobRoute(workspace), {
+    navigate(getDataDesignerJobBuildRoute(workspace), {
       state: { cloneJobRequest },
     });
   }, [job, navigate, workspace]);

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.test.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.test.ts
@@ -7,6 +7,7 @@ import type { ColumnTypeOption } from '@studio/components/AddColumnPalette/types
 import { FILESET_TEMPLATES } from '@studio/components/CreateFilesetStart/templates';
 import {
   type BuilderColumn,
+  buildColumnsFromConfig,
   buildColumnsFromTemplate,
   buildDataDesignerConfig,
   buildGraph,
@@ -553,6 +554,66 @@ describe('topologicalSortColumns', () => {
       column('c2', 'two', 'expression', { expr: '{{ one }}' }),
     ];
     expect(ids(topologicalSortColumns(input)).sort()).toEqual(['c1', 'c2']);
+  });
+});
+
+describe('buildColumnsFromConfig', () => {
+  it('round-trips a mixed recipe: config → columns → config is stable', () => {
+    const original = [
+      column('a', 'domain', 'sampler', { values: 'a, b, c', weights: '3, 1, 1' }, 'category'),
+      column('b', 'score', 'sampler', { mean: '1.5', stddev: '0.25' }, 'gaussian'),
+      column('c', 'answer', 'llm-text', {
+        prompt: 'Answer about {{ domain }}',
+        model_alias: 'default',
+      }),
+      column('d', 'structured', 'llm-structured', {
+        prompt: 'Structure {{ answer }}',
+        model_alias: 'default',
+        output_format: '{ "type": "object" }',
+      }),
+    ];
+    const config = buildDataDesignerConfig(original);
+
+    const rebuilt = buildColumnsFromConfig(config);
+    expect(rebuilt.map((c) => c.name)).toEqual(['domain', 'score', 'answer', 'structured']);
+    expect(rebuilt.map((c) => c.option.columnType)).toEqual([
+      'sampler',
+      'sampler',
+      'llm-text',
+      'llm-structured',
+    ]);
+    expect(buildDataDesignerConfig(rebuilt)).toEqual(config);
+  });
+
+  it('reconstructs the seed-dataset column from seed_config', () => {
+    const config = buildDataDesignerConfig([
+      column('a', 'seed', 'seed-dataset', {
+        fileset_ref: 'default/my-fileset',
+        file_path: 'data.parquet',
+        sampling_strategy: 'shuffle',
+      }),
+      column('b', 'graded', 'llm-text', { prompt: 'Grade {{ answer }}', model_alias: 'default' }),
+    ]);
+
+    const rebuilt = buildColumnsFromConfig(config);
+    const seed = rebuilt.find((c) => c.option.columnType === 'seed-dataset');
+    expect(seed?.values).toEqual({
+      fileset_ref: 'default/my-fileset',
+      file_path: 'data.parquet',
+      sampling_strategy: 'shuffle',
+    });
+    expect(buildDataDesignerConfig(rebuilt).seed_config).toEqual(config.seed_config);
+  });
+
+  it('numbers ids from startId and skips column types absent from the palette', () => {
+    const config = buildDataDesignerConfig([
+      column('a', 'answer', 'llm-text', { prompt: 'Hi', model_alias: 'default' }),
+    ]);
+    config.columns.push({ name: 'mystery', column_type: 'not-a-type' } as never);
+
+    const rebuilt = buildColumnsFromConfig(config, 5);
+    expect(rebuilt).toHaveLength(1);
+    expect(rebuilt[0]).toMatchObject({ id: 'col-5', name: 'answer' });
   });
 });
 

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/columns.ts
@@ -4,7 +4,9 @@
 import {
   type DataDesignerConfig,
   DatetimeSamplerParamsUnit,
+  type FilesetFileSeedSource,
   PersonSamplerParamsSex,
+  type SamplerColumnConfig,
   SamplerType,
   type SamplingStrategy,
   type SeedConfig,
@@ -972,4 +974,125 @@ export const buildDataDesignerConfig = (
   const seedConfig = buildSeedConfig(columns);
   if (seedConfig) config.seed_config = seedConfig;
   return config;
+};
+
+/**
+ * Inverse of {@link serializeFieldValue}: renders a column config's stored value back into
+ * the string form the builder edits. Mirrors the same {@link ColumnField.dataType} branches
+ * so a config → builder → config round-trip reproduces the original value. JSON fields are
+ * pretty-printed for readability in the textarea.
+ */
+const deserializeFieldValue = (field: ColumnField, raw: unknown): string => {
+  if (raw == null) return '';
+  if (field.dataType === 'json' || field.key === 'output_format') {
+    return JSON.stringify(raw, null, 2);
+  }
+  switch (field.dataType) {
+    case 'number':
+      return String(raw);
+    case 'boolean':
+      return raw ? 'true' : 'false';
+    case 'number-list':
+      return Array.isArray(raw) ? raw.join(', ') : String(raw);
+    default:
+      return field.list || field.reference === 'list'
+        ? Array.isArray(raw)
+          ? raw.join(', ')
+          : String(raw)
+        : String(raw);
+  }
+};
+
+/**
+ * Reconstructs a column's `values` record from its SDK config. Sampler param fields are read
+ * from the nested `params` object; every other field (including a sampler's `convert_to`)
+ * reads from the config's top level, matching how {@link toColumnConfig}/{@link toSamplerConfig}
+ * wrote them.
+ */
+const valuesFromConfig = (
+  option: ColumnTypeOption,
+  columnConfig: Record<string, unknown>
+): Record<string, string> => {
+  const values: Record<string, string> = {};
+  const paramKeys =
+    option.columnType === 'sampler'
+      ? new Set(getSamplerParamFields(option.samplerType).map((field) => field.key))
+      : null;
+  const params = (columnConfig.params as Record<string, unknown> | undefined) ?? {};
+
+  for (const field of getColumnFields(option)) {
+    const source = paramKeys?.has(field.key) ? params : columnConfig;
+    const value = deserializeFieldValue(field, source[field.key]);
+    if (value !== '') values[field.key] = value;
+  }
+  return values;
+};
+
+/** Inverse of {@link buildSeedFilesetPath}: splits `{fileset}#{file}` back into its parts. */
+const parseSeedFilesetPath = (path: string): { filesetRef: string; filePath: string } => {
+  const hashIndex = path.indexOf('#');
+  if (hashIndex === -1) return { filesetRef: path, filePath: '' };
+  return { filesetRef: path.slice(0, hashIndex), filePath: path.slice(hashIndex + 1) };
+};
+
+/**
+ * Rebuilds the builder's seed-dataset column from `seed_config` (which is where
+ * {@link buildDataDesignerConfig} moves seed columns — they never live in `config.columns`).
+ * Only NMP fileset sources map back; other seed source kinds aren't builder-editable. The
+ * seed file's discovered columns aren't recoverable from the config, so `available_columns`
+ * stays empty until the fileset is re-inspected.
+ */
+const seedColumnFromConfig = (
+  seedConfig: SeedConfig | undefined,
+  id: string
+): BuilderColumn | null => {
+  const source = seedConfig?.source as FilesetFileSeedSource | undefined;
+  if (!source || source.seed_type !== 'nmp' || typeof source.path !== 'string') return null;
+  const option = findColumnOption({ columnType: 'seed-dataset' });
+  if (!option) return null;
+
+  const { filesetRef, filePath } = parseSeedFilesetPath(source.path);
+  const values: Record<string, string> = {
+    [SEED_FILESET_REF_KEY]: filesetRef,
+    [SEED_FILE_PATH_KEY]: filePath,
+  };
+  if (seedConfig?.sampling_strategy) {
+    values[SEED_SAMPLING_STRATEGY_KEY] = seedConfig.sampling_strategy;
+  }
+  return { id, option, name: 'seed', values };
+};
+
+/**
+ * Reverses {@link buildDataDesignerConfig} into builder columns so an existing job's config
+ * can pre-fill the build canvas (used when cloning a job). Column configs whose type isn't in
+ * the palette are skipped; the seed column is reconstructed from `seed_config`.
+ */
+export const buildColumnsFromConfig = (
+  config: DataDesignerConfig,
+  startId = 0
+): BuilderColumn[] => {
+  const columns: BuilderColumn[] = [];
+  let nextId = startId;
+
+  const seedColumn = seedColumnFromConfig(config.seed_config, `col-${nextId}`);
+  if (seedColumn) {
+    columns.push(seedColumn);
+    nextId++;
+  }
+
+  for (const columnConfig of config.columns) {
+    if (columnConfig.column_type === 'seed-dataset') continue;
+    const option = findColumnOption({
+      columnType: columnConfig.column_type,
+      samplerType: (columnConfig as SamplerColumnConfig).sampler_type,
+    });
+    if (!option) continue;
+    columns.push({
+      id: `col-${nextId++}`,
+      option,
+      name: columnConfig.name,
+      values: valuesFromConfig(option, columnConfig as unknown as Record<string, unknown>),
+    });
+  }
+  return columns;
 };

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
@@ -11,6 +11,7 @@ import { getErrorMessage } from '@studio/api/common/utils';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { findTemplate } from '@studio/components/CreateFilesetStart/templates';
 import { usePreview } from '@studio/components/NewDataDesignerJobForm/usePreview';
+import { getCloneJobRequestFromState } from '@studio/components/NewDataDesignerJobForm/utils';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { BuilderCanvas } from '@studio/routes/DataDesignerJobBuildRoute/BuilderCanvas';
@@ -22,15 +23,20 @@ import {
   type BuilderViewMode,
 } from '@studio/routes/DataDesignerJobBuildRoute/BuilderToolbar';
 import {
+  buildColumnsFromConfig,
   buildDataDesignerConfig,
   validateColumns,
 } from '@studio/routes/DataDesignerJobBuildRoute/columns';
 import {
+  buildModelsFromConfig,
   buildServedModelNames,
   validateModels,
 } from '@studio/routes/DataDesignerJobBuildRoute/models';
 import { SchemaList } from '@studio/routes/DataDesignerJobBuildRoute/SchemaList';
-import { useJobBuilder } from '@studio/routes/DataDesignerJobBuildRoute/useJobBuilder';
+import {
+  type JobBuilderSeed,
+  useJobBuilder,
+} from '@studio/routes/DataDesignerJobBuildRoute/useJobBuilder';
 import {
   getDataDesignerJobDetailsRoute,
   getDataDesignerJobListRoute,
@@ -39,7 +45,7 @@ import {
 import { type FC, useCallback, useMemo, useState } from 'react';
 import { FormProvider } from 'react-hook-form';
 import { useAuth } from 'react-oidc-context';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 /**
  * Edges are derived from entered values: Jinja2 `{{ column_name }}` references (and
@@ -50,14 +56,30 @@ export const DataDesignerJobBuildRoute: FC = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
+  const { state: locationState } = useLocation();
 
-  // `?template=<id>` seeds the canvas from a template recipe; absent = empty canvas.
   const template = useMemo(() => {
     const templateId = searchParams.get('template');
     return templateId ? (findTemplate(templateId) ?? null) : null;
   }, [searchParams]);
 
-  const heading = template ? template.title : 'Build from scratch';
+  const cloneSeed = useMemo<JobBuilderSeed | null>(() => {
+    const cloneRequest = getCloneJobRequestFromState(locationState);
+    if (!cloneRequest?.spec) return null;
+    const { config, num_records } = cloneRequest.spec;
+    return {
+      name: cloneRequest.name ?? 'untitled-dataset',
+      rows: String(num_records),
+      columns: buildColumnsFromConfig(config),
+      models: buildModelsFromConfig(config.model_configs),
+    };
+  }, [locationState]);
+
+  const heading = cloneSeed
+    ? `Clone of ${cloneSeed.name}`
+    : template
+      ? template.title
+      : 'Build from scratch';
 
   useBreadcrumbs({
     items: [
@@ -82,7 +104,7 @@ export const DataDesignerJobBuildRoute: FC = () => {
   );
   const modelsSettled = !isLoadingModels && !hasNextPage && !isFetchingNextPage;
 
-  const builder = useJobBuilder(template, modelGroups, modelsSettled);
+  const builder = useJobBuilder(template, modelGroups, modelsSettled, cloneSeed);
   const { data: providersPage } = useModelsListProviders(
     workspace,
     { page_size: DEFAULT_LARGE_PAGE_SIZE },

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/models.test.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/models.test.ts
@@ -6,6 +6,7 @@ import type { ModelProvider } from '@nemo/sdk/generated/platform/schema';
 import {
   type BuilderModel,
   buildModelConfigs,
+  buildModelsFromConfig,
   buildModelsFromTemplate,
   buildServedModelNames,
   builderModelFromSelection,
@@ -209,6 +210,52 @@ describe('validateModels', () => {
       model({ id: 'model-1', alias: 'dupe' }),
     ]);
     expect(errors.filter((e) => e.includes('already exists'))).toHaveLength(2);
+  });
+});
+
+describe('buildModelsFromConfig', () => {
+  it('reverses chat-completion model configs, numbering ids from startId', () => {
+    const configs = buildModelConfigs([
+      model({ alias: 'gen', inferenceParams: { temperature: 0.7, top_p: 0.9, max_tokens: 512 } }),
+    ]);
+
+    expect(buildModelsFromConfig(configs, 2)).toEqual([
+      {
+        id: 'model-2',
+        alias: 'gen',
+        model: 'nvidia/llama-3.3-nemotron-super-49b-v1',
+        provider: 'nvidia',
+        inferenceParams: {
+          generation_type: 'chat-completion',
+          temperature: 0.7,
+          top_p: 0.9,
+          max_tokens: 512,
+        },
+      },
+    ]);
+  });
+
+  it('preserves embedding params so a config round-trips unchanged', () => {
+    const models = [
+      model({
+        id: 'model-0',
+        alias: 'embedder',
+        model: 'nvidia/nv-embedqa-e5-v5',
+        provider: 'steramae/build',
+        inferenceParams: {
+          generation_type: 'embedding',
+          encoding_format: 'float',
+          extra_body: { input_type: 'query' },
+        },
+      }),
+    ];
+    const configs = buildModelConfigs(models);
+
+    expect(buildModelConfigs(buildModelsFromConfig(configs))).toEqual(configs);
+  });
+
+  it('returns an empty array for an absent model_configs list', () => {
+    expect(buildModelsFromConfig()).toEqual([]);
   });
 });
 

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/models.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/models.ts
@@ -207,3 +207,42 @@ export const buildModelConfigs = (
   servedModelNames: Map<string, string> = new Map()
 ): ModelConfig[] | undefined =>
   models.length > 0 ? models.map((model) => toModelConfig(model, servedModelNames)) : undefined;
+
+/**
+ * Inverse of {@link toInferenceParameters}: maps an SDK inference-parameter object back into
+ * the loose {@link InferenceParams} shape the builder edits, keeping the `generation_type`
+ * marker so embedding models round-trip through {@link toInferenceParameters} unchanged.
+ */
+const inferenceParamsFromConfig = (
+  params: ModelConfig['inference_parameters']
+): Partial<InferenceParams> => {
+  if (!params) return {};
+  if (params.generation_type === 'embedding') {
+    const inference: Partial<InferenceParams> = { generation_type: 'embedding' };
+    if (params.encoding_format) inference.encoding_format = params.encoding_format;
+    if (params.extra_body) inference.extra_body = params.extra_body;
+    if (typeof params.dimensions === 'number') inference.dimensions = params.dimensions;
+    return inference;
+  }
+
+  const chat = params as ChatCompletionInferenceParams;
+  const inference: Partial<InferenceParams> = { generation_type: 'chat-completion' };
+  if (typeof chat.temperature === 'number') inference.temperature = chat.temperature;
+  if (typeof chat.top_p === 'number') inference.top_p = chat.top_p;
+  if (typeof chat.max_tokens === 'number') inference.max_tokens = chat.max_tokens;
+  return inference;
+};
+
+/**
+ * Reverses {@link buildModelConfigs} into builder models so an existing job's `model_configs`
+ * can pre-fill the build canvas (used when cloning a job). The stored `model` is the served
+ * model name; it is preserved verbatim so the cloned job submits the same config.
+ */
+export const buildModelsFromConfig = (configs: ModelConfig[] = [], startId = 0): BuilderModel[] =>
+  configs.map((config, index) => ({
+    id: `model-${startId + index}`,
+    alias: config.alias,
+    model: config.model,
+    provider: config.provider ?? '',
+    inferenceParams: inferenceParamsFromConfig(config.inference_parameters),
+  }));

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/useJobBuilder.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/useJobBuilder.ts
@@ -39,6 +39,17 @@ export interface JobBuilderValues {
 }
 
 /**
+ * Fully-formed initial builder state used to clone an existing job. When present it seeds the
+ * form instead of the template, so the canvas opens pre-filled with the source job's schema.
+ */
+export interface JobBuilderSeed {
+  name: string;
+  rows: string;
+  columns: BuilderColumn[];
+  models: BuilderModel[];
+}
+
+/**
  * Column/model state for the recipe builder. Selecting a column and selecting a model are
  * mutually exclusive — only one config panel shows at a time.
  *
@@ -47,20 +58,26 @@ export interface JobBuilderValues {
  *
  * `modelGroups` auto-fills a template's seeded models once the platform model list loads.
  * `modelsSettled` gates that auto-fill on the full (all-pages) model list being available.
+ *
+ * `seed`, when provided (cloning a job), takes precedence over the template and pre-fills the
+ * form with the source job's columns, models, name, and row count.
  */
 export const useJobBuilder = (
   template: FilesetTemplate | null,
   modelGroups: ModelWorkspaceGroup[],
-  modelsSettled: boolean
+  modelsSettled: boolean,
+  seed: JobBuilderSeed | null = null
 ) => {
-  // Seed once from the template (if any). `useForm` keeps these values outside the route's
-  // render cycle, so a field edit notifies only components that subscribe to that field.
-  const initialColumns = useRef(template ? buildColumnsFromTemplate(template.columns) : []);
-  const initialModels = useRef(buildModelsFromTemplate(template?.models));
+  // Seed once from the clone source, else the template (if any). `useForm` keeps these values
+  // outside the route's render cycle, so a field edit notifies only subscribing components.
+  const initialColumns = useRef(
+    seed ? seed.columns : template ? buildColumnsFromTemplate(template.columns) : []
+  );
+  const initialModels = useRef(seed ? seed.models : buildModelsFromTemplate(template?.models));
   const form = useForm<JobBuilderFormValues>({
     defaultValues: {
-      name: template?.id ?? 'untitled-dataset',
-      rows: '100',
+      name: seed?.name ?? template?.id ?? 'untitled-dataset',
+      rows: seed?.rows ?? '100',
       columns: initialColumns.current,
       models: initialModels.current,
     },


### PR DESCRIPTION

<img width="431" height="469" alt="Screenshot 2026-07-23 at 12 25 33 PM" src="https://github.com/user-attachments/assets/db383e04-cd1a-46af-9983-fffe20feb57c" />

Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to clone existing data designer jobs.
  * Cloned jobs open in the builder with their name, row count, columns, models, and configuration prefilled.
  * Added support for preserving sampler, seed-dataset, chat-completion, and embedding settings when cloning.
  * Unsupported column types are skipped during reconstruction.

* **Bug Fixes**
  * Improved handling of cloned job settings and model configuration details in the builder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->