### PR TITLE
fix(tests): group ClickHouse integration tests under xdist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,10 +300,11 @@ test: test-unit  ## Run all Python unit tests (fast tests without infrastructure
 PYTEST_VERBOSITY := $(if $(filter true,$(CI)),-q,-v)
 PYTEST_WORKERS ?= auto
 PYTEST_MAX_WORKERS ?= 16
-PYTEST_CMD := env PYTHONWARNINGS="ignore::UserWarning:pytest_only.version" uv run --frozen \
+PYTEST_DIST ?= loadscope
+PYTEST_CMD = env PYTHONWARNINGS="ignore::UserWarning:pytest_only.version" uv run --frozen \
 	pytest \
 	-n $(PYTEST_WORKERS) --maxprocesses=$(PYTEST_MAX_WORKERS) --max-worker-restart=2 \
-	--dist loadscope --timeout=120 $(PYTEST_VERBOSITY) $(PYTEST_EXTRA)
+	--dist $(PYTEST_DIST) --timeout=120 $(PYTEST_VERBOSITY) $(PYTEST_EXTRA)
 
 PYTEST_CI_OPTS := --cov=src --cov=packages \
 	--junitxml=report.xml \
@@ -315,7 +316,16 @@ PYTEST_CI_OPTS := --cov=src --cov=packages \
 # a pytest-xdist worker crashes (e.g. SIGABRT from wasmtime) and doesn't exit.
 # timeout sends SIGTERM after PYTEST_CI_TIMEOUT seconds, then SIGKILL after 60s.
 PYTEST_CI_TIMEOUT ?= 1800
-PYTEST_CI_CMD := timeout --kill-after=60s $(PYTEST_CI_TIMEOUT)s $(PYTEST_CMD)
+PYTEST_CI_CMD = timeout --kill-after=60s $(PYTEST_CI_TIMEOUT)s $(PYTEST_CMD)
+
+# Unit/default runs keep ``loadscope`` so tests from the same module/class stay
+# on one worker and reuse normal pytest fixtures efficiently. The integration
+# targets collect tests that share real external resources (Docker containers,
+# service ports, etc.). Those tests can mark the resource with ``xdist_group``,
+# but pytest-xdist only honors those labels under ``loadgroup``. Both local and
+# CI integration runs therefore use ``loadgroup`` while unit runs keep
+# ``loadscope``.
+test-integration test-integration-ci: PYTEST_DIST := loadgroup
 
 .PHONY: test-unit
 test-unit: ## Run Python unit tests across all packages and services

--- a/conftest.py
+++ b/conftest.py
@@ -347,4 +347,9 @@ LoadScopeScheduling._reschedule = _patched_reschedule  # type: ignore[invalid-as
 
 
 def pytest_xdist_make_scheduler(config, log):
-    return LoadGroupScheduling(config, log)
+    dist = config.getvalue("dist")
+    if dist == "loadgroup":
+        return LoadGroupScheduling(config, log)
+    if dist == "loadscope":
+        return LoadScopeScheduling(config, log)
+    return None

--- a/plugins/nemo-deployments/tests/integration/conftest.py
+++ b/plugins/nemo-deployments/tests/integration/conftest.py
@@ -21,6 +21,7 @@ _DOCKER_INTEGRATION_XDIST_GROUP = "nemo_deployments_docker_integration"
 _K8S_INTEGRATION_XDIST_GROUP = "nemo_deployments_k8s_integration"
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     integration_dir = Path(__file__).parent.resolve()
     k8s_dir = (integration_dir / "backends" / "k8s").resolve()

--- a/plugins/nemo-evaluator/tests/integration/conftest.py
+++ b/plugins/nemo-evaluator/tests/integration/conftest.py
@@ -34,6 +34,8 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 #: each fixture's ``env_overrides``.
 MOCK_PROVIDER_PREFIX = "igw-mock-"
 MOCK_PROVIDER_PREFIX_ENVVAR = "NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX"
+CLICKHOUSE_XDIST_GROUP = "nmp_intake_clickhouse"
+CLICKHOUSE_XDIST_FIXTURE = "_clickhouse"
 
 #: Base URL (and therefore port) for the agent-eval subprocess-backend platform. Distinct from
 #: other integration platforms so both can run in the same session without a port clash.
