### PR TITLE
fix: render evaluator scores as raw numbers, not percentages

### DIFF
--- a/web/packages/common/src/utils/formatters.test.ts
+++ b/web/packages/common/src/utils/formatters.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getTextWithCount } from '@nemo/common/src/utils/formatters';
+import { formatEvaluatorScore, getTextWithCount } from '@nemo/common/src/utils/formatters';
 
 describe('#getTextWithCount', () => {
   it('should return the correct text with count using default suffix', () => {
@@ -14,5 +14,26 @@ describe('#getTextWithCount', () => {
     expect(getTextWithCount('entry', 0, 'entries')).toBe('0 entries');
     expect(getTextWithCount('entry', 1, 'entries')).toBe('1 entry');
     expect(getTextWithCount('entry', 2, 'entries')).toBe('2 entries');
+  });
+});
+
+describe('#formatEvaluatorScore', () => {
+  it('renders integers as integers, never as percentages (ASE-667)', () => {
+    expect(formatEvaluatorScore(1)).toBe('1');
+    expect(formatEvaluatorScore(0)).toBe('0');
+    expect(formatEvaluatorScore(1337)).toBe('1337');
+  });
+
+  it('trims trailing zeros on fractional values', () => {
+    expect(formatEvaluatorScore(0.5)).toBe('0.5');
+    expect(formatEvaluatorScore(0.603125)).toBe('0.603');
+    expect(formatEvaluatorScore(0.899)).toBe('0.899');
+  });
+
+  it('returns a dash for nullish or non-finite values', () => {
+    expect(formatEvaluatorScore(null)).toBe('-');
+    expect(formatEvaluatorScore(undefined)).toBe('-');
+    expect(formatEvaluatorScore(NaN)).toBe('-');
+    expect(formatEvaluatorScore(Infinity)).toBe('-');
   });
 });

--- a/web/packages/common/src/utils/formatters.ts
+++ b/web/packages/common/src/utils/formatters.ts
@@ -126,6 +126,18 @@ export const toScientificNotation = (value: number) => {
   return value.toString();
 };
 
+/**
+ * Formats an evaluator score for display as a raw number. Evaluator values are stored as bare
+ * floats with no scale metadata, so we cannot know whether one is a ratio, a pass/fail flag, or a
+ * point count — rendering everything as a percentage (the old behavior) turned an integer `1` into
+ * a misleading `100%`. Show the number as-is instead: `toFixed(3)` bounds the precision, then
+ * trailing zeros are stripped so integers stay integers (`1`) and fractions read cleanly (`0.603`).
+ */
+export const formatEvaluatorScore = (value: number | null | undefined): string => {
+  if (value == null || !Number.isFinite(value)) return '-';
+  return value.toFixed(3).replace(/\.?0+$/, '');
+};
+
 const COLORS = ['#76b900', '#9525c6', '#ef9100', '#d2308e', '#1dbba4'];
 /**
  * Returns a color array of length N using the secondary color palette from KUI. Repeats past 5 colors.

--- a/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
@@ -11,7 +11,7 @@ import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
 import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
 import { formatDurationMs } from '@nemo/common/src/utils/date';
-import { snakeCaseToTitleCase } from '@nemo/common/src/utils/formatters';
+import { formatEvaluatorScore, snakeCaseToTitleCase } from '@nemo/common/src/utils/formatters';
 import {
   listEvaluationSessions,
   useGetEvaluation,
@@ -44,8 +44,6 @@ interface EvaluationSessionsDataViewProps {
 
 const mapStatusForBadge = (status: EvaluationSessionResponse['status']) =>
   status === 'success' ? 'completed' : status;
-
-const formatScore = (value: number): string => `${(value * 100).toFixed(1)}%`;
 
 const isUnsupportedModeError = (error: unknown): boolean => {
   if (!isAxiosError(error)) return false;
@@ -289,7 +287,7 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
         meta: { alignment: 'right' },
         cell: ({ row }) => {
           const value = row.original.evaluator_scores?.[name];
-          return <Text>{value != null ? formatScore(value) : '-'}</Text>;
+          return <Text>{formatEvaluatorScore(value)}</Text>;
         },
       })
     ),

--- a/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentGroupDataView/index.tsx
@@ -16,7 +16,7 @@ import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { formatDurationMs } from '@nemo/common/src/utils/date';
-import { snakeCaseToTitleCase } from '@nemo/common/src/utils/formatters';
+import { formatEvaluatorScore, snakeCaseToTitleCase } from '@nemo/common/src/utils/formatters';
 import type {
   EvaluationFilter,
   ExperimentGroupResponse,
@@ -130,16 +130,6 @@ interface ExperimentGroupDataViewProps {
    * render — the sorting state is initialized once and not reactive. */
   group: ExperimentGroupResponse;
 }
-
-/**
- * Formats an evaluator's mean score for display. Scores in the normalized 0–1 range read
- * best as percentages; values outside that range are on a different scale (e.g. a 1–5 or
- * 1–10 rubric), so they're shown as a raw number rather than a misleading percentage.
- */
-const formatEvaluatorScore = (mean: number | null | undefined): string => {
-  if (mean == null || !Number.isFinite(mean)) return '-';
-  return mean >= 0 && mean <= 1 ? `${(mean * 100).toFixed(1)}%` : mean.toFixed(3);
-};
 
 /** Lists the experiments that belong to a single experiment group. */
 export const ExperimentGroupDataView: FC<ExperimentGroupDataViewProps> = ({ group }) => {


### PR DESCRIPTION

| Before | After |
| --- | --- |
| <img width="1750" height="1103" alt="Screenshot 2026-07-23 at 12 59 23" src="https://github.com/user-attachments/assets/c5fab474-3dea-49e9-a5b2-711c0725da2c" /> | <img width="1750" height="1103" alt="Screenshot 2026-07-23 at 12 58 55" src="https://github.com/user-attachments/assets/4da1eddc-6572-4cbb-8730-d78498fb1bb6" /> |


## Summary

Fixes [ASE-667](https://linear.app/nvidia/issue/ASE-667/evaluation-scores-always-represented-as-100percent-even-when-value). Evaluation scores rendered as `100.0%` even when the scorer value should be an integer (e.g. a Harbor `reward` of `1`).

The Experiments UI formatted every evaluator score as `(value * 100).toFixed(1) + '%'`. Evaluator values are stored as bare floats with no scale metadata, so the UI cannot know whether a value is a ratio, a pass/fail flag, or a point count — percentage is the wrong default. An integer `1` became a misleading `100.0%`.

Per discussion with the Experiments team, this is a **FE-only** fix (no datatype/denominator change): show the raw number instead of a percentage.

## Changes

- Add shared `formatEvaluatorScore` in `formatters.ts`: `-` for nullish/non-finite, else `value.toFixed(3)` with trailing zeros stripped, so integers stay integers (`1`) and fractions read cleanly (`0.603`).
- `EvaluationSessionsDataView` — replace the unconditional `×100 + '%'` formatter with the shared one.
- `ExperimentGroupDataView` — replace the `[0,1] ? % : toFixed(3)` heuristic with the shared one, so the two views agree.
- Unit tests for the formatter (integers, fractions, nullish/non-finite).

## Verification

- `vitest` 5/5 on `formatters.test.ts`
- `common` `tsc` clean; prettier + eslint clean on touched files
- `reward = 1` now renders `1` (was `100.0%`); `0.603` renders `0.603`

## Out of scope

Surfacing `data_type` for Pass/Fail rendering, and any denominator/scale column for bounded scores (`1/1337`). Those need a data-model change; deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluator score display formatting across evaluation and experiment views.
  * Scores now appear as plain numbers without unnecessary percentage formatting or trailing zeros.
  * Missing, invalid, or non-finite scores are displayed as a dash.

* **Tests**
  * Added coverage for integer, decimal, missing, and invalid evaluator score values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->