### PR TITLE
fix(docker): align Python base builds and auth policy packaging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,10 @@ jobs:
       - name: Print bake groups
         shell: bash
         run: |
+          default_python_base_target="$(docker buildx bake --print docker-cpu | jq -r '.target["nmp-python-base"].target')"
+          prebuilt_python_base_target="$(USE_PREBUILT_BASES=1 docker buildx bake --print docker-cpu | jq -r '.target["nmp-python-base"].target')"
+          test "${default_python_base_target}" = "nmp-python-base-builder"
+          test "${prebuilt_python_base_target}" = "${default_python_base_target}"
           make docker-print TARGET=docker-cpu
           make docker-print TARGET=docker-gpu
           make docker-print TARGET=docker-auditor

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,10 +111,6 @@ jobs:
       - name: Print bake groups
         shell: bash
         run: |
-          default_python_base_target="$(docker buildx bake --print docker-cpu | jq -r '.target["nmp-python-base"].target')"
-          prebuilt_python_base_target="$(USE_PREBUILT_BASES=1 docker buildx bake --print docker-cpu | jq -r '.target["nmp-python-base"].target')"
-          test "${default_python_base_target}" = "nmp-python-base-builder"
-          test "${prebuilt_python_base_target}" = "${default_python_base_target}"
           make docker-print TARGET=docker-cpu
           make docker-print TARGET=docker-gpu
           make docker-print TARGET=docker-auditor

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -28,14 +28,6 @@ variable "USE_PREBUILT_BASES" {
   default = ""
 }
 
-variable "PYTHON_BASE_TARGET" {
-  default = ""
-}
-
-variable "PYTHON_DEV_BASE_TARGET" {
-  default = ""
-}
-
 variable "NMP_PYTHON_IMAGE" {
   default = "python:3.13.14-slim-trixie"
 }
