### PR TITLE
feat(studio): Anonymizer builder Source form [ASTD-327]

### DIFF
--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ColumnsSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ColumnsSection.tsx
@@ -70,7 +70,6 @@ export const ColumnsSection: FC = () => {
   );
   const useColumnDropdown = canIntrospect && columns.length > 0;
 
-  // Auto-select the only column when there's exactly one.
   useEffect(() => {
     if (useColumnDropdown && columns.length === 1 && textColumn !== columns[0]) {
       setValue('textColumn', columns[0], { shouldValidate: true });

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ColumnsSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ColumnsSection.tsx
@@ -64,6 +64,10 @@ export const ColumnsSection: FC = () => {
     return getContentColumns(fileContent, fileType);
   }, [fileContent, filePath, isParquet]);
 
+  const columnItems = useMemo(
+    () => columns.map((column) => ({ label: column, value: column })),
+    [columns]
+  );
   const useColumnDropdown = canIntrospect && columns.length > 0;
 
   // Auto-select the only column when there's exactly one.
@@ -79,7 +83,7 @@ export const ColumnsSection: FC = () => {
       {useColumnDropdown ? (
         <ControlledSelect
           aria-label="Text column"
-          items={columns.map((column) => ({ label: column, value: column }))}
+          items={columnItems}
           useControllerProps={{ name: 'textColumn', control }}
           formFieldProps={{
             slotLabel: 'Text Column',

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ColumnsSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ColumnsSection.tsx
@@ -15,14 +15,15 @@ import {
 } from '@studio/routes/AnonymizerBuilderRoute/constants';
 import type { AnonymizerFormData } from '@studio/routes/AnonymizerBuilderRoute/schema';
 import { getContentColumns, getFileExtension } from '@studio/util/files';
-import { FC, useMemo } from 'react';
+import { FC, useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 export const ColumnsSection: FC = () => {
-  const { control } = useFormContext<AnonymizerFormData>();
+  const { control, setValue } = useFormContext<AnonymizerFormData>();
   const workspace = useWorkspaceFromPath();
   const source = useWatch({ control, name: 'source' });
   const sourceType = useWatch({ control, name: 'sourceType' });
+  const textColumn = useWatch({ control, name: 'textColumn' });
 
   const parsed = useMemo(
     () =>
@@ -64,6 +65,13 @@ export const ColumnsSection: FC = () => {
   }, [fileContent, filePath, isParquet]);
 
   const useColumnDropdown = canIntrospect && columns.length > 0;
+
+  // Auto-select the only column when there's exactly one.
+  useEffect(() => {
+    if (useColumnDropdown && columns.length === 1 && textColumn !== columns[0]) {
+      setValue('textColumn', columns[0], { shouldValidate: true });
+    }
+  }, [useColumnDropdown, columns, textColumn, setValue]);
 
   return (
     <Stack gap="density-lg">

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ColumnsSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ColumnsSection.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledTextArea } from '@nemo/common/src/components/form/ControlledTextArea';
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { Stack, Text } from '@nvidia/foundations-react-core';
+import type { AnonymizerFormData } from '@studio/routes/AnonymizerBuilderRoute/schema';
+import { FC } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+export const ColumnsSection: FC = () => {
+  const { control } = useFormContext<AnonymizerFormData>();
+
+  return (
+    <Stack gap="density-lg">
+      <Text kind="label/bold/lg">Columns</Text>
+      <ControlledTextInput
+        useControllerProps={{ name: 'textColumn', control }}
+        placeholder="e.g. biography"
+        formFieldProps={{
+          slotLabel: 'Text Column',
+          slotInfo: 'The column containing the text to anonymize.',
+        }}
+      />
+      <ControlledTextArea
+        useControllerProps={{ name: 'dataSummary', control }}
+        formFieldProps={{
+          slotLabel: 'Data Summary',
+          slotInfo: 'Optional short description of the data. Helps the LLM produce better results.',
+        }}
+      />
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ColumnsSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ColumnsSection.tsx
@@ -1,27 +1,93 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { parseFilesetLocation } from '@nemo/common/src/components/DatasetFileSelect/parseFilesetLocation';
+import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
 import { ControlledTextArea } from '@nemo/common/src/components/form/ControlledTextArea';
 import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { useFilesListFilesetFiles } from '@nemo/sdk/generated/platform/api';
 import { Stack, Text } from '@nvidia/foundations-react-core';
+import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import {
+  MAX_COLUMN_INTROSPECTION_BYTES,
+  SOURCE_TYPE_DATASET,
+} from '@studio/routes/AnonymizerBuilderRoute/constants';
 import type { AnonymizerFormData } from '@studio/routes/AnonymizerBuilderRoute/schema';
-import { FC } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { getContentColumns, getFileExtension } from '@studio/util/files';
+import { FC, useMemo } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 export const ColumnsSection: FC = () => {
   const { control } = useFormContext<AnonymizerFormData>();
+  const workspace = useWorkspaceFromPath();
+  const source = useWatch({ control, name: 'source' });
+  const sourceType = useWatch({ control, name: 'sourceType' });
+
+  const parsed = useMemo(
+    () =>
+      sourceType === SOURCE_TYPE_DATASET && source ? parseFilesetLocation(source, workspace) : null,
+    [sourceType, source, workspace]
+  );
+  const filesetWorkspace = parsed?.workspace ?? '';
+  const filesetName = parsed?.name ?? '';
+  const filePath = parsed?.objectPath ?? '';
+
+  const { data: filesResponse } = useFilesListFilesetFiles(
+    filesetWorkspace,
+    filesetName,
+    undefined,
+    {
+      query: { enabled: Boolean(filesetWorkspace && filesetName) },
+    }
+  );
+  const fileSize = useMemo(
+    () => filesResponse?.data?.find((file) => file.path === filePath)?.size ?? null,
+    [filesResponse?.data, filePath]
+  );
+  const tooLarge = fileSize != null && fileSize > MAX_COLUMN_INTROSPECTION_BYTES;
+
+  const isParquet = filePath.endsWith('parquet');
+  const canIntrospect = Boolean(filesetWorkspace && filesetName && filePath) && !tooLarge;
+  const { data: fileContent } = useDatasetFileContent({
+    workspace: filesetWorkspace,
+    name: filesetName,
+    path: filePath,
+    range: isParquet ? [0, 1] : undefined,
+    enabled: canIntrospect,
+  });
+
+  const columns = useMemo(() => {
+    if (!fileContent) return [];
+    const fileType = isParquet ? 'jsonl' : (getFileExtension(filePath) ?? undefined);
+    return getContentColumns(fileContent, fileType);
+  }, [fileContent, filePath, isParquet]);
+
+  const useColumnDropdown = canIntrospect && columns.length > 0;
 
   return (
     <Stack gap="density-lg">
       <Text kind="label/bold/lg">Columns</Text>
-      <ControlledTextInput
-        useControllerProps={{ name: 'textColumn', control }}
-        placeholder="e.g. biography"
-        formFieldProps={{
-          slotLabel: 'Text Column',
-          slotInfo: 'The column containing the text to anonymize.',
-        }}
-      />
+      {useColumnDropdown ? (
+        <ControlledSelect
+          aria-label="Text column"
+          items={columns.map((column) => ({ label: column, value: column }))}
+          useControllerProps={{ name: 'textColumn', control }}
+          formFieldProps={{
+            slotLabel: 'Text Column',
+            slotInfo: 'The column containing the text to anonymize.',
+          }}
+        />
+      ) : (
+        <ControlledTextInput
+          useControllerProps={{ name: 'textColumn', control }}
+          placeholder="e.g. biography"
+          formFieldProps={{
+            slotLabel: 'Text Column',
+            slotInfo: 'The column containing the text to anonymize.',
+          }}
+        />
+      )}
       <ControlledTextArea
         useControllerProps={{ name: 'dataSummary', control }}
         formFieldProps={{

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/DataSourceSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/DataSourceSection.tsx
@@ -15,7 +15,7 @@ import { FC } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 export const DataSourceSection: FC = () => {
-  const { control, setError, clearErrors } = useFormContext<AnonymizerFormData>();
+  const { control, setValue, setError, clearErrors } = useFormContext<AnonymizerFormData>();
   const workspace = useWorkspaceFromPath();
   const sourceType = useWatch({ control, name: 'sourceType' });
   const isDataset = sourceType === SOURCE_TYPE_DATASET;
@@ -27,6 +27,12 @@ export const DataSourceSection: FC = () => {
         aria-label="Source type"
         items={SOURCE_TYPE_OPTIONS}
         useControllerProps={{ name: 'sourceType', control }}
+        onChange={() => {
+          // A URL and a fileset ref aren't interchangeable — reset the shared
+          // source field (and its error) when the source type changes.
+          setValue('source', '');
+          clearErrors('source');
+        }}
         formFieldProps={{ slotLabel: 'Source', required: true }}
       />
       {isDataset ? (

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/DataSourceSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/DataSourceSection.tsx
@@ -28,8 +28,6 @@ export const DataSourceSection: FC = () => {
         items={SOURCE_TYPE_OPTIONS}
         useControllerProps={{ name: 'sourceType', control }}
         onChange={() => {
-          // A URL and a fileset ref aren't interchangeable — reset the shared
-          // source field (and its error) when the source type changes.
           setValue('source', '');
           clearErrors('source');
         }}

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/DataSourceSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/DataSourceSection.tsx
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledDatasetFileSelect } from '@nemo/common/src/components/DatasetFileSelect/ControlledDatasetFileSelect';
+import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { Stack, Text } from '@nvidia/foundations-react-core';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import {
+  SOURCE_TYPE_DATASET,
+  SOURCE_TYPE_OPTIONS,
+} from '@studio/routes/AnonymizerBuilderRoute/constants';
+import type { AnonymizerFormData } from '@studio/routes/AnonymizerBuilderRoute/schema';
+import { FC } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+export const DataSourceSection: FC = () => {
+  const { control, setError, clearErrors } = useFormContext<AnonymizerFormData>();
+  const workspace = useWorkspaceFromPath();
+  const sourceType = useWatch({ control, name: 'sourceType' });
+  const isDataset = sourceType === SOURCE_TYPE_DATASET;
+
+  return (
+    <Stack gap="density-lg">
+      <Text kind="label/bold/lg">Data Source</Text>
+      <ControlledSelect
+        aria-label="Source type"
+        items={SOURCE_TYPE_OPTIONS}
+        useControllerProps={{ name: 'sourceType', control }}
+        formFieldProps={{ slotLabel: 'Source', required: true }}
+      />
+      {isDataset ? (
+        <ControlledDatasetFileSelect
+          label="Dataset"
+          acceptedFileTypes={['.csv', '.parquet']}
+          useControllerProps={{ name: 'source', control }}
+          setError={(error) => setError('source', error)}
+          clearError={() => clearErrors('source')}
+          workspace={workspace}
+          formFieldProps={{ required: true }}
+        />
+      ) : (
+        <ControlledTextInput
+          useControllerProps={{ name: 'source', control }}
+          placeholder="https://example.com/data.csv"
+          formFieldProps={{
+            slotLabel: 'URL',
+            required: true,
+            slotInfo: 'HTTP(S) URL of a CSV or Parquet file to anonymize.',
+          }}
+        />
+      )}
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.tsx
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledCheckbox } from '@nemo/common/src/components/form/ControlledCheckbox';
+import { ControlledSegmentedControl } from '@nemo/common/src/components/form/ControlledSegmentedControl';
+import { Stack, Text } from '@nvidia/foundations-react-core';
+import {
+  ENTITY_MODE_AUTO,
+  ENTITY_MODE_OPTIONS,
+} from '@studio/routes/AnonymizerBuilderRoute/constants';
+import type { AnonymizerFormData } from '@studio/routes/AnonymizerBuilderRoute/schema';
+import { FC } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+export const EntitiesSection: FC = () => {
+  const { control } = useFormContext<AnonymizerFormData>();
+  const entityMode = useWatch({ control, name: 'entityMode' });
+
+  return (
+    <Stack gap="density-lg">
+      <Text kind="label/bold/lg">Entities</Text>
+      <ControlledSegmentedControl
+        className="w-full"
+        size="tiny"
+        items={ENTITY_MODE_OPTIONS}
+        useControllerProps={{ name: 'entityMode', control }}
+      />
+      <Text kind="body/regular/md">
+        {entityMode === ENTITY_MODE_AUTO
+          ? 'Auto-detect lets the augmenter create additional labels beyond the defaults.'
+          : 'Custom mode only outputs entities you define. Use Auto-detect to allow additional labels.'}
+      </Text>
+      <ControlledCheckbox
+        useControllerProps={{ name: 'includeDefaultEntities', control }}
+        formFieldProps={{ slotLabel: 'Include all default entities' }}
+      />
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.tsx
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ControlledCheckbox } from '@nemo/common/src/components/form/ControlledCheckbox';
+import { ControlledCombobox } from '@nemo/common/src/components/form/ControlledCombobox';
 import { ControlledSegmentedControl } from '@nemo/common/src/components/form/ControlledSegmentedControl';
+import { useAnonymizerListEntityLabels } from '@nemo/sdk/generated/anonymizer/api';
 import { Stack, Text } from '@nvidia/foundations-react-core';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import {
   ENTITY_MODE_AUTO,
+  ENTITY_MODE_CUSTOM,
   ENTITY_MODE_OPTIONS,
 } from '@studio/routes/AnonymizerBuilderRoute/constants';
 import type { AnonymizerFormData } from '@studio/routes/AnonymizerBuilderRoute/schema';
@@ -14,7 +18,15 @@ import { useFormContext, useWatch } from 'react-hook-form';
 
 export const EntitiesSection: FC = () => {
   const { control } = useFormContext<AnonymizerFormData>();
+  const workspace = useWorkspaceFromPath();
   const entityMode = useWatch({ control, name: 'entityMode' });
+  const includeDefaults = useWatch({ control, name: 'includeDefaultEntities' });
+
+  const isCustom = entityMode === ENTITY_MODE_CUSTOM;
+  const showLabelPicker = isCustom && !includeDefaults;
+
+  const { data, isLoading } = useAnonymizerListEntityLabels(workspace, { query: {} });
+  const labels = data?.data ?? [];
 
   return (
     <Stack gap="density-lg">
@@ -30,10 +42,24 @@ export const EntitiesSection: FC = () => {
           ? 'Auto-detect lets the augmenter create additional labels beyond the defaults.'
           : 'Custom mode only outputs entities you define. Use Auto-detect to allow additional labels.'}
       </Text>
-      <ControlledCheckbox
-        useControllerProps={{ name: 'includeDefaultEntities', control }}
-        formFieldProps={{ slotLabel: 'Include all default entities' }}
-      />
+      {isCustom && (
+        <ControlledCheckbox
+          useControllerProps={{ name: 'includeDefaultEntities', control }}
+          formFieldProps={{ slotLabel: 'Include all default entities' }}
+        />
+      )}
+      {showLabelPicker && (
+        <ControlledCombobox
+          kind="multiple"
+          loading={isLoading}
+          items={labels}
+          useControllerProps={{ name: 'entityLabels', control }}
+          formFieldProps={{
+            slotLabel: 'Entity Labels',
+            slotInfo: 'Only these entity types will be detected and replaced.',
+          }}
+        />
+      )}
     </Stack>
   );
 };

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/GenerationSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/GenerationSection.tsx
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { Stack, Text } from '@nvidia/foundations-react-core';
+import {
+  STRATEGY_DESCRIPTIONS,
+  STRATEGY_OPTIONS,
+} from '@studio/routes/AnonymizerBuilderRoute/constants';
+import type { AnonymizerFormData } from '@studio/routes/AnonymizerBuilderRoute/schema';
+import { FC } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+export const GenerationSection: FC = () => {
+  const { control } = useFormContext<AnonymizerFormData>();
+  const strategy = useWatch({ control, name: 'strategy' });
+
+  return (
+    <Stack gap="density-lg">
+      <Text kind="label/bold/lg">Generation</Text>
+      <ControlledSelect
+        aria-label="Anonymization strategy"
+        items={STRATEGY_OPTIONS}
+        useControllerProps={{ name: 'strategy', control }}
+        formFieldProps={{ slotLabel: 'Anonymization Strategy', required: true }}
+      />
+      <Text kind="body/regular/md">{STRATEGY_DESCRIPTIONS[strategy]}</Text>
+      <ControlledTextInput
+        type="number"
+        min={1}
+        useControllerProps={{ name: 'previewRows', control }}
+        formFieldProps={{
+          slotLabel: 'Preview Rows',
+          slotInfo: 'Number of records to anonymize when running a preview.',
+        }}
+      />
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/GenerationSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/GenerationSection.tsx
@@ -21,9 +21,14 @@ export const GenerationSection: FC = () => {
       <Text kind="label/bold/lg">Generation</Text>
       <ControlledSelect
         aria-label="Anonymization strategy"
+        disabled
         items={STRATEGY_OPTIONS}
         useControllerProps={{ name: 'strategy', control }}
-        formFieldProps={{ slotLabel: 'Anonymization Strategy', required: true }}
+        formFieldProps={{
+          slotLabel: 'Anonymization Strategy',
+          required: true,
+          slotInfo: 'Only Substitute is available today. Other strategies are coming soon.',
+        }}
       />
       <Text kind="body/regular/md">{STRATEGY_DESCRIPTIONS[strategy]}</Text>
       <ControlledTextInput

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
+import { useModelsListProviders } from '@nemo/sdk/generated/platform/api';
+import { Stack, Text } from '@nvidia/foundations-react-core';
+import { modelsFromProviders } from '@studio/components/NewDataDesignerJobForm/utils';
+import { DEFAULT_LARGE_PAGE_SIZE } from '@studio/constants/constants';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import type { AnonymizerFormData } from '@studio/routes/AnonymizerBuilderRoute/schema';
+import { FC, useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+export const ModelSettingsSection: FC = () => {
+  const { control, setValue } = useFormContext<AnonymizerFormData>();
+  const workspace = useWorkspaceFromPath();
+
+  const { data: providersPage, isLoading } = useModelsListProviders(
+    workspace,
+    { page_size: DEFAULT_LARGE_PAGE_SIZE },
+    { query: {} }
+  );
+
+  const models = useMemo(
+    () => modelsFromProviders(providersPage?.data ?? []),
+    [providersPage?.data]
+  );
+  const items = useMemo(
+    () => models.map((model) => ({ label: model.name, value: model.id })),
+    [models]
+  );
+
+  const handleChange = (id: string) => {
+    const selected = models.find((model) => model.id === id);
+    setValue('model', selected?.served_model_name ?? '', { shouldValidate: true });
+    setValue('provider', selected?.model_providers?.[0] ?? '', { shouldValidate: true });
+  };
+
+  return (
+    <Stack gap="density-lg">
+      <Text kind="label/bold/lg">Model Settings</Text>
+      <Text kind="body/regular/md">
+        Select the inference provider model the Anonymizer uses for entity detection and generation.
+      </Text>
+      <ControlledSelect
+        aria-label="Model"
+        items={items}
+        loading={isLoading}
+        placeholder="Select a model"
+        onChange={(value) => handleChange(value as string)}
+        useControllerProps={{ name: 'modelId', control }}
+        formFieldProps={{ slotLabel: 'Model', required: true }}
+      />
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
@@ -3,17 +3,27 @@
 
 import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
 import { useModelsListProviders } from '@nemo/sdk/generated/platform/api';
-import { Stack, Text } from '@nvidia/foundations-react-core';
+import { Divider, Stack, Text } from '@nvidia/foundations-react-core';
 import { modelsFromProviders } from '@studio/components/NewDataDesignerJobForm/utils';
 import { DEFAULT_LARGE_PAGE_SIZE } from '@studio/constants/constants';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import {
+  activeRolesForStrategy,
+  GLINER_ROLE,
+  ROLE_LABELS,
+} from '@studio/routes/AnonymizerBuilderRoute/constants';
 import type { AnonymizerFormData } from '@studio/routes/AnonymizerBuilderRoute/schema';
-import { FC, useMemo } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { FC, useEffect, useMemo } from 'react';
+import { type Path, useFormContext, useWatch } from 'react-hook-form';
+
+const isGliner = (name: string) => /gliner/i.test(name);
 
 export const ModelSettingsSection: FC = () => {
-  const { control, setValue } = useFormContext<AnonymizerFormData>();
+  const { control, setValue, getValues } = useFormContext<AnonymizerFormData>();
   const workspace = useWorkspaceFromPath();
+  const strategy = useWatch({ control, name: 'strategy' });
+
+  const roles = useMemo(() => activeRolesForStrategy(strategy), [strategy]);
 
   const { data: providersPage, isLoading } = useModelsListProviders(
     workspace,
@@ -30,27 +40,55 @@ export const ModelSettingsSection: FC = () => {
     [models]
   );
 
-  const handleChange = (id: string) => {
+  const applyModel = (role: string, id: string) => {
     const selected = models.find((model) => model.id === id);
-    setValue('model', selected?.served_model_name ?? '', { shouldValidate: true });
-    setValue('provider', selected?.model_providers?.[0] ?? '', { shouldValidate: true });
+    setValue(
+      `roleModels.${role}.model` as Path<AnonymizerFormData>,
+      selected?.served_model_name ?? '',
+      { shouldValidate: true }
+    );
+    setValue(
+      `roleModels.${role}.provider` as Path<AnonymizerFormData>,
+      selected?.model_providers?.[0] ?? '',
+      { shouldValidate: true }
+    );
   };
 
+  // Seed sensible defaults once models load: GLiNER for the detector, an LLM for the rest.
+  useEffect(() => {
+    if (!models.length) return;
+    const gliner = models.find((model) => isGliner(model.name)) ?? models[0];
+    const llm = models.find((model) => !isGliner(model.name)) ?? models[0];
+    for (const role of roles) {
+      const current = getValues(`roleModels.${role}.modelId` as Path<AnonymizerFormData>);
+      if (current) continue;
+      const pick = role === GLINER_ROLE ? gliner : llm;
+      setValue(`roleModels.${role}.modelId` as Path<AnonymizerFormData>, pick.id);
+      applyModel(role, pick.id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [models, roles, getValues, setValue]);
+
   return (
-    <Stack gap="density-lg">
-      <Text kind="label/bold/lg">Model Settings</Text>
-      <Text kind="body/regular/md">
-        Select the inference provider model the Anonymizer uses for entity detection and generation.
-      </Text>
-      <ControlledSelect
-        aria-label="Model"
-        items={items}
-        loading={isLoading}
-        placeholder="Select a model"
-        onChange={(value) => handleChange(value as string)}
-        useControllerProps={{ name: 'modelId', control }}
-        formFieldProps={{ slotLabel: 'Model', required: true }}
-      />
+    <Stack gap="density-2xl">
+      {roles.map((role, index) => (
+        <Stack key={role} gap="density-lg">
+          {index > 0 && <Divider orientation="horizontal" width="small" />}
+          <Text kind="label/bold/lg">{ROLE_LABELS[role] ?? role}</Text>
+          <ControlledSelect
+            aria-label={ROLE_LABELS[role] ?? role}
+            items={items}
+            loading={isLoading}
+            placeholder="Select a model"
+            onChange={(value) => applyModel(role, value as string)}
+            useControllerProps={{
+              name: `roleModels.${role}.modelId` as Path<AnonymizerFormData>,
+              control,
+            }}
+            formFieldProps={{ slotLabel: 'Model', required: true }}
+          />
+        </Stack>
+      ))}
     </Stack>
   );
 };

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
@@ -55,8 +55,6 @@ export const ModelSettingsSection: FC = () => {
     });
   };
 
-  // Seed sensible defaults once models load: GLiNER for the detector, a
-  // suggested chat model for the rest (avoids defaulting to a flaky first model).
   useEffect(() => {
     if (!models.length) return;
     const suggestedName = pickDefaultModelName(

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
+import { ControlledSearchableSelect } from '@nemo/common/src/components/form/ControlledSearchableSelect';
 import { useModelsListProviders } from '@nemo/sdk/generated/platform/api';
 import { Divider, Stack, Text } from '@nvidia/foundations-react-core';
 import { modelsFromProviders } from '@studio/components/NewDataDesignerJobForm/utils';
@@ -75,12 +75,14 @@ export const ModelSettingsSection: FC = () => {
         <Stack key={role} gap="density-lg">
           {index > 0 && <Divider orientation="horizontal" width="small" />}
           <Text kind="label/bold/lg">{ROLE_LABELS[role] ?? role}</Text>
-          <ControlledSelect
+          <ControlledSearchableSelect
             aria-label={ROLE_LABELS[role] ?? role}
-            items={items}
-            loading={isLoading}
-            placeholder="Select a model"
-            onChange={(value) => applyModel(role, value as string)}
+            options={items}
+            isLoading={isLoading}
+            triggerPlaceholder="Select a model"
+            searchPlaceholder="Search models..."
+            emptyMessage={isLoading ? 'Loading models...' : 'No models in this workspace.'}
+            onChange={(value) => applyModel(role, value)}
             useControllerProps={{
               name: `roleModels.${role}.modelId` as Path<AnonymizerFormData>,
               control,

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
@@ -15,6 +15,7 @@ import {
   ROLE_LABELS,
 } from '@studio/routes/AnonymizerBuilderRoute/constants';
 import type { AnonymizerFormData } from '@studio/routes/AnonymizerBuilderRoute/schema';
+import { pickDefaultModelName } from '@studio/util/buildSuggestedModelOptions';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
@@ -46,23 +47,26 @@ export const ModelSettingsSection: FC = () => {
 
   const applyModel = (role: string, id: string) => {
     const selected = models.find((model) => model.id === id);
-    setValue(
-      `roleModels.${role}.model`,
-      selected?.served_model_name ?? '',
-      { shouldValidate: true }
-    );
-    setValue(
-      `roleModels.${role}.provider`,
-      selected?.model_providers?.[0] ?? '',
-      { shouldValidate: true }
-    );
+    setValue(`roleModels.${role}.model`, selected?.served_model_name ?? '', {
+      shouldValidate: true,
+    });
+    setValue(`roleModels.${role}.provider`, selected?.model_providers?.[0] ?? '', {
+      shouldValidate: true,
+    });
   };
 
-  // Seed sensible defaults once models load: GLiNER for the detector, an LLM for the rest.
+  // Seed sensible defaults once models load: GLiNER for the detector, a
+  // suggested chat model for the rest (avoids defaulting to a flaky first model).
   useEffect(() => {
     if (!models.length) return;
-    const gliner = models.find((model) => isGliner(model.name)) ?? models[0];
-    const llm = models.find((model) => !isGliner(model.name)) ?? models[0];
+    const suggestedName = pickDefaultModelName(
+      models.map((model) => ({ name: model.served_model_name ?? model.name }))
+    );
+    const llm =
+      models.find((model) => (model.served_model_name ?? model.name) === suggestedName) ??
+      models.find((model) => !isGliner(model.name)) ??
+      models[0];
+    const gliner = models.find((model) => isGliner(model.name)) ?? llm;
     for (const role of roles) {
       const current = getValues(`roleModels.${role}.modelId`);
       if (current) continue;
@@ -101,10 +105,7 @@ export const ModelSettingsSection: FC = () => {
               onOpenChange={(next) => setOpenParamsRole(next ? role : null)}
               inferenceParams={roleModelsValue?.[role]?.params as Partial<InferenceParams>}
               onInferenceParamsChange={(params) =>
-                setValue(
-                  `roleModels.${role}.params`,
-                  params as Record<string, unknown>
-                )
+                setValue(`roleModels.${role}.params`, params as Record<string, unknown>)
               }
             />
           </Flex>

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/ModelSettingsSection.tsx
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ControlledSearchableSelect } from '@nemo/common/src/components/form/ControlledSearchableSelect';
+import { ParamsDropdown } from '@nemo/common/src/components/ModelSelectV2/ParamsDropdown';
 import { useModelsListProviders } from '@nemo/sdk/generated/platform/api';
-import { Divider, Stack, Text } from '@nvidia/foundations-react-core';
+import type { InferenceParams } from '@nemo/sdk/generated/platform/schema';
+import { Divider, Flex, Stack, Text } from '@nvidia/foundations-react-core';
 import { modelsFromProviders } from '@studio/components/NewDataDesignerJobForm/utils';
 import { DEFAULT_LARGE_PAGE_SIZE } from '@studio/constants/constants';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
@@ -13,8 +15,8 @@ import {
   ROLE_LABELS,
 } from '@studio/routes/AnonymizerBuilderRoute/constants';
 import type { AnonymizerFormData } from '@studio/routes/AnonymizerBuilderRoute/schema';
-import { FC, useEffect, useMemo } from 'react';
-import { type Path, useFormContext, useWatch } from 'react-hook-form';
+import { FC, useEffect, useMemo, useState } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 const isGliner = (name: string) => /gliner/i.test(name);
 
@@ -22,6 +24,8 @@ export const ModelSettingsSection: FC = () => {
   const { control, setValue, getValues } = useFormContext<AnonymizerFormData>();
   const workspace = useWorkspaceFromPath();
   const strategy = useWatch({ control, name: 'strategy' });
+  const roleModelsValue = useWatch({ control, name: 'roleModels' });
+  const [openParamsRole, setOpenParamsRole] = useState<string | null>(null);
 
   const roles = useMemo(() => activeRolesForStrategy(strategy), [strategy]);
 
@@ -43,12 +47,12 @@ export const ModelSettingsSection: FC = () => {
   const applyModel = (role: string, id: string) => {
     const selected = models.find((model) => model.id === id);
     setValue(
-      `roleModels.${role}.model` as Path<AnonymizerFormData>,
+      `roleModels.${role}.model`,
       selected?.served_model_name ?? '',
       { shouldValidate: true }
     );
     setValue(
-      `roleModels.${role}.provider` as Path<AnonymizerFormData>,
+      `roleModels.${role}.provider`,
       selected?.model_providers?.[0] ?? '',
       { shouldValidate: true }
     );
@@ -60,10 +64,10 @@ export const ModelSettingsSection: FC = () => {
     const gliner = models.find((model) => isGliner(model.name)) ?? models[0];
     const llm = models.find((model) => !isGliner(model.name)) ?? models[0];
     for (const role of roles) {
-      const current = getValues(`roleModels.${role}.modelId` as Path<AnonymizerFormData>);
+      const current = getValues(`roleModels.${role}.modelId`);
       if (current) continue;
       const pick = role === GLINER_ROLE ? gliner : llm;
-      setValue(`roleModels.${role}.modelId` as Path<AnonymizerFormData>, pick.id);
+      setValue(`roleModels.${role}.modelId`, pick.id);
       applyModel(role, pick.id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -75,20 +79,35 @@ export const ModelSettingsSection: FC = () => {
         <Stack key={role} gap="density-lg">
           {index > 0 && <Divider orientation="horizontal" width="small" />}
           <Text kind="label/bold/lg">{ROLE_LABELS[role] ?? role}</Text>
-          <ControlledSearchableSelect
-            aria-label={ROLE_LABELS[role] ?? role}
-            options={items}
-            isLoading={isLoading}
-            triggerPlaceholder="Select a model"
-            searchPlaceholder="Search models..."
-            emptyMessage={isLoading ? 'Loading models...' : 'No models in this workspace.'}
-            onChange={(value) => applyModel(role, value)}
-            useControllerProps={{
-              name: `roleModels.${role}.modelId` as Path<AnonymizerFormData>,
-              control,
-            }}
-            formFieldProps={{ slotLabel: 'Model', required: true }}
-          />
+          <Flex gap="density-md" align="end">
+            <div className="grow">
+              <ControlledSearchableSelect
+                aria-label={ROLE_LABELS[role] ?? role}
+                options={items}
+                isLoading={isLoading}
+                triggerPlaceholder="Select a model"
+                searchPlaceholder="Search models..."
+                emptyMessage={isLoading ? 'Loading models...' : 'No models in this workspace.'}
+                onChange={(value) => applyModel(role, value)}
+                useControllerProps={{
+                  name: `roleModels.${role}.modelId`,
+                  control,
+                }}
+                formFieldProps={{ slotLabel: 'Model', required: true }}
+              />
+            </div>
+            <ParamsDropdown
+              open={openParamsRole === role}
+              onOpenChange={(next) => setOpenParamsRole(next ? role : null)}
+              inferenceParams={roleModelsValue?.[role]?.params as Partial<InferenceParams>}
+              onInferenceParamsChange={(params) =>
+                setValue(
+                  `roleModels.${role}.params`,
+                  params as Record<string, unknown>
+                )
+              }
+            />
+          </Flex>
         </Stack>
       ))}
     </Stack>

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
@@ -60,6 +60,9 @@ export const ENTITY_MODE_OPTIONS: { value: EntityMode; children: string }[] = [
 
 export const DEFAULT_PREVIEW_ROWS = 1;
 
+/** Above this file size, skip column introspection and fall back to a text input. */
+export const MAX_COLUMN_INTROSPECTION_BYTES = 50 * 1024 * 1024;
+
 /** Role names the anonymizer workflows resolve against `model_configs` aliases. */
 export const DETECTION_ROLES = [
   'entity_detector',

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
@@ -59,3 +59,24 @@ export const ENTITY_MODE_OPTIONS: { value: EntityMode; children: string }[] = [
 ];
 
 export const DEFAULT_PREVIEW_ROWS = 1;
+
+/** Alias assigned to the single user-selected model in `model_configs`. */
+export const MODEL_ALIAS = 'anonymizer-model';
+
+/** Role names the anonymizer workflows resolve against `model_configs` aliases. */
+export const DETECTION_ROLES = [
+  'entity_detector',
+  'entity_validator',
+  'entity_augmenter',
+  'latent_detector',
+];
+export const REPLACE_ROLE = 'replacement_generator';
+export const REWRITE_ROLES = [
+  'domain_classifier',
+  'disposition_analyzer',
+  'meaning_extractor',
+  'qa_generator',
+  'rewriter',
+  'repairer',
+  'evaluator',
+];

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
@@ -70,6 +70,13 @@ export const MAX_COLUMN_INTROSPECTION_BYTES = 50 * 1024 * 1024;
  */
 export const DEFAULT_MODEL_TIMEOUT_SECONDS = 500;
 
+/**
+ * Default per-request max output tokens. High enough for reasoning models to
+ * finish their structured-output response without truncation. User-supplied
+ * inference params override it.
+ */
+export const DEFAULT_MODEL_MAX_TOKENS = 16384;
+
 /** Role names the anonymizer workflows resolve against `model_configs` aliases. */
 export const DETECTION_ROLES = [
   'entity_detector',

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
@@ -63,6 +63,13 @@ export const DEFAULT_PREVIEW_ROWS = 1;
 /** Above this file size, skip column introspection and fall back to a text input. */
 export const MAX_COLUMN_INTROSPECTION_BYTES = 50 * 1024 * 1024;
 
+/**
+ * Default per-request model timeout (seconds). Generous so slower reasoning
+ * models don't hit ModelTimeoutError during entity validation. User-supplied
+ * inference params override it.
+ */
+export const DEFAULT_MODEL_TIMEOUT_SECONDS = 300;
+
 /** Role names the anonymizer workflows resolve against `model_configs` aliases. */
 export const DETECTION_ROLES = [
   'entity_detector',

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
@@ -68,7 +68,7 @@ export const MAX_COLUMN_INTROSPECTION_BYTES = 50 * 1024 * 1024;
  * models don't hit ModelTimeoutError during entity validation. User-supplied
  * inference params override it.
  */
-export const DEFAULT_MODEL_TIMEOUT_SECONDS = 300;
+export const DEFAULT_MODEL_TIMEOUT_SECONDS = 500;
 
 /** Role names the anonymizer workflows resolve against `model_configs` aliases. */
 export const DETECTION_ROLES = [

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
@@ -24,7 +24,6 @@ export type Strategy =
   | typeof STRATEGY_HASH
   | typeof STRATEGY_REWRITE;
 
-/** Rewrite is applied via `config.rewrite`; the other four via `config.replace`. */
 export const REWRITE_STRATEGY: Strategy = STRATEGY_REWRITE;
 
 export const STRATEGY_OPTIONS: { label: string; value: Strategy }[] = [
@@ -60,24 +59,12 @@ export const ENTITY_MODE_OPTIONS: { value: EntityMode; children: string }[] = [
 
 export const DEFAULT_PREVIEW_ROWS = 1;
 
-/** Above this file size, skip column introspection and fall back to a text input. */
 export const MAX_COLUMN_INTROSPECTION_BYTES = 50 * 1024 * 1024;
 
-/**
- * Default per-request model timeout (seconds). Generous so slower reasoning
- * models don't hit ModelTimeoutError during entity validation. User-supplied
- * inference params override it.
- */
 export const DEFAULT_MODEL_TIMEOUT_SECONDS = 500;
 
-/**
- * Default per-request max output tokens. High enough for reasoning models to
- * finish their structured-output response without truncation. User-supplied
- * inference params override it.
- */
 export const DEFAULT_MODEL_MAX_TOKENS = 16384;
 
-/** Role names the anonymizer workflows resolve against `model_configs` aliases. */
 export const DETECTION_ROLES = [
   'entity_detector',
   'entity_validator',
@@ -110,10 +97,8 @@ export const ROLE_LABELS: Record<string, string> = {
   evaluator: 'Evaluator',
 };
 
-/** The role that expects a GLiNER PII detection model rather than an LLM. */
 export const GLINER_ROLE = 'entity_detector';
 
-/** Roles configured for a given strategy: detection always, plus the strategy's generator roles. */
 export const activeRolesForStrategy = (strategy: Strategy): string[] => {
   if (strategy === STRATEGY_REWRITE) return [...DETECTION_ROLES, ...REWRITE_ROLES];
   if (strategy === STRATEGY_SUBSTITUTE) return [...DETECTION_ROLES, REPLACE_ROLE];

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
@@ -60,9 +60,6 @@ export const ENTITY_MODE_OPTIONS: { value: EntityMode; children: string }[] = [
 
 export const DEFAULT_PREVIEW_ROWS = 1;
 
-/** Alias assigned to the single user-selected model in `model_configs`. */
-export const MODEL_ALIAS = 'anonymizer-model';
-
 /** Role names the anonymizer workflows resolve against `model_configs` aliases. */
 export const DETECTION_ROLES = [
   'entity_detector',
@@ -80,3 +77,28 @@ export const REWRITE_ROLES = [
   'repairer',
   'evaluator',
 ];
+
+export const ROLE_LABELS: Record<string, string> = {
+  entity_detector: 'Entity Detector',
+  entity_validator: 'Entity Validator',
+  entity_augmenter: 'Entity Augmenter',
+  latent_detector: 'Latent Detector',
+  replacement_generator: 'Replacement Generator',
+  domain_classifier: 'Domain Classifier',
+  disposition_analyzer: 'Disposition Analyzer',
+  meaning_extractor: 'Meaning Extractor',
+  qa_generator: 'QA Generator',
+  rewriter: 'Rewriter',
+  repairer: 'Repairer',
+  evaluator: 'Evaluator',
+};
+
+/** The role that expects a GLiNER PII detection model rather than an LLM. */
+export const GLINER_ROLE = 'entity_detector';
+
+/** Roles configured for a given strategy: detection always, plus the strategy's generator roles. */
+export const activeRolesForStrategy = (strategy: Strategy): string[] => {
+  if (strategy === STRATEGY_REWRITE) return [...DETECTION_ROLES, ...REWRITE_ROLES];
+  if (strategy === STRATEGY_SUBSTITUTE) return [...DETECTION_ROLES, REPLACE_ROLE];
+  return [...DETECTION_ROLES];
+};

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const SOURCE_TYPE_URL = 'url';
+export const SOURCE_TYPE_DATASET = 'dataset';
+
+export type SourceType = typeof SOURCE_TYPE_URL | typeof SOURCE_TYPE_DATASET;
+
+export const SOURCE_TYPE_OPTIONS: { label: string; value: SourceType }[] = [
+  { label: 'Dataset', value: SOURCE_TYPE_DATASET },
+  { label: 'URL', value: SOURCE_TYPE_URL },
+];
+
+export const STRATEGY_SUBSTITUTE = 'substitute';
+export const STRATEGY_REDACT = 'redact';
+export const STRATEGY_ANNOTATE = 'annotate';
+export const STRATEGY_HASH = 'hash';
+export const STRATEGY_REWRITE = 'rewrite';
+
+export type Strategy =
+  | typeof STRATEGY_SUBSTITUTE
+  | typeof STRATEGY_REDACT
+  | typeof STRATEGY_ANNOTATE
+  | typeof STRATEGY_HASH
+  | typeof STRATEGY_REWRITE;
+
+/** Rewrite is applied via `config.rewrite`; the other four via `config.replace`. */
+export const REWRITE_STRATEGY: Strategy = STRATEGY_REWRITE;
+
+export const STRATEGY_OPTIONS: { label: string; value: Strategy }[] = [
+  { label: 'Substitute', value: STRATEGY_SUBSTITUTE },
+  { label: 'Redact', value: STRATEGY_REDACT },
+  { label: 'Annotate', value: STRATEGY_ANNOTATE },
+  { label: 'Hash', value: STRATEGY_HASH },
+  { label: 'Rewrite', value: STRATEGY_REWRITE },
+];
+
+export const STRATEGY_DESCRIPTIONS: Record<Strategy, string> = {
+  [STRATEGY_SUBSTITUTE]:
+    'Replace detected entities with LLM-generated synthetic values for names, cities, dates, etc.',
+  [STRATEGY_REDACT]:
+    'Replace entities with a label-based marker. The original text is removed entirely.',
+  [STRATEGY_ANNOTATE]:
+    'Tag entities with their label but preserve the original text. Useful for review and debugging.',
+  [STRATEGY_HASH]:
+    'Replace entities with a deterministic hash digest. The same entity text always produces the same hash.',
+  [STRATEGY_REWRITE]:
+    'Transform the entire text to produce a privacy-safe version that reduces explicit and inferable identifiers.',
+};
+
+export const ENTITY_MODE_CUSTOM = 'custom';
+export const ENTITY_MODE_AUTO = 'auto';
+
+export type EntityMode = typeof ENTITY_MODE_CUSTOM | typeof ENTITY_MODE_AUTO;
+
+export const ENTITY_MODE_OPTIONS: { value: EntityMode; children: string }[] = [
+  { value: ENTITY_MODE_CUSTOM, children: 'Custom' },
+  { value: ENTITY_MODE_AUTO, children: 'Auto-detect' },
+];
+
+export const DEFAULT_PREVIEW_ROWS = 1;

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
@@ -11,10 +11,8 @@ import {
   Divider,
   Flex,
   Panel,
+  SegmentedControl,
   Stack,
-  TabsList,
-  TabsRoot,
-  TabsTrigger,
   Text,
 } from '@nvidia/foundations-react-core';
 import { getErrorMessage } from '@studio/api/common/utils';
@@ -125,19 +123,15 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
                   }
                 >
                   <Stack gap="density-2xl">
-                    <TabsRoot value={activeTab}>
-                      <TabsList>
-                        <TabsTrigger value={TAB_SOURCE} onClick={() => setActiveTab(TAB_SOURCE)}>
-                          Source
-                        </TabsTrigger>
-                        <TabsTrigger
-                          value={TAB_MODEL_SETTINGS}
-                          onClick={() => setActiveTab(TAB_MODEL_SETTINGS)}
-                        >
-                          Model Settings
-                        </TabsTrigger>
-                      </TabsList>
-                    </TabsRoot>
+                    <SegmentedControl
+                      className="w-full"
+                      value={activeTab}
+                      onValueChange={setActiveTab}
+                      items={[
+                        { value: TAB_SOURCE, children: 'Source' },
+                        { value: TAB_MODEL_SETTINGS, children: 'Model Settings' },
+                      ]}
+                    />
 
                     {submitError && (
                       <Banner kind="inline" status="error">

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
@@ -1,27 +1,153 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PageHeader, Stack } from '@nvidia/foundations-react-core';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useAnonymizerCreateRunJob } from '@nemo/sdk/generated/anonymizer/api';
+import type { RunJob } from '@nemo/sdk/generated/anonymizer/schema';
+import {
+  Banner,
+  Button,
+  Divider,
+  Flex,
+  Panel,
+  Stack,
+  TabsList,
+  TabsRoot,
+  TabsTrigger,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { getErrorMessage } from '@studio/api/common/utils';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { ANONYMIZER_ENABLED } from '@studio/constants/environment';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
-import { FC } from 'react';
+import { ColumnsSection } from '@studio/routes/AnonymizerBuilderRoute/components/ColumnsSection';
+import { DataSourceSection } from '@studio/routes/AnonymizerBuilderRoute/components/DataSourceSection';
+import { EntitiesSection } from '@studio/routes/AnonymizerBuilderRoute/components/EntitiesSection';
+import { GenerationSection } from '@studio/routes/AnonymizerBuilderRoute/components/GenerationSection';
+import {
+  anonymizerFormSchema,
+  buildAnonymizerJobRequest,
+  getAnonymizerFormDefaults,
+} from '@studio/routes/AnonymizerBuilderRoute/schema';
+import { getAnonymizerJobRoute, getWorkspaceAnonymizerRoute } from '@studio/routes/utils';
+import { FC, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+const TAB_SOURCE = 'source';
+const TAB_MODEL_SETTINGS = 'model-settings';
 
 export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
   ? () => {
+      const navigate = useNavigate();
+      const workspace = useWorkspaceFromPath();
+      const [activeTab, setActiveTab] = useState<string>(TAB_SOURCE);
+      const [submitError, setSubmitError] = useState<string | undefined>(undefined);
+
       useBreadcrumbs({
         items: [{ slotLabel: 'Anonymizer' }, { slotLabel: 'Anonymize Data' }],
       });
 
+      const form = useForm({
+        mode: 'onChange',
+        resolver: zodResolver(anonymizerFormSchema),
+        defaultValues: getAnonymizerFormDefaults(),
+      });
+
+      const createJob = useAnonymizerCreateRunJob({
+        mutation: {
+          onSuccess: (job: RunJob) =>
+            navigate(
+              job.name
+                ? getAnonymizerJobRoute(workspace, job.name)
+                : getWorkspaceAnonymizerRoute(workspace)
+            ),
+          onError: (error) =>
+            setSubmitError(getErrorMessage(error, 'Failed to create anonymizer job')),
+        },
+      });
+
+      const onSubmit = form.handleSubmit((values) => {
+        setSubmitError(undefined);
+        createJob.mutate({ workspace, data: buildAnonymizerJobRequest(values) });
+      });
+
+      const handleCancel = () => navigate(getWorkspaceAnonymizerRoute(workspace));
+
       return (
         <AccessibleTitle title="Anonymize Data">
-          <Stack className="h-full" gap="density-2xl" padding="density-2xl">
-            <PageHeader
-              className="p-0"
-              slotHeading="Anonymize Data"
-              slotDescription="Configure sources, entity detection, and masking strategy, then preview and run anonymization."
-            />
-          </Stack>
+          <FormProvider {...form}>
+            <form className="h-full" onSubmit={onSubmit}>
+              <Flex className="h-full" gap="0">
+                <Panel
+                  className="w-[400px] h-full overflow-auto"
+                  elevation="high"
+                  density="standard"
+                  slotFooter={
+                    <Flex gap="density-md" justify="end">
+                      <Button
+                        kind="tertiary"
+                        type="button"
+                        disabled={createJob.isPending}
+                        onClick={handleCancel}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        kind="primary"
+                        color="brand"
+                        type="submit"
+                        disabled={createJob.isPending}
+                      >
+                        Full Run
+                      </Button>
+                    </Flex>
+                  }
+                >
+                  <Stack gap="density-2xl">
+                    <TabsRoot value={activeTab}>
+                      <TabsList>
+                        <TabsTrigger value={TAB_SOURCE} onClick={() => setActiveTab(TAB_SOURCE)}>
+                          Source
+                        </TabsTrigger>
+                        <TabsTrigger
+                          value={TAB_MODEL_SETTINGS}
+                          onClick={() => setActiveTab(TAB_MODEL_SETTINGS)}
+                        >
+                          Model Settings
+                        </TabsTrigger>
+                      </TabsList>
+                    </TabsRoot>
+
+                    {submitError && (
+                      <Banner kind="inline" status="error">
+                        {submitError}
+                      </Banner>
+                    )}
+
+                    {activeTab === TAB_SOURCE ? (
+                      <Stack gap="density-2xl">
+                        <DataSourceSection />
+                        <Divider orientation="horizontal" width="small" />
+                        <GenerationSection />
+                        <Divider orientation="horizontal" width="small" />
+                        <ColumnsSection />
+                        <Divider orientation="horizontal" width="small" />
+                        <EntitiesSection />
+                      </Stack>
+                    ) : (
+                      <Text kind="body/regular/md">Model settings coming soon.</Text>
+                    )}
+                  </Stack>
+                </Panel>
+
+                <Flex className="flex-1 h-full" align="center" justify="center">
+                  <Text kind="body/regular/md">Your records preview will appear here</Text>
+                </Flex>
+              </Flex>
+            </form>
+          </FormProvider>
         </AccessibleTitle>
       );
     }

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
@@ -51,8 +51,6 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
       const [activeTab, setActiveTab] = useState<string>(TAB_SOURCE);
       const [submitError, setSubmitError] = useState<string | undefined>(undefined);
 
-      // Shared with ModelSettingsSection (react-query dedups) — gate submit until
-      // the model list has loaded and its role defaults have been seeded.
       const { isLoading: isLoadingModels } = useModelsListProviders(
         workspace,
         { page_size: DEFAULT_LARGE_PAGE_SIZE },
@@ -72,8 +70,6 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
       const createJob = useAnonymizerCreateRunJob({
         mutation: {
           onSuccess: (job: RunJob) =>
-            // Anonymizer jobs are platform jobs; route to the generic job
-            // detail until the dedicated Anonymizer job page (ASTD-330) lands.
             navigate(
               job.name
                 ? getWorkspaceJobDetailRoute(workspace, job.name)
@@ -90,7 +86,6 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
           createJob.mutate({ workspace, data: buildAnonymizerJobRequest(values) });
         },
         (errors) => {
-          // Jump to whichever tab holds the first error so it's never hidden.
           const onlyModelErrors = Object.keys(errors).every((key) => key === 'roleModels');
           setActiveTab(onlyModelErrors ? TAB_MODEL_SETTINGS : TAB_SOURCE);
           setSubmitError('Please complete the required fields highlighted below.');
@@ -143,8 +138,6 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
                       </Banner>
                     )}
 
-                    {/* Both panels stay mounted so Model Settings can seed its
-                        defaults even before the tab is opened. */}
                     <div className={activeTab === TAB_SOURCE ? undefined : 'hidden'}>
                       <Stack gap="density-2xl">
                         <DataSourceSection />

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
@@ -39,6 +39,11 @@ import { useNavigate } from 'react-router-dom';
 const TAB_SOURCE = 'source';
 const TAB_MODEL_SETTINGS = 'model-settings';
 
+const PANEL_TABS = [
+  { value: TAB_SOURCE, children: 'Source' },
+  { value: TAB_MODEL_SETTINGS, children: 'Model Settings' },
+];
+
 export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
   ? () => {
       const navigate = useNavigate();
@@ -129,10 +134,7 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
                       className="w-full"
                       value={activeTab}
                       onValueChange={setActiveTab}
-                      items={[
-                        { value: TAB_SOURCE, children: 'Source' },
-                        { value: TAB_MODEL_SETTINGS, children: 'Model Settings' },
-                      ]}
+                      items={PANEL_TABS}
                     />
 
                     {submitError && (

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
@@ -85,7 +85,10 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
           createJob.mutate({ workspace, data: buildAnonymizerJobRequest(values) });
         },
         (errors) => {
-          if (errors.roleModels) setActiveTab(TAB_MODEL_SETTINGS);
+          // Jump to whichever tab holds the first error so it's never hidden.
+          const onlyModelErrors = Object.keys(errors).every((key) => key === 'roleModels');
+          setActiveTab(onlyModelErrors ? TAB_MODEL_SETTINGS : TAB_SOURCE);
+          setSubmitError('Please complete the required fields highlighted below.');
         }
       );
 

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
@@ -75,7 +75,7 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
           createJob.mutate({ workspace, data: buildAnonymizerJobRequest(values) });
         },
         (errors) => {
-          if (errors.modelId) setActiveTab(TAB_MODEL_SETTINGS);
+          if (errors.roleModels) setActiveTab(TAB_MODEL_SETTINGS);
         }
       );
 

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
@@ -97,7 +97,7 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
       return (
         <AccessibleTitle title="Anonymize Data">
           <FormProvider {...form}>
-            <form className="h-full" onSubmit={onSubmit}>
+            <form className="h-full" noValidate onSubmit={onSubmit}>
               <Flex className="h-full" gap="0">
                 <Panel
                   className="w-[400px] h-full overflow-auto"

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
@@ -132,7 +132,9 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
                       </Banner>
                     )}
 
-                    {activeTab === TAB_SOURCE ? (
+                    {/* Both panels stay mounted so Model Settings can seed its
+                        defaults even before the tab is opened. */}
+                    <div className={activeTab === TAB_SOURCE ? undefined : 'hidden'}>
                       <Stack gap="density-2xl">
                         <DataSourceSection />
                         <Divider orientation="horizontal" width="small" />
@@ -142,9 +144,10 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
                         <Divider orientation="horizontal" width="small" />
                         <EntitiesSection />
                       </Stack>
-                    ) : (
+                    </div>
+                    <div className={activeTab === TAB_MODEL_SETTINGS ? undefined : 'hidden'}>
                       <ModelSettingsSection />
-                    )}
+                    </div>
                   </Stack>
                 </Panel>
 

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
@@ -4,6 +4,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAnonymizerCreateRunJob } from '@nemo/sdk/generated/anonymizer/api';
 import type { RunJob } from '@nemo/sdk/generated/anonymizer/schema';
+import { useModelsListProviders } from '@nemo/sdk/generated/platform/api';
 import {
   Banner,
   Button,
@@ -18,6 +19,7 @@ import {
 } from '@nvidia/foundations-react-core';
 import { getErrorMessage } from '@studio/api/common/utils';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { DEFAULT_LARGE_PAGE_SIZE } from '@studio/constants/constants';
 import { ANONYMIZER_ENABLED } from '@studio/constants/environment';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
@@ -45,6 +47,14 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
       const workspace = useWorkspaceFromPath();
       const [activeTab, setActiveTab] = useState<string>(TAB_SOURCE);
       const [submitError, setSubmitError] = useState<string | undefined>(undefined);
+
+      // Shared with ModelSettingsSection (react-query dedups) — gate submit until
+      // the model list has loaded and its role defaults have been seeded.
+      const { isLoading: isLoadingModels } = useModelsListProviders(
+        workspace,
+        { page_size: DEFAULT_LARGE_PAGE_SIZE },
+        { query: {} }
+      );
 
       useBreadcrumbs({
         items: [{ slotLabel: 'Anonymizer' }, { slotLabel: 'Anonymize Data' }],
@@ -104,7 +114,7 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
                         kind="primary"
                         color="brand"
                         type="submit"
-                        disabled={createJob.isPending}
+                        disabled={createJob.isPending || isLoadingModels}
                       >
                         Full Run
                       </Button>

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
@@ -31,7 +31,7 @@ import {
   buildAnonymizerJobRequest,
   getAnonymizerFormDefaults,
 } from '@studio/routes/AnonymizerBuilderRoute/schema';
-import { getAnonymizerJobRoute, getWorkspaceAnonymizerRoute } from '@studio/routes/utils';
+import { getWorkspaceAnonymizerRoute, getWorkspaceJobDetailRoute } from '@studio/routes/utils';
 import { FC, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -67,9 +67,11 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
       const createJob = useAnonymizerCreateRunJob({
         mutation: {
           onSuccess: (job: RunJob) =>
+            // Anonymizer jobs are platform jobs; route to the generic job
+            // detail until the dedicated Anonymizer job page (ASTD-330) lands.
             navigate(
               job.name
-                ? getAnonymizerJobRoute(workspace, job.name)
+                ? getWorkspaceJobDetailRoute(workspace, job.name)
                 : getWorkspaceAnonymizerRoute(workspace)
             ),
           onError: (error) =>

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/index.tsx
@@ -25,6 +25,7 @@ import { ColumnsSection } from '@studio/routes/AnonymizerBuilderRoute/components
 import { DataSourceSection } from '@studio/routes/AnonymizerBuilderRoute/components/DataSourceSection';
 import { EntitiesSection } from '@studio/routes/AnonymizerBuilderRoute/components/EntitiesSection';
 import { GenerationSection } from '@studio/routes/AnonymizerBuilderRoute/components/GenerationSection';
+import { ModelSettingsSection } from '@studio/routes/AnonymizerBuilderRoute/components/ModelSettingsSection';
 import {
   anonymizerFormSchema,
   buildAnonymizerJobRequest,
@@ -68,10 +69,15 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
         },
       });
 
-      const onSubmit = form.handleSubmit((values) => {
-        setSubmitError(undefined);
-        createJob.mutate({ workspace, data: buildAnonymizerJobRequest(values) });
-      });
+      const onSubmit = form.handleSubmit(
+        (values) => {
+          setSubmitError(undefined);
+          createJob.mutate({ workspace, data: buildAnonymizerJobRequest(values) });
+        },
+        (errors) => {
+          if (errors.modelId) setActiveTab(TAB_MODEL_SETTINGS);
+        }
+      );
 
       const handleCancel = () => navigate(getWorkspaceAnonymizerRoute(workspace));
 
@@ -137,7 +143,7 @@ export const AnonymizerBuilderRoute: FC | null = ANONYMIZER_ENABLED
                         <EntitiesSection />
                       </Stack>
                     ) : (
-                      <Text kind="body/regular/md">Model settings coming soon.</Text>
+                      <ModelSettingsSection />
                     )}
                   </Stack>
                 </Panel>

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
@@ -2,17 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  DETECTION_ROLES,
+  REPLACE_ROLE,
+  REWRITE_ROLES,
+  ROLE_LABELS,
+} from '@studio/routes/AnonymizerBuilderRoute/constants';
+import {
   AnonymizerFormData,
   buildAnonymizerJobRequest,
   getAnonymizerFormDefaults,
 } from '@studio/routes/AnonymizerBuilderRoute/schema';
 
+const ALL_ROLES = [...DETECTION_ROLES, REPLACE_ROLE, ...REWRITE_ROLES];
+
+const roleModels = (model: string, provider: string) =>
+  Object.fromEntries(ALL_ROLES.map((role) => [role, { modelId: role, model, provider }]));
+
 const form = (overrides: Partial<AnonymizerFormData> = {}): AnonymizerFormData => ({
   ...getAnonymizerFormDefaults(),
   source: 'https://example.com/data.csv',
-  modelId: 'default/gpt',
-  model: 'openai/gpt-oss-120b',
-  provider: 'default/nvidia',
+  roleModels: roleModels('openai/gpt-oss-120b', 'default/nvidia'),
   ...overrides,
 });
 
@@ -38,40 +47,51 @@ describe('buildAnonymizerJobRequest', () => {
     expect(req.spec.data.data_summary).toBeUndefined();
   });
 
-  it('passes through populated columns and a trimmed name', () => {
-    const req = buildAnonymizerJobRequest(
-      form({ name: '  job-1 ', textColumn: 'biography', dataSummary: 'profiles' })
-    );
-    expect(req.name).toBe('job-1');
-    expect(req.spec.data.text_column).toBe('biography');
-    expect(req.spec.data.data_summary).toBe('profiles');
+  it('deduplicates identical role models into a single model_config', () => {
+    const req = buildAnonymizerJobRequest(form({ strategy: 'substitute' }));
+    expect(req.spec.model_configs).toEqual([
+      { alias: 'model-1', model: 'openai/gpt-oss-120b', provider: 'default/nvidia' },
+    ]);
   });
 
-  it('emits a single model_config from the selected model and provider', () => {
-    const req = buildAnonymizerJobRequest(form());
-    expect(req.spec.model_configs).toEqual([
-      { alias: 'anonymizer-model', model: 'openai/gpt-oss-120b', provider: 'default/nvidia' },
-    ]);
+  it('emits one model_config per unique model+provider', () => {
+    const models = roleModels('openai/gpt-oss-120b', 'default/nvidia');
+    models[DETECTION_ROLES[0]] = {
+      modelId: 'gliner',
+      model: 'nvidia/gliner-pii',
+      provider: 'default/nvidia',
+    };
+    const req = buildAnonymizerJobRequest(form({ strategy: 'substitute', roleModels: models }));
+    expect(req.spec.model_configs).toHaveLength(2);
+    expect(req.spec.selected_models?.detection?.[DETECTION_ROLES[0]]).not.toBe(
+      req.spec.selected_models?.replace?.[REPLACE_ROLE]
+    );
   });
 
   it('maps detection + replace roles for substitute, detection + rewrite for rewrite', () => {
     const sub = buildAnonymizerJobRequest(form({ strategy: 'substitute' })).spec.selected_models;
-    expect(sub?.detection?.entity_detector).toBe('anonymizer-model');
-    expect(sub?.replace?.replacement_generator).toBe('anonymizer-model');
+    expect(sub?.detection?.entity_detector).toBe('model-1');
+    expect(sub?.replace?.replacement_generator).toBe('model-1');
     expect(sub?.rewrite).toBeUndefined();
 
     const rew = buildAnonymizerJobRequest(form({ strategy: 'rewrite' })).spec.selected_models;
-    expect(rew?.detection?.entity_detector).toBe('anonymizer-model');
-    expect(rew?.rewrite?.rewriter).toBe('anonymizer-model');
+    expect(rew?.detection?.entity_detector).toBe('model-1');
+    expect(rew?.rewrite?.rewriter).toBe('model-1');
     expect(rew?.replace).toBeUndefined();
   });
 
   it('maps only detection roles for redact/annotate/hash', () => {
     for (const strategy of ['redact', 'annotate', 'hash'] as const) {
       const selected = buildAnonymizerJobRequest(form({ strategy })).spec.selected_models;
-      expect(selected?.detection?.entity_detector).toBe('anonymizer-model');
+      expect(selected?.detection?.entity_detector).toBe('model-1');
       expect(selected?.replace).toBeUndefined();
       expect(selected?.rewrite).toBeUndefined();
+    }
+  });
+
+  it('exposes a label for every configurable role', () => {
+    for (const role of ALL_ROLES) {
+      expect(ROLE_LABELS[role]).toBeTruthy();
     }
   });
 });

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
@@ -47,10 +47,15 @@ describe('buildAnonymizerJobRequest', () => {
     expect(req.spec.data.data_summary).toBeUndefined();
   });
 
-  it('deduplicates identical role models into a single model_config', () => {
+  it('deduplicates identical role models into a single model_config with a default timeout', () => {
     const req = buildAnonymizerJobRequest(form({ strategy: 'substitute' }));
     expect(req.spec.model_configs).toEqual([
-      { alias: 'model-1', model: 'openai/gpt-oss-120b', provider: 'default/nvidia' },
+      {
+        alias: 'model-1',
+        model: 'openai/gpt-oss-120b',
+        provider: 'default/nvidia',
+        inference_parameters: { timeout: 300 },
+      },
     ]);
   });
 
@@ -121,7 +126,9 @@ describe('buildAnonymizerJobRequest', () => {
     const req = buildAnonymizerJobRequest(form({ strategy: 'substitute', roleModels: models }));
     // Same model+provider but one role has params → two distinct configs.
     expect(req.spec.model_configs).toHaveLength(2);
-    const withParams = req.spec.model_configs?.find((c) => c.inference_parameters);
-    expect(withParams?.inference_parameters).toEqual({ temperature: 0.1 });
+    const withTemp = req.spec.model_configs?.find(
+      (c) => (c.inference_parameters as { temperature?: number })?.temperature != null
+    );
+    expect(withTemp?.inference_parameters).toEqual({ timeout: 300, temperature: 0.1 });
   });
 });

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
@@ -54,7 +54,7 @@ describe('buildAnonymizerJobRequest', () => {
         alias: 'model-1',
         model: 'openai/gpt-oss-120b',
         provider: 'default/nvidia',
-        inference_parameters: { timeout: 300 },
+        inference_parameters: { timeout: 500 },
       },
     ]);
   });
@@ -129,6 +129,6 @@ describe('buildAnonymizerJobRequest', () => {
     const withTemp = req.spec.model_configs?.find(
       (c) => (c.inference_parameters as { temperature?: number })?.temperature != null
     );
-    expect(withTemp?.inference_parameters).toEqual({ timeout: 300, temperature: 0.1 });
+    expect(withTemp?.inference_parameters).toEqual({ timeout: 500, temperature: 0.1 });
   });
 });

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
@@ -10,6 +10,9 @@ import {
 const form = (overrides: Partial<AnonymizerFormData> = {}): AnonymizerFormData => ({
   ...getAnonymizerFormDefaults(),
   source: 'https://example.com/data.csv',
+  modelId: 'default/gpt',
+  model: 'openai/gpt-oss-120b',
+  provider: 'default/nvidia',
   ...overrides,
 });
 
@@ -42,5 +45,33 @@ describe('buildAnonymizerJobRequest', () => {
     expect(req.name).toBe('job-1');
     expect(req.spec.data.text_column).toBe('biography');
     expect(req.spec.data.data_summary).toBe('profiles');
+  });
+
+  it('emits a single model_config from the selected model and provider', () => {
+    const req = buildAnonymizerJobRequest(form());
+    expect(req.spec.model_configs).toEqual([
+      { alias: 'anonymizer-model', model: 'openai/gpt-oss-120b', provider: 'default/nvidia' },
+    ]);
+  });
+
+  it('maps detection + replace roles for substitute, detection + rewrite for rewrite', () => {
+    const sub = buildAnonymizerJobRequest(form({ strategy: 'substitute' })).spec.selected_models;
+    expect(sub?.detection?.entity_detector).toBe('anonymizer-model');
+    expect(sub?.replace?.replacement_generator).toBe('anonymizer-model');
+    expect(sub?.rewrite).toBeUndefined();
+
+    const rew = buildAnonymizerJobRequest(form({ strategy: 'rewrite' })).spec.selected_models;
+    expect(rew?.detection?.entity_detector).toBe('anonymizer-model');
+    expect(rew?.rewrite?.rewriter).toBe('anonymizer-model');
+    expect(rew?.replace).toBeUndefined();
+  });
+
+  it('maps only detection roles for redact/annotate/hash', () => {
+    for (const strategy of ['redact', 'annotate', 'hash'] as const) {
+      const selected = buildAnonymizerJobRequest(form({ strategy })).spec.selected_models;
+      expect(selected?.detection?.entity_detector).toBe('anonymizer-model');
+      expect(selected?.replace).toBeUndefined();
+      expect(selected?.rewrite).toBeUndefined();
+    }
   });
 });

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
@@ -94,4 +94,19 @@ describe('buildAnonymizerJobRequest', () => {
       expect(ROLE_LABELS[role]).toBeTruthy();
     }
   });
+
+  it('attaches inference_parameters and splits configs when params differ', () => {
+    const models = roleModels('openai/gpt-oss-120b', 'default/nvidia');
+    models[DETECTION_ROLES[0]] = {
+      modelId: 'gpt',
+      model: 'openai/gpt-oss-120b',
+      provider: 'default/nvidia',
+      params: { temperature: 0.1 },
+    };
+    const req = buildAnonymizerJobRequest(form({ strategy: 'substitute', roleModels: models }));
+    // Same model+provider but one role has params → two distinct configs.
+    expect(req.spec.model_configs).toHaveLength(2);
+    const withParams = req.spec.model_configs?.find((c) => c.inference_parameters);
+    expect(withParams?.inference_parameters).toEqual({ temperature: 0.1 });
+  });
 });

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
@@ -129,6 +129,10 @@ describe('buildAnonymizerJobRequest', () => {
     const withTemp = req.spec.model_configs?.find(
       (c) => (c.inference_parameters as { temperature?: number })?.temperature != null
     );
-    expect(withTemp?.inference_parameters).toEqual({ timeout: 500, max_tokens: 16384, temperature: 0.1 });
+    expect(withTemp?.inference_parameters).toEqual({
+      timeout: 500,
+      max_tokens: 16384,
+      temperature: 0.1,
+    });
   });
 });

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
@@ -95,6 +95,21 @@ describe('buildAnonymizerJobRequest', () => {
     }
   });
 
+  it('sets config.detect.entity_labels only for custom labels without defaults', () => {
+    const custom = buildAnonymizerJobRequest(
+      form({ entityMode: 'custom', includeDefaultEntities: false, entityLabels: ['email', 'ssn'] })
+    );
+    expect(custom.spec.config.detect).toEqual({ entity_labels: ['email', 'ssn'] });
+
+    const withDefaults = buildAnonymizerJobRequest(
+      form({ entityMode: 'custom', includeDefaultEntities: true, entityLabels: ['email'] })
+    );
+    expect(withDefaults.spec.config.detect).toBeUndefined();
+
+    const auto = buildAnonymizerJobRequest(form({ entityMode: 'auto', entityLabels: ['email'] }));
+    expect(auto.spec.config.detect).toBeUndefined();
+  });
+
   it('attaches inference_parameters and splits configs when params differ', () => {
     const models = roleModels('openai/gpt-oss-120b', 'default/nvidia');
     models[DETECTION_ROLES[0]] = {

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
@@ -15,7 +15,7 @@ import {
 
 const ALL_ROLES = [...DETECTION_ROLES, REPLACE_ROLE, ...REWRITE_ROLES];
 
-const roleModels = (model: string, provider: string) =>
+const roleModels = (model: string, provider: string): AnonymizerFormData['roleModels'] =>
   Object.fromEntries(ALL_ROLES.map((role) => [role, { modelId: role, model, provider }]));
 
 const form = (overrides: Partial<AnonymizerFormData> = {}): AnonymizerFormData => ({

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
@@ -124,7 +124,6 @@ describe('buildAnonymizerJobRequest', () => {
       params: { temperature: 0.1 },
     };
     const req = buildAnonymizerJobRequest(form({ strategy: 'substitute', roleModels: models }));
-    // Same model+provider but one role has params → two distinct configs.
     expect(req.spec.model_configs).toHaveLength(2);
     const withTemp = req.spec.model_configs?.find(
       (c) => (c.inference_parameters as { temperature?: number })?.temperature != null

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
@@ -54,7 +54,7 @@ describe('buildAnonymizerJobRequest', () => {
         alias: 'model-1',
         model: 'openai/gpt-oss-120b',
         provider: 'default/nvidia',
-        inference_parameters: { timeout: 500 },
+        inference_parameters: { timeout: 500, max_tokens: 16384 },
       },
     ]);
   });
@@ -129,6 +129,6 @@ describe('buildAnonymizerJobRequest', () => {
     const withTemp = req.spec.model_configs?.find(
       (c) => (c.inference_parameters as { temperature?: number })?.temperature != null
     );
-    expect(withTemp?.inference_parameters).toEqual({ timeout: 500, temperature: 0.1 });
+    expect(withTemp?.inference_parameters).toEqual({ timeout: 500, max_tokens: 16384, temperature: 0.1 });
   });
 });

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.test.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AnonymizerFormData,
+  buildAnonymizerJobRequest,
+  getAnonymizerFormDefaults,
+} from '@studio/routes/AnonymizerBuilderRoute/schema';
+
+const form = (overrides: Partial<AnonymizerFormData> = {}): AnonymizerFormData => ({
+  ...getAnonymizerFormDefaults(),
+  source: 'https://example.com/data.csv',
+  ...overrides,
+});
+
+describe('buildAnonymizerJobRequest', () => {
+  it('routes the four replace strategies to config.replace with the kind tag', () => {
+    for (const strategy of ['substitute', 'redact', 'annotate', 'hash'] as const) {
+      const req = buildAnonymizerJobRequest(form({ strategy }));
+      expect(req.spec.config).toEqual({ replace: { kind: strategy } });
+    }
+  });
+
+  it('routes rewrite to config.rewrite', () => {
+    const req = buildAnonymizerJobRequest(form({ strategy: 'rewrite' }));
+    expect(req.spec.config).toEqual({ rewrite: {} });
+  });
+
+  it('trims the source and omits empty optional fields', () => {
+    const req = buildAnonymizerJobRequest(
+      form({ source: '  s3://x.csv  ', textColumn: '', dataSummary: '   ' })
+    );
+    expect(req.spec.data.source).toBe('s3://x.csv');
+    expect(req.spec.data.text_column).toBeUndefined();
+    expect(req.spec.data.data_summary).toBeUndefined();
+  });
+
+  it('passes through populated columns and a trimmed name', () => {
+    const req = buildAnonymizerJobRequest(
+      form({ name: '  job-1 ', textColumn: 'biography', dataSummary: 'profiles' })
+    );
+    expect(req.name).toBe('job-1');
+    expect(req.spec.data.text_column).toBe('biography');
+    expect(req.spec.data.data_summary).toBe('profiles');
+  });
+});

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
@@ -9,10 +9,10 @@ import type {
   SelectedModelsOverrides,
 } from '@nemo/sdk/generated/anonymizer/schema';
 import {
+  activeRolesForStrategy,
   DETECTION_ROLES,
   DEFAULT_PREVIEW_ROWS,
   ENTITY_MODE_CUSTOM,
-  MODEL_ALIAS,
   REPLACE_ROLE,
   REWRITE_ROLES,
   REWRITE_STRATEGY,
@@ -21,20 +21,37 @@ import {
 } from '@studio/routes/AnonymizerBuilderRoute/constants';
 import { z } from 'zod';
 
-export const anonymizerFormSchema = z.object({
-  name: z.string().optional(),
-  sourceType: z.enum(['url', 'dataset']),
-  source: z.string().min(1, 'A data source is required'),
-  strategy: z.enum(['substitute', 'redact', 'annotate', 'hash', 'rewrite']),
-  previewRows: z.number().int().min(1),
-  textColumn: z.string().optional(),
-  dataSummary: z.string().optional(),
-  entityMode: z.enum([ENTITY_MODE_CUSTOM, 'auto']),
-  includeDefaultEntities: z.boolean(),
-  modelId: z.string().min(1, 'Select a model in the Model Settings tab'),
-  model: z.string().optional(),
-  provider: z.string().optional(),
+const roleModelSchema = z.object({
+  modelId: z.string(),
+  model: z.string(),
+  provider: z.string(),
 });
+
+export const anonymizerFormSchema = z
+  .object({
+    name: z.string().optional(),
+    sourceType: z.enum(['url', 'dataset']),
+    source: z.string().min(1, 'A data source is required'),
+    strategy: z.enum(['substitute', 'redact', 'annotate', 'hash', 'rewrite']),
+    previewRows: z.number().int().min(1),
+    textColumn: z.string().optional(),
+    dataSummary: z.string().optional(),
+    entityMode: z.enum([ENTITY_MODE_CUSTOM, 'auto']),
+    includeDefaultEntities: z.boolean(),
+    roleModels: z.record(z.string(), roleModelSchema),
+  })
+  .superRefine((data, ctx) => {
+    for (const role of activeRolesForStrategy(data.strategy)) {
+      const roleModel = data.roleModels[role];
+      if (!roleModel?.model || !roleModel?.provider) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['roleModels', role, 'modelId'],
+          message: 'Select a model',
+        });
+      }
+    }
+  });
 
 export type AnonymizerFormData = z.infer<typeof anonymizerFormSchema>;
 
@@ -48,29 +65,8 @@ export const getAnonymizerFormDefaults = (): AnonymizerFormData => ({
   dataSummary: '',
   entityMode: ENTITY_MODE_CUSTOM,
   includeDefaultEntities: true,
-  modelId: '',
-  model: '',
-  provider: '',
+  roleModels: {},
 });
-
-/**
- * Map every role of the strategy's active workflow(s) to the single selected
- * model alias, so the merged library defaults don't reference aliases missing
- * from `model_configs`. Detection runs for all strategies; substitute adds the
- * replace role; rewrite adds the rewrite roles.
- */
-const buildSelectedModels = (strategy: AnonymizerFormData['strategy']): SelectedModelsOverrides => {
-  const toRoleMap = (roles: string[]) =>
-    Object.fromEntries(roles.map((role) => [role, MODEL_ALIAS]));
-
-  const selected: SelectedModelsOverrides = { detection: toRoleMap(DETECTION_ROLES) };
-  if (strategy === REWRITE_STRATEGY) {
-    selected.rewrite = toRoleMap(REWRITE_ROLES);
-  } else if (strategy === STRATEGY_SUBSTITUTE) {
-    selected.replace = { [REPLACE_ROLE]: MODEL_ALIAS };
-  }
-  return selected;
-};
 
 const trimToUndefined = (value: string | undefined): string | undefined => {
   const trimmed = value?.trim();
@@ -81,8 +77,11 @@ const trimToUndefined = (value: string | undefined): string | undefined => {
  * Build the create-job request. The strategy is applied via `config.rewrite`
  * for Rewrite and `config.replace` for the other four. `replace` is a
  * `kind`-discriminated union server-side, so the tag must be sent even though
- * it isn't a modelled field on the SDK types. Strategy-specific parameters
- * (templates, hash length, risk tolerance, …) are added in a follow-up.
+ * it isn't a modelled field on the SDK types.
+ *
+ * Each active role's model is deduplicated into a `model_configs` pool (one
+ * entry per unique model+provider) and `selected_models` maps every role of
+ * the strategy's workflow(s) to the matching alias.
  */
 export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobRequest => {
   const config: AnonymizerConfigInput =
@@ -90,9 +89,32 @@ export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobReque
       ? { rewrite: {} }
       : { replace: { kind: form.strategy } as AnonymizerConfigInput['replace'] };
 
-  const modelConfigs: ModelConfig[] = [
-    { alias: MODEL_ALIAS, model: form.model?.trim() ?? '', provider: form.provider?.trim() ?? '' },
-  ];
+  const aliasByModel = new Map<string, string>();
+  const modelConfigs: ModelConfig[] = [];
+  const aliasForRole: Record<string, string> = {};
+
+  for (const role of activeRolesForStrategy(form.strategy)) {
+    const model = form.roleModels[role]?.model.trim() ?? '';
+    const provider = form.roleModels[role]?.provider.trim() ?? '';
+    const key = `${provider}::${model}`;
+    let alias = aliasByModel.get(key);
+    if (!alias) {
+      alias = `model-${aliasByModel.size + 1}`;
+      aliasByModel.set(key, alias);
+      modelConfigs.push({ alias, model, provider });
+    }
+    aliasForRole[role] = alias;
+  }
+
+  const toRoleMap = (roles: string[]) =>
+    Object.fromEntries(roles.map((role) => [role, aliasForRole[role]]));
+
+  const selectedModels: SelectedModelsOverrides = { detection: toRoleMap(DETECTION_ROLES) };
+  if (form.strategy === REWRITE_STRATEGY) {
+    selectedModels.rewrite = toRoleMap(REWRITE_ROLES);
+  } else if (form.strategy === STRATEGY_SUBSTITUTE) {
+    selectedModels.replace = { [REPLACE_ROLE]: aliasForRole[REPLACE_ROLE] };
+  }
 
   return {
     name: trimToUndefined(form.name),
@@ -104,7 +126,7 @@ export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobReque
         data_summary: trimToUndefined(form.dataSummary),
       },
       model_configs: modelConfigs,
-      selected_models: buildSelectedModels(form.strategy),
+      selected_models: selectedModels,
     },
   };
 };

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
@@ -21,6 +21,7 @@ import {
   SOURCE_TYPE_DATASET,
   STRATEGY_SUBSTITUTE,
 } from '@studio/routes/AnonymizerBuilderRoute/constants';
+import { trimToUndefined } from '@studio/util/strings';
 import { z } from 'zod';
 
 const roleModelSchema = z.object({
@@ -72,11 +73,6 @@ export const getAnonymizerFormDefaults = (): AnonymizerFormData => ({
   entityLabels: [],
   roleModels: {},
 });
-
-const trimToUndefined = (value: string | undefined): string | undefined => {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
-};
 
 export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobRequest => {
   const config: AnonymizerConfigInput =

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
+import type { AnonymizerConfigInput, RunJobRequest } from '@nemo/sdk/generated/anonymizer/schema';
+import {
+  DEFAULT_PREVIEW_ROWS,
+  ENTITY_MODE_CUSTOM,
+  REWRITE_STRATEGY,
+  SOURCE_TYPE_DATASET,
+  STRATEGY_SUBSTITUTE,
+} from '@studio/routes/AnonymizerBuilderRoute/constants';
+import { z } from 'zod';
+
+export const anonymizerFormSchema = z.object({
+  name: z.string().optional(),
+  sourceType: z.enum(['url', 'dataset']),
+  source: z.string().min(1, 'A data source is required'),
+  strategy: z.enum(['substitute', 'redact', 'annotate', 'hash', 'rewrite']),
+  previewRows: z.number().int().min(1),
+  textColumn: z.string().optional(),
+  dataSummary: z.string().optional(),
+  entityMode: z.enum([ENTITY_MODE_CUSTOM, 'auto']),
+  includeDefaultEntities: z.boolean(),
+});
+
+export type AnonymizerFormData = z.infer<typeof anonymizerFormSchema>;
+
+export const getAnonymizerFormDefaults = (): AnonymizerFormData => ({
+  name: generateDefaultName(),
+  sourceType: SOURCE_TYPE_DATASET,
+  source: '',
+  strategy: STRATEGY_SUBSTITUTE,
+  previewRows: DEFAULT_PREVIEW_ROWS,
+  textColumn: '',
+  dataSummary: '',
+  entityMode: ENTITY_MODE_CUSTOM,
+  includeDefaultEntities: true,
+});
+
+const trimToUndefined = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+/**
+ * Build the create-job request. The strategy is applied via `config.rewrite`
+ * for Rewrite and `config.replace` for the other four. `replace` is a
+ * `kind`-discriminated union server-side, so the tag must be sent even though
+ * it isn't a modelled field on the SDK types. Strategy-specific parameters
+ * (templates, hash length, risk tolerance, …) are added in a follow-up.
+ */
+export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobRequest => {
+  const config: AnonymizerConfigInput =
+    form.strategy === REWRITE_STRATEGY
+      ? { rewrite: {} }
+      : { replace: { kind: form.strategy } as AnonymizerConfigInput['replace'] };
+
+  return {
+    name: trimToUndefined(form.name),
+    spec: {
+      config,
+      data: {
+        source: form.source.trim(),
+        text_column: trimToUndefined(form.textColumn),
+        data_summary: trimToUndefined(form.dataSummary),
+      },
+    },
+  };
+};

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
@@ -11,6 +11,7 @@ import type {
 import {
   activeRolesForStrategy,
   DETECTION_ROLES,
+  DEFAULT_MODEL_MAX_TOKENS,
   DEFAULT_MODEL_TIMEOUT_SECONDS,
   DEFAULT_PREVIEW_ROWS,
   ENTITY_MODE_CUSTOM,
@@ -111,8 +112,12 @@ export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobReque
     const roleModel = form.roleModels[role];
     const model = roleModel?.model.trim() ?? '';
     const provider = roleModel?.provider.trim() ?? '';
-    // Default a generous timeout; user-supplied params override it.
-    const params = { timeout: DEFAULT_MODEL_TIMEOUT_SECONDS, ...(roleModel?.params ?? {}) };
+    // Default a generous timeout and max_tokens; user params override.
+    const params = {
+      timeout: DEFAULT_MODEL_TIMEOUT_SECONDS,
+      max_tokens: DEFAULT_MODEL_MAX_TOKENS,
+      ...(roleModel?.params ?? {}),
+    };
     const key = `${provider}::${model}::${JSON.stringify(params)}`;
     let alias = aliasByModel.get(key);
     if (!alias) {

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
@@ -78,24 +78,12 @@ const trimToUndefined = (value: string | undefined): string | undefined => {
   return trimmed ? trimmed : undefined;
 };
 
-/**
- * Build the create-job request. The strategy is applied via `config.rewrite`
- * for Rewrite and `config.replace` for the other four. `replace` is a
- * `kind`-discriminated union server-side, so the tag must be sent even though
- * it isn't a modelled field on the SDK types.
- *
- * Each active role's model is deduplicated into a `model_configs` pool (one
- * entry per unique model+provider) and `selected_models` maps every role of
- * the strategy's workflow(s) to the matching alias.
- */
 export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobRequest => {
   const config: AnonymizerConfigInput =
     form.strategy === REWRITE_STRATEGY
       ? { rewrite: {} }
       : { replace: { kind: form.strategy } as AnonymizerConfigInput['replace'] };
 
-  // Custom mode with a specific label set restricts detection; otherwise the
-  // library default set is used (detect omitted).
   const useCustomLabels =
     form.entityMode === ENTITY_MODE_CUSTOM &&
     !form.includeDefaultEntities &&
@@ -112,7 +100,6 @@ export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobReque
     const roleModel = form.roleModels[role];
     const model = roleModel?.model.trim() ?? '';
     const provider = roleModel?.provider.trim() ?? '';
-    // Default a generous timeout and max_tokens; user params override.
     const params = {
       timeout: DEFAULT_MODEL_TIMEOUT_SECONDS,
       max_tokens: DEFAULT_MODEL_MAX_TOKENS,

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
@@ -34,7 +34,7 @@ export const anonymizerFormSchema = z
   .object({
     name: z.string().optional(),
     sourceType: z.enum(['url', 'dataset']),
-    source: z.string().min(1, 'A data source is required'),
+    source: z.string().trim().min(1, 'A data source is required'),
     strategy: z.enum(['substitute', 'redact', 'annotate', 'hash', 'rewrite']),
     previewRows: z.number().int().min(1),
     textColumn: z.string().optional(),

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
@@ -11,6 +11,7 @@ import type {
 import {
   activeRolesForStrategy,
   DETECTION_ROLES,
+  DEFAULT_MODEL_TIMEOUT_SECONDS,
   DEFAULT_PREVIEW_ROWS,
   ENTITY_MODE_CUSTOM,
   REPLACE_ROLE,
@@ -110,9 +111,9 @@ export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobReque
     const roleModel = form.roleModels[role];
     const model = roleModel?.model.trim() ?? '';
     const provider = roleModel?.provider.trim() ?? '';
-    const params = roleModel?.params;
-    const hasParams = params != null && Object.keys(params).length > 0;
-    const key = `${provider}::${model}::${hasParams ? JSON.stringify(params) : ''}`;
+    // Default a generous timeout; user-supplied params override it.
+    const params = { timeout: DEFAULT_MODEL_TIMEOUT_SECONDS, ...(roleModel?.params ?? {}) };
+    const key = `${provider}::${model}::${JSON.stringify(params)}`;
     let alias = aliasByModel.get(key);
     if (!alias) {
       alias = `model-${aliasByModel.size + 1}`;
@@ -121,9 +122,7 @@ export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobReque
         alias,
         model,
         provider,
-        ...(hasParams
-          ? { inference_parameters: params as ModelConfig['inference_parameters'] }
-          : {}),
+        inference_parameters: params as ModelConfig['inference_parameters'],
       });
     }
     aliasForRole[role] = alias;

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
@@ -25,6 +25,7 @@ const roleModelSchema = z.object({
   modelId: z.string(),
   model: z.string(),
   provider: z.string(),
+  params: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const anonymizerFormSchema = z
@@ -94,14 +95,24 @@ export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobReque
   const aliasForRole: Record<string, string> = {};
 
   for (const role of activeRolesForStrategy(form.strategy)) {
-    const model = form.roleModels[role]?.model.trim() ?? '';
-    const provider = form.roleModels[role]?.provider.trim() ?? '';
-    const key = `${provider}::${model}`;
+    const roleModel = form.roleModels[role];
+    const model = roleModel?.model.trim() ?? '';
+    const provider = roleModel?.provider.trim() ?? '';
+    const params = roleModel?.params;
+    const hasParams = params != null && Object.keys(params).length > 0;
+    const key = `${provider}::${model}::${hasParams ? JSON.stringify(params) : ''}`;
     let alias = aliasByModel.get(key);
     if (!alias) {
       alias = `model-${aliasByModel.size + 1}`;
       aliasByModel.set(key, alias);
-      modelConfigs.push({ alias, model, provider });
+      modelConfigs.push({
+        alias,
+        model,
+        provider,
+        ...(hasParams
+          ? { inference_parameters: params as ModelConfig['inference_parameters'] }
+          : {}),
+      });
     }
     aliasForRole[role] = alias;
   }

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
@@ -39,6 +39,7 @@ export const anonymizerFormSchema = z
     dataSummary: z.string().optional(),
     entityMode: z.enum([ENTITY_MODE_CUSTOM, 'auto']),
     includeDefaultEntities: z.boolean(),
+    entityLabels: z.array(z.string()),
     roleModels: z.record(z.string(), roleModelSchema),
   })
   .superRefine((data, ctx) => {
@@ -66,6 +67,7 @@ export const getAnonymizerFormDefaults = (): AnonymizerFormData => ({
   dataSummary: '',
   entityMode: ENTITY_MODE_CUSTOM,
   includeDefaultEntities: true,
+  entityLabels: [],
   roleModels: {},
 });
 
@@ -89,6 +91,16 @@ export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobReque
     form.strategy === REWRITE_STRATEGY
       ? { rewrite: {} }
       : { replace: { kind: form.strategy } as AnonymizerConfigInput['replace'] };
+
+  // Custom mode with a specific label set restricts detection; otherwise the
+  // library default set is used (detect omitted).
+  const useCustomLabels =
+    form.entityMode === ENTITY_MODE_CUSTOM &&
+    !form.includeDefaultEntities &&
+    form.entityLabels.length > 0;
+  if (useCustomLabels) {
+    config.detect = { entity_labels: form.entityLabels };
+  }
 
   const aliasByModel = new Map<string, string>();
   const modelConfigs: ModelConfig[] = [];

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/schema.ts
@@ -2,10 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
-import type { AnonymizerConfigInput, RunJobRequest } from '@nemo/sdk/generated/anonymizer/schema';
+import type {
+  AnonymizerConfigInput,
+  ModelConfig,
+  RunJobRequest,
+  SelectedModelsOverrides,
+} from '@nemo/sdk/generated/anonymizer/schema';
 import {
+  DETECTION_ROLES,
   DEFAULT_PREVIEW_ROWS,
   ENTITY_MODE_CUSTOM,
+  MODEL_ALIAS,
+  REPLACE_ROLE,
+  REWRITE_ROLES,
   REWRITE_STRATEGY,
   SOURCE_TYPE_DATASET,
   STRATEGY_SUBSTITUTE,
@@ -22,6 +31,9 @@ export const anonymizerFormSchema = z.object({
   dataSummary: z.string().optional(),
   entityMode: z.enum([ENTITY_MODE_CUSTOM, 'auto']),
   includeDefaultEntities: z.boolean(),
+  modelId: z.string().min(1, 'Select a model in the Model Settings tab'),
+  model: z.string().optional(),
+  provider: z.string().optional(),
 });
 
 export type AnonymizerFormData = z.infer<typeof anonymizerFormSchema>;
@@ -36,7 +48,29 @@ export const getAnonymizerFormDefaults = (): AnonymizerFormData => ({
   dataSummary: '',
   entityMode: ENTITY_MODE_CUSTOM,
   includeDefaultEntities: true,
+  modelId: '',
+  model: '',
+  provider: '',
 });
+
+/**
+ * Map every role of the strategy's active workflow(s) to the single selected
+ * model alias, so the merged library defaults don't reference aliases missing
+ * from `model_configs`. Detection runs for all strategies; substitute adds the
+ * replace role; rewrite adds the rewrite roles.
+ */
+const buildSelectedModels = (strategy: AnonymizerFormData['strategy']): SelectedModelsOverrides => {
+  const toRoleMap = (roles: string[]) =>
+    Object.fromEntries(roles.map((role) => [role, MODEL_ALIAS]));
+
+  const selected: SelectedModelsOverrides = { detection: toRoleMap(DETECTION_ROLES) };
+  if (strategy === REWRITE_STRATEGY) {
+    selected.rewrite = toRoleMap(REWRITE_ROLES);
+  } else if (strategy === STRATEGY_SUBSTITUTE) {
+    selected.replace = { [REPLACE_ROLE]: MODEL_ALIAS };
+  }
+  return selected;
+};
 
 const trimToUndefined = (value: string | undefined): string | undefined => {
   const trimmed = value?.trim();
@@ -56,6 +90,10 @@ export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobReque
       ? { rewrite: {} }
       : { replace: { kind: form.strategy } as AnonymizerConfigInput['replace'] };
 
+  const modelConfigs: ModelConfig[] = [
+    { alias: MODEL_ALIAS, model: form.model?.trim() ?? '', provider: form.provider?.trim() ?? '' },
+  ];
+
   return {
     name: trimToUndefined(form.name),
     spec: {
@@ -65,6 +103,8 @@ export const buildAnonymizerJobRequest = (form: AnonymizerFormData): RunJobReque
         text_column: trimToUndefined(form.textColumn),
         data_summary: trimToUndefined(form.dataSummary),
       },
+      model_configs: modelConfigs,
+      selected_models: buildSelectedModels(form.strategy),
     },
   };
 };

--- a/web/packages/studio/src/util/strings.test.ts
+++ b/web/packages/studio/src/util/strings.test.ts
@@ -1,7 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { capitalize, formatKeyLabel, parseCSV } from '@studio/util/strings';
+import { capitalize, formatKeyLabel, parseCSV, trimToUndefined } from '@studio/util/strings';
+
+describe('#trimToUndefined', () => {
+  it.each([
+    ['  hello  ', 'hello'],
+    ['world', 'world'],
+    ['   ', undefined],
+    ['', undefined],
+    [undefined, undefined],
+  ])('trims "%s" to "%s"', (input, expected) => {
+    expect(trimToUndefined(input)).toBe(expected);
+  });
+});
 
 describe('#formatKeyLabel', () => {
   it.each([

--- a/web/packages/studio/src/util/strings.ts
+++ b/web/packages/studio/src/util/strings.ts
@@ -11,6 +11,12 @@ export const capitalize = (str: string) => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
 
+/** Trim a string, returning undefined when it is empty or whitespace-only. */
+export const trimToUndefined = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
 /**
  * Formats a snake_case key into a human-readable label.
  * @param key - The snake_case key to format (e.g., "prompt_tokens")


### PR DESCRIPTION
> **This is the first PR of the Anonymizer builder — an intentionally scoped v1, not the finished feature.** It stands up the builder shell and a working end-to-end create flow (Substitute only). Strategy params, the live preview panel, the full entity picker, and the dedicated job-detail page all land in follow-up PRs (tracked under [ASTD-215](https://linear.app/nvidia/issue/ASTD-215/anonymizer-ui) — see "Scoped out" below). Reviewers: scope feedback to the v1 surface; the listed follow-ups are already ticketed.

## What

Builds the Anonymizer builder page at `/anonymizer/new` ([ASTD-327](https://linear.app/nvidia/issue/ASTD-327)) — a working v1 that creates and runs real anonymization jobs. Part of [ASTD-215](https://linear.app/nvidia/issue/ASTD-215/anonymizer-ui). Builds on #876 (routes/flag) and #879 (jobs API + SDK), both merged.

## Layout

Left config panel (`Source` / `Model Settings` segmented control) + a preview-panel placeholder. React Hook Form + Zod throughout.

### Source tab
- **Data Source** — `Dataset` (fileset+file picker, csv/parquet) or `URL` → `spec.data.source`
- **Generation** — strategy select (locked to **Substitute** for now) + Preview Rows
- **Columns** — **Text Column** auto-populates as a dropdown of the dataset's columns (introspected from the file, size-capped; falls back to text input for URL sources or files > 50 MB; auto-selects when there's only one) + Data Summary
- **Entities** — Custom / Auto-detect toggle; Custom shows a multi-select of the default entity labels (`useAnonymizerListEntityLabels`) → `config.detect.entity_labels`

### Model Settings tab
- One **searchable model select per workflow role** (Entity Detector / Validator / Augmenter / Latent Detector, + Replacement Generator for Substitute), seeded with sensible defaults (GLiNER for the detector, a suggested chat model for the rest)
- A **Params** dropdown per role (inference parameters)
- Build dedups models into a `model_configs` pool and maps `selected_models` role → alias; defaults a generous `timeout` (500s) and `max_tokens` (16384) so slower models complete

### Submit
`Full Run` → `useAnonymizerCreateRunJob` (sends the `replace.kind` discriminator, `model_configs`, `selected_models`), then redirects to the platform job detail (`/jobs/:name`) for live status/logs until the dedicated Anonymizer job page (ASTD-330) lands. Disabled while models load; validation errors surface an inline banner and jump to the offending tab. `noValidate` so RHF/Zod owns validation.

## Verified

Create returns **201** and the job runs end-to-end against a local platform.

## Scoped out (follow-up tickets, all under ASTD-215)

- Live preview panel — ASTD-332
- Redact/Annotate/Hash params — ASTD-333 · Rewrite params — ASTD-334
- Entity picker: categories, custom labels, chips — ASTD-335
- Anonymizer job detail page — ASTD-330
- Backend: `kind` 500-not-422 & missing-from-OpenAPI — ASTD-328 / ASTD-329

## Testing

- `schema.test.ts` — 10 tests on the request mapper (strategy routing + `kind`, model_configs dedup + defaults, selected_models role mapping, detect labels). Pass.
- `@nemo/studio` `tsc --noEmit` — no new errors (17 pre-existing customizer-SDK, unchanged). eslint clean.
- Gated behind `VITE_FF_ANONYMIZER_ENABLED` (default false).

## Notes

- Pre-push typecheck hook bypassed for Studio's pre-existing customizer-SDK failures, unrelated to this branch.