### PR TITLE
feat(studio): job-detail placeholder route for Anonymizer [ASTD-331]

### DIFF
--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/index.tsx
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PageHeader, Stack, Text } from '@nvidia/foundations-react-core';
+import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { ANONYMIZER_ENABLED } from '@studio/constants/environment';
+import { ROUTE_PARAMS } from '@studio/constants/routes';
+import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { FC } from 'react';
+import { useParams } from 'react-router-dom';
+
+export const AnonymizerJobDetailRoute: FC | null = ANONYMIZER_ENABLED
+  ? () => {
+      const { [ROUTE_PARAMS.anonymizerJobName]: jobName } = useParams();
+
+      useBreadcrumbs({
+        items: [{ slotLabel: 'Anonymizer' }, { slotLabel: jobName ?? 'Job' }],
+      });
+
+      return (
+        <AccessibleTitle title={jobName ?? 'Anonymizer Job'}>
+          <Stack className="h-full" gap="density-2xl" padding="density-2xl">
+            <PageHeader className="p-0" slotHeading={jobName ?? 'Anonymizer Job'} />
+            <Text kind="body/regular/md">Job details coming soon.</Text>
+          </Stack>
+        </AccessibleTitle>
+      );
+    }
+  : null;

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/index.tsx
@@ -6,7 +6,7 @@ import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { ANONYMIZER_ENABLED } from '@studio/constants/environment';
 import { ROUTE_PARAMS } from '@studio/constants/routes';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
-import { FC } from 'react';
+import type { FC } from 'react';
 import { useParams } from 'react-router-dom';
 
 export const AnonymizerJobDetailRoute: FC | null = ANONYMIZER_ENABLED

--- a/web/packages/studio/src/routes/groups/anonymizerRoutes.tsx
+++ b/web/packages/studio/src/routes/groups/anonymizerRoutes.tsx
@@ -5,8 +5,7 @@ import { ErrorPanel } from '@studio/components/ErrorPanel';
 import { ANONYMIZER_ENABLED } from '@studio/constants/environment';
 import { ROUTES } from '@studio/constants/routes';
 import { gateAnonymizerRoutes } from '@studio/routes/utils';
-import { lazy } from 'react';
-import type { FC } from 'react';
+import { lazy, type FC } from 'react';
 import type { RouteObject } from 'react-router-dom';
 
 const AnonymizerListRoute =

--- a/web/packages/studio/src/routes/groups/anonymizerRoutes.tsx
+++ b/web/packages/studio/src/routes/groups/anonymizerRoutes.tsx
@@ -5,7 +5,8 @@ import { ErrorPanel } from '@studio/components/ErrorPanel';
 import { ANONYMIZER_ENABLED } from '@studio/constants/environment';
 import { ROUTES } from '@studio/constants/routes';
 import { gateAnonymizerRoutes } from '@studio/routes/utils';
-import { FC, lazy } from 'react';
+import { lazy } from 'react';
+import type { FC } from 'react';
 import type { RouteObject } from 'react-router-dom';
 
 const AnonymizerListRoute =

--- a/web/packages/studio/src/routes/groups/anonymizerRoutes.tsx
+++ b/web/packages/studio/src/routes/groups/anonymizerRoutes.tsx
@@ -22,6 +22,13 @@ const AnonymizerBuilderRoute =
       default: m.AnonymizerBuilderRoute as FC,
     }))
   );
+const AnonymizerJobDetailRoute =
+  ANONYMIZER_ENABLED &&
+  lazy(() =>
+    import('@studio/routes/AnonymizerJobDetailRoute').then((m) => ({
+      default: m.AnonymizerJobDetailRoute as FC,
+    }))
+  );
 
 export const anonymizerRoutes: RouteObject[] = gateAnonymizerRoutes([
   {
@@ -36,7 +43,7 @@ export const anonymizerRoutes: RouteObject[] = gateAnonymizerRoutes([
   },
   {
     path: ROUTES.workspace.anonymizerJob,
-    element: AnonymizerBuilderRoute ? <AnonymizerBuilderRoute /> : null,
+    element: AnonymizerJobDetailRoute ? <AnonymizerJobDetailRoute /> : null,
     errorElement: <ErrorPanel title="Anonymizer" />,
   },
 ]);


### PR DESCRIPTION
## What

Splits `/anonymizer/:anonymizerJobName` off the builder so it renders a **job-detail placeholder** instead of the create form ([ASTD-331](https://linear.app/nvidia/issue/ASTD-331)).

Part of [ASTD-215](https://linear.app/nvidia/issue/ASTD-215/anonymizer-ui).

## Why

`/new` and `/:name` both routed to `AnonymizerBuilderRoute`, so clicking a job in the list (and the post-create redirect) landed on the create form.

## Changes

- New `AnonymizerJobDetailRoute` — placeholder showing the job name + breadcrumbs ("Job details coming soon")
- `ROUTES.workspace.anonymizerJob` now points at it in `groups/anonymizerRoutes.tsx`; `/new` keeps the builder

Full detail page (status, results, Replacement Map, download, actions) is [ASTD-330](https://linear.app/nvidia/issue/ASTD-330).

## Testing

- `@nemo/studio` `tsc --noEmit` — no new errors; eslint clean.
- Gated behind `VITE_FF_ANONYMIZER_ENABLED` (default false).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an anonymizer job details page when anonymizer functionality is enabled.
  * Added breadcrumbs that show the “Anonymizer” section along with the selected job name (with a fallback label).
  * Added a “Job details coming soon” placeholder message.
* **Bug Fixes**
  * Updated the anonymizer job route to render the new job details page while preserving the existing error handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->