### PR TITLE
fix(platform): initialize logging before config resolution

### DIFF
--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -473,6 +473,9 @@ openshiftRoute:
 # # -- OpenTelemetry configuration settings for all services.
 # @default -- This object has the following default values for the OpenTelemetry configuration.
 telemetry:
+  # -- Log output format for all services. Set here as an environment variable, rather than only
+  # via `config.service.log_format`, so that logging is configured before the config file is read.
+  LOG_FORMAT: "json"
   # -- Disable OpenTelemetry instrumentation and exporting for all services.
   OTEL_SDK_DISABLED: false
   # -- The OpenTelemetry grpc collector endpoint to export traces and metrics to.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/services/cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 import os
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -110,7 +111,9 @@ def _wait_for_healthy(
 
 
 def _warn_bind_all(host: str) -> None:
-    if host in ("0.0.0.0", "::"):  # noqa: S104
+    # Only meaningful at an interactive terminal. In a container, binding to all interfaces is
+    # the intended configuration, and this would emit unstructured text into the log stream.
+    if host in ("0.0.0.0", "::") and sys.stderr.isatty():  # noqa: S104
         typer.echo(
             f"Warning: binding to {host} makes the service reachable on all network interfaces.",
             err=True,

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/run.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/run.py
@@ -16,6 +16,7 @@ from typing import cast
 from nmp.common.config import get_auth_config, get_common_service_config, get_platform_config, get_service_config
 from nmp.common.observability import initialize_obs, setup_global_instrumentations
 from nmp.common.observability.otel import settings as otel_settings
+from nmp.common.observability.structured_logging import initialize_logging
 from nmp.common.service import CircularDependencyError, Service
 from nmp.platform_runner.config import (
     PlatformAppConfig,
@@ -84,21 +85,27 @@ def run_platform(
     """Start the platform API and selected controllers in-process."""
     t_total = time.perf_counter()
 
+    # Configure logging before resolving config so that config-loading logs are structured.
+    # otel_settings is env-only (LOG_FORMAT / LOG_LEVEL), so this needs no config file. Without
+    # it, anything logged during config resolution falls back to logging.lastResort, which emits
+    # bare text and drops everything below WARNING.
+    t0 = time.perf_counter()
+    initialize_obs(resource_attributes=get_platform_resource_attributes())
+    setup_global_instrumentations()
+    _startup_phase("observability_init", t0)
+
     t0 = time.perf_counter()
     resolved = resolve_run_configuration(config)
     apply_run_environment(resolved)
     _startup_phase("resolve_config", t0)
 
+    # The config file may still override the environment (local / CLI use), so re-initialize
+    # logging when it disagrees with what the environment already configured.
     service_config = get_common_service_config()
-    if otel_settings.log_format != service_config.log_format:
+    if (otel_settings.log_format, otel_settings.log_level) != (service_config.log_format, service_config.log_level):
         otel_settings.log_format = service_config.log_format
-    if otel_settings.log_level != service_config.log_level:
         otel_settings.log_level = service_config.log_level
-
-    t0 = time.perf_counter()
-    initialize_obs(resource_attributes=get_platform_resource_attributes())
-    setup_global_instrumentations()
-    _startup_phase("observability_init", t0)
+        initialize_logging()
 
     collisions = resolved.controllers & resolved.sidecars
     if collisions:

--- a/packages/nmp_platform_runner/tests/test_run.py
+++ b/packages/nmp_platform_runner/tests/test_run.py
@@ -94,3 +94,49 @@ def test_run_platform_marks_loaded_services_local_before_starting_controllers(mo
         Configuration.clear_cache()
 
     assert captured["services"] == "entities,jobs"
+
+
+def test_run_platform_initializes_logging_before_resolving_config(monkeypatch):
+    """Logging must be configured before any config loading happens.
+
+    Config resolution logs (missing config file, Docker runtime fallback, ...). If those records
+    are emitted before handlers are installed, Python falls back to ``logging.lastResort``, which
+    prints bare text to stderr and drops everything below WARNING. That is how unstructured lines
+    ended up interleaved with the JSON log stream.
+    """
+    Configuration.clear_cache()
+    call_order: list[str] = []
+
+    resolved = ResolvedRunConfiguration(
+        services=set(),
+        controllers=set(),
+        sidecars=set(),
+        host="127.0.0.1",
+        port=8080,
+        config_path="",
+    )
+
+    def record_resolve(*_args, **_kwargs):
+        call_order.append("resolve_run_configuration")
+        return resolved
+
+    def record_initialize_obs(*, resource_attributes):
+        call_order.append("initialize_obs")
+
+    monkeypatch.setattr(runner, "initialize_obs", record_initialize_obs)
+    monkeypatch.setattr(runner, "resolve_run_configuration", record_resolve)
+    monkeypatch.setattr(runner, "apply_run_environment", lambda config: None)
+    monkeypatch.setattr(runner, "setup_global_instrumentations", lambda: None)
+    monkeypatch.setattr(runner, "_load_service_instances", lambda service_names, available_services: [])
+    monkeypatch.setattr(runner, "_load_run_functions", lambda names, registry, kind: {})
+    monkeypatch.setattr(runner, "_display_banner", lambda **_: None)
+    monkeypatch.setattr(runner, "run_server", lambda services, host, port, socket_path=None: None)
+    monkeypatch.setattr(runner, "run_controllers_in_threads", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(runner.signal, "signal", lambda *args: None)
+
+    try:
+        runner.run_platform()
+    finally:
+        Configuration.clear_cache()
+
+    assert call_order == ["initialize_obs", "resolve_run_configuration"]


### PR DESCRIPTION
## Problem

Piping platform logs to `jq` fails. Startup emits plain text before JSON logging is configured:

```
Warning: binding to 0.0.0.0 makes the service reachable on all network interfaces.
Docker is not available, setting runtime to NONE
{"level": "info", ... "[STARTUP] observability_init: 169ms"}
```

Two separate causes:

1. `run_platform()` resolved configuration **before** calling `initialize_obs()`. Anything logged in that window has no handler on the root logger, so Python falls back to `logging.lastResort` — bare text on stderr, and everything below WARNING silently dropped. `[STARTUP] resolve_config` was being lost this way.
2. The bind warning is a `typer.echo`, not a log record at all.

The format could not be known earlier because the chart only set `config.service.log_format: json` in the mounted config file — and reading that file is exactly what logs.

## Changes

- **`run.py`** — move `initialize_obs()` ahead of config resolution. Re-initialize logging afterward only if the config file disagrees with the environment (local / CLI use).
- **`values.yaml`** — set `LOG_FORMAT: "json"` under the existing `telemetry:` env passthrough. Both `OTELSettings` and `CommonServiceConfig` read the bare `LOG_FORMAT`, so logging can be configured with no config file. No template changes; the existing `nemo-common.otel-env` helper already feeds both deployments.
- **`cli.py`** — gate the bind warning on `sys.stderr.isatty()`. In a pod, binding to `0.0.0.0` is the intended configuration.

## Verification

- Live startup log: **0 non-JSON lines**. `[STARTUP] resolve_config` now appears instead of being dropped.
- `helm template` renders `LOG_FORMAT` into both the api and core-controller deployments.
- `nmp_platform_runner` 112 passed, `test_common_config.py` + `test_otel.py` 45 passed. New test asserts `initialize_obs` runs before `resolve_run_configuration`.
- Bind warning verified both ways: emitted on a pty, silent on a pipe.
- `ruff check` / `ruff format` clean.

## Not included

`Docker is not available` still logs twice, now as two JSON lines. Separate cause: `global_settings_to_service_config` constructs the config model twice (once for defaults + env, once with file values merged), and Pydantic runs `validate_runtime` on each. Both constructions are load-bearing. Left for a follow-up.

The vendored SDK copy of `cli.py` still has the ungated warning; it picks up the change on the next `make update-sdk`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Log format can now be configured via environment variable across all services, enabling JSON output control without code changes.

* **Bug Fixes**
  * Binding warnings now display only in interactive terminal sessions, reducing unnecessary noise in container deployments.
  * Improved logging initialization sequencing to ensure configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->