### PR TITLE
ci: stop publishing SDK wheels nightly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       release-type:
-        description: "Release type."
+        description: "Release type. Nightlies publish containers and Helm only."
         required: false
         type: choice
         default: nightly
@@ -29,7 +29,7 @@ on:
         type: string
         default: ""
       release-scope:
-        description: "Release artifact scope."
+        description: "Artifact scope. Nightly all means containers and Helm; wheels are stable-only."
         required: false
         type: choice
         default: all
@@ -41,7 +41,7 @@ on:
           - custom
       wheel-ids:
         description: >-
-          Custom only. Comma-separated wheel IDs.
+          Stable custom releases only. Comma-separated wheel IDs.
           Allowed: nemo-platform, nemo-platform-plugin.
         required: false
         type: string
@@ -220,7 +220,11 @@ jobs:
             sourceSha = sourceSha.toLowerCase();
 
             const presets = {
-              all: { wheels: allWheels, containers: allContainers, includeHelm: true },
+              all: {
+                wheels: releaseType === "stable" ? allWheels : [],
+                containers: allContainers,
+                includeHelm: true,
+              },
               wheels: { wheels: allWheels, containers: [], includeHelm: false },
               containers: { wheels: [], containers: allContainers, includeHelm: false },
               helm: { wheels: [], containers: [], includeHelm: true },
@@ -285,6 +289,12 @@ jobs:
             }
 
             const { wheels, containers, includeHelm } = selection;
+            if (releaseType === "nightly" && wheels.length > 0) {
+              throw new Error(
+                "Nightly releases do not publish wheels. Select containers or Helm, or use a stable release.",
+              );
+            }
+
             const wheelIds = wheels.map((wheel) => wheel.id);
             const containerIds = containers.map((container) => container.id);
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -84,10 +84,10 @@ America/Los_Angeles.
 2. Checks out the selected source and validates the selected wheel paths,
    Docker Bake targets, and NGC overview files.
 3. Optionally synchronizes NGC metadata, when requested on a non-dry-run.
-4. Dispatches selected container and stable wheel work to the configured
-   internal release repository. Stable releases also dispatch registration.
-   The selected source SHA, release type, version, and selected IDs are passed
-   with the dispatch.
+4. For non-dry-run releases, dispatches selected container and stable wheel
+   work to the configured internal release repository. Stable releases also
+   dispatch registration. The selected source SHA, release type, version, and
+   selected IDs are passed with the dispatch.
 5. Packages the Helm chart with the planned chart version. A nightly chart uses
    the latest release or RC Git tag core reachable from the selected source with
    `-nightly-<UTC timestamp>` appended, falling back to the `Chart.yaml`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,14 +1,15 @@
 # Releasing NeMo Platform
 
 [`release.yaml`](.github/workflows/release.yaml) is the single release workflow
-for NeMo Platform. It handles scheduled nightlies and manually dispatched
-nightly or stable releases. The release catalog is deliberately defined in that
-workflow so contributors can see and validate every releasable artifact in one
-place.
+for NeMo Platform. It handles scheduled container-and-Helm nightlies and
+manually dispatched nightly or stable releases. The release catalog is
+deliberately defined in that workflow so contributors can see and validate
+every releasable artifact in one place.
 
 Anyone with permission to run repository workflows can start a release. A
 stable release requires a specific source commit and version; a nightly can use
-the default branch head.
+the default branch head. Nightlies publish containers and Helm only; wheels are
+stable-only.
 
 ## Before starting a stable release
 
@@ -50,11 +51,12 @@ and select **Run workflow**. The form shows the allowed custom artifact IDs.
 
 | Input | Use |
 | --- | --- |
-| `release-type` | `nightly` by default. Select `stable` for a full release. |
+| `release-type` | `nightly` by default, publishing containers and Helm only. Select `stable` to enable wheel releases. |
 | `source-sha` | Required for stable releases. Optional for nightlies; a normal nightly with no SHA uses the current default-branch head. A dry-run nightly with no SHA uses the workflow commit so a branch can be validated. |
 | `version` | Required for stable releases. Enter the `MAJOR.MINOR.PATCH` release version. |
