### PR TITLE
fix(helm): use API Service address for NMP_BASE_URL

### DIFF
--- a/k8s/helm/templates/api/api-deployment.yaml
+++ b/k8s/helm/templates/api/api-deployment.yaml
@@ -69,12 +69,9 @@ spec:
             {{- end }}
             - name: NMP_CONFIG_FILE_PATH
               value: /etc/nmp/config.yaml
+            {{- /* Service address, not loopback: copied into agent configs that run in another container. */}}
             - name: NMP_BASE_URL
-              {{- if include "nemo-platform.embeddedPdpEnabled" . }}
-              value: {{ include "nemo-platform.apiLoopbackBaseUrl" . | quote }}
-              {{- else }}
               value: {{ include "nemo-platform.internalBaseUrl" . | quote }}
-              {{- end }}
             - name: NMP_AUTOMODEL_DEFAULT_TRAINING_EXECUTION_PROFILE
               value: {{ dig "automodel" "default_training_execution_profile" "default" $platformConfig | quote }}
             - name: NMP_UNSLOTH_DEFAULT_TRAINING_EXECUTION_PROFILE

--- a/tests/auth_idp/static/test_authentik_kubernetes_demo.py
+++ b/tests/auth_idp/static/test_authentik_kubernetes_demo.py
@@ -1178,6 +1178,25 @@ def test_nemo_platform_controller_uses_internal_api_service_url_for_embedded_pdp
     ) in template
 
 
+def test_nemo_platform_api_uses_internal_api_service_url_for_agent_configs() -> None:
+    """NMP_BASE_URL on the API pod must be the Service address, never loopback.
+
+    The API copies this value into agent workflow configs, which run in a different
+    container -- loopback there resolves to the agent itself, not the platform.
+    Embedded PDP gets its loopback from NMP_AUTH_POLICY_DECISION_POINT_BASE_URL instead.
+    """
+    template = Path("k8s/helm/templates/api/api-deployment.yaml").read_text(encoding="utf-8")
+
+    assert (
+        'name: NMP_BASE_URL\n              value: {{ include "nemo-platform.internalBaseUrl" . | quote }}'
+    ) in template
+    assert "nemo-platform.apiLoopbackBaseUrl" not in template.split("NMP_AUTOMODEL")[0]
+    assert (
+        "name: NMP_AUTH_POLICY_DECISION_POINT_BASE_URL\n              value: "
+        '{{ include "nemo-platform.apiLoopbackBaseUrl" . | quote }}'
+    ) in template
+
+
 def test_authentik_helm_demo_does_not_inject_legacy_workload_token_envs() -> None:
     template_files = sorted(path for path in (HELM_DIR / "templates").rglob("*") if path.is_file())
     text_files = [


### PR DESCRIPTION
The API pod set `NMP_BASE_URL` to loopback when the embedded PDP is enabled. That value is copied into agent workflow configs, which run in a separate container — where loopback resolves to the agent itself, not the platform.

Use the in-cluster API Service address instead, matching what the controller and seed job already use. The embedded PDP keeps its own loopback via `NMP_AUTH_POLICY_DECISION_POINT_BASE_URL`.

Adds a template test, alongside the existing ones for the controller and seed job.

## Testing

- `helm template` with auth on and off: `NMP_BASE_URL` is the Service address, PDP var still loopback
- `helm lint` clean
- New test fails without the template change, passes with it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API service configuration to consistently use the internal service URL for agent configurations.
  * Preserved the loopback URL for authorization policy decision point communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->