### PR TITLE
fix(studio): Remove reference to agent suggestions route

### DIFF
--- a/web/packages/studio/src/constants/routes.ts
+++ b/web/packages/studio/src/constants/routes.ts
@@ -124,7 +124,6 @@ export const ROUTES = {
     /** Detail view for a single agent-evaluation job. */
     agentEvaluationDetail: `/workspaces/:${P.workspace}/agents/evaluations/:${P.agentEvalJobName}`,
     modelCompare: `/workspaces/:${P.workspace}/playground`,
-    agentOptimizations: `/workspaces/:${P.workspace}/agents/suggestions`,
     agentMonitor: `/workspaces/:${P.workspace}/agents/monitor`,
   },
   models: {

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/studioUiNavigationSuggestions.test.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/studioUiNavigationSuggestions.test.ts
@@ -48,10 +48,6 @@ describe('getStudioUiNavigationSuggestion', () => {
   it('keeps navigation shortcuts when prompts include Studio product context', () => {
     const cases = [
       {
-        prompt: 'Review model sizing for an agent',
-        id: 'agent-optimizations',
-      },
-      {
         prompt: 'Show agent token usage',
         id: 'agent-monitor',
       },

--- a/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/studioUiNavigationSuggestions.ts
+++ b/web/packages/studio/src/routes/agents/ClaudeCodeChatRoute/studioUiNavigationSuggestions.ts
@@ -6,7 +6,6 @@ import type { FeatureFlags } from '@studio/constants/featureFlags/featureFlags';
 import {
   getAgentEvaluationsListRoute,
   getAgentMonitorRoute,
-  getAgentOptimizationsRoute,
   getAgentsListRoute,
   getDataDesignerJobListRoute,
   getEvaluationResultsRoute,
@@ -71,20 +70,6 @@ const STUDIO_UI_DESTINATIONS: readonly StudioUiDestination[] = [
       /\bevaluat(e|ing|ion)s? (an? )?agent\b/i,
       /\brun (an? )?(eval|evaluation) (for|on) (an? )?agent\b/i,
       /\b(agent|agents).*\b(eval|evaluation|evaluations) jobs?\b/i,
-    ],
-  },
-  {
-    id: 'agent-optimizations',
-    title: 'Open Agent Suggestions',
-    description: 'Studio has a UI for generating optimization suggestions for deployed agents.',
-    getHref: getAgentOptimizationsRoute,
-    requiredFeatureFlags: ['agentsEnabled'],
-    patterns: [
-      /\boptimi[sz]e (an? )?agent\b/i,
-      /\b(agent|agents).*\b(cheaper|faster|smaller|right[-\s]?size)\b/i,
-      /\b(agent|agents).*\bmodel sizing\b/i,
-      /\bmodel sizing (for|on|of) (an? )?agent\b/i,
-      /\bsuggestions? for (an? )?agent\b/i,
     ],
   },
   {

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -529,10 +529,6 @@ export const getAgentDeploymentDetailRoute = (workspace: string, agentDeployment
   });
 };
 
-export const getAgentOptimizationsRoute = (workspace: string) => {
-  return generatePath(ROUTES.workspace.agentOptimizations, { workspace });
-};
-
 export const getAgentMonitorRoute = (workspace: string) => {
   return generatePath(ROUTES.workspace.agentMonitor, { workspace });
 };


### PR DESCRIPTION
Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added navigation for agent evaluation job details.
  * Added a model comparison route.
* **Changes**
  * Removed the Agent Optimizations page from the studio workspace navigation.
  * Updated prompt-based navigation so “optimization suggestions” no longer resolve to a dedicated destination.
  * Adjusted workspace routing to flow directly from agent deployment details to agent monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->