-| `release-scope` | `all` by default. Select `wheels`, `containers`, `helm`, or `custom` for a subset. |
-| `wheel-ids`, `container-ids` | Comma-separated IDs used only with `release-scope: custom`. Each ID must be in the catalog above; duplicates and empty entries fail validation. |
+| `release-scope` | `all` by default. For nightlies, `all` means containers and Helm. Wheel selections require `release-type: stable`. |
+| `wheel-ids` | Stable custom releases only. Comma-separated wheel IDs used with `release-scope: custom`. |
+| `container-ids` | Comma-separated container IDs used with `release-scope: custom`. |
 | `include-helm` | Includes the Helm chart in a custom release. |
 | `helm-version` | Optional exact SemVer Helm chart version for stable Helm-only releases. The stable release label still comes from `version`. |
 | `update-ngc-metadata` | Also runs the reusable NGC metadata workflow for `nemo-platform` and `nemo-platform-dev`. It checks out the workflow ref, normally `main`. |
@@ -65,7 +67,7 @@ Examples:
 
 | Goal | Inputs |
 | --- | --- |
-| Scheduled-style nightly | Leave `release-type` as `nightly` and use the default `all` scope. |
+| Scheduled-style nightly | Leave `release-type` as `nightly` and use the default `all` scope to publish containers and Helm. |
 | Stable full release | `release-type: stable`, `source-sha: <40-character SHA>`, `version: <MAJOR.MINOR.PATCH>`, `release-scope: all`. |
 | One container | `release-scope: custom`, `container-ids: nmp-customizer-tasks`. |
 | Helm-only validation | `release-scope: helm`, `dry-run: true`. |
@@ -76,16 +78,16 @@ America/Los_Angeles.
 
 ## What the workflow does
 
-1. Resolves the source, release label, selected artifacts, wheel version, and
-   Helm chart version. Stable versions use the supplied release version.
-   Nightly labels use `nightly-<UTC timestamp>` and the wheel version is
-   resolved by `.github/scripts/stamp_sdk_version.py`.
+1. Resolves the source, release label, selected artifacts, and their versions.
+   Stable versions use the supplied release version. Nightly labels use
+   `nightly-<UTC timestamp>`.
 2. Checks out the selected source and validates the selected wheel paths,
    Docker Bake targets, and NGC overview files.
 3. Optionally synchronizes NGC metadata, when requested on a non-dry-run.
-4. Dispatches wheel, container, and stable-release registration work to the
-   configured internal release repository. The selected source SHA, release
-   type, version, and selected IDs are passed with the dispatch.
+4. Dispatches selected container and stable wheel work to the configured
+   internal release repository. Stable releases also dispatch registration.
+   The selected source SHA, release type, version, and selected IDs are passed
+   with the dispatch.
 5. Packages the Helm chart with the planned chart version. A nightly chart uses
    the latest release or RC Git tag core reachable from the selected source with
    `-nightly-<UTC timestamp>` appended, falling back to the `Chart.yaml`
@@ -107,9 +109,12 @@ America/Los_Angeles.
 
 | Artifact | Nightly | Stable |
 | --- | --- | --- |
-| Wheels | [`pypi.nvidia.com`](https://pypi.nvidia.com) | [PyPI](https://pypi.org) |
+| Wheels | Not published | [PyPI](https://pypi.org) |
 | Containers | `ghcr.io/nvidia-nemo/nemo-platform/<id>:nightly-...` | `nvcr.io/nvidia/nemo-platform/<id>:<version>` and the public NGC catalog |
 | Helm chart | OCI chart at `oci://ghcr.io/nvidia-nemo/nemo-platform` | Initially staged at `0921617854601259/nemo-platform`, then promoted to the public [NGC Helm repository](https://helm.ngc.nvidia.com/nvidia/nemo-platform) |
+
+Selecting wheels for a nightly fails during release planning, before any
+external release work is dispatched.
 
 The stable Helm promotion is external to this workflow. The workflow polls the
 public NGC Helm repository, not the internal staging endpoint, before it marks


### PR DESCRIPTION
Nightly releases currently use `release-scope: all`, which publishes SDK wheels alongside containers and Helm. This changes nightly `all` to select only containers and Helm, and rejects explicit nightly wheel selections before anything is dispatched. Stable releases are unchanged.

## Human attention needed

- Decision: nightlies publish containers and Helm only; SDK wheels remain stable-only.
- Proof: full pre-commit, actionlint, and release-planner checks passed.
- Biggest risk: the first scheduled run is the live end-to-end confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified release workflow inputs and help text for release type/scope and wheel selection.
  * Updated release guidance to reflect that nightly releases publish only containers and Helm; wheels are stable-only.
  * Added notes that wheel selections for nightly releases fail during planning.

* **Bug Fixes**
  * Fixed the `all` preset to select wheels only for stable releases (nightly yields no wheels).
  * Added validation to error out when nightly releases include selected wheel artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->