### PR TITLE
fix(inference-gateway): preserve backend authentication errors

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/errors.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/errors.py
@@ -75,6 +75,13 @@ def _format_api_error(error: APIError) -> str:
     return str(error)
 
 
+def _is_model_provider_error(error: APIError) -> bool:
+    """Return whether the inference gateway attributed an error to a ModelProvider."""
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    return headers is not None and headers.get("x-nemo-error-source") == "model-provider"
+
+
 def _format_api_request(error: APIError) -> str | None:
     request = getattr(error, "request", None)
     method = getattr(request, "method", None)
@@ -233,6 +240,24 @@ def handle_exception(error: Exception, ctx: click.Context | None = None) -> None
     if isinstance(error, typer.Exit):
         # Re-raise typer.Exit with its original exit code (don't treat Exit(0) as error)
         raise error
+    if isinstance(error, AuthenticationError) and _is_model_provider_error(error):
+        console.print(
+            f"[bold red]Model provider authentication error:[/] ({error.status_code}) {_format_api_error(error)}"
+        )
+        console.print(
+            "[yellow]Hint:[/] The ModelProvider rejected its configured credentials. "
+            "Check the provider's API key secret and authentication configuration."
+        )
+        raise typer.Exit(code=1)
+    if isinstance(error, PermissionDeniedError) and _is_model_provider_error(error):
+        console.print(
+            f"[bold red]Model provider permission denied:[/] ({error.status_code}) {_format_api_error(error)}"
+        )
+        console.print(
+            "[yellow]Hint:[/] The ModelProvider denied access for its configured credentials. "
+            "Check the configured credential's permissions and model access."
+        )
+        raise typer.Exit(code=1)
     if isinstance(error, AuthenticationError):
         console.print(f"[bold red]Authentication error:[/] ({error.status_code}) {_format_api_error(error)}")
         console.print(

--- a/packages/nemo_platform_ext/tests/cli/core/test_errors.py
+++ b/packages/nemo_platform_ext/tests/cli/core/test_errors.py
@@ -98,6 +98,35 @@ def test_handle_api_connection_error(capsys):
     assert "base-url" in captured.err
 
 
+@pytest.mark.parametrize(
+    "error_class,status_code,expected_prefix,expected_hint",
+    [
+        (AuthenticationError, 401, "Model provider authentication error:", "API key secret"),
+        (PermissionDeniedError, 403, "Model provider permission denied:", "model access"),
+    ],
+)
+def test_handle_model_provider_auth_errors(
+    capsys,
+    error_class,
+    status_code,
+    expected_prefix,
+    expected_hint,
+):
+    response = Mock()
+    response.status_code = status_code
+    response.headers = {"x-nemo-error-source": "model-provider"}
+    error = error_class("Authentication failed", response=response, body=None)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        handle_exception(error)
+
+    assert exc_info.value.exit_code == 1
+    captured = capsys.readouterr()
+    assert expected_prefix in captured.err
+    assert expected_hint in captured.err
+    assert "nemo auth login" not in captured.err
+
+
 def test_handle_api_timeout_error(capsys):
     request = Mock()
     error = APITimeoutError(request=request)

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/errors.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/errors.py
@@ -241,14 +241,18 @@ def handle_exception(error: Exception, ctx: click.Context | None = None) -> None
         # Re-raise typer.Exit with its original exit code (don't treat Exit(0) as error)
         raise error
     if isinstance(error, AuthenticationError) and _is_model_provider_error(error):
-        console.print(f"[bold red]Model provider authentication error:[/] ({error.status_code}) {_format_api_error(error)}")
+        console.print(
+            f"[bold red]Model provider authentication error:[/] ({error.status_code}) {_format_api_error(error)}"
+        )
         console.print(
             "[yellow]Hint:[/] The ModelProvider rejected its configured credentials. "
             "Check the provider's API key secret and authentication configuration."
         )
         raise typer.Exit(code=1)
     if isinstance(error, PermissionDeniedError) and _is_model_provider_error(error):
-        console.print(f"[bold red]Model provider permission denied:[/] ({error.status_code}) {_format_api_error(error)}")
+        console.print(
+            f"[bold red]Model provider permission denied:[/] ({error.status_code}) {_format_api_error(error)}"
+        )
         console.print(
             "[yellow]Hint:[/] The ModelProvider denied access for its configured credentials. "
             "Check the configured credential's permissions and model access."

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/errors.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/errors.py
@@ -75,6 +75,13 @@ def _format_api_error(error: APIError) -> str:
     return str(error)
 
 
+def _is_model_provider_error(error: APIError) -> bool:
+    """Return whether the inference gateway attributed an error to a ModelProvider."""
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    return headers is not None and headers.get("x-nemo-error-source") == "model-provider"
+
+
 def _format_api_request(error: APIError) -> str | None:
     request = getattr(error, "request", None)
     method = getattr(request, "method", None)
@@ -233,6 +240,20 @@ def handle_exception(error: Exception, ctx: click.Context | None = None) -> None
     if isinstance(error, typer.Exit):
         # Re-raise typer.Exit with its original exit code (don't treat Exit(0) as error)
         raise error
+    if isinstance(error, AuthenticationError) and _is_model_provider_error(error):
+        console.print(f"[bold red]Model provider authentication error:[/] ({error.status_code}) {_format_api_error(error)}")
+        console.print(
+            "[yellow]Hint:[/] The ModelProvider rejected its configured credentials. "
+            "Check the provider's API key secret and authentication configuration."
+        )
+        raise typer.Exit(code=1)
+    if isinstance(error, PermissionDeniedError) and _is_model_provider_error(error):
+        console.print(f"[bold red]Model provider permission denied:[/] ({error.status_code}) {_format_api_error(error)}")
+        console.print(
+            "[yellow]Hint:[/] The ModelProvider denied access for its configured credentials. "
+            "Check the configured credential's permissions and model access."
+        )
+        raise typer.Exit(code=1)
     if isinstance(error, AuthenticationError):
         console.print(f"[bold red]Authentication error:[/] ({error.status_code}) {_format_api_error(error)}")
         console.print(

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/core/test_errors.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/core/test_errors.py
@@ -98,6 +98,35 @@ def test_handle_api_connection_error(capsys):
     assert "base-url" in captured.err
 
 
+@pytest.mark.parametrize(
+    "error_class,status_code,expected_prefix,expected_hint",
+    [
+        (AuthenticationError, 401, "Model provider authentication error:", "API key secret"),
+        (PermissionDeniedError, 403, "Model provider permission denied:", "model access"),
+    ],
+)
+def test_handle_model_provider_auth_errors(
+    capsys,
+    error_class,
+    status_code,
+    expected_prefix,
+    expected_hint,
+):
+    response = Mock()
+    response.status_code = status_code
+    response.headers = {"x-nemo-error-source": "model-provider"}
+    error = error_class("Authentication failed", response=response, body=None)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        handle_exception(error)
+
+    assert exc_info.value.exit_code == 1
+    captured = capsys.readouterr()
+    assert expected_prefix in captured.err
+    assert expected_hint in captured.err
+    assert "nemo auth login" not in captured.err
+
+
 def test_handle_api_timeout_error(capsys):
     request = Mock()
     error = APITimeoutError(request=request)

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -7,7 +7,7 @@ import logging
 import uuid
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncIterator, Union
+from typing import TYPE_CHECKING, Any, AsyncIterator, NoReturn, Union
 
 import aiohttp
 from aiohttp import ClientSession
@@ -309,6 +309,8 @@ def _close_response(response: aiohttp.ClientResponse | None):
 _MAX_ERROR_BODY_LEN = 2048
 _BODY_FRAMING_HEADERS_TO_STRIP = frozenset({"content-length", "content-encoding", "transfer-encoding"})
 _BACKEND_AUTH_ERROR_STATUSES = frozenset({401, 403})
+_ERROR_SOURCE_HEADER = "X-NeMo-Error-Source"
+_MODEL_PROVIDER_ERROR_SOURCE = "model-provider"
 
 
 async def _read_error_body(response: aiohttp.ClientResponse) -> tuple[bytes, str]:
@@ -321,14 +323,71 @@ async def _read_error_body(response: aiohttp.ClientResponse) -> tuple[bytes, str
     return raw_body, raw_body.decode("utf-8", errors="replace")[:_MAX_ERROR_BODY_LEN]
 
 
+def mark_model_provider_auth_error(response: Response) -> Response:
+    """Normalize and mark a 401/403 response originating from a ModelProvider."""
+    if response.status_code in _BACKEND_AUTH_ERROR_STATUSES:
+        # Mock responses can carry framing metadata that does not match their
+        # rendered body. Match the real-backend path by dropping it and deriving
+        # content-length from a buffered response body when one is available.
+        for header in _BODY_FRAMING_HEADERS_TO_STRIP:
+            del response.headers[header]
+        body = getattr(response, "body", None)
+        if isinstance(body, (bytes, bytearray, memoryview)):
+            response.headers["content-length"] = str(len(body))
+        response.headers[_ERROR_SOURCE_HEADER] = _MODEL_PROVIDER_ERROR_SOURCE
+    return response
+
+
 def _raw_response(
     body: bytes | bytearray | memoryview | str,
     status_code: int,
     headers: CIMultiDict[str],
 ) -> Response:
     """Return a buffered body with upstream metadata and corrected framing headers."""
-    safe_headers = {k: v for k, v in headers.items() if k.lower() not in _BODY_FRAMING_HEADERS_TO_STRIP}
-    return Response(content=body, status_code=status_code, headers=safe_headers)
+    response = Response(content=body, status_code=status_code)
+    # Response(headers=...) accepts only a plain dict, which silently drops repeated
+    # header names such as Set-Cookie or WWW-Authenticate. Appending to raw_headers
+    # directly preserves every value from the upstream CIMultiDict.
+    response.raw_headers.extend(
+        (key.encode("latin-1"), value.encode("latin-1"))
+        for key, value in headers.items()
+        if key.lower() not in _BODY_FRAMING_HEADERS_TO_STRIP
+    )
+    return mark_model_provider_auth_error(response)
+
+
+def _raise_backend_error(status_code: int, error_body: str) -> NoReturn:
+    """Raise the gateway response for a non-authentication backend error."""
+    if status_code == 404:
+        detail = f"Backend returned {status_code}: {error_body}" if error_body else f"Backend returned {status_code}"
+        raise HTTPException(status_code=502, detail=detail)
+    raise HTTPException(status_code=status_code, detail=error_body or str(status_code))
+
+
+async def _handle_backend_error(
+    response: aiohttp.ClientResponse,
+    url: str,
+) -> tuple[bytes, CIMultiDict[str], int]:
+    """Return a preserved auth failure or raise for another failed backend response.
+
+    The returned headers belong only to a backend 401/403 response. Successful
+    response headers continue through the normal proxy path.
+    """
+    response_status = response.status
+    auth_response_headers = (
+        _filter_response_headers(response.headers) if response_status in _BACKEND_AUTH_ERROR_STATUSES else CIMultiDict()
+    )
+    raw_error_body, error_body = await _read_error_body(response)
+    _close_response(response)
+    logger.warning(
+        "Backend error %d from %s: %s",
+        response_status,
+        url,
+        error_body,
+    )
+    if response_status in _BACKEND_AUTH_ERROR_STATUSES:
+        return raw_error_body, auth_response_headers, response_status
+    _raise_backend_error(response_status, error_body)
 
 
 async def proxy_request(http_client: ClientSession, next_request_info: NextRequestInfo) -> Response:
@@ -367,31 +426,11 @@ async def proxy_request(http_client: ClientSession, next_request_info: NextReque
         )
 
         if response.status >= 400:
-            response_status = response.status
-            response_headers = (
-                _filter_response_headers(response.headers)
-                if response_status in _BACKEND_AUTH_ERROR_STATUSES
-                else CIMultiDict()
-            )
-            raw_error_body, error_body = await _read_error_body(response)
-            _close_response(response)
-            logger.warning(
-                "Backend error %d from %s: %s",
-                response_status,
+            raw_error_body, auth_response_headers, response_status = await _handle_backend_error(
+                response,
                 next_request_info.url,
-                error_body,
             )
-            if response_status in _BACKEND_AUTH_ERROR_STATUSES:
-                return _raw_response(raw_error_body, response_status, response_headers)
-            if response_status == 404:
-                detail = (
-                    f"Backend returned {response_status}: {error_body}"
-                    if error_body
-                    else f"Backend returned {response_status}"
-                )
-                raise HTTPException(status_code=502, detail=detail)
-            detail = error_body if error_body else str(response_status)
-            raise HTTPException(status_code=response_status, detail=detail)
+            return _raw_response(raw_error_body, response_status, auth_response_headers)
 
         response_headers = _filter_response_headers(response.headers)
 
@@ -513,31 +552,7 @@ async def fetch_proxy_response(
         )
 
         if response.status >= 400:
-            response_status = response.status
-            response_headers = (
-                _filter_response_headers(response.headers)
-                if response_status in _BACKEND_AUTH_ERROR_STATUSES
-                else CIMultiDict()
-            )
-            raw_error_body, error_body = await _read_error_body(response)
-            _close_response(response)
-            logger.warning(
-                "Backend error %d from %s: %s",
-                response_status,
-                next_request_info.url,
-                error_body,
-            )
-            if response_status in _BACKEND_AUTH_ERROR_STATUSES:
-                return raw_error_body, response_headers, response_status
-            if response_status == 404:
-                detail = (
-                    f"Backend returned {response_status}: {error_body}"
-                    if error_body
-                    else f"Backend returned {response_status}"
-                )
-                raise HTTPException(status_code=502, detail=detail)
-            detail = error_body if error_body else str(response_status)
-            raise HTTPException(status_code=response_status, detail=detail)
+            return await _handle_backend_error(response, next_request_info.url)
 
         response_headers = _filter_response_headers(response.headers)
         status_code = response.status
@@ -899,16 +914,8 @@ async def virtual_model_proxy(
             # wrap backend 404 as 502, and pass through other statuses.
             if mock_response.status_code >= 400:
                 if mock_response.status_code in _BACKEND_AUTH_ERROR_STATUSES:
-                    return mock_response
-                if mock_response.status_code == 404:
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Backend returned {mock_response.status_code}",
-                    )
-                raise HTTPException(
-                    status_code=mock_response.status_code,
-                    detail=str(mock_response.status_code),
-                )
+                    return mark_model_provider_auth_error(mock_response)
+                _raise_backend_error(mock_response.status_code, "")
             if isinstance(mock_response, StreamingResponse):
                 proxy_response_result = _parse_sse_chunks(mock_response.body_iterator)
                 response_headers = CIMultiDict(mock_response.headers)
@@ -975,8 +982,8 @@ async def virtual_model_proxy(
             json_body["model"] = f"{modified_model_ref.workspace}/{modified_model_ref.name}"
 
         # Authentication failures are transport-level responses, not inference
-        # payloads. Return them before model rewriting or response/post-response
-        # middleware attempts to parse them as a typed completion.
+        # payloads. Return them before rewriting the response body's model field
+        # or invoking response middleware.
         if response_status in _BACKEND_AUTH_ERROR_STATUSES:
             if not isinstance(proxy_response_result, bytes):
                 raise HTTPException(

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -50,9 +50,7 @@ if TYPE_CHECKING:
     from nmp.core.inference_gateway.api.model_cache import ModelCache
 
 ResponseResult = Union[dict[str, Any], AsyncIterator[dict[str, Any]]]
-"""Either a fully-buffered JSON response (``dict``) or a lazy SSE stream
-(``AsyncIterator[dict]``).  Mirrors the type defined in
-``nemo_platform_plugin.inference_middleware`` and used throughout the middleware chain."""
+"""Either a fully-buffered JSON response or lazy SSE stream."""
 
 logger = logging.getLogger(__name__)
 
@@ -309,38 +307,53 @@ def _close_response(response: aiohttp.ClientResponse | None):
 
 
 _MAX_ERROR_BODY_LEN = 2048
+_BODY_FRAMING_HEADERS_TO_STRIP = frozenset({"content-length", "content-encoding", "transfer-encoding"})
+_BACKEND_AUTH_ERROR_STATUSES = frozenset({401, 403})
 
 
-async def _read_error_body(response: aiohttp.ClientResponse) -> str:
-    """Read a truncated text snippet from an error response for diagnostic logging."""
+async def _read_error_body(response: aiohttp.ClientResponse) -> tuple[bytes, str]:
+    """Read an error body while retaining the upstream status if reading fails."""
     try:
-        raw = await response.read()
-        return raw.decode("utf-8", errors="replace")[:_MAX_ERROR_BODY_LEN]
-    except Exception:
-        return ""
+        raw_body = await response.read()
+    except Exception as exc:
+        logger.warning("Failed to read backend error response body: %s", exc)
+        return b"", ""
+    return raw_body, raw_body.decode("utf-8", errors="replace")[:_MAX_ERROR_BODY_LEN]
 
 
-async def proxy_request(http_client: ClientSession, next_request_info: NextRequestInfo) -> StreamingResponse:
+def _raw_response(
+    body: bytes | bytearray | memoryview | str,
+    status_code: int,
+    headers: CIMultiDict[str],
+) -> Response:
+    """Return a buffered body with upstream metadata and corrected framing headers."""
+    safe_headers = {k: v for k, v in headers.items() if k.lower() not in _BODY_FRAMING_HEADERS_TO_STRIP}
+    return Response(content=body, status_code=status_code, headers=safe_headers)
+
+
+async def proxy_request(http_client: ClientSession, next_request_info: NextRequestInfo) -> Response:
     """Execute a proxied HTTP request and stream the response back to the client.
 
-    This function forwards the request to an upstream service and streams the response
-    back without buffering. It handles both regular and server-sent event responses.
+    This function forwards the request to an upstream service. Successful responses
+    are streamed without buffering; error responses are buffered for logging and
+    status handling.
 
-    Certain backend errors (401/403/404) are wrapped in 502 Bad Gateway with a clear
-    error message indicating the error came from the backend, not the gateway. Other
-    backend errors (429, 422, 5xx, etc.) are passed through with their original status.
-    In both cases the backend's error body is included in the detail for diagnostics.
+    Backend authentication errors (401/403) are returned unchanged so callers can
+    distinguish invalid credentials from transient gateway failures. Backend 404
+    responses are wrapped in 502 Bad Gateway; other backend errors retain their
+    original status.
 
     Args:
         http_client: The HTTP client session to use for the request
         next_request_info: Information about the request to proxy
 
     Returns:
-        StreamingResponse containing the proxied response
+        A buffered response for authentication errors or a streaming response
+        for successful upstream responses.
 
     Raises:
-        HTTPException: 502 for certain backend errors (401/403/404) or network errors,
-            original status for other backend errors, 500 for internal errors
+        HTTPException: 502 for backend 404 or network errors, original status for
+            other backend errors, 500 for internal errors
     """
     response: aiohttp.ClientResponse | None = None
     try:
@@ -354,24 +367,31 @@ async def proxy_request(http_client: ClientSession, next_request_info: NextReque
         )
 
         if response.status >= 400:
-            error_body = await _read_error_body(response)
+            response_status = response.status
+            response_headers = (
+                _filter_response_headers(response.headers)
+                if response_status in _BACKEND_AUTH_ERROR_STATUSES
+                else CIMultiDict()
+            )
+            raw_error_body, error_body = await _read_error_body(response)
             _close_response(response)
             logger.warning(
                 "Backend error %d from %s: %s",
-                response.status,
+                response_status,
                 next_request_info.url,
                 error_body,
             )
-            if response.status in (401, 403, 404):
+            if response_status in _BACKEND_AUTH_ERROR_STATUSES:
+                return _raw_response(raw_error_body, response_status, response_headers)
+            if response_status == 404:
                 detail = (
-                    f"Backend returned {response.status}: {error_body}"
+                    f"Backend returned {response_status}: {error_body}"
                     if error_body
-                    else f"Backend returned {response.status}"
+                    else f"Backend returned {response_status}"
                 )
                 raise HTTPException(status_code=502, detail=detail)
-            else:
-                detail = error_body if error_body else str(response.status)
-                raise HTTPException(status_code=response.status, detail=detail)
+            detail = error_body if error_body else str(response_status)
+            raise HTTPException(status_code=response_status, detail=detail)
 
         response_headers = _filter_response_headers(response.headers)
 
@@ -460,7 +480,7 @@ async def _parse_sse_stream(response: aiohttp.ClientResponse) -> AsyncIterator[d
 async def fetch_proxy_response(
     http_client: ClientSession,
     next_request_info: NextRequestInfo,
-) -> tuple[ResponseResult, CIMultiDict[str], int]:
+) -> tuple[ResponseResult | bytes, CIMultiDict[str], int]:
     """Execute a proxied HTTP request and return the response as a ``ResponseResult``.
 
     Unlike :func:`proxy_request`, this function does **not** stream the response
@@ -468,11 +488,12 @@ async def fetch_proxy_response(
     responsible for applying response middleware and then streaming via
     :func:`stream_response_result`.
 
-    For ``Content-Type: text/event-stream`` responses the result is an
+    Authentication failures return raw bytes so their body can bypass inference
+    middleware unchanged. For successful ``Content-Type: text/event-stream``
+    responses the result is an
     ``AsyncIterator[dict]`` backed by the live aiohttp response — the iterator
     **must** be fully consumed or the underlying connection will leak.  For all
-    other responses the body is buffered and parsed as JSON (falling back to an
-    empty dict for non-JSON bodies).
+    other successful responses the body is buffered and parsed as a JSON object.
 
     Returns:
         A ``(response_result, headers, status_code)`` tuple.
@@ -492,24 +513,31 @@ async def fetch_proxy_response(
         )
 
         if response.status >= 400:
-            error_body = await _read_error_body(response)
+            response_status = response.status
+            response_headers = (
+                _filter_response_headers(response.headers)
+                if response_status in _BACKEND_AUTH_ERROR_STATUSES
+                else CIMultiDict()
+            )
+            raw_error_body, error_body = await _read_error_body(response)
             _close_response(response)
             logger.warning(
                 "Backend error %d from %s: %s",
-                response.status,
+                response_status,
                 next_request_info.url,
                 error_body,
             )
-            if response.status in (401, 403, 404):
+            if response_status in _BACKEND_AUTH_ERROR_STATUSES:
+                return raw_error_body, response_headers, response_status
+            if response_status == 404:
                 detail = (
-                    f"Backend returned {response.status}: {error_body}"
+                    f"Backend returned {response_status}: {error_body}"
                     if error_body
-                    else f"Backend returned {response.status}"
+                    else f"Backend returned {response_status}"
                 )
                 raise HTTPException(status_code=502, detail=detail)
-            else:
-                detail = error_body if error_body else str(response.status)
-                raise HTTPException(status_code=response.status, detail=detail)
+            detail = error_body if error_body else str(response_status)
+            raise HTTPException(status_code=response_status, detail=detail)
 
         response_headers = _filter_response_headers(response.headers)
         status_code = response.status
@@ -552,7 +580,7 @@ async def fetch_proxy_response(
 # when stream_response_result re-serializes the payload.  Forwarding them after
 # body mutation produces truncated responses (wrong content-length), failed
 # decompression (stale content-encoding), and framing errors (transfer-encoding).
-_BODY_HEADERS_TO_STRIP = frozenset({"content-length", "content-encoding", "transfer-encoding", "content-type"})
+_BODY_HEADERS_TO_STRIP = _BODY_FRAMING_HEADERS_TO_STRIP | {"content-type"}
 
 
 def _rewrite_model_field(payload: Any, served_model_name: str, restored_model_id: str) -> None:
@@ -623,7 +651,7 @@ def _active_response_result(response_result: Any) -> Any:
 
 def _is_streaming_response_result(response_result: Any) -> bool:
     if isinstance(response_result, InferenceResponse):
-        return not isinstance(response_result.result, dict)
+        return not isinstance(response_result.result, dict | BaseModel)
     return not isinstance(response_result, dict | BaseModel)
 
 
@@ -682,9 +710,7 @@ async def stream_response_result(
 
     Body-framing headers (``content-length``, ``content-encoding``,
     ``transfer-encoding``, ``content-type``) are stripped from *headers* and
-    replaced with values that match the re-serialized payload.  Forwarding the
-    upstream values after body mutation would produce truncated or garbled
-    responses for the caller.
+    replaced with values that match the re-serialized payload.
     """
     safe_headers = _strip_body_headers(headers)
     response_payload = _serialization_response_result(response_result)
@@ -869,9 +895,12 @@ async def virtual_model_proxy(
                 default_extra_headers=resolved_model_provider_info.model_provider.default_extra_headers,
                 request_body=json_body,
             )
-            # Match fetch_proxy_response error semantics: 401/403/404 → 502, else passthrough.
+            # Match fetch_proxy_response error semantics: preserve auth failures,
+            # wrap backend 404 as 502, and pass through other statuses.
             if mock_response.status_code >= 400:
-                if mock_response.status_code in (401, 403, 404):
+                if mock_response.status_code in _BACKEND_AUTH_ERROR_STATUSES:
+                    return mock_response
+                if mock_response.status_code == 404:
                     raise HTTPException(
                         status_code=502,
                         detail=f"Backend returned {mock_response.status_code}",
@@ -944,6 +973,22 @@ async def virtual_model_proxy(
                 http_client, next_request_info
             )
             json_body["model"] = f"{modified_model_ref.workspace}/{modified_model_ref.name}"
+
+        # Authentication failures are transport-level responses, not inference
+        # payloads. Return them before model rewriting or response/post-response
+        # middleware attempts to parse them as a typed completion.
+        if response_status in _BACKEND_AUTH_ERROR_STATUSES:
+            if not isinstance(proxy_response_result, bytes):
+                raise HTTPException(
+                    status_code=500,
+                    detail="Backend authentication response was not returned as raw bytes.",
+                )
+            return _raw_response(proxy_response_result, response_status, response_headers)
+        if isinstance(proxy_response_result, bytes):
+            raise HTTPException(
+                status_code=500,
+                detail="Unexpected raw backend response for a successful inference request.",
+            )
 
         # Rewrite the served-model name back to the post-middleware model entity reference
         # in the response body so the user never sees the upstream's served_model_name. This

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/models.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/models.py
@@ -23,6 +23,7 @@ from nmp.core.inference_gateway.api.mock_provider import (
 from nmp.core.inference_gateway.api.model_cache import ModelCache
 from nmp.core.inference_gateway.api.proxy import (
     PROXY_OPENAPI_EXTRA,
+    mark_model_provider_auth_error,
     virtual_model_proxy,
 )
 from nmp.core.inference_gateway.api.validation import validate_entity_name, validate_model_entity_name
@@ -93,7 +94,8 @@ async def model_entity_proxy(
     """
     # If mock mode enabled and request has explicit mock response, skip model lookup
     if is_mock_request(request):
-        return await handle_mock_request(request=request, trailing_uri=trailing_uri)
+        response = await handle_mock_request(request=request, trailing_uri=trailing_uri)
+        return mark_model_provider_auth_error(response)
 
     # ``name`` may be a composite LoRA model_entity_name like
     # ``base&adapters/{adapter_ws}/{adapter_name}``; ``validate_model_entity_name``

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/openai.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/openai.py
@@ -26,6 +26,7 @@ from nmp.core.inference_gateway.api.mock_provider import (
 from nmp.core.inference_gateway.api.model_cache import ModelCache
 from nmp.core.inference_gateway.api.proxy import (
     PROXY_OPENAPI_EXTRA,
+    mark_model_provider_auth_error,
     virtual_model_proxy,
 )
 from nmp.core.inference_gateway.api.validation import validate_entity_name, validate_model_entity_name
@@ -218,7 +219,8 @@ async def openai_proxy(
     """
     # If mock mode enabled and request has explicit mock response, skip model lookup
     if is_mock_request(request):
-        return await handle_mock_request(request=request, trailing_uri=trailing_uri)
+        response = await handle_mock_request(request=request, trailing_uri=trailing_uri)
+        return mark_model_provider_auth_error(response)
 
     try:
         json_body = await request.json()

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/providers.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/providers.py
@@ -14,7 +14,12 @@ from nmp.core.inference_gateway.api.mock_provider import (
     is_mock_request,
 )
 from nmp.core.inference_gateway.api.model_cache import ModelCache
-from nmp.core.inference_gateway.api.proxy import PROXY_OPENAPI_EXTRA, build_next_request, proxy_request
+from nmp.core.inference_gateway.api.proxy import (
+    PROXY_OPENAPI_EXTRA,
+    build_next_request,
+    mark_model_provider_auth_error,
+    proxy_request,
+)
 from nmp.core.inference_gateway.api.validation import validate_workspace_and_name
 
 logger = logging.getLogger(__name__)
@@ -116,7 +121,8 @@ async def provider_proxy(
     """
     # If mock mode enabled and request has explicit mock response, skip provider lookup
     if is_mock_request(request):
-        return await handle_mock_request(request=request, trailing_uri=trailing_uri)
+        response = await handle_mock_request(request=request, trailing_uri=trailing_uri)
+        return mark_model_provider_auth_error(response)
 
     validate_workspace_and_name(workspace, name)
     model_info = model_cache.get_from_provider(workspace, name)
@@ -128,11 +134,12 @@ async def provider_proxy(
 
     # Check if this specific provider is a mock provider based on name prefix
     if is_mock_provider(name):
-        return await handle_mock_request(
+        response = await handle_mock_request(
             request=request,
             trailing_uri=trailing_uri,
             default_extra_headers=model_info.model_provider.default_extra_headers,
         )
+        return mark_model_provider_auth_error(response)
 
     next_request_info = await build_next_request(
         request,

--- a/services/core/inference-gateway/tests/integration/test_igw_with_auth.py
+++ b/services/core/inference-gateway/tests/integration/test_igw_with_auth.py
@@ -68,6 +68,7 @@ class TestIGWUnauthenticated:
             json={"model": "test", "messages": [{"role": "user", "content": "hi"}]},
         )
         assert response.status_code == 401
+        assert "x-nemo-error-source" not in response.headers
 
     def test_openai_list_models_without_auth_fails(self, sdk: NeMoPlatform):
         response = sdk._client.get(
@@ -441,6 +442,7 @@ class TestIGWUnauthorizedWorkspace:
             },
         )
         assert response.status_code == 403
+        assert "x-nemo-error-source" not in response.headers
 
     def test_no_role_denied_model_proxy(self, sdk: NeMoPlatform):
         workspace = short_unique_name("igw-nm")
@@ -494,6 +496,69 @@ class TestIGWUnauthorizedWorkspace:
             },
         )
         assert response.status_code == 403
+
+
+@pytest.mark.integration
+class TestIGWBackendAuthErrors:
+    """Authorized requests can distinguish ModelProvider auth failures from platform auth failures."""
+
+    @pytest.mark.parametrize("status_code", [401, 403])
+    @pytest.mark.parametrize("route_type", ["provider", "model", "openai"])
+    def test_backend_auth_error_preserves_origin(
+        self,
+        sdk: NeMoPlatform,
+        status_code: int,
+        route_type: str,
+    ):
+        workspace = short_unique_name("igw-be")
+        viewer_email = unique_email("viewer")
+        model_name = short_unique_name("mdl")
+        error_body = {
+            "error": {
+                "message": "ModelProvider rejected its configured credentials",
+                "status": status_code,
+            }
+        }
+
+        admin_sdk = as_user(sdk, TEST_ADMIN_EMAIL)
+        admin_sdk.workspaces.create(name=workspace)
+        provider = add_mock_provider(
+            admin_sdk,
+            workspace=workspace,
+            name=model_name,
+            mock_response_body=error_body,
+            mock_status=status_code,
+        )
+        grant_workspace_role(
+            admin_sdk,
+            workspace=workspace,
+            principal=viewer_email,
+            roles=["Viewer"],
+        )
+
+        if route_type == "provider":
+            path = f"/apis/inference-gateway/v2/workspaces/{workspace}/provider/{provider.name}/-/v1/chat/completions"
+            request_model = "test"
+        elif route_type == "model":
+            path = f"/apis/inference-gateway/v2/workspaces/{workspace}/model/{model_name}/-/v1/chat/completions"
+            request_model = model_name
+        else:
+            path = f"/apis/inference-gateway/v2/workspaces/{workspace}/openai/-/v1/chat/completions"
+            request_model = f"{workspace}/{model_name}"
+
+        viewer_sdk = as_user(sdk, viewer_email)
+        response = viewer_sdk._client.post(
+            path,
+            json={"model": request_model, "messages": [{"role": "user", "content": "hi"}]},
+            headers={
+                "X-NMP-Principal-Id": viewer_email,
+                "X-NMP-Principal-Email": viewer_email,
+            },
+        )
+
+        assert response.status_code == status_code
+        assert response.json() == error_body
+        assert response.headers["x-nemo-error-source"] == "model-provider"
 
 
 # --- Scope test helpers (mirrors models test pattern with patched_authz_data) ---

--- a/services/core/inference-gateway/tests/unit/test_model_router.py
+++ b/services/core/inference-gateway/tests/unit/test_model_router.py
@@ -8,7 +8,9 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 from urllib.parse import urlparse
 
+import pytest
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from nemo_platform.types.inference import ModelProvider, ServedModelMapping
 from nemo_platform.types.inference.virtual_model import VirtualModel as SDKVirtualModel
@@ -56,6 +58,46 @@ def test_model_entity_proxy_endpoint(client: TestClient, mock_proxy_client, mock
     mock_proxy_client.request.assert_called_once()
     assert response.status_code == 200
     assert response.json() == upstream
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_model_entity_proxy_marks_and_normalizes_explicit_mock_auth_error(
+    client: TestClient,
+    mocker,
+    status_code: int,
+):
+    """The model router marks mock auth errors and corrects body framing."""
+    error_body = {"error": "ModelProvider authentication failed"}
+    mocker.patch(
+        "nmp.core.inference_gateway.api.v2.models.is_mock_request",
+        return_value=True,
+    )
+    mocker.patch(
+        "nmp.core.inference_gateway.api.v2.models.handle_mock_request",
+        new=AsyncMock(
+            return_value=JSONResponse(
+                error_body,
+                status_code=status_code,
+                headers={
+                    "content-length": "999",
+                    "content-encoding": "gzip",
+                    "transfer-encoding": "chunked",
+                },
+            )
+        ),
+    )
+
+    response = client.post(
+        "/v2/workspaces/default/model/unknown/-/v1/chat/completions",
+        json={"model": "unknown", "messages": []},
+    )
+
+    assert response.status_code == status_code
+    assert response.json() == error_body
+    assert response.headers["x-nemo-error-source"] == "model-provider"
+    assert response.headers["content-length"] == str(len(response.content))
+    assert "content-encoding" not in response.headers
+    assert "transfer-encoding" not in response.headers
 
 
 def test_model_entity_proxy_not_found(client: TestClient):

--- a/services/core/inference-gateway/tests/unit/test_openai_router.py
+++ b/services/core/inference-gateway/tests/unit/test_openai_router.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 
 import pytest
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from nemo_platform.types.inference import ModelProvider, ServedModelMapping
 from nemo_platform.types.inference.virtual_model import VirtualModel as SDKVirtualModel
@@ -70,6 +71,46 @@ def _custom_vm(workspace: str, name: str, default_model_entity: str | None = Non
 
 
 # OpenAI List Models Tests
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_openai_proxy_marks_and_normalizes_explicit_mock_auth_error(
+    client: TestClient,
+    mocker,
+    status_code: int,
+):
+    """The OpenAI router marks mock auth errors and corrects body framing."""
+    error_body = {"error": "ModelProvider authentication failed"}
+    mocker.patch(
+        "nmp.core.inference_gateway.api.v2.openai.is_mock_request",
+        return_value=True,
+    )
+    mocker.patch(
+        "nmp.core.inference_gateway.api.v2.openai.handle_mock_request",
+        new=AsyncMock(
+            return_value=JSONResponse(
+                error_body,
+                status_code=status_code,
+                headers={
+                    "content-length": "999",
+                    "content-encoding": "gzip",
+                    "transfer-encoding": "chunked",
+                },
+            )
+        ),
+    )
+
+    response = client.post(
+        "/v2/workspaces/default/openai/-/v1/chat/completions",
+        json={"model": "unknown", "messages": []},
+    )
+
+    assert response.status_code == status_code
+    assert response.json() == error_body
+    assert response.headers["x-nemo-error-source"] == "model-provider"
+    assert response.headers["content-length"] == str(len(response.content))
+    assert "content-encoding" not in response.headers
+    assert "transfer-encoding" not in response.headers
 
 
 def test_list_models_empty_cache(app: FastAPI, client: TestClient):

--- a/services/core/inference-gateway/tests/unit/test_provider_router.py
+++ b/services/core/inference-gateway/tests/unit/test_provider_router.py
@@ -4,9 +4,11 @@
 """Tests for provider router endpoints."""
 
 import json
+from unittest.mock import AsyncMock
 
+import pytest
 from fastapi.testclient import TestClient
-from multidict import CIMultiDict
+from multidict import CIMultiDict, CIMultiDictProxy
 from nmp.core.inference_gateway.api.model_cache import ModelCache
 
 
@@ -20,6 +22,39 @@ def test_provider_proxy_endpoint(client: TestClient, mock_proxy_client, mock_pro
     mock_proxy_client.request.assert_called_once()
     assert response.status_code == 200
     assert response.content == content
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_provider_proxy_propagates_backend_auth_error(
+    client: TestClient,
+    mock_proxy_response,
+    status_code: int,
+):
+    """The provider route preserves backend auth status, body, and challenge headers."""
+    body = json.dumps(
+        {"status": status_code, "title": "Unauthorized", "detail": "Authentication failed"},
+        separators=(",", ":"),
+    ).encode()
+    mock_proxy_response.status = status_code
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "application/problem+json"),
+                ("www-authenticate", 'Bearer realm="inference"'),
+            ]
+        )
+    )
+    mock_proxy_response.read = AsyncMock(return_value=body)
+
+    response = client.post(
+        "/v2/workspaces/default/provider/ollama/-/v1/chat/completions",
+        json={"model": "example-model", "messages": [{"role": "user", "content": "Hello"}]},
+    )
+
+    assert response.status_code == status_code
+    assert response.content == body
+    assert response.headers["content-type"] == "application/problem+json"
+    assert response.headers["www-authenticate"] == 'Bearer realm="inference"'
 
 
 def test_provider_proxy_with_headers(client: TestClient, mock_proxy_client):

--- a/services/core/inference-gateway/tests/unit/test_provider_router.py
+++ b/services/core/inference-gateway/tests/unit/test_provider_router.py
@@ -7,6 +7,7 @@ import json
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from multidict import CIMultiDict, CIMultiDictProxy
 from nmp.core.inference_gateway.api.model_cache import ModelCache
@@ -22,6 +23,46 @@ def test_provider_proxy_endpoint(client: TestClient, mock_proxy_client, mock_pro
     mock_proxy_client.request.assert_called_once()
     assert response.status_code == 200
     assert response.content == content
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_provider_proxy_marks_and_normalizes_explicit_mock_auth_error(
+    client: TestClient,
+    mocker,
+    status_code: int,
+):
+    """The provider router marks mock auth errors and corrects body framing."""
+    error_body = {"error": "ModelProvider authentication failed"}
+    mocker.patch(
+        "nmp.core.inference_gateway.api.v2.providers.is_mock_request",
+        return_value=True,
+    )
+    mocker.patch(
+        "nmp.core.inference_gateway.api.v2.providers.handle_mock_request",
+        new=AsyncMock(
+            return_value=JSONResponse(
+                error_body,
+                status_code=status_code,
+                headers={
+                    "content-length": "999",
+                    "content-encoding": "gzip",
+                    "transfer-encoding": "chunked",
+                },
+            )
+        ),
+    )
+
+    response = client.post(
+        "/v2/workspaces/default/provider/unknown/-/v1/chat/completions",
+        json={"model": "unknown", "messages": []},
+    )
+
+    assert response.status_code == status_code
+    assert response.json() == error_body
+    assert response.headers["x-nemo-error-source"] == "model-provider"
+    assert response.headers["content-length"] == str(len(response.content))
+    assert "content-encoding" not in response.headers
+    assert "transfer-encoding" not in response.headers
 
 
 @pytest.mark.parametrize("status_code", [401, 403])
@@ -41,6 +82,9 @@ def test_provider_proxy_propagates_backend_auth_error(
             [
                 ("content-type", "application/problem+json"),
                 ("www-authenticate", 'Bearer realm="inference"'),
+                ("www-authenticate", 'Basic realm="fallback"'),
+                ("set-cookie", "first=one"),
+                ("set-cookie", "second=two"),
             ]
         )
     )
@@ -54,7 +98,12 @@ def test_provider_proxy_propagates_backend_auth_error(
     assert response.status_code == status_code
     assert response.content == body
     assert response.headers["content-type"] == "application/problem+json"
-    assert response.headers["www-authenticate"] == 'Bearer realm="inference"'
+    assert response.headers.get_list("www-authenticate") == [
+        'Bearer realm="inference"',
+        'Basic realm="fallback"',
+    ]
+    assert response.headers.get_list("set-cookie") == ["first=one", "second=two"]
+    assert response.headers["x-nemo-error-source"] == "model-provider"
 
 
 def test_provider_proxy_with_headers(client: TestClient, mock_proxy_client):

--- a/services/core/inference-gateway/tests/unit/test_proxy.py
+++ b/services/core/inference-gateway/tests/unit/test_proxy.py
@@ -174,7 +174,6 @@ async def test_build_next_request(mock_request):
     assert "x-forwarded-for" not in result.headers
 
 
-# Below was claudes work that I need to fix up massively
 @pytest.mark.asyncio
 async def test_proxy_request_success(mock_proxy_client, next_request_info):
     response = await proxy_request(mock_proxy_client, next_request_info)
@@ -1444,6 +1443,9 @@ async def test_proxy_request_propagates_backend_auth_errors(
                 ("content-length", "999"),
                 ("content-encoding", "gzip"),
                 ("www-authenticate", 'Bearer realm="inference"'),
+                ("www-authenticate", 'Basic realm="fallback"'),
+                ("set-cookie", "first=one"),
+                ("set-cookie", "second=two"),
             ]
         )
     )
@@ -1455,7 +1457,12 @@ async def test_proxy_request_propagates_backend_auth_errors(
     assert await _read_streaming_response(response) == error_body
     assert response.headers["content-type"] == "application/problem+json"
     assert response.headers["content-length"] == str(len(error_body))
-    assert response.headers["www-authenticate"] == 'Bearer realm="inference"'
+    assert response.headers.getlist("www-authenticate") == [
+        'Bearer realm="inference"',
+        'Basic realm="fallback"',
+    ]
+    assert response.headers.getlist("set-cookie") == ["first=one", "second=two"]
+    assert response.headers["x-nemo-error-source"] == "model-provider"
     assert "content-encoding" not in response.headers
     assert "transfer-encoding" not in response.headers
 
@@ -1477,6 +1484,7 @@ async def test_proxy_request_preserves_non_json_backend_auth_body(
     assert response.status_code == 401
     assert await _read_streaming_response(response) == error_body
     assert response.headers["content-type"] == "text/html"
+    assert response.headers["x-nemo-error-source"] == "model-provider"
 
 
 @pytest.mark.asyncio
@@ -1606,6 +1614,7 @@ async def test_virtual_model_proxy_auth_errors_bypass_response_middleware_and_mo
     assert await _read_streaming_response(response) == raw_error_body
     assert response.headers["content-type"] == "application/problem+json"
     assert response.headers["www-authenticate"] == 'Bearer realm="inference"'
+    assert response.headers["x-nemo-error-source"] == "model-provider"
     assert middleware_calls == []
 
 
@@ -1651,6 +1660,7 @@ async def test_virtual_model_proxy_mock_provider_auth_errors_bypass_response_mid
     assert response.status_code == status_code
     assert json.loads(await _read_streaming_response(response)) == error_body
     assert response.headers["www-authenticate"] == 'Bearer realm="inference"'
+    assert response.headers["x-nemo-error-source"] == "model-provider"
     assert middleware_calls == []
 
 
@@ -1693,6 +1703,7 @@ async def test_virtual_model_proxy_mock_streaming_auth_error_is_returned_unchang
     assert await _read_streaming_response(response) == b"Authentication failed"
     assert response.headers["content-type"] == "text/plain; charset=utf-8"
     assert response.headers["www-authenticate"] == 'Bearer realm="inference"'
+    assert response.headers["x-nemo-error-source"] == "model-provider"
 
 
 @pytest.mark.asyncio

--- a/services/core/inference-gateway/tests/unit/test_proxy.py
+++ b/services/core/inference-gateway/tests/unit/test_proxy.py
@@ -6,7 +6,7 @@
 import asyncio
 import json
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 
@@ -14,9 +14,9 @@ import anthropic.types as anthropic_types
 import openai.types.chat as openai_chat_types
 import pytest
 import pytest_asyncio
-from aiohttp import ClientError
+from aiohttp import ClientError, ClientPayloadError
 from fastapi import HTTPException, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from multidict import CIMultiDict, CIMultiDictProxy
 from nemo_platform.types.inference import ModelProvider, ServedModelMapping
 from nemo_platform.types.inference.virtual_model import VirtualModel as SDKVirtualModel
@@ -41,6 +41,7 @@ from nmp.core.inference_gateway.api.proxy import (
     _rewrite_model_field,
     _rewrite_model_field_in_stream,
     build_next_request,
+    fetch_proxy_response,
     normalize_proxy_url,
     proxy_request,
     stream_response_result,
@@ -65,7 +66,10 @@ async def next_request_info(mock_request):
     return await build_next_request(mock_request, "http://example.com", "api")
 
 
-async def _read_streaming_response(response: StreamingResponse) -> bytes:
+async def _read_streaming_response(response: Response) -> bytes:
+    if not isinstance(response, StreamingResponse):
+        return bytes(response.body)
+
     chunks: list[bytes] = []
     async for chunk in response.body_iterator:
         if isinstance(chunk, str):
@@ -78,6 +82,81 @@ async def _read_streaming_response(response: StreamingResponse) -> bytes:
 def _json_request_body(result: NextRequestInfo) -> dict[str, Any]:
     assert result.body is not None
     return json.loads(result.body)
+
+
+def _virtual_model_backend(
+    workspace: str,
+    vm_name: str,
+    *,
+    provider_name: str = "nim",
+) -> tuple[ModelCache, SDKVirtualModel, str, str]:
+    model_entity_id = f"{workspace}/model"
+    served_model_name = "served-model"
+    model_cache = ModelCache()
+    model_cache.update_model_info(
+        ModelProviderInfo(
+            model_provider=ModelProvider(
+                workspace="default",
+                name=provider_name,
+                host_url=f"http://{provider_name}.local",
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+                served_models=[
+                    ServedModelMapping(
+                        model_entity_id=model_entity_id,
+                        served_model_name=served_model_name,
+                    )
+                ],
+                status="READY",
+            )
+        )
+    )
+    model_cache.rebuild_model_entity_map()
+    virtual_model = SDKVirtualModel(
+        id=f"{workspace}/{vm_name}",
+        entity_id=f"{workspace}/{vm_name}",
+        name=vm_name,
+        workspace=workspace,
+        parent=workspace,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        default_model_entity=model_entity_id,
+    )
+    return model_cache, virtual_model, model_entity_id, served_model_name
+
+
+def _mock_inference_request() -> Mock:
+    request = Mock(spec=Request)
+    request.method = "POST"
+    request.headers = {"content-type": "application/json"}
+    request.query_params = {}
+    return request
+
+
+def _unexpected_response_middleware_registry(
+    workspace: str,
+    vm_name: str,
+    middleware_calls: list[str],
+) -> MiddlewareRegistry:
+    class _UnexpectedResponsePlugin(NemoInferenceMiddleware):
+        async def process_response(
+            self,
+            ctx: InferenceMiddlewareContext,
+            response: InferenceResponse,
+            middleware_config: object,
+        ) -> InferenceResponse:
+            middleware_calls.append("called")
+            return response
+
+    registry = MiddlewareRegistry(plugins={"unexpected-plugin": _UnexpectedResponsePlugin()})
+    middleware_call = ResolvedMiddlewareCall(
+        plugin_name="unexpected-plugin",
+        config_type="t",
+        resolved_config={},
+    )
+    registry.response_middleware_calls[(workspace, vm_name)] = [middleware_call]
+    registry.post_response_middleware_calls[(workspace, vm_name)] = [middleware_call]
+    return registry
 
 
 @pytest.mark.asyncio
@@ -1019,6 +1098,7 @@ async def test_proxy_request_client_error(mock_proxy_client, next_request_info):
 @pytest.mark.asyncio
 async def test_proxy_request_streaming_closes_connection(mock_proxy_client, mock_proxy_response, next_request_info):
     response = await proxy_request(mock_proxy_client, next_request_info)
+    assert isinstance(response, StreamingResponse)
 
     # Consume the streaming response to trigger cleanup
     async for _ in response.body_iterator:
@@ -1347,13 +1427,315 @@ def test_normalize_proxy_url(host_url, trailing_uri, expected):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("status_code", [401, 403, 404])
-async def test_proxy_request_wraps_certain_errors_in_502(mock_proxy_client, next_request_info, status_code):
-    """Test that certain backend errors (401/403/404) are wrapped in 502."""
+@pytest.mark.parametrize("status_code", [401, 403])
+async def test_proxy_request_propagates_backend_auth_errors(
+    mock_proxy_client, mock_proxy_response, next_request_info, status_code
+):
+    """Backend auth errors retain status, body, and authentication headers."""
+    error_body = json.dumps(
+        {"status": status_code, "title": "Unauthorized", "detail": "Authentication failed"},
+        separators=(",", ":"),
+    ).encode()
+    mock_proxy_response.status = status_code
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "application/problem+json"),
+                ("content-length", "999"),
+                ("content-encoding", "gzip"),
+                ("www-authenticate", 'Bearer realm="inference"'),
+            ]
+        )
+    )
+    mock_proxy_response.read = AsyncMock(return_value=error_body)
+
+    response = await proxy_request(mock_proxy_client, next_request_info)
+
+    assert response.status_code == status_code
+    assert await _read_streaming_response(response) == error_body
+    assert response.headers["content-type"] == "application/problem+json"
+    assert response.headers["content-length"] == str(len(error_body))
+    assert response.headers["www-authenticate"] == 'Bearer realm="inference"'
+    assert "content-encoding" not in response.headers
+    assert "transfer-encoding" not in response.headers
+
+
+@pytest.mark.asyncio
+async def test_proxy_request_preserves_non_json_backend_auth_body(
+    mock_proxy_client,
+    mock_proxy_response,
+    next_request_info,
+):
+    """Direct provider auth failures preserve intermediary HTML responses."""
+    error_body = b"<html>Authentication failed</html>"
+    mock_proxy_response.status = 401
+    mock_proxy_response.headers = CIMultiDictProxy(CIMultiDict([("content-type", "text/html")]))
+    mock_proxy_response.read = AsyncMock(return_value=error_body)
+
+    response = await proxy_request(mock_proxy_client, next_request_info)
+
+    assert response.status_code == 401
+    assert await _read_streaming_response(response) == error_body
+    assert response.headers["content-type"] == "text/html"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [401, 403])
+async def test_fetch_proxy_response_propagates_backend_auth_errors(
+    mock_proxy_client, mock_proxy_response, next_request_info, status_code
+):
+    """Buffered virtual-model requests retain backend auth response bytes unchanged."""
+    error_body = json.dumps(
+        {"status": status_code, "title": "Unauthorized", "detail": "Authentication failed"},
+        separators=(",", ":"),
+    ).encode()
+    mock_proxy_response.status = status_code
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "application/problem+json"),
+                ("www-authenticate", 'Bearer realm="inference"'),
+            ]
+        )
+    )
+    mock_proxy_response.read = AsyncMock(return_value=error_body)
+
+    result, response_headers, response_status = await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert response_status == status_code
+    assert result == error_body
+    assert response_headers["content-type"] == "application/problem+json"
+    assert response_headers["www-authenticate"] == 'Bearer realm="inference"'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_body",
+    [
+        b"",
+        b"<html>Authentication failed</html>",
+        b"x" * 4096,
+    ],
+)
+async def test_fetch_proxy_response_preserves_arbitrary_backend_auth_bodies(
+    mock_proxy_client, mock_proxy_response, next_request_info, error_body
+):
+    """Buffered auth failures preserve empty, non-JSON, and long bodies."""
+    mock_proxy_response.status = 401
+    mock_proxy_response.read = AsyncMock(return_value=error_body)
+
+    result, _, response_status = await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert response_status == 401
+    assert result == error_body
+
+
+@pytest.mark.asyncio
+async def test_proxy_request_auth_status_survives_error_body_read_failure(
+    mock_proxy_client,
+    mock_proxy_response,
+    next_request_info,
+):
+    """A malformed upstream body cannot turn a known authentication failure into 502."""
+    mock_proxy_response.status = 401
+    mock_proxy_response.read = AsyncMock(side_effect=ClientPayloadError("truncated body"))
+
+    result = await proxy_request(mock_proxy_client, next_request_info)
+
+    assert isinstance(result, Response)
+    assert result.status_code == 401
+    assert await _read_streaming_response(result) == b""
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_auth_status_survives_error_body_read_failure(
+    mock_proxy_client,
+    mock_proxy_response,
+    next_request_info,
+):
+    """A malformed upstream body cannot turn a known authentication failure into 502."""
+    mock_proxy_response.status = 401
+    mock_proxy_response.read = AsyncMock(side_effect=ClientPayloadError("truncated body"))
+
+    body, _, response_status = await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert response_status == 401
+    assert body == b""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [401, 403])
+async def test_virtual_model_proxy_auth_errors_bypass_response_middleware_and_model_rewrite(
+    mock_proxy_client, mock_proxy_response, status_code
+):
+    """Auth failures are returned as transport errors, not typed inference responses."""
+    middleware_calls: list[str] = []
+
+    workspace = "e2e-test"
+    vm_name = "auth-error-router"
+    model_cache, virtual_model, _, served_model_name = _virtual_model_backend(workspace, vm_name)
+    error_body = {
+        "error": {"message": "Authentication failed"},
+        "model": served_model_name,
+    }
+    mock_proxy_response.status = status_code
+    raw_error_body = json.dumps(error_body, separators=(",", ":")).encode()
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "application/problem+json"),
+                ("www-authenticate", 'Bearer realm="inference"'),
+            ]
+        )
+    )
+    mock_proxy_response.read = AsyncMock(return_value=raw_error_body)
+
+    response = await virtual_model_proxy(
+        request=_mock_inference_request(),
+        workspace=workspace,
+        vm_name=vm_name,
+        virtual_model=virtual_model,
+        trailing_uri="v1/chat/completions",
+        json_body={"model": vm_name, "messages": []},
+        http_client=mock_proxy_client,
+        model_cache=model_cache,
+        registry=_unexpected_response_middleware_registry(workspace, vm_name, middleware_calls),
+    )
+
+    assert response.status_code == status_code
+    assert await _read_streaming_response(response) == raw_error_body
+    assert response.headers["content-type"] == "application/problem+json"
+    assert response.headers["www-authenticate"] == 'Bearer realm="inference"'
+    assert middleware_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [401, 403])
+async def test_virtual_model_proxy_mock_provider_auth_errors_bypass_response_middleware(mocker, status_code):
+    """Mock-provider auth failures follow the same short-circuit as real backends."""
+    middleware_calls: list[str] = []
+
+    workspace = "e2e-test"
+    vm_name = "mock-auth-error-router"
+    model_cache, virtual_model, _, served_model_name = _virtual_model_backend(
+        workspace, vm_name, provider_name="mock-provider"
+    )
+    error_body = {
+        "error": {"message": "Authentication failed"},
+        "model": served_model_name,
+    }
+    mocker.patch("nmp.core.inference_gateway.api.proxy.is_mock_provider", return_value=True)
+    mocker.patch(
+        "nmp.core.inference_gateway.api.proxy.handle_mock_request",
+        new=AsyncMock(
+            return_value=JSONResponse(
+                error_body,
+                status_code=status_code,
+                headers={"www-authenticate": 'Bearer realm="inference"'},
+            )
+        ),
+    )
+
+    response = await virtual_model_proxy(
+        request=_mock_inference_request(),
+        workspace=workspace,
+        vm_name=vm_name,
+        virtual_model=virtual_model,
+        trailing_uri="v1/chat/completions",
+        json_body={"model": vm_name, "messages": []},
+        http_client=Mock(),
+        model_cache=model_cache,
+        registry=_unexpected_response_middleware_registry(workspace, vm_name, middleware_calls),
+    )
+
+    assert response.status_code == status_code
+    assert json.loads(await _read_streaming_response(response)) == error_body
+    assert response.headers["www-authenticate"] == 'Bearer realm="inference"'
+    assert middleware_calls == []
+
+
+@pytest.mark.asyncio
+async def test_virtual_model_proxy_mock_streaming_auth_error_is_returned_unchanged(mocker):
+    """Mock streaming auth failures bypass SSE parsing and response middleware."""
+    workspace = "e2e-test"
+    vm_name = "mock-streaming-auth-error-router"
+    model_cache, virtual_model, _, _ = _virtual_model_backend(workspace, vm_name, provider_name="mock-provider")
+
+    async def error_body():
+        yield b"Authentication failed"
+
+    mock_response = StreamingResponse(
+        error_body(),
+        status_code=401,
+        media_type="text/plain",
+        headers={"www-authenticate": 'Bearer realm="inference"'},
+    )
+    mocker.patch("nmp.core.inference_gateway.api.proxy.is_mock_provider", return_value=True)
+    mocker.patch(
+        "nmp.core.inference_gateway.api.proxy.handle_mock_request",
+        new=AsyncMock(return_value=mock_response),
+    )
+
+    response = await virtual_model_proxy(
+        request=_mock_inference_request(),
+        workspace=workspace,
+        vm_name=vm_name,
+        virtual_model=virtual_model,
+        trailing_uri="v1/chat/completions",
+        json_body={"model": vm_name, "messages": []},
+        http_client=Mock(),
+        model_cache=model_cache,
+        registry=MiddlewareRegistry(),
+    )
+
+    assert response is mock_response
+    assert response.status_code == 401
+    assert await _read_streaming_response(response) == b"Authentication failed"
+    assert response.headers["content-type"] == "text/plain; charset=utf-8"
+    assert response.headers["www-authenticate"] == 'Bearer realm="inference"'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [422, 429, 500])
+async def test_virtual_model_proxy_mock_provider_raises_non_auth_errors(mocker, status_code):
+    """Mock providers retain the same non-auth error behavior as real backends."""
+    workspace = "e2e-test"
+    vm_name = "mock-error-router"
+    model_cache, virtual_model, _, _ = _virtual_model_backend(workspace, vm_name, provider_name="mock-provider")
+    mocker.patch("nmp.core.inference_gateway.api.proxy.is_mock_provider", return_value=True)
+    mocker.patch(
+        "nmp.core.inference_gateway.api.proxy.handle_mock_request",
+        new=AsyncMock(return_value=JSONResponse({"error": "backend failed"}, status_code=status_code)),
+    )
+
+    request = Mock(spec=Request)
+    request.method = "POST"
+    request.headers = {"content-type": "application/json"}
+    request.query_params = {}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await virtual_model_proxy(
+            request=request,
+            workspace=workspace,
+            vm_name=vm_name,
+            virtual_model=virtual_model,
+            trailing_uri="v1/chat/completions",
+            json_body={"model": vm_name, "messages": []},
+            http_client=Mock(),
+            model_cache=model_cache,
+            registry=MiddlewareRegistry(),
+        )
+
+    assert exc_info.value.status_code == status_code
+
+
+@pytest.mark.asyncio
+async def test_proxy_request_wraps_backend_not_found_in_502(mock_proxy_client, next_request_info):
+    """A backend 404 remains a gateway routing failure."""
     import aiohttp
 
     mock_response = Mock(spec=aiohttp.ClientResponse)
-    mock_response.status = status_code
+    mock_response.status = 404
     mock_response.closed = False
     mock_response.read = AsyncMock(return_value=b'{"error": "model not found on backend"}')
     mock_proxy_client.request = AsyncMock(return_value=mock_response)
@@ -1362,7 +1744,7 @@ async def test_proxy_request_wraps_certain_errors_in_502(mock_proxy_client, next
         await proxy_request(mock_proxy_client, next_request_info)
 
     assert exc_info.value.status_code == 502
-    assert f"Backend returned {status_code}" in exc_info.value.detail
+    assert "Backend returned 404" in exc_info.value.detail
     assert "model not found on backend" in exc_info.value.detail
 
 
@@ -1448,6 +1830,7 @@ async def test_compressed_response_bytes_passed_through(mock_proxy_client, mock_
     mock_proxy_response.content.iter_chunked = Mock(return_value=compressed_chunk_iterator())
 
     response = await proxy_request(mock_proxy_client, next_request_info)
+    assert isinstance(response, StreamingResponse)
 
     # Verify Content-Encoding header is preserved
     assert response.headers.get("content-encoding") == "gzip"


### PR DESCRIPTION
## Summary

Preserve backend `401 Unauthorized` and `403 Forbidden` responses in the inference gateway instead of wrapping them in `502 Bad Gateway`.

Backend authentication failures now include:

~~~http
X-NeMo-Error-Source: model-provider
~~~

This lets the CLI, SDK, and API consumers distinguish ModelProvider authentication failures from authentication or authorization failures produced by NeMo Platform itself.

The CLI uses this provenance header to display provider-specific guidance instead of suggesting `nemo auth login`.

## Behavior

| Failure source | Status | Provenance header | CLI guidance |
|---|---:|---|---|
| NeMo Platform authentication | `401` | Absent | Authenticate with `nemo auth login` |
| NeMo Platform authorization | `403` | Absent | Check platform roles and permissions |
| ModelProvider authentication | `401` | `X-NeMo-Error-Source: model-provider` | Check the provider API-key secret and authentication configuration |
| ModelProvider authorization | `403` | `X-NeMo-Error-Source: model-provider` | Check credential permissions and model access |
| ModelProvider model/path not found | `404` | N/A | Continues to be mapped to `502 Bad Gateway` |

## Changes

### Inference gateway

- Propagate backend `401` and `403` status codes.
- Preserve the complete backend response body without JSON parsing, rewriting, or truncation.
- Preserve upstream response metadata, including:
  - `Content-Type`
  - Repeated `WWW-Authenticate` challenges
  - Repeated `Set-Cookie` headers
- Add `X-NeMo-Error-Source: model-provider` to ModelProvider `401` and `403` responses.
- Strip stale body-framing headers and recalculate `Content-Length` from the buffered body:
  - `Content-Length`
  - `Content-Encoding`
  - `Transfer-Encoding`
- Preserve the authentication status if reading the upstream response body fails.
- Bypass model rewriting and response/post-response middleware for authentication failures.
- Apply the same behavior to real and mock ModelProviders.
- Cover direct provider, model-entity, and OpenAI-compatible routes.
- Keep backend `404` responses mapped to `502`.
- Consolidate backend-error handling to keep proxy paths consistent.

### CLI

- Detect ModelProvider failures using `X-NeMo-Error-Source`.
- Display distinct messages for:
  - ModelProvider `401` authentication failures
  - ModelProvider `403` permission failures
- Avoid suggesting `nemo auth login` when NeMo Platform authentication succeeded and the configured backend credentials were rejected.
- Apply the behavior to both the source CLI and vendored SDK CLI implementation.

## Example

A backend response such as:

~~~http
HTTP/1.1 401 Unauthorized
Content-Type: application/json
WWW-Authenticate: Bearer realm="provider"
X-NeMo-Error-Source: model-provider

{"error":{"message":"Invalid API key"}}
~~~

is returned to the caller with the original status, body, and authentication challenge.

The CLI reports:

~~~text
Model provider authentication error: (401) Invalid API key
Hint: The ModelProvider rejected its configured credentials.
Check the provider's API key secret and authentication configuration.
~~~

## Test coverage

Added coverage for:

- Backend `401` and `403` responses.
- Platform-generated `401` and `403` responses without the provenance header.
- Provider, model-entity, OpenAI-compatible, and virtual-model proxy paths.
- Real and mock ModelProvider responses.
- Router-level explicit mock-response fast paths.
- JSON, HTML, empty, and large response bodies.
- Failed or truncated upstream body reads.
- Repeated `WWW-Authenticate` and `Set-Cookie` headers.
- Incorrect mock response framing headers.
- JSON and streaming mock responses.
- Response and post-response middleware bypass.
- Provider-specific CLI messages.
- Existing non-authentication error behavior.

## Verification

- Full inference-gateway suite: `572 passed, 5 skipped`
- Focused proxy and router suite: `198 passed`
- Auth-enabled integration suite: `35 passed`
- CLI error-handling suite: `43 passed`
- Ruff lint and formatting: passed
- `git diff --check`: passed

## Linear

[AIRCORE-345 — Inference gateway wraps backend 401 Unauthorized in 502](https://linear.app/nvidia/issue/AIRCORE-345/inference-gateway-wraps-backend-401-unauthorized-in-502-preventing)