### PR TITLE
feat(studio): Add the option to clone Customizer Jobs

### DIFF
--- a/web/packages/studio/src/components/NewCustomizationForm/index.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/index.tsx
@@ -41,19 +41,22 @@ import { useNavigate } from 'react-router-dom';
 interface NewCustomizationFormProps {
   workspace: string;
   initialModel?: string;
+  initialValues?: CustomizationFormFields;
 }
 
 export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
   workspace,
   initialModel,
+  initialValues,
 }) => {
   const navigate = useNavigate();
   const toast = useToast();
   const errorBannerRef = useRef<HTMLDivElement>(null);
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
 
-  const defaultValues = useMemo<CustomizationFormFields>(
-    () => ({
+  const defaultValues = useMemo<CustomizationFormFields>(() => {
+    if (initialValues) return initialValues;
+    return {
       ...FORM_DEFAULTS,
       outputName: generateDefaultName(),
       automodel: { ...FORM_DEFAULTS.automodel, model: initialModel ?? '' },
@@ -61,9 +64,8 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
         ...FORM_DEFAULTS.unsloth,
         model: { ...FORM_DEFAULTS.unsloth.model, name: initialModel ?? '' },
       },
-    }),
-    [initialModel]
-  );
+    };
+  }, [initialModel, initialValues]);
 
   const form = useForm<CustomizationFormFields>({
     resolver: zodResolver(customizationFormSchema) as unknown as Resolver<CustomizationFormFields>,

--- a/web/packages/studio/src/routes/CustomizationJobDetailsRoute/DetailActions.test.tsx
+++ b/web/packages/studio/src/routes/CustomizationJobDetailsRoute/DetailActions.test.tsx
@@ -33,7 +33,7 @@ describe('DetailActions', () => {
         />
       </TestProviders>
     );
-    expect(screen.getByRole('button', { name: 'Cancel Job' })).toBeEnabled();
+    expect(screen.getByRole('menuitem', { name: 'Cancel Job' })).toBeEnabled();
   });
   it('should render evaluate button when status is launchable', () => {
     render(
@@ -70,10 +70,11 @@ describe('DetailActions', () => {
       </TestProviders>
     );
 
-    await user.click(screen.getByRole('button', { name: 'Cancel Job' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Cancel Job' }));
 
-    // Wait for the loading state to appear (Spinner has role="status")
-    expect(await screen.findByRole('status')).toBeInTheDocument();
+    // While the mutation is pending the item becomes disabled and its label changes
+    const cancellingItem = await screen.findByRole('menuitem', { name: 'Cancelling…' });
+    expect(cancellingItem).toBeDisabled();
   });
   it.each([
     PlatformJobStatus.cancelled,

--- a/web/packages/studio/src/routes/CustomizationJobDetailsRoute/DetailActions.tsx
+++ b/web/packages/studio/src/routes/CustomizationJobDetailsRoute/DetailActions.tsx
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { LoadingButton } from '@nemo/common/src/components/LoadingButton';
 import { CJobCancellableStatuses, CJobLaunchableStatuses } from '@nemo/common/src/constants/query';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import {
@@ -10,13 +9,15 @@ import {
 } from '@nemo/sdk/generated/customizer/api';
 import { getJobsGetJobQueryKey } from '@nemo/sdk/generated/platform/api';
 import { PlatformJobStatus, type PlatformJobResponse } from '@nemo/sdk/generated/platform/schema';
-import { Button } from '@nvidia/foundations-react-core';
+import { Button, Flex } from '@nvidia/foundations-react-core';
 import { getErrorMessage } from '@studio/api/common/utils';
+import { QuickActionsMenuRoot } from '@studio/components/QuickActionsMenu/QuickActionsMenuRoot';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
-import { getNewEvaluationMetricRoute } from '@studio/routes/utils';
-import { CustomizationBackend } from '@studio/util/customizationBackend';
+import { getNewCustomizationJobRoute, getNewEvaluationMetricRoute } from '@studio/routes/utils';
+import { CustomizationBackend, type CustomizationJob } from '@studio/util/customizationBackend';
 import { useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { Ban, Copy } from 'lucide-react';
 import { FC } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -27,28 +28,26 @@ interface DetailActionsProps {
   backend?: CustomizationBackend;
   /** Job name (from the route). */
   name: string;
+  job?: CustomizationJob;
 }
 
 /**
  * This component renders the primary top-level CTAs for the customization job details page.
  */
-export const DetailActions: FC<DetailActionsProps> = ({ model, status, backend, name }) => {
+export const DetailActions: FC<DetailActionsProps> = ({ model, status, backend, name, job }) => {
   const toast = useToast();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const workspace = useWorkspaceFromPath();
+
   const cancelMutation = {
     onSuccess: () => {
       toast.success('Job cancelled successfully.');
-      // Optimistically update the cached (generic) job status to cancelled
       queryClient.setQueryData(
         getJobsGetJobQueryKey(workspace, name),
         (oldData: PlatformJobResponse | undefined) => {
           if (!oldData) return oldData;
-          return {
-            ...oldData,
-            status: PlatformJobStatus.cancelled,
-          };
+          return { ...oldData, status: PlatformJobStatus.cancelled };
         }
       );
     },
@@ -77,30 +76,41 @@ export const DetailActions: FC<DetailActionsProps> = ({ model, status, backend, 
     }
   };
 
-  const disabled = isPending || !backend;
-  if (isPending || status === PlatformJobStatus.cancelling) {
-    return (
-      <LoadingButton kind="secondary" loading disabled>
-        Cancelling...
-      </LoadingButton>
-    );
-  } else if (status && CJobCancellableStatuses.includes(status)) {
-    return (
-      <Button kind="secondary" onClick={cancelJob} disabled={disabled}>
-        Cancel Job
-      </Button>
-    );
-  } else if (status && CJobLaunchableStatuses.includes(status)) {
-    return (
-      <Button
-        color="brand"
-        disabled={disabled}
-        onClick={() => {
-          navigate(getNewEvaluationMetricRoute(workspace, { model }));
-        }}
-      >
-        Evaluate
-      </Button>
-    );
-  }
+  const isCancellable = status !== undefined && CJobCancellableStatuses.includes(status);
+  const isCancelling = isPending || status === PlatformJobStatus.cancelling;
+  const isLaunchable = status !== undefined && CJobLaunchableStatuses.includes(status);
+
+  return (
+    <Flex gap="density-sm" align="center">
+      {isLaunchable && (
+        <Button
+          color="brand"
+          onClick={() => navigate(getNewEvaluationMetricRoute(workspace, { model }))}
+        >
+          Evaluate
+        </Button>
+      )}
+      <QuickActionsMenuRoot
+        actions={[
+          {
+            label: 'Clone',
+            icon: <Copy />,
+            onSelect: () =>
+              navigate(getNewCustomizationJobRoute(workspace), { state: { cloneFromJob: job } }),
+          },
+          ...(isCancellable || isCancelling
+            ? [
+                {
+                  label: isCancelling ? 'Cancelling…' : 'Cancel Job',
+                  icon: <Ban />,
+                  danger: !isCancelling,
+                  disabled: isCancelling || !backend,
+                  onSelect: cancelJob,
+                },
+              ]
+            : []),
+        ]}
+      />
+    </Flex>
+  );
 };

--- a/web/packages/studio/src/routes/CustomizationJobDetailsRoute/index.tsx
+++ b/web/packages/studio/src/routes/CustomizationJobDetailsRoute/index.tsx
@@ -68,6 +68,7 @@ export const CustomizationJobDetailsRoute: FC = () => {
               status={status}
               backend={backend}
               name={customizationJobName}
+              job={job}
             />
           }
         />

--- a/web/packages/studio/src/routes/NewCustomizationRoute/index.tsx
+++ b/web/packages/studio/src/routes/NewCustomizationRoute/index.tsx
@@ -5,14 +5,22 @@ import { NewCustomizationForm } from '@studio/components/NewCustomizationForm';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { getWorkspaceCustomizationJobListRoute } from '@studio/routes/utils';
-import type { CustomizationJob } from '@studio/util/customizationBackend';
+import {
+  isAutomodelSpec,
+  isUnslothSpec,
+  type CustomizationJob,
+} from '@studio/util/customizationBackend';
 import { jobToFormFields } from '@studio/util/forms/customization';
 import { useMemo } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 
-interface NewCustomizationRouteState {
-  cloneFromJob?: CustomizationJob;
-}
+const isCloneFromJobState = (value: unknown): value is { cloneFromJob: CustomizationJob } => {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = (value as Record<string, unknown>).cloneFromJob;
+  if (typeof candidate !== 'object' || candidate === null) return false;
+  const spec = (candidate as Record<string, unknown>).spec;
+  return isAutomodelSpec(spec) || isUnslothSpec(spec);
+};
 
 export const NewCustomizationRoute = () => {
   const workspace = useWorkspaceFromPath();
@@ -20,7 +28,7 @@ export const NewCustomizationRoute = () => {
   const initialModel = searchParams.get('model') ?? undefined;
 
   const { state: locationState } = useLocation();
-  const { cloneFromJob } = (locationState as NewCustomizationRouteState | null) ?? {};
+  const cloneFromJob = isCloneFromJobState(locationState) ? locationState.cloneFromJob : undefined;
 
   const initialValues = useMemo(
     () => (cloneFromJob ? jobToFormFields(cloneFromJob) : undefined),

--- a/web/packages/studio/src/routes/NewCustomizationRoute/index.tsx
+++ b/web/packages/studio/src/routes/NewCustomizationRoute/index.tsx
@@ -5,12 +5,27 @@ import { NewCustomizationForm } from '@studio/components/NewCustomizationForm';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { getWorkspaceCustomizationJobListRoute } from '@studio/routes/utils';
-import { useSearchParams } from 'react-router-dom';
+import type { CustomizationJob } from '@studio/util/customizationBackend';
+import { jobToFormFields } from '@studio/util/forms/customization';
+import { useMemo } from 'react';
+import { useLocation, useSearchParams } from 'react-router-dom';
+
+interface NewCustomizationRouteState {
+  cloneFromJob?: CustomizationJob;
+}
 
 export const NewCustomizationRoute = () => {
   const workspace = useWorkspaceFromPath();
   const [searchParams] = useSearchParams();
   const initialModel = searchParams.get('model') ?? undefined;
+
+  const { state: locationState } = useLocation();
+  const { cloneFromJob } = (locationState as NewCustomizationRouteState | null) ?? {};
+
+  const initialValues = useMemo(
+    () => (cloneFromJob ? jobToFormFields(cloneFromJob) : undefined),
+    [cloneFromJob]
+  );
 
   useBreadcrumbs({
     items: [
@@ -24,5 +39,11 @@ export const NewCustomizationRoute = () => {
     ],
   });
 
-  return <NewCustomizationForm workspace={workspace} initialModel={initialModel} />;
+  return (
+    <NewCustomizationForm
+      workspace={workspace}
+      initialModel={initialModel}
+      initialValues={initialValues}
+    />
+  );
 };

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -350,7 +350,7 @@ export const getPromptTuningFormRoute = (workspace: string, options?: { model?: 
 export const getNewCustomizationJobRoute = (workspace: string, options?: { model?: string }) => {
   const basePath = generatePath(ROUTES.workspace.newCustomizationJob, { workspace });
   if (options?.model) {
-    return `${basePath}?model=${encodeURIComponent(options.model)}`;
+    return `${basePath}?${QUERY_PARAMETERS.model}=${encodeURIComponent(options.model)}`;
   }
   return basePath;
 };

--- a/web/packages/studio/src/util/forms/customization.ts
+++ b/web/packages/studio/src/util/forms/customization.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
 import type {
   AutomodelJobInput,
   AutomodelJobsJobRequest,
@@ -9,6 +10,7 @@ import type {
 } from '@nemo/sdk/generated/customizer/schema';
 import { CustomizationCreateAutomodelJobBody } from '@nemo/sdk/generated/customizer/zod/automodel-jobs';
 import { CustomizationCreateUnslothJobBody } from '@nemo/sdk/generated/customizer/zod/unsloth-jobs';
+import { isAutomodelJob, type CustomizationJob } from '@studio/util/customizationBackend';
 import { z } from 'zod';
 
 export interface CustomizationFormFields {
@@ -189,5 +191,35 @@ export const formToUnslothCreate = (f: CustomizationFormFields): UnslothJobsJobR
       training: training && { ...training, lora: usesLora ? training.lora : undefined },
       output: { name: f.outputName || undefined, description: f.description || undefined },
     },
+  };
+};
+
+const stripNulls = <T>(value: T): T => {
+  if (value === null) return undefined as unknown as T;
+  if (Array.isArray(value)) return value.map(stripNulls) as unknown as T;
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, stripNulls(v)])
+    ) as T;
+  }
+  return value;
+};
+
+export const jobToFormFields = (job: CustomizationJob): CustomizationFormFields => {
+  if (isAutomodelJob(job)) {
+    return {
+      ...FORM_DEFAULTS,
+      outputName: generateDefaultName(),
+      description: job.description ?? '',
+      backend: 'automodel',
+      automodel: stripNulls(job.spec) as AutomodelJobInput,
+    };
+  }
+  return {
+    ...FORM_DEFAULTS,
+    outputName: generateDefaultName(),
+    description: job.description ?? '',
+    backend: 'unsloth',
+    unsloth: stripNulls(job.spec) as UnslothJobInput,
   };
 };


### PR DESCRIPTION
<img width="1498" height="666" alt="image" src="https://github.com/user-attachments/assets/0b4fe366-e4bc-42b4-a911-b15c4f851a0c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified quick-actions menu for customization jobs, including clone and evaluate options.
  * Cloning a job now prepopulates the “new customization” form with the selected job’s settings.
  * The customization form now supports starting from provided preset values.

* **Bug Fixes**
  * Improved cancellation feedback by disabling the “Cancelling…” menu item while the cancel request is in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->