@@ -161,16 +153,6 @@ function "base_tags" {
   result = [
     notequal(BAKE_TAG, "") ? "${BASE_REGISTRY}/${name}:${BAKE_TAG}" : "",
   ]
-}
-
-function "python_base_target" {
-  params = []
-  result = notequal(PYTHON_BASE_TARGET, "") ? PYTHON_BASE_TARGET : notequal(USE_PREBUILT_BASES, "") ? "nmp-python-base" : "nmp-python-base-builder"
-}
-
-function "python_dev_base_target" {
-  params = []
-  result = notequal(PYTHON_DEV_BASE_TARGET, "") ? PYTHON_DEV_BASE_TARGET : notequal(USE_PREBUILT_BASES, "") ? "nmp-python-dev-base" : "nmp-python-dev-base-builder"
 }
 
 function "automodel_base_context" {
@@ -429,12 +411,10 @@ target "nmp-rl-training" {
 
 # Base images for consolidated containers
 target "nmp-python-base" {
-  target     = python_base_target()
+  target     = "nmp-python-base-builder"
   context    = "."
   dockerfile = "docker/base/Dockerfile.nmp-python-base"
   args = {
-    BASE_REGISTRY    = "${BASE_REGISTRY}"
-    BASE_TAG_PYTHON  = "${BASE_TAG_PYTHON}"
     NMP_PYTHON_IMAGE = "${NMP_PYTHON_IMAGE}"
   }
   cache-from = maybe_registry_cache_from("nmp-python-base")
@@ -446,8 +426,6 @@ target "nmp-python-base-builder" {
   context    = "."
   dockerfile = "docker/base/Dockerfile.nmp-python-base"
   args = {
-    BASE_REGISTRY    = "${BASE_REGISTRY}"
-    BASE_TAG_PYTHON  = "${BASE_TAG_PYTHON}"
     NMP_PYTHON_IMAGE = "${NMP_PYTHON_IMAGE}"
   }
   cache-to   = maybe_registry_cache_to("nmp-python-base")
@@ -458,12 +436,10 @@ target "nmp-python-base-builder" {
 }
 
 target "nmp-python-dev-base" {
-  target     = python_dev_base_target()
+  target     = "nmp-python-dev-base-builder"
   context    = "."
   dockerfile = "docker/base/Dockerfile.nmp-python-base"
   args = {
-    BASE_REGISTRY    = "${BASE_REGISTRY}"
-    BASE_TAG_PYTHON  = "${BASE_TAG_PYTHON}"
     NMP_PYTHON_IMAGE = "${NMP_PYTHON_IMAGE}"
   }
   cache-from = maybe_registry_cache_from("nmp-python-dev-base")
@@ -475,8 +451,6 @@ target "nmp-python-dev-base-builder" {
   context    = "."
   dockerfile = "docker/base/Dockerfile.nmp-python-base"
   args = {
-    BASE_REGISTRY    = "${BASE_REGISTRY}"
-    BASE_TAG_PYTHON  = "${BASE_TAG_PYTHON}"
     NMP_PYTHON_IMAGE = "${NMP_PYTHON_IMAGE}"
   }
   cache-to   = maybe_registry_cache_to("nmp-python-dev-base")

--- a/docker/Dockerfile.nmp-api
+++ b/docker/Dockerfile.nmp-api
@@ -5,6 +5,10 @@ ARG NMP_PYTHON_BASE=nmp-python-base
 
 FROM ${NMP_PYTHON_BASE} AS builder
 COPY --from=nmp-workspace . .
+# Put the generated authorization policy into the source package before uv
+# installs it. This keeps the artifact aligned with the venv's actual Python
+# version instead of assuming a hard-coded site-packages path.
+COPY --from=policy-wasm-artifacts /artifacts/policy.wasm /app/services/core/auth/src/nmp/core/auth/assets/policy.wasm
 
 # Prevents annoy (a dependency of the nemoguardrails library) from generating CPU-specific instructions
 # that cause Guardrails to crash at inference-time with SIGILL on AVX2-only CPUs (e.g. AMD EPYC Zen 2).
@@ -21,6 +25,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     VIRTUAL_ENV=/app/.venv \
     uv sync --frozen --active --only-group functional-services --no-editable \
     --reinstall-package annoy --refresh-package annoy --no-binary-package annoy --no-cache
+
+# Fail the image build if the installed auth package cannot see its generated policy.
+RUN python -c 'from nmp.core.auth.app.embedded_pdp.policy_wasm import ensure_embedded_policy_wasm; ensure_embedded_policy_wasm(auto_build=False)'
 
 # Pre-install DuckDB aws + httpfs so OTLP log ingestion works without outbound network.
 # Download the extension artifacts directly over HTTPS and install from local files
@@ -50,8 +57,6 @@ ENV USERNAME=nvs \
 COPY --chown=nvs:nvs --from=builder /root/.duckdb /root/.duckdb
 COPY --chown=nvs:nvs --from=builder /root/.duckdb /home/nvs/.duckdb
 COPY --chown=nvs:nvs --from=builder /app/.venv /app/.venv
-# Authz evaluates the packaged policy WASM from nmp.core.auth.assets at runtime.
-COPY --chown=nvs:nvs --from=policy-wasm-artifacts /artifacts/policy.wasm /app/.venv/lib/python3.13/site-packages/nmp/core/auth/assets/policy.wasm
 ENV PATH="/app/.venv/bin:$PATH"
 COPY --chown=nvs:nvs --from=nmp-jobs-launcher /artifacts/jobs-launcher /tools/jobs-launcher
 COPY --chown=nvs:nvs --from=nmp-studio-ui /artifacts /static/studio

--- a/docker/Dockerfile.nmp-api
+++ b/docker/Dockerfile.nmp-api
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --reinstall-package annoy --refresh-package annoy --no-binary-package annoy --no-cache
 
 # Fail the image build if the installed auth package cannot see its generated policy.
-RUN python -c 'from nmp.core.auth.app.embedded_pdp.policy_wasm import ensure_embedded_policy_wasm; ensure_embedded_policy_wasm(auto_build=False)'
+RUN /app/.venv/bin/python -c 'from nmp.core.auth.app.embedded_pdp.policy_wasm import ensure_embedded_policy_wasm; ensure_embedded_policy_wasm(auto_build=False)'
 
 # Pre-install DuckDB aws + httpfs so OTLP log ingestion works without outbound network.
 # Download the extension artifacts directly over HTTPS and install from local files

--- a/docker/Dockerfile.nmp-core
+++ b/docker/Dockerfile.nmp-core
@@ -12,7 +12,7 @@ COPY --from=policy-wasm-artifacts /artifacts/policy.wasm /app/services/core/auth
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --only-group core-services --no-editable
 # Fail the image build if the installed auth package cannot see its generated policy.
-RUN python -c 'from nmp.core.auth.app.embedded_pdp.policy_wasm import ensure_embedded_policy_wasm; ensure_embedded_policy_wasm(auto_build=False)'
+RUN /app/.venv/bin/python -c 'from nmp.core.auth.app.embedded_pdp.policy_wasm import ensure_embedded_policy_wasm; ensure_embedded_policy_wasm(auto_build=False)'
 # Pre-install DuckDB aws + httpfs so OTLP log ingestion works without outbound network.
 # Download the extension artifacts directly over HTTPS and install from local files
 # because DuckDB's default remote INSTALL path can be blocked or flaky in some build environments.

--- a/docker/Dockerfile.nmp-core
+++ b/docker/Dockerfile.nmp-core
@@ -5,8 +5,14 @@ ARG NMP_PYTHON_BASE=nmp-python-base
 
 FROM ${NMP_PYTHON_BASE} AS builder
 COPY --from=nmp-workspace . .
+# Put the generated authorization policy into the source package before uv
+# installs it. This keeps the artifact aligned with the venv's actual Python
+# version instead of assuming a hard-coded site-packages path.
+COPY --from=policy-wasm-artifacts /artifacts/policy.wasm /app/services/core/auth/src/nmp/core/auth/assets/policy.wasm
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --only-group core-services --no-editable
+# Fail the image build if the installed auth package cannot see its generated policy.
+RUN python -c 'from nmp.core.auth.app.embedded_pdp.policy_wasm import ensure_embedded_policy_wasm; ensure_embedded_policy_wasm(auto_build=False)'
 # Pre-install DuckDB aws + httpfs so OTLP log ingestion works without outbound network.
 # Download the extension artifacts directly over HTTPS and install from local files
 # because DuckDB's default remote INSTALL path can be blocked or flaky in some build environments.
@@ -25,8 +31,6 @@ ENV USERNAME=nvs \
 COPY --chown=nvs:nvs --from=builder /root/.duckdb /root/.duckdb
 COPY --chown=nvs:nvs --from=builder /root/.duckdb /home/nvs/.duckdb
 COPY --chown=nvs:nvs --from=builder /app/.venv /app/.venv
-# Authz evaluates the packaged policy WASM from nmp.core.auth.assets at runtime.
-COPY --chown=nvs:nvs --from=policy-wasm-artifacts /artifacts/policy.wasm /app/.venv/lib/python3.13/site-packages/nmp/core/auth/assets/policy.wasm
 ENV PATH="/app/.venv/bin:$PATH"
 COPY --chown=nvs:nvs --from=nmp-jobs-launcher /artifacts/jobs-launcher /tools/jobs-launcher
 ENTRYPOINT ["nemo", "services", "run"]

--- a/docker/base/Dockerfile.nmp-python-base
+++ b/docker/base/Dockerfile.nmp-python-base
@@ -2,18 +2,13 @@
 #######
 # NMP Python Base Images
 #
-# Two images, both pinned to BASE_TAG_PYTHON:
+# Two builder stages:
 #
-# nmp-python-base         - minimal runtime base (API, CPU tasks)
-# nmp-python-dev-base     - runtime base + dev tools for building native extensions
+# nmp-python-base-builder     - minimal runtime base (API, CPU tasks)
+# nmp-python-dev-base-builder - runtime base + dev tools for building native extensions
 #######
 
-ARG BASE_REGISTRY=my-registry
-ARG BASE_TAG_PYTHON=local
 ARG NMP_PYTHON_IMAGE=python:3.13.14-slim-trixie
-FROM ${BASE_REGISTRY}/nmp-python-base:${BASE_TAG_PYTHON} AS nmp-python-base
-FROM ${BASE_REGISTRY}/nmp-python-dev-base:${BASE_TAG_PYTHON} AS nmp-python-dev-base
-
 FROM ${NMP_PYTHON_IMAGE} AS nmp-python-base-builder
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \

--- a/tests/unit/test_policy_wasm_container_packaging.py
+++ b/tests/unit/test_policy_wasm_container_packaging.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POLICY_WASM_DESTINATION = "/app/services/core/auth/src/nmp/core/auth/assets/policy.wasm"
+
+
+@pytest.mark.parametrize(
+    "dockerfile",
+    [
+        "docker/Dockerfile.nmp-api",
+        "docker/Dockerfile.nmp-core",
+    ],
+)
+def test_policy_wasm_is_added_before_workspace_install(dockerfile: str) -> None:
+    contents = (REPO_ROOT / dockerfile).read_text()
+
+    policy_copy = contents.index(f"COPY --from=policy-wasm-artifacts /artifacts/policy.wasm {POLICY_WASM_DESTINATION}")
+    workspace_install = contents.index("uv sync --frozen")
+
+    assert policy_copy < workspace_install
+    assert "site-packages/nmp/core/auth/assets/policy.wasm" not in contents
+    assert "ensure_embedded_policy_wasm(auto_build=False)" in contents

--- a/tests/unit/test_policy_wasm_container_packaging.py
+++ b/tests/unit/test_policy_wasm_container_packaging.py
@@ -25,3 +25,22 @@ def test_policy_wasm_is_added_before_workspace_install(dockerfile: str) -> None:
     assert policy_copy < workspace_install
     assert "site-packages/nmp/core/auth/assets/policy.wasm" not in contents
     assert "ensure_embedded_policy_wasm(auto_build=False)" in contents
+
+
+@pytest.mark.parametrize(
+    "dockerfile",
+    [
+        "docker/Dockerfile.nmp-api",
+        "docker/Dockerfile.nmp-core",
+    ],
+)
+def test_policy_wasm_is_validated_with_installed_venv_after_workspace_install(dockerfile: str) -> None:
+    contents = (REPO_ROOT / dockerfile).read_text()
+
+    workspace_install = contents.index("uv sync --frozen")
+    policy_validation = contents.index(
+        "/app/.venv/bin/python -c 'from nmp.core.auth.app.embedded_pdp.policy_wasm "
+        "import ensure_embedded_policy_wasm; ensure_embedded_policy_wasm(auto_build=False)'"
+    )
+
+    assert workspace_install < policy_validation


### PR DESCRIPTION
CI built the current Python 3.13 base while Deploy could select an older Python 3.11 base. That caused `policy.wasm` to be installed into the wrong environment and auth crashed at startup.

This PR makes both build modes use the same Python base recipe, packages `policy.wasm` before `uv sync`, and validates it with the installed venv.

Testing:
- policy packaging tests: 4 passed
- normal and `USE_PREBUILT_BASES=1` both resolve `nmp-python-base-builder`
