### PR TITLE
fix(deployments): handle Docker restart races

### DIFF
--- a/packages/nmp_customization_common/src/nmp/customization_common/config.py
+++ b/packages/nmp_customization_common/src/nmp/customization_common/config.py
@@ -7,7 +7,7 @@ from nmp.common.config import create_service_config_class, get_service_config
 from pydantic import Field
 
 
-class CustomizationCommonConfig(create_service_config_class("customizer")):  # type: ignore[misc]
+class CustomizationCommonConfig(create_service_config_class("customizer")):  # ty: ignore[unsupported-base]
     """Environment variables use the ``NMP_CUSTOMIZER_`` prefix."""
 
     tasks_image: str | None = Field(

--- a/plugins/nemo-agents/examples/calculator-agent/src/calculator_agent/register.py
+++ b/plugins/nemo-agents/examples/calculator-agent/src/calculator_agent/register.py
@@ -8,10 +8,10 @@
 
 from collections.abc import AsyncGenerator
 
-from nat.builder.builder import Builder  # type: ignore
-from nat.builder.function import FunctionGroup  # type: ignore
-from nat.cli.register_workflow import register_function_group  # type: ignore
-from nat.data_models.function import FunctionGroupBaseConfig  # type: ignore
+from nat.builder.builder import Builder
+from nat.builder.function import FunctionGroup
+from nat.cli.register_workflow import register_function_group
+from nat.data_models.function import FunctionGroupBaseConfig
 from pydantic import Field
 
 

--- a/plugins/nemo-deployments/openapi/openapi.yaml
+++ b/plugins/nemo-deployments/openapi/openapi.yaml
@@ -649,7 +649,10 @@ components:
           default: Always
         backoff_limit:
           type: integer
+          minimum: 1.0
           title: Backoff Limit
+          description: Retry limit for OnFailure deployments; must be positive. Never
+            deployments disable retries internally.
           default: 6
         drift_recovery:
           $ref: '#/components/schemas/DriftRecoveryPolicy'
@@ -897,7 +900,10 @@ components:
           default: Always
         backoffLimit:
           type: integer
+          minimum: 1.0
           title: Backofflimit
+          description: Retry limit for OnFailure deployments; must be positive. Never
+            deployments disable retries internally.
           default: 6
         driftRecovery:
           $ref: '#/components/schemas/DriftRecoveryPolicy'

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
@@ -78,7 +78,7 @@ from nemo_deployments_plugin.secrets import (
     SecretResolutionError,
     resolve_deployment_config_secrets,
 )
-from nemo_deployments_plugin.types import Endpoint, RestartPolicy
+from nemo_deployments_plugin.types import NON_TERMINAL_DEPLOYMENT_STATUSES, Endpoint, RestartPolicy
 from nemo_platform_plugin.capabilities import docker_from_env_kwargs, probe_docker
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.config import LOOPBACK_ADDRESSES
@@ -137,6 +137,21 @@ def _config_files_tar(config_files: list[ConfigFile]) -> bytes:
             info.mode = 0o644
             tar.addfile(info, io.BytesIO(data))
     return buf.getvalue()
+
+
+def _docker_inspect_attrs(container: DockerContainer) -> dict[str, Any]:
+    return container.attrs or {}
+
+
+def _docker_inspect_exit_code(container: DockerContainer) -> int:
+    state = _docker_inspect_attrs(container).get("State") or {}
+    if not isinstance(state, dict):
+        return 1
+    return int(state.get("ExitCode", 1))
+
+
+def _docker_inspect_restart_count(container: DockerContainer) -> int:
+    return int(_docker_inspect_attrs(container).get("RestartCount", 0))
 
 
 class DockerDeploymentBackend(DeploymentBackend):
@@ -676,12 +691,15 @@ class DockerDeploymentBackend(DeploymentBackend):
             container = await asyncio.to_thread(self._client.containers.get, c_name)
             if not self._container_matches_deployment_group(container, workspace, name):
                 restart_policy = await self._resolve_restart_policy(workspace, name)
-                return missing_container_status(restart_policy, container_name=c_name)
+                status_update = missing_container_status(restart_policy, container_name=c_name)
+                if status_update.status not in NON_TERMINAL_DEPLOYMENT_STATUSES and self._gpu_pool is not None:
+                    self._gpu_pool.release_gpu(dep_key)
+                return status_update
             await asyncio.to_thread(container.reload)
         except self._docker_errors.NotFound:
             restart_policy = await self._resolve_restart_policy(workspace, name)
             status_update = missing_container_status(restart_policy, container_name=c_name)
-            if restart_policy in _ONE_SHOT_RESTART_POLICIES and self._gpu_pool is not None:
+            if status_update.status not in NON_TERMINAL_DEPLOYMENT_STATUSES and self._gpu_pool is not None:
                 self._gpu_pool.release_gpu(dep_key)
             return status_update
         except (
@@ -751,8 +769,8 @@ class DockerDeploymentBackend(DeploymentBackend):
             )
 
         if state in ("exited", "dead"):
-            exit_code = int(container.attrs.get("State", {}).get("ExitCode", 1))
-            restart_count = int(container.attrs.get("RestartCount", 0))
+            exit_code = _docker_inspect_exit_code(container)
+            restart_count = _docker_inspect_restart_count(container)
             return self._status_from_exited_container(
                 exit_code=exit_code,
                 restart_policy=restart_policy,
@@ -805,6 +823,13 @@ class DockerDeploymentBackend(DeploymentBackend):
             )
         if restart_policy == "OnFailure":
             backoff_limit = int(labels.get(BACKOFF_LIMIT_LABEL, "6"))
+            if backoff_limit == 0:
+                return BackendStatusUpdate(
+                    status="STARTING",
+                    status_message=(f"Container exited (code {exit_code}); retry {restart_count}/unlimited"),
+                    exit_code=exit_code,
+                    endpoints=resolved_endpoints,
+                )
             if restart_count < backoff_limit:
                 return BackendStatusUpdate(
                     status="STARTING",
@@ -887,9 +912,8 @@ class DockerDeploymentBackend(DeploymentBackend):
                 endpoints=endpoints,
             )
         if container.status in _EXITED_CONTAINER_STATES:
-            attrs = container.attrs or {}
-            exit_code = int(attrs.get("State", {}).get("ExitCode", 1))
-            restart_count = int(attrs.get("RestartCount", 0))
+            exit_code = _docker_inspect_exit_code(container)
+            restart_count = _docker_inspect_restart_count(container)
             return self._status_from_exited_container(
                 exit_code=exit_code,
                 restart_policy=restart_policy,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/containers.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/containers.py
@@ -95,6 +95,8 @@ def restart_policy_kwargs(restart_policy: RestartPolicy, backoff_limit: int) -> 
     if restart_policy == "Always":
         return {"restart_policy": {"Name": "always"}}
     if restart_policy == "OnFailure":
+        if backoff_limit < 1:
+            raise DeploymentConfigError("backoff_limit must be at least 1 for OnFailure restart policy")
         return {"restart_policy": {"Name": "on-failure", "MaximumRetryCount": backoff_limit}}
     return {}
 

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
@@ -285,7 +285,12 @@ class DeploymentConfig(NemoEntity, entity_type=ENTITY_TYPE_DEPLOYMENT_CONFIG):
     volume_mounts: list[VolumeMount] = Field(default_factory=list, alias="volumeMounts")
     config_files: list[ConfigFile] = Field(default_factory=list, alias="configFiles")
     restart_policy: RestartPolicy = Field(default="Always", alias="restartPolicy")
-    backoff_limit: int = Field(default=6, alias="backoffLimit")
+    backoff_limit: int = Field(
+        default=6,
+        ge=1,
+        alias="backoffLimit",
+        description="Retry limit for OnFailure deployments; must be positive. Never deployments disable retries internally.",
+    )
     drift_recovery: DriftRecoveryPolicy = Field(default_factory=DriftRecoveryPolicy, alias="driftRecovery")
     labels: dict[str, str] = Field(default_factory=dict)
     backend_config: DeploymentBackendConfig = Field(default_factory=DeploymentBackendConfig, alias="backendConfig")

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/schema.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/schema.py
@@ -86,7 +86,11 @@ class CreateDeploymentConfigRequest(BaseModel):
     volume_mounts: list[VolumeMount] = Field(default_factory=list)
     config_files: list[ConfigFile] = Field(default_factory=list)
     restart_policy: RestartPolicy = "Always"
-    backoff_limit: int = 6
+    backoff_limit: int = Field(
+        default=6,
+        ge=1,
+        description="Retry limit for OnFailure deployments; must be positive. Never deployments disable retries internally.",
+    )
     drift_recovery: DriftRecoveryPolicy | None = None
     labels: dict[str, str] = Field(default_factory=dict)
     backend_config: DeploymentBackendConfig = Field(default_factory=DeploymentBackendConfig)

--- a/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
+++ b/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
@@ -49,8 +49,19 @@ def _worker_port_base(worker_id: str) -> int:
     return TEST_PORT_RANGE_START + worker_index * TEST_PORT_RANGE_SIZE
 
 
-def _build_docker_backend(worker_id: str = "master", **config_overrides: Any) -> DockerDeploymentBackend:
-    mock_entities = AsyncMock()
+@pytest.fixture
+def mock_entities() -> AsyncMock:
+    return AsyncMock()
+
+
+def _build_docker_backend(
+    worker_id: str = "master",
+    *,
+    mock_entities: AsyncMock | None = None,
+    **config_overrides: Any,
+) -> DockerDeploymentBackend:
+    if mock_entities is None:
+        mock_entities = AsyncMock()
     mock_sdk = MagicMock()
     port_base = _worker_port_base(worker_id)
     executor_config: dict[str, Any] = {
@@ -70,8 +81,8 @@ def _build_docker_backend(worker_id: str = "master", **config_overrides: Any) ->
 
 
 @pytest.fixture
-def docker_backend(worker_id: str) -> DockerDeploymentBackend:
-    return _build_docker_backend(worker_id)
+def docker_backend(worker_id: str, mock_entities: AsyncMock) -> DockerDeploymentBackend:
+    return _build_docker_backend(worker_id, mock_entities=mock_entities)
 
 
 def _never_config() -> DeploymentConfig:
@@ -148,9 +159,12 @@ async def test_volume_lifecycle(docker_backend: DockerDeploymentBackend) -> None
 
 
 @pytest.mark.asyncio
-async def test_never_deployment_succeeds(docker_backend: DockerDeploymentBackend) -> None:
+async def test_never_deployment_succeeds(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+) -> None:
     config = _never_config()
-    docker_backend._entities.get.return_value = config  # ty: ignore[unresolved-attribute]
+    mock_entities.get.return_value = config
     c_name = container_name("itest", "echo-job")
     client = docker.from_env()
 
@@ -189,7 +203,14 @@ async def test_never_deployment_outlives_observe_wait_then_succeeds(worker_id: s
         oneshot_observe_timeout_seconds=observe_timeout_seconds,
     )
     config = _never_sleep_config(sleep_seconds=job_sleep_seconds)
-    docker_backend._entities.get.return_value = config  # ty: ignore[unresolved-attribute]
+    deployment = Deployment(name="sleep-job", workspace="itest", deployment_config="sleep-cfg")
+
+    async def get_side_effect(entity_type, name, workspace=None):
+        if entity_type is Deployment:
+            return deployment
+        return config
+
+    docker_backend._entities.get.side_effect = get_side_effect  # ty: ignore[unresolved-attribute]
     c_name = container_name("itest", "sleep-job")
     client = docker.from_env()
 
@@ -233,7 +254,55 @@ async def test_never_deployment_outlives_observe_wait_then_succeeds(worker_id: s
 
 
 @pytest.mark.asyncio
-async def test_lost_detection_for_always(docker_backend: DockerDeploymentBackend) -> None:
+async def test_removed_never_deployment_reports_missing(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+) -> None:
+    config = _never_config()
+    deployment = Deployment(name="removed-job", workspace="itest", deployment_config="echo-cfg")
+
+    async def get_side_effect(entity_type, name, workspace=None):
+        if entity_type is Deployment:
+            return deployment
+        return config
+
+    mock_entities.get.side_effect = get_side_effect
+    c_name = container_name("itest", "removed-job")
+    client = docker.from_env()
+
+    try:
+        created = await docker_backend.create_deployment(
+            workspace="itest",
+            name="removed-job",
+            config_name="echo-cfg",
+            labels={"managed-by": MANAGED_BY_LABEL},
+            backend_config={},
+        )
+        assert created.status == "SUCCEEDED"
+        assert created.exit_code == 0
+
+        container = client.containers.get(c_name)
+        result = container.wait(timeout=20)
+        assert result["StatusCode"] == 0
+        container.remove(force=True)
+
+        status = await docker_backend.read_status(workspace="itest", name="removed-job")
+
+        assert status.status == "FAILED"
+        assert status.exit_code is None
+        assert status.error_details == {
+            "expected_container_name": c_name,
+        }
+    finally:
+        await docker_backend.delete_deployment("itest", "removed-job")
+        force_remove_container(client, c_name)
+
+
+@pytest.mark.asyncio
+async def test_lost_detection_for_always(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+) -> None:
     deployment = Deployment(name="lost-srv", workspace="itest", deployment_config="http-cfg")
     config = _always_http_config()
 
@@ -242,7 +311,7 @@ async def test_lost_detection_for_always(docker_backend: DockerDeploymentBackend
             return deployment
         return config
 
-    docker_backend._entities.get.side_effect = get_side_effect  # ty: ignore[unresolved-attribute]
+    mock_entities.get.side_effect = get_side_effect
     c_name = container_name("itest", "lost-srv")
     client = docker.from_env()
 

--- a/plugins/nemo-deployments/tests/unit/backends/docker/docker_helpers.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/docker_helpers.py
@@ -119,9 +119,9 @@ def lora_config(*, restart_policy: RestartPolicy = "Always") -> DeploymentConfig
     )
 
 
-def container_attrs(*, status: str = "running", exit_code: int = 0) -> dict[str, Any]:
+def container_attrs(*, status: str = "running", exit_code: int = 0, restart_count: int = 0) -> dict[str, Any]:
     del status
     return {
         "State": {"ExitCode": exit_code, "StartedAt": "2026-01-01T00:00:00Z"},
-        "RestartCount": 0,
+        "RestartCount": restart_count,
     }

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
@@ -976,15 +976,145 @@ async def test_read_status_failed_and_releases_gpu_when_missing_one_shot(
 
 
 @pytest.mark.asyncio
+async def test_read_status_observes_exited_never_container_without_removing(
+    docker_backend: DockerDeploymentBackend,
+    mock_docker_client: MagicMock,
+) -> None:
+    container = MagicMock()
+    container.id = "abc123def456"
+    container.status = "exited"
+    container.labels = {
+        "managed-by": MANAGED_BY_LABEL,
+        DEPLOYMENT_WORKSPACE_LABEL: "default",
+        DEPLOYMENT_NAME_LABEL: "job",
+        RESTART_POLICY_LABEL: "Never",
+        CONFIG_NAME_LABEL: "cfg1",
+        RESOURCE_SCOPE_LABEL: DEFAULT_RESOURCE_SCOPE,
+    }
+    container.ports = {}
+    container.attrs = container_attrs(exit_code=0)
+    mock_docker_client.containers.get.return_value = container
+
+    update = await docker_backend.read_status(workspace="default", name="job")
+
+    assert update.status == "SUCCEEDED"
+    assert update.exit_code == 0
+    container.remove.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_read_status_retries_exited_on_failure_container_under_backoff_limit(
+    docker_backend: DockerDeploymentBackend,
+    mock_docker_client: MagicMock,
+) -> None:
+    container = MagicMock()
+    container.id = "abc123def456"
+    container.status = "exited"
+    container.labels = {
+        "managed-by": MANAGED_BY_LABEL,
+        DEPLOYMENT_WORKSPACE_LABEL: "default",
+        DEPLOYMENT_NAME_LABEL: "job",
+        RESTART_POLICY_LABEL: "OnFailure",
+        CONFIG_NAME_LABEL: "cfg1",
+        BACKOFF_LIMIT_LABEL: "3",
+        RESOURCE_SCOPE_LABEL: DEFAULT_RESOURCE_SCOPE,
+    }
+    container.ports = {}
+    container.attrs = container_attrs(exit_code=1, restart_count=2)
+    mock_docker_client.containers.get.return_value = container
+    gpu_pool = MagicMock()
+    docker_backend._gpu_pool = gpu_pool
+
+    update = await docker_backend.read_status(workspace="default", name="job")
+
+    assert update.status == "STARTING"
+    assert update.exit_code == 1
+    assert "retry 2/3" in update.status_message
+    gpu_pool.release_gpu.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_read_status_fails_exited_on_failure_container_after_backoff_limit(
+    docker_backend: DockerDeploymentBackend,
+    mock_docker_client: MagicMock,
+) -> None:
+    container = MagicMock()
+    container.id = "abc123def456"
+    container.status = "exited"
+    container.labels = {
+        "managed-by": MANAGED_BY_LABEL,
+        DEPLOYMENT_WORKSPACE_LABEL: "default",
+        DEPLOYMENT_NAME_LABEL: "job",
+        RESTART_POLICY_LABEL: "OnFailure",
+        CONFIG_NAME_LABEL: "cfg1",
+        BACKOFF_LIMIT_LABEL: "3",
+        RESOURCE_SCOPE_LABEL: DEFAULT_RESOURCE_SCOPE,
+    }
+    container.ports = {}
+    container.attrs = container_attrs(exit_code=1, restart_count=3)
+    mock_docker_client.containers.get.return_value = container
+    gpu_pool = MagicMock()
+    docker_backend._gpu_pool = gpu_pool
+
+    update = await docker_backend.read_status(workspace="default", name="job")
+
+    assert update.status == "FAILED"
+    assert update.exit_code == 1
+    gpu_pool.release_gpu.assert_called_once_with(deployment_key("default", "job"))
+
+
+@pytest.mark.asyncio
+async def test_read_status_treats_zero_on_failure_backoff_as_unlimited(
+    docker_backend: DockerDeploymentBackend,
+    mock_docker_client: MagicMock,
+) -> None:
+    container = MagicMock()
+    container.id = "abc123def456"
+    container.status = "exited"
+    container.labels = {
+        "managed-by": MANAGED_BY_LABEL,
+        DEPLOYMENT_WORKSPACE_LABEL: "default",
+        DEPLOYMENT_NAME_LABEL: "job",
+        RESTART_POLICY_LABEL: "OnFailure",
+        CONFIG_NAME_LABEL: "cfg1",
+        BACKOFF_LIMIT_LABEL: "0",
+        RESOURCE_SCOPE_LABEL: DEFAULT_RESOURCE_SCOPE,
+    }
+    container.ports = {}
+    container.attrs = container_attrs(exit_code=1, restart_count=7)
+    mock_docker_client.containers.get.return_value = container
+    gpu_pool = MagicMock()
+    docker_backend._gpu_pool = gpu_pool
+
+    update = await docker_backend.read_status(workspace="default", name="job")
+
+    assert update.status == "STARTING"
+    assert update.exit_code == 1
+    assert "retry 7/unlimited" in update.status_message
+    gpu_pool.release_gpu.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("restart_policy", "expected_status", "should_release_gpu"),
+    [
+        ("Always", "LOST", False),
+        ("Never", "FAILED", True),
+    ],
+)
 async def test_read_status_treats_foreign_container_as_missing(
     mock_sdk: MagicMock,
     mock_entities: AsyncMock,
     mock_docker_client: MagicMock,
+    restart_policy: RestartPolicy,
+    expected_status: str,
+    should_release_gpu: bool,
 ) -> None:
+    gpu_pool = MagicMock()
     with (
         patch("nemo_deployments_plugin.backends.docker.backend.client_from_platform"),
         patch("nemo_deployments_plugin.backends.docker.backend.NemoEntitiesClient", return_value=mock_entities),
-        patch("nemo_deployments_plugin.backends.docker.backend.get_shared_gpu_pool", return_value=None),
+        patch("nemo_deployments_plugin.backends.docker.backend.get_shared_gpu_pool", return_value=gpu_pool),
         patch("docker.from_env", return_value=mock_docker_client),
     ):
         backend = DockerDeploymentBackend(
@@ -1007,14 +1137,18 @@ async def test_read_status_treats_foreign_container_as_missing(
     async def get_side_effect(entity_type, name, workspace=None):
         if entity_type is Deployment:
             return deployment_entity
-        return sample_config(restart_policy="Always")
+        return sample_config(restart_policy=restart_policy)
 
     mock_entities.get.side_effect = get_side_effect
 
     update = await backend.read_status(workspace="default", name="srv")
 
-    assert update.status == "LOST"
+    assert update.status == expected_status
     foreign.reload.assert_not_called()
+    if should_release_gpu:
+        gpu_pool.release_gpu.assert_called_once_with(deployment_key("default", "srv"))
+    else:
+        gpu_pool.release_gpu.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_restart_policy.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_restart_policy.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import pytest
-from nemo_deployments_plugin.backends.docker.containers import restart_policy_kwargs
+from nemo_deployments_plugin.backends.docker.containers import DeploymentConfigError, restart_policy_kwargs
 
 
 @pytest.mark.parametrize(
@@ -19,3 +19,8 @@ from nemo_deployments_plugin.backends.docker.containers import restart_policy_kw
 )
 def test_restart_policy_kwargs(policy: str, backoff: int, expected: dict) -> None:
     assert restart_policy_kwargs(policy, backoff) == expected  # type: ignore[arg-type]
+
+
+def test_restart_policy_kwargs_rejects_zero_on_failure_backoff() -> None:
+    with pytest.raises(DeploymentConfigError, match="backoff_limit"):
+        restart_policy_kwargs("OnFailure", 0)

--- a/plugins/nemo-deployments/tests/unit/test_api_deployment_configs.py
+++ b/plugins/nemo-deployments/tests/unit/test_api_deployment_configs.py
@@ -40,6 +40,23 @@ def test_create_deployment_config_201(client: TestClient, mock_entity_client: As
     assert resp.json()["name"] == "cfg1"
 
 
+def test_create_deployment_config_rejects_zero_backoff_limit(
+    client: TestClient,
+    mock_entity_client: AsyncMock,
+) -> None:
+    resp = client.post(
+        "/apis/deployments/v2/workspaces/default/deployment-configs",
+        json={
+            "name": "cfg1",
+            "containers": [{"name": "main", "image": "nginx"}],
+            "backoff_limit": 0,
+        },
+    )
+
+    assert resp.status_code == 422
+    mock_entity_client.create.assert_not_awaited()
+
+
 def test_get_deployment_config_404(client: TestClient, mock_entity_client: AsyncMock) -> None:
     mock_entity_client.get.side_effect = NemoEntityNotFoundError("missing")
     resp = client.get("/apis/deployments/v2/workspaces/default/deployment-configs/missing")

--- a/plugins/nemo-deployments/tests/unit/test_entities.py
+++ b/plugins/nemo-deployments/tests/unit/test_entities.py
@@ -24,6 +24,18 @@ def test_deployment_config_requires_containers_shape() -> None:
     assert cfg.containers[0].image == "nginx:latest"
 
 
+def test_deployment_config_rejects_zero_backoff_limit() -> None:
+    with pytest.raises(ValidationError):
+        DeploymentConfig.model_validate(
+            {
+                "name": "cfg",
+                "workspace": "default",
+                "containers": [Container(name="main", image="nginx:latest")],
+                "backoff_limit": 0,
+            }
+        )
+
+
 def test_volume_default_status_pending() -> None:
     vol = Volume(name="v1", workspace="default")
     assert vol.status == "PENDING"

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/strategies/evolutionary.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/strategies/evolutionary.py
@@ -460,10 +460,7 @@ class EvolutionaryStrategy(Agent, roles.Strategy):
                         result=validation_candidate_results[candidate.label],
                     )
             if config.trajectory_scorer is not None:
-                scorer = cast(
-                    "roles.TrajectoryScorer",
-                    self._trajectory_scorer(ctx, config),
-                )
+                scorer = self._trajectory_scorer(ctx, config)
                 # round_num - 1: the counter has already advanced past the round this
                 # analysis describes, and the scorer names its state after that round.
                 scored = await scorer.run(ctx, candidates=candidates, round_num=round_num - 1, analysis=analysis)

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging_runner.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging_runner.py
@@ -5,7 +5,7 @@
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from doubles import FakeBackend, fake_client
@@ -207,6 +207,4 @@ async def test_authored_metrics_and_suite_reach_the_run(
         "the strategy must receive the settled contract through the context"
     )
     assert [t.name for t in runner._config.regression_metrics] == ["reward"], "configured targets demote to guardrails"
-    assert cast(Any, distributed["suite"]).id == "insight-suite", (
-        "the authored suite must reach the splits the loop evaluates"
-    )
+    assert distributed["suite"].id == "insight-suite", "the authored suite must reach the splits the loop evaluates"

--- a/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/sdk/job_builder.py
+++ b/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/sdk/job_builder.py
@@ -167,7 +167,7 @@ class SafeSynthesizerJobBuilder:
             data_source_path = Path(self._data_source)
             match data_source_path.suffix.lower():
                 case ".parquet":
-                    df = cast(pd.DataFrame, pd.read_parquet(data_source_path, **kwargs))
+                    df = pd.read_parquet(data_source_path, **kwargs)
                 case ".jsonl":
                     df = cast(pd.DataFrame, pd.read_json(data_source_path, lines=True, **kwargs))
                 case ".json":

--- a/services/hello-world/src/nmp/hello_world/config.py
+++ b/services/hello-world/src/nmp/hello_world/config.py
@@ -7,7 +7,7 @@ from nmp.common.config import create_service_config_class
 from pydantic import Field
 
 
-class HelloWorldConfig(create_service_config_class("hello_world")):  # type: ignore[unsupported-base]
+class HelloWorldConfig(create_service_config_class("hello_world")):  # ty: ignore[unsupported-base]
     """Configuration for the Hello World service.
 
     This configuration is loaded from the 'hello_world' section of the

--- a/services/rl/src/nmp/rl/config.py
+++ b/services/rl/src/nmp/rl/config.py
@@ -12,7 +12,7 @@ from nmp.common.config import create_service_config_class, get_platform_config, 
 from pydantic import Field
 
 
-class RlConfig(create_service_config_class("rl")):  # type: ignore[misc]
+class RlConfig(create_service_config_class("rl")):  # ty: ignore[unsupported-base]
     """Environment variables use the ``NMP_RL_`` prefix."""
 
     image_registry: str | None = Field(

--- a/services/unsloth/src/nmp/unsloth/config.py
+++ b/services/unsloth/src/nmp/unsloth/config.py
@@ -12,7 +12,7 @@ from nmp.common.config import create_service_config_class, get_platform_config, 
 from pydantic import Field
 
 
-class UnslothConfig(create_service_config_class("unsloth")):  # type: ignore[misc]
+class UnslothConfig(create_service_config_class("unsloth")):  # ty: ignore[unsupported-base]
     """Environment variables use the ``NMP_UNSLOTH_`` prefix."""
 
     image_registry: str | None = Field(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Docker deployment status reads now reconcile from Docker inspect state instead of mutating containers in the read path. This preserves one-shot and retry semantics across controller restarts and avoids releasing Docker GPU allocations before a deployment reaches a terminal status.

This PR no longer carries the Authentik/Envoy keep-alive template changes; that work has already merged into `main` via #1101.

## Changes
- Read Docker `State.ExitCode` and `RestartCount` from inspect attrs for create-time status mapping and `read_status()`.
- Keep stopped `Never` containers observable and report their terminal status without removing them from `read_status()`.
- Preserve retryable `OnFailure` deployments by comparing Docker's persisted restart count with the deployment backoff limit.
- Require positive `backoffLimit` / `backoff_limit` values in `DeploymentConfig`, the create request schema, and generated OpenAPI.
- Guard Docker `on-failure` run kwargs against `MaximumRetryCount=0`, and treat legacy zero-backoff Docker labels as unlimited retry and non-terminal so GPU allocations are not released while Docker would keep retrying.
- Release Docker GPU allocations only when status handling reaches a terminal deployment result.
- Map missing containers through restart-policy-aware status so `Always` stays recoverable as `LOST` while one-shot policies report terminal failure when the backend resource is gone.
- Treat foreign resource-scope containers like missing containers, including GPU release for terminal one-shot status results.
- Add Docker unit and integration coverage for terminal containers, retryable and exhausted `OnFailure` exits, missing one-shot containers, lost `Always` containers, foreign-container mismatch handling, zero-backoff legacy handling, API/entity validation, and GPU-release behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `script/generate-openapi-spec.sh` — completed successfully.
- `uv run --frozen pytest plugins/nemo-deployments/tests/unit/test_entities.py plugins/nemo-deployments/tests/unit/test_api_deployment_configs.py plugins/nemo-deployments/tests/unit/backends/docker/test_restart_policy.py plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py plugins/nemo-deployments/tests/unit/backends/k8s/test_jobs.py -v` — 90 passed.
- `uv run pre-commit run -a` — blocked by local environment after all other hooks passed. Passed: `ruff (legacy alias)`, `ruff format`, `Run ty typechecks`, `Check config reference doc is up to date`, `Helm Docs Container`, `Run uv lock with platform uv`, `Check for uv.lock drift`, `Fix copyright headers`, `Plugins must not import from nmp-common`, and `check for merge conflicts`. Blocked: `studio-lint-staged` failed because `lint-staged` is not installed.
- `git diff --cached --check` — passed before amend.
- `git diff --check origin/main...HEAD` — passed after amend.
- DCO audit across `origin/main..HEAD` — passed for `8b6ad17a7`.