@@ -44,6 +46,12 @@ AGENT_DOCKER_PLATFORM_BASE_URL = os.environ.get("NMP_AGENT_DOCKER_BASE_URL", "ht
 
 #: Base URL for the auth-enabled subprocess platform (own port, coexists with the others).
 AGENT_AUTH_PLATFORM_BASE_URL = os.environ.get("NMP_AGENT_AUTH_BASE_URL", "http://localhost:8092")
+
+# xdist ``loadgroup`` does not infer shared fixtures; it only groups tests that
+# carry the same ``xdist_group`` marker. Any evaluator test that depends on the
+# ClickHouse fixture uses Intake's fixed local container, so keep those tests on
+# one worker to avoid cross-worker startup/teardown races. ``tryfirst`` matters:
+# xdist reads these markers during collection to build its scheduling groups.
 
 
 def _docker_available() -> bool:
@@ -72,6 +80,13 @@ def _port_in_use(host: str, port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(1)
         return sock.connect_ex((host, port)) == 0
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        if CLICKHOUSE_XDIST_FIXTURE in item.fixturenames:
+            item.add_marker(pytest.mark.xdist_group(CLICKHOUSE_XDIST_GROUP))
 
 
 @contextmanager


### PR DESCRIPTION
## Summary

- Fixes the evaluator publish-to-intake integration flake by running integration tests with pytest-xdist's `loadgroup` scheduler.
- Dynamically marks evaluator tests that depend on the ClickHouse fixture with `xdist_group("nmp_intake_clickhouse")`, so those tests stay on one worker.
- Keeps existing deployments integration groups working under `loadgroup` by adding their dynamic markers early enough for xdist to see them.
- Updates the root xdist scheduler hook to honor `--dist`, so unit/default runs can actually use `loadscope` while integration runs use `loadgroup`.

## Root cause

The failing CI job hit a test-infrastructure race, not an application-code failure. The publish-to-intake tests use a session-scoped fixture that starts a fixed local ClickHouse container and removes it at fixture teardown.

With xdist, session scope is per worker, not global across all workers. If ClickHouse-backed tests are split across workers, each worker can independently start and tear down the same singleton container. That can produce startup conflicts or let one worker remove the container while another worker still needs it.

`--dist loadgroup` is the xdist mode that honors `xdist_group` markers, but it does not infer shared fixtures by itself. The test suite has to mark tests that share an external resource.

The repo also had a root `pytest_xdist_make_scheduler` hook that always returned `LoadGroupScheduling`, regardless of the requested `--dist` value. This patch teaches that hook to honor `loadscope` vs. `loadgroup`, so the Makefile split is real rather than just command-line text.

## Fix

- Make `PYTEST_DIST` configurable in `Makefile`.
- Keep unit/default test runs on `loadscope` for normal fixture locality.
- Run `test-integration` and `test-integration-ci` with `loadgroup`.
- In evaluator integration collection, add `xdist_group("nmp_intake_clickhouse")` to any test whose fixture closure includes `_clickhouse`.
- Mark dynamic grouping hooks with `tryfirst=True` so the markers exist before xdist reads them for scheduling.
- Update root `pytest_xdist_make_scheduler` to return `LoadGroupScheduling` only for `--dist loadgroup`, `LoadScopeScheduling` for `--dist loadscope`, and otherwise fall through to xdist defaults.

## Test plan

- [x] `make -n test-unit PYTEST_WORKERS=2` shows `--dist loadscope`.
- [x] `make -n test-integration PYTEST_WORKERS=2` shows `--dist loadgroup`.
- [x] `uv run --frozen ruff check conftest.py plugins/nemo-evaluator/tests/integration/conftest.py plugins/nemo-deployments/tests/integration/conftest.py`
- [x] `uv run --frozen pytest packages/nmp_common/tests/observability/test_otel.py::TestLoggingIntegration::test_initialize_obs_configures_plain_logging_by_default -v --no-cov -n 2 --dist loadscope` shows `scheduling tests via LoadScopeScheduling`.
- [x] `uv run --frozen pytest plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py -v --no-cov -n 2 --dist loadgroup` shows `scheduling tests via LoadGroupScheduling` and groups tests under `@nmp_intake_clickhouse`.
- [x] `uv run --frozen pytest plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py::test_volume_lifecycle -v --no-cov -n 2 --dist loadgroup` shows `scheduling tests via LoadGroupScheduling` and groups the test under `@nemo_deployments_docker_integration`.

The original failing commit touched unrelated frontend files; this PR addresses the pre-existing integration-test infrastructure flake exposed by that CI